### PR TITLE
Feature/payment method toggle

### DIFF
--- a/BTCPayServer/Controllers/InvoiceController.UI.cs
+++ b/BTCPayServer/Controllers/InvoiceController.UI.cs
@@ -505,7 +505,7 @@ namespace BTCPayServer.Controllers
                 return View(model);
             }
 
-            if (store.GetSupportedPaymentMethods(_NetworkProvider).Count() == 0)
+            if (!store.GetSupportedPaymentMethods(_NetworkProvider, true).Any())
             {
                 ModelState.AddModelError(nameof(model.StoreId), "You need to configure the derivation scheme in order to create an invoice");
                 return View(model);

--- a/BTCPayServer/Controllers/InvoiceController.cs
+++ b/BTCPayServer/Controllers/InvoiceController.cs
@@ -124,7 +124,7 @@ namespace BTCPayServer.Controllers
             HashSet<CurrencyPair> currencyPairsToFetch = new HashSet<CurrencyPair>();
             var rules = storeBlob.GetRateRules(_NetworkProvider);
 
-            foreach (var network in store.GetSupportedPaymentMethods(_NetworkProvider)
+            foreach (var network in store.GetSupportedPaymentMethods(_NetworkProvider, true)
                                                .Select(c => _NetworkProvider.GetNetwork(c.PaymentId.CryptoCode))
                                                 .Where(c => c != null))
             {
@@ -139,7 +139,7 @@ namespace BTCPayServer.Controllers
             var fetchingByCurrencyPair = _RateProvider.FetchRates(currencyPairsToFetch, rateRules);
 
             var fetchingAll = WhenAllFetched(logs, fetchingByCurrencyPair);
-            var supportedPaymentMethods = store.GetSupportedPaymentMethods(_NetworkProvider)
+            var supportedPaymentMethods = store.GetSupportedPaymentMethods(_NetworkProvider, true)
                                                .Select(c =>
                                                 (Handler: (IPaymentMethodHandler)_ServiceProvider.GetService(typeof(IPaymentMethodHandler<>).MakeGenericType(c.GetType())),
                                                 SupportedPaymentMethod: c,

--- a/BTCPayServer/Controllers/RateController.cs
+++ b/BTCPayServer/Controllers/RateController.cs
@@ -47,7 +47,7 @@ namespace BTCPayServer.Controllers
                 return err;
             }
             var currencypairs = "";
-            var supportedMethods = store.GetSupportedPaymentMethods(_NetworkProvider);
+            var supportedMethods = store.GetSupportedPaymentMethods(_NetworkProvider, true);
 
             var currencyCodes = supportedMethods.Where(method => !string.IsNullOrEmpty(method.PaymentId.CryptoCode))
                 .Select(method => method.PaymentId.CryptoCode).Distinct();
@@ -119,7 +119,7 @@ namespace BTCPayServer.Controllers
             if (currencyPairs == null)
             {
                 currencyPairs = "";
-                var supportedMethods = store.GetSupportedPaymentMethods(_NetworkProvider);
+                var supportedMethods = store.GetSupportedPaymentMethods(_NetworkProvider, false);
                 var currencyCodes = supportedMethods.Where(method => !string.IsNullOrEmpty(method.PaymentId.CryptoCode))
                     .Select(method => method.PaymentId.CryptoCode).Distinct();
                 var defaultCrypto = store.GetDefaultCrypto(_NetworkProvider);

--- a/BTCPayServer/Controllers/StoresController.BTCLike.cs
+++ b/BTCPayServer/Controllers/StoresController.BTCLike.cs
@@ -53,7 +53,7 @@ namespace BTCPayServer.Controllers
         private DerivationStrategy GetExistingDerivationStrategy(string cryptoCode, StoreData store)
         {
             var id = new PaymentMethodId(cryptoCode, PaymentTypes.BTCLike);
-            var existing = store.GetSupportedPaymentMethods(_NetworkProvider)
+            var existing = store.GetSupportedPaymentMethods(_NetworkProvider, false)
                 .OfType<DerivationStrategy>()
                 .FirstOrDefault(d => d.PaymentId == id);
             return existing;
@@ -98,16 +98,6 @@ namespace BTCPayServer.Controllers
                 vm.Confirmation = false;
                 return View(vm);
             }
-            if (command == "toggle")
-            {
-                strategy.Enabled = !strategy.Enabled;
-                vm.Enabled = strategy.Enabled;
-                store.SetSupportedPaymentMethod(paymentMethodId, strategy);
-                await _Repo.UpdateStore(store);
-                StatusMessage = $"Derivation Scheme({cryptoCode}) {(strategy.Enabled ? "Enabled" : "Disabled")}";
-                return RedirectToAction(nameof(UpdateStore), new { storeId = storeId });
-            }
-
             if (!vm.Confirmation && strategy != null)
                 return ShowAddresses(vm, strategy);
             
@@ -143,16 +133,8 @@ namespace BTCPayServer.Controllers
             {
                 try
                 {
-                    if (strategy != null)
-                    {
+                    if (strategy != null)                 
                         await wallet.TrackAsync(strategy.DerivationStrategyBase);
-                        if (command == "save_toggle")
-                        {
-                            strategy.Enabled = !strategy.Enabled;
-                            vm.Enabled = strategy.Enabled;
-                        }
-                    }
-
                     store.SetSupportedPaymentMethod(paymentMethodId, strategy);
                 }
                 catch (Exception e)

--- a/BTCPayServer/Controllers/StoresController.BTCLike.cs
+++ b/BTCPayServer/Controllers/StoresController.BTCLike.cs
@@ -103,6 +103,7 @@ namespace BTCPayServer.Controllers
                 strategy.Enabled = !strategy.Enabled;
                 vm.Enabled = strategy.Enabled;
                 store.SetSupportedPaymentMethod(paymentMethodId, strategy);
+                await _Repo.UpdateStore(store);
                 StatusMessage = $"Derivation Scheme({cryptoCode}) {(strategy.Enabled ? "Enabled" : "Disabled")}";
                 return RedirectToAction(nameof(UpdateStore), new { storeId = storeId });
             }
@@ -143,15 +144,24 @@ namespace BTCPayServer.Controllers
                 try
                 {
                     if (strategy != null)
+                    {
                         await wallet.TrackAsync(strategy.DerivationStrategyBase);
+                        if (command == "save_toggle")
+                        {
+                            strategy.Enabled = !strategy.Enabled;
+                            vm.Enabled = strategy.Enabled;
+                        }
+                    }
+
                     store.SetSupportedPaymentMethod(paymentMethodId, strategy);
                 }
-                catch
+                catch (Exception e)
                 {
                     ModelState.AddModelError(nameof(vm.DerivationScheme), "Invalid Derivation Scheme");
                     return View(vm);
                 }
 
+               
                 await _Repo.UpdateStore(store);
                 StatusMessage = $"Derivation scheme for {network.CryptoCode} has been modified.";
                 return RedirectToAction(nameof(UpdateStore), new { storeId = storeId });

--- a/BTCPayServer/Controllers/StoresController.BTCLike.cs
+++ b/BTCPayServer/Controllers/StoresController.BTCLike.cs
@@ -37,7 +37,6 @@ namespace BTCPayServer.Controllers
             vm.ServerUrl = WalletsController.GetLedgerWebsocketUrl(this.HttpContext, cryptoCode, null);
             vm.CryptoCode = cryptoCode;
             vm.RootKeyPath = network.GetRootKeyPath();
-           
             SetExistingValues(store, vm);
             return View(vm);
         }
@@ -45,7 +44,6 @@ namespace BTCPayServer.Controllers
         private void SetExistingValues(StoreData store, DerivationSchemeViewModel vm)
         {
             var strategy = GetExistingDerivationStrategy(vm.CryptoCode, store);
-            
             vm.DerivationScheme = strategy?.DerivationStrategyBase.ToString();
             vm.Enabled = strategy?.Enabled ?? false;
         }
@@ -100,7 +98,6 @@ namespace BTCPayServer.Controllers
             }
             if (!vm.Confirmation && strategy != null)
                 return ShowAddresses(vm, strategy);
-            
             if (vm.Confirmation && !string.IsNullOrWhiteSpace(vm.HintAddress))
             {
                 BitcoinAddress address = null;
@@ -137,7 +134,7 @@ namespace BTCPayServer.Controllers
                         await wallet.TrackAsync(strategy.DerivationStrategyBase);
                     store.SetSupportedPaymentMethod(paymentMethodId, strategy);
                 }
-                catch (Exception e)
+                catch
                 {
                     ModelState.AddModelError(nameof(vm.DerivationScheme), "Invalid Derivation Scheme");
                     return View(vm);

--- a/BTCPayServer/Controllers/StoresController.BTCLike.cs
+++ b/BTCPayServer/Controllers/StoresController.BTCLike.cs
@@ -57,7 +57,7 @@ namespace BTCPayServer.Controllers
 
         [HttpPost]
         [Route("{storeId}/derivations/{cryptoCode}")]
-        public async Task<IActionResult> AddDerivationScheme(string storeId, DerivationSchemeViewModel vm, string cryptoCode)
+        public async Task<IActionResult> AddDerivationScheme(string storeId, DerivationSchemeViewModel vm, string command, string cryptoCode)
         {
             vm.ServerUrl = WalletsController.GetLedgerWebsocketUrl(this.HttpContext, cryptoCode, null);
             vm.CryptoCode = cryptoCode;
@@ -96,6 +96,12 @@ namespace BTCPayServer.Controllers
 
             if (!vm.Confirmation && strategy != null)
                 return ShowAddresses(vm, strategy);
+
+            if (command == "toggle")
+            {
+                StatusMessage = $"Toggled!";
+                return RedirectToAction(nameof(UpdateStore), new { storeId = storeId });
+            }
 
             if (vm.Confirmation && !string.IsNullOrWhiteSpace(vm.HintAddress))
             {

--- a/BTCPayServer/Controllers/StoresController.BTCLike.cs
+++ b/BTCPayServer/Controllers/StoresController.BTCLike.cs
@@ -47,7 +47,7 @@ namespace BTCPayServer.Controllers
             var strategy = GetExistingDerivationStrategy(vm.CryptoCode, store);
             
             vm.DerivationScheme = strategy?.DerivationStrategyBase.ToString();
-            vm.Enabled = strategy.Enabled;
+            vm.Enabled = strategy?.Enabled ?? false;
         }
 
         private DerivationStrategy GetExistingDerivationStrategy(string cryptoCode, StoreData store)

--- a/BTCPayServer/Controllers/StoresController.BTCLike.cs
+++ b/BTCPayServer/Controllers/StoresController.BTCLike.cs
@@ -87,7 +87,7 @@ namespace BTCPayServer.Controllers
             {
                 if (!string.IsNullOrEmpty(vm.DerivationScheme))
                 {
-                    strategy = ParseDerivationStrategy(vm.DerivationScheme, null, network);
+                    strategy = ParseDerivationStrategy(vm.DerivationScheme, null, network, vm.Enabled);
                     vm.DerivationScheme = strategy.ToString();
                     vm.Enabled = strategy.Enabled;
                 }
@@ -125,7 +125,7 @@ namespace BTCPayServer.Controllers
 
                 try
                 {
-                    strategy = ParseDerivationStrategy(vm.DerivationScheme, address.ScriptPubKey, network);
+                    strategy = ParseDerivationStrategy(vm.DerivationScheme, address.ScriptPubKey, network, vm.Enabled);
                 }
                 catch
                 {

--- a/BTCPayServer/Controllers/StoresController.LightningLike.cs
+++ b/BTCPayServer/Controllers/StoresController.LightningLike.cs
@@ -174,6 +174,10 @@ namespace BTCPayServer.Controllers
                 vm.StatusMessage = $"Toggled!";
                 return View(vm);
             }
+            else
+            {
+                return View(vm);
+            }
         }
 
         private bool CanUseInternalLightning()

--- a/BTCPayServer/Controllers/StoresController.LightningLike.cs
+++ b/BTCPayServer/Controllers/StoresController.LightningLike.cs
@@ -42,7 +42,7 @@ namespace BTCPayServer.Controllers
         private LightningSupportedPaymentMethod GetExistingLightningSupportedPaymentMethod(string cryptoCode, StoreData store)
         {
             var id = new PaymentMethodId(cryptoCode, PaymentTypes.LightningLike);
-            var existing = store.GetSupportedPaymentMethods(_NetworkProvider)
+            var existing = store.GetSupportedPaymentMethods(_NetworkProvider, false)
                 .OfType<LightningSupportedPaymentMethod>()
                 .FirstOrDefault(d => d.PaymentId == id);
             return existing;
@@ -67,6 +67,7 @@ namespace BTCPayServer.Controllers
                 return NotFound();
             var network = vm.CryptoCode == null ? null : _ExplorerProvider.GetNetwork(vm.CryptoCode);
 
+            //SetExistingValues(store, vm);
             var internalLightning = GetInternalLighningNode(network.CryptoCode);
             vm.InternalLightningNode = internalLightning?.ToString();
             if (network == null)
@@ -133,64 +134,44 @@ namespace BTCPayServer.Controllers
 
                 paymentMethod = new Payments.Lightning.LightningSupportedPaymentMethod()
                 {
-                    CryptoCode = paymentMethodId.CryptoCode
+                    CryptoCode = paymentMethodId.CryptoCode,
+                    Enabled = vm.Enabled
                 };
                 paymentMethod.SetLightningUrl(connectionString);
             }
 
-            if (command == "toggle" && paymentMethod != null)
+            switch (command)
             {
-                paymentMethod.Enabled = !paymentMethod.Enabled;
-            }
-
-            if (command == "save" || command == "toggle" || command== "save_toggle")
-            {
-                if (command == "save_toggle" && paymentMethod != null)
-                {
-                    paymentMethod.Enabled = !paymentMethod.Enabled;
-                }
-
-                store.SetSupportedPaymentMethod(paymentMethodId, paymentMethod);
-                await _Repo.UpdateStore(store);
-                StatusMessage = $"Lightning node modified ({network.CryptoCode})";
-                return RedirectToAction(nameof(UpdateStore), new { storeId = storeId });
-            }
-            else if(command == "test")
-            {
-                if (paymentMethod == null)
-                {
+                case "save":
+                    store.SetSupportedPaymentMethod(paymentMethodId, paymentMethod);
+                    await _Repo.UpdateStore(store);
+                    StatusMessage = $"Lightning node modified ({network.CryptoCode})";
+                    return RedirectToAction(nameof(UpdateStore), new { storeId = storeId });
+                case "test" when paymentMethod == null:
                     ModelState.AddModelError(nameof(vm.ConnectionString), "Missing url parameter");
                     return View(vm);
-                }
-                var handler = (LightningLikePaymentHandler)_ServiceProvider.GetRequiredService<IPaymentMethodHandler<Payments.Lightning.LightningSupportedPaymentMethod>>();
-                try
-                {
-                    var info = await handler.Test(paymentMethod, network);
-                    if (!vm.SkipPortTest)
+                case "test":
+                    var handler = (LightningLikePaymentHandler)_ServiceProvider.GetRequiredService<IPaymentMethodHandler<Payments.Lightning.LightningSupportedPaymentMethod>>();
+                    try
                     {
-                        using (CancellationTokenSource cts = new CancellationTokenSource(TimeSpan.FromSeconds(20)))
+                        var info = await handler.Test(paymentMethod, network);
+                        if (!vm.SkipPortTest)
                         {
-                            await handler.TestConnection(info, cts.Token);
+                            using (CancellationTokenSource cts = new CancellationTokenSource(TimeSpan.FromSeconds(20)))
+                            {
+                                await handler.TestConnection(info, cts.Token);
+                            }
                         }
+                        vm.StatusMessage = $"Connection to the lightning node succeeded ({info})";
                     }
-                    vm.StatusMessage = $"Connection to the lightning node succeeded ({info})";
-                }
-                catch (Exception ex)
-                {
-                    vm.StatusMessage = $"Error: {ex.Message}";
+                    catch (Exception ex)
+                    {
+                        vm.StatusMessage = $"Error: {ex.Message}";
+                        return View(vm);
+                    }
                     return View(vm);
-                }
-                return View(vm);
-            }
-            else if (command == "toggle")
-            {
-
-                vm.StatusMessage = $"Toggled!";
-                return View(vm);
-            }
-            else
-            {
-                return View(vm);
+                default:
+                    return View(vm);
             }
         }
 

--- a/BTCPayServer/Controllers/StoresController.LightningLike.cs
+++ b/BTCPayServer/Controllers/StoresController.LightningLike.cs
@@ -141,7 +141,7 @@ namespace BTCPayServer.Controllers
                 StatusMessage = $"Lightning node modified ({network.CryptoCode})";
                 return RedirectToAction(nameof(UpdateStore), new { storeId = storeId });
             }
-            else // if(command == "test")
+            else if(command == "test")
             {
                 if (paymentMethod == null)
                 {
@@ -166,6 +166,12 @@ namespace BTCPayServer.Controllers
                     vm.StatusMessage = $"Error: {ex.Message}";
                     return View(vm);
                 }
+                return View(vm);
+            }
+            else if (command == "toggle")
+            {
+
+                vm.StatusMessage = $"Toggled!";
                 return View(vm);
             }
         }

--- a/BTCPayServer/Controllers/StoresController.cs
+++ b/BTCPayServer/Controllers/StoresController.cs
@@ -428,7 +428,7 @@ namespace BTCPayServer.Controllers
                     Crypto = network.CryptoCode,
                     Value = strategy?.DerivationStrategyBase?.ToString() ?? string.Empty,
                     WalletId = new WalletId(store.Id, network.CryptoCode),
-                    Enabled = strategy?.Enabled
+                    Enabled = strategy?.Enabled ?? false
                 });
             }
 
