### PR TITLE
Add Pairing Code to URL

### DIFF
--- a/BTCPayServer/Controllers/StoresController.cs
+++ b/BTCPayServer/Controllers/StoresController.cs
@@ -789,7 +789,8 @@ namespace BTCPayServer.Controllers
                     StatusMessage = "Server initiated pairing code: " + pairingCode;
                 return RedirectToAction(nameof(ListTokens), new
                 {
-                    storeId = store.Id
+                    storeId = store.Id,
+                    pairingCode = pairingCode
                 });
             }
             else


### PR DESCRIPTION
With this PR, we'll be able to automatically grab the pairing code through woo commerce when pairing( in a future release)  by loading the pairing request in an iframe in a popup for a more fluid UX