### PR TITLE
Filtering invoice list by startdate and enddate, other fixes

### DIFF
--- a/BTCPayServer.Tests/UnitTest1.cs
+++ b/BTCPayServer.Tests/UnitTest1.cs
@@ -742,6 +742,12 @@ namespace BTCPayServer.Tests
                 AssertSearchInvoice(acc, false, invoice.Id, $"exceptionstatus:paidOver");
                 AssertSearchInvoice(acc, true, invoice.Id, $"unusual:true");
                 AssertSearchInvoice(acc, false, invoice.Id, $"unusual:false");
+
+                var time = invoice.InvoiceTime;
+                AssertSearchInvoice(acc, true, invoice.Id, $"startdate:{time.ToString("yyyy-MM-dd HH:mm:ss")}");
+                AssertSearchInvoice(acc, true, invoice.Id, $"enddate:{time.ToStringLowerInvariant()}");
+                AssertSearchInvoice(acc, false, invoice.Id, $"startdate:{time.AddSeconds(1).ToString("yyyy-MM-dd HH:mm:ss")}");
+                AssertSearchInvoice(acc, false, invoice.Id, $"enddate:{time.AddSeconds(-1).ToString("yyyy-MM-dd HH:mm:ss")}");
             }
         }
 
@@ -879,22 +885,28 @@ namespace BTCPayServer.Tests
         [Trait("Fast", "Fast")]
         public void CanParseFilter()
         {
-            var filter = "storeid:abc status:abed blabhbalh ";
+            var filter = "storeid:abc, status:abed, blabhbalh ";
             var search = new SearchString(filter);
-            Assert.Equal("storeid:abc status:abed blabhbalh", search.ToString());
+            Assert.Equal("storeid:abc, status:abed, blabhbalh", search.ToString());
             Assert.Equal("blabhbalh", search.TextSearch);
             Assert.Single(search.Filters["storeid"]);
             Assert.Single(search.Filters["status"]);
             Assert.Equal("abc", search.Filters["storeid"].First());
             Assert.Equal("abed", search.Filters["status"].First());
 
-            filter = "status:abed status:abed2";
+            filter = "status:abed, status:abed2";
             search = new SearchString(filter);
-            Assert.Equal("status:abed status:abed2", search.ToString());
+            Assert.Equal("", search.TextSearch);
+            Assert.Equal("status:abed, status:abed2", search.ToString());
             Assert.Throws<KeyNotFoundException>(() => search.Filters["test"]);
             Assert.Equal(2, search.Filters["status"].Count);
             Assert.Equal("abed", search.Filters["status"].First());
             Assert.Equal("abed2", search.Filters["status"].Skip(1).First());
+
+            filter = "StartDate:2019-04-25 01:00 AM, hekki";
+            search = new SearchString(filter);
+            Assert.Equal("2019-04-25 01:00 AM", search.Filters["startdate"].First());
+            Assert.Equal("hekki", search.TextSearch);
         }
 
         [Fact]

--- a/BTCPayServer.Tests/UnitTest1.cs
+++ b/BTCPayServer.Tests/UnitTest1.cs
@@ -1677,10 +1677,10 @@ donation:
                 
 
                 // testing custom amount
-                var action = Assert.IsType<RedirectToActionResult>(publicApps.ViewPointOfSale(appId, 5, null, null, null, null, "donation").Result);
+                var action = Assert.IsType<RedirectToActionResult>(publicApps.ViewPointOfSale(appId, 6.6m, null, null, null, null, "donation").Result);
                 Assert.Equal(nameof(InvoiceController.Checkout), action.ActionName);
                 invoices = user.BitPay.GetInvoices();
-                var donationInvoice = invoices.Single(i => i.Price == 5m);
+                var donationInvoice = invoices.Single(i => i.Price == 6.6m);
                 Assert.NotNull(donationInvoice);
                 Assert.Equal("CAD", donationInvoice.Currency);
                 Assert.Equal("donation", donationInvoice.ItemDesc);