@@ -444,7 +444,7 @@ namespace BTCPayServer.Controllers
                 {
                     CryptoCode = network.CryptoCode,
                     Address = lightning?.GetLightningUrl()?.BaseUri.AbsoluteUri ?? string.Empty,
-                    Enabled = lightning?.Enabled
+                    Enabled = lightning?.Enabled ?? false
                 });
             }
         }

--- a/BTCPayServer/Controllers/StoresController.cs
+++ b/BTCPayServer/Controllers/StoresController.cs
@@ -525,11 +525,11 @@ namespace BTCPayServer.Controllers
                     .ToArray();
         }
 
-        private DerivationStrategy ParseDerivationStrategy(string derivationScheme, Script hint, BTCPayNetwork network)
+        private DerivationStrategy ParseDerivationStrategy(string derivationScheme, Script hint, BTCPayNetwork network, bool enabled)
         {
             var parser = new DerivationSchemeParser(network.NBitcoinNetwork);
             parser.HintScriptPubKey = hint;
-            return new DerivationStrategy(parser.Parse(derivationScheme), network);
+            return new DerivationStrategy(parser.Parse(derivationScheme), network, enabled);
         }
 
         [HttpGet]

--- a/BTCPayServer/Controllers/StoresController.cs
+++ b/BTCPayServer/Controllers/StoresController.cs
@@ -417,7 +417,7 @@ namespace BTCPayServer.Controllers
         {
             var derivationByCryptoCode =
                 store
-                .GetSupportedPaymentMethods(_NetworkProvider)
+                .GetSupportedPaymentMethods(_NetworkProvider, false)
                 .OfType<DerivationStrategy>()
                 .ToDictionary(c => c.Network.CryptoCode);
             foreach (var network in _NetworkProvider.GetAll())
@@ -433,7 +433,7 @@ namespace BTCPayServer.Controllers
             }
 
             var lightningByCryptoCode = store
