### PR TITLE
Always showing currency name to prevent LND confusion

### DIFF
--- a/BTCPayServer/Views/Invoice/Checkout-Body.cshtml
+++ b/BTCPayServer/Views/Invoice/Checkout-Body.cshtml
@@ -33,45 +33,52 @@
     </div>
 </div>
 <div class="order-details">
-    @if (Model.AvailableCryptos.Count > 1)
-    {
-        <div class="currency-selection">
-            <div class="single-item-order__left">
-                <div style="font-weight: 600;">
-                    {{$t("Pay with")}}
-                </div>
-            </div>
-            <div class="single-item-order__right">
-                @if (Model.AvailableCryptos.Count > 1)
-                {
-                    <div class="payment__currencies" onclick="openPaymentMethodDialog()">
-                        <img v-bind:src="srvModel.cryptoImage" />
-                        <span class="clickable_underline">{{srvModel.paymentMethodName}} ({{srvModel.cryptoCode}})</span>
-                        <span v-show="srvModel.isLightning">&#9889;</span>
-                        <span class="clickable_indicator fa fa-angle-right"></span>
-                    </div>
-                    <div id="vexPopupDialog">
-                        <ul class="vexmenu">
-                            @foreach (var crypto in Model.AvailableCryptos)
-                            {
-                                <li class="vexmenuitem">
-                                    <a href="@crypto.Link" onclick="return closePaymentMethodDialog('@crypto.PaymentMethodId');">
-                                        <img alt="@crypto.PaymentMethodName" src="@crypto.CryptoImage" />
-                                        @crypto.PaymentMethodName
-                                        @(crypto.IsLightning ? Html.Raw("&#9889;") : null)
-                                        <span>@crypto.CryptoCode</span>
-                                    </a>
-                                </li>
-                            }
-                        </ul>
-                    </div>
-                }
-                <div class="payment__spinner">
-                    <partial name="Checkout-Spinner" />
-                </div>
+    <div class="currency-selection">
+        <div class="single-item-order__left">
+            <div style="font-weight: 600;">
+                {{$t("Pay with")}}
             </div>
         </div>
-    }
+        <div class="single-item-order__right">
+            @if (Model.AvailableCryptos.Count > 1)
+            {
+                <div class="payment__currencies cursorPointer" onclick="openPaymentMethodDialog()">
+                    <img v-bind:src="srvModel.cryptoImage" />
+                    <span class="clickable_underline">{{srvModel.paymentMethodName}} ({{srvModel.cryptoCode}})</span>
+                    <span v-show="srvModel.isLightning">&#9889;</span>
+                    <span class="clickable_indicator fa fa-angle-right"></span>
+                </div>
+                <div id="vexPopupDialog">
+                    <ul class="vexmenu">
+                        @foreach (var crypto in Model.AvailableCryptos)
+                        {
+                            <li class="vexmenuitem">
+                                <a href="@crypto.Link" onclick="return closePaymentMethodDialog('@crypto.PaymentMethodId');">
+                                    <img alt="@crypto.PaymentMethodName" src="@crypto.CryptoImage" />
+                                    @crypto.PaymentMethodName
+                                    @(crypto.IsLightning ? Html.Raw("&#9889;") : null)
+                                    <span>@crypto.CryptoCode</span>
+                                </a>
+                            </li>
+                        }
+                    </ul>
+                </div>
+            }
+            else
+            {
+                <div class="payment__currencies">
+                    <img v-bind:src="srvModel.cryptoImage" />
+                    <span>{{srvModel.paymentMethodName}} ({{srvModel.cryptoCode}})</span>
+                    <span v-show="srvModel.isLightning">&#9889;</span>
+                </div>
+
+            }
+            <div class="payment__spinner">
+                <partial name="Checkout-Spinner" />
+            </div>
+        </div>
+    </div>
+
     <div class="single-item-order buyerTotalLine">
         <div class="single-item-order__left">
             <div class="single-item-order__left__name">

--- a/BTCPayServer/wwwroot/checkout/css/vex-extrastyles.css
+++ b/BTCPayServer/wwwroot/checkout/css/vex-extrastyles.css
@@ -40,9 +40,12 @@
     display: none;
 }
 
+.cursorPointer {
+    cursor: pointer;
+}
+
 .payment__currencies {
     font-size: 14px;
-    cursor: pointer;
 }
 
     .payment__currencies img {


### PR DESCRIPTION
Discussion: https://forkbitpay.slack.com/archives/C6PSCRFAM/p1533125977000141

Image showing when there is only one currency:

![single-currency-checkout](https://user-images.githubusercontent.com/5191402/43689910-6f493e8e-9901-11e8-9e98-155813355fe8.jpg)

And gif showing indicators that are displayed when there are multiple currencies you can switch between:

![switching currencies](https://user-images.githubusercontent.com/5191402/43689913-7f502bee-9901-11e8-85f1-e9909eb0d95d.gif)