--- a/BTCPayServer/Models/InvoicingModels/InvoicesModel.cs
+++ b/BTCPayServer/Models/InvoicingModels/InvoicesModel.cs
@@ -7,32 +7,14 @@ namespace BTCPayServer.Models.InvoicingModels
 {
     public class InvoicesModel
     {
-        public int Skip
-        {
-            get; set;
-        }
-        public int Count
-        {
-            get; set;
-        }
-        public int Total
-        {
-            get; set;
-        }
-        public string SearchTerm
-        {
-            get; set;
-        }
+        public int Skip { get; set; }
+        public int Count { get; set; }
+        public int Total { get; set; }
+        public string SearchTerm { get; set; }
+        public int? TimezoneOffset { get; set; }
 
-        public List<InvoiceModel> Invoices
-        {
-            get; set;
-        } = new List<InvoiceModel>();
-        public string StatusMessage
-        {
-            get;
-            set;
-        }
+        public List<InvoiceModel> Invoices { get; set; } = new List<InvoiceModel>();
+        public string StatusMessage { get; set; }
     }
 
     public class InvoiceModel
@@ -41,27 +23,15 @@ namespace BTCPayServer.Models.InvoicingModels
 
         public string OrderId { get; set; }
         public string RedirectUrl { get; set; }
-        public string InvoiceId
-        {
-            get; set;
-        }
+        public string InvoiceId { get; set; }
 
-        public string Status
-        {
-            get; set;
-        }
+        public string Status { get; set; }
         public bool CanMarkComplete { get; set; }
         public bool CanMarkInvalid { get; set; }
         public bool CanMarkStatus => CanMarkComplete || CanMarkInvalid;
         public bool ShowCheckout { get; set; }
         public string ExceptionStatus { get; set; }
-        public string AmountCurrency
-        {
-            get; set;
-        }
-        public string StatusMessage
-        {
-            get; set;
-        }
+        public string AmountCurrency { get; set; }
+        public string StatusMessage { get; set; }
     }
 }

--- a/BTCPayServer/SearchString.cs
+++ b/BTCPayServer/SearchString.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
@@ -15,35 +16,58 @@ namespace BTCPayServer
             str = str.Trim();
             _OriginalString = str.Trim();
             TextSearch = _OriginalString;
-            var splitted = str.Split(new char[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
+            var splitted = str.Split(new char[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
             Filters
                 = splitted
-                    .Select(t => t.Split(new char[] { ':' }, StringSplitOptions.RemoveEmptyEntries))
+                    .Select(t => t.Split(new char[] { ':' }, 2, StringSplitOptions.RemoveEmptyEntries))
                     .Where(kv => kv.Length == 2)
-                    .Select(kv => new KeyValuePair<string, string>(kv[0].ToLowerInvariant(), kv[1]))
+                    .Select(kv => new KeyValuePair<string, string>(kv[0].ToLowerInvariant().Trim(), kv[1]))
                     .ToMultiValueDictionary(o => o.Key, o => o.Value);
 
-            foreach(var filter in splitted)
-            {
-                if(filter.Split(new char[] { ':' }, StringSplitOptions.RemoveEmptyEntries).Length == 2)
-                { 
-                    TextSearch = TextSearch.Replace(filter, string.Empty, StringComparison.InvariantCulture);
-                }
-            }
-            TextSearch = TextSearch.Trim();
+            var val = splitted.FirstOrDefault(a => a?.IndexOf(':', StringComparison.OrdinalIgnoreCase) == -1);
+            if (val != null)
+                TextSearch = val.Trim();
+            else
+                TextSearch = "";
         }
 
-        public string TextSearch
-        {
-            get;
-            private set;
-        }
-        
+        public string TextSearch { get; private set; }
+
         public MultiValueDictionary<string, string> Filters { get; private set; }
 
         public override string ToString()
         {
             return _OriginalString;
+        }
+
+        internal string[] GetFilterArray(string key)
+        {
+            return Filters.ContainsKey(key) ? Filters[key].ToArray() : null;
+        }
+
+        internal bool? GetFilterBool(string key)
+        {
+            if (!Filters.ContainsKey(key))
+                return null;
+
+            return bool.TryParse(Filters[key].First(), out var r) ?
+                r : (bool?)null;
+        }
+
+        internal DateTimeOffset? GetFilterDate(string key, int timezoneOffset)
+        {
+            if (!Filters.ContainsKey(key))
+                return null;
+
+            var val = Filters[key].First();
+            var success = DateTimeOffset.TryParse(val, null as IFormatProvider, DateTimeStyles.AssumeUniversal, out var r);
+            if (success)
+            {
+                r = r.AddMinutes(timezoneOffset);
+                return r;
+            }
+
+            return null;
         }
     }
 }

--- a/BTCPayServer/Services/Invoices/InvoiceRepository.cs
+++ b/BTCPayServer/Services/Invoices/InvoiceRepository.cs
@@ -463,7 +463,7 @@ retry:
                 {
                     // Hacky way to return an empty query object. The nice way is much too elaborate:
                     // https://stackoverflow.com/questions/33305495/how-to-return-empty-iqueryable-in-an-async-repository-method
-                    return query.Where(x => false); 
+                    return query.Where(x => false);
                 }
                 query = query.Where(i => ids.Contains(i.Id));
             }

