### PR TITLE
Refactor Network Provider to add networks through interfaces 

### DIFF
--- a/BTCPayServer.Common/BTCPayNetwork.cs
+++ b/BTCPayServer.Common/BTCPayNetwork.cs
@@ -5,7 +5,6 @@ using System.Linq;
 using System.Threading.Tasks;
 using NBitcoin;
 using NBXplorer;
-using Newtonsoft.Json;
 
 namespace BTCPayServer
 {
@@ -97,43 +96,6 @@ namespace BTCPayServer
         public override string ToString<T>(T obj)
         {
             return NBXplorerNetwork.Serializer.ToString(obj);
-        }
-    }
-
-    public abstract class BTCPayNetworkBase
-    {
-        
-        public string CryptoCode { get; internal set; }
-        public string BlockExplorerLink { get; internal set; }
-        public string UriScheme { get; internal set; }
-        public string DisplayName { get; set; }
-
-        [Obsolete("Should not be needed")]
-        public bool IsBTC
-        {
-            get
-            {
-                return CryptoCode == "BTC";
-            }
-        }
-
-        public string CryptoImagePath { get; set; }
-
-        public int MaxTrackedConfirmation { get; internal set; } = 6;
-        public string[] DefaultRateRules { get; internal set; } = Array.Empty<string>();
-        public override string ToString()
-        {
-            return CryptoCode;
-        }
-
-        public virtual T ToObject<T>(string json)
-        {
-            return JsonConvert.DeserializeObject<T>(json);
-        }
-
-        public virtual string ToString<T>(T obj)
-        {
-            return JsonConvert.SerializeObject(obj);
         }
     }
 }

--- a/BTCPayServer.Common/BTCPayNetworkBase.cs
+++ b/BTCPayServer.Common/BTCPayNetworkBase.cs
@@ -1,0 +1,42 @@
+using System;
+using Newtonsoft.Json;
+
+namespace BTCPayServer
+{
+    public abstract class BTCPayNetworkBase
+    {
+        
+        public string CryptoCode { get; internal set; }
+        public string BlockExplorerLink { get; internal set; }
+        public string UriScheme { get; internal set; }
+        public string DisplayName { get; set; }
+
+        [Obsolete("Should not be needed")]
+        public bool IsBTC
+        {
+            get
+            {
+                return CryptoCode == "BTC";
+            }
+        }
+
+        public string CryptoImagePath { get; set; }
+
+        public int MaxTrackedConfirmation { get; internal set; } = 6;
+        public string[] DefaultRateRules { get; internal set; } = Array.Empty<string>();
+        public override string ToString()
+        {
+            return CryptoCode;
+        }
+
+        public virtual T ToObject<T>(string json)
+        {
+            return JsonConvert.DeserializeObject<T>(json);
+        }
+
+        public virtual string ToString<T>(T obj)
+        {
+            return JsonConvert.SerializeObject(obj);
+        }
+    }
+}

--- a/BTCPayServer.Common/BTCPayNetworkProvider.Bitcoin.cs
+++ b/BTCPayServer.Common/BTCPayNetworkProvider.Bitcoin.cs
@@ -7,39 +7,55 @@ using NBXplorer;
 
 namespace BTCPayServer
 {
-    public partial class BitcoinBTCPayNetworkProvider
+    public class BitcoinBTCPayNetworkProvider : IBTCPayNetworkProvider
     {
-        public void InitBitcoin()
+        public IEnumerable<BTCPayNetworkBase> GetNetworks(NetworkType networkType)
         {
-            var nbxplorerNetwork = NBXplorerNetworkProvider.GetFromCryptoCode("BTC");
-            Add(new BTCPayNetwork()
+            var nbxplorerNetwork = GetNBXplorerNetworkProvider(networkType).GetFromCryptoCode("BTC");
+            return new[]
             {
-                CryptoCode = nbxplorerNetwork.CryptoCode,
-                DisplayName = "Bitcoin",
-                BlockExplorerLink = NetworkType == NetworkType.Mainnet ? "https://blockstream.info/tx/{0}" : "https://blockstream.info/testnet/tx/{0}",
-                NBitcoinNetwork = nbxplorerNetwork.NBitcoinNetwork,
-                NBXplorerNetwork = nbxplorerNetwork,
-                UriScheme = "bitcoin",
-                CryptoImagePath = "imlegacy/bitcoin.svg",
-                LightningImagePath = "imlegacy/bitcoin-lightning.svg",
-                DefaultSettings = BTCPayDefaultSettings.GetDefaultSettings(NetworkType),
-                CoinType = NetworkType == NetworkType.Mainnet ? new KeyPath("0'") : new KeyPath("1'"),
-                SupportRBF = true,
-                //https://github.com/spesmilo/electrum/blob/11733d6bc271646a00b69ff07657119598874da4/electrum/constants.py
-                ElectrumMapping = NetworkType == NetworkType.Mainnet
-                    ? new Dictionary<uint, DerivationType>()
-                    {
-                        {0x0488b21eU, DerivationType.Legacy }, // xpub
-                        {0x049d7cb2U, DerivationType.SegwitP2SH }, // ypub
-                        {0x4b24746U, DerivationType.Segwit }, //zpub
-                    }
-                    : new Dictionary<uint, DerivationType>()
-                    {
-                        {0x043587cfU, DerivationType.Legacy},
-                        {0x044a5262U, DerivationType.SegwitP2SH},
-                        {0x045f1cf6U, DerivationType.Segwit}
-                    }
-            });
+                new BTCPayNetwork()
+                {
+                    CryptoCode = nbxplorerNetwork.CryptoCode,
+                    DisplayName = "Bitcoin",
+                    BlockExplorerLink =
+                        networkType == NetworkType.Mainnet
+                            ? "https://blockstream.info/tx/{0}"
+                            : "https://blockstream.info/testnet/tx/{0}",
+                    NBitcoinNetwork = nbxplorerNetwork.NBitcoinNetwork,
+                    NBXplorerNetwork = nbxplorerNetwork,
+                    UriScheme = "bitcoin",
+                    CryptoImagePath = "imlegacy/bitcoin.svg",
+                    LightningImagePath = "imlegacy/bitcoin-lightning.svg",
+                    DefaultSettings = BTCPayDefaultSettings.GetDefaultSettings(networkType),
+                    CoinType = networkType == NetworkType.Mainnet ? new KeyPath("0'") : new KeyPath("1'"),
+                    SupportRBF = true,
+                    //https://github.com/spesmilo/electrum/blob/11733d6bc271646a00b69ff07657119598874da4/electrum/constants.py
+                    ElectrumMapping = GetElectrumMapping(networkType)
+                }
+            };
+        }
+
+        public static NBXplorerNetworkProvider GetNBXplorerNetworkProvider(NetworkType networkType)
+        {
+            return new NBXplorerNetworkProvider(networkType);
+        }
+
+        public static Dictionary<uint, DerivationType> GetElectrumMapping(NetworkType networkType)
+        {
+            return networkType == NetworkType.Mainnet
+                ? new Dictionary<uint, DerivationType>()
+                {
+                    {0x0488b21eU, DerivationType.Legacy}, // xpub
+                    {0x049d7cb2U, DerivationType.SegwitP2SH}, // ypub
+                    {0x4b24746U, DerivationType.Segwit}, //zpub
+                }
+                : new Dictionary<uint, DerivationType>()
+                {
+                    {0x043587cfU, DerivationType.Legacy},
+                    {0x044a5262U, DerivationType.SegwitP2SH},
+                    {0x045f1cf6U, DerivationType.Segwit}
+                };
         }
     }
 }