-                                        .GetSupportedPaymentMethods(_NetworkProvider)
+                                        .GetSupportedPaymentMethods(_NetworkProvider, false)
                                         .OfType<Payments.Lightning.LightningSupportedPaymentMethod>()
                                         .ToDictionary(c => c.CryptoCode);
 

--- a/BTCPayServer/Controllers/StoresController.cs
+++ b/BTCPayServer/Controllers/StoresController.cs
@@ -428,6 +428,7 @@ namespace BTCPayServer.Controllers
                     Crypto = network.CryptoCode,
                     Value = strategy?.DerivationStrategyBase?.ToString() ?? string.Empty,
                     WalletId = new WalletId(store.Id, network.CryptoCode),
+                    Enabled = strategy?.Enabled
                 });
             }
 
@@ -442,7 +443,8 @@ namespace BTCPayServer.Controllers
                 vm.LightningNodes.Add(new StoreViewModel.LightningNode()
                 {
                     CryptoCode = network.CryptoCode,
-                    Address = lightning?.GetLightningUrl()?.BaseUri.AbsoluteUri ?? string.Empty
+                    Address = lightning?.GetLightningUrl()?.BaseUri.AbsoluteUri ?? string.Empty,
+                    Enabled = lightning?.Enabled
                 });
             }
         }

