### PR TITLE
Increasing default monitoring expiration time

### DIFF
--- a/BTCPayServer/Data/StoreData.cs
+++ b/BTCPayServer/Data/StoreData.cs
@@ -298,7 +298,7 @@ namespace BTCPayServer.Data
         public StoreBlob()
         {
             InvoiceExpiration = 15;
-            MonitoringExpiration = 60;
+            MonitoringExpiration = 1440;
             PaymentTolerance = 0;
             RequiresRefundEmail = true;
         }


### PR DESCRIPTION
With value 60 what would often happen is that invoice ends up being declared invalid, and then payment arrives later when system is not monitoring. After lots of production testing we decided to increase this value by default so that new users don't need to manually reassign invoices from `invalid` status, especially if they use third party plugin like wooCommerce.