### PR TITLE
Added Macaroons to 'v1/invoices/subscribe' call

### DIFF
--- a/BTCPayServer/Payments/Lightning/Lnd/LndInvoiceClient.cs
+++ b/BTCPayServer/Payments/Lightning/Lnd/LndInvoiceClient.cs
@@ -46,6 +46,7 @@ namespace BTCPayServer.Payments.Lightning.Lnd
                     _Client = _Parent.CreateHttpClient();
                     _Client.Timeout = TimeSpan.FromMilliseconds(Timeout.Infinite);
                     var request = new HttpRequestMessage(HttpMethod.Get, _Parent.BaseUrl.WithTrailingSlash() + "v1/invoices/subscribe");
+                    _Parent._Authentication.AddAuthentication(request);
                     _Response = await _Client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, _Cts.Token);
                     _Body = await _Response.Content.ReadAsStreamAsync();
                     _Reader = new StreamReader(_Body);

--- a/BTCPayServer/Payments/Lightning/Lnd/LndSwaggerClient.partial.cs
+++ b/BTCPayServer/Payments/Lightning/Lnd/LndSwaggerClient.partial.cs
@@ -69,7 +69,7 @@ namespace BTCPayServer.Payments.Lightning.Lnd
             });
         }
         LndRestSettings _LndSettings;
-        LndAuthentication _Authentication;
+        public LndAuthentication _Authentication;
 
         partial void PrepareRequest(HttpClient client, HttpRequestMessage request, string url)
         {


### PR DESCRIPTION
This PR is more for reference what I've done to make it work. Probably it is not that good of an idea to expose `_Authentication`. Also there is `public async System.Threading.Tasks.Task<LnrpcInvoice> SubscribeInvoicesAsync(System.Threading.CancellationToken cancellationToken)` in `LndSwaggerClient` that might do the trick, haven't tried it.

The result of this 'fix' is successfully payed BTG LND invoice:
https://www.screencast.com/t/Z9EVhLQz
https://www.screencast.com/t/jEo6pIi2h