### PR TITLE
Allow apps server admin does not have access to to be mapped in domain-to-app policy settings

### DIFF
--- a/BTCPayServer/Controllers/ServerController.cs
+++ b/BTCPayServer/Controllers/ServerController.cs
@@ -579,18 +579,10 @@ namespace BTCPayServer.Controllers
 
         private async Task<List<SelectListItem>> GetAppSelectList()
         {
-            // load display app dropdown
-            using (var ctx = _ContextFactory.CreateContext())
-            {
-                var userId = _UserManager.GetUserId(base.User);
-                var selectList = await ctx.Users.Where(user => user.Id == userId)
-                    .SelectMany(s => s.UserStores)
-                    .Select(s => s.StoreData)
-                    .SelectMany(s => s.Apps)
-                    .Select(a => new SelectListItem($"{a.AppType} - {a.Name}", a.Id)).ToListAsync();
-                selectList.Insert(0, new SelectListItem("(None)", null));
-                return selectList;
-            }
+            var apps = (await _AppService.GetAllApps(null, true))
+                .Select(a => new SelectListItem($"{a.AppType} - {a.AppName} - {a.StoreName}", a.Id)).ToList();
+            apps.Insert(0, new SelectListItem("(None)", null));
+            return apps;
         }
 
         private static bool TryParseAsExternalService(TorService torService, out ExternalService externalService)

--- a/BTCPayServer/Controllers/ServerController.cs
+++ b/BTCPayServer/Controllers/ServerController.cs
@@ -44,12 +44,11 @@ namespace BTCPayServer.Controllers
         private UserManager<ApplicationUser> _UserManager;
         SettingsRepository _SettingsRepository;
         private readonly NBXplorerDashboard _dashBoard;
-        private RateFetcher _RateProviderFactory;
         private StoreRepository _StoreRepository;
         LightningConfigurationProvider _LnConfigProvider;
         private readonly TorServices _torServices;
-        BTCPayServerOptions _Options;
-        ApplicationDbContextFactory _ContextFactory;
+        private BTCPayServerOptions _Options;
+        private readonly AppService _AppService;
         private readonly StoredFileRepository _StoredFileRepository;
         private readonly FileService _FileService;
         private readonly IEnumerable<IStorageProviderService> _StorageProviderServices;
@@ -59,14 +58,13 @@ namespace BTCPayServer.Controllers
             FileService fileService,
             IEnumerable<IStorageProviderService> storageProviderServices,
             BTCPayServerOptions options,
-            RateFetcher rateProviderFactory,
             SettingsRepository settingsRepository,
             NBXplorerDashboard dashBoard,
             IHttpClientFactory httpClientFactory,
             LightningConfigurationProvider lnConfigProvider,
             TorServices torServices,
             StoreRepository storeRepository,
-            ApplicationDbContextFactory contextFactory)
+            AppService appService)
         {
             _Options = options;
             _StoredFileRepository = storedFileRepository;
@@ -76,11 +74,10 @@ namespace BTCPayServer.Controllers
             _SettingsRepository = settingsRepository;
             _dashBoard = dashBoard;
             HttpClientFactory = httpClientFactory;
-            _RateProviderFactory = rateProviderFactory;
             _StoreRepository = storeRepository;
             _LnConfigProvider = lnConfigProvider;
             _torServices = torServices;
-            _ContextFactory = contextFactory;
+            _AppService = appService;
         }
 
         [Route("server/rates")]
@@ -503,19 +500,16 @@ namespace BTCPayServer.Controllers
 
             if (appIdsToFetch.Any())
             {
-                using (var ctx = _ContextFactory.CreateContext())
+                var apps = (await _AppService.GetApps(appIdsToFetch.ToArray()))
+                    .ToDictionary(data => data.Id, data => Enum.Parse<AppType>(data.AppType));;
+                if (!string.IsNullOrEmpty(settings.RootAppId))
                 {
-                    var apps = await ctx.Apps.Where(data => appIdsToFetch.Contains(data.Id))
-                        .ToDictionaryAsync(data => data.Id, data => Enum.Parse<AppType>(data.AppType));
-                    if (!string.IsNullOrEmpty(settings.RootAppId))
-                    {
-                        settings.RootAppType = apps[settings.RootAppId];
-                    }
+                    settings.RootAppType = apps[settings.RootAppId];
+                }
 
-                    foreach (var domainToAppMappingItem in settings.DomainToAppMapping)
-                    {
-                        domainToAppMappingItem.AppType = apps[domainToAppMappingItem.AppId];
-                    }
+                foreach (var domainToAppMappingItem in settings.DomainToAppMapping)
+                {
+                    domainToAppMappingItem.AppType = apps[domainToAppMappingItem.AppId];
                 }
             }
 

--- a/BTCPayServer/Services/Apps/AppService.cs
+++ b/BTCPayServer/Services/Apps/AppService.cs
@@ -231,7 +231,21 @@ namespace BTCPayServer.Services.Apps
                     .ToArrayAsync();
             }
         }
+        
+        public async Task<List<AppData>> GetApps(string[] appIds, bool includeStore = false)
+        {
+            using (var ctx = _ContextFactory.CreateContext())
+            {
+                var query = ctx.Apps
+                    .Where(us => appIds.Contains(us.Id));
 
+                if (includeStore)
+                {
+                    query = query.Include(data => data.StoreData);
+                }
+                return await query.ToListAsync();
+            }
+        }
 
         public async Task<AppData> GetApp(string appId, AppType appType, bool includeStore = false)
         {


### PR DESCRIPTION
This is a bugfix imo:
If you have 2 server admins, where only Admin1 has access to a specific app and Admin2 goes to edit the policies, the mapping would be overwritten to "None" .
This PR exposes all apps on all stores to this mapping dropdown irrespective of user. I think it makes sense to leak this minor data here to server admins.