--- a/BTCPayServer/Views/Invoice/ListInvoices.cshtml
+++ b/BTCPayServer/Views/Invoice/ListInvoices.cshtml
@@ -24,6 +24,7 @@
                 <div id="help" class="collapse text-left">
                     <p>
                         You can search for invoice Id, deposit address, price, order id, store id, any buyer information and any product information.<br />
+                        Be sure to split your search parameters with comma, for example: <code>startdate:2019-04-25 13:00:00, status:paid</code><br />
                         You can also apply filters to your search by searching for <code>filtername:value</code>, here is a list of supported filters
                     </p>
                     <ul>
@@ -37,7 +38,7 @@
                         <li><code>enddate:yyyy-MM-dd HH:mm:ss</code> getting invoices that were created before certain date</li>
                     </ul>
                     <p>
-                        If you want all confirmed and complete invoices, you can duplicate a filter <code>status:confirmed status:complete</code>.
+                        If you want all confirmed and complete invoices, you can duplicate a filter <code>status:confirmed, status:complete</code>.
                     </p>
                 </div>
             </div>
@@ -211,16 +212,6 @@
     </div>
 
     <script type="text/javascript">
-        function switchTimeFormat() {
-            $(".switchTimeFormat").each(function (index) {
-                var htmlVal = $(this).html();
-                var switchVal = $(this).attr("data-switch");
-
-                $(this).html(switchVal);
-                $(this).attr("data-switch", htmlVal);
-            });
-        }
-
         $(function () {
             var timezoneOffset = new Date().getTimezoneOffset()
             $("#TimezoneOffset").val(timezoneOffset);

--- a/BTCPayServer/Views/Invoice/ListInvoices.cshtml
+++ b/BTCPayServer/Views/Invoice/ListInvoices.cshtml
@@ -33,6 +33,8 @@
                         <li><code>status:(expired|invalid|complete|confirmed|paid|new)</code> for filtering a specific status</li>
                         <li><code>exceptionstatus:(paidover|paidlate|paidpartial)</code> for filtering a specific exception state</li>
                         <li><code>unusual:(true|false)</code> for filtering invoices which might requires merchant attention (those invalid or with an exceptionstatus)</li>
+                        <li><code>startdate:yyyy-MM-dd HH:mm:ss</code> getting invoices that were created after certain date</li>
+                        <li><code>enddate:yyyy-MM-dd HH:mm:ss</code> getting invoices that were created before certain date</li>
                     </ul>
                     <p>
                         If you want all confirmed and complete invoices, you can duplicate a filter <code>status:confirmed status:complete</code>.
@@ -52,15 +54,16 @@
                     <span class="fa fa-question-circle-o" title="More information..."></span>
                 </a>
                 <div class="dropdown-menu" aria-labelledby="dropdownMenuLink">
-                    <a asp-action="Export" asp-route-format="csv" asp-route-searchTerm="@Model.SearchTerm" class="dropdown-item" target="_blank">CSV</a>
-                    <a asp-action="Export" asp-route-format="json" asp-route-searchTerm="@Model.SearchTerm" class="dropdown-item" target="_blank">JSON</a>
+                    <a asp-action="Export" asp-route-timezoneoffset="0" asp-route-format="csv" asp-route-searchTerm="@Model.SearchTerm" class="dropdown-item export-link" target="_blank">CSV</a>
+                    <a asp-action="Export" asp-route-timezoneoffset="0" asp-route-format="json" asp-route-searchTerm="@Model.SearchTerm" class="dropdown-item export-link" target="_blank">JSON</a>
                 </div>
             </div>
 
             <div class="col-lg-6">
                 <div class="form-group">
-                    <form asp-action="SearchInvoice" method="post" style="float:right;">
+                    <form asp-action="ListInvoices" method="get" style="float:right;">
                         <div class="input-group">
+                            <input asp-for="TimezoneOffset" type="hidden" />
                             <input asp-for="SearchTerm" class="form-control" style="width:300px;" />
                             <span class="input-group-btn">
                                 <button type="submit" class="btn btn-primary" title="Search invoice">
@@ -217,5 +220,13 @@
                 $(this).attr("data-switch", htmlVal);
             });
         }
