### PR TITLE
[Translation Dutch]: improve translation

### DIFF
--- a/BTCPayServer/wwwroot/checkout/js/langs/nl.js
+++ b/BTCPayServer/wwwroot/checkout/js/langs/nl.js
@@ -8,7 +8,7 @@ const locales_nl = {
     "Contact_Body": "Bedankt om je email adres in te vullen voor een mogelijke opvolging. We contacteren je indien er een probleem optreedt.",
     "Your email": "Je email adres",
     "Continue": "Verdergaan",
-    "Please enter a valid email address": "Bedankt om een geldig email adres in te vullen",
+    "Please enter a valid email address": "Vul een geldig email adres in",
     "Order Amount": "Bedrag van je bestelling",
     "Network Cost": "Netwerk kosten",
     "Already Paid": "Reeds betaald",
@@ -25,25 +25,25 @@ const locales_nl = {
     "Address": "Adres",
     "Copied": "Gekopieerd",
     // Conversion tab
-    "ConversionTab_BodyTop": "Je kan alternatieve cryptocurrencies gebruiken die niet ondersteund zijn door de verkoper, om {{btcDue}} {{cryptoCode}} te betalen.",
+    "ConversionTab_BodyTop": "Je kan altcoins gebruiken die niet ondersteund zijn door de verkoper, om {{btcDue}} {{cryptoCode}} te betalen.",
     "ConversionTab_BodyDesc": "Deze dienst wordt door een externe partij geleverd. Bijgevolg, hebben we geen zicht over jouw fondsen. De factuur wordt pas als betaald beschouwd, wanneer de fondsen door de blockchain aanvaard zijn {{ cryptoCode }}.",
-    "Shapeshift_Button_Text": "Betalen met een alternatieve cryptocurrency",
+    "Shapeshift_Button_Text": "Betalen met altcoins",
     "ConversionTab_Lightning": "Geen leverancier beschikbaar voor de betalingen op het Lightning Network",
     // Invoice expired
-    "Invoice expiring soon...": "De factuur zal weldra vervallen...",
+    "Invoice expiring soon...": "De factuur verloopt binnenkort...",
     "Invoice expired": "Vervallen factuur",
     "What happened?": "Wat gebeurde er?",
-    "InvoiceExpired_Body_1": "De factuur is vervallen. Een factuur is geldig voor {{maxTimeMinutes}} minuten.  \
-Je kan terug komen naar {{storeName}} indien je nog eens je betaling wilt proberen uit te voeren.",
-    "InvoiceExpired_Body_2": "Indien je een betaling uitvoerde, werd deze nog niet aanvaard door de blockchain. We hebben je fondsen nog niet ontvangen.",
-    "InvoiceExpired_Body_3": "Indien je transactie niet door de blockchain werd aanvaard, zullen je fondsen terug in wallet verschijnen. Volgens de wallet, kan dit 48 to 72 uren duren.",
+    "InvoiceExpired_Body_1": "De factuur is vervallen. Een factuur is alleen geldig voor {{maxTimeMinutes}} minuten.  \
+Je kan terug komen naar {{storeName}} als je de betaling opnieuw wilt proberen",
+    "InvoiceExpired_Body_2": "Als je een betaling uitvoerde, dan werd dit nog niet bevestigd door het netwerk. We hebben je fondsen nog niet ontvangen.",
+    "InvoiceExpired_Body_3": "Als de transactie niet geaccepteerd werd door het netwerk, zullen je fondsen terug in wallet verschijnen. Afhankelijk van je wallet, kan dit 48 to 72 uren duren.",
     "Invoice ID": "Factuurnummer",
     "Order ID": "Bestllingsnummer",
     "Return to StoreName": "Terug naar {{storeName}}",
     // Invoice paid
-    "This invoice has been paid": "Deze factuur werd betaald",
+    "This invoice has been paid": "Deze factuur is betaald",
     // Invoice archived
-    "This invoice has been archived": "Deze factuur werd geactiveerd",
+    "This invoice has been archived": "Deze factuur is gearchiveerd",
     "Archived_Body": "Bedankt om de winkel te contacteren voor bijstand met of informatie over deze bestelling",
     // Lightning
     "BOLT 11 Invoice": "BOLT 11 Factuur",


### PR DESCRIPTION
some inconsistency between english an dutch translations.

English: Altcoins 
Dutch: Alternative cryptocurrencies 

We can remove it and make it altcoins too.
Dutch people use the word "altcoins" more often. It only leads to confusing. 

English: please enter
Dutch: Thank you enter 

That doesn't sound right. Actually the "please" in dutch can be skipped. 

some more inconsistency in translation
English: Network
Dutch: Blockchain

I changed it to Network, so it's the same as English.

I also changed some old dutch words to a bit more modern dutch. almost nobody uses those old words and it can lead to confusion. 

I did not edit this but
In dutch for the word "you" we have "je" but old fashioned we say "u" sometimes to people one respects like parents, teachers, customers etc.
This is old fashioned but people in Belgium who speak dutch too only use "u".

Might be worth to think about changing.