--- a/BTCPayServer/Controllers/WalletsController.cs
+++ b/BTCPayServer/Controllers/WalletsController.cs
@@ -73,7 +73,7 @@ namespace BTCPayServer.Controllers
             var stores = await _Repo.GetStoresByUserId(GetUserId());
 
             var onChainWallets = stores
-                                .SelectMany(s => s.GetSupportedPaymentMethods(_NetworkProvider)
+                                .SelectMany(s => s.GetSupportedPaymentMethods(_NetworkProvider, false)
                                               .OfType<DerivationStrategy>()
                                               .Select(d => ((Wallet: _walletProvider.GetWallet(d.Network),
                                                             DerivationStrategy: d.DerivationStrategyBase,
@@ -197,7 +197,7 @@ namespace BTCPayServer.Controllers
                 return null;
 
             var paymentMethod = store
-                            .GetSupportedPaymentMethods(_NetworkProvider)
+                            .GetSupportedPaymentMethods(_NetworkProvider, false)
                             .OfType<DerivationStrategy>()
                             .FirstOrDefault(p => p.PaymentId.PaymentType == Payments.PaymentTypes.BTCLike && p.PaymentId.CryptoCode == walletId.CryptoCode);
             return paymentMethod;

--- a/BTCPayServer/Data/StoreData.cs
+++ b/BTCPayServer/Data/StoreData.cs
@@ -65,7 +65,7 @@ namespace BTCPayServer.Data
                 if (networks.BTC != null)
                 {
                     btcReturned = true;
-                    yield return BTCPayServer.DerivationStrategy.Parse(DerivationStrategy, networks.BTC);
+                    yield return BTCPayServer.DerivationStrategy.Parse(DerivationStrategy, networks.BTC, true);
                 }
             }
 

--- a/BTCPayServer/Data/StoreData.cs
+++ b/BTCPayServer/Data/StoreData.cs
@@ -54,7 +54,7 @@ namespace BTCPayServer.Data
             set;
         }
 
-        public IEnumerable<ISupportedPaymentMethod> GetSupportedPaymentMethods(BTCPayNetworkProvider networks)
+        public IEnumerable<ISupportedPaymentMethod> GetSupportedPaymentMethods(BTCPayNetworkProvider networks, bool enabledOnly)
         {
 #pragma warning disable CS0618
             bool btcReturned = false;
@@ -83,7 +83,10 @@ namespace BTCPayServer.Data
                             continue;
                         if (strat.Value.Type == JTokenType.Null)
                             continue;
-                        yield return PaymentMethodExtensions.Deserialize(paymentMethodId, strat.Value, network);
+                        var paymentMethod = PaymentMethodExtensions.Deserialize(paymentMethodId, strat.Value, network);
+                        if (enabledOnly && !paymentMethod.Enabled)
+                            continue;
+                        yield return paymentMethod;
                     }
                 }
             }
@@ -199,7 +202,7 @@ namespace BTCPayServer.Data
 #pragma warning disable CS0618
         public string GetDefaultCrypto(BTCPayNetworkProvider networkProvider = null)
         {
-            return DefaultCrypto ?? (networkProvider == null? "BTC" : GetSupportedPaymentMethods(networkProvider).First().PaymentId.CryptoCode);
+            return DefaultCrypto ?? (networkProvider == null? "BTC" : GetSupportedPaymentMethods(networkProvider, true).First().PaymentId.CryptoCode);
         }
         public void SetDefaultCrypto(string defaultCryptoCurrency)
         {

--- a/BTCPayServer/DerivationStrategy.cs
+++ b/BTCPayServer/DerivationStrategy.cs
@@ -14,20 +14,21 @@ namespace BTCPayServer
         private DerivationStrategyBase _DerivationStrategy;
         private BTCPayNetwork _Network;
 
-        public DerivationStrategy(DerivationStrategyBase result, BTCPayNetwork network)
+        public DerivationStrategy(DerivationStrategyBase result, BTCPayNetwork network, bool enabled)
         {
             this._DerivationStrategy = result;
             this._Network = network;
+            Enabled = enabled;
         }
         
-        public static DerivationStrategy Parse(string derivationStrategy, BTCPayNetwork network)
+        public static DerivationStrategy Parse(string derivationStrategy, BTCPayNetwork network, bool enabled)
         {
             if (network == null)
                 throw new ArgumentNullException(nameof(network));
             if (derivationStrategy == null)
                 throw new ArgumentNullException(nameof(derivationStrategy));
             var result = new NBXplorer.DerivationStrategy.DerivationStrategyFactory(network.NBitcoinNetwork).Parse(derivationStrategy);
-            return new DerivationStrategy(result, network);
+            return new DerivationStrategy(result, network, enabled);
         }
 
         public BTCPayNetwork Network { get { return this._Network; } }
@@ -41,5 +42,11 @@ namespace BTCPayServer
         {
             return _DerivationStrategy.ToString();
         }
+    }
+
+    public class DerivationStrategyData
+    {
+        public string DerivationStrategy { get; set; }
+        public bool Enabled { get; set; }
     }
 }

--- a/BTCPayServer/DerivationStrategy.cs
+++ b/BTCPayServer/DerivationStrategy.cs
@@ -35,6 +35,7 @@ namespace BTCPayServer
         public DerivationStrategyBase DerivationStrategyBase => this._DerivationStrategy;
 
         public PaymentMethodId PaymentId => new PaymentMethodId(Network.CryptoCode, PaymentTypes.BTCLike);
