### PR TITLE
Fix currency format for total amount

### DIFF
--- a/BTCPayServer/Controllers/AppsPublicController.cs
+++ b/BTCPayServer/Controllers/AppsPublicController.cs
@@ -47,6 +47,7 @@ namespace BTCPayServer.Controllers
                 Step = step.ToString(CultureInfo.InvariantCulture),
                 EnableShoppingCart = settings.EnableShoppingCart,
                 ShowCustomAmount = settings.ShowCustomAmount,
+                CurrencyCode = currency.Code,
                 CurrencySymbol = currency.Symbol,
                 Items = _AppsHelper.Parse(settings.Template, settings.Currency),
                 ButtonText = settings.ButtonText,

--- a/BTCPayServer/Models/AppViewModels/ViewPointOfSaleViewModel.cs
+++ b/BTCPayServer/Models/AppViewModels/ViewPointOfSaleViewModel.cs
@@ -27,6 +27,7 @@ namespace BTCPayServer.Models.AppViewModels
         public string Step { get; set; }
         public string Title { get; set; }
         public Item[] Items { get; set; }
+        public string CurrencyCode { get; set; }
         public string CurrencySymbol { get; set; }
 
         public string ButtonText { get; set; }

--- a/BTCPayServer/wwwroot/cart/js/cart.js
+++ b/BTCPayServer/wwwroot/cart/js/cart.js
@@ -115,7 +115,7 @@ Cart.prototype.getTotal = function(plain) {
 }
 
 Cart.prototype.updateTotal = function() {
-    $('#js-cart-total').text(this.formatCurrency(this.getTotal()));
+    $('#js-cart-total').text(this.formatCurrency(this.getTotal(), srvModel.currencyCode, srvModel.currencySymbol));
 }
 
 Cart.prototype.updateAmount = function() {
@@ -135,7 +135,7 @@ Cart.prototype.escape = function(input) {
 Cart.prototype.listItems = function() {
     var $table = $('#js-cart-list').find('tbody'),
         self = this,
-        list = []
+        list = [],
         tableTemplate = '';
     
     if (this.content.length > 0) {
@@ -147,8 +147,9 @@ Cart.prototype.listItems = function() {
                 image = this.escape(item.image),
                 count = this.escape(item.count),
                 price = this.escape(item.price.formatted),
-                currencySymbol = this.escape(srvModel.currencySymbol),
+                total = this.escape(this.formatCurrency(this.getTotal(), srvModel.currencyCode, srvModel.currencySymbol)),
                 step = this.escape(srvModel.step),
+                tip = this.escape(this.tip || ''),
                 customTipText = this.escape(srvModel.customTipText);
 
             tableTemplate = '<tr data-id="' + id + '">' + 
@@ -166,14 +167,14 @@ Cart.prototype.listItems = function() {
         tableTemplate = '<tr><td colspan="4"><div class="row"><div class="col-sm-7 py-2">' + customTipText + '</div><div class="col-sm-5">' +
     '<div class="input-group">' + 
         '<div class="input-group-prepend">' +
-            '<span class="input-group-text">' + (currencySymbol != 'null' ? currencySymbol : '<i class="fa fa-money"></i>') + '</span>' +
+            '<span class="input-group-text"><i class="fa fa-money"></i></span>' +
         '</div>' +
-        '<input class="js-cart-tip form-control" type="number" min="0" step="' + step + '" value="' + this.escape(this.tip || '') + '" name="tip" placeholder="Amount">' +
+        '<input class="js-cart-tip form-control" type="number" min="0" step="' + step + '" value="' + tip + '" name="tip" placeholder="Amount">' +
     '</div>' +
     '</div></div></td></tr>';
         list.push($(tableTemplate));
 
-        tableTemplate = '<tr class="bg-light h4"><td colspan="1">Total</td><td colspan="3" align="right"><span id="js-cart-total">' + this.escape(this.formatCurrency(this.getTotal())) + '</span></td></tr>';
+        tableTemplate = '<tr class="bg-light h4"><td colspan="1">Total</td><td colspan="3" align="right"><span id="js-cart-total">' + total + '</span></td></tr>';
         list.push($(tableTemplate));
 
         // Add the list to DOM
@@ -239,32 +240,202 @@ Cart.prototype.emptyList = function() {
     $table.html('<tr><td colspan="4">The cart is empty.</td></tr>');
 }
 
-/* Get the currency symbol from an existing amount and use it with the new amount */
-Cart.prototype.formatCurrency = function(amount, example) {
-    var regex = /[0-9 .,]/gm,
-        curSign = '',
-        amt = '',
-        sep = '';
+Cart.prototype.formatCurrency = function(amount, currency, symbol) {
+    var amt = '',
+        thousandsSep = '',
+        decimalSep = ''
+        prefix = '',
+        postfix = '',
+        currencyName = currency.toLowerCase();
 
-    // Get the first item's format
-    if (typeof example == 'undefined' && typeof srvModel != 'undefined') {
-        example = srvModel.items[0].price.formatted;
+    // Currency symbols
+    switch (currencyName) {
+        case 'usd':
+        case 'aud':
+        case 'cad':
+        case 'clp':
+        case 'mxn':
+        case 'nzd':
+        case 'sgd':
+            prefix = '$';
+            break;
+        case 'eur':
+            postfix = ' €';
+            break;
+        case 'chf':
+            prefix = 'CHF ';
+            break;
+        case 'gbp':
+            prefix = '£';
+            break;
+        case 'jpy':
+        case 'cny':
+            prefix = '¥';
+            break;
+        case 'hkd':
+            prefix = 'HK$';
+            break;
+        case 'ars':
+        case 'cop':
+            prefix = '$ ';
+            break;
+        case 'brl':
+            prefix = 'R$ ';
+            break;
+        case 'bdt':
+            postfix = '৳';
+            break;
+        case 'czk':
+            postfix = ' Kč';
+            break;
+        case 'dkk':
+            postfix = ' kr.';
+            break;
+        case 'huf':
+            postfix = ' Ft';
+            break;
+        case 'hrk':
+            postfix = ' HRK';
+            break;
+        case 'ils':
+            postfix = ' ₪';
+            break;
+        case 'inr':
+            prefix = '₹ ';
+            break;
+        case 'isk':
+            postfix = ' ISK';
+            break;
+        case 'kzt':
+            postfix = ' ₸';
+            break;
+        case 'myr':
+            prefix = 'RM';
+            break;
+        case 'ngn':
+            prefix = '₦';
+            break;
+        case 'nok':
+            prefix = 'kr ';
+            break;
+        case 'php':
+            prefix = '₱';
+            break;
+        case 'pen':
+            prefix = 'S/';
+            break;
+        case 'pln':
+            postfix = ' zł';
+            break;
+        case 'ron':
+            postfix = ' RON';
+            break;
+        case 'rub':
+            postifx = ' ₽';
+            break;
+        case 'sek':
+            postfix = ' kr';
+            break;
+        case 'aed':
+            prefix = 'د.إ. ‏';
+            break;
+        case 'egp':
+            prefix = 'ج.م.‏';
+            break;
+        case 'irr':
+            prefix = 'ریال';
+            break;
+        case 'pkr':
+            prefix = ' ر';
+            break;
+        case 'sar':
+            prefix = 'ر.س.‏';
+            break;
+        case 'try':
+            prefix = '₺';
+            break;
+        case 'uah':
+            postfix = ' ₴';
+            break;
+        case 'vnd':
+            postfix = ' ₫';
+            break;
+        case 'zar':
+            prefix = 'R';
+            break;
+
+        default:
+            prefix = symbol || currency;
+    }
+    
+    // Currency separators
+    switch (currencyName) {
+        case 'eur':
+        case 'czk':
+        case 'huf':
+        case 'kzt':
+        case 'nok':
+        case 'pln':
+        case 'rub':
+        case 'sek':
+        case 'uah':
+        case 'zar':
+            thousandsSep = ' ';
+            decimalSep = ',';
+            break;
+
+        case 'chf':
+            thousandsSep = '’';
+            decimalSep = '.';
+            break;
+
+        case 'cop':
+        case 'clp':
+        case 'idr':
+        case 'isk':
+        case 'vnd':
+            thousandsSep = '.';
+            break;
+
+        case 'jpy':
+            thousandsSep = ',';
+            break;
+        
+        case 'ars':
+        case 'brl':
+        case 'dkk':
+        case 'hrk':
+        case 'ron':
+        case 'try':
+            thousandsSep = '.';
+            decimalSep = ',';
+            break;
+
+        case 'irr':
+        case 'pkr':
+            thousandsSep = '٬';
+            break;
+
+        case 'egp':
+        case 'sar':
+            thousandsSep = '٬';
+            decimalSep = '٫';
+            break;
+
+        default:
+            thousandsSep = ',';
+            decimalSep = '.';
     }
 
-    // Have the currency sign on a proper side (e.g. left for usd, right for eur)
-    curSign = example.replace(regex, ' ').replace(/\s\s+/g, 'n');
-    amt = curSign.replace('n', amount.toFixed(2));
-
-    if (example.indexOf('.') === -1) {
-        // Separate decimal by comma for EUR and other currencies
-        amt = amt.replace('.', ',');
-        sep = ' ';
+    if (decimalSep !== '') {
+        // Replace decimal separator
+        amt = amount.toFixed(2).replace(/.(\d{2})$/g, decimalSep + '\$1');
     } else {
-        sep = ',';
+        // No decimal separator
+        amt = amount.toString();
     }
-
-    // Add thousands separator
-    amt = amt.replace(/\B(?=(\d{3})+(?!\d))/g, sep);
+    // Add currency sign and thousands separator
+    amt = prefix + amt.replace(/\B(?=(\d{3})+(?!\d))/g, thousandsSep) + postfix;
 
     return amt;
 }

--- a/BTCPayServer/wwwroot/cart/js/cart.js
+++ b/BTCPayServer/wwwroot/cart/js/cart.js
@@ -163,17 +163,17 @@ Cart.prototype.listItems = function() {
             list.push($(tableTemplate));
         }
 
-        tableTemplate = '<tr><td colspan="4"><div class="row"><div class="col-sm-8 py-2">' + customTipText + '</div><div class="col-sm-4">' +
+        tableTemplate = '<tr><td colspan="4"><div class="row"><div class="col-sm-7 py-2">' + customTipText + '</div><div class="col-sm-5">' +
     '<div class="input-group">' + 
         '<div class="input-group-prepend">' +
-            '<span class="input-group-text">' + currencySymbol + '</span>' +
+            '<span class="input-group-text">' + (currencySymbol != 'null' ? currencySymbol : '<i class="fa fa-money"></i>') + '</span>' +
         '</div>' +
-        '<input class="js-cart-tip form-control" type="number" min="0" step="' + step + '" name="tip" placeholder="Amount">' +
+        '<input class="js-cart-tip form-control" type="number" min="0" step="' + step + '" value="' + (this.tip || '') + '" name="tip" placeholder="Amount">' +
     '</div>' +
     '</div></div></td></tr>';
         list.push($(tableTemplate));
 
-        tableTemplate = '<tr class="bg-light h4"><td colspan="2">Total</td><td colspan="2" align="right"><span id="js-cart-total">' + this.formatCurrency(this.getTotal()) + '</span></td></tr>';
+        tableTemplate = '<tr class="bg-light h4"><td colspan="1">Total</td><td colspan="3" align="right"><span id="js-cart-total">' + this.formatCurrency(this.getTotal()) + '</span></td></tr>';
         list.push($(tableTemplate));
 
         // Add the list to DOM
@@ -239,16 +239,34 @@ Cart.prototype.emptyList = function() {
     $table.html('<tr><td colspan="4">The cart is empty.</td></tr>');
 }
 
-/* Get the currency symbol from an existing amount and use it with the new amount*/
+/* Get the currency symbol from an existing amount and use it with the new amount */
 Cart.prototype.formatCurrency = function(amount, example) {
-    var regex = /([0-9.]+)/gm;
+    var regex = /[0-9 .,]/gm,
+        curSign = '',
+        amt = '',
+        sep = '';
 
-    // Get the first item's formated price
+    // Get the first item's format
     if (typeof example == 'undefined' && typeof srvModel != 'undefined') {
         example = srvModel.items[0].price.formatted;
     }
 
-    return example.replace(regex, amount.toFixed(2));
+    // Have the currency sign on a proper side (e.g. left for usd, right for eur)
+    curSign = example.replace(regex, ' ').replace(/\s\s+/g, 'n');
+    amt = curSign.replace('n', amount.toFixed(2));
+
+    if (example.indexOf('.') === -1) {
+        // Separate decimal by comma for EUR and other currencies
+        amt = amt.replace('.', ',');
+        sep = ' ';
+    } else {
+        sep = ',';
+    }
+
+    // Add thousands separator
+    amt = amt.replace(/\B(?=(\d{3})+(?!\d))/g, sep);
+
+    return amt;
 }
 
 Cart.prototype.toCents = function(num) {
@@ -279,4 +297,5 @@ Cart.prototype.destroy = function() {
     this.content = [];
     this.items = 0;
     this.totalAmount = 0;
+    this.tip = 0;
 }

--- a/BTCPayServer/wwwroot/cart/js/cart.js
+++ b/BTCPayServer/wwwroot/cart/js/cart.js
@@ -168,12 +168,12 @@ Cart.prototype.listItems = function() {
         '<div class="input-group-prepend">' +
             '<span class="input-group-text">' + (currencySymbol != 'null' ? currencySymbol : '<i class="fa fa-money"></i>') + '</span>' +
         '</div>' +
-        '<input class="js-cart-tip form-control" type="number" min="0" step="' + step + '" value="' + (this.tip || '') + '" name="tip" placeholder="Amount">' +
+        '<input class="js-cart-tip form-control" type="number" min="0" step="' + step + '" value="' + this.escape(this.tip || '') + '" name="tip" placeholder="Amount">' +
     '</div>' +
     '</div></div></td></tr>';
         list.push($(tableTemplate));
 
-        tableTemplate = '<tr class="bg-light h4"><td colspan="1">Total</td><td colspan="3" align="right"><span id="js-cart-total">' + this.formatCurrency(this.getTotal()) + '</span></td></tr>';
+        tableTemplate = '<tr class="bg-light h4"><td colspan="1">Total</td><td colspan="3" align="right"><span id="js-cart-total">' + this.escape(this.formatCurrency(this.getTotal())) + '</span></td></tr>';
         list.push($(tableTemplate));
 
         // Add the list to DOM


### PR DESCRIPTION
Fixed a bug where the total amount would be displayed in a weird way when using non-USD currencies (the bug had no impact on the functionality, just the UI) because they use `<space>`  instead of `,` for thousands, and `,` instead of `.` for decimals.

Since I don't have any useful information from the server about the currency format other than a currency sign ($, € etc.. and sometimes the srvModel returns no sign at all, for example for a currency like INR), and javascript can't natively work with currencies either, I have to hack it a bit.

It should display the correct total amount now for both type of currency formats.