### PR TITLE
Update Readme, Fix Broken Pebble Link

### DIFF
--- a/BTCPayServer/Views/Server/LndServices.cshtml
+++ b/BTCPayServer/Views/Server/LndServices.cshtml
@@ -28,7 +28,7 @@
         {
             <div class="row">
                 <div class="col-lg-3 ml-auto text-center">
-                    <a href="https://www.pebble.indiesquare.me/ target="_blank"">
+                    <a href="https://www.pebble.indiesquare.me/" target="_blank">
                         <img src="~/img/pebblewallet.jpg" height="100" />
                     </a>
                     <p><a href="https://www.pebble.indiesquare.me/" target="_blank">Pebble</a></p>

--- a/README.md
+++ b/README.md
@@ -34,16 +34,18 @@ Thanks to the [apps](https://github.com/btcpayserver/btcpayserver-doc/blob/maste
 * Self-hosted
 * SegWit support
 * Lightning Network support (LND and c-lightning)
-* Altcoin support
+* Tor support
+* Opt-in Altcoin integrations
 * Full compatibility with BitPay API (easy migration)
 * Process payments for others
 * Easy-embeddable Payment buttons
 * Point of sale app
 * Crowdfunding app
+* Payment requests
 
 ## Supported Altcoins
 
-Bitcoin is the only focus of the project and its core developers. However, support is implemented for several altcoins:
+Bitcoin is the only focus of the project and its core developers. However, opt in integrations for several altcoins maintained by altcoins community is implemented for several altcoins:
 
 * Bitcoin Gold (BTG)
 * Bitcoin Plus (XBC)


### PR DESCRIPTION
This PR, updates the readme file:
In features:
- Adds TOR
- Adds Payment requests
- explains alts support (for the 100th time)

There's a broken link to pebble wallet in Services > GRPC, caused by double "" so I fixed that as well in a single PR.