+        public bool Enabled { get; set; }
 
         public override string ToString()
         {

--- a/BTCPayServer/HostedServices/MigratorHostedService.cs
+++ b/BTCPayServer/HostedServices/MigratorHostedService.cs
@@ -72,7 +72,7 @@ namespace BTCPayServer.HostedServices
             {
                 foreach (var store in await ctx.Stores.ToArrayAsync())
                 {
-                    foreach (var method in store.GetSupportedPaymentMethods(_NetworkProvider).OfType<Payments.Lightning.LightningSupportedPaymentMethod>())
+                    foreach (var method in store.GetSupportedPaymentMethods(_NetworkProvider, false).OfType<Payments.Lightning.LightningSupportedPaymentMethod>())
                     {
                         var lightning = method.GetLightningUrl();
                         if (lightning.IsLegacy)

--- a/BTCPayServer/Hosting/Startup.cs
+++ b/BTCPayServer/Hosting/Startup.cs
@@ -41,6 +41,7 @@ using System.Net;
 using BTCPayServer.JsonConverters;
 using Meziantou.AspNetCore.BundleTagHelpers;
 using BTCPayServer.Security;
+using Newtonsoft.Json;
 
 namespace BTCPayServer.Hosting
 {
@@ -96,7 +97,13 @@ namespace BTCPayServer.Hosting
             {
                 options.SerializerSettings.Converters.Add(new DerivationStrategyConverter());
             });
-
+            JsonConvert.DefaultSettings = () => new JsonSerializerSettings()
+            {
+                Converters = new List<JsonConverter>()
+                {
+                    new DerivationStrategyConverter()
+                }
+            };
             services.TryAddScoped<ContentSecurityPolicies>();
             services.Configure<IdentityOptions>(options =>
             {

--- a/BTCPayServer/Hosting/Startup.cs
+++ b/BTCPayServer/Hosting/Startup.cs
@@ -38,6 +38,7 @@ using Microsoft.Extensions.Options;
 using Microsoft.AspNetCore.Mvc.Cors.Internal;
 using Microsoft.AspNetCore.Server.Kestrel.Core;
 using System.Net;
+using BTCPayServer.JsonConverters;
 using Meziantou.AspNetCore.BundleTagHelpers;
 using BTCPayServer.Security;
 
@@ -91,7 +92,11 @@ namespace BTCPayServer.Hosting
                 //    StyleSrc = "'self' 'unsafe-inline'",
                 //    ScriptSrc = "'self' 'unsafe-inline'"
                 //});
+            }).AddJsonOptions(options =>
+            {
+                options.SerializerSettings.Converters.Add(new DerivationStrategyConverter());
             });
+
             services.TryAddScoped<ContentSecurityPolicies>();
             services.Configure<IdentityOptions>(options =>
             {

--- a/BTCPayServer/JsonConverters/DerivationStrategyConverter.cs
+++ b/BTCPayServer/JsonConverters/DerivationStrategyConverter.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.Reflection;
+using BTCPayServer.Payments;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace BTCPayServer.JsonConverters
+{
+    public class DerivationStrategyConverter : JsonConverter
+    {
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            var derivationStrategy = (DerivationStrategy)value;
+            var derivationStrategyData =  new DerivationStrategyData()
+            {
+                DerivationStrategy = derivationStrategy.ToString(),
+                Enabled =  derivationStrategy.Enabled
+            };
+            serializer.Serialize(writer, derivationStrategyData);
+        }
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            throw new InvalidOperationException("Cannot deserialize DerivationStrategy manually: Deserialize to type DerivationStrategyData");
+        }
+
+        public override bool CanConvert(Type objectType)
+        {
+            return typeof(DerivationStrategy).GetTypeInfo().IsAssignableFrom(objectType.GetTypeInfo());
+        }
+    }
+
+    //public class PaymentMethodConverter : JsonConverter
+    //{
+    //    public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+    //    {
+    //        var paymentMethod = (ISupportedPaymentMethod)value;
+    //        switch (paymentMethod.PaymentId.PaymentType)
+    //        {
+    //            case PaymentTypes.BTCLike:
+    //                writer.WriteRaw(JObject.FromObject((DerivationStrategy)value).ToString());
+    //                break;
+    //            case PaymentTypes.LightningLike:
+    //                writer.WriteRaw(JObject.FromObject((DerivationStrategy)value).ToString());
+    //                break;
+    //        }
+    //        var derivationStrategyData = new DerivationStrategyData()
+    //        {
+    //            DerivationStrategy = derivationStrategy.ToString(),
+    //            Enabled = derivationStrategy.Enabled
+    //        };
+    //        serializer.Serialize(writer, derivationStrategyData);
+    //    }
+
+    //    public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+    //    {
+    //        throw new NotImplementedException();
+    //    }
+
+    //    public override bool CanConvert(Type objectType)
+    //    {
+    //        return typeof(ISupportedPaymentMethod).GetTypeInfo().IsAssignableFrom(objectType.GetTypeInfo());
+    //    }
+    //}
+}

--- a/BTCPayServer/JsonConverters/DerivationStrategyConverter.cs
+++ b/BTCPayServer/JsonConverters/DerivationStrategyConverter.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Reflection;
 using BTCPayServer.Payments;
+using BTCPayServer.Payments.Lightning;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
@@ -29,37 +30,4 @@ namespace BTCPayServer.JsonConverters
             return typeof(DerivationStrategy).GetTypeInfo().IsAssignableFrom(objectType.GetTypeInfo());
         }
     }
-
-    //public class PaymentMethodConverter : JsonConverter
-    //{
-    //    public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
-    //    {
-    //        var paymentMethod = (ISupportedPaymentMethod)value;
-    //        switch (paymentMethod.PaymentId.PaymentType)
-    //        {
-    //            case PaymentTypes.BTCLike:
-    //                writer.WriteRaw(JObject.FromObject((DerivationStrategy)value).ToString());
-    //                break;
-    //            case PaymentTypes.LightningLike:
-    //                writer.WriteRaw(JObject.FromObject((DerivationStrategy)value).ToString());
-    //                break;
-    //        }
-    //        var derivationStrategyData = new DerivationStrategyData()
-    //        {
-    //            DerivationStrategy = derivationStrategy.ToString(),
-    //            Enabled = derivationStrategy.Enabled
-    //        };
-    //        serializer.Serialize(writer, derivationStrategyData);
-    //    }
-
-    //    public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
-    //    {
-    //        throw new NotImplementedException();
-    //    }
-
-    //    public override bool CanConvert(Type objectType)
-    //    {
-    //        return typeof(ISupportedPaymentMethod).GetTypeInfo().IsAssignableFrom(objectType.GetTypeInfo());
-    //    }
-    //}
 }

--- a/BTCPayServer/Models/StoreViewModels/DerivationSchemeViewModel.cs
+++ b/BTCPayServer/Models/StoreViewModels/DerivationSchemeViewModel.cs
@@ -27,6 +27,7 @@ namespace BTCPayServer.Models.StoreViewModels
         [Display(Name = "Hint address")]
         public string HintAddress { get; set; }
         public bool Confirmation { get; set; }
+        public bool Enabled { get; set; }
 
         public string ServerUrl { get; set; }
         public string StatusMessage { get; internal set; }

--- a/BTCPayServer/Models/StoreViewModels/LightningNodeViewModel.cs
+++ b/BTCPayServer/Models/StoreViewModels/LightningNodeViewModel.cs
@@ -24,5 +24,6 @@ namespace BTCPayServer.Models.StoreViewModels
         public string StatusMessage { get; set; }
         public string InternalLightningNode { get; internal set; }
         public bool SkipPortTest { get; set; }
+        public bool Enabled { get; set; }
     }
 }

