### PR TITLE
Small improvement to the paging buttons on the list invoices page

### DIFF
--- a/BTCPayServer/Models/InvoicingModels/InvoicesModel.cs
+++ b/BTCPayServer/Models/InvoicingModels/InvoicesModel.cs
@@ -15,6 +15,10 @@ namespace BTCPayServer.Models.InvoicingModels
         {
             get; set;
         }
+        public int Total
+        {
+            get; set;
+        }
         public string SearchTerm
         {
             get; set;

--- a/BTCPayServer/Views/Invoice/ListInvoices.cshtml
+++ b/BTCPayServer/Views/Invoice/ListInvoices.cshtml
@@ -142,23 +142,31 @@
                     }
                 </tbody>
             </table>
-            <span>
-                @if (Model.Skip != 0)
-                {
-                    <a href="@Url.Action("ListInvoices", new
+
+            <nav aria-label="...">
+                <ul class="pagination">
+                    <li class="page-item  @(Model.Skip == 0 ? "disabled" : null)">
+                        <a class="page-link" tabindex="-1" href="@Url.Action("ListInvoices", new
                         {
                             searchTerm = Model.SearchTerm,
                             skip = Math.Max(0, Model.Skip - Model.Count),
                             count = Model.Count,
-                        })"><<</a><span> - </span>
-                }
-                <a href="@Url.Action("ListInvoices", new
-                    {
-                        searchTerm = Model.SearchTerm,
-                        skip = Model.Skip + Model.Count,
-                        count = Model.Count,
-                    })">>></a>
-            </span>
+                        })">Previous</a>
+                    </li>
+                    <li class="page-item disabled">
+                        <span class="page-link">@(Model.Skip + 1) to @(Model.Skip + Model.Invoices.Count) of @Model.Total</span>
+                    </li>
+                    <li class="page-item @(Model.Total > (Model.Skip + Model.Invoices.Count) ? null : "disabled")">
+                        <a class="page-link" href="@Url.Action("ListInvoices", new
+                        {
+                            searchTerm = Model.SearchTerm,
+                            skip = Model.Skip + Model.Count,
+                            count = Model.Count,
+                        })">Next</a>
+                    </li>
+                </ul>
+            </nav>
+
         </div>
 
     </div>


### PR DESCRIPTION
Fixes the current nit with the "next" icon (represented as >>) on the list invoices page that will keep paging even when there are no more invoices to display. At the same time I adopted the bootstrap approach for paging buttons. IMHO makes the page look a bit more professional. Screenshots below.

![btcpayinvoices_next](https://user-images.githubusercontent.com/197660/51277205-3509ab80-19d7-11e9-8b7c-05574eaacec8.png)
![btcpay_invoices_previous](https://user-images.githubusercontent.com/197660/51277206-3509ab80-19d7-11e9-8890-fae21a4a627a.png)
![btcpay_invoices_all](https://user-images.githubusercontent.com/197660/51277207-3509ab80-19d7-11e9-8606-453da6e70d64.png)
