### PR TITLE
Update text in Services to reflect LN in general not just LND

### DIFF
--- a/BTCPayServer/Views/Server/Services.cshtml
+++ b/BTCPayServer/Views/Server/Services.cshtml
@@ -17,7 +17,7 @@
     <div class="col-md-8">
         <h4>Crypto services</h4>
         <div class="form-group">
-            <span>You can get access here to LND (gRPC, Rest) services exposed by your server</span>
+            <span>Access the Lightning Network services (gRPC, Rest) exposed by your server.</span>
         </div>
 
         <div class="form-group">


### PR DESCRIPTION
Making it more generic to suit c-lightning not just LND.

Perhaps the headline "Crypto Services" should be changed to Lightning Services since we break down different plugins into categories anyway.

Close #573 
