### PR TITLE
bootstrap.css deleted last line

### DIFF
--- a/BTCPayServer/wwwroot/vendor/bootstrap/css/bootstrap.css
+++ b/BTCPayServer/wwwroot/vendor/bootstrap/css/bootstrap.css
@@ -9890,4 +9890,3 @@ a.text-dark:focus, a.text-dark:hover {
 .invisible {
     visibility: hidden !important;
 }
-/*# sourceMappingURL=bootstrap.css.map */


### PR DESCRIPTION
deleted this line 
/*# sourceMappingURL=bootstrap.css.map */
because of a debug error in browser's
[Error] Failed to load resource: the server responded with a status of 404 
(Not Found) (bootstrap.css.map, line 0)
https://btcpay-server-testnet.azurewebsites.net/vendor/bootstrap/css/bootstrap.css.map