### PR TITLE
do not add ln payment if amount couldn't be parsed

### DIFF
--- a/BTCPayServer/Payments/Lightning/LightningListener.cs
+++ b/BTCPayServer/Payments/Lightning/LightningListener.cs
@@ -156,7 +156,8 @@ namespace BTCPayServer.Payments.Lightning
                     if (notification.Id == listenedInvoice.PaymentMethodDetails.InvoiceId &&
                        notification.BOLT11 == listenedInvoice.PaymentMethodDetails.BOLT11)
                     {
-                        if (notification.Status == LightningInvoiceStatus.Paid && notification.PaidAt.HasValue)
+                        if (notification.Status == LightningInvoiceStatus.Paid && 
+                            notification.PaidAt.HasValue && notification.Amount != null)
                         {
                             await AddPayment(network, notification, listenedInvoice);
                             if (DoneListening(listenedInvoice))


### PR DESCRIPTION
When BTCPayServer.Lightning cannot parse the amount from an ln invoice, it sends a null value which gets saved to the btcpay db and breaks down the whole system( invoice ui crashes, checkout ui crashes, invoice watcher crashes, etc)