--- a/BTCPayServer/Models/StoreViewModels/StoreViewModel.cs
+++ b/BTCPayServer/Models/StoreViewModels/StoreViewModel.cs
@@ -19,7 +19,7 @@ namespace BTCPayServer.Models.StoreViewModels
             public string Crypto { get; set; }
             public string Value { get; set; }
             public WalletId WalletId { get; set; }
-            public bool? Enabled { get; set; }
+            public bool Enabled { get; set; }
         }
 
         public StoreViewModel()
@@ -84,7 +84,8 @@ namespace BTCPayServer.Models.StoreViewModels
         {
             public string CryptoCode { get; set; }
             public string Address { get; set; }
-            public bool? Enabled { get; set; }
+            public bool
+                Enabled { get; set; }
         }
         public List<LightningNode> LightningNodes
         {

--- a/BTCPayServer/Models/StoreViewModels/StoreViewModel.cs
+++ b/BTCPayServer/Models/StoreViewModels/StoreViewModel.cs
@@ -19,6 +19,7 @@ namespace BTCPayServer.Models.StoreViewModels
             public string Crypto { get; set; }
             public string Value { get; set; }
             public WalletId WalletId { get; set; }
+            public bool? Enabled { get; set; }
         }
 
         public StoreViewModel()
@@ -83,6 +84,7 @@ namespace BTCPayServer.Models.StoreViewModels
         {
             public string CryptoCode { get; set; }
             public string Address { get; set; }
+            public bool? Enabled { get; set; }
         }
         public List<LightningNode> LightningNodes
         {

--- a/BTCPayServer/Payments/ISupportedPaymentMethod.cs
+++ b/BTCPayServer/Payments/ISupportedPaymentMethod.cs
@@ -14,5 +14,6 @@ namespace BTCPayServer.Payments
     public interface ISupportedPaymentMethod
     {
         PaymentMethodId PaymentId { get; }
+        bool Enabled { get; set; }
     }
 }

--- a/BTCPayServer/Payments/Lightning/LightningSupportedPaymentMethod.cs
+++ b/BTCPayServer/Payments/Lightning/LightningSupportedPaymentMethod.cs
@@ -16,6 +16,7 @@ namespace BTCPayServer.Payments.Lightning
 
         // This property MUST be after CryptoCode or else JSON serialization fails
         public PaymentMethodId PaymentId => new PaymentMethodId(CryptoCode, PaymentTypes.LightningLike);
+        public bool Enabled { get; set; }
 
         [Obsolete("Use Get/SetLightningUrl")]
         public string LightningChargeUrl { get; set; }

--- a/BTCPayServer/Payments/PaymentMethodExtensions.cs
+++ b/BTCPayServer/Payments/PaymentMethodExtensions.cs
@@ -45,8 +45,7 @@ namespace BTCPayServer.Payments
 
         public static JToken Serialize(ISupportedPaymentMethod factory)
         {
-            var str = JsonConvert.SerializeObject(factory);
-            return JObject.Parse(str);
+            return JObject.FromObject(factory);
         }
 
     }

--- a/BTCPayServer/Services/Invoices/InvoiceEntity.cs
+++ b/BTCPayServer/Services/Invoices/InvoiceEntity.cs
@@ -206,7 +206,7 @@ namespace BTCPayServer.Services.Invoices
             {
                 if (networks.BTC != null)
                 {
-                    yield return BTCPayServer.DerivationStrategy.Parse(DerivationStrategy, networks.BTC);
+                    yield return BTCPayServer.DerivationStrategy.Parse(DerivationStrategy, networks.BTC, true);
                 }
             }
 #pragma warning restore CS0618

--- a/BTCPayServer/Services/Invoices/InvoiceEntity.cs
+++ b/BTCPayServer/Services/Invoices/InvoiceEntity.cs
@@ -220,7 +220,7 @@ namespace BTCPayServer.Services.Invoices
                 obj.Add(strat.PaymentId.ToString(), PaymentMethodExtensions.Serialize(strat));
 #pragma warning disable CS0618
                 if (strat.PaymentId.IsBTCOnChain)
-                    DerivationStrategy = ((JValue)PaymentMethodExtensions.Serialize(strat)).Value<string>();
+                    DerivationStrategy = ((DerivationStrategy)strat).DerivationStrategyBase.ToString();
             }
             DerivationStrategies = JsonConvert.SerializeObject(obj);
 #pragma warning restore CS0618

--- a/BTCPayServer/Views/Stores/AddDerivationScheme.cshtml
+++ b/BTCPayServer/Views/Stores/AddDerivationScheme.cshtml
@@ -77,7 +77,8 @@
                         </tbody>
                     </table>
                 </div>
-                <button name="command" type="submit" class="btn btn-primary">Continue</button>
+                <button name="command" type="submit" class="btn btn-primary" value="save">Continue</button>
+                <button name="command" type="submit" value="toggle" class="btn btn-secondary">Toggle</button>
             }
             else
             {
@@ -116,7 +117,7 @@
                     <input asp-for="HintAddress" class="form-control" />
                     <span asp-validation-for="HintAddress" class="text-danger"></span>
                 </div>
-                <button name="command" type="submit" class="btn btn-primary">Confirm</button>
+                <button name="command" type="submit" class="btn btn-primary" value="save">Confirm</button>
             }
         </form>
     </div>

