### PR TITLE
Improve scanability of payment QR codes

### DIFF
--- a/BTCPayServer/Views/Invoice/Checkout-Body.cshtml
+++ b/BTCPayServer/Views/Invoice/Checkout-Body.cshtml
@@ -207,7 +207,7 @@
         <div class="payment__scan">
             <img v-bind:src="srvModel.cryptoImage" class="qr_currency_icon"
                  v-if="scanDisplayQr" />
-            <qrcode v-bind:value="scanDisplayQr" :options="{ width: 256, margin: 0, color: {dark:'#000', light:'#f5f5f7'} }"
+            <qrcode v-bind:value="scanDisplayQr" :options="{ width: 512, margin: 0, color: {dark:'#000', light:'#f5f5f7'} }"
                     v-if="scanDisplayQr">
             </qrcode>
 

--- a/BTCPayServer/wwwroot/checkout/css/normalizer.css
+++ b/BTCPayServer/wwwroot/checkout/css/normalizer.css
@@ -9448,6 +9448,11 @@ strong {
     margin-bottom: 5px;
 }
 
+.payment__scan canvas {
+    width: 256px !important;
+    height: 256px !important;
+}
+
 .payment__scan__checkmark-wrapper {
     display: flex;
     justify-content: center;


### PR DESCRIPTION
Doubles the resolution of the payment QR codes, so they are consistently readable when shown on high-res displays.

We have to add `!important` to the CSS rules for now, because [node-qrcode doesn't have an option to change the rendered size](https://github.com/soldair/node-qrcode/issues/140) separately from the canvas/image size itself.

fixes #609