### PR TITLE
Adjusted mechanism for setting https binding configuration option

### DIFF
--- a/BTCPayServer/Configuration/BTCPayServerOptions.cs
+++ b/BTCPayServer/Configuration/BTCPayServerOptions.cs
@@ -262,15 +262,5 @@ namespace BTCPayServer.Configuration
             builder.Path = RootPath;
             return builder.ToString();
         }
-        public string HttpsCertificateFilePath  // Certificate and key file (typically .pfx) to use when binding to HTTPS listener.
-        {
-            get;
-            set;
-        }
-        public string HttpsCertificateFilePassword // Password for certificate when binding to HTTPS listener.
-        {
-            get;
-            set;
-        }
     }
 }

--- a/BTCPayServer/Configuration/BTCPayServerOptions.cs
+++ b/BTCPayServer/Configuration/BTCPayServerOptions.cs
@@ -262,5 +262,15 @@ namespace BTCPayServer.Configuration
             builder.Path = RootPath;
             return builder.ToString();
         }
+        public string HttpsCertificateFilePath  // Certificate and key file (typically .pfx) to use when binding to HTTPS listener.
+        {
+            get;
+            set;
+        }
+        public string HttpsCertificateFilePassword // Password for certificate when binding to HTTPS listener.
+        {
+            get;
+            set;
+        }
     }
 }

--- a/BTCPayServer/Configuration/ConfigurationExtensions.cs
+++ b/BTCPayServer/Configuration/ConfigurationExtensions.cs
@@ -37,6 +37,8 @@ namespace BTCPayServer.Configuration
                 }
             else if (typeof(T) == typeof(string))
                 return (T)(object)str;
+            else if (typeof(T) == typeof(IPAddress))
+                return (T)(object)IPAddress.Parse(str);
             else if (typeof(T) == typeof(IPEndPoint))
             {
                 var separator = str.LastIndexOf(":", StringComparison.InvariantCulture);

--- a/BTCPayServer/Configuration/DefaultConfiguration.cs
+++ b/BTCPayServer/Configuration/DefaultConfiguration.cs
@@ -106,6 +106,8 @@ namespace BTCPayServer.Configuration
             builder.AppendLine("### Server settings ###");
             builder.AppendLine("#port=" + defaultSettings.DefaultPort);
             builder.AppendLine("#bind=127.0.0.1");
+            builder.AppendLine("#httpscertificatefilepath=devtest.pfx");
+            builder.AppendLine("#httpscertificatefilepassword=toto");
             builder.AppendLine();
             builder.AppendLine("### Database ###");
             builder.AppendLine("#postgres=User ID=root;Password=myPassword;Host=localhost;Port=5432;Database=myDataBase;");

--- a/BTCPayServer/Hosting/Startup.cs
+++ b/BTCPayServer/Hosting/Startup.cs
@@ -120,11 +120,7 @@ namespace BTCPayServer.Hosting
             });
 
             // If the HTTPS certificate path is not set this logic will NOT be used and the default Kestrel binding logic will be.
-            var networkType = DefaultConfiguration.GetNetworkType(Configuration);
-            var defaultSettings = BTCPayDefaultSettings.GetDefaultSettings(networkType);
-            var btcPaySettings = Configuration.Get<BTCPayServerOptions>();
-
-            string httpsCertificateFilePath = btcPaySettings.HttpsCertificateFilePath;
+            string httpsCertificateFilePath = Configuration.GetOrDefault<string>("HttpsCertificateFilePath", null);
 
             if (!String.IsNullOrEmpty(httpsCertificateFilePath))
             {
@@ -142,7 +138,7 @@ namespace BTCPayServer.Hosting
                     Logs.Configuration.LogInformation($"Https certificate file path {httpsCertificateFilePath}.");
                     kestrel.Listen(bindAddress, bindPort, l =>
                     {
-                        l.UseHttps(httpsCertificateFilePath, btcPaySettings.HttpsCertificateFilePassword);
+                        l.UseHttps(httpsCertificateFilePath, Configuration.GetOrDefault<string>("HttpsCertificateFilePassword", null));
                     });
                 });
             }


### PR DESCRIPTION
I've done some further investigation on the Ketstrel and BtcPayServer socket binding behaviour and documented it below (main [Kestrel reference](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/servers/kestrel?view=aspnetcore-2.1#endpoint-configuration) page). 

Current Behaviour:
1. If `--bind` and/or `--port` are set on the command line they take precedence and Kestrel will attempt to bind on the corresponding end point (no way to set the HTTPS certificate options),

2. If `bind` and/or `port` are set in the <network>.settings file then they will be set as the `urls` environment variable and cause Kestrel to attempt to bind to that IP end point. If the command line option is also set the `port` on the command line gets used. If `bind` on the command line is also set then both are used resulting in multiple end points,

3. If neither of the previous 2 options are set then if present the `ASPNETCORE_URLS` environment variable will be used. This can set multiple end points (no way to set HTTPS certification options),

4. If none of the previous 3 options are set then if present the `applicationUrl` option from the `launchSettigns.json` file will be used. This can set multiple end points (no way to set HTTPS certification options),

5. If none of the above are set the default Kestrel endpoints of `https://localhost:5001` and `http://localhost:5000` will be attempted.

Options that don't work with BtcPayServer:

- The `--urls` command line argument,
- The `Kestrel` options from an appsettings.json (or custom config file), note this option does allow the setting of a HTTPS certificate file).

Given the above findings I've changed the mechanism in the original #360 PR so that the `services.Configure<KestrelServerOptions>` method is only called for the first two cases. That allows the default behaviour for cases 3 to 5 when the bind,port and https certificate options are not set on the command line or `<network>.settings` file.

An alternative could be to add `httpscertificatefilepath` and `httpscertificatefilepassword` as command line arguments but that seems clunky and less secure.