### PR TITLE
Allow invoice creation to only allow specific payment methods in UI

### DIFF
--- a/BTCPayServer.Tests/UnitTest1.cs
+++ b/BTCPayServer.Tests/UnitTest1.cs
@@ -2609,7 +2609,7 @@ donation:
         }
         
         [Fact]
-        [Trait("Fast", "Fast")]
+        [Trait("Integration", "Integration")]
        public  async Task CanCreateInvoiceWithSpecificPaymentMethods()
         {
             using (var tester = ServerTester.Create())

--- a/BTCPayServer.Tests/UnitTest1.cs
+++ b/BTCPayServer.Tests/UnitTest1.cs
@@ -2624,22 +2624,18 @@ donation:
 
                 var invoice = await user.BitPay.CreateInvoiceAsync(new Invoice(100, "BTC"));
                 Assert.Equal(2, invoice.SupportedTransactionCurrencies.Count);
-
-                Assert.Equal(nameof(InvoiceController.ListInvoices),Assert.IsType<RedirectToActionResult>(await user.GetController<InvoiceController>()
-                    .CreateInvoice(
-                        new CreateInvoiceModel()
+               
+                
+                invoice = await user.BitPay.CreateInvoiceAsync(new Invoice(100, "BTC")
+                {
+                    SupportedTransactionCurrencies = new Dictionary<string, InvoiceSupportedTransactionCurrency>()
+                    {
+                        {"BTC", new InvoiceSupportedTransactionCurrency()
                         {
-                            Amount = 77,
-                            Currency = "BTC",
-                            PaymentMethods = new List<string>()
-                            {
-                                "BTC"
-                            },
-                            StoreId = user.StoreId
-                        }, CancellationToken.None)).ActionName);
-
-                var invoices =  await user.BitPay.GetInvoicesAsync();
-                invoice = invoices.Single(invoice1 => invoice1.Price == 77);
+                            Enabled = true
+                        }}
+                    }
+                });
                 
                 Assert.Equal(1, invoice.SupportedTransactionCurrencies.Count);
             }

--- a/BTCPayServer/Controllers/InvoiceController.UI.cs
+++ b/BTCPayServer/Controllers/InvoiceController.UI.cs
@@ -632,7 +632,10 @@ namespace BTCPayServer.Controllers
                     ItemDesc = model.ItemDesc,
                     FullNotifications = true,
                     BuyerEmail = model.BuyerEmail,
-                    PaymentMethods = model.PaymentMethods?.ToArray()
+                    SupportedTransactionCurrencies = model.SupportedTransactionCurrencies?.ToDictionary(s => s, s => new InvoiceSupportedTransactionCurrency()
+                    {
+                        Enabled =true
+                    })
                 }, store, HttpContext.Request.GetAbsoluteRoot(), cancellationToken: cancellationToken);
 
                 StatusMessage = $"Invoice {result.Data.Id} just created!";

--- a/BTCPayServer/Controllers/InvoiceController.cs
+++ b/BTCPayServer/Controllers/InvoiceController.cs
@@ -179,8 +179,6 @@ namespace BTCPayServer.Controllers
                 var paymentMethod = await o.PaymentMethod;
                 if (paymentMethod == null)
                     continue;
-                
-                
                 supported.Add(o.SupportedPaymentMethod);
                 paymentMethods.Add(paymentMethod);
             }

--- a/BTCPayServer/Controllers/InvoiceController.cs
+++ b/BTCPayServer/Controllers/InvoiceController.cs
@@ -163,13 +163,6 @@ namespace BTCPayServer.Controllers
             var fetchingAll = WhenAllFetched(logs, fetchingByCurrencyPair);
             var supportedPaymentMethods = store.GetSupportedPaymentMethods(_NetworkProvider)
                                                .Where(s => !excludeFilter.Match(s.PaymentId))
