### PR TITLE
Issue #237 add debug log file command line option --debuglog.

### DIFF
--- a/BTCPayServer/BTCPayServer.csproj
+++ b/BTCPayServer/BTCPayServer.csproj
@@ -53,6 +53,9 @@
     <PackageReference Include="NicolasDorier.RateLimits" Version="1.0.0.3" />
     <PackageReference Include="NicolasDorier.StandardConfiguration" Version="1.0.0.18" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="2.1.0" />
+    <PackageReference Include="Serilog" Version="2.7.1" />
+    <PackageReference Include="Serilog.AspNetCore" Version="2.1.1" />
+    <PackageReference Include="Serilog.Sinks.File" Version="4.0.0" />
     <PackageReference Include="SSH.NET" Version="2016.1.0" />
     <PackageReference Include="System.Xml.XmlSerializer" Version="4.3.0" />
     <PackageReference Include="Text.Analyzers" Version="2.6.0" />

--- a/BTCPayServer/Configuration/DefaultConfiguration.cs
+++ b/BTCPayServer/Configuration/DefaultConfiguration.cs
@@ -39,6 +39,7 @@ namespace BTCPayServer.Configuration
             app.Option("--sshkeyfile", "SSH private key file to manage BTCPay (default: empty)", CommandOptionType.SingleValue);
             app.Option("--sshkeyfilepassword", "Password of the SSH keyfile (default: empty)", CommandOptionType.SingleValue);
             app.Option("--sshtrustedfingerprints", "SSH Host public key fingerprint or sha256 (default: empty, it will allow untrusted connections)", CommandOptionType.SingleValue);
+            app.Option("--debuglog", "A rolling log file for debug messages.", CommandOptionType.SingleValue);
             foreach (var network in provider.GetAll())
             {
                 var crypto = network.CryptoCode.ToLowerInvariant();

--- a/BTCPayServer/Properties/launchSettings.json
+++ b/BTCPayServer/Properties/launchSettings.json
@@ -2,6 +2,7 @@
   "profiles": {
     "Docker-Regtest": {
       "commandName": "Project",
+      "commandLineArgs": "--debuglog debug.log",
       "launchBrowser": true,
       "environmentVariables": {
         "BTCPAY_NETWORK": "regtest",


### PR DESCRIPTION
Adds a --debugfile command line option to log console messages to a rolling debug file (limited to 2MB in size and rolls when full). If warranted other options such as the size, number of files to retain etc. could also be added.

Example usage:
` dotnet run -c Debug -p BTCPayServer/BTCPayServer.csproj --testnet --debuglog ~/btcpayserver.debug`