--- a/BTCPayServer.Common/BTCPayNetworkProvider.Bitcoin.cs
+++ b/BTCPayServer.Common/BTCPayNetworkProvider.Bitcoin.cs
@@ -7,7 +7,7 @@ using NBXplorer;
 
 namespace BTCPayServer
 {
-    public partial class BTCPayNetworkProvider
+    public partial class BitcoinBTCPayNetworkProvider
     {
         public void InitBitcoin()
         {

--- a/BTCPayServer.Common/BTCPayNetworkProvider.BitcoinGold.cs
+++ b/BTCPayServer.Common/BTCPayNetworkProvider.BitcoinGold.cs
@@ -2,7 +2,7 @@
 
 namespace BTCPayServer
 {
-    public partial class BitcoinBTCPayNetworkProvider
+    public partial class ShitcoinBTCPayNetworkProvider
     {
         public void InitBitcoinGold()
         {

--- a/BTCPayServer.Common/BTCPayNetworkProvider.BitcoinGold.cs
+++ b/BTCPayServer.Common/BTCPayNetworkProvider.BitcoinGold.cs
@@ -2,7 +2,7 @@
 
 namespace BTCPayServer
 {
-    public partial class BTCPayNetworkProvider
+    public partial class BitcoinBTCPayNetworkProvider
     {
         public void InitBitcoinGold()
         {

--- a/BTCPayServer.Common/BTCPayNetworkProvider.Bitcoinplus.cs
+++ b/BTCPayServer.Common/BTCPayNetworkProvider.Bitcoinplus.cs
@@ -7,7 +7,7 @@ using NBXplorer;
 
 namespace BTCPayServer
 {
-    public partial class BitcoinBTCPayNetworkProvider
+    public partial class ShitcoinBTCPayNetworkProvider
     {
         public void InitBitcoinplus()
         {

--- a/BTCPayServer.Common/BTCPayNetworkProvider.Bitcoinplus.cs
+++ b/BTCPayServer.Common/BTCPayNetworkProvider.Bitcoinplus.cs
@@ -7,7 +7,7 @@ using NBXplorer;
 
 namespace BTCPayServer
 {
-    public partial class BTCPayNetworkProvider
+    public partial class BitcoinBTCPayNetworkProvider
     {
         public void InitBitcoinplus()
         {

--- a/BTCPayServer.Common/BTCPayNetworkProvider.Bitcore.cs
+++ b/BTCPayServer.Common/BTCPayNetworkProvider.Bitcore.cs
@@ -7,7 +7,7 @@ using NBXplorer;
 
 namespace BTCPayServer
 {
-    public partial class BTCPayNetworkProvider
+    public partial class BitcoinBTCPayNetworkProvider
     {
         public void InitBitcore()
         {

--- a/BTCPayServer.Common/BTCPayNetworkProvider.Bitcore.cs
+++ b/BTCPayServer.Common/BTCPayNetworkProvider.Bitcore.cs
@@ -7,7 +7,7 @@ using NBXplorer;
 
 namespace BTCPayServer
 {
-    public partial class BitcoinBTCPayNetworkProvider
+    public partial class ShitcoinBTCPayNetworkProvider
     {
         public void InitBitcore()
         {

--- a/BTCPayServer.Common/BTCPayNetworkProvider.Dash.cs
+++ b/BTCPayServer.Common/BTCPayNetworkProvider.Dash.cs
@@ -2,7 +2,7 @@
 
 namespace BTCPayServer
 {
-    public partial class BTCPayNetworkProvider
+    public partial class BitcoinBTCPayNetworkProvider
     {
         public void InitDash()
         {

--- a/BTCPayServer.Common/BTCPayNetworkProvider.Dash.cs
+++ b/BTCPayServer.Common/BTCPayNetworkProvider.Dash.cs
@@ -2,7 +2,7 @@
 
 namespace BTCPayServer
 {
-    public partial class BitcoinBTCPayNetworkProvider
+    public partial class ShitcoinBTCPayNetworkProvider
     {
         public void InitDash()
         {

--- a/BTCPayServer.Common/BTCPayNetworkProvider.Dogecoin.cs
+++ b/BTCPayServer.Common/BTCPayNetworkProvider.Dogecoin.cs
@@ -7,7 +7,7 @@ using NBXplorer;
 
 namespace BTCPayServer
 {
-    public partial class BitcoinBTCPayNetworkProvider
+    public partial class ShitcoinBTCPayNetworkProvider
     {
         public void InitDogecoin()
         {

--- a/BTCPayServer.Common/BTCPayNetworkProvider.Dogecoin.cs
+++ b/BTCPayServer.Common/BTCPayNetworkProvider.Dogecoin.cs
@@ -7,7 +7,7 @@ using NBXplorer;
 
 namespace BTCPayServer
 {
-    public partial class BTCPayNetworkProvider
+    public partial class BitcoinBTCPayNetworkProvider
     {
         public void InitDogecoin()
         {

--- a/BTCPayServer.Common/BTCPayNetworkProvider.Feathercoin.cs
+++ b/BTCPayServer.Common/BTCPayNetworkProvider.Feathercoin.cs
@@ -7,7 +7,7 @@ using NBXplorer;
 
 namespace BTCPayServer
 {
-    public partial class BitcoinBTCPayNetworkProvider
+    public partial class ShitcoinBTCPayNetworkProvider
     {
         public void InitFeathercoin()
         {

--- a/BTCPayServer.Common/BTCPayNetworkProvider.Feathercoin.cs
+++ b/BTCPayServer.Common/BTCPayNetworkProvider.Feathercoin.cs
@@ -7,7 +7,7 @@ using NBXplorer;
 
 namespace BTCPayServer
 {
-    public partial class BTCPayNetworkProvider
+    public partial class BitcoinBTCPayNetworkProvider
     {
         public void InitFeathercoin()
         {

--- a/BTCPayServer.Common/BTCPayNetworkProvider.Groestlcoin.cs
+++ b/BTCPayServer.Common/BTCPayNetworkProvider.Groestlcoin.cs
@@ -6,7 +6,7 @@ using NBitcoin;
 
 namespace BTCPayServer
 {
-    public partial class BTCPayNetworkProvider
+    public partial class BitcoinBTCPayNetworkProvider
     {
         public void InitGroestlcoin()
         {

--- a/BTCPayServer.Common/BTCPayNetworkProvider.Groestlcoin.cs
+++ b/BTCPayServer.Common/BTCPayNetworkProvider.Groestlcoin.cs
@@ -6,7 +6,7 @@ using NBitcoin;
 
 namespace BTCPayServer
 {
-    public partial class BitcoinBTCPayNetworkProvider
+    public partial class ShitcoinBTCPayNetworkProvider
     {
         public void InitGroestlcoin()
         {

--- a/BTCPayServer.Common/BTCPayNetworkProvider.Litecoin.cs
+++ b/BTCPayServer.Common/BTCPayNetworkProvider.Litecoin.cs
@@ -7,7 +7,7 @@ using NBXplorer;
 
 namespace BTCPayServer
 {
-    public partial class BitcoinBTCPayNetworkProvider
+    public partial class ShitcoinBTCPayNetworkProvider
     {
         public void InitLitecoin()
         {

--- a/BTCPayServer.Common/BTCPayNetworkProvider.Litecoin.cs
+++ b/BTCPayServer.Common/BTCPayNetworkProvider.Litecoin.cs
@@ -7,7 +7,7 @@ using NBXplorer;
 
 namespace BTCPayServer
 {
-    public partial class BTCPayNetworkProvider
+    public partial class BitcoinBTCPayNetworkProvider
     {
         public void InitLitecoin()
         {

--- a/BTCPayServer.Common/BTCPayNetworkProvider.Monacoin.cs
+++ b/BTCPayServer.Common/BTCPayNetworkProvider.Monacoin.cs
@@ -7,7 +7,7 @@ using NBXplorer;
 
 namespace BTCPayServer
 {
-    public partial class BitcoinBTCPayNetworkProvider
+    public partial class ShitcoinBTCPayNetworkProvider
     {
         public void InitMonacoin()
         {

--- a/BTCPayServer.Common/BTCPayNetworkProvider.Monacoin.cs
+++ b/BTCPayServer.Common/BTCPayNetworkProvider.Monacoin.cs
@@ -7,7 +7,7 @@ using NBXplorer;
 
 namespace BTCPayServer
 {
-    public partial class BTCPayNetworkProvider
+    public partial class BitcoinBTCPayNetworkProvider
     {
         public void InitMonacoin()
         {

--- a/BTCPayServer.Common/BTCPayNetworkProvider.Polis.cs
+++ b/BTCPayServer.Common/BTCPayNetworkProvider.Polis.cs
@@ -7,7 +7,7 @@ using NBXplorer;
 
 namespace BTCPayServer
 {
-    public partial class BTCPayNetworkProvider
+    public partial class BitcoinBTCPayNetworkProvider
     {
         public void InitPolis()
         {

--- a/BTCPayServer.Common/BTCPayNetworkProvider.Polis.cs
+++ b/BTCPayServer.Common/BTCPayNetworkProvider.Polis.cs
@@ -7,7 +7,7 @@ using NBXplorer;
 
 namespace BTCPayServer
 {
-    public partial class BitcoinBTCPayNetworkProvider
+    public partial class ShitcoinBTCPayNetworkProvider
     {
         public void InitPolis()
         {

--- a/BTCPayServer.Common/BTCPayNetworkProvider.Ufo.cs
+++ b/BTCPayServer.Common/BTCPayNetworkProvider.Ufo.cs
@@ -7,7 +7,7 @@ using NBXplorer;
 
 namespace BTCPayServer
 {
-    public partial class BitcoinBTCPayNetworkProvider
+    public partial class ShitcoinBTCPayNetworkProvider
     {
         public void InitUfo()
         {

--- a/BTCPayServer.Common/BTCPayNetworkProvider.Ufo.cs
+++ b/BTCPayServer.Common/BTCPayNetworkProvider.Ufo.cs
@@ -7,7 +7,7 @@ using NBXplorer;
 
 namespace BTCPayServer
 {
-    public partial class BTCPayNetworkProvider
+    public partial class BitcoinBTCPayNetworkProvider
     {
         public void InitUfo()
         {

--- a/BTCPayServer.Common/BTCPayNetworkProvider.Viacoin.cs
+++ b/BTCPayServer.Common/BTCPayNetworkProvider.Viacoin.cs
@@ -7,7 +7,7 @@ using NBXplorer;
 
 namespace BTCPayServer
 {
-    public partial class BTCPayNetworkProvider
+    public partial class BitcoinBTCPayNetworkProvider
     {
         public void InitViacoin()
         {

--- a/BTCPayServer.Common/BTCPayNetworkProvider.Viacoin.cs
+++ b/BTCPayServer.Common/BTCPayNetworkProvider.Viacoin.cs
@@ -7,7 +7,7 @@ using NBXplorer;
 
 namespace BTCPayServer
 {
-    public partial class BitcoinBTCPayNetworkProvider
+    public partial class ShitcoinBTCPayNetworkProvider
     {
         public void InitViacoin()
         {

--- a/BTCPayServer.Common/BTCPayNetworkProvider.cs
+++ b/BTCPayServer.Common/BTCPayNetworkProvider.cs
@@ -17,7 +17,7 @@ namespace BTCPayServer
 
         public static IEnumerable<IBTCPayNetworkProvider> GetDefaultNetworkProviders()
         {
-            return new IBTCPayNetworkProvider[] {new BitcoinBTCPayNetworkProvider()};
+            return new IBTCPayNetworkProvider[] {new BitcoinBTCPayNetworkProvider(), new ShitcoinBTCPayNetworkProvider()};
         }
     }
 
@@ -29,7 +29,6 @@ namespace BTCPayServer
         public BTCPayNetworkProvider(IEnumerable<IBTCPayNetworkProvider> btcPayNetworkProviders)
         {
             _BtcPayNetworkProviders = btcPayNetworkProviders;
-           
         }
 
         public BTCPayNetworkProvider(IEnumerable<IBTCPayNetworkProvider> btcPayNetworkProviders, NetworkType networkType)
@@ -79,7 +78,7 @@ namespace BTCPayServer
         }
     }
     
-    public partial class BitcoinBTCPayNetworkProvider: IBTCPayNetworkProvider
+    public partial class ShitcoinBTCPayNetworkProvider: IBTCPayNetworkProvider
     {
         Dictionary<string, BTCPayNetwork> _Networks = new Dictionary<string, BTCPayNetwork>();
 
@@ -107,7 +106,6 @@ namespace BTCPayServer
         {
             _NBXplorerNetworkProvider = new NBXplorerNetworkProvider(networkType);
             NetworkType = networkType;
-            InitBitcoin();
             InitLitecoin();
             InitBitcore();
             InitDogecoin();

--- a/BTCPayServer.Common/BTCPayNetworkProvider.cs
+++ b/BTCPayServer.Common/BTCPayNetworkProvider.cs
@@ -8,11 +8,6 @@ using NBXplorer;
 
 namespace BTCPayServer
 {
-    public interface IBTCPayNetworkProvider
-    {
-        IEnumerable<BTCPayNetworkBase> GetNetworks(NetworkType networkType);
-    }
-
     public static class BTCPayNetworkProviderFactory
     {
         public static BTCPayNetworkProvider GetProvider(NetworkType type)

--- a/BTCPayServer.Common/BTCPayNetworkProvider.cs
+++ b/BTCPayServer.Common/BTCPayNetworkProvider.cs
@@ -10,9 +10,11 @@ namespace BTCPayServer
 {
     public static class BTCPayNetworkProviderFactory
     {
+        public static BTCPayNetworkProvider Instance { get; set; }
+
         public static BTCPayNetworkProvider GetProvider(NetworkType type)
         {
-            return new BTCPayNetworkProvider(GetDefaultNetworkProviders(), type);
+            return Instance?.NetworkType == type ? Instance : new BTCPayNetworkProvider(GetDefaultNetworkProviders(), type);
         }
 
         public static IEnumerable<IBTCPayNetworkProvider> GetDefaultNetworkProviders()

--- a/BTCPayServer.Common/BTCPayNetworkProvider.cs
+++ b/BTCPayServer.Common/BTCPayNetworkProvider.cs
@@ -12,10 +12,12 @@ namespace BTCPayServer
     {
         public static BTCPayNetworkProvider GetProvider(NetworkType type)
         {
-            return new BTCPayNetworkProvider(new IBTCPayNetworkProvider[]
-            {
-                new BitcoinBTCPayNetworkProvider()
-            }, type);
+            return new BTCPayNetworkProvider(GetDefaultNetworkProviders(), type);
+        }
+
+        public static IEnumerable<IBTCPayNetworkProvider> GetDefaultNetworkProviders()
+        {
+            return new IBTCPayNetworkProvider[] {new BitcoinBTCPayNetworkProvider()};
         }
     }
 

--- a/BTCPayServer.Common/BTCPayNetworkProvider.cs
+++ b/BTCPayServer.Common/BTCPayNetworkProvider.cs
@@ -41,7 +41,7 @@ namespace BTCPayServer
     {
         private readonly IEnumerable<IBTCPayNetworkProvider> _BtcPayNetworkProviders;
         public NetworkType NetworkType;
-        private Dictionary<string, BTCPayNetworkBase> _Networks;
+        protected Dictionary<string, BTCPayNetworkBase> _Networks;
 
         public BTCPayNetworkProvider(IEnumerable<IBTCPayNetworkProvider> btcPayNetworkProviders)
         {
@@ -55,7 +55,7 @@ namespace BTCPayServer
             Init(networkType);
         }
 
-        public void Init(NetworkType networkType)
+        public virtual void Init(NetworkType networkType)
         {
             NetworkType = networkType;
             _Networks = _BtcPayNetworkProviders.SelectMany(provider => provider.GetNetworks(networkType))

--- a/BTCPayServer.Common/BTCPayNetworkProvider.cs
+++ b/BTCPayServer.Common/BTCPayNetworkProvider.cs
@@ -121,7 +121,7 @@ namespace BTCPayServer
             {
                 if(network.ElectrumMapping.Count == 0)
                 {
-                    network.ElectrumMapping = _Networks["BTC"].ElectrumMapping;
+                    network.ElectrumMapping = BitcoinBTCPayNetworkProvider.GetElectrumMapping(networkType);
                     if (!network.NBitcoinNetwork.Consensus.SupportSegwit)
                     {
                         network.ElectrumMapping =

--- a/BTCPayServer.Common/IBTCPayNetworkProvider.cs
+++ b/BTCPayServer.Common/IBTCPayNetworkProvider.cs
@@ -1,0 +1,10 @@
+using System.Collections.Generic;
+using NBitcoin;
+
+namespace BTCPayServer
+{
+    public interface IBTCPayNetworkProvider
+    {
+        IEnumerable<BTCPayNetworkBase> GetNetworks(NetworkType networkType);
+    }
+}

--- a/BTCPayServer.Rating/CurrencyPair.cs
+++ b/BTCPayServer.Rating/CurrencyPair.cs
@@ -2,12 +2,14 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using NBitcoin;
 
 namespace BTCPayServer.Rating
 {
     public class CurrencyPair
     {
-        static readonly BTCPayNetworkProvider _NetworkProvider = new BTCPayNetworkProvider(NBitcoin.NetworkType.Mainnet);
+        private static readonly BTCPayNetworkProvider _NetworkProvider =
+            BTCPayNetworkProviderFactory.GetProvider(NetworkType.Mainnet);
         public CurrencyPair(string left, string right)
         {
             if (right == null)

--- a/BTCPayServer.Rating/CurrencyPair.cs
+++ b/BTCPayServer.Rating/CurrencyPair.cs
@@ -53,7 +53,7 @@ namespace BTCPayServer.Rating
                 for (int i = 3; i < 5; i++)
                 {
                     var potentialCryptoName = currencyPair.Substring(0, i);
-                    var network = BTCPayNetworkProviderFactory.Instance.GetNetwork<BTCPayNetworkBase>(potentialCryptoName);
+                    var network = BTCPayNetworkProviderFactory.Instance[NetworkType.Mainnet].GetNetwork<BTCPayNetworkBase>(potentialCryptoName);
                     if (network != null)
                     {
                         value = new CurrencyPair(network.CryptoCode, currencyPair.Substring(i));

--- a/BTCPayServer.Rating/CurrencyPair.cs
+++ b/BTCPayServer.Rating/CurrencyPair.cs
@@ -8,8 +8,6 @@ namespace BTCPayServer.Rating
 {
     public class CurrencyPair
     {
-        private static readonly BTCPayNetworkProvider _NetworkProvider =
-            BTCPayNetworkProviderFactory.GetProvider(NetworkType.Mainnet);
         public CurrencyPair(string left, string right)
         {
             if (right == null)
@@ -55,7 +53,7 @@ namespace BTCPayServer.Rating
                 for (int i = 3; i < 5; i++)
                 {
                     var potentialCryptoName = currencyPair.Substring(0, i);
-                    var network = _NetworkProvider.GetNetwork<BTCPayNetworkBase>(potentialCryptoName);
+                    var network = BTCPayNetworkProviderFactory.Instance.GetNetwork<BTCPayNetworkBase>(potentialCryptoName);
                     if (network != null)
                     {
                         value = new CurrencyPair(network.CryptoCode, currencyPair.Substring(i));

--- a/BTCPayServer.Tests/ChangellyTests.cs
+++ b/BTCPayServer.Tests/ChangellyTests.cs
@@ -184,8 +184,8 @@ namespace BTCPayServer.Tests
                 var fetcher = new RateFetcher(factory);
                 var httpClientFactory = new MockHttpClientFactory();
                 var changellyController = new ChangellyController(
-                    new ChangellyClientProvider(tester.PayTester.StoreRepository, httpClientFactory),
-                    tester.NetworkProvider, fetcher, tester.PayTester.GetService<BTCPayServerOptions>());
+                    new ChangellyClientProvider(tester.PayTester.StoreRepository, httpClientFactory), fetcher,
+                    tester.PayTester.GetService<BTCPayServerOptions>());
                 changellyController.IsTest = true;
                 var result = Assert
                     .IsType<OkObjectResult>(await changellyController.GetCurrencyList(user.StoreId))
@@ -216,7 +216,7 @@ namespace BTCPayServer.Tests
                 var httpClientFactory = new MockHttpClientFactory();
                 var changellyController = new ChangellyController(
                     new ChangellyClientProvider(tester.PayTester.StoreRepository, httpClientFactory),
-                    tester.NetworkProvider, fetcher, tester.PayTester.GetService<BTCPayServerOptions>());
+                    fetcher, tester.PayTester.GetService<BTCPayServerOptions>());
                 changellyController.IsTest = true;
                 Assert.IsType<decimal>(Assert
                     .IsType<OkObjectResult>(await changellyController.CalculateAmount(user.StoreId, "ltc", "btc", 1.0m, default))

--- a/BTCPayServer.Tests/ChangellyTests.cs
+++ b/BTCPayServer.Tests/ChangellyTests.cs
@@ -185,7 +185,7 @@ namespace BTCPayServer.Tests
                 var httpClientFactory = new MockHttpClientFactory();
                 var changellyController = new ChangellyController(
                     new ChangellyClientProvider(tester.PayTester.StoreRepository, httpClientFactory), fetcher,
-                    tester.PayTester.GetService<BTCPayServerOptions>());
+                    tester.PayTester.GetService<AvailableBTCPayNetworkProvider>());
                 changellyController.IsTest = true;
                 var result = Assert
                     .IsType<OkObjectResult>(await changellyController.GetCurrencyList(user.StoreId))
@@ -216,7 +216,7 @@ namespace BTCPayServer.Tests
                 var httpClientFactory = new MockHttpClientFactory();
                 var changellyController = new ChangellyController(
                     new ChangellyClientProvider(tester.PayTester.StoreRepository, httpClientFactory),
-                    fetcher, tester.PayTester.GetService<BTCPayServerOptions>());
+                    fetcher, tester.PayTester.GetService<AvailableBTCPayNetworkProvider>());
                 changellyController.IsTest = true;
                 Assert.IsType<decimal>(Assert
                     .IsType<OkObjectResult>(await changellyController.CalculateAmount(user.StoreId, "ltc", "btc", 1.0m, default))

--- a/BTCPayServer.Tests/ChangellyTests.cs
+++ b/BTCPayServer.Tests/ChangellyTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
 using System.Threading.Tasks;
+using BTCPayServer.Configuration;
 using BTCPayServer.Controllers;
 using BTCPayServer.Data;
 using BTCPayServer.Models;
@@ -184,7 +185,7 @@ namespace BTCPayServer.Tests
                 var httpClientFactory = new MockHttpClientFactory();
                 var changellyController = new ChangellyController(
                     new ChangellyClientProvider(tester.PayTester.StoreRepository, httpClientFactory),
-                    tester.NetworkProvider, fetcher);
+                    tester.NetworkProvider, fetcher, tester.PayTester.GetService<BTCPayServerOptions>());
                 changellyController.IsTest = true;
                 var result = Assert
                     .IsType<OkObjectResult>(await changellyController.GetCurrencyList(user.StoreId))
@@ -215,7 +216,7 @@ namespace BTCPayServer.Tests
                 var httpClientFactory = new MockHttpClientFactory();
                 var changellyController = new ChangellyController(
                     new ChangellyClientProvider(tester.PayTester.StoreRepository, httpClientFactory),
-                    tester.NetworkProvider, fetcher);
+                    tester.NetworkProvider, fetcher, tester.PayTester.GetService<BTCPayServerOptions>());
                 changellyController.IsTest = true;
                 Assert.IsType<decimal>(Assert
                     .IsType<OkObjectResult>(await changellyController.CalculateAmount(user.StoreId, "ltc", "btc", 1.0m, default))

--- a/BTCPayServer.Tests/ServerTester.cs
+++ b/BTCPayServer.Tests/ServerTester.cs
@@ -42,8 +42,7 @@ namespace BTCPayServer.Tests
                 Utils.DeleteDirectory(_Directory);
             if (!Directory.Exists(_Directory))
                 Directory.CreateDirectory(_Directory);
-            BTCPayNetworkProviderFactory.Instance = BTCPayNetworkProviderFactory.GetProvider(NetworkType.Regtest);
-            NetworkProvider = BTCPayNetworkProviderFactory.Instance;
+            NetworkProvider = BTCPayNetworkProviderFactory.Instance[NetworkType.Regtest];
             ExplorerNode = new RPCClient(RPCCredentialString.Parse(GetEnvironment("TESTS_BTCRPCCONNECTION", "server=http://127.0.0.1:43782;ceiwHEbqWI83:DwubwWsoo3")), NetworkProvider.GetNetwork<BTCPayNetwork>("BTC").NBitcoinNetwork);
             ExplorerNode.ScanRPCCapabilities();
             LTCExplorerNode = new RPCClient(RPCCredentialString.Parse(GetEnvironment("TESTS_LTCRPCCONNECTION", "server=http://127.0.0.1:43783;ceiwHEbqWI83:DwubwWsoo3")), NetworkProvider.GetNetwork<BTCPayNetwork>("LTC").NBitcoinNetwork);

--- a/BTCPayServer.Tests/ServerTester.cs
+++ b/BTCPayServer.Tests/ServerTester.cs
@@ -43,7 +43,7 @@ namespace BTCPayServer.Tests
             if (!Directory.Exists(_Directory))
                 Directory.CreateDirectory(_Directory);
 
-            NetworkProvider = new BTCPayNetworkProvider(NetworkType.Regtest);
+            NetworkProvider = BTCPayNetworkProviderFactory.GetProvider(NetworkType.Regtest);
             ExplorerNode = new RPCClient(RPCCredentialString.Parse(GetEnvironment("TESTS_BTCRPCCONNECTION", "server=http://127.0.0.1:43782;ceiwHEbqWI83:DwubwWsoo3")), NetworkProvider.GetNetwork<BTCPayNetwork>("BTC").NBitcoinNetwork);
             ExplorerNode.ScanRPCCapabilities();
             LTCExplorerNode = new RPCClient(RPCCredentialString.Parse(GetEnvironment("TESTS_LTCRPCCONNECTION", "server=http://127.0.0.1:43783;ceiwHEbqWI83:DwubwWsoo3")), NetworkProvider.GetNetwork<BTCPayNetwork>("LTC").NBitcoinNetwork);

--- a/BTCPayServer.Tests/ServerTester.cs
+++ b/BTCPayServer.Tests/ServerTester.cs
@@ -42,8 +42,8 @@ namespace BTCPayServer.Tests
                 Utils.DeleteDirectory(_Directory);
             if (!Directory.Exists(_Directory))
                 Directory.CreateDirectory(_Directory);
-
-            NetworkProvider = BTCPayNetworkProviderFactory.GetProvider(NetworkType.Regtest);
+            BTCPayNetworkProviderFactory.Instance = BTCPayNetworkProviderFactory.GetProvider(NetworkType.Regtest);
+            NetworkProvider = BTCPayNetworkProviderFactory.Instance;
             ExplorerNode = new RPCClient(RPCCredentialString.Parse(GetEnvironment("TESTS_BTCRPCCONNECTION", "server=http://127.0.0.1:43782;ceiwHEbqWI83:DwubwWsoo3")), NetworkProvider.GetNetwork<BTCPayNetwork>("BTC").NBitcoinNetwork);
             ExplorerNode.ScanRPCCapabilities();
             LTCExplorerNode = new RPCClient(RPCCredentialString.Parse(GetEnvironment("TESTS_LTCRPCCONNECTION", "server=http://127.0.0.1:43783;ceiwHEbqWI83:DwubwWsoo3")), NetworkProvider.GetNetwork<BTCPayNetwork>("LTC").NBitcoinNetwork);

--- a/BTCPayServer.Tests/UnitTest1.cs
+++ b/BTCPayServer.Tests/UnitTest1.cs
@@ -1525,9 +1525,9 @@ namespace BTCPayServer.Tests
         [Trait("Fast", "Fast")]
         public void CanParseDerivationScheme()
         {
-            var testnetNetworkProvider = BTCPayNetworkProviderFactory.GetProvider(NetworkType.Testnet);
-            var regtestNetworkProvider = BTCPayNetworkProviderFactory.GetProvider(NetworkType.Regtest);
-            var mainnetNetworkProvider = BTCPayNetworkProviderFactory.GetProvider(NetworkType.Mainnet);
+            var testnetNetworkProvider = BTCPayNetworkProviderFactory.Instance[NetworkType.Testnet];
+            var regtestNetworkProvider =BTCPayNetworkProviderFactory.Instance[NetworkType.Regtest];
+            var mainnetNetworkProvider = BTCPayNetworkProviderFactory.Instance[NetworkType.Mainnet];
             var testnetParser = new DerivationSchemeParser(testnetNetworkProvider.GetNetwork<BTCPayNetwork>("BTC"));
             var mainnetParser = new DerivationSchemeParser(mainnetNetworkProvider.GetNetwork<BTCPayNetwork>("BTC"));
             NBXplorer.DerivationStrategy.DerivationStrategyBase result;
@@ -2552,7 +2552,7 @@ donation:
         [Trait("Integration", "Integration")]
         public void CanGetRateCryptoCurrenciesByDefault()
         {
-            var provider = BTCPayNetworkProviderFactory.GetProvider(NetworkType.Mainnet);
+            var provider = BTCPayNetworkProviderFactory.Instance[NetworkType.Mainnet];
             var factory = CreateBTCPayRateFactory();
             var fetcher = new RateFetcher(factory);
             var pairs =
@@ -2738,7 +2738,7 @@ donation:
         [Trait("Fast", "Fast")]
         public void ParseDerivationSchemeSettings()
         {
-            var mainnet = BTCPayNetworkProviderFactory.GetProvider(NetworkType.Mainnet).GetNetwork<BTCPayNetwork>("BTC");
+            var mainnet = BTCPayNetworkProviderFactory.Instance[NetworkType.Mainnet].GetNetwork<BTCPayNetwork>("BTC");
             var root = new Mnemonic("usage fever hen zero slide mammal silent heavy donate budget pulse say brain thank sausage brand craft about save attract muffin advance illegal cabbage").DeriveExtKey();
             Assert.True(DerivationSchemeSettings.TryParseFromColdcard("{\"keystore\": {\"ckcc_xpub\": \"xpub661MyMwAqRbcGVBsTGeNZN6QGVHmMHLdSA4FteGsRrEriu4pnVZMZWnruFFFXkMnyoBjyHndD3Qwcfz4MPzBUxjSevweNFQx7SAYZATtcDw\", \"xpub\": \"ypub6WWc2gWwHbdnAAyJDnR4SPL1phRh7REqrPBfZeizaQ1EmTshieRXJC3Z5YoU4wkcdKHEjQGkh6AYEzCQC1Kz3DNaWSwdc1pc8416hAjzqyD\", \"label\": \"Coldcard Import 0x60d1af8b\", \"ckcc_xfp\": 1624354699, \"type\": \"hardware\", \"hw_type\": \"coldcard\", \"derivation\": \"m/49'/0'/0'\"}, \"wallet_type\": \"standard\", \"use_encryption\": false, \"seed_version\": 17}", mainnet, out var settings));
             Assert.Equal(root.GetPublicKey().GetHDFingerPrint(), settings.AccountKeySettings[0].RootFingerprint);
@@ -2748,7 +2748,7 @@ donation:
             Assert.Equal("ypub6WWc2gWwHbdnAAyJDnR4SPL1phRh7REqrPBfZeizaQ1EmTshieRXJC3Z5YoU4wkcdKHEjQGkh6AYEzCQC1Kz3DNaWSwdc1pc8416hAjzqyD", settings.AccountOriginal);
             Assert.Equal(root.Derive(new KeyPath("m/49'/0'/0'")).Neuter().PubKey.WitHash.ScriptPubKey.Hash.ScriptPubKey, settings.AccountDerivation.Derive(new KeyPath()).ScriptPubKey);
 
-            var testnet = BTCPayNetworkProviderFactory.GetProvider(NetworkType.Testnet).GetNetwork<BTCPayNetwork>("BTC");
+            var testnet = BTCPayNetworkProviderFactory.Instance[NetworkType.Testnet].GetNetwork<BTCPayNetwork>("BTC");
 
             // Should be legacy
             Assert.True(DerivationSchemeSettings.TryParseFromColdcard("{\"keystore\": {\"ckcc_xpub\": \"tpubD6NzVbkrYhZ4YHNiuTdTmHRmbcPRLfqgyneZFCL1mkzkUBjXriQShxTh9HL34FK2mhieasJVk9EzJrUfkFqRNQBjiXgx3n5BhPkxKBoFmaS\", \"xpub\": \"tpubDDWYqT3P24znfsaGX7kZcQhNc5LAjnQiKQvUCHF2jS6dsgJBRtymopEU5uGpMaR5YChjuiExZG1X2aTbqXkp82KqH5qnqwWHp6EWis9ZvKr\", \"label\": \"Coldcard Import 0x60d1af8b\", \"ckcc_xfp\": 1624354699, \"type\": \"hardware\", \"hw_type\": \"coldcard\", \"derivation\": \"m/44'/1'/0'\"}, \"wallet_type\": \"standard\", \"use_encryption\": false, \"seed_version\": 17}", testnet, out settings));

--- a/BTCPayServer.Tests/UnitTest1.cs
+++ b/BTCPayServer.Tests/UnitTest1.cs
@@ -484,7 +484,7 @@ namespace BTCPayServer.Tests
                 (1000.0001m, "₹ 1,000.00 (INR)", "INR")
             })
             {
-                var actual = new CurrencyNameTable().DisplayFormatCurrency(test.Item1, test.Item3);
+                var actual = new CurrencyNameTable(BTCPayNetworkProviderFactory.GetProvider(NetworkType.Mainnet)).DisplayFormatCurrency(test.Item1, test.Item3);
                 actual = actual.Replace("￥", "¥"); // Hack so JPY test pass on linux as well
                 Assert.Equal(test.Item2, actual);
             }
@@ -1522,21 +1522,22 @@ namespace BTCPayServer.Tests
         [Trait("Fast", "Fast")]
         public void CanParseCurrencyValue()
         {
-            Assert.True(CurrencyValue.TryParse("1.50USD", out var result));
+            var cnt = new CurrencyNameTable(BTCPayNetworkProviderFactory.GetProvider(NetworkType.Mainnet));
+            Assert.True(CurrencyValue.TryParse("1.50USD", cnt, out var result));
             Assert.Equal("1.50 USD", result.ToString());
-            Assert.True(CurrencyValue.TryParse("1.50 USD", out result));
+            Assert.True(CurrencyValue.TryParse("1.50 USD", cnt, out result));
             Assert.Equal("1.50 USD", result.ToString());
-            Assert.True(CurrencyValue.TryParse("1.50 usd", out result));
+            Assert.True(CurrencyValue.TryParse("1.50 usd", cnt, out result));
             Assert.Equal("1.50 USD", result.ToString());
-            Assert.True(CurrencyValue.TryParse("1 usd", out result));
+            Assert.True(CurrencyValue.TryParse("1 usd", cnt, out result));
             Assert.Equal("1 USD", result.ToString());
-            Assert.True(CurrencyValue.TryParse("1usd", out result));
+            Assert.True(CurrencyValue.TryParse("1usd", cnt, out result));
             Assert.Equal("1 USD", result.ToString());
-            Assert.True(CurrencyValue.TryParse("1.501 usd", out result));
+            Assert.True(CurrencyValue.TryParse("1.501 usd", cnt, out result));
             Assert.Equal("1.50 USD", result.ToString());
-            Assert.False(CurrencyValue.TryParse("1.501 WTFF", out result));
-            Assert.False(CurrencyValue.TryParse("1,501 usd", out result));
-            Assert.False(CurrencyValue.TryParse("1.501", out result));
+            Assert.False(CurrencyValue.TryParse("1.501 WTFF", cnt, out result));
+            Assert.False(CurrencyValue.TryParse("1,501 usd", cnt, out result));
+            Assert.False(CurrencyValue.TryParse("1.501", cnt, out result));
         }
 
         [Fact]

--- a/BTCPayServer.Tests/UnitTest1.cs
+++ b/BTCPayServer.Tests/UnitTest1.cs
@@ -102,11 +102,6 @@ namespace BTCPayServer.Tests
 #pragma warning disable CS0618
             var dummy = new Key().PubKey.GetAddress(ScriptPubKeyType.Legacy, Network.RegTest).ToString();
             var networkProvider = BTCPayNetworkProviderFactory.GetProvider(NetworkType.Regtest);
-            var paymentMethodHandlerDictionary = new PaymentMethodHandlerDictionary(new IPaymentMethodHandler[]
-            {
-                new BitcoinLikePaymentHandler(null, networkProvider, null, null),
-                new LightningLikePaymentHandler(null, null, networkProvider, null),
-            });
             InvoiceEntity invoiceEntity = new InvoiceEntity();
             invoiceEntity.Payments = new System.Collections.Generic.List<PaymentEntity>();
             invoiceEntity.ProductInformation = new ProductInformation() {Price = 100};
@@ -209,11 +204,6 @@ namespace BTCPayServer.Tests
         public void CanCalculateCryptoDue()
         {
             var networkProvider = BTCPayNetworkProviderFactory.GetProvider(NetworkType.Regtest);
-            var paymentMethodHandlerDictionary = new PaymentMethodHandlerDictionary(new IPaymentMethodHandler[]
-            {
-                new BitcoinLikePaymentHandler(null, networkProvider, null, null),
-                new LightningLikePaymentHandler(null, null, networkProvider, null),
-            });
             var entity = new InvoiceEntity();
 #pragma warning disable CS0618
             entity.Payments = new System.Collections.Generic.List<PaymentEntity>();
@@ -396,11 +386,7 @@ namespace BTCPayServer.Tests
         public void CanAcceptInvoiceWithTolerance()
         {
             var networkProvider = BTCPayNetworkProviderFactory.GetProvider(NetworkType.Regtest);
-            var paymentMethodHandlerDictionary = new PaymentMethodHandlerDictionary(new IPaymentMethodHandler[]
-            {
-                new BitcoinLikePaymentHandler(null, networkProvider, null, null),
-                new LightningLikePaymentHandler(null, null, networkProvider, null),
-            });
+
             var entity = new InvoiceEntity();
 #pragma warning disable CS0618
             entity.Payments = new List<PaymentEntity>();

--- a/BTCPayServer.Tests/UnitTest1.cs
+++ b/BTCPayServer.Tests/UnitTest1.cs
@@ -470,7 +470,7 @@ namespace BTCPayServer.Tests
                 (1000.0001m, "₹ 1,000.00 (INR)", "INR")
             })
             {
-                var actual = new CurrencyNameTable(BTCPayNetworkProviderFactory.GetProvider(NetworkType.Mainnet)).DisplayFormatCurrency(test.Item1, test.Item3);
+                var actual = new CurrencyNameTable().DisplayFormatCurrency(test.Item1, test.Item3);
                 actual = actual.Replace("￥", "¥"); // Hack so JPY test pass on linux as well
                 Assert.Equal(test.Item2, actual);
             }
@@ -1508,22 +1508,21 @@ namespace BTCPayServer.Tests
         [Trait("Fast", "Fast")]
         public void CanParseCurrencyValue()
         {
-            var cnt = new CurrencyNameTable(BTCPayNetworkProviderFactory.GetProvider(NetworkType.Mainnet));
-            Assert.True(CurrencyValue.TryParse("1.50USD", cnt, out var result));
+            Assert.True(CurrencyValue.TryParse("1.50USD", out var result));
             Assert.Equal("1.50 USD", result.ToString());
-            Assert.True(CurrencyValue.TryParse("1.50 USD", cnt, out result));
+            Assert.True(CurrencyValue.TryParse("1.50 USD", out result));
             Assert.Equal("1.50 USD", result.ToString());
-            Assert.True(CurrencyValue.TryParse("1.50 usd", cnt, out result));
+            Assert.True(CurrencyValue.TryParse("1.50 usd", out result));
             Assert.Equal("1.50 USD", result.ToString());
-            Assert.True(CurrencyValue.TryParse("1 usd", cnt, out result));
+            Assert.True(CurrencyValue.TryParse("1 usd", out result));
             Assert.Equal("1 USD", result.ToString());
-            Assert.True(CurrencyValue.TryParse("1usd", cnt, out result));
+            Assert.True(CurrencyValue.TryParse("1usd", out result));
             Assert.Equal("1 USD", result.ToString());
-            Assert.True(CurrencyValue.TryParse("1.501 usd", cnt, out result));
+            Assert.True(CurrencyValue.TryParse("1.501 usd", out result));
             Assert.Equal("1.50 USD", result.ToString());
-            Assert.False(CurrencyValue.TryParse("1.501 WTFF", cnt, out result));
-            Assert.False(CurrencyValue.TryParse("1,501 usd", cnt, out result));
-            Assert.False(CurrencyValue.TryParse("1.501", cnt, out result));
+            Assert.False(CurrencyValue.TryParse("1.501 WTFF", out result));
+            Assert.False(CurrencyValue.TryParse("1,501 usd", out result));
+            Assert.False(CurrencyValue.TryParse("1.501", out result));
         }
 
         [Fact]

--- a/BTCPayServer.Tests/UnitTest1.cs
+++ b/BTCPayServer.Tests/UnitTest1.cs
@@ -2560,7 +2560,7 @@ donation:
                     .Select(c => new CurrencyPair(c.CryptoCode, "USD"))
                     .ToHashSet();
 
-            var rules = new StoreBlob().GetDefaultRateRules(provider.GetAll());
+            var rules = new StoreBlob().GetDefaultRateRules(provider);
             var result = fetcher.FetchRates(pairs, rules, default);
             foreach (var value in result)
             {

--- a/BTCPayServer.Tests/UnitTest1.cs
+++ b/BTCPayServer.Tests/UnitTest1.cs
@@ -2578,7 +2578,7 @@ donation:
                     .Select(c => new CurrencyPair(c.CryptoCode, "USD"))
                     .ToHashSet();
 
-            var rules = new StoreBlob().GetDefaultRateRules(provider);
+            var rules = new StoreBlob().GetDefaultRateRules(provider.GetAll());
             var result = fetcher.FetchRates(pairs, rules, default);
             foreach (var value in result)
             {

--- a/BTCPayServer.Tests/UnitTest1.cs
+++ b/BTCPayServer.Tests/UnitTest1.cs
@@ -101,7 +101,7 @@ namespace BTCPayServer.Tests
         {
 #pragma warning disable CS0618
             var dummy = new Key().PubKey.GetAddress(ScriptPubKeyType.Legacy, Network.RegTest).ToString();
-            var networkProvider = new BTCPayNetworkProvider(NetworkType.Regtest);
+            var networkProvider = BTCPayNetworkProviderFactory.GetProvider(NetworkType.Regtest);
             var paymentMethodHandlerDictionary = new PaymentMethodHandlerDictionary(new IPaymentMethodHandler[]
             {
                 new BitcoinLikePaymentHandler(null, networkProvider, null, null),
@@ -208,7 +208,7 @@ namespace BTCPayServer.Tests
         [Trait("Fast", "Fast")]
         public void CanCalculateCryptoDue()
         {
-            var networkProvider = new BTCPayNetworkProvider(NetworkType.Regtest);
+            var networkProvider = BTCPayNetworkProviderFactory.GetProvider(NetworkType.Regtest);
             var paymentMethodHandlerDictionary = new PaymentMethodHandlerDictionary(new IPaymentMethodHandler[]
             {
                 new BitcoinLikePaymentHandler(null, networkProvider, null, null),
@@ -395,7 +395,7 @@ namespace BTCPayServer.Tests
         [Trait("Fast", "Fast")]
         public void CanAcceptInvoiceWithTolerance()
         {
-            var networkProvider = new BTCPayNetworkProvider(NetworkType.Regtest);
+            var networkProvider = BTCPayNetworkProviderFactory.GetProvider(NetworkType.Regtest);
             var paymentMethodHandlerDictionary = new PaymentMethodHandlerDictionary(new IPaymentMethodHandler[]
             {
                 new BitcoinLikePaymentHandler(null, networkProvider, null, null),
@@ -712,7 +712,6 @@ namespace BTCPayServer.Tests
         [Trait("Integration", "Integration")]
         public void CanSolveTheDogesRatesOnKraken()
         {
-            var provider = new BTCPayNetworkProvider(NetworkType.Mainnet);
             var factory = CreateBTCPayRateFactory();
             var fetcher = new RateFetcher(factory);
 
@@ -1544,9 +1543,9 @@ namespace BTCPayServer.Tests
         [Trait("Fast", "Fast")]
         public void CanParseDerivationScheme()
         {
-            var  testnetNetworkProvider = new BTCPayNetworkProvider(NetworkType.Testnet);
-            var regtestNetworkProvider = new BTCPayNetworkProvider(NetworkType.Regtest);
-            var mainnetNetworkProvider = new BTCPayNetworkProvider(NetworkType.Mainnet);
+            var testnetNetworkProvider = BTCPayNetworkProviderFactory.GetProvider(NetworkType.Testnet);
+            var regtestNetworkProvider = BTCPayNetworkProviderFactory.GetProvider(NetworkType.Regtest);
+            var mainnetNetworkProvider = BTCPayNetworkProviderFactory.GetProvider(NetworkType.Mainnet);
             var testnetParser = new DerivationSchemeParser(testnetNetworkProvider.GetNetwork<BTCPayNetwork>("BTC"));
             var mainnetParser = new DerivationSchemeParser(mainnetNetworkProvider.GetNetwork<BTCPayNetwork>("BTC"));
             NBXplorer.DerivationStrategy.DerivationStrategyBase result;
@@ -2571,7 +2570,7 @@ donation:
         [Trait("Integration", "Integration")]
         public void CanGetRateCryptoCurrenciesByDefault()
         {
-            var provider = new BTCPayNetworkProvider(NetworkType.Mainnet);
+            var provider = BTCPayNetworkProviderFactory.GetProvider(NetworkType.Mainnet);
             var factory = CreateBTCPayRateFactory();
             var fetcher = new RateFetcher(factory);
             var pairs =
@@ -2757,7 +2756,7 @@ donation:
         [Trait("Fast", "Fast")]
         public void ParseDerivationSchemeSettings()
         {
-            var mainnet = new BTCPayNetworkProvider(NetworkType.Mainnet).GetNetwork<BTCPayNetwork>("BTC");
+            var mainnet = BTCPayNetworkProviderFactory.GetProvider(NetworkType.Mainnet).GetNetwork<BTCPayNetwork>("BTC");
             var root = new Mnemonic("usage fever hen zero slide mammal silent heavy donate budget pulse say brain thank sausage brand craft about save attract muffin advance illegal cabbage").DeriveExtKey();
             Assert.True(DerivationSchemeSettings.TryParseFromColdcard("{\"keystore\": {\"ckcc_xpub\": \"xpub661MyMwAqRbcGVBsTGeNZN6QGVHmMHLdSA4FteGsRrEriu4pnVZMZWnruFFFXkMnyoBjyHndD3Qwcfz4MPzBUxjSevweNFQx7SAYZATtcDw\", \"xpub\": \"ypub6WWc2gWwHbdnAAyJDnR4SPL1phRh7REqrPBfZeizaQ1EmTshieRXJC3Z5YoU4wkcdKHEjQGkh6AYEzCQC1Kz3DNaWSwdc1pc8416hAjzqyD\", \"label\": \"Coldcard Import 0x60d1af8b\", \"ckcc_xfp\": 1624354699, \"type\": \"hardware\", \"hw_type\": \"coldcard\", \"derivation\": \"m/49'/0'/0'\"}, \"wallet_type\": \"standard\", \"use_encryption\": false, \"seed_version\": 17}", mainnet, out var settings));
             Assert.Equal(root.GetPublicKey().GetHDFingerPrint(), settings.AccountKeySettings[0].RootFingerprint);
@@ -2767,7 +2766,7 @@ donation:
             Assert.Equal("ypub6WWc2gWwHbdnAAyJDnR4SPL1phRh7REqrPBfZeizaQ1EmTshieRXJC3Z5YoU4wkcdKHEjQGkh6AYEzCQC1Kz3DNaWSwdc1pc8416hAjzqyD", settings.AccountOriginal);
             Assert.Equal(root.Derive(new KeyPath("m/49'/0'/0'")).Neuter().PubKey.WitHash.ScriptPubKey.Hash.ScriptPubKey, settings.AccountDerivation.Derive(new KeyPath()).ScriptPubKey);
 
-            var testnet = new BTCPayNetworkProvider(NetworkType.Testnet).GetNetwork<BTCPayNetwork>("BTC");
+            var testnet = BTCPayNetworkProviderFactory.GetProvider(NetworkType.Testnet).GetNetwork<BTCPayNetwork>("BTC");
 
             // Should be legacy
             Assert.True(DerivationSchemeSettings.TryParseFromColdcard("{\"keystore\": {\"ckcc_xpub\": \"tpubD6NzVbkrYhZ4YHNiuTdTmHRmbcPRLfqgyneZFCL1mkzkUBjXriQShxTh9HL34FK2mhieasJVk9EzJrUfkFqRNQBjiXgx3n5BhPkxKBoFmaS\", \"xpub\": \"tpubDDWYqT3P24znfsaGX7kZcQhNc5LAjnQiKQvUCHF2jS6dsgJBRtymopEU5uGpMaR5YChjuiExZG1X2aTbqXkp82KqH5qnqwWHp6EWis9ZvKr\", \"label\": \"Coldcard Import 0x60d1af8b\", \"ckcc_xfp\": 1624354699, \"type\": \"hardware\", \"hw_type\": \"coldcard\", \"derivation\": \"m/44'/1'/0'\"}, \"wallet_type\": \"standard\", \"use_encryption\": false, \"seed_version\": 17}", testnet, out settings));

--- a/BTCPayServer.Tests/UnitTest1.cs
+++ b/BTCPayServer.Tests/UnitTest1.cs
@@ -101,7 +101,6 @@ namespace BTCPayServer.Tests
         {
 #pragma warning disable CS0618
             var dummy = new Key().PubKey.GetAddress(ScriptPubKeyType.Legacy, Network.RegTest).ToString();
-            var networkProvider = BTCPayNetworkProviderFactory.GetProvider(NetworkType.Regtest);
             InvoiceEntity invoiceEntity = new InvoiceEntity();
             invoiceEntity.Payments = new System.Collections.Generic.List<PaymentEntity>();
             invoiceEntity.ProductInformation = new ProductInformation() {Price = 100};
@@ -203,7 +202,6 @@ namespace BTCPayServer.Tests
         [Trait("Fast", "Fast")]
         public void CanCalculateCryptoDue()
         {
-            var networkProvider = BTCPayNetworkProviderFactory.GetProvider(NetworkType.Regtest);
             var entity = new InvoiceEntity();
 #pragma warning disable CS0618
             entity.Payments = new System.Collections.Generic.List<PaymentEntity>();
@@ -385,8 +383,6 @@ namespace BTCPayServer.Tests
         [Trait("Fast", "Fast")]
         public void CanAcceptInvoiceWithTolerance()
         {
-            var networkProvider = BTCPayNetworkProviderFactory.GetProvider(NetworkType.Regtest);
-
             var entity = new InvoiceEntity();
 #pragma warning disable CS0618
             entity.Payments = new List<PaymentEntity>();

--- a/BTCPayServer/BTCPayServer.csproj
+++ b/BTCPayServer/BTCPayServer.csproj
@@ -12,7 +12,7 @@
     <Content Remove="Build\dockerfiles\**" />
     <Content Remove="wwwroot\bundles\jqueryvalidate\**" />
     <Content Remove="wwwroot\css\**" />
-    <Content Remove="wwwroot\vendor\jquery-nice-selectBitcoinBTCPayNetworkProvider\**" />
+    <Content Remove="wwwroot\vendor\jquery-nice-select\**" />
     <EmbeddedResource Remove="Build\dockerfiles\**" />
     <EmbeddedResource Remove="wwwroot\bundles\jqueryvalidate\**" />
     <EmbeddedResource Remove="wwwroot\css\**" />

--- a/BTCPayServer/BTCPayServer.csproj
+++ b/BTCPayServer/BTCPayServer.csproj
@@ -12,7 +12,7 @@
     <Content Remove="Build\dockerfiles\**" />
     <Content Remove="wwwroot\bundles\jqueryvalidate\**" />
     <Content Remove="wwwroot\css\**" />
-    <Content Remove="wwwroot\vendor\jquery-nice-select\**" />
+    <Content Remove="wwwroot\vendor\jquery-nice-selectBitcoinBTCPayNetworkProvider\**" />
     <EmbeddedResource Remove="Build\dockerfiles\**" />
     <EmbeddedResource Remove="wwwroot\bundles\jqueryvalidate\**" />
     <EmbeddedResource Remove="wwwroot\css\**" />

--- a/BTCPayServer/Configuration/BTCPayServerOptions.cs
+++ b/BTCPayServer/Configuration/BTCPayServerOptions.cs
@@ -57,6 +57,7 @@ namespace BTCPayServer.Configuration
         }
         
         public string[] SupportedChains { get; set; }
+        public IEnumerable<BTCPayNetworkBase> FilteredNetworks { get; set; }
 
         public static string GetDebugLog(IConfiguration configuration)
         {
@@ -82,14 +83,14 @@ namespace BTCPayServer.Configuration
                 .Select(t => t.ToUpperInvariant())
                 .ToArray();
             NetworkProvider = BTCPayNetworkProviderFactory.GetProvider(NetworkType);
+            FilteredNetworks = NetworkProvider.Filter(SupportedChains);
             foreach (var chain in SupportedChains)
             {
                 if (NetworkProvider.GetNetwork<BTCPayNetworkBase>(chain) == null)
                     throw new ConfigException($"Invalid chains \"{chain}\"");
             }
 
-            var validChains = new List<string>();
-            foreach (var net in NetworkProvider.Filter(SupportedChains).OfType<BTCPayNetwork>())
+            foreach (var net in FilteredNetworks.OfType<BTCPayNetwork>())
             {
                 NBXplorerConnectionSetting setting = new NBXplorerConnectionSetting();
                 setting.CryptoCode = net.CryptoCode;
@@ -213,6 +214,7 @@ namespace BTCPayServer.Configuration
 
             DisableRegistration = conf.GetOrDefault<bool>("disable-registration", true);
         }
+
 
 
         private SSHSettings ParseSSHConfiguration(IConfiguration conf)

--- a/BTCPayServer/Configuration/BTCPayServerOptions.cs
+++ b/BTCPayServer/Configuration/BTCPayServerOptions.cs
@@ -81,7 +81,7 @@ namespace BTCPayServer.Configuration
                 .Split(',', StringSplitOptions.RemoveEmptyEntries)
                 .Select(t => t.ToUpperInvariant())
                 .ToArray();
-            NetworkProvider = BTCPayNetworkProviderFactory.GetProvider(NetworkType.Mainnet);
+            NetworkProvider = BTCPayNetworkProviderFactory.GetProvider(NetworkType);
             foreach (var chain in SupportedChains)
             {
                 if (NetworkProvider.GetNetwork<BTCPayNetworkBase>(chain) == null)

--- a/BTCPayServer/Configuration/BTCPayServerOptions.cs
+++ b/BTCPayServer/Configuration/BTCPayServerOptions.cs
@@ -20,6 +20,20 @@ namespace BTCPayServer.Configuration
         public string CookieFile { get; internal set; }
     }
 
+    public class AvailableBTCPayNetworkProvider : BTCPayNetworkProvider
+    {
+        public AvailableBTCPayNetworkProvider(IEnumerable<IBTCPayNetworkProvider> btcPayNetworkProviders, BTCPayServerOptions options) : base(btcPayNetworkProviders)
+        {
+            _Networks = options.FilteredNetworks.ToDictionary(n=> n.CryptoCode, n=> n);
+            NetworkType = options.NetworkType;
+        }
+
+        public override void Init(NetworkType networkType)
+        {
+            throw new NotSupportedException("The AvailableBtcPayNetworkProvider cannot be init manually");
+        }
+    }
+
     public class BTCPayServerOptions
     {
         private readonly IEnumerable<IBTCPayNetworkProvider> _BtcPayNetworkProviders;

--- a/BTCPayServer/Configuration/BTCPayServerOptions.cs
+++ b/BTCPayServer/Configuration/BTCPayServerOptions.cs
@@ -90,6 +90,7 @@ namespace BTCPayServer.Configuration
                 .Select(t => t.ToUpperInvariant())
                 .ToArray();
             NetworkProvider = new BTCPayNetworkProvider(_BtcPayNetworkProviders, NetworkType);
+            BTCPayNetworkProviderFactory.Instance = NetworkProvider;
             FilteredNetworks = NetworkProvider.Filter(SupportedChains);
             foreach (var chain in SupportedChains)
             {

--- a/BTCPayServer/Configuration/BTCPayServerOptions.cs
+++ b/BTCPayServer/Configuration/BTCPayServerOptions.cs
@@ -78,7 +78,7 @@ namespace BTCPayServer.Configuration
             var supportedChains = conf.GetOrDefault<string>("chains", "btc")
                                       .Split(',', StringSplitOptions.RemoveEmptyEntries)
                                       .Select(t => t.ToUpperInvariant());
-            NetworkProvider = new BTCPayNetworkProvider(NetworkType).Filter(supportedChains.ToArray());
+            NetworkProvider = BTCPayNetworkProviderFactory.GetProvider(NetworkType.Mainnet);
             foreach (var chain in supportedChains)
             {
                 if (NetworkProvider.GetNetwork<BTCPayNetworkBase>(chain) == null)
@@ -86,7 +86,7 @@ namespace BTCPayServer.Configuration
             }
 
             var validChains = new List<string>();
-            foreach (var net in NetworkProvider.GetAll().OfType<BTCPayNetwork>())
+            foreach (var net in NetworkProvider.Filter(supportedChains.ToArray()).OfType<BTCPayNetwork>())
             {
                 NBXplorerConnectionSetting setting = new NBXplorerConnectionSetting();
                 setting.CryptoCode = net.CryptoCode;

--- a/BTCPayServer/Configuration/BTCPayServerOptions.cs
+++ b/BTCPayServer/Configuration/BTCPayServerOptions.cs
@@ -90,7 +90,6 @@ namespace BTCPayServer.Configuration
                 .Select(t => t.ToUpperInvariant())
                 .ToArray();
             NetworkProvider = new BTCPayNetworkProvider(_BtcPayNetworkProviders, NetworkType);
-            BTCPayNetworkProviderFactory.Instance = NetworkProvider;
             FilteredNetworks = NetworkProvider.Filter(SupportedChains);
             foreach (var chain in SupportedChains)
             {

--- a/BTCPayServer/Configuration/BTCPayServerOptions.cs
+++ b/BTCPayServer/Configuration/BTCPayServerOptions.cs
@@ -22,6 +22,13 @@ namespace BTCPayServer.Configuration
 
     public class BTCPayServerOptions
     {
+        private readonly IEnumerable<IBTCPayNetworkProvider> _BtcPayNetworkProviders;
+
+        public BTCPayServerOptions(IEnumerable<IBTCPayNetworkProvider> btcPayNetworkProviders)
+        {
+            _BtcPayNetworkProviders = btcPayNetworkProviders;
+        }
+
         public NetworkType NetworkType
         {
             get; set;
@@ -73,7 +80,7 @@ namespace BTCPayServer.Configuration
         {
             NetworkType = DefaultConfiguration.GetNetworkType(conf);
             DataDir = conf.GetDataDir(NetworkType);
-            Logs.Configuration.LogInformation("Network: " + NetworkType.ToString());
+            Logs.Configuration.LogInformation("Network: " + NetworkType);
 
             if (conf.GetOrDefault<bool>("launchsettings", false) && NetworkType != NetworkType.Regtest)
                 throw new ConfigException($"You need to run BTCPayServer with the run.sh or run.ps1 script");
@@ -82,7 +89,7 @@ namespace BTCPayServer.Configuration
                 .Split(',', StringSplitOptions.RemoveEmptyEntries)
                 .Select(t => t.ToUpperInvariant())
                 .ToArray();
-            NetworkProvider = BTCPayNetworkProviderFactory.GetProvider(NetworkType);
+            NetworkProvider = new BTCPayNetworkProvider(_BtcPayNetworkProviders, NetworkType);
             FilteredNetworks = NetworkProvider.Filter(SupportedChains);
             foreach (var chain in SupportedChains)
             {

--- a/BTCPayServer/Configuration/DefaultConfiguration.cs
+++ b/BTCPayServer/Configuration/DefaultConfiguration.cs
@@ -18,7 +18,7 @@ namespace BTCPayServer.Configuration
     {
         protected override CommandLineApplication CreateCommandLineApplicationCore()
         {
-            var provider = new BTCPayNetworkProvider(NetworkType.Mainnet);
+            var provider = BTCPayNetworkProviderFactory.GetProvider(NetworkType.Mainnet);
             var chains = string.Join(",", provider.GetAll().Select(n => n.CryptoCode.ToLowerInvariant()).ToArray());
             CommandLineApplication app = new CommandLineApplication(true)
             {
@@ -123,7 +123,7 @@ namespace BTCPayServer.Configuration
             builder.AppendLine("#mysql=User ID=root;Password=myPassword;Host=localhost;Port=3306;Database=myDataBase;");
             builder.AppendLine();
             builder.AppendLine("### NBXplorer settings ###");
-            foreach (var n in new BTCPayNetworkProvider(networkType).GetAll().OfType<BTCPayNetwork>())
+            foreach (var n in BTCPayNetworkProviderFactory.GetProvider(networkType).GetAll().OfType<BTCPayNetwork>())
             {
                 builder.AppendLine($"#{n.CryptoCode}.explorer.url={n.NBXplorerNetwork.DefaultSettings.DefaultUrl}");
                 builder.AppendLine($"#{n.CryptoCode}.explorer.cookiefile={ n.NBXplorerNetwork.DefaultSettings.DefaultCookieFile}");

--- a/BTCPayServer/Configuration/DefaultConfiguration.cs
+++ b/BTCPayServer/Configuration/DefaultConfiguration.cs
@@ -18,7 +18,7 @@ namespace BTCPayServer.Configuration
     {
         protected override CommandLineApplication CreateCommandLineApplicationCore()
         {
-            var provider = BTCPayNetworkProviderFactory.GetProvider(NetworkType.Mainnet);
+            var provider = BTCPayNetworkProviderFactory.Instance[NetworkType.Mainnet];
             var chains = string.Join(",", provider.GetAll().Select(n => n.CryptoCode.ToLowerInvariant()).ToArray());
             CommandLineApplication app = new CommandLineApplication(true)
             {
@@ -123,7 +123,7 @@ namespace BTCPayServer.Configuration
             builder.AppendLine("#mysql=User ID=root;Password=myPassword;Host=localhost;Port=3306;Database=myDataBase;");
             builder.AppendLine();
             builder.AppendLine("### NBXplorer settings ###");
-            foreach (var n in BTCPayNetworkProviderFactory.GetProvider(networkType).GetAll().OfType<BTCPayNetwork>())
+            foreach (var n in BTCPayNetworkProviderFactory.Instance[networkType].GetAll().OfType<BTCPayNetwork>())
             {
                 builder.AppendLine($"#{n.CryptoCode}.explorer.url={n.NBXplorerNetwork.DefaultSettings.DefaultUrl}");
                 builder.AppendLine($"#{n.CryptoCode}.explorer.cookiefile={ n.NBXplorerNetwork.DefaultSettings.DefaultCookieFile}");

--- a/BTCPayServer/Controllers/ChangellyController.cs
+++ b/BTCPayServer/Controllers/ChangellyController.cs
@@ -13,16 +13,16 @@ namespace BTCPayServer.Controllers
     [Route("[controller]/{storeId}")]
     public class ChangellyController : Controller
     {
+        private readonly AvailableBTCPayNetworkProvider _availableBtcPayNetworkProvider;
         private readonly ChangellyClientProvider _changellyClientProvider;
         private readonly RateFetcher _RateProviderFactory;
-        private readonly BTCPayServerOptions _BtcPayServerOptions;
 
         public ChangellyController(ChangellyClientProvider changellyClientProvider,
             RateFetcher rateProviderFactory,
-            BTCPayServerOptions btcPayServerOptions)
+            AvailableBTCPayNetworkProvider availableBtcPayNetworkProvider)
         {
+            _availableBtcPayNetworkProvider = availableBtcPayNetworkProvider;
             _RateProviderFactory = rateProviderFactory ?? throw new ArgumentNullException(nameof(rateProviderFactory));
-            _BtcPayServerOptions = btcPayServerOptions;
             _changellyClientProvider = changellyClientProvider;
         }
 
@@ -106,7 +106,7 @@ namespace BTCPayServer.Controllers
             decimal toCurrencyAmount, CancellationToken cancellationToken)
         {
             var store = HttpContext.GetStoreData();
-            var rules = store.GetStoreBlob().GetRateRules(_BtcPayServerOptions.FilteredNetworks);
+            var rules = store.GetStoreBlob().GetRateRules(_availableBtcPayNetworkProvider);
             var rate = await _RateProviderFactory.FetchRate(new CurrencyPair(toCurrency, fromCurrency), rules, cancellationToken);
             if (rate.BidAsk == null) return BadRequest();
             var flatRate = rate.BidAsk.Center;

--- a/BTCPayServer/Controllers/ChangellyController.cs
+++ b/BTCPayServer/Controllers/ChangellyController.cs
@@ -14,20 +14,16 @@ namespace BTCPayServer.Controllers
     public class ChangellyController : Controller
     {
         private readonly ChangellyClientProvider _changellyClientProvider;
-        private readonly BTCPayNetworkProvider _btcPayNetworkProvider;
         private readonly RateFetcher _RateProviderFactory;
         private readonly BTCPayServerOptions _BtcPayServerOptions;
 
         public ChangellyController(ChangellyClientProvider changellyClientProvider,
-            BTCPayNetworkProvider btcPayNetworkProvider,
             RateFetcher rateProviderFactory,
             BTCPayServerOptions btcPayServerOptions)
         {
             _RateProviderFactory = rateProviderFactory ?? throw new ArgumentNullException(nameof(rateProviderFactory));
             _BtcPayServerOptions = btcPayServerOptions;
-
             _changellyClientProvider = changellyClientProvider;
-            _btcPayNetworkProvider = btcPayNetworkProvider;
         }
 
         [HttpGet]
@@ -110,7 +106,7 @@ namespace BTCPayServer.Controllers
             decimal toCurrencyAmount, CancellationToken cancellationToken)
         {
             var store = HttpContext.GetStoreData();
-            var rules = store.GetStoreBlob().GetRateRules(_btcPayNetworkProvider.Filter(_BtcPayServerOptions.SupportedChains));
+            var rules = store.GetStoreBlob().GetRateRules(_BtcPayServerOptions.FilteredNetworks);
             var rate = await _RateProviderFactory.FetchRate(new CurrencyPair(toCurrency, fromCurrency), rules, cancellationToken);
             if (rate.BidAsk == null) return BadRequest();
             var flatRate = rate.BidAsk.Center;

--- a/BTCPayServer/Controllers/InvoiceController.UI.cs
+++ b/BTCPayServer/Controllers/InvoiceController.UI.cs
@@ -219,7 +219,7 @@ namespace BTCPayServer.Controllers
             if (network == null && isDefaultPaymentId)
             {
                 //TODO: need to look into a better way for this as it does not scale
-                network = _BtcPayServerOptions.FilteredNetworks.OfType<BTCPayNetwork>().FirstOrDefault();
+                network = _AvailableBtcPayNetworkProvider.GetAll().OfType<BTCPayNetwork>().FirstOrDefault();
                 paymentMethodId = new PaymentMethodId(network.CryptoCode, PaymentTypes.BTCLike);
             }
             if (invoice == null || network == null)

--- a/BTCPayServer/Controllers/InvoiceController.UI.cs
+++ b/BTCPayServer/Controllers/InvoiceController.UI.cs
@@ -219,7 +219,7 @@ namespace BTCPayServer.Controllers
             if (network == null && isDefaultPaymentId)
             {
                 //TODO: need to look into a better way for this as it does not scale
-                network = _NetworkProvider.Filter(_BtcPayServerOptions.SupportedChains).OfType<BTCPayNetwork>().FirstOrDefault();
+                network = _BtcPayServerOptions.FilteredNetworks.OfType<BTCPayNetwork>().FirstOrDefault();
                 paymentMethodId = new PaymentMethodId(network.CryptoCode, PaymentTypes.BTCLike);
             }
             if (invoice == null || network == null)

--- a/BTCPayServer/Controllers/InvoiceController.UI.cs
+++ b/BTCPayServer/Controllers/InvoiceController.UI.cs
@@ -219,7 +219,7 @@ namespace BTCPayServer.Controllers
             if (network == null && isDefaultPaymentId)
             {
                 //TODO: need to look into a better way for this as it does not scale
-                network = _NetworkProvider.GetAll().OfType<BTCPayNetwork>().FirstOrDefault();
+                network = _NetworkProvider.Filter(_BtcPayServerOptions.SupportedChains).OfType<BTCPayNetwork>().FirstOrDefault();
                 paymentMethodId = new PaymentMethodId(network.CryptoCode, PaymentTypes.BTCLike);
             }
             if (invoice == null || network == null)

--- a/BTCPayServer/Controllers/InvoiceController.cs
+++ b/BTCPayServer/Controllers/InvoiceController.cs
@@ -38,7 +38,7 @@ namespace BTCPayServer.Controllers
         EventAggregator _EventAggregator;
         BTCPayNetworkProvider _NetworkProvider;
         private readonly PaymentMethodHandlerDictionary _paymentMethodHandlerDictionary;
-        private readonly BTCPayServerOptions _BtcPayServerOptions;
+        private readonly AvailableBTCPayNetworkProvider _AvailableBtcPayNetworkProvider;
 
         public InvoiceController(
             InvoiceRepository invoiceRepository,
@@ -50,7 +50,7 @@ namespace BTCPayServer.Controllers
             ContentSecurityPolicies csp,
             BTCPayNetworkProvider networkProvider,
             PaymentMethodHandlerDictionary paymentMethodHandlerDictionary,
-            BTCPayServerOptions btcPayServerOptions)
+            AvailableBTCPayNetworkProvider availableBtcPayNetworkProvider)
         {
             _CurrencyNameTable = currencyNameTable ?? throw new ArgumentNullException(nameof(currencyNameTable));
             _StoreRepository = storeRepository ?? throw new ArgumentNullException(nameof(storeRepository));
@@ -60,7 +60,7 @@ namespace BTCPayServer.Controllers
             _EventAggregator = eventAggregator;
             _NetworkProvider = networkProvider;
             _paymentMethodHandlerDictionary = paymentMethodHandlerDictionary;
-            _BtcPayServerOptions = btcPayServerOptions;
+            _AvailableBtcPayNetworkProvider = availableBtcPayNetworkProvider;
             _CSP = csp;
         }
 
@@ -156,7 +156,7 @@ namespace BTCPayServer.Controllers
                     currencyPairsToFetch.Add(new CurrencyPair(network.CryptoCode, storeBlob.OnChainMinValue.Currency));
             }
 
-            var rateRules = storeBlob.GetRateRules(_BtcPayServerOptions.FilteredNetworks);
+            var rateRules = storeBlob.GetRateRules(_AvailableBtcPayNetworkProvider);
             var fetchingByCurrencyPair = _RateProvider.FetchRates(currencyPairsToFetch, rateRules, cancellationToken);
             var fetchingAll = WhenAllFetched(logs, fetchingByCurrencyPair);
             var supportedPaymentMethods = store.GetSupportedPaymentMethods(_NetworkProvider)

--- a/BTCPayServer/Controllers/InvoiceController.cs
+++ b/BTCPayServer/Controllers/InvoiceController.cs
@@ -156,7 +156,7 @@ namespace BTCPayServer.Controllers
                     currencyPairsToFetch.Add(new CurrencyPair(network.CryptoCode, storeBlob.OnChainMinValue.Currency));
             }
 
-            var rateRules = storeBlob.GetRateRules(_NetworkProvider.Filter(_BtcPayServerOptions.SupportedChains));
+            var rateRules = storeBlob.GetRateRules(_BtcPayServerOptions.FilteredNetworks);
             var fetchingByCurrencyPair = _RateProvider.FetchRates(currencyPairsToFetch, rateRules, cancellationToken);
             var fetchingAll = WhenAllFetched(logs, fetchingByCurrencyPair);
             var supportedPaymentMethods = store.GetSupportedPaymentMethods(_NetworkProvider)

--- a/BTCPayServer/Controllers/RateController.cs
+++ b/BTCPayServer/Controllers/RateController.cs
@@ -153,7 +153,7 @@ namespace BTCPayServer.Controllers
             }
 
 
-            var rules = store.GetStoreBlob().GetRateRules(_NetworkProvider.Filter(_BtcPayServerOptions.SupportedChains));
+            var rules = store.GetStoreBlob().GetRateRules(_BtcPayServerOptions.FilteredNetworks);
 
             HashSet<CurrencyPair> pairs = new HashSet<CurrencyPair>();
             foreach (var currency in currencyPairs.Split(','))

--- a/BTCPayServer/Controllers/RateController.cs
+++ b/BTCPayServer/Controllers/RateController.cs
@@ -14,6 +14,7 @@ using Microsoft.AspNetCore.Authorization;
 using BTCPayServer.Authentication;
 using Microsoft.AspNetCore.Cors;
 using System.Threading;
+using BTCPayServer.Configuration;
 
 namespace BTCPayServer.Controllers
 {
@@ -25,6 +26,7 @@ namespace BTCPayServer.Controllers
         RateFetcher _RateProviderFactory;
         BTCPayNetworkProvider _NetworkProvider;
         CurrencyNameTable _CurrencyNameTable;
+        private readonly BTCPayServerOptions _BtcPayServerOptions;
         StoreRepository _StoreRepo;
 
         public TokenRepository TokenRepository { get; }
@@ -34,13 +36,15 @@ namespace BTCPayServer.Controllers
             BTCPayNetworkProvider networkProvider,
             TokenRepository tokenRepository,
             StoreRepository storeRepo,
-            CurrencyNameTable currencyNameTable)
+            CurrencyNameTable currencyNameTable, 
+            BTCPayServerOptions btcPayServerOptions)
         {
             _RateProviderFactory = rateProviderFactory ?? throw new ArgumentNullException(nameof(rateProviderFactory));
             _NetworkProvider = networkProvider;
             TokenRepository = tokenRepository;
             _StoreRepo = storeRepo;
             _CurrencyNameTable = currencyNameTable ?? throw new ArgumentNullException(nameof(currencyNameTable));
+            _BtcPayServerOptions = btcPayServerOptions;
         }
 
         [Route("rates/{baseCurrency}")]
@@ -149,7 +153,7 @@ namespace BTCPayServer.Controllers
             }
 
 
-            var rules = store.GetStoreBlob().GetRateRules(_NetworkProvider);
+            var rules = store.GetStoreBlob().GetRateRules(_NetworkProvider.Filter(_BtcPayServerOptions.SupportedChains));
 
             HashSet<CurrencyPair> pairs = new HashSet<CurrencyPair>();
             foreach (var currency in currencyPairs.Split(','))

--- a/BTCPayServer/Controllers/RateController.cs
+++ b/BTCPayServer/Controllers/RateController.cs
@@ -25,8 +25,8 @@ namespace BTCPayServer.Controllers
     {
         RateFetcher _RateProviderFactory;
         BTCPayNetworkProvider _NetworkProvider;
+        private readonly AvailableBTCPayNetworkProvider _AvailableBtcPayNetworkProvider;
         CurrencyNameTable _CurrencyNameTable;
-        private readonly BTCPayServerOptions _BtcPayServerOptions;
         StoreRepository _StoreRepo;
 
         public TokenRepository TokenRepository { get; }
@@ -34,17 +34,17 @@ namespace BTCPayServer.Controllers
         public RateController(
             RateFetcher rateProviderFactory,
             BTCPayNetworkProvider networkProvider,
+            AvailableBTCPayNetworkProvider availableBtcPayNetworkProvider,
             TokenRepository tokenRepository,
             StoreRepository storeRepo,
-            CurrencyNameTable currencyNameTable, 
-            BTCPayServerOptions btcPayServerOptions)
+            CurrencyNameTable currencyNameTable)
         {
             _RateProviderFactory = rateProviderFactory ?? throw new ArgumentNullException(nameof(rateProviderFactory));
             _NetworkProvider = networkProvider;
+            _AvailableBtcPayNetworkProvider = availableBtcPayNetworkProvider;
             TokenRepository = tokenRepository;
             _StoreRepo = storeRepo;
             _CurrencyNameTable = currencyNameTable ?? throw new ArgumentNullException(nameof(currencyNameTable));
-            _BtcPayServerOptions = btcPayServerOptions;
         }
 
         [Route("rates/{baseCurrency}")]
@@ -153,7 +153,7 @@ namespace BTCPayServer.Controllers
             }
 
 
-            var rules = store.GetStoreBlob().GetRateRules(_BtcPayServerOptions.FilteredNetworks);
+            var rules = store.GetStoreBlob().GetRateRules(_AvailableBtcPayNetworkProvider);
 
             HashSet<CurrencyPair> pairs = new HashSet<CurrencyPair>();
             foreach (var currency in currencyPairs.Split(','))

--- a/BTCPayServer/Controllers/StoresController.LightningLike.cs
+++ b/BTCPayServer/Controllers/StoresController.LightningLike.cs
@@ -50,7 +50,7 @@ namespace BTCPayServer.Controllers
 
         private LightningConnectionString GetInternalLighningNode(string cryptoCode)
         {
-            if (_BtcpayServerOptions.InternalLightningByCryptoCode.TryGetValue(cryptoCode, out var connectionString))
+            if (_BtcPayServerOptions.InternalLightningByCryptoCode.TryGetValue(cryptoCode, out var connectionString))
             {
                 return CanUseInternalLightning() ? connectionString : null;
             }

--- a/BTCPayServer/Controllers/StoresController.cs
+++ b/BTCPayServer/Controllers/StoresController.cs
@@ -195,7 +195,7 @@ namespace BTCPayServer.Controllers
         [Route("{storeId}/rates")]
         public IActionResult Rates(string storeId)
         {
-            var networks = _NetworkProvider.Filter(_BtcpayServerOptions.SupportedChains).ToArray();
+            var networks = _BtcpayServerOptions.FilteredNetworks;
             var storeBlob = StoreData.GetStoreBlob();
             var vm = new RatesViewModel();
             vm.SetExchangeRates(GetSupportedExchanges(), storeBlob.PreferredExchange ?? CoinAverageRateProvider.CoinAverageName);
@@ -234,7 +234,7 @@ namespace BTCPayServer.Controllers
             if (model.PreferredExchange != null)
                 model.PreferredExchange = model.PreferredExchange.Trim().ToLowerInvariant();
 
-            var networks = _NetworkProvider.Filter(_BtcpayServerOptions.SupportedChains);
+            var networks = _BtcpayServerOptions.FilteredNetworks;
             var blob = StoreData.GetStoreBlob();
             model.DefaultScript = blob.GetDefaultRateRules(networks).ToString();
             model.AvailableExchanges = GetSupportedExchanges();
@@ -340,7 +340,7 @@ namespace BTCPayServer.Controllers
         {
             var blob = StoreData.GetStoreBlob();
             blob.RateScripting = scripting;
-            var networks = _NetworkProvider.Filter(_BtcpayServerOptions.SupportedChains);
+            var networks = _BtcpayServerOptions.FilteredNetworks;
             blob.RateScript = blob.GetDefaultRateRules(networks).ToString();
             StoreData.SetStoreBlob(blob);
             await _Repo.UpdateStore(StoreData);

--- a/BTCPayServer/Controllers/StoresController.cs
+++ b/BTCPayServer/Controllers/StoresController.cs
@@ -58,7 +58,8 @@ namespace BTCPayServer.Controllers
             ChangellyClientProvider changellyClientProvider,
             IOptions<MvcJsonOptions> mvcJsonOptions,
             IHostingEnvironment env, IHttpClientFactory httpClientFactory,
-            PaymentMethodHandlerDictionary paymentMethodHandlerDictionary)
+            PaymentMethodHandlerDictionary paymentMethodHandlerDictionary,
+            CurrencyNameTable currencyNameTable)
         {
             _RateFactory = rateFactory;
             _Repo = repo;
@@ -72,6 +73,7 @@ namespace BTCPayServer.Controllers
             _Env = env;
             _httpClientFactory = httpClientFactory;
             _paymentMethodHandlerDictionary = paymentMethodHandlerDictionary;
+            _CurrencyNameTable = currencyNameTable;
             _NetworkProvider = networkProvider;
             _ExplorerProvider = explorerProvider;
             _FeeRateProvider = feeRateProvider;
@@ -95,6 +97,7 @@ namespace BTCPayServer.Controllers
         IHostingEnvironment _Env;
         private IHttpClientFactory _httpClientFactory;
         private readonly PaymentMethodHandlerDictionary _paymentMethodHandlerDictionary;
+        private readonly CurrencyNameTable _CurrencyNameTable;
 
         [TempData]
         public string StatusMessage
@@ -384,7 +387,7 @@ namespace BTCPayServer.Controllers
             CurrencyValue lightningMaxValue = null;
             if (!string.IsNullOrWhiteSpace(model.LightningMaxValue))
             {
-                if (!CurrencyValue.TryParse(model.LightningMaxValue, out lightningMaxValue))
+                if (!CurrencyValue.TryParse(model.LightningMaxValue,_CurrencyNameTable, out lightningMaxValue))
                 {
                     ModelState.AddModelError(nameof(model.LightningMaxValue), "Invalid lightning max value");
                 }
@@ -393,7 +396,7 @@ namespace BTCPayServer.Controllers
             CurrencyValue onchainMinValue = null;
             if (!string.IsNullOrWhiteSpace(model.OnChainMinValue))
             {
-                if (!CurrencyValue.TryParse(model.OnChainMinValue, out onchainMinValue))
+                if (!CurrencyValue.TryParse(model.OnChainMinValue, _CurrencyNameTable, out onchainMinValue))
                 {
                     ModelState.AddModelError(nameof(model.OnChainMinValue), "Invalid on chain min value");
                 }

--- a/BTCPayServer/Controllers/StoresController.cs
+++ b/BTCPayServer/Controllers/StoresController.cs
@@ -58,8 +58,7 @@ namespace BTCPayServer.Controllers
             ChangellyClientProvider changellyClientProvider,
             IOptions<MvcJsonOptions> mvcJsonOptions,
             IHostingEnvironment env, IHttpClientFactory httpClientFactory,
-            PaymentMethodHandlerDictionary paymentMethodHandlerDictionary,
-            CurrencyNameTable currencyNameTable)
+            PaymentMethodHandlerDictionary paymentMethodHandlerDictionary)
         {
             _RateFactory = rateFactory;
             _Repo = repo;
@@ -73,7 +72,6 @@ namespace BTCPayServer.Controllers
             _Env = env;
             _httpClientFactory = httpClientFactory;
             _paymentMethodHandlerDictionary = paymentMethodHandlerDictionary;
-            _CurrencyNameTable = currencyNameTable;
             _NetworkProvider = networkProvider;
             _ExplorerProvider = explorerProvider;
             _FeeRateProvider = feeRateProvider;
@@ -97,7 +95,6 @@ namespace BTCPayServer.Controllers
         IHostingEnvironment _Env;
         private IHttpClientFactory _httpClientFactory;
         private readonly PaymentMethodHandlerDictionary _paymentMethodHandlerDictionary;
-        private readonly CurrencyNameTable _CurrencyNameTable;
 
         [TempData]
         public string StatusMessage
@@ -387,7 +384,7 @@ namespace BTCPayServer.Controllers
             CurrencyValue lightningMaxValue = null;
             if (!string.IsNullOrWhiteSpace(model.LightningMaxValue))
             {
-                if (!CurrencyValue.TryParse(model.LightningMaxValue,_CurrencyNameTable, out lightningMaxValue))
+                if (!CurrencyValue.TryParse(model.LightningMaxValue, out lightningMaxValue))
                 {
                     ModelState.AddModelError(nameof(model.LightningMaxValue), "Invalid lightning max value");
                 }
@@ -396,7 +393,7 @@ namespace BTCPayServer.Controllers
             CurrencyValue onchainMinValue = null;
             if (!string.IsNullOrWhiteSpace(model.OnChainMinValue))
             {
-                if (!CurrencyValue.TryParse(model.OnChainMinValue, _CurrencyNameTable, out onchainMinValue))
+                if (!CurrencyValue.TryParse(model.OnChainMinValue, out onchainMinValue))
                 {
                     ModelState.AddModelError(nameof(model.OnChainMinValue), "Invalid on chain min value");
                 }

--- a/BTCPayServer/Controllers/StoresController.cs
+++ b/BTCPayServer/Controllers/StoresController.cs
@@ -195,13 +195,14 @@ namespace BTCPayServer.Controllers
         [Route("{storeId}/rates")]
         public IActionResult Rates(string storeId)
         {
+            var networks = _NetworkProvider.Filter(_BtcpayServerOptions.SupportedChains).ToArray();
             var storeBlob = StoreData.GetStoreBlob();
             var vm = new RatesViewModel();
             vm.SetExchangeRates(GetSupportedExchanges(), storeBlob.PreferredExchange ?? CoinAverageRateProvider.CoinAverageName);
             vm.Spread = (double)(storeBlob.Spread * 100m);
             vm.StoreId = storeId;
-            vm.Script = storeBlob.GetRateRules(_NetworkProvider).ToString();
-            vm.DefaultScript = storeBlob.GetDefaultRateRules(_NetworkProvider).ToString();
+            vm.Script = storeBlob.GetRateRules(networks).ToString();
+            vm.DefaultScript = storeBlob.GetDefaultRateRules(networks).ToString();
             vm.AvailableExchanges = GetSupportedExchanges();
             vm.DefaultCurrencyPairs = storeBlob.GetDefaultCurrencyPairString();
             vm.ShowScripting = storeBlob.RateScripting;
@@ -233,8 +234,9 @@ namespace BTCPayServer.Controllers
             if (model.PreferredExchange != null)
                 model.PreferredExchange = model.PreferredExchange.Trim().ToLowerInvariant();
 
+            var networks = _NetworkProvider.Filter(_BtcpayServerOptions.SupportedChains);
             var blob = StoreData.GetStoreBlob();
-            model.DefaultScript = blob.GetDefaultRateRules(_NetworkProvider).ToString();
+            model.DefaultScript = blob.GetDefaultRateRules(networks).ToString();
             model.AvailableExchanges = GetSupportedExchanges();
 
             blob.PreferredExchange = model.PreferredExchange;
@@ -265,7 +267,7 @@ namespace BTCPayServer.Controllers
                     model.Script = blob.RateScript;
                 }
             }
-            rules = blob.GetRateRules(_NetworkProvider);
+            rules = blob.GetRateRules(networks);
 
             if (command == "Test")
             {
@@ -338,7 +340,8 @@ namespace BTCPayServer.Controllers
         {
             var blob = StoreData.GetStoreBlob();
             blob.RateScripting = scripting;
-            blob.RateScript = blob.GetDefaultRateRules(_NetworkProvider).ToString();
+            var networks = _NetworkProvider.Filter(_BtcpayServerOptions.SupportedChains);
+            blob.RateScript = blob.GetDefaultRateRules(networks).ToString();
             StoreData.SetStoreBlob(blob);
             await _Repo.UpdateStore(StoreData);
             StatusMessage = "Rate rules scripting activated";

--- a/BTCPayServer/Controllers/WalletsController.cs
+++ b/BTCPayServer/Controllers/WalletsController.cs
@@ -49,7 +49,7 @@ namespace BTCPayServer.Controllers
 
         private readonly IFeeProviderFactory _feeRateProvider;
         private readonly BTCPayWalletProvider _walletProvider;
-        private readonly BTCPayServerOptions _BtcPayServerOptions;
+        private readonly AvailableBTCPayNetworkProvider _AvailableBtcPayNetworkProvider;
         public RateFetcher RateFetcher { get; }
         [TempData]
         public string StatusMessage { get; set; }
@@ -65,7 +65,7 @@ namespace BTCPayServer.Controllers
                                  ExplorerClientProvider explorerProvider,
                                  IFeeProviderFactory feeRateProvider,
                                  BTCPayWalletProvider walletProvider,
-                                 BTCPayServerOptions btcPayServerOptions)
+                                 AvailableBTCPayNetworkProvider availableBtcPayNetworkProvider)
         {
             _currencyTable = currencyTable;
             Repository = repo;
@@ -77,7 +77,7 @@ namespace BTCPayServer.Controllers
             ExplorerClientProvider = explorerProvider;
             _feeRateProvider = feeRateProvider;
             _walletProvider = walletProvider;
-            _BtcPayServerOptions = btcPayServerOptions;
+            _AvailableBtcPayNetworkProvider = availableBtcPayNetworkProvider;
         }
 
         public async Task<IActionResult> ListWallets()
@@ -164,7 +164,7 @@ namespace BTCPayServer.Controllers
             if (network == null)
                 return NotFound();
             var storeData = store.GetStoreBlob();
-            var rateRules = store.GetStoreBlob().GetRateRules(_BtcPayServerOptions.FilteredNetworks);
+            var rateRules = store.GetStoreBlob().GetRateRules(_AvailableBtcPayNetworkProvider);
             rateRules.Spread = 0.0m;
             var currencyPair = new Rating.CurrencyPair(paymentMethod.PaymentId.CryptoCode, GetCurrencyCode(storeData.DefaultLang) ?? "USD");
             double.TryParse(defaultAmount, out var amount);

--- a/BTCPayServer/Controllers/WalletsController.cs
+++ b/BTCPayServer/Controllers/WalletsController.cs
@@ -164,7 +164,7 @@ namespace BTCPayServer.Controllers
             if (network == null)
                 return NotFound();
             var storeData = store.GetStoreBlob();
-            var rateRules = store.GetStoreBlob().GetRateRules(NetworkProvider.Filter(_BtcPayServerOptions.SupportedChains));
+            var rateRules = store.GetStoreBlob().GetRateRules(_BtcPayServerOptions.FilteredNetworks);
             rateRules.Spread = 0.0m;
             var currencyPair = new Rating.CurrencyPair(paymentMethod.PaymentId.CryptoCode, GetCurrencyCode(storeData.DefaultLang) ?? "USD");
             double.TryParse(defaultAmount, out var amount);

--- a/BTCPayServer/Controllers/WalletsController.cs
+++ b/BTCPayServer/Controllers/WalletsController.cs
@@ -7,6 +7,7 @@ using System.Net.WebSockets;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using BTCPayServer.Configuration;
 using BTCPayServer.Data;
 using BTCPayServer.HostedServices;
 using BTCPayServer.ModelBinders;
@@ -48,6 +49,7 @@ namespace BTCPayServer.Controllers
 
         private readonly IFeeProviderFactory _feeRateProvider;
         private readonly BTCPayWalletProvider _walletProvider;
+        private readonly BTCPayServerOptions _BtcPayServerOptions;
         public RateFetcher RateFetcher { get; }
         [TempData]
         public string StatusMessage { get; set; }
@@ -62,7 +64,8 @@ namespace BTCPayServer.Controllers
                                  RateFetcher rateProvider,
                                  ExplorerClientProvider explorerProvider,
                                  IFeeProviderFactory feeRateProvider,
-                                 BTCPayWalletProvider walletProvider)
+                                 BTCPayWalletProvider walletProvider,
+                                 BTCPayServerOptions btcPayServerOptions)
         {
             _currencyTable = currencyTable;
             Repository = repo;
@@ -74,6 +77,7 @@ namespace BTCPayServer.Controllers
             ExplorerClientProvider = explorerProvider;
             _feeRateProvider = feeRateProvider;
             _walletProvider = walletProvider;
+            _BtcPayServerOptions = btcPayServerOptions;
         }
 
         public async Task<IActionResult> ListWallets()
@@ -160,7 +164,7 @@ namespace BTCPayServer.Controllers
             if (network == null)
                 return NotFound();
             var storeData = store.GetStoreBlob();
-            var rateRules = store.GetStoreBlob().GetRateRules(NetworkProvider);
+            var rateRules = store.GetStoreBlob().GetRateRules(NetworkProvider.Filter(_BtcPayServerOptions.SupportedChains));
             rateRules.Spread = 0.0m;
             var currencyPair = new Rating.CurrencyPair(paymentMethod.PaymentId.CryptoCode, GetCurrencyCode(storeData.DefaultLang) ?? "USD");
             double.TryParse(defaultAmount, out var amount);

--- a/BTCPayServer/CurrencyValue.cs
+++ b/BTCPayServer/CurrencyValue.cs
@@ -11,8 +11,8 @@ namespace BTCPayServer
     public class CurrencyValue
     {
         static Regex _Regex = new Regex("^([0-9]+(\\.[0-9]+)?)\\s*([a-zA-Z]+)$");
-        
-        public static bool TryParse(string str, CurrencyNameTable currencyNameTable, out CurrencyValue value)
+        static CurrencyNameTable _CurrencyTable = new CurrencyNameTable();
+        public static bool TryParse(string str, out CurrencyValue value)
         {
             value = null;
             var match = _Regex.Match(str);
@@ -21,7 +21,7 @@ namespace BTCPayServer
                 return false;
 
             var currency = match.Groups.Last().Value.ToUpperInvariant();
-            var currencyData = currencyNameTable.GetCurrencyData(currency, false);
+            var currencyData = _CurrencyTable.GetCurrencyData(currency, false);
             if (currencyData == null)
                 return false;
             v = Math.Round(v, currencyData.Divisibility);

--- a/BTCPayServer/CurrencyValue.cs
+++ b/BTCPayServer/CurrencyValue.cs
@@ -11,8 +11,8 @@ namespace BTCPayServer
     public class CurrencyValue
     {
         static Regex _Regex = new Regex("^([0-9]+(\\.[0-9]+)?)\\s*([a-zA-Z]+)$");
-        static CurrencyNameTable _CurrencyTable = new CurrencyNameTable();
-        public static bool TryParse(string str, out CurrencyValue value)
+        
+        public static bool TryParse(string str, CurrencyNameTable currencyNameTable, out CurrencyValue value)
         {
             value = null;
             var match = _Regex.Match(str);
@@ -21,7 +21,7 @@ namespace BTCPayServer
                 return false;
 
             var currency = match.Groups.Last().Value.ToUpperInvariant();
-            var currencyData = _CurrencyTable.GetCurrencyData(currency, false);
+            var currencyData = currencyNameTable.GetCurrencyData(currency, false);
             if (currencyData == null)
                 return false;
             v = Math.Round(v, currencyData.Divisibility);

--- a/BTCPayServer/Data/StoreData.cs
+++ b/BTCPayServer/Data/StoreData.cs
@@ -64,7 +64,6 @@ namespace BTCPayServer.Data
         }
         public IEnumerable<ISupportedPaymentMethod> GetSupportedPaymentMethods(BTCPayNetworkProvider networks)
         {
-            networks = networks.UnfilteredNetworks;
 #pragma warning disable CS0618
             bool btcReturned = false;
 

--- a/BTCPayServer/Data/StoreData.cs
+++ b/BTCPayServer/Data/StoreData.cs
@@ -399,13 +399,13 @@ namespace BTCPayServer.Data
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.Populate)]
         public double PaymentTolerance { get; set; }
 
-        public BTCPayServer.Rating.RateRules GetRateRules(BTCPayNetworkProvider networkProvider)
+        public BTCPayServer.Rating.RateRules GetRateRules(IEnumerable<BTCPayNetworkBase> networks)
         {
             if (!RateScripting ||
                 string.IsNullOrEmpty(RateScript) ||
                 !BTCPayServer.Rating.RateRules.TryParse(RateScript, out var rules))
             {
-                return GetDefaultRateRules(networkProvider);
+                return GetDefaultRateRules(networks);
             }
             else
             {
@@ -414,10 +414,10 @@ namespace BTCPayServer.Data
             }
         }
 
-        public RateRules GetDefaultRateRules(BTCPayNetworkProvider networkProvider)
+        public RateRules GetDefaultRateRules(IEnumerable<BTCPayNetworkBase> networks)
         {
             StringBuilder builder = new StringBuilder();
-            foreach (var network in networkProvider.GetAll())
+            foreach (var network in networks)
             {
                 if (network.DefaultRateRules.Length != 0)
                 {

--- a/BTCPayServer/Data/StoreData.cs
+++ b/BTCPayServer/Data/StoreData.cs
@@ -399,13 +399,13 @@ namespace BTCPayServer.Data
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.Populate)]
         public double PaymentTolerance { get; set; }
 
-        public BTCPayServer.Rating.RateRules GetRateRules(IEnumerable<BTCPayNetworkBase> networks)
+        public BTCPayServer.Rating.RateRules GetRateRules(BTCPayNetworkProvider networkProvider)
         {
             if (!RateScripting ||
                 string.IsNullOrEmpty(RateScript) ||
                 !BTCPayServer.Rating.RateRules.TryParse(RateScript, out var rules))
             {
-                return GetDefaultRateRules(networks);
+                return GetDefaultRateRules(networkProvider);
             }
             else
             {
@@ -414,10 +414,10 @@ namespace BTCPayServer.Data
             }
         }
 
-        public RateRules GetDefaultRateRules(IEnumerable<BTCPayNetworkBase> networks)
+        public RateRules GetDefaultRateRules(BTCPayNetworkProvider networkProvider)
         {
             StringBuilder builder = new StringBuilder();
-            foreach (var network in networks)
+            foreach (var network in networkProvider.GetAll())
             {
                 if (network.DefaultRateRules.Length != 0)
                 {

--- a/BTCPayServer/ExplorerClientProvider.cs
+++ b/BTCPayServer/ExplorerClientProvider.cs
@@ -15,8 +15,6 @@ namespace BTCPayServer
     {
         BTCPayNetworkProvider _NetworkProviders;
         BTCPayServerOptions _Options;
-
-        public BTCPayNetworkProvider NetworkProviders => _NetworkProviders;
         NBXplorerDashboard _Dashboard;
         public ExplorerClientProvider(IHttpClientFactory httpClientFactory, BTCPayNetworkProvider networkProviders, BTCPayServerOptions options, NBXplorerDashboard dashboard)
         {
@@ -94,7 +92,7 @@ namespace BTCPayServer
 
         public IEnumerable<(BTCPayNetwork, ExplorerClient)> GetAll()
         {
-            foreach (var net in _NetworkProviders.Filter(_Options.SupportedChains).OfType<BTCPayNetwork>())
+            foreach (var net in _Options.FilteredNetworks.OfType<BTCPayNetwork>())
             {
                 if (_Clients.TryGetValue(net.CryptoCode, out ExplorerClient explorer))
                 {

--- a/BTCPayServer/ExplorerClientProvider.cs
+++ b/BTCPayServer/ExplorerClientProvider.cs
@@ -14,13 +14,18 @@ namespace BTCPayServer
     public class ExplorerClientProvider
     {
         BTCPayNetworkProvider _NetworkProviders;
-        BTCPayServerOptions _Options;
         NBXplorerDashboard _Dashboard;
-        public ExplorerClientProvider(IHttpClientFactory httpClientFactory, BTCPayNetworkProvider networkProviders, BTCPayServerOptions options, NBXplorerDashboard dashboard)
+        private readonly AvailableBTCPayNetworkProvider _AvailableBtcPayNetworkProvider;
+
+        public ExplorerClientProvider(IHttpClientFactory httpClientFactory, 
+            BTCPayNetworkProvider networkProviders, 
+            BTCPayServerOptions options, 
+            NBXplorerDashboard dashboard, 
+            AvailableBTCPayNetworkProvider availableBtcPayNetworkProvider)
         {
             _Dashboard = dashboard;
+            _AvailableBtcPayNetworkProvider = availableBtcPayNetworkProvider;
             _NetworkProviders = networkProviders;
-            _Options = options;
 
             foreach (var setting in options.NBXplorerConnectionSettings)
             {
@@ -56,7 +61,7 @@ namespace BTCPayServer
 
         public ExplorerClient GetExplorerClient(string cryptoCode)
         {
-            var network = _NetworkProviders.GetNetwork<BTCPayNetwork>(cryptoCode);
+            var network = _AvailableBtcPayNetworkProvider.GetNetwork<BTCPayNetwork>(cryptoCode);
             if (network == null)
                 return null;
             _Clients.TryGetValue(network.CryptoCode, out ExplorerClient client);
@@ -92,7 +97,7 @@ namespace BTCPayServer
 
         public IEnumerable<(BTCPayNetwork, ExplorerClient)> GetAll()
         {
-            foreach (var net in _Options.FilteredNetworks.OfType<BTCPayNetwork>())
+            foreach (var net in _AvailableBtcPayNetworkProvider.GetAll().OfType<BTCPayNetwork>())
             {
                 if (_Clients.TryGetValue(net.CryptoCode, out ExplorerClient explorer))
                 {

--- a/BTCPayServer/ExplorerClientProvider.cs
+++ b/BTCPayServer/ExplorerClientProvider.cs
@@ -94,7 +94,7 @@ namespace BTCPayServer
 
         public IEnumerable<(BTCPayNetwork, ExplorerClient)> GetAll()
         {
-            foreach (var net in _NetworkProviders.GetAll().OfType<BTCPayNetwork>())
+            foreach (var net in _NetworkProviders.Filter(_Options.SupportedChains).OfType<BTCPayNetwork>())
             {
                 if (_Clients.TryGetValue(net.CryptoCode, out ExplorerClient explorer))
                 {

--- a/BTCPayServer/Extensions.cs
+++ b/BTCPayServer/Extensions.cs
@@ -35,6 +35,7 @@ using Microsoft.EntityFrameworkCore.Infrastructure;
 using NBXplorer.DerivationStrategy;
 using System.Net;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace BTCPayServer
 {
@@ -318,9 +319,11 @@ namespace BTCPayServer
 
         public static IServiceCollection ConfigureBTCPayServer(this IServiceCollection services, IConfiguration conf)
         {
-            services.Configure<BTCPayServerOptions>(o =>
+            services.TryAddSingleton<BTCPayServerOptions>(provider =>
             {
-                o.LoadArgs(conf);
+                var config = new BTCPayServerOptions(provider.GetServices<IBTCPayNetworkProvider>());
+                config.LoadArgs(conf);
+                return config;
             });
             return services;
         }

--- a/BTCPayServer/Hosting/BTCPayServerServices.cs
+++ b/BTCPayServer/Hosting/BTCPayServerServices.cs
@@ -76,8 +76,6 @@ namespace BTCPayServer.Hosting
             services.TryAddSingleton<SocketFactory>();
             services.TryAddSingleton<LightningClientFactoryService>();
             services.TryAddSingleton<InvoicePaymentNotification>();
-            services.TryAddSingleton<BTCPayServerOptions>(o =>
-                o.GetRequiredService<IOptions<BTCPayServerOptions>>().Value);
             services.AddStartupTask<MigrationStartupTask>();
             services.TryAddSingleton<InvoiceRepository>(o =>
             {

--- a/BTCPayServer/Hosting/BTCPayServerServices.cs
+++ b/BTCPayServer/Hosting/BTCPayServerServices.cs
@@ -115,7 +115,8 @@ namespace BTCPayServer.Hosting
                  
                 return dbContext;
             });
-
+            services.AddSingleton<IBTCPayNetworkProvider, BitcoinBTCPayNetworkProvider>();
+            services.AddSingleton<IBTCPayNetworkProvider, ShitcoinBTCPayNetworkProvider>();
             services.TryAddSingleton<BTCPayNetworkProvider>(o => 
             {
                 var opts = o.GetRequiredService<BTCPayServerOptions>();

--- a/BTCPayServer/Hosting/BTCPayServerServices.cs
+++ b/BTCPayServer/Hosting/BTCPayServerServices.cs
@@ -122,6 +122,7 @@ namespace BTCPayServer.Hosting
                 var opts = o.GetRequiredService<BTCPayServerOptions>();
                 return opts.NetworkProvider;
             });
+            services.TryAddSingleton<AvailableBTCPayNetworkProvider>();
 
             services.TryAddSingleton<AppService>();
             services.TryAddSingleton<Ganss.XSS.HtmlSanitizer>(o =>

--- a/BTCPayServer/JsonConverters/CurrencyValueJsonConverter.cs
+++ b/BTCPayServer/JsonConverters/CurrencyValueJsonConverter.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using System.Reflection;
+using BTCPayServer.Services.Rates;
 using Newtonsoft.Json;
 using NBitcoin.JsonConverters;
 
@@ -10,6 +11,12 @@ namespace BTCPayServer.JsonConverters
 {
     public class CurrencyValueJsonConverter : JsonConverter
     {
+        private readonly CurrencyNameTable _CurrencyNameTable;
+
+        public CurrencyValueJsonConverter(CurrencyNameTable currencyNameTable)
+        {
+            _CurrencyNameTable = currencyNameTable;
+        }
         public override bool CanConvert(Type objectType)
         {
             return typeof(CurrencyValue).GetTypeInfo().IsAssignableFrom(objectType.GetTypeInfo());
@@ -20,7 +27,7 @@ namespace BTCPayServer.JsonConverters
             try
             {
                 return reader.TokenType == JsonToken.Null ? null :
-                       CurrencyValue.TryParse((string)reader.Value, out var result) ? result :
+                       CurrencyValue.TryParse((string)reader.Value, _CurrencyNameTable, out var result) ? result :
                        throw new JsonObjectException("Invalid Currency value", reader);
             }
             catch (InvalidCastException)

--- a/BTCPayServer/JsonConverters/CurrencyValueJsonConverter.cs
+++ b/BTCPayServer/JsonConverters/CurrencyValueJsonConverter.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using System.Reflection;
-using BTCPayServer.Services.Rates;
 using Newtonsoft.Json;
 using NBitcoin.JsonConverters;
 
@@ -11,12 +10,6 @@ namespace BTCPayServer.JsonConverters
 {
     public class CurrencyValueJsonConverter : JsonConverter
     {
-        private readonly CurrencyNameTable _CurrencyNameTable;
-
-        public CurrencyValueJsonConverter(CurrencyNameTable currencyNameTable)
-        {
-            _CurrencyNameTable = currencyNameTable;
-        }
         public override bool CanConvert(Type objectType)
         {
             return typeof(CurrencyValue).GetTypeInfo().IsAssignableFrom(objectType.GetTypeInfo());
@@ -27,7 +20,7 @@ namespace BTCPayServer.JsonConverters
             try
             {
                 return reader.TokenType == JsonToken.Null ? null :
-                       CurrencyValue.TryParse((string)reader.Value, _CurrencyNameTable, out var result) ? result :
+                       CurrencyValue.TryParse((string)reader.Value, out var result) ? result :
                        throw new JsonObjectException("Invalid Currency value", reader);
             }
             catch (InvalidCastException)

--- a/BTCPayServer/PaymentRequest/PaymentRequestService.cs
+++ b/BTCPayServer/PaymentRequest/PaymentRequestService.cs
@@ -51,7 +51,6 @@ namespace BTCPayServer.PaymentRequest
             }
             else if (pr.Status == PaymentRequestData.PaymentRequestStatus.Pending)
             {
-                var rateRules = pr.StoreData.GetStoreBlob().GetRateRules(_BtcPayNetworkProvider);
                 var invoices = await _PaymentRequestRepository.GetInvoicesForPaymentRequest(pr.Id);
                 var contributions = _AppService.GetContributionsByPaymentMethodId(blob.Currency, invoices, true);
                 if (contributions.TotalCurrency >= blob.Amount)
@@ -76,8 +75,6 @@ namespace BTCPayServer.PaymentRequest
             }
 
             var blob = pr.GetBlob();
-            var rateRules = pr.StoreData.GetStoreBlob().GetRateRules(_BtcPayNetworkProvider);
-
             var invoices = await _PaymentRequestRepository.GetInvoicesForPaymentRequest(id);
 
             var paymentStats = _AppService.GetContributionsByPaymentMethodId(blob.Currency, invoices, true);

--- a/BTCPayServer/Payments/Bitcoin/BitcoinLikePaymentHandler.cs
+++ b/BTCPayServer/Payments/Bitcoin/BitcoinLikePaymentHandler.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading.Tasks;
+using BTCPayServer.Configuration;
 using BTCPayServer.Data;
 using BTCPayServer.Models;
 using BTCPayServer.Models.InvoicingModels;
@@ -21,16 +22,19 @@ namespace BTCPayServer.Payments.Bitcoin
     {
         ExplorerClientProvider _ExplorerProvider;
         private readonly BTCPayNetworkProvider _networkProvider;
+        private readonly BTCPayServerOptions _BtcPayServerOptions;
         private IFeeProviderFactory _FeeRateProviderFactory;
         private Services.Wallets.BTCPayWalletProvider _WalletProvider;
 
         public BitcoinLikePaymentHandler(ExplorerClientProvider provider,
             BTCPayNetworkProvider networkProvider,
+            BTCPayServerOptions btcPayServerOptions,
             IFeeProviderFactory feeRateProviderFactory,
             Services.Wallets.BTCPayWalletProvider walletProvider)
         {
             _ExplorerProvider = provider;
             _networkProvider = networkProvider;
+            _BtcPayServerOptions = btcPayServerOptions;
             _FeeRateProviderFactory = feeRateProviderFactory;
             _WalletProvider = walletProvider;
         }
@@ -108,7 +112,7 @@ namespace BTCPayServer.Payments.Bitcoin
 
         public override IEnumerable<PaymentMethodId> GetSupportedPaymentMethods()
         {
-            return _networkProvider.GetAll()
+            return _BtcPayServerOptions.FilteredNetworks.OfType<BTCPayNetwork>()
                 .Select(network => new PaymentMethodId(network.CryptoCode, PaymentTypes.BTCLike));
         }
 

--- a/BTCPayServer/Payments/Bitcoin/BitcoinLikePaymentHandler.cs
+++ b/BTCPayServer/Payments/Bitcoin/BitcoinLikePaymentHandler.cs
@@ -22,19 +22,19 @@ namespace BTCPayServer.Payments.Bitcoin
     {
         ExplorerClientProvider _ExplorerProvider;
         private readonly BTCPayNetworkProvider _networkProvider;
-        private readonly BTCPayServerOptions _BtcPayServerOptions;
+        private readonly AvailableBTCPayNetworkProvider _AvailableBtcPayNetworkProvider;
         private IFeeProviderFactory _FeeRateProviderFactory;
         private Services.Wallets.BTCPayWalletProvider _WalletProvider;
 
         public BitcoinLikePaymentHandler(ExplorerClientProvider provider,
             BTCPayNetworkProvider networkProvider,
-            BTCPayServerOptions btcPayServerOptions,
+            AvailableBTCPayNetworkProvider availableBtcPayNetworkProvider,
             IFeeProviderFactory feeRateProviderFactory,
             Services.Wallets.BTCPayWalletProvider walletProvider)
         {
             _ExplorerProvider = provider;
             _networkProvider = networkProvider;
-            _BtcPayServerOptions = btcPayServerOptions;
+            _AvailableBtcPayNetworkProvider = availableBtcPayNetworkProvider;
             _FeeRateProviderFactory = feeRateProviderFactory;
             _WalletProvider = walletProvider;
         }
@@ -112,7 +112,7 @@ namespace BTCPayServer.Payments.Bitcoin
 
         public override IEnumerable<PaymentMethodId> GetSupportedPaymentMethods()
         {
-            return _BtcPayServerOptions.FilteredNetworks.OfType<BTCPayNetwork>()
+            return _AvailableBtcPayNetworkProvider.GetAll().OfType<BTCPayNetwork>()
                 .Select(network => new PaymentMethodId(network.CryptoCode, PaymentTypes.BTCLike));
         }
 

--- a/BTCPayServer/Payments/Lightning/LightningLikePaymentHandler.cs
+++ b/BTCPayServer/Payments/Lightning/LightningLikePaymentHandler.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using BTCPayServer.Configuration;
 using BTCPayServer.Data;
 using BTCPayServer.HostedServices;
 using BTCPayServer.Lightning;
@@ -26,17 +27,20 @@ namespace BTCPayServer.Payments.Lightning
         NBXplorerDashboard _Dashboard;
         private readonly LightningClientFactoryService _lightningClientFactory;
         private readonly BTCPayNetworkProvider _networkProvider;
+        private readonly BTCPayServerOptions _BtcPayServerOptions;
         private readonly SocketFactory _socketFactory;
 
         public LightningLikePaymentHandler(
             NBXplorerDashboard dashboard,
             LightningClientFactoryService lightningClientFactory,
             BTCPayNetworkProvider networkProvider,
+            BTCPayServerOptions btcPayServerOptions,
             SocketFactory socketFactory)
         {
             _Dashboard = dashboard;
             _lightningClientFactory = lightningClientFactory;
             _networkProvider = networkProvider;
+            _BtcPayServerOptions = btcPayServerOptions;
             _socketFactory = socketFactory;
         }
 
@@ -141,7 +145,8 @@ namespace BTCPayServer.Payments.Lightning
 
         public override IEnumerable<PaymentMethodId> GetSupportedPaymentMethods()
         {
-            return _networkProvider.GetAll()
+            return _BtcPayServerOptions.FilteredNetworks.OfType<BTCPayNetwork>()
+                .Where(network => network.NBitcoinNetwork.Consensus.SupportSegwit)
                 .Select(network => new PaymentMethodId(network.CryptoCode, PaymentTypes.LightningLike));
         }
         

--- a/BTCPayServer/Payments/Lightning/LightningLikePaymentHandler.cs
+++ b/BTCPayServer/Payments/Lightning/LightningLikePaymentHandler.cs
@@ -27,20 +27,20 @@ namespace BTCPayServer.Payments.Lightning
         NBXplorerDashboard _Dashboard;
         private readonly LightningClientFactoryService _lightningClientFactory;
         private readonly BTCPayNetworkProvider _networkProvider;
-        private readonly BTCPayServerOptions _BtcPayServerOptions;
+        private readonly AvailableBTCPayNetworkProvider _AvailableBtcPayNetworkProvider;
         private readonly SocketFactory _socketFactory;
 
         public LightningLikePaymentHandler(
             NBXplorerDashboard dashboard,
             LightningClientFactoryService lightningClientFactory,
             BTCPayNetworkProvider networkProvider,
-            BTCPayServerOptions btcPayServerOptions,
+            AvailableBTCPayNetworkProvider availableBtcPayNetworkProvider,
             SocketFactory socketFactory)
         {
             _Dashboard = dashboard;
             _lightningClientFactory = lightningClientFactory;
             _networkProvider = networkProvider;
-            _BtcPayServerOptions = btcPayServerOptions;
+            _AvailableBtcPayNetworkProvider = availableBtcPayNetworkProvider;
             _socketFactory = socketFactory;
         }
 
@@ -145,7 +145,7 @@ namespace BTCPayServer.Payments.Lightning
 
         public override IEnumerable<PaymentMethodId> GetSupportedPaymentMethods()
         {
-            return _BtcPayServerOptions.FilteredNetworks.OfType<BTCPayNetwork>()
+            return _AvailableBtcPayNetworkProvider.GetAll().OfType<BTCPayNetwork>()
                 .Where(network => network.NBitcoinNetwork.Consensus.SupportSegwit)
                 .Select(network => new PaymentMethodId(network.CryptoCode, PaymentTypes.LightningLike));
         }

--- a/BTCPayServer/Payments/Manual/StubBtcPayNetwork.cs
+++ b/BTCPayServer/Payments/Manual/StubBtcPayNetwork.cs
@@ -1,0 +1,6 @@
+namespace BTCPayServer.Payments.Bitcoin
+{
+    public class StubBtcPayNetwork : BTCPayNetworkBase
+    {
+    }
+}

--- a/BTCPayServer/Program.cs
+++ b/BTCPayServer/Program.cs
@@ -39,7 +39,7 @@ namespace BTCPayServer
                 if (conf == null)
                     return;
                 Logs.Configure(loggerFactory);
-                new BTCPayServerOptions().LoadArgs(conf);
+                new BTCPayServerOptions(BTCPayNetworkProviderFactory.GetDefaultNetworkProviders()).LoadArgs(conf);
                 Logs.Configure(null);
                 /////
 

--- a/BTCPayServer/Services/Invoices/InvoiceEntity.cs
+++ b/BTCPayServer/Services/Invoices/InvoiceEntity.cs
@@ -544,7 +544,7 @@ namespace BTCPayServer.Services.Invoices
                     r.CryptoCode = paymentMethodId.CryptoCode;
                     r.PaymentType = paymentMethodId.PaymentType.ToString();
                     r.ParentEntity = this;
-                    r.Network = Networks?.UnfilteredNetworks.GetNetwork<BTCPayNetworkBase>(r.CryptoCode);
+                    r.Network = Networks?.GetNetwork<BTCPayNetworkBase>(r.CryptoCode);
                     paymentMethods.Add(r);
                 }
             }

--- a/BTCPayServer/Services/Invoices/InvoiceRepository.cs
+++ b/BTCPayServer/Services/Invoices/InvoiceRepository.cs
@@ -52,7 +52,7 @@ retry:
             catch when (retryCount++ < 5) { goto retry; }
             _IndexerThread = new CustomThreadPool(1, "Invoice Indexer");
             _ContextFactory = contextFactory;
-            _Networks = networks.UnfilteredNetworks;
+            _Networks = networks;
         }
 
         public InvoiceEntity CreateNewInvoice()

--- a/BTCPayServer/Services/Rates/CurrencyNameTable.cs
+++ b/BTCPayServer/Services/Rates/CurrencyNameTable.cs
@@ -35,11 +35,8 @@ namespace BTCPayServer.Services.Rates
     }
     public class CurrencyNameTable
     {
-        private readonly BTCPayNetworkProvider _BtcPayNetworkProvider;
-
-        public CurrencyNameTable(BTCPayNetworkProvider btcPayNetworkProvider)
+        public CurrencyNameTable()
         {
-            _BtcPayNetworkProvider = btcPayNetworkProvider;
             _Currencies = LoadCurrency().ToDictionary(k => k.Code);
         }
 
@@ -148,7 +145,7 @@ namespace BTCPayServer.Services.Rates
 
         Dictionary<string, CurrencyData> _Currencies;
 
-        CurrencyData[] LoadCurrency()
+        static CurrencyData[] LoadCurrency()
         {
             var stream = Assembly.GetExecutingAssembly().GetManifestResourceStream("BTCPayServer.Currencies.txt");
             string content = null;
@@ -178,7 +175,7 @@ namespace BTCPayServer.Services.Rates
                 }
             }
 
-            foreach (var network in _BtcPayNetworkProvider.GetAll())
+            foreach (var network in BTCPayNetworkProviderFactory.GetProvider(NetworkType.Mainnet).GetAll())
             {
                 if (!dico.TryAdd(network.CryptoCode, new CurrencyData()
                 {

--- a/BTCPayServer/Services/Rates/CurrencyNameTable.cs
+++ b/BTCPayServer/Services/Rates/CurrencyNameTable.cs
@@ -94,7 +94,7 @@ namespace BTCPayServer.Services.Rates
                         catch { }
                     }
 
-                    foreach (var network in new BTCPayNetworkProvider(NetworkType.Mainnet).GetAll())
+                    foreach (var network in BTCPayNetworkProviderFactory.GetProvider(NetworkType.Mainnet).GetAll())
                     {
                         AddCurrency(_CurrencyProviders, network.CryptoCode, 8, network.CryptoCode);
                     }
@@ -175,7 +175,7 @@ namespace BTCPayServer.Services.Rates
                 }
             }
 
-            foreach (var network in new BTCPayNetworkProvider(NetworkType.Mainnet).GetAll())
+            foreach (var network in BTCPayNetworkProviderFactory.GetProvider(NetworkType.Mainnet).GetAll())
             {
                 if (!dico.TryAdd(network.CryptoCode, new CurrencyData()
                 {

--- a/BTCPayServer/Services/Rates/CurrencyNameTable.cs
+++ b/BTCPayServer/Services/Rates/CurrencyNameTable.cs
@@ -94,7 +94,7 @@ namespace BTCPayServer.Services.Rates
                         catch { }
                     }
 
-                    foreach (var network in BTCPayNetworkProviderFactory.GetProvider(NetworkType.Mainnet).GetAll())
+                    foreach (var network in BTCPayNetworkProviderFactory.Instance[NetworkType.Mainnet].GetAll())
                     {
                         AddCurrency(_CurrencyProviders, network.CryptoCode, 8, network.CryptoCode);
                     }
@@ -175,7 +175,7 @@ namespace BTCPayServer.Services.Rates
                 }
             }
 
-            foreach (var network in BTCPayNetworkProviderFactory.GetProvider(NetworkType.Mainnet).GetAll())
+            foreach (var network in BTCPayNetworkProviderFactory.Instance[NetworkType.Mainnet].GetAll())
             {
                 if (!dico.TryAdd(network.CryptoCode, new CurrencyData()
                 {

--- a/BTCPayServer/Services/Rates/CurrencyNameTable.cs
+++ b/BTCPayServer/Services/Rates/CurrencyNameTable.cs
@@ -35,8 +35,11 @@ namespace BTCPayServer.Services.Rates
     }
     public class CurrencyNameTable
     {
-        public CurrencyNameTable()
+        private readonly BTCPayNetworkProvider _BtcPayNetworkProvider;
+
+        public CurrencyNameTable(BTCPayNetworkProvider btcPayNetworkProvider)
         {
+            _BtcPayNetworkProvider = btcPayNetworkProvider;
             _Currencies = LoadCurrency().ToDictionary(k => k.Code);
         }
 
@@ -145,7 +148,7 @@ namespace BTCPayServer.Services.Rates
 
         Dictionary<string, CurrencyData> _Currencies;
 
-        static CurrencyData[] LoadCurrency()
+        CurrencyData[] LoadCurrency()
         {
             var stream = Assembly.GetExecutingAssembly().GetManifestResourceStream("BTCPayServer.Currencies.txt");
             string content = null;
@@ -175,7 +178,7 @@ namespace BTCPayServer.Services.Rates
                 }
             }
 
-            foreach (var network in BTCPayNetworkProviderFactory.GetProvider(NetworkType.Mainnet).GetAll())
+            foreach (var network in _BtcPayNetworkProvider.GetAll())
             {
                 if (!dico.TryAdd(network.CryptoCode, new CurrencyData()
                 {

--- a/BTCPayServer/Services/Wallets/BTCPayWalletProvider.cs
+++ b/BTCPayServer/Services/Wallets/BTCPayWalletProvider.cs
@@ -11,9 +11,10 @@ namespace BTCPayServer.Services.Wallets
     public class BTCPayWalletProvider
     {
         private ExplorerClientProvider _Client;
+
         public BTCPayWalletProvider(ExplorerClientProvider client,
             BTCPayServerOptions btcPayServerOptions,
-                                    IOptions<MemoryCacheOptions> memoryCacheOption)
+            IOptions<MemoryCacheOptions> memoryCacheOption)
         {
             if (client == null)
                 throw new ArgumentNullException(nameof(client));

--- a/BTCPayServer/Services/Wallets/BTCPayWalletProvider.cs
+++ b/BTCPayServer/Services/Wallets/BTCPayWalletProvider.cs
@@ -11,23 +11,20 @@ namespace BTCPayServer.Services.Wallets
     public class BTCPayWalletProvider
     {
         private ExplorerClientProvider _Client;
-        IOptions<MemoryCacheOptions> _Options;
         public BTCPayWalletProvider(ExplorerClientProvider client,
             BTCPayServerOptions btcPayServerOptions,
-                                    IOptions<MemoryCacheOptions> memoryCacheOption,
-                                    BTCPayNetworkProvider networkProvider)
+                                    IOptions<MemoryCacheOptions> memoryCacheOption)
         {
             if (client == null)
                 throw new ArgumentNullException(nameof(client));
             _Client = client;
-            _Options = memoryCacheOption;
 
-            foreach(var network in networkProvider.Filter(btcPayServerOptions.SupportedChains).OfType<BTCPayNetwork>())
+            foreach(var network in btcPayServerOptions.FilteredNetworks.OfType<BTCPayNetwork>())
             {
                 var explorerClient = _Client.GetExplorerClient(network.CryptoCode);
                 if (explorerClient == null)
                     continue;
-                _Wallets.Add(network.CryptoCode, new BTCPayWallet(explorerClient, new MemoryCache(_Options), network));
+                _Wallets.Add(network.CryptoCode, new BTCPayWallet(explorerClient, new MemoryCache(memoryCacheOption), network));
             }
         }
 

--- a/BTCPayServer/Services/Wallets/BTCPayWalletProvider.cs
+++ b/BTCPayServer/Services/Wallets/BTCPayWalletProvider.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using BTCPayServer.Configuration;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Options;
 
@@ -10,19 +11,18 @@ namespace BTCPayServer.Services.Wallets
     public class BTCPayWalletProvider
     {
         private ExplorerClientProvider _Client;
-        BTCPayNetworkProvider _NetworkProvider;
         IOptions<MemoryCacheOptions> _Options;
         public BTCPayWalletProvider(ExplorerClientProvider client,
+            BTCPayServerOptions btcPayServerOptions,
                                     IOptions<MemoryCacheOptions> memoryCacheOption,
                                     BTCPayNetworkProvider networkProvider)
         {
             if (client == null)
                 throw new ArgumentNullException(nameof(client));
             _Client = client;
-            _NetworkProvider = networkProvider;
             _Options = memoryCacheOption;
 
-            foreach(var network in networkProvider.GetAll().OfType<BTCPayNetwork>())
+            foreach(var network in networkProvider.Filter(btcPayServerOptions.SupportedChains).OfType<BTCPayNetwork>())
             {
                 var explorerClient = _Client.GetExplorerClient(network.CryptoCode);
                 if (explorerClient == null)


### PR DESCRIPTION
Still a bit rough; this is a first step to eventually allow the possibility to use DI to add networks( and make the shitcoins code be in a separate dll/project). There's a static factory method so far that replaces the tricky parts of the code where you create new instances of the network provider whichI hope to clear out later on