-                                               .Where(s => invoice.PaymentMethods == null || 
-                                                           !invoice.PaymentMethods.Any() || 
-                                                           invoice.PaymentMethods.Any(selectedPaymentMethod =>
-                                                               s.PaymentId.ToString()
-                                                                   .Equals(
-                                                                       selectedPaymentMethod, 
-                                                                       StringComparison.InvariantCultureIgnoreCase)))
                                                .Select(c =>
                                                 (Handler: (IPaymentMethodHandler)_ServiceProvider.GetService(typeof(IPaymentMethodHandler<>).MakeGenericType(c.GetType())),
                                                 SupportedPaymentMethod: c,

--- a/BTCPayServer/Models/CreateInvoiceRequest.cs
+++ b/BTCPayServer/Models/CreateInvoiceRequest.cs
@@ -82,5 +82,8 @@ namespace BTCPayServer.Models
 
         [JsonProperty(PropertyName = "redirectAutomatically", DefaultValueHandling = DefaultValueHandling.Ignore)]
         public bool? RedirectAutomatically { get; set; }
+
+        [JsonProperty(PropertyName = "paymentMethods", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public string[] PaymentMethods { get; set; } = null;
     }
 }

--- a/BTCPayServer/Models/CreateInvoiceRequest.cs
+++ b/BTCPayServer/Models/CreateInvoiceRequest.cs
@@ -82,8 +82,5 @@ namespace BTCPayServer.Models
 
         [JsonProperty(PropertyName = "redirectAutomatically", DefaultValueHandling = DefaultValueHandling.Ignore)]
         public bool? RedirectAutomatically { get; set; }
-
-        [JsonProperty(PropertyName = "paymentMethods", DefaultValueHandling = DefaultValueHandling.Ignore)]
-        public string[] PaymentMethods { get; set; } = null;
     }
 }

--- a/BTCPayServer/Models/InvoicingModels/CreateInvoiceModel.cs
+++ b/BTCPayServer/Models/InvoicingModels/CreateInvoiceModel.cs
@@ -71,7 +71,7 @@ namespace BTCPayServer.Models.InvoicingModels
             set;
         }
         
-        public List<string> PaymentMethods
+        public List<string> SupportedTransactionCurrencies
         {
             get;
             set;

--- a/BTCPayServer/Models/InvoicingModels/CreateInvoiceModel.cs
+++ b/BTCPayServer/Models/InvoicingModels/CreateInvoiceModel.cs
@@ -70,5 +70,16 @@ namespace BTCPayServer.Models.InvoicingModels
             get;
             set;
         }
+        
+        public List<string> PaymentMethods
+        {
+            get;
+            set;
+        }
+        public SelectList AvailablePaymentMethods
+        {
+            get;
+            set;
+        }
     }
 }

--- a/BTCPayServer/Views/Invoice/CreateInvoice.cshtml
+++ b/BTCPayServer/Views/Invoice/CreateInvoice.cshtml
@@ -68,9 +68,9 @@
                         <span asp-validation-for="StoreId" class="text-danger"></span>
                     </div>
                     <div class="form-group">
-                        <label asp-for="PaymentMethods" class="control-label"></label>
-                        <select asp-for="PaymentMethods" asp-items="Model.AvailablePaymentMethods" class="form-control" multiple="multiple"></select>
-                        <span asp-validation-for="PaymentMethods" class="text-danger"></span>
+                        <label asp-for="SupportedTransactionCurrencies" class="control-label"></label>
+                        <select asp-for="SupportedTransactionCurrencies" asp-items="Model.AvailablePaymentMethods" class="form-control" multiple="multiple"></select>
+                        <span asp-validation-for="SupportedTransactionCurrencies" class="text-danger"></span>
                     </div>
                     <div class="form-group">
                         <input type="submit" value="Create" class="btn btn-primary" />

--- a/BTCPayServer/Views/Invoice/CreateInvoice.cshtml
+++ b/BTCPayServer/Views/Invoice/CreateInvoice.cshtml
@@ -68,6 +68,11 @@
                         <span asp-validation-for="StoreId" class="text-danger"></span>
                     </div>
                     <div class="form-group">
+                        <label asp-for="PaymentMethods" class="control-label"></label>
+                        <select asp-for="PaymentMethods" asp-items="Model.AvailablePaymentMethods" class="form-control" multiple="multiple"></select>
+                        <span asp-validation-for="PaymentMethods" class="text-danger"></span>
+                    </div>
+                    <div class="form-group">
                         <input type="submit" value="Create" class="btn btn-primary" />
                     </div>
                 </form>


### PR DESCRIPTION
This PR introduces a new parameter to the invoice creation api and on the Create Invoice UI, "Payment Methods". It allows you to specify which coins( and their lightning counterparts) are to be enabled for this invoice.  If this list is left null or is an empty string, it enabled all by default. If a specified payment method is not available, it is ignored. 

This is slightly related to #22. With this new option, merchants can build UIs that allow them to choose what coins they would like to pay with before creating the invoice