### PR TITLE
bootstrap.min.css deleted last line

### DIFF
--- a/BTCPayServer/wwwroot/vendor/bootstrap/css/bootstrap.min.css
+++ b/BTCPayServer/wwwroot/vendor/bootstrap/css/bootstrap.min.css
@@ -8593,4 +8593,3 @@ a.text-dark:focus, a.text-dark:hover {
 .invisible {
     visibility: hidden !important
 }
-/*# sourceMappingURL=bootstrap.min.css.map */


### PR DESCRIPTION
deleted this line
/*# sourceMappingURL=bootstrap.min.css.map */
because of a debug error in browser's
[Error] Failed to load resource: the server responded with a status of 404
(Not Found) (bootstrap.min.css.map, line 0)
https://btcpay-server-testnet.azurewebsites.net/vendor/bootstrap/css/bootstrap.min.css.map