### PR TITLE
Add migration for maxLength to address columns 

### DIFF
--- a/BTCPayServer/Data/AddressInvoiceData.cs
+++ b/BTCPayServer/Data/AddressInvoiceData.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using System.Threading.Tasks;
 using BTCPayServer.Payments;
@@ -15,6 +16,7 @@ namespace BTCPayServer.Data
         /// For not having exceptions thrown by two address on different network, we suffix by "#CRYPTOCODE" 
         /// </summary>
         [Obsolete("Use GetHash instead")]
+        [MaxLength(512)]
         public string Address
         {
             get; set;

--- a/BTCPayServer/Data/ApplicationDbContext.cs
+++ b/BTCPayServer/Data/ApplicationDbContext.cs
@@ -197,8 +197,14 @@ namespace BTCPayServer.Data
                     o.Address
 #pragma warning restore CS0618
                 });
-
-
+#pragma warning disable 618
+            builder.Entity<HistoricalAddressInvoiceData>()
+                .Property(o => o.Address)
+                .HasMaxLength(512);
+            builder.Entity<AddressInvoiceData>()
+                .Property(o => o.Address)
+                .HasMaxLength(512);
+#pragma warning restore 618
             builder.Entity<InvoiceEventData>()
                    .HasOne(o => o.InvoiceData)
                    .WithMany(i => i.Events).OnDelete(DeleteBehavior.Cascade);

--- a/BTCPayServer/Data/HistoricalAddressInvoiceData.cs
+++ b/BTCPayServer/Data/HistoricalAddressInvoiceData.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using System.Threading.Tasks;
 
@@ -22,6 +23,7 @@ namespace BTCPayServer.Data
         /// For not having exceptions thrown by two address on different network, we suffix by "#CRYPTOCODE" 
         /// </summary>
         [Obsolete("Use GetCryptoCode instead")]
+        [MaxLength(512)]
         public string Address
         {
             get; set;

--- a/BTCPayServer/Migrations/20190322074448_IncreaseLengthInAddressColumns.Designer.cs
+++ b/BTCPayServer/Migrations/20190322074448_IncreaseLengthInAddressColumns.Designer.cs
@@ -3,14 +3,16 @@ using System;
 using BTCPayServer.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace BTCPayServer.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20190322074448_IncreaseLengthInAddressColumns")]
+    partial class IncreaseLengthInAddressColumns
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/BTCPayServer/Migrations/20190322074448_IncreaseLengthInAddressColumns.cs
+++ b/BTCPayServer/Migrations/20190322074448_IncreaseLengthInAddressColumns.cs
@@ -1,0 +1,21 @@
+﻿using BTCPayServer.Data;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace BTCPayServer.Migrations
+{
+    public partial class IncreaseLengthInAddressColumns : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>("Address", "AddressInvoices", maxLength: 512);
+            migrationBuilder.AlterColumn<string>("Address", "HistoricalAddressInvoices", maxLength: 512);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+
+            migrationBuilder.AlterColumn<string>("Address", "AddressInvoices", maxLength: 450);
+            migrationBuilder.AlterColumn<string>("Address", "HistoricalAddressInvoices", maxLength: 450);
+        }
+    }
+}


### PR DESCRIPTION
For #669 #703 and #578

I tried to add both data annotations and to the fluent migration builder but migrations are not generated there so I manually made the migration script. 

The reasoning behind the bug is that any indexed key is given a a specific max length instead of MAX 