### PR TITLE
Checkout Experience Language Setting

### DIFF
--- a/BTCPayServer/Models/StoreViewModels/CheckoutExperienceViewModel.cs
+++ b/BTCPayServer/Models/StoreViewModels/CheckoutExperienceViewModel.cs
@@ -58,7 +58,7 @@ namespace BTCPayServer.Models.StoreViewModels
 
         public void SetLanguages(LanguageService langService, string defaultLang)
         {
-            defaultLang = defaultLang ?? "en";
+            defaultLang = langService.GetLanguages().Any(language => language.Code == default)? defaultLang : "en";
             var choices = langService.GetLanguages().Select(o => new Format() { Name = o.DisplayName, Value = o.Code }).ToArray();
             var chosen = choices.FirstOrDefault(f => f.Value == defaultLang) ?? choices.FirstOrDefault();
             Languages = new SelectList(choices, nameof(chosen.Value), nameof(chosen.Name), chosen);

--- a/BTCPayServer/Models/StoreViewModels/CheckoutExperienceViewModel.cs
+++ b/BTCPayServer/Models/StoreViewModels/CheckoutExperienceViewModel.cs
@@ -58,7 +58,7 @@ namespace BTCPayServer.Models.StoreViewModels
 
         public void SetLanguages(LanguageService langService, string defaultLang)
         {
-            defaultLang = langService.GetLanguages().Any(language => language.Code == default)? defaultLang : "en";
+            defaultLang = langService.GetLanguages().Any(language => language.Code == defaultLang)? defaultLang : "en";
             var choices = langService.GetLanguages().Select(o => new Format() { Name = o.DisplayName, Value = o.Code }).ToArray();
             var chosen = choices.FirstOrDefault(f => f.Value == defaultLang) ?? choices.FirstOrDefault();
             Languages = new SelectList(choices, nameof(chosen.Value), nameof(chosen.Name), chosen);


### PR DESCRIPTION
Fixes:
If you had en-US selected as the default store, the dropdown would select the first item in the list instead since we changed the locale to be en instead now.