### PR TITLE
Fix registration password length

### DIFF
--- a/BTCPayServer/Hosting/Startup.cs
+++ b/BTCPayServer/Hosting/Startup.cs
@@ -99,7 +99,7 @@ namespace BTCPayServer.Hosting
             services.Configure<IdentityOptions>(options =>
             {
                 options.Password.RequireDigit = false;
-                options.Password.RequiredLength = 7;
+                options.Password.RequiredLength = 6;
                 options.Password.RequireLowercase = false;
                 options.Password.RequireNonAlphanumeric = false;
                 options.Password.RequireUppercase = false;


### PR DESCRIPTION
Fix: Minimum registration password length is set to both 6 and 7 characters. 

![6char](https://user-images.githubusercontent.com/39231115/50870148-09057f00-1374-11e9-85ef-4d8c7047cd93.PNG)

![7char](https://user-images.githubusercontent.com/39231115/50870153-11f65080-1374-11e9-9c17-eec962390645.PNG)
