### PR TITLE
Fix format on expired invoice DON'T MERGE

### DIFF
--- a/BTCPayServer/wwwroot/locales/en.json
+++ b/BTCPayServer/wwwroot/locales/en.json
@@ -31,7 +31,7 @@
   "Invoice expiring soon...": "Invoice expiring soon...",
   "Invoice expired": "Invoice expired",
   "What happened?": "What happened?",
-  "InvoiceExpired_Body_1": "This invoice has expired. An invoice is only valid for {{maxTimeMinutes}} minutes.  \\nYou can return to {{storeName}} if you would like to submit your payment again.",
+  "InvoiceExpired_Body_1": "This invoice has expired. An invoice is only valid for {{maxTimeMinutes}} minutes.  \nYou can return to {{storeName}} if you would like to submit your payment again.",
   "InvoiceExpired_Body_2": "If you tried to send a payment, it has not yet been accepted by the network. We have not yet received your funds.",
   "InvoiceExpired_Body_3": "If the transaction is not accepted by the network, the funds will be spendable again in your wallet. Depending on your wallet, this may take 48-72 hours.",
   "Invoice ID": "Invoice ID",

--- a/BTCPayServer/wwwroot/locales/fr-FR.json
+++ b/BTCPayServer/wwwroot/locales/fr-FR.json
@@ -31,7 +31,7 @@
   "Invoice expiring soon...": "La facture va bientôt expirer...",
   "Invoice expired": "Facture expirée",
   "What happened?": "Que s'est-il passé ?",
-  "InvoiceExpired_Body_1": "La facture a expiré. Une facture est valide seulement {{maxTimeMinutes}} minutes.  \\nSi vous voulez soumettre à nouveau votre paiement, vous pouvez revenir sur {{storeName}} .",
+  "InvoiceExpired_Body_1": "La facture a expiré. Une facture est valide seulement {{maxTimeMinutes}} minutes.  \nSi vous voulez soumettre à nouveau votre paiement, vous pouvez revenir sur {{storeName}} .",
   "InvoiceExpired_Body_2": "Si vous avez envoyé un paiement, ce dernier n'a pas encore été inscrit dans la blockchain. Nous n'avons pas reçu vos fonds.",
   "InvoiceExpired_Body_3": "Si votre transaction n'est pas inscrite dans la blockchain, vos fonds reviendront dans votre portefeuille. Selon votre portefeuille, cela peut prendre entre 48 et 72 heures.",
   "Invoice ID": "Numéro de facture",


### PR DESCRIPTION
\n was showing up in expired invoice. This change hides it but I couldn't get a newline to work so maybe it could just be removed.