### PR TITLE
WIP: "Auto trade" feature

### DIFF
--- a/BTCPayServer.Tests/AutoTradeTests.cs
+++ b/BTCPayServer.Tests/AutoTradeTests.cs
@@ -1,0 +1,59 @@
+using BTCPayServer.Controllers;
+using BTCPayServer.Models.StoreViewModels;
+using BTCPayServer.Payments.AutoTrade;
+using BTCPayServer.Tests.Logging;
+using Microsoft.AspNetCore.Mvc;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace BTCPayServer.Tests
+{
+    public class AutoTradeTests
+    {
+        public AutoTradeTests(ITestOutputHelper helper)
+        {
+            Logs.Tester = new XUnitLog(helper) {Name = "Tests"};
+            Logs.LogProvider = new XUnitLogProvider(helper);
+        }
+
+        [Fact]
+        [Trait("Integration", "Integration")]
+        public async void CanSetAndToggleAutoTradeExchangeSettings()
+        {
+            using (var tester = ServerTester.Create())
+            {
+                tester.Start();
+                foreach (var name in AutoTradeExchangeClientProvider.GetAllSupportedExchangeNames())
+                {
+                    var user = tester.NewAccount();
+                    user.GrantAccess();
+                    var controller = tester.PayTester.GetController<StoresController>(user.UserId, user.StoreId);
+                    var updateModel = new UpdateAutoTradeSettingsViewModel()
+                    {
+                        ApiKey = "apiKey",
+                        ApiSecret = "apiSecret",
+                        ApiUrl = "http://gozo.com",
+                        Enabled = true
+                    };
+
+                    Assert.Equal("UpdateStore", Assert.IsType<RedirectToActionResult>(
+                        await controller.UpdateAutoTradeSettings(user.StoreId, updateModel, name, "save")).ActionName);
+
+                    var store = await tester.PayTester.StoreRepository.FindStore(user.StoreId);
+                    Assert.True(store.GetStoreBlob().AutoTradeExchangeSettings.Enabled);
+                    updateModel.Enabled = false;
+                    Assert.Equal("UpdateStore", Assert.IsType<RedirectToActionResult>(
+                        await controller.UpdateAutoTradeSettings(user.StoreId, updateModel, name, "save")).ActionName);
+
+                    store = await tester.PayTester.StoreRepository.FindStore(user.StoreId);
+                    Assert.False(store.GetStoreBlob().AutoTradeExchangeSettings.Enabled);
+                }
+            }
+        }
+        [Fact]
+        [Trait("Integration", "Integration")]
+        public async void CannotUseAutoExchangeFeatureWithoutMethodSet()
+        {
+        }
+    }
+}

--- a/BTCPayServer/BTCPayServer.csproj
+++ b/BTCPayServer/BTCPayServer.csproj
@@ -33,6 +33,7 @@
     <EmbeddedResource Include="Currencies.txt" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="BitBankApi" Version="1.0.0" />
     <PackageReference Include="BTCPayServer.Lightning.All" Version="1.1.0.5" />
     <PackageReference Include="BuildBundlerMinifier" Version="2.7.385" />
     <PackageReference Include="DigitalRuby.ExchangeSharp" Version="0.5.3" />

