### PR TITLE
Issue #237 add debug log file command line option --debuglog.

### DIFF
--- a/BTCPayServer.Tests/BTCPayServer.Tests.csproj
+++ b/BTCPayServer.Tests/BTCPayServer.Tests.csproj
@@ -10,6 +10,9 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
+    <PackageReference Include="Serilog" Version="2.7.1" />
+    <PackageReference Include="Serilog.AspNetCore" Version="2.1.1" />
+    <PackageReference Include="Serilog.Sinks.File" Version="4.0.0" />
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0">
       <PrivateAssets>all</PrivateAssets>

--- a/BTCPayServer/BTCPayServer.csproj
+++ b/BTCPayServer/BTCPayServer.csproj
@@ -53,6 +53,9 @@
     <PackageReference Include="NicolasDorier.RateLimits" Version="1.0.0.3" />
     <PackageReference Include="NicolasDorier.StandardConfiguration" Version="1.0.0.18" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="2.1.0" />
+    <PackageReference Include="Serilog" Version="2.7.1" />
+    <PackageReference Include="Serilog.AspNetCore" Version="2.1.1" />
+    <PackageReference Include="Serilog.Sinks.File" Version="4.0.0" />
     <PackageReference Include="SSH.NET" Version="2016.1.0" />
     <PackageReference Include="System.Xml.XmlSerializer" Version="4.3.0" />
     <PackageReference Include="Text.Analyzers" Version="2.6.0" />

--- a/BTCPayServer/Configuration/DefaultConfiguration.cs
+++ b/BTCPayServer/Configuration/DefaultConfiguration.cs
@@ -39,6 +39,7 @@ namespace BTCPayServer.Configuration
             app.Option("--sshkeyfile", "SSH private key file to manage BTCPay (default: empty)", CommandOptionType.SingleValue);
             app.Option("--sshkeyfilepassword", "Password of the SSH keyfile (default: empty)", CommandOptionType.SingleValue);
             app.Option("--sshtrustedfingerprints", "SSH Host public key fingerprint or sha256 (default: empty, it will allow untrusted connections)", CommandOptionType.SingleValue);
+            app.Option("--debuglog", "A rolling log file for debug messages.", CommandOptionType.SingleValue);
             foreach (var network in provider.GetAll())
             {
                 var crypto = network.CryptoCode.ToLowerInvariant();

--- a/BTCPayServer/Program.cs
+++ b/BTCPayServer/Program.cs
@@ -15,11 +15,14 @@ using System.Collections.Generic;
 using System.Collections;
 using Microsoft.AspNetCore.Hosting.Server.Features;
 using System.Threading;
+using Serilog;
 
 namespace BTCPayServer
 {
     class Program
     {
+        private const long MAX_DEBUG_LOG_FILE_SIZE = 2000000; // If debug log is in use roll it every N MB.
+
         static void Main(string[] args)
         {
             ServicePointManager.DefaultConnectionLimit = 100;
@@ -31,11 +34,20 @@ namespace BTCPayServer
             var logger = loggerFactory.CreateLogger("Configuration");
             try
             {
-                // This is the only way toat LoadArgs can print to console. Because LoadArgs is called by the HostBuilder before Logs.Configure is called
+                // This is the only way that LoadArgs can print to console. Because LoadArgs is called by the HostBuilder before Logs.Configure is called
                 var conf = new DefaultConfiguration() { Logger = logger }.CreateConfiguration(args);
                 if (conf == null)
                     return;
                 Logs.Configure(loggerFactory);
+                string debugLogFile = conf.GetOrDefault<string>("debuglog", null);
+                if (String.IsNullOrEmpty(debugLogFile) == false)
+                {
+                    Log.Logger = new LoggerConfiguration()
+                    .Enrich.FromLogContext()
+                    .MinimumLevel.Debug()
+                    .WriteTo.File(debugLogFile, rollingInterval: RollingInterval.Day, fileSizeLimitBytes: MAX_DEBUG_LOG_FILE_SIZE, rollOnFileSizeLimit: true, retainedFileCountLimit: 1)
+                    .CreateLogger();
+                }
                 new BTCPayServerOptions().LoadArgs(conf);
                 Logs.Configure(null);
                 /////
@@ -50,6 +62,7 @@ namespace BTCPayServer
                         l.AddFilter("Microsoft", LogLevel.Error);
                         l.AddFilter("Microsoft.AspNetCore.Antiforgery.Internal", LogLevel.Critical);
                         l.AddProvider(new CustomConsoleLogProvider(processor));
+                        l.AddSerilog();
                     })
                     .UseStartup<Startup>()
                     .Build();


### PR DESCRIPTION
Adds a --debugfile command line option to log console messages to a rolling debug file (limited to 2MB in size and rolls when full). If warranted other options such as the size, number of files to retain etc. could also be added.

Example usage:
` dotnet run --project=BTCPayServer/BTCPayServer.csproj --debuglog c:\temp\debug.log`