### PR TITLE
Fix pos currency format

### DIFF
--- a/BTCPayServer.Tests/UnitTest1.cs
+++ b/BTCPayServer.Tests/UnitTest1.cs
@@ -80,7 +80,7 @@ namespace BTCPayServer.Tests
             Assert.False(attribute.IsValid("http://"));
             Assert.False(attribute.IsValid("httpdsadsa.com"));
         }
-        
+
         [Fact]
         [Trait("Fast", "Fast")]
         public void CanCalculateCryptoDue2()
@@ -596,7 +596,7 @@ namespace BTCPayServer.Tests
             var fetcher = new RateFetcher(factory);
 
             Assert.True(RateRules.TryParse("X_X=kraken(X_BTC) * kraken(BTC_X)", out var rule));
-            foreach(var pair in new[] { "DOGE_USD", "DOGE_CAD", "DASH_CAD", "DASH_USD", "DASH_EUR" })
+            foreach (var pair in new[] { "DOGE_USD", "DOGE_CAD", "DASH_CAD", "DASH_USD", "DASH_EUR" })
             {
                 var result = fetcher.FetchRate(CurrencyPair.Parse(pair), rule).GetAwaiter().GetResult();
                 Assert.NotNull(result.BidAsk);
@@ -1508,7 +1508,7 @@ donation:
                 Assert.Equal("donation", donationInvoice.ItemDesc);
             }
         }
-        
+
         [Fact]
         [Trait("Fast", "Fast")]
         public void PosDataParser_ParsesCorrectly()
@@ -1527,13 +1527,13 @@ donation:
                         new Dictionary<string, string>(){ {"key", "value"}, {"key2", "value,value2"}})},
                     {("{ invalidjson file here}", new Dictionary<string, string>(){ {String.Empty, "{ invalidjson file here}"}})}
                 };
-            
+
             testCases.ForEach(tuple =>
             {
                 Assert.Equal(tuple.expectedOutput, InvoiceController.PosDataParser.ParsePosData(tuple.input));
             });
         }
-        
+
         [Fact]
         [Trait("Integration", "Integration")]
         public async Task PosDataParser_ParsesCorrectly_Slower()
@@ -1544,7 +1544,7 @@ donation:
                 var user = tester.NewAccount();
                 user.GrantAccess();
                 user.RegisterDerivationScheme("BTC");
-                
+
                 var controller = tester.PayTester.GetController<InvoiceController>(null);
 
                 var testCases =
@@ -1582,7 +1582,120 @@ donation:
             }
         }
 
