### PR TITLE
Increase Address max length to 512

### DIFF
--- a/BTCPayServer/Migrations/20171006013443_AddressMapping.cs
+++ b/BTCPayServer/Migrations/20171006013443_AddressMapping.cs
@@ -12,7 +12,7 @@ namespace BTCPayServer.Migrations
                 name: "AddressInvoices",
                 columns: table => new
                 {
-                    Address = table.Column<string>(nullable: false),
+                    Address = table.Column<string>(nullable: false, maxLength: 512),
                     InvoiceDataId = table.Column<string>(nullable: true)
                 },
                 constraints: table =>


### PR DESCRIPTION
Should solve #578 when deploying new BtcPay server instances with MySQL.