--- a/BTCPayServer/Controllers/StoreController.AutoTrade.cs
+++ b/BTCPayServer/Controllers/StoreController.AutoTrade.cs
@@ -1,0 +1,76 @@
+using BTCPayServer.Data;
+using BTCPayServer.Models.StoreViewModels;
+using static BTCPayServer.Extensions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using System.Threading.Tasks;
+using BTCPayServer.Payments.AutoTrade;
+
+namespace BTCPayServer.Controllers
+{
+    public partial class StoresController
+    {
+        [HttpGet]
+        [Route("(storeId/autotrade/exchangeName)")]
+        public IActionResult UpdateAutoTradeSettings(string storeId, string exchangeName)
+        {
+            var store = HttpContext.GetStoreData();
+            if (store == null)
+                return NotFound();
+            UpdateAutoTradeSettingsViewModel vm = new UpdateAutoTradeSettingsViewModel();
+            UpdateAutoTradeSettingsVMFromValues(store, vm, exchangeName);
+            return View(vm);
+        }
+
+        private void UpdateAutoTradeSettingsVMFromValues(StoreData store, UpdateAutoTradeSettingsViewModel vm, string exchangeName)
+        {
+            var existing = store.GetStoreBlob().AutoTradeExchangeSettings;
+            if (existing == null) return;
+
+            vm.ApiKey = existing.ApiKey;
+            vm.ApiSecret = existing.ApiSecret;
+            vm.ApiUrl = existing.ApiUrl;
+            vm.Enabled = existing.Enabled;
+            vm.AmountMarkupPercentage = existing.AmountMarkupPercentage;
+        }
+
+        [HttpPost]
+        [Route("{storeId}/autotrade/exchangeName")]
+        public async Task<IActionResult> UpdateAutoTradeSettings(string storeId, UpdateAutoTradeSettingsViewModel vm, string exchangeName, string cmd)
+        {
+            var store = HttpContext.GetStoreData(); ;
+            if (store == null)
+                return NotFound();
+
+            if (vm.Enabled)
+            {
+                if (!ModelState.IsValid)
+                {
+                    return View(vm);
+                }
+            }
+
+            var settings = _autoTradeProvider.GetSettings(exchangeName);
+            settings.ApiKey = vm.ApiKey;
+            settings.ApiSecret = vm.ApiSecret;
+            settings.ApiUrl = vm.ApiUrl;
+            settings.Enabled = vm.Enabled;
+            settings.AmountMarkupPercentage = vm.AmountMarkupPercentage;
+
+            switch (cmd)
+            {
+                case "save":
+                    var storeBlob = store.GetStoreBlob();
+                    storeBlob.AutoTradeExchangeSettings = settings;
+                    store.SetStoreBlob(storeBlob);
+                    await _Repo.UpdateStore(store);
+                    StatusMessage = "Auto trade settings modified";
+                    return View(vm);
+                case "test":
+                default:
+                    return View(vm);
+            }
+        }
+    }
+}

--- a/BTCPayServer/Controllers/StoresController.cs
+++ b/BTCPayServer/Controllers/StoresController.cs
@@ -11,6 +11,7 @@ using BTCPayServer.Models;
 using BTCPayServer.Models.AppViewModels;
 using BTCPayServer.Models.StoreViewModels;
 using BTCPayServer.Payments;
+using BTCPayServer.Payments.AutoTrade;
 using BTCPayServer.Payments.Changelly;
 using BTCPayServer.Payments.Lightning;
 using BTCPayServer.Rating;
@@ -55,7 +56,8 @@ namespace BTCPayServer.Controllers
             LanguageService langService,
             ChangellyClientProvider changellyClientProvider,
             IOptions<MvcJsonOptions> mvcJsonOptions,