-       
+        [Fact]
+        [Trait("Integration", "Integration")]
+        public void CanExportInvoicesJson()
+        {
+            using (var tester = ServerTester.Create())
+            {
+                tester.Start();
+                var user = tester.NewAccount();
+                user.GrantAccess();
+                user.RegisterDerivationScheme("BTC");
+
+                var invoice = user.BitPay.CreateInvoice(new Invoice()
+                {
+                    Price = 500,
+                    Currency = "USD",
+                    PosData = "posData",
+                    OrderId = "orderId",
+                    ItemDesc = "Some description",
+                    FullNotifications = true
+                }, Facade.Merchant);
+
+                // ensure 0 invoices exported because there are no payments yet
+                var jsonResult = user.GetController<InvoiceController>().Export("json").GetAwaiter().GetResult();
+                var result = Assert.IsType<ContentResult>(jsonResult);
+                Assert.Equal("application/json", result.ContentType);
+                Assert.Equal("[]", result.Content);
+
+                var cashCow = tester.ExplorerNode;
+                var invoiceAddress = BitcoinAddress.Create(invoice.CryptoInfo[0].Address, cashCow.Network);
+                var firstPayment = invoice.CryptoInfo[0].TotalDue - Money.Satoshis(10);
+                cashCow.SendToAddress(invoiceAddress, firstPayment);
+
+                Eventually(() =>
+                {
+                    var jsonResultPaid = user.GetController<InvoiceController>().Export("json").GetAwaiter().GetResult();
+                    var paidresult = Assert.IsType<ContentResult>(jsonResultPaid);
+                    Assert.Equal("application/json", paidresult.ContentType);
+                    Assert.Contains("\"ItemDesc\": \"Some description\"", paidresult.Content);
+                    Assert.Contains("\"FiatPrice\": 500.0", paidresult.Content);
+                    Assert.Contains("\"ConversionRate\": 5000.0", paidresult.Content);
+                    Assert.Contains("\"PaymentDue\": \"0.10020000 BTC\"", paidresult.Content);
+                    Assert.Contains($"\"InvoiceId\": \"{invoice.Id}\",", paidresult.Content);
+                });
+
+                /*
+                [
+                  {
+                    "PaymentId": "f6298c80250ba91cdcf6747ae592871c96cbb50128df3e93cc26f5fdb4e4445c - 0",
+                    "CryptoCode": "BTC",
+                    "ConversionRate": 5000.0,
+                    "PaymentType": "BTCLike",
+                    "Destination": "mj8CG5EF7tA2RwvJ1bfXzdGoCEVvyWUFm7",
+                    "PaymentDue": "0.10020000 BTC",
+                    "PaymentPaid": "0.10009990 BTC",
+                    "PaymentOverpaid": "0.00000000 BTC",
+                    "InvoiceId": "D5AmAAsDBrSoPFMso96RyP",
+                    "CreatedDate": "2018-11-30T08:23:32Z",
+                    "ExpirationDate": "2018-11-30T08:38:32Z",
+                    "MonitoringDate": "2018-11-30T09:38:32Z",
+                    "Status": "new",
+                    "ItemCode": null,
+                    "ItemDesc": "Some description",
+                    "FiatPrice": 500.0,
+                    "FiatCurrency": "USD"
+                  }
+                ]
+                */
+            }
+        }
+
+        [Fact]
+        [Trait("Integration", "Integration")]
+        public void CanExportInvoicesCsv()
+        {
+            using (var tester = ServerTester.Create())
+            {
+                tester.Start();
+                var user = tester.NewAccount();
+                user.GrantAccess();
+                user.RegisterDerivationScheme("BTC");
+
+                var invoice = user.BitPay.CreateInvoice(new Invoice()
+                {
+                    Price = 500,
+                    Currency = "USD",
+                    PosData = "posData",
+                    OrderId = "orderId",
+                    ItemDesc = "Some \", description",
+                    FullNotifications = true
+                }, Facade.Merchant);
+
+                var cashCow = tester.ExplorerNode;
+                var invoiceAddress = BitcoinAddress.Create(invoice.CryptoInfo[0].Address, cashCow.Network);
+                var firstPayment = invoice.CryptoInfo[0].TotalDue - Money.Satoshis(10);
+                cashCow.SendToAddress(invoiceAddress, firstPayment);
+
+                Eventually(() =>
+                {
+                    var exportResultPaid = user.GetController<InvoiceController>().Export("csv").GetAwaiter().GetResult();
+                    var paidresult = Assert.IsType<ContentResult>(exportResultPaid);
+                    Assert.Equal("application/csv", paidresult.ContentType);
+                    Assert.Contains("\"BTC\",\"5000.0\",\"BTCLike\",", paidresult.Content);
+                    Assert.Contains($",\"0.10020000 BTC\",\"0.10009990 BTC\",\"0.00000000 BTC\",\"{invoice.Id}\",", paidresult.Content);
+                    Assert.Contains(",\"new\",\"\",\"Some ``, description\",\"500.0\",\"USD\"", paidresult.Content);
+                });
+
+                /* 
+PaymentId,CryptoCode,ConversionRate,PaymentType,Destination,PaymentDue,PaymentPaid,PaymentOverpaid,InvoiceId,CreatedDate,ExpirationDate,MonitoringDate,Status,ItemCode,ItemDesc,FiatPrice,FiatCurrency
+                60f2fa93169734978e42142ff83518e9d1c2493ac19ca3cbadaf5ce6d673df5b-0,BTC,5000.0,BTCLike,mgQELrS6iQCUSBTkoAuB7zs92eLndnRQWc,0.10020000 BTC,0.10009990 BTC,0.00000000 BTC,9adSxs7dBzn9bGxHUy5vTk,11/30/2018 8:31:15 AM,11/30/2018 8:46:15 AM,11/30/2018 9:46:15 AM,new,,Some description,500.0,USD
+                */
+            }
+        }
+
+
 
         [Fact]
         [Trait("Integration", "Integration")]
