### PR TITLE
Add noindex,nofollow to invoices, checkouts and fix create invoice ui bug

### DIFF
--- a/BTCPayServer/Views/Invoice/Checkout.cshtml
+++ b/BTCPayServer/Views/Invoice/Checkout.cshtml
@@ -13,6 +13,7 @@
 
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
+    <META NAME="robots" CONTENT="noindex,nofollow">
     <title>@Model.HtmlTitle</title>
 
     <bundle name="wwwroot/bundles/checkout-bundle.min.css" />

--- a/BTCPayServer/Views/Invoice/CreateInvoice.cshtml
+++ b/BTCPayServer/Views/Invoice/CreateInvoice.cshtml
@@ -2,6 +2,14 @@
 @{
     ViewData["Title"] = "Create an invoice";
 }
+<script>
+    $(function() {
+        $("#create-invoice-form").on("submit",
+            function() {
+                $(this).find("input[type='submit']").prop('disabled', true);
+            });
+    })
+</script>
 <section>
     <div class="container">
         <div class="row">
@@ -12,7 +20,7 @@
         </div>
         <div class="row">
             <div class="col-lg-12">
-                <form asp-action="CreateInvoice" method="post">
+                <form asp-action="CreateInvoice" method="post" id="create-invoice-form">
                     <div asp-validation-summary="ModelOnly" class="text-danger"></div>
                     <div class="form-group">
                         <label asp-for="Amount" class="control-label"></label>*

--- a/BTCPayServer/Views/Invoice/Invoice.cshtml
+++ b/BTCPayServer/Views/Invoice/Invoice.cshtml
@@ -2,6 +2,9 @@
 @{
     ViewData["Title"] = "Invoice " + Model.Id;
 }
+@section HeaderContent{
+    <META NAME="robots" CONTENT="noindex,nofollow">
+}
 
 <style type="text/css">
     .linethrough {

--- a/BTCPayServer/Views/Shared/_Layout.cshtml
+++ b/BTCPayServer/Views/Shared/_Layout.cshtml
@@ -28,6 +28,7 @@
     <bundle name="wwwroot/bundles/main-bundle.min.js" />
 
     @RenderSection("HeadScripts", required: false)
+    @RenderSection("HeaderContent", false)
 </head>
 
 <body id="page-top">


### PR DESCRIPTION
* Added a `noindex,nofollow` meta tag to Checkout and Invoice pages so that they do not get indexed by search engines at least.
* Disabled button on Create Invoice Page on form submission as double clicking before the page reloads results in duplicate invoices.