-            IHostingEnvironment env, IHttpClientFactory httpClientFactory)
+            IHostingEnvironment env, IHttpClientFactory httpClientFactory,
+            AutoTradeExchangeClientProvider autoTradeProvider)
         {
             _RateFactory = rateFactory;
             _Repo = repo;
@@ -68,6 +70,7 @@ namespace BTCPayServer.Controllers
             _WalletProvider = walletProvider;
             _Env = env;
             _httpClientFactory = httpClientFactory;
+            _autoTradeProvider = autoTradeProvider;
             _NetworkProvider = networkProvider;
             _ExplorerProvider = explorerProvider;
             _FeeRateProvider = feeRateProvider;
@@ -90,6 +93,7 @@ namespace BTCPayServer.Controllers
         private readonly ChangellyClientProvider _changellyClientProvider;
         IHostingEnvironment _Env;
         private IHttpClientFactory _httpClientFactory;
+        private readonly AutoTradeExchangeClientProvider _autoTradeProvider;
 
         [TempData]
         public string StatusMessage

--- a/BTCPayServer/Data/StoreData.cs
+++ b/BTCPayServer/Data/StoreData.cs
@@ -22,6 +22,7 @@ using BTCPayServer.Payments.CoinSwitch;
 using BTCPayServer.Security;
 using BTCPayServer.Rating;
 using BTCPayServer.Services.Mails;
+using BTCPayServer.Payments.AutoTrade;
 
 namespace BTCPayServer.Data
 {
@@ -344,6 +345,7 @@ namespace BTCPayServer.Data
         public ChangellySettings ChangellySettings { get; set; }
         public CoinSwitchSettings CoinSwitchSettings { get; set; }
 
+        public AutoTradeExchangeSettingsBase AutoTradeExchangeSettings { get; set; }
 
         string _LightningDescriptionTemplate;
         public string LightningDescriptionTemplate

--- a/BTCPayServer/Hosting/BTCPayServerServices.cs
+++ b/BTCPayServer/Hosting/BTCPayServerServices.cs
@@ -47,6 +47,8 @@ using Microsoft.AspNetCore.Mvc.ModelBinding;
 using NBXplorer.DerivationStrategy;
 using NicolasDorier.RateLimits;
 using Npgsql;
+using BTCPayServer.Payments.AutoTrade.BitBank;
+using BTCPayServer.Payments.AutoTrade;
 
 namespace BTCPayServer.Hosting
 {
@@ -140,6 +142,8 @@ namespace BTCPayServer.Hosting
             services.AddSingleton<IHostedService, Payments.Lightning.LightningListener>();
             
             services.AddSingleton<ChangellyClientProvider>();
+
+            services.AddSingleton<AutoTradeExchangeClientProvider>();
 
             services.AddSingleton<IHostedService, NBXplorerWaiters>();
             services.AddSingleton<IHostedService, InvoiceNotificationManager>();

--- a/BTCPayServer/Models/StoreViewModels/UpdateAutoTradeSettingsViewModel.cs
+++ b/BTCPayServer/Models/StoreViewModels/UpdateAutoTradeSettingsViewModel.cs
@@ -1,0 +1,24 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace BTCPayServer.Models.StoreViewModels
+{
+    public class UpdateAutoTradeSettingsViewModel
+    {
+        [Required] public string ApiKey { get; set; }
+        [Required] public string ApiSecret { get; set; }
+        [Required] public string ApiUrl { get; set; }
+
+        [Display(Name = "Show Fiat Currencies as option in conversion")]
+        public bool ShowFiat { get; set; } = true;
+
+        [Required]
+        [Range(0, 100)]
+        [Display(Name =
+            "Percentage to multiply amount requested at Changelly to avoid underpaid situations due to Changelly not guaranteeing rates. ")]
+        public decimal AmountMarkupPercentage { get; set; } = new decimal(2);
+
+        public bool Enabled { get; set; }
+
+        public string StatusMessage { get; set; }
+    }
+}

--- a/BTCPayServer/Payments/AutoTrade/AutoTradeException.cs
+++ b/BTCPayServer/Payments/AutoTrade/AutoTradeException.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace BTCPayServer.Payments.AutoTrade
+{
+    public class AutoTradeException : Exception
+    {
+        public AutoTradeException(string message) : base(message)
+        {
+        }
+    }
+}

--- a/BTCPayServer/Payments/AutoTrade/AutoTradeExchangeClientProvider.cs
+++ b/BTCPayServer/Payments/AutoTrade/AutoTradeExchangeClientProvider.cs
@@ -1,0 +1,87 @@
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Net.Http;
+using BTCPayServer.Services.Stores;
+using System.Threading.Tasks;
+using BTCPayServer.Data;
+using BTCPayServer.Payments.AutoTrade.BitBank;
+using NBitcoin;
+using System;
+
+namespace BTCPayServer.Payments.AutoTrade
+{
+    public class AutoTradeExchangeClientProvider
+    {
+        public static List<string> GetAllSupportedExchangeNames() => new List<string> { "BitBank" };
+
+        public AutoTradeExchangeSettingsBase GetSettings(string name)
+        {
+            switch (name)
+            {
+                case "BitBank":
+                    return new BitBankSettings();
+                default:
+                    throw new ArgumentException($"Unknown exchange name {name}");
+            }
+        }
+
+        private readonly ConcurrentDictionary<string, IAutoTradeExchangeClient> _clientCache = new ConcurrentDictionary<string, IAutoTradeExchangeClient>();
+
+        private StoreRepository _storeRepository { get; }
+        private IHttpClientFactory _httpClientFactory { get; }
+
+        public AutoTradeExchangeClientProvider(StoreRepository storeRepository, IHttpClientFactory httpClientFactory)
+        {
+            _storeRepository = storeRepository;
+            _httpClientFactory = httpClientFactory;
+        }
+
+        public void InvalidateClient(string storeId, string clientType)
+        {
+            if (_clientCache.ContainsKey(clientType))
+            {
+                _clientCache.Remove(clientType, out var value);
+            }
+        }
+        public virtual async Task<IAutoTradeExchangeClient> TryGetClient(string storeId, string exchangeName, StoreData storeData = null)
+        {
+            if (_clientCache.ContainsKey(storeId))
+            {
+                return _clientCache[storeId];
+            }
+
+            if (storeData == null)
+            {
+                storeData = await _storeRepository.FindStore(storeId);
+                if (storeData == null)
+                {
+                    throw new AutoTradeException("Store not found");
+                }
+            }
+
+            var blob = storeData.GetStoreBlob();
+            var autoTradeSettings = blob.AutoTradeExchangeSettings;
+            if (autoTradeSettings == null || !autoTradeSettings.IsConfigured())
+            {
+                throw new AutoTradeException("AutoTrading Feature is not configured for this store.");
+            }
+            if (!autoTradeSettings.Enabled)
+            {
+                throw new AutoTradeException("AutoTrading Not enabled in this store.");
+            }
+
+            switch (exchangeName)
+            {
+                case "BitBank":
+                    var client = new BitBankClient(
+                        autoTradeSettings.ApiKey,
+                        autoTradeSettings.ApiSecret,
+                        autoTradeSettings.ApiUrl);
+                    _clientCache.AddOrReplace(storeId, client);
+                    return client;
+                default:
+                    throw new AutoTradeException($"Unknown Exchange Name {exchangeName} !");
+            }
+        }
+    }
+}

--- a/BTCPayServer/Payments/AutoTrade/AutoTradeExchangeSettingsBase.cs
+++ b/BTCPayServer/Payments/AutoTrade/AutoTradeExchangeSettingsBase.cs
@@ -1,0 +1,22 @@
+namespace BTCPayServer.Payments.AutoTrade
+{
+    public abstract class AutoTradeExchangeSettingsBase
+    {
+        public string ApiKey { get; set; }
+        public string ApiSecret { get; set; }
+        public string ApiUrl { get; set; }
+        public bool Enabled { get; set; }
+
+        public abstract string ExchangeName { get; }
+        public string CurrencyTypeToBuy { get; }
+        public decimal AmountMarkupPercentage { get; set; }
+
+        public bool IsConfigured()
+        {
+            return
+                !string.IsNullOrEmpty(ApiKey) ||
+                !string.IsNullOrEmpty(ApiSecret) ||
+                !string.IsNullOrEmpty(ApiUrl);
+        }
+    }
+}

--- a/BTCPayServer/Payments/AutoTrade/BitBank/BitBankClient.cs
+++ b/BTCPayServer/Payments/AutoTrade/BitBank/BitBankClient.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Threading.Tasks;
+using BitBankApi;
+using NBitcoin;
+
+namespace BTCPayServer.Payments.AutoTrade.BitBank
+{
+    public class BitBankClient : IAutoTradeExchangeClient
+    {
+        private readonly string _apisecret;
+        private readonly bool _showFiat;
+        private readonly PrivateApi _client;
+        private readonly string _currencyTypeToBuy;
+        private static List<string> SupportedCurrencies = new List<string> { "btc", "ltc" };
+
+        public BitBankClient(string apiKey, string apiSecret, string apiUrl,string currencyTypeToBuy = "jpy", bool showFiat = true)
+        {
+            if (currencyTypeToBuy != "jpy")
+            {
+                throw new ArgumentException($"{currencyTypeToBuy} is not supported currency type in BitBank!");
+            }
+            _apisecret = apiSecret;
+            _currencyTypeToBuy = currencyTypeToBuy;
+            _showFiat = showFiat;
+            _client = new PrivateApi(apiKey, apiSecret);
+        }
+
+
+        public async Task<bool> Sell(string cryptoCode, Money amount, decimal? expectedPrice = null)
+        {
+            var lowerCC = cryptoCode.ToLower();
+            if (!SupportedCurrencies.Contains(lowerCC))
+            {
+                throw new ArgumentException($"{cryptoCode} is not supported in BitBank");
+            }
+            var currencyPair = _currencyTypeToBuy + lowerCC;
+            var amountInBTCString = amount.ToUnit(MoneyUnit.BTC).ToString();
+            await _client.PostOrderAsync(currencyPair, amountInBTCString, "sell", "market");
+            return true;
+        }
+    }
+}

--- a/BTCPayServer/Payments/AutoTrade/BitBank/BitBankSettings.cs
+++ b/BTCPayServer/Payments/AutoTrade/BitBank/BitBankSettings.cs
@@ -1,0 +1,7 @@
+namespace BTCPayServer.Payments.AutoTrade.BitBank
+{
+    public class BitBankSettings : AutoTradeExchangeSettingsBase
+    {
+        public override string ExchangeName { get; } = "BitBank";
+    }
+}

--- a/BTCPayServer/Payments/AutoTrade/IAutoTradeExchangeClient.cs
+++ b/BTCPayServer/Payments/AutoTrade/IAutoTradeExchangeClient.cs
@@ -1,0 +1,10 @@
+using System.Threading.Tasks;
+using NBitcoin;
+
+namespace BTCPayServer.Payments.AutoTrade
+{
+    public interface IAutoTradeExchangeClient
+    {
+        Task<bool> Sell(string cryptoCode, Money amount, decimal? expectedPrice = null);
+    }
+}

--- a/BTCPayServer/Payments/Changelly/ChangellyClientProvider.cs
+++ b/BTCPayServer/Payments/Changelly/ChangellyClientProvider.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using BTCPayServer.Data;
 using BTCPayServer.Services.Stores;
 using NBitcoin;
+using static NBitcoin.Extensions;
 
 namespace BTCPayServer.Payments.Changelly
 {


### PR DESCRIPTION
Hi.

My company wants to start using BTCPayServer for receiving BTC from our customers.
But for some mysterious accounting reason, they want to treat incoming payments are payed as fiat.

So I decided to implement a feature to sell the pre-existing balance in the exchange automatically when our server received a payment. 
In this way, we still have to buy BTC beforehand but it can be treated as a necessary expense. so it can (hopefully) avoid the regulation.

I'm planning to add a section to set the "Auto Exchange" settings under third party payment methods.
<img width="596" alt="btcpay_server" src="https://user-images.githubusercontent.com/10084960/52220948-680ed300-28e3-11e9-9dae-903d97214bdd.png">

I've just started this PR, and it is far from finished. But I want to have a feedback from community beforehand if possible.

So far, the only exchange I'm planning to support is https://bitbank.cc/ because our company resides in Japan. But I want to make it extendable to support any exchange.
NOTE: My current plan is to support only one exchange per store. Since it might be too complicated otherwise.

TODO:
* [ ] finish writing controller and tests. 
* [ ] finish view.
* [ ] check if API token is not for withdrawing (only trading)
* [ ] send BTC automatically to the exchange when the balance in the exchange has become too low.
* [ ] add test case for the reorg.

Rationale ... Users should be able to pay in any currency they want. At the same time, merchant should be able to receive in any currency they want( including fiat)