@@ -1895,12 +2008,12 @@ donation:
                 var user = tester.NewAccount();
                 user.GrantAccess();
                 user.RegisterDerivationScheme("BTC");
-                
+
                 var serverController = user.GetController<ServerController>();
                 var vm = Assert.IsType<LogsViewModel>(Assert.IsType<ViewResult>(await serverController.LogsView()).Model);
             }
-        } 
-       
+        }
+
         [Fact]
         [Trait("Fast", "Fast")]
         public void CheckRatesProvider()

--- a/BTCPayServer/Services/Invoices/Export/CsvSerializer.cs
+++ b/BTCPayServer/Services/Invoices/Export/CsvSerializer.cs
@@ -1,0 +1,146 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+
+// Ref: https://www.codeproject.com/Articles/566656/CSV-Serializer-for-NET
+namespace BTCPayServer.Services.Invoices.Export
+{
+    /// <summary>
+    /// Serialize and Deserialize Lists of any object type to CSV.
+    /// </summary>
+    public class CsvSerializer<T> where T : class, new()
+	{
+		private List<PropertyInfo> _properties;
+
+        public bool IgnoreEmptyLines { get; set; } = true;
+        public bool IgnoreReferenceTypesExceptString { get; set; } = true;
+        public string NewlineReplacement { get; set; } = ((char)0x254).ToString(CultureInfo.InvariantCulture);
+
+        public char Separator { get; set; } = ',';
+
+		public string RowNumberColumnTitle { get; set; } = "RowNumber";
+        public bool UseLineNumbers { get; set; } = false;
+        public bool UseEofLiteral { get; set; } = false;
+
+        /// <summary>
+        /// Csv Serializer
+        /// Initialize by selected properties from the type to be de/serialized
+        /// </summary>
+        public CsvSerializer()
+		{
+			var type = typeof(T);
+
+			var properties = type.GetProperties(BindingFlags.Public | BindingFlags.Instance
+				| BindingFlags.GetProperty | BindingFlags.SetProperty);
+
+
+			var q = properties.AsQueryable();
+
+			if (IgnoreReferenceTypesExceptString)
+			{
+				q = q.Where(a => a.PropertyType.IsValueType || a.PropertyType.Name == "String");
+			}
+
+			var r = from a in q
+					where a.GetCustomAttribute<CsvIgnoreAttribute>() == null
+					select a;
+
+			_properties = r.ToList();
+		}
+
+		/// <summary>
+		/// Serialize
+		/// </summary>
+		/// <param name="stream">stream</param>
+		/// <param name="data">data</param>
+		public string Serialize(IList<T> data)
+		{
+			var sb = new StringBuilder();
+			var values = new List<string>();
+
+			sb.AppendLine(GetHeader());
+
+			var row = 1;
+			foreach (var item in data)
+			{
+				values.Clear();
+
+				if (UseLineNumbers)
+				{
+					values.Add(row++.ToString(CultureInfo.InvariantCulture));
+				}
+
+				foreach (var p in _properties)
+				{
+					var raw = p.GetValue(item);
+					var value = raw == null ? "" :
+						raw.ToString()
+                        .Replace("\"", "``", StringComparison.OrdinalIgnoreCase)
+						.Replace(Environment.NewLine, NewlineReplacement, StringComparison.OrdinalIgnoreCase);
+
+					value = String.Format(CultureInfo.InvariantCulture, "\"{0}\"", value);
+
+					values.Add(value);
+				}
+				sb.AppendLine(String.Join(Separator.ToString(CultureInfo.InvariantCulture), values.ToArray()));
+			}
+
+			if (UseEofLiteral)
+			{
+				values.Clear();
+
+				if (UseLineNumbers)
+				{
+					values.Add(row++.ToString(CultureInfo.InvariantCulture));
+				}
+
+				values.Add("EOF");
+
+				sb.AppendLine(string.Join(Separator.ToString(CultureInfo.InvariantCulture), values.ToArray()));
+			}
+
+            return sb.ToString();
+		}
+
+		/// <summary>
+		/// Get Header
+		/// </summary>
+		/// <returns></returns>
+		private string GetHeader()
+		{
+			var header = _properties.Select(a => a.Name);
+
+			if (UseLineNumbers)
+			{
+				header = new string[] { RowNumberColumnTitle }.Union(header);
+			}
+
+			return string.Join(Separator.ToString(CultureInfo.InvariantCulture), header.ToArray());
+		}
+    }
+
+    public class CsvIgnoreAttribute : Attribute { }
+
+	public class InvalidCsvFormatException : Exception
+	{
+		/// <summary>
+		/// Invalid Csv Format Exception
+		/// </summary>
+		/// <param name="message">message</param>
+		public InvalidCsvFormatException(string message)
+			: base(message)
+		{
+		}
+
+		public InvalidCsvFormatException(string message, Exception ex)
+			: base(message, ex)
+		{
+		}
+	}
+}

