### PR TITLE
PoS: Fix z-index of search cancel button that overlaps modal confirmation

### DIFF
--- a/BTCPayServer/Views/AppsPublic/ViewPointOfSale.cshtml
+++ b/BTCPayServer/Views/AppsPublic/ViewPointOfSale.cshtml
@@ -212,7 +212,7 @@
                         <div class="col-sm-8 col-lg-9 mb-2">
                             <div class="input-group mb-2">
                                 <input type="text" class="js-search form-control" placeholder="Find product">
-                                <a class="js-search-reset btn btn-link text-black" href="#" style="position: absolute;right: 0px; z-index: 9999; display: none;"><i class="fa fa-times-circle fa-lg"></i></a>
+                                <a class="js-search-reset btn btn-link text-black" href="#" style="position: absolute;right: 0px; z-index: 1049; display: none;"><i class="fa fa-times-circle fa-lg"></i></a>
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
Thanks @darkban for reporting the bug 

![img_20181227_161801](https://user-images.githubusercontent.com/3636406/50501287-0eb8b600-0a92-11e9-9448-7613e23ceeba.jpg)
