### PR TITLE
Fix issue with changelly rates for destination coins with inverted value rates

### DIFF
--- a/BTCPayServer/Controllers/ChangellyController.cs
+++ b/BTCPayServer/Controllers/ChangellyController.cs
@@ -61,8 +61,8 @@ namespace BTCPayServer.Controllers
                 }
                 
                 var callCounter = 0;
-                var response1 = await client.GetExchangeAmount(fromCurrency, toCurrency, 1);
-                var currentAmount = response1;
+                var baseRate = await client.GetExchangeAmount(fromCurrency, toCurrency, 1);
+                var currentAmount = ChangellyCalculationHelper.ComputeBaseAmount(baseRate, toCurrencyAmount);
                 while (true)
                 {
                     if (callCounter > 10)
@@ -70,13 +70,13 @@ namespace BTCPayServer.Controllers
                         BadRequest();
                     }
 
-                    var response2 = await client.GetExchangeAmount(fromCurrency, toCurrency, currentAmount);
+                    var computedAmount = await client.GetExchangeAmount(fromCurrency, toCurrency, currentAmount);
                     callCounter++;
-                    if (response2 < toCurrencyAmount)
+                    if (computedAmount < toCurrencyAmount)
                     {
-                        var newCurrentAmount = ((toCurrencyAmount / response2) * 1m) * currentAmount;
-
-                        currentAmount = newCurrentAmount;
+                        currentAmount =
+                            ChangellyCalculationHelper.ComputeCorrectAmount(currentAmount, computedAmount,
+                                toCurrencyAmount);
                     }
                     else
                     {
@@ -114,4 +114,6 @@ namespace BTCPayServer.Controllers
 
         public bool IsTest { get; set; } = false;
     }
+    
+    
 }

--- a/BTCPayServer/Payments/Changelly/ChangellyCalculationHelper.cs
+++ b/BTCPayServer/Payments/Changelly/ChangellyCalculationHelper.cs
@@ -1,0 +1,16 @@
+namespace BTCPayServer.Payments.Changelly
+{
+    public static class ChangellyCalculationHelper
+    {
+        public static decimal ComputeBaseAmount(decimal baseRate, decimal toAmount)
+        {
+            return (1m / baseRate) * toAmount;
+        }
+
+        public static decimal ComputeCorrectAmount(decimal currentFromAmount, decimal currentAmount,
+            decimal expectedAmount)
+        {
+            return (currentFromAmount / currentAmount) * expectedAmount;
+        }
+    }
+}


### PR DESCRIPTION
There was an issue detected by GRSPay where the rate was invalid when paying from high-value coins to low value coins (BTC to GRS in this instance).  This PR fixes it and also adds in UTs to cover those calculations