--- a/BTCPayServer/Services/Invoices/Export/InvoiceExport.cs
+++ b/BTCPayServer/Services/Invoices/Export/InvoiceExport.cs
@@ -1,0 +1,108 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using BTCPayServer.Payments.Bitcoin;
+using BTCPayServer.Services.Invoices;
+using Newtonsoft.Json;
+
+namespace BTCPayServer.Services.Invoices.Export
+{
+    public class InvoiceExport
+    {
+        public string Process(InvoiceEntity[] invoices, string fileFormat)
+        {
+            var csvInvoices = new List<ExportInvoiceHolder>();
+            foreach (var i in invoices)
+            {
+                csvInvoices.AddRange(convertFromDb(i));
+            }
+
+            if (String.Equals(fileFormat, "json", StringComparison.OrdinalIgnoreCase))
+                return processJson(csvInvoices);
+            else if (String.Equals(fileFormat, "csv", StringComparison.OrdinalIgnoreCase))
+                return processCsv(csvInvoices);
+            else
+                throw new Exception("Export format not supported");
+        }
+
+        private string processJson(List<ExportInvoiceHolder> invoices)
+        {
+            var serializerSett = new JsonSerializerSettings { ReferenceLoopHandling = ReferenceLoopHandling.Ignore };
+            var json = JsonConvert.SerializeObject(invoices, Formatting.Indented, serializerSett);
+
+            return json;
+        }
+
+        private string processCsv(List<ExportInvoiceHolder> invoices)
+        {
+            var serializer = new CsvSerializer<ExportInvoiceHolder>();
+            var csv = serializer.Serialize(invoices);
+
+            return csv;
+        }
+
+        private IEnumerable<ExportInvoiceHolder> convertFromDb(InvoiceEntity invoice)
+        {
+            var exportList = new List<ExportInvoiceHolder>();
+            // in this first version we are only exporting invoices that were paid
+            foreach (var payment in invoice.GetPayments())
+            {
+                var cryptoCode = payment.GetPaymentMethodId().CryptoCode;
+                var pdata = payment.GetCryptoPaymentData();
+
+                var pmethod = invoice.GetPaymentMethod(payment.GetPaymentMethodId(), null);
+                var accounting = pmethod.Calculate();
+                var details = pmethod.GetPaymentMethodDetails();
+
+                var target = new ExportInvoiceHolder
+                {
+                    PaymentId = pdata.GetPaymentId(),
+                    CryptoCode = cryptoCode,
+                    ConversionRate = pmethod.Rate,
+                    PaymentType =  details.GetPaymentType().ToString(),
+                    Destination = details.GetPaymentDestination(),
+                    PaymentDue = $"{accounting.MinimumTotalDue} {cryptoCode}",
+                    PaymentPaid = $"{accounting.CryptoPaid} {cryptoCode}",
+                    PaymentOverpaid = $"{accounting.OverpaidHelper} {cryptoCode}",
+
+                    InvoiceId = invoice.Id,
+                    CreatedDate = invoice.InvoiceTime.UtcDateTime,
+                    ExpirationDate = invoice.ExpirationTime.UtcDateTime,
+                    MonitoringDate = invoice.MonitoringExpiration.UtcDateTime,
+                    Status = invoice.Status,
+                    ItemCode = invoice.ProductInformation?.ItemCode,
+                    ItemDesc = invoice.ProductInformation?.ItemDesc,
+                    FiatPrice = invoice.ProductInformation?.Price ?? 0,
+                    FiatCurrency = invoice.ProductInformation?.Currency,
+                };
+
+                exportList.Add(target);
+            }
+
+            return exportList;
+        }
+    }
+
+    public class ExportInvoiceHolder
+    {
+        public string PaymentId { get; set; }
+        public string CryptoCode { get; set; }
+        public decimal ConversionRate { get; set; }
+        public string PaymentType { get; set; }
+        public string Destination { get; set; }
+        public string PaymentDue { get; set; }
+        public string PaymentPaid { get; set; }
+        public string PaymentOverpaid { get; set; }
+
+        public string InvoiceId { get; set; }
+        public DateTime CreatedDate { get; set; }
+        public DateTime ExpirationDate { get; set; }
+        public DateTime MonitoringDate { get; set; }
+        public string Status { get; set; }
+        public string ItemCode { get; set; }
+        public string ItemDesc { get; set; }
+        public decimal FiatPrice { get; set; }
+        public string FiatCurrency { get; set; }
+    }
+}

