### PR TITLE
Add Issue Templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,34 @@
+---
+name: Report a problem
+about: File a technical problem or report a bug
+---
+
+**Describe the problem/bug**
+A clear and concise description of what the bug is.
+
+**Your environment**
+* Version of BTCPay Server:
+* Deployment method: 
+* Other relevant environment details:
+
+**Logs (if applicable)**
+Basic logs can be found in Server Settings > Logs.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Actual behavior**
+Tell us what happens instead
+
+**Screenshots/Links**
+If applicable, add screenshots or links to help explain your problem.
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Ideas and feature requests
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Provide examples**
+If applicable provide examples, wireframes, sketches or images to better explain your idea.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.


### PR DESCRIPTION
This PR adds a new folder ./github that has two files:
- feature_request.md
- bug_report.md

Those two files will provide an issue template to people when they're opening an issue. Templates are great way to get as much information as possible without spending too much time going back and fort just to get some basic information. 

Also templates eliminate easy questions that can easily be Googled since whoever is filing an issue will go down the path which takes less effort. 

I got this idea from[ RTL project](https://github.com/ShahanaFarooqui/RTL/issues/new/choose).

This is how user will be greeted when he clicks new issue

![Screen Shot 2019-03-09 at 23 25 07](https://user-images.githubusercontent.com/36959754/54078091-a7558880-42c2-11e9-940f-fcbeebdb0066.png)

These templates are just a suggestion, feedback and ideas are welcome. 