+
+        $(function () {
+            var timezoneOffset = new Date().getTimezoneOffset()
+            $("#TimezoneOffset").val(timezoneOffset);
+            $(".export-link").each(function () {
+                this.href = this.href.replace("timezoneoffset=0", "timezoneoffset=" + timezoneOffset);
+            });
+        })
     </script>
 </section>

--- a/BTCPayServer/Views/Wallets/WalletTransactions.cshtml
+++ b/BTCPayServer/Views/Wallets/WalletTransactions.cshtml
@@ -28,17 +28,22 @@
 </div>
 <h4>@ViewData["Title"]</h4>
 <div class="row">
-    <div class="col-md-10">
+    <div class="col-md-12">
         If BTCPay Server shows you an invalid balance, <a asp-action="WalletRescan">rescan your wallet</a>. <br />
         If some transactions appear in BTCPay Server, but are missing on Electrum or another wallet, <a href="https://docs.btcpayserver.org/faq-and-common-issues/faq-wallet#missing-payments-in-my-software-or-hardware-wallet">follow those instructions</a>.
     </div>
 </div>
 <div class="row">
-    <div class="col-md-10">
+    <div class="col-md-12">
         <table class="table table-sm table-responsive-lg">
             <thead class="thead-inverse">
                 <tr>
-                    <th>Timestamp</th>
+                    <th style="min-width: 90px;" class="col-md-auto">
+                        Date
+                        <a href="javascript:switchTimeFormat()">
+                            <span class="fa fa-clock-o" title="Switch date format"></span>
+                        </a>
+                    </th>
                     <th>Transaction Id</th>
                     <th style="text-align:right">Balance</th>
                 </tr>
@@ -47,7 +52,11 @@
                 @foreach (var transaction in Model.Transactions)
                 {
                     <tr class="@(transaction.IsConfirmed ? "" : "unconf")">
-                        <td>@transaction.Timestamp.ToTimeAgo()</td>
+                        <td>
+                            <span class="switchTimeFormat" data-switch="@transaction.Timestamp.ToTimeAgo()">
+                                @transaction.Timestamp.ToBrowserDate()
+                            </span>
+                        </td>
                         <td class="smMaxWidth text-truncate">
                             <a href="@transaction.Link" target="_blank">
                                 @transaction.Id

--- a/BTCPayServer/wwwroot/main/site.js
+++ b/BTCPayServer/wwwroot/main/site.js
@@ -33,3 +33,13 @@
         }
     }
 });
+
+function switchTimeFormat() {
+    $(".switchTimeFormat").each(function (index) {
+        var htmlVal = $(this).html();
+        var switchVal = $(this).attr("data-switch");
+
+        $(this).html(switchVal);
+        $(this).attr("data-switch", htmlVal);
+    });
+}


### PR DESCRIPTION
One notice: since datetime can be specified like `4/11/2019 3:34:00 PM` I needed to enforce splitting of parameters in search string with comma.

Also because our client side dates are displayed based on browser timezone settings, I am now passing that value back to server to ensure smooth search (user doesn't need to convert his local time to UTC... which is how invoices are saved in database). Note this works both for invoice display and invoice export.

Finally, tons of small fixes, would appreciate if @Kukks can verify that `CanUsePoSApp` test was broken and that change I made is good.

Here is that main feature in action:

![ability-to-search-1](https://user-images.githubusercontent.com/5191402/56774447-60dfbe80-6788-11e9-8201-b09dc55448ea.jpg)

And then when start date for search is provided:

![ability-to-search-2](https://user-images.githubusercontent.com/5191402/56774504-984e6b00-6788-11e9-9db6-238c4344872a.jpg)