--- a/BTCPayServer/Services/Invoices/InvoiceEntity.cs
+++ b/BTCPayServer/Services/Invoices/InvoiceEntity.cs
@@ -533,20 +533,21 @@ namespace BTCPayServer.Services.Invoices
 
     public class PaymentMethodAccounting
     {
-        /// <summary>
-        /// Total amount of this invoice
-        /// </summary>
+        /// <summary>Total amount of this invoice</summary>
         public Money TotalDue { get; set; }
 
-        /// <summary>
-        /// Amount of crypto remaining to pay this invoice
-        /// </summary>
+        /// <summary>Amount of crypto remaining to pay this invoice</summary>
         public Money Due { get; set; }
 
-        /// <summary>
-        /// Same as Due, can be negative
-        /// </summary>
+        /// <summary>Same as Due, can be negative</summary>
         public Money DueUncapped { get; set; }
+
+        /// <summary>If DueUncapped is negative, that means user overpaid invoice</summary>
+        public Money OverpaidHelper
+        {
+            get { return DueUncapped > Money.Zero ? Money.Zero : -DueUncapped; }
+        }
+
         /// <summary>
         /// Total amount of the invoice paid after conversion to this crypto currency
         /// </summary>

--- a/BTCPayServer/Views/Invoice/Checkout-Body.cshtml
+++ b/BTCPayServer/Views/Invoice/Checkout-Body.cshtml
@@ -296,8 +296,8 @@
                                     </option>
                                 </select>
                             </div>
-                            <a  v-on:click="openDialog($event)" :href="url" class="changelly-component-button">
-                                <img src="https://changelly.com/pay_button.png" alt="Changelly" v-show="url"/>
+                            <a  v-on:click="openDialog($event)" :href="url" class="btn btn-primary retry-button changelly-component-button"  v-show="url">
+                               Pay with Changelly
                             </a>
                             <button class="retry-button" v-if="calculateError" v-on:click="retry('calculateAmount')">
                                 {{$t("ConversionTab_CalculateAmount_Error")}}

--- a/BTCPayServer/Views/Invoice/ListInvoices.cshtml
+++ b/BTCPayServer/Views/Invoice/ListInvoices.cshtml
@@ -41,11 +41,19 @@
         </div>
 
         <div class="row no-gutter" style="margin-bottom: 5px;">
-            <div class="col-lg-4">
+            <div class="col-lg-6">
                 <a asp-action="CreateInvoice" class="btn btn-primary" role="button"><span class="fa fa-plus"></span> Create a new invoice</a>
+
+                <a class="btn btn-primary dropdown-toggle" href="#" role="button" id="dropdownMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                    Export
+                </a>
+                <div class="dropdown-menu" aria-labelledby="dropdownMenuLink">
+                    <a asp-action="Export" asp-route-format="csv" asp-route-searchTerm="@Model.SearchTerm" class="dropdown-item" target="_blank">CSV</a>
+                    <a asp-action="Export" asp-route-format="json" asp-route-searchTerm="@Model.SearchTerm" class="dropdown-item" target="_blank">JSON</a>
+                </div>
             </div>
 
-            <div class="col-lg-8">
+            <div class="col-lg-6">
                 <div class="form-group">
                     <form asp-action="SearchInvoice" method="post" style="float:right;">
                         <div class="input-group">

--- a/BTCPayServer/wwwroot/cart/js/cart.js
+++ b/BTCPayServer/wwwroot/cart/js/cart.js
@@ -163,17 +163,17 @@ Cart.prototype.listItems = function() {
             list.push($(tableTemplate));
         }
 
-        tableTemplate = '<tr><td colspan="4"><div class="row"><div class="col-sm-8 py-2">' + customTipText + '</div><div class="col-sm-4">' +
+        tableTemplate = '<tr><td colspan="4"><div class="row"><div class="col-sm-7 py-2">' + customTipText + '</div><div class="col-sm-5">' +
     '<div class="input-group">' + 
         '<div class="input-group-prepend">' +
-            '<span class="input-group-text">' + currencySymbol + '</span>' +
+            '<span class="input-group-text">' + (currencySymbol != 'null' ? currencySymbol : '<i class="fa fa-money"></i>') + '</span>' +
         '</div>' +
-        '<input class="js-cart-tip form-control" type="number" min="0" step="' + step + '" name="tip" placeholder="Amount">' +
+        '<input class="js-cart-tip form-control" type="number" min="0" step="' + step + '" value="' + (this.tip || '') + '" name="tip" placeholder="Amount">' +
     '</div>' +
     '</div></div></td></tr>';
         list.push($(tableTemplate));
 
-        tableTemplate = '<tr class="bg-light h4"><td colspan="2">Total</td><td colspan="2" align="right"><span id="js-cart-total">' + this.formatCurrency(this.getTotal()) + '</span></td></tr>';
+        tableTemplate = '<tr class="bg-light h4"><td colspan="1">Total</td><td colspan="3" align="right"><span id="js-cart-total">' + this.formatCurrency(this.getTotal()) + '</span></td></tr>';
         list.push($(tableTemplate));
 
         // Add the list to DOM
@@ -239,16 +239,34 @@ Cart.prototype.emptyList = function() {
     $table.html('<tr><td colspan="4">The cart is empty.</td></tr>');
 }
 
-/* Get the currency symbol from an existing amount and use it with the new amount*/
+/* Get the currency symbol from an existing amount and use it with the new amount */
 Cart.prototype.formatCurrency = function(amount, example) {
-    var regex = /([0-9.]+)/gm;
+    var regex = /[0-9 .,]/gm,
+        curSign = '',
+        amt = '',
+        sep = '';
 
-    // Get the first item's formated price
+    // Get the first item's format
     if (typeof example == 'undefined' && typeof srvModel != 'undefined') {
         example = srvModel.items[0].price.formatted;
     }
 
-    return example.replace(regex, amount.toFixed(2));
+    // Have the currency sign on a proper side (e.g. left for usd, right for eur)
+    curSign = example.replace(regex, ' ').replace(/\s\s+/g, 'n');
+    amt = curSign.replace('n', amount.toFixed(2));
+
+    if (example.indexOf('.') === -1) {
+        // Separate decimal by comma for EUR and other currencies
+        amt = amt.replace('.', ',');
+        sep = ' ';
+    } else {
+        sep = ',';
+    }
+
+    // Add thousands separator
+    amt = amt.replace(/\B(?=(\d{3})+(?!\d))/g, sep);
+
+    return amt;
 }
 
 Cart.prototype.toCents = function(num) {
@@ -279,4 +297,5 @@ Cart.prototype.destroy = function() {
     this.content = [];
     this.items = 0;
     this.totalAmount = 0;
+    this.tip = 0;
 }


### PR DESCRIPTION
Fixed a bug where the **total amount** would be displayed in a weird way when using non-USD currencies (the bug had no impact on the functionality, just the UI) because they use ` ` instead of `,` for thousands, and `,` instead of `.` for decimals.

Since I don't have any useful information from the server about the currency format other than a currency sign ($, € etc.. and sometimes the server returns no sign at all, for example for a currency like INR), and javascript can't natively work with currencies either, I have to hack it a bit. 

I tested currencies similar to USD (commas and dots), EUR (spaces and commas) as well as currency that don't have any symbol or use something like INR 100.00 (for Indian rupee). It should display the correct total amount now.