### PR TITLE
Update Anyone can enable invoices text so its much more clear

### DIFF
--- a/BTCPayServer/Views/Stores/AddDerivationScheme.cshtml
+++ b/BTCPayServer/Views/Stores/AddDerivationScheme.cshtml
@@ -36,7 +36,7 @@
                         No ledger wallet detected. If you own one, use chrome, open the app, and refresh this page.
                     </p>
                     <div id="ledger-info" class="form-text text-muted" style="display: none;">
-                        <span>A ledger wallet is detected, which account do you want to use?</span>
+                        <span>A ledger wallet is detected, which account do you want to use? No need to paste manually xpub if your ledger device was detected. Just select derivation scheme from the list bellow and xpub will automatically populate.</span>
                         <ul>
                             @for (int i = 0; i < 4; i++)
                             {

--- a/BTCPayServer/Views/Stores/PayButtonEnable.cshtml
+++ b/BTCPayServer/Views/Stores/PayButtonEnable.cshtml
@@ -1,6 +1,6 @@
 ﻿@{
     Layout = "../Shared/_NavLayout.cshtml";
-    ViewData.SetActivePageAndTitle(StoreNavPages.PayButton, "Please confirm you want to allow anyone to create invoices in your store");
+    ViewData.SetActivePageAndTitle(StoreNavPages.PayButton, "Please confirm you want to allow outside world to create invoices in your store (via API).");
     ViewBag.MainTitle = "Pay Button";
 }
 
@@ -12,10 +12,10 @@
             <div class="form-group">
                 <p>
                     To start using Pay Buttons you need to explicitly turn on this feature.
-                    Once you do so, any source will be able to create an invoice on your instance store.
+                    Once you do so, any 3rd party entity will be able to create an invoice on your instance store (via API for example).
                 </p>
                 @Html.Hidden("EnableStore", true)
-                <button name="command" type="submit" value="save" class="btn btn-primary">Allow anyone to create invoices</button>
+                <button name="command" type="submit" value="save" class="btn btn-primary">Allow outside world to create invoices via API (POS app is preauthorised and does not need this enabled).</button>
             </div>
         </form>
     </div>


### PR DESCRIPTION
I think that: 

Please confirm you want to allow outside world to create invoices in your store (via API).");

is much better then

Please confirm you want to allow anyone to create invoices in your store")