--- a/BTCPayServer/Views/Stores/AddDerivationScheme.cshtml
+++ b/BTCPayServer/Views/Stores/AddDerivationScheme.cshtml
@@ -44,36 +44,36 @@
                     <span>BTCPay format memo</span>
                     <table class="table table-sm table-responsive-md">
                         <thead>
-                        <tr>
-                            <th>Address type</th>
-                            <th>Example</th>
-                        </tr>
+                            <tr>
+                                <th>Address type</th>
+                                <th>Example</th>
+                            </tr>
                         </thead>
                         <tbody>
-                        <tr>
-                            <td>P2WPKH</td>
-                            <td>xpub</td>
-                        </tr>
-                        <tr>
-                            <td>P2SH-P2WPKH</td>
-                            <td>xpub-[p2sh]</td>
-                        </tr>
-                        <tr>
-                            <td>P2PKH</td>
-                            <td>xpub-[legacy]</td>
-                        </tr>
-                        <tr>
-                            <td>Multi-sig P2WSH</td>
-                            <td>2-of-xpub1-xpub2</td>
-                        </tr>
-                        <tr>
-                            <td>Multi-sig P2SH-P2WSH</td>
-                            <td>2-of-xpub1-xpub2-[p2sh]</td>
-                        </tr>
-                        <tr>
-                            <td>Multi-sig P2SH</td>
-                            <td>2-of-xpub1-xpub2-[legacy]</td>
-                        </tr>
+                            <tr>
+                                <td>P2WPKH</td>
+                                <td>xpub</td>
+                            </tr>
+                            <tr>
+                                <td>P2SH-P2WPKH</td>
+                                <td>xpub-[p2sh]</td>
+                            </tr>
+                            <tr>
+                                <td>P2PKH</td>
+                                <td>xpub-[legacy]</td>
+                            </tr>
+                            <tr>
+                                <td>Multi-sig P2WSH</td>
+                                <td>2-of-xpub1-xpub2</td>
+                            </tr>
+                            <tr>
+                                <td>Multi-sig P2SH-P2WSH</td>
+                                <td>2-of-xpub1-xpub2-[p2sh]</td>
+                            </tr>
+                            <tr>
+                                <td>Multi-sig P2SH</td>
+                                <td>2-of-xpub1-xpub2-[legacy]</td>
+                            </tr>
                         </tbody>
                     </table>
                 </div>

--- a/BTCPayServer/Views/Stores/AddDerivationScheme.cshtml
+++ b/BTCPayServer/Views/Stores/AddDerivationScheme.cshtml
@@ -1,7 +1,7 @@
 ﻿@model DerivationSchemeViewModel
 @{
     Layout = "../Shared/_NavLayout.cshtml";
-    ViewData["Title"] = "Add derivation scheme";
+    ViewData["Title"] = $"{Model.CryptoCode} Derivation scheme";
     ViewData.AddActivePage(BTCPayServer.Views.Stores.StoreNavPages.Index);
 }
 
@@ -44,45 +44,45 @@
                     <span>BTCPay format memo</span>
                     <table class="table table-sm table-responsive-md">
                         <thead>
-                            <tr>
-                                <th>Address type</th>
-                                <th>Example</th>
-                            </tr>
+                        <tr>
+                            <th>Address type</th>
+                            <th>Example</th>
+                        </tr>
                         </thead>
                         <tbody>
-                            <tr>
-                                <td>P2WPKH</td>
-                                <td>xpub</td>
-                            </tr>
-                            <tr>
-                                <td>P2SH-P2WPKH</td>
-                                <td>xpub-[p2sh]</td>
-                            </tr>
-                            <tr>
-                                <td>P2PKH</td>
-                                <td>xpub-[legacy]</td>
-                            </tr>
-                            <tr>
-                                <td>Multi-sig P2WSH</td>
-                                <td>2-of-xpub1-xpub2</td>
-                            </tr>
-                            <tr>
-                                <td>Multi-sig P2SH-P2WSH</td>
-                                <td>2-of-xpub1-xpub2-[p2sh]</td>
-                            </tr>
-                            <tr>
-                                <td>Multi-sig P2SH</td>
-                                <td>2-of-xpub1-xpub2-[legacy]</td>
-                            </tr>
+                        <tr>
+                            <td>P2WPKH</td>
+                            <td>xpub</td>
+                        </tr>
+                        <tr>
+                            <td>P2SH-P2WPKH</td>
+                            <td>xpub-[p2sh]</td>
+                        </tr>
+                        <tr>
+                            <td>P2PKH</td>
+                            <td>xpub-[legacy]</td>
+                        </tr>
+                        <tr>
+                            <td>Multi-sig P2WSH</td>
+                            <td>2-of-xpub1-xpub2</td>
+                        </tr>
+                        <tr>
+                            <td>Multi-sig P2SH-P2WSH</td>
+                            <td>2-of-xpub1-xpub2-[p2sh]</td>
+                        </tr>
+                        <tr>
+                            <td>Multi-sig P2SH</td>
+                            <td>2-of-xpub1-xpub2-[legacy]</td>
+                        </tr>
                         </tbody>
                     </table>
                 </div>
+                <div class="form-check">
+                    <input id="enabled" asp-for="Enabled" class="form-check-input" />
+                    <label asp-for="Enabled" class="form-check-label"></label>
+                    <span asp-validation-for="Enabled" class="text-danger"></span>
+                </div>
                 <button name="command" type="submit" class="btn btn-primary" value="save">Continue</button>
-                if(!string.IsNullOrEmpty(Model.DerivationScheme))
-                {
-                    <button name="command" type="submit" value="toggle" class="btn btn-secondary">@(Model.Enabled ? "Disable" : "Enable") </button>
-
-                }
             }
             else
             {
@@ -92,6 +92,7 @@
                 </div>
                 <input type="hidden" asp-for="Confirmation" />
                 <input type="hidden" asp-for="DerivationScheme" />
+                <input type="hidden" asp-for="Enabled" />
                 <div class="form-group">
                     <table class="table table-sm table-responsive-md">
                         <thead>
@@ -122,10 +123,6 @@
                     <span asp-validation-for="HintAddress" class="text-danger"></span>
                 </div>
                 <button name="command" type="submit" class="btn btn-primary" value="save">Confirm</button>
-                if (!Model.Enabled)
-                {
-                    <button name="command" type="submit" class="btn btn-primary" value="save_toggle">Confirm & Enable</button>
-                }
             }
         </form>
     </div>

--- a/BTCPayServer/Views/Stores/AddDerivationScheme.cshtml
+++ b/BTCPayServer/Views/Stores/AddDerivationScheme.cshtml
@@ -122,6 +122,10 @@
                     <span asp-validation-for="HintAddress" class="text-danger"></span>
                 </div>
                 <button name="command" type="submit" class="btn btn-primary" value="save">Confirm</button>
+                if (!Model.Enabled)
+                {
+                    <button name="command" type="submit" class="btn btn-primary" value="save_toggle">Confirm & Enable</button>
+                }
             }
         </form>
     </div>

--- a/BTCPayServer/Views/Stores/AddDerivationScheme.cshtml
+++ b/BTCPayServer/Views/Stores/AddDerivationScheme.cshtml
@@ -78,7 +78,11 @@
                     </table>
                 </div>
                 <button name="command" type="submit" class="btn btn-primary" value="save">Continue</button>
-                <button name="command" type="submit" value="toggle" class="btn btn-secondary">Toggle</button>
+                if(!string.IsNullOrEmpty(Model.DerivationScheme))
+                {
+                    <button name="command" type="submit" value="toggle" class="btn btn-secondary">@(Model.Enabled ? "Disable" : "Enable") </button>
+
+                }
             }
             else
             {

--- a/BTCPayServer/Views/Stores/AddLightningNode.cshtml
+++ b/BTCPayServer/Views/Stores/AddLightningNode.cshtml
@@ -52,7 +52,7 @@
                 <p>You can set <code>allowinsecure</code> to <code>true</code> if your LND REST server is using HTTP or HTTPS with an untrusted certificate which you don't know the <code>certthumprint</code></p>
             </div>
             <div class="form-group">
-                <label asp-for="ConnectionString" class=""></label>
+                <label asp-for="ConnectionString"></label>
                 <input id="lightningurl" asp-for="ConnectionString" class="form-control" />
                 <span asp-validation-for="ConnectionString" class="text-danger"></span>
                 @if (Model.InternalLightningNode != null)

--- a/BTCPayServer/Views/Stores/AddLightningNode.cshtml
+++ b/BTCPayServer/Views/Stores/AddLightningNode.cshtml
@@ -64,6 +64,7 @@
             </div>
             <button name="command" type="submit" value="save" class="btn btn-primary">Submit</button>
             <button name="command" type="submit" value="test" class="btn btn-secondary">Test connection</button>
+            <button name="command" type="submit" value="toggle" class="btn btn-secondary">Toggle</button>
         </form>
     </div>
 </div>

--- a/BTCPayServer/Views/Stores/AddLightningNode.cshtml
+++ b/BTCPayServer/Views/Stores/AddLightningNode.cshtml
@@ -63,8 +63,10 @@
                 }
             </div>
             <button name="command" type="submit" value="save" class="btn btn-primary">Submit</button>
+            <button name="command" type="submit" value="save_toggle" class="btn btn-primary">Submit & Enable</button>
             <button name="command" type="submit" value="test" class="btn btn-secondary">Test connection</button>
-            <button name="command" type="submit" value="toggle" class="btn btn-secondary">Toggle</button>
+            <button name="command" type="submit" value="toggle" class="btn btn-secondary">
+            @(Model.Enabled? "Disable" : "Enable")</button>
         </form>
     </div>
 </div>

--- a/BTCPayServer/Views/Stores/AddLightningNode.cshtml
+++ b/BTCPayServer/Views/Stores/AddLightningNode.cshtml
@@ -52,21 +52,23 @@
                 <p>You can set <code>allowinsecure</code> to <code>true</code> if your LND REST server is using HTTP or HTTPS with an untrusted certificate which you don't know the <code>certthumprint</code></p>
             </div>
             <div class="form-group">
-                <label asp-for="ConnectionString"></label>
+                <label asp-for="ConnectionString" class=""></label>
                 <input id="lightningurl" asp-for="ConnectionString" class="form-control" />
                 <span asp-validation-for="ConnectionString" class="text-danger"></span>
-                @if(Model.InternalLightningNode != null)
+                @if (Model.InternalLightningNode != null)
                 {
                     <p class="form-text text-muted">
                         You can use the internal lightning node by <a href="#" onclick="$('#lightningurl').val('@Model.InternalLightningNode'); return false;">clicking here</a>
                     </p>
                 }
             </div>
+            <div class="form-check">
+                <input id="enabled" asp-for="Enabled" class="form-check-input" />
+                <label asp-for="Enabled" class="form-check-label"></label>
+                <span asp-validation-for="Enabled" class="text-danger"></span>
+            </div>
             <button name="command" type="submit" value="save" class="btn btn-primary">Submit</button>
-            <button name="command" type="submit" value="save_toggle" class="btn btn-primary">Submit & Enable</button>
             <button name="command" type="submit" value="test" class="btn btn-secondary">Test connection</button>
-            <button name="command" type="submit" value="toggle" class="btn btn-secondary">
-            @(Model.Enabled? "Disable" : "Enable")</button>
         </form>
     </div>
 </div>

--- a/BTCPayServer/Views/Stores/UpdateStore.cshtml
+++ b/BTCPayServer/Views/Stores/UpdateStore.cshtml
@@ -70,6 +70,7 @@
                         <tr>
                             <th>Crypto</th>
                             <th>Derivation Scheme</th>
+                            <th>Status</th>
                             <th style="text-align:right">Actions</th>
                         </tr>
                     </thead>
@@ -79,6 +80,12 @@
                             <tr>
                                 <td>@scheme.Crypto</td>
                                 <td style="max-width:300px;overflow:hidden;">@scheme.Value</td>
+                                <td>
+                                    @if (!string.IsNullOrWhiteSpace(scheme.Value))
+                                    {
+                                        @(scheme.Enabled ? "Enabled" : "Disabled")
+                                    }
+                                </td>
                                 <td style="text-align:right">
                                     @if(!string.IsNullOrWhiteSpace(scheme.Value))
                                     {
@@ -106,6 +113,7 @@
                             <tr>
                                 <th>Crypto</th>
                                 <th>Address</th>
+                                <th>Status</th>
                                 <th style="text-align:right">Actions</th>
                             </tr>
                         </thead>
@@ -115,6 +123,9 @@
                                 <tr>
                                     <td>@scheme.CryptoCode</td>
                                     <td>@scheme.Address</td>
+                                    <td>
+                                        @(scheme.Enabled ? "Enabled" : "Disabled")
+                                    </td>
                                     <td style="text-align:right"><a asp-action="AddLightningNode" asp-route-cryptoCode="@scheme.CryptoCode">Modify</a></td>
                                 </tr>
                             }


### PR DESCRIPTION
This PR will allow you to enable/disable payment methods on each store. Benefits include you not having to erase your derivation scheme each time you want to toggle a crypto payment method. Works for both LightningLike and BtcLike