### PR TITLE
MySQL Support

### DIFF
--- a/BTCPayServer.Tests/BTCPayServerTester.cs
+++ b/BTCPayServer.Tests/BTCPayServerTester.cs
@@ -57,6 +57,11 @@ namespace BTCPayServer.Tests
             set;
         }
 
+        public string MySQL
+        {
+            get; set;
+        }
+
         public string Postgres
         {
             get; set;
@@ -94,7 +99,9 @@ namespace BTCPayServer.Tests
 
             config.AppendLine($"btc.lightning={IntegratedLightning.AbsoluteUri}");
 
-            if (Postgres != null)
+            if (MySQL != null)
+                config.AppendLine($"mysql=" + MySQL);
+            else if (Postgres != null)
                 config.AppendLine($"postgres=" + Postgres);
             var confPath = Path.Combine(chainDirectory, "settings.config");
             File.WriteAllText(confPath, config.ToString());

--- a/BTCPayServer.Tests/BTCPayServerTester.cs
+++ b/BTCPayServer.Tests/BTCPayServerTester.cs
@@ -35,6 +35,12 @@ using Xunit;
 
 namespace BTCPayServer.Tests
 {
+    public enum TestDatabases
+    {
+        Postgres,
+        MySQL,
+    }
+
     public class BTCPayServerTester : IDisposable
     {
         private string _Directory;
@@ -73,6 +79,10 @@ namespace BTCPayServer.Tests
             get; set;
         }
 
+        public TestDatabases TestDatabase
+        {
+            get; set;
+        }
 
         public bool MockRates { get; set; } = true;
 
@@ -99,9 +109,9 @@ namespace BTCPayServer.Tests
 
             config.AppendLine($"btc.lightning={IntegratedLightning.AbsoluteUri}");
 
-            if (MySQL != null)
+            if (TestDatabase == TestDatabases.MySQL && !String.IsNullOrEmpty(MySQL))
                 config.AppendLine($"mysql=" + MySQL);
-            else if (Postgres != null)
+            else if (!String.IsNullOrEmpty(Postgres))
                 config.AppendLine($"postgres=" + Postgres);
             var confPath = Path.Combine(chainDirectory, "settings.config");
             File.WriteAllText(confPath, config.ToString());

--- a/BTCPayServer.Tests/ServerTester.cs
+++ b/BTCPayServer.Tests/ServerTester.cs
@@ -60,8 +60,9 @@ namespace BTCPayServer.Tests
             {
                 NBXplorerUri = ExplorerClient.Address,
                 LTCNBXplorerUri = LTCExplorerClient.Address,
+                TestDatabase = Enum.Parse<TestDatabases>(GetEnvironment("TESTS_DB", TestDatabases.Postgres.ToString()), true),
                 Postgres = GetEnvironment("TESTS_POSTGRES", "User ID=postgres;Host=127.0.0.1;Port=39372;Database=btcpayserver"),
-                MySQL = GetEnvironment("TESTS_MYSQL", null),
+                MySQL = GetEnvironment("TESTS_MYSQL", "User ID=root;Host=127.0.0.1;Port=33036;Database=btcpayserver"),
                 IntegratedLightning = MerchantCharge.Client.Uri
             };
             PayTester.Port = int.Parse(GetEnvironment("TESTS_PORT", Utils.FreeTcpPort().ToString(CultureInfo.InvariantCulture)), CultureInfo.InvariantCulture);

--- a/BTCPayServer.Tests/ServerTester.cs
+++ b/BTCPayServer.Tests/ServerTester.cs
@@ -61,6 +61,7 @@ namespace BTCPayServer.Tests
                 NBXplorerUri = ExplorerClient.Address,
                 LTCNBXplorerUri = LTCExplorerClient.Address,
                 Postgres = GetEnvironment("TESTS_POSTGRES", "User ID=postgres;Host=127.0.0.1;Port=39372;Database=btcpayserver"),
+                MySQL = GetEnvironment("TESTS_MYSQL", null),
                 IntegratedLightning = MerchantCharge.Client.Uri
             };
             PayTester.Port = int.Parse(GetEnvironment("TESTS_PORT", Utils.FreeTcpPort().ToString(CultureInfo.InvariantCulture)), CultureInfo.InvariantCulture);

--- a/BTCPayServer.Tests/docker-compose.yml
+++ b/BTCPayServer.Tests/docker-compose.yml
@@ -14,6 +14,7 @@ services:
       TESTS_LTCRPCCONNECTION: server=http://litecoind:43782;ceiwHEbqWI83:DwubwWsoo3
       TESTS_BTCNBXPLORERURL: http://nbxplorer:32838/
       TESTS_LTCNBXPLORERURL: http://nbxplorer:32838/
+      TESTS_DB: "Postgres"
       TESTS_POSTGRES: User ID=postgres;Host=postgres;Port=5432;Database=btcpayserver
       TESTS_MYSQL: User ID=root;Host=mysql;Port=3306;Database=btcpayserver
       TESTS_PORT: 80
@@ -210,7 +211,7 @@ services:
     expose:
       - "3306"
     ports:
-      - "33306:3306"
+      - "33036:3306"
     environment:
       - MYSQL_ALLOW_EMPTY_PASSWORD=yes
 

--- a/BTCPayServer.Tests/docker-compose.yml
+++ b/BTCPayServer.Tests/docker-compose.yml
@@ -15,6 +15,7 @@ services:
       TESTS_BTCNBXPLORERURL: http://nbxplorer:32838/
       TESTS_LTCNBXPLORERURL: http://nbxplorer:32838/
       TESTS_POSTGRES: User ID=postgres;Host=postgres;Port=5432;Database=btcpayserver
+      TESTS_MYSQL: User ID=root;Host=mysql;Port=3306;Database=btcpayserver
       TESTS_PORT: 80
       TESTS_HOSTNAME: tests
       TEST_MERCHANTLIGHTNINGD: "type=clightning;server=/etc/merchant_lightningd_datadir/lightning-rpc"
@@ -43,6 +44,7 @@ services:
     links:
       - nbxplorer
       - postgres
+      - mysql
       - customer_lightningd
       - merchant_lightningd
       - lightning-charged
@@ -59,6 +61,7 @@ services:
     links:
       - nbxplorer
       - postgres
+      - mysql
       - customer_lnd
       - merchant_lnd
 
@@ -201,6 +204,15 @@ services:
       - "39372:5432"
     expose:
       - "5432"
+      
+  mysql:
+    image:  mysql:8.0.12
+    expose:
+      - "3306"
+    ports:
+      - "33306:3306"
+    environment:
+      - MYSQL_ALLOW_EMPTY_PASSWORD=yes
 
   merchant_lnd:
     image: btcpayserver/lnd:0.5-beta

--- a/BTCPayServer/BTCPayServer.csproj
+++ b/BTCPayServer/BTCPayServer.csproj
@@ -53,6 +53,7 @@
     <PackageReference Include="NicolasDorier.RateLimits" Version="1.0.0.3" />
     <PackageReference Include="NicolasDorier.StandardConfiguration" Version="1.0.0.18" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="2.1.0" />
+    <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="2.1.2" />
     <PackageReference Include="Serilog" Version="2.7.1" />
     <PackageReference Include="Serilog.AspNetCore" Version="2.1.1" />
     <PackageReference Include="Serilog.Sinks.File" Version="4.0.0" />

--- a/BTCPayServer/Configuration/BTCPayServerOptions.cs
+++ b/BTCPayServer/Configuration/BTCPayServerOptions.cs
@@ -118,6 +118,7 @@ namespace BTCPayServer.Configuration
             Logs.Configuration.LogInformation("Supported chains: " + String.Join(',', supportedChains.ToArray()));
 
             PostgresConnectionString = conf.GetOrDefault<string>("postgres", null);
+            MySQLConnectionString = conf.GetOrDefault<string>("mysql", null);
             BundleJsCss = conf.GetOrDefault<bool>("bundlejscss", true);
             ExternalUrl = conf.GetOrDefault<Uri>("externalurl", null);
 
@@ -220,6 +221,11 @@ namespace BTCPayServer.Configuration
 
         public BTCPayNetworkProvider NetworkProvider { get; set; }
         public string PostgresConnectionString
+        {
+            get;
+            set;
+        }
+        public string MySQLConnectionString
         {
             get;
             set;

--- a/BTCPayServer/Configuration/DefaultConfiguration.cs
+++ b/BTCPayServer/Configuration/DefaultConfiguration.cs
@@ -31,6 +31,7 @@ namespace BTCPayServer.Configuration
             app.Option("--regtest | -regtest", $"Use regtest (deprecated, use --network instead)", CommandOptionType.BoolValue);
             app.Option("--chains | -c", $"Chains to support as a comma separated (default: btc; available: {chains})", CommandOptionType.SingleValue);
             app.Option("--postgres", $"Connection string to a PostgreSQL database (default: SQLite)", CommandOptionType.SingleValue);
+            app.Option("--mysql", $"Connection string to a MySQL database (default: SQLite)", CommandOptionType.SingleValue);
             app.Option("--externalurl", $"The expected external URL of this service, to use if BTCPay is behind a reverse proxy (default: empty, use the incoming HTTP request to figure out)", CommandOptionType.SingleValue);
             app.Option("--bundlejscss", $"Bundle JavaScript and CSS files for better performance (default: true)", CommandOptionType.SingleValue);
             app.Option("--rootpath", "The root path in the URL to access BTCPay (default: /)", CommandOptionType.SingleValue);
@@ -108,6 +109,7 @@ namespace BTCPayServer.Configuration
             builder.AppendLine();
             builder.AppendLine("### Database ###");
             builder.AppendLine("#postgres=User ID=root;Password=myPassword;Host=localhost;Port=5432;Database=myDataBase;");
+            builder.AppendLine("#mysql=User ID=root;Password=myPassword;Host=localhost;Port=3306;Database=myDataBase;");
             builder.AppendLine();
             builder.AppendLine("### NBXplorer settings ###");
             foreach (var n in new BTCPayNetworkProvider(networkType).GetAll())

--- a/BTCPayServer/Data/ApplicationDbContextFactory.cs
+++ b/BTCPayServer/Data/ApplicationDbContextFactory.cs
@@ -17,7 +17,8 @@ namespace BTCPayServer.Data
     public enum DatabaseType
     {
         Sqlite,
-        Postgres
+        Postgres,
+        MySQL,
     }
     public class ApplicationDbContextFactory
     {
@@ -95,6 +96,8 @@ namespace BTCPayServer.Data
                 builder
                     .UseNpgsql(_ConnectionString)
                     .ReplaceService<IMigrationsSqlGenerator, CustomNpgsqlMigrationsSqlGenerator>();
+            else if (_Type == DatabaseType.MySQL)
+                builder.UseMySql(_ConnectionString);
         }
 
         public void ConfigureHangfireBuilder(IGlobalConfiguration builder)

--- a/BTCPayServer/Hosting/BTCPayServerServices.cs
+++ b/BTCPayServer/Hosting/BTCPayServerServices.cs
@@ -75,12 +75,12 @@ namespace BTCPayServer.Hosting
             {
                 var opts = o.GetRequiredService<BTCPayServerOptions>();
                 ApplicationDbContextFactory dbContext = null;
-                if (String.IsNullOrEmpty(opts.PostgresConnectionString) == false)
+                if (!String.IsNullOrEmpty(opts.PostgresConnectionString))
                 {
                     Logs.Configuration.LogInformation($"Postgres DB used ({opts.PostgresConnectionString})");
                     dbContext = new ApplicationDbContextFactory(DatabaseType.Postgres, opts.PostgresConnectionString);
                 }
-                else if(String.IsNullOrEmpty(opts.MySQLConnectionString) == false)
+                else if(!String.IsNullOrEmpty(opts.MySQLConnectionString))
                 {
                     Logs.Configuration.LogInformation($"MySQL DB used ({opts.MySQLConnectionString})");
                     dbContext = new ApplicationDbContextFactory(DatabaseType.MySQL, opts.MySQLConnectionString);

--- a/BTCPayServer/Hosting/BTCPayServerServices.cs
+++ b/BTCPayServer/Hosting/BTCPayServerServices.cs
@@ -75,17 +75,23 @@ namespace BTCPayServer.Hosting
             {
                 var opts = o.GetRequiredService<BTCPayServerOptions>();
                 ApplicationDbContextFactory dbContext = null;
-                if (opts.PostgresConnectionString == null)
+                if (String.IsNullOrEmpty(opts.PostgresConnectionString) == false)
+                {
+                    Logs.Configuration.LogInformation($"Postgres DB used ({opts.PostgresConnectionString})");
+                    dbContext = new ApplicationDbContextFactory(DatabaseType.Postgres, opts.PostgresConnectionString);
+                }
+                else if(String.IsNullOrEmpty(opts.MySQLConnectionString) == false)
+                {
+                    Logs.Configuration.LogInformation($"MySQL DB used ({opts.MySQLConnectionString})");
+                    dbContext = new ApplicationDbContextFactory(DatabaseType.MySQL, opts.MySQLConnectionString);
+                }
+                else
                 {
                     var connStr = "Data Source=" + Path.Combine(opts.DataDir, "sqllite.db");
                     Logs.Configuration.LogInformation($"SQLite DB used ({connStr})");
                     dbContext = new ApplicationDbContextFactory(DatabaseType.Sqlite, connStr);
                 }
-                else
-                {
-                    Logs.Configuration.LogInformation($"Postgres DB used ({opts.PostgresConnectionString})");
-                    dbContext = new ApplicationDbContextFactory(DatabaseType.Postgres, opts.PostgresConnectionString);
-                }
+                 
                 return dbContext;
             });
 


### PR DESCRIPTION
PR for #344 to add MySQL support using the open source [Pomelo.EntityFrameworkCore.MySql](https://github.com/PomeloFoundation/Pomelo.EntityFrameworkCore.MySql) driver.

The existing Postgresql configuration options have been duplicated.

Example command line option: 
`--mysql "User ID=root;Password=password;Host=localhost;Port=3306;Database=btcpay;"`

Example environment variable: 
`BTCPAY_MYSQL : User ID=root;Password=password;Host=127.0.0.1;Port=3306;Database=btcpayserver;`

![mysql_btcpay](https://user-images.githubusercontent.com/197660/47255234-e13a0580-d46d-11e8-948f-af96c6b709e4.png)
