### PR TITLE
allow showing addresses from derivationscheme even if not updating it

### DIFF
--- a/BTCPayServer/Controllers/StoresController.BTCLike.cs
+++ b/BTCPayServer/Controllers/StoresController.BTCLike.cs
@@ -58,7 +58,7 @@ namespace BTCPayServer.Controllers
 
         [HttpPost]
         [Route("{storeId}/derivations/{cryptoCode}")]
-        public async Task<IActionResult> AddDerivationScheme(string storeId, DerivationSchemeViewModel vm, string cryptoCode)
+        public async Task<IActionResult> AddDerivationScheme(string storeId, DerivationSchemeViewModel vm, string cryptoCode, string command)
         {
             vm.ServerUrl = WalletsController.GetLedgerWebsocketUrl(this.HttpContext, cryptoCode, null);
             vm.CryptoCode = cryptoCode;
@@ -100,7 +100,7 @@ namespace BTCPayServer.Controllers
                 return View(vm);
             }
 
-            var showAddress = (vm.Confirmation && !string.IsNullOrWhiteSpace(vm.HintAddress)) || // Testing hint address
+            var showAddress = command == "confirm" || (vm.Confirmation && !string.IsNullOrWhiteSpace(vm.HintAddress)) || // Testing hint address
                               (!vm.Confirmation && strategy != null && exisingStrategy != strategy.DerivationStrategyBase.ToString());  // Checking addresses after setting xpub
 
             if (!showAddress)

--- a/BTCPayServer/Views/Stores/AddDerivationScheme.cshtml
+++ b/BTCPayServer/Views/Stores/AddDerivationScheme.cshtml
@@ -81,6 +81,7 @@
                     <input asp-for="Enabled" type="checkbox" class="form-check" />
                 </div>
                 <button name="command" type="submit" class="btn btn-primary" value="save">Continue</button>
+                <button name="command" type="submit" class="btn btn-primary" value="confirm">Confirm Derivation</button>
             }
             else
             {


### PR DESCRIPTION
closes #279
This adds the option to check the derivation scheme's generated addresses at will.
