### PR TITLE
Fixing broken link in Wallets/WalletSend.cshtml

### DIFF
--- a/BTCPayServer/Views/Wallets/WalletSend.cshtml
+++ b/BTCPayServer/Views/Wallets/WalletSend.cshtml
@@ -19,7 +19,7 @@
         </p>
         <ul>
             <li>Make sure you are running the Ledger app with version superior or equal to 1.2.4</li>
-            <li>Use a browser supporting the <a href="https://www.yubico.com/support/knowledge-base/categories/articles/browsers-support-u2f/">U2F protocol</a></li>
+            <li>Use Google Chrome browser and open the coin app on your Ledger</li>
         </ul>
         <p id="hw-loading"><span class="fa fa-question-circle" style="color:orange"></span> <span>Detecting hardware wallet...</span></p>
         <p id="hw-error" style="display:none;"><span class="fa fa-times-circle" style="color:red;"></span> <span class="hw-label">An error happened</span></p>


### PR DESCRIPTION
1. Removing the broken Yubico link U2F browsers -  the article no longer exists.
2. I tested this integration with other U2F supporting browsers (Firefox Nightly, Firefox) and it only works in Google Chrome, so I suggest we only suggest what works, and for now, that's Chrome only.
3. Explained that user has to open the coin app in Ledger for integration to work.

Review the wording and feel free to modify.
