### PR TITLE
Added configuration options for BtcPayServer https binding

### DIFF
--- a/BTCPayServer/Configuration/BTCPayServerOptions.cs
+++ b/BTCPayServer/Configuration/BTCPayServerOptions.cs
@@ -262,5 +262,15 @@ namespace BTCPayServer.Configuration
             builder.Path = RootPath;
             return builder.ToString();
         }
+        public string HttpsCertificateFilePath  // Certificate and key file (typically .pfx) to use when binding to HTTPS listener.
+        {
+            get;
+            set;
+        }
+        public string HttpsCertificateFilePassword // Password for certificate when binding to HTTPS listener.
+        {
+            get;
+            set;
+        }
     }
 }

--- a/BTCPayServer/Configuration/ConfigurationExtensions.cs
+++ b/BTCPayServer/Configuration/ConfigurationExtensions.cs
@@ -37,6 +37,8 @@ namespace BTCPayServer.Configuration
                 }
             else if (typeof(T) == typeof(string))
                 return (T)(object)str;
+            else if (typeof(T) == typeof(IPAddress))
+                return (T)(object)IPAddress.Parse(str);
             else if (typeof(T) == typeof(IPEndPoint))
             {
                 var separator = str.LastIndexOf(":", StringComparison.InvariantCulture);

--- a/BTCPayServer/Configuration/DefaultConfiguration.cs
+++ b/BTCPayServer/Configuration/DefaultConfiguration.cs
@@ -106,6 +106,8 @@ namespace BTCPayServer.Configuration
             builder.AppendLine("### Server settings ###");
             builder.AppendLine("#port=" + defaultSettings.DefaultPort);
             builder.AppendLine("#bind=127.0.0.1");
+            builder.AppendLine("#httpscertificatefilepath=devtest.pfx");
+            builder.AppendLine("#httpscertificatefilepassword=toto");
             builder.AppendLine();
             builder.AppendLine("### Database ###");
             builder.AppendLine("#postgres=User ID=root;Password=myPassword;Host=localhost;Port=5432;Database=myDataBase;");

--- a/BTCPayServer/Properties/launchSettings.json
+++ b/BTCPayServer/Properties/launchSettings.json
@@ -15,8 +15,7 @@
             "ASPNETCORE_ENVIRONMENT": "Development",
             "BTCPAY_CHAINS": "btc,ltc",
             "BTCPAY_POSTGRES": "User ID=postgres;Host=127.0.0.1;Port=39372;Database=btcpayserver"
-        },
-      "applicationUrl": "http://127.0.0.1:14142/"
+        }
     }
   }
 }


### PR DESCRIPTION
While the nginx/letsencrypt deployment approach should suit most people there are still going to be some that would like to have BtcPayServer listen directly on an HTTPS endpoint with an existing certificate file.

This PR adds two new options to the configuration file:

```
httpscertificatefilepath=btcpaydev.pfx
httpscertificatefilepassword=
```

If the `httpscertificatefilepath` is set and the file exists then BtcPayServer will attempt to bind to a HTTPS endpoint.

As an example to bind to a HTTPS endpoint that listens on all interfaces the configuration file options could be set as:

```
port=433
bind=0.0.0.0
httpscertificatefilepath=btcpaydev.pfx
httpscertificatefilepassword=
```

For ipv6 loopback:

`bind=::1`

Having this option is also very helpful for developers integrating with BtcPayServer as it makes it simpler to run and debug through Visual Studio or the command line without requiring IIS.