### PR TITLE
Prevent autofilling SMTP config user and password

### DIFF
--- a/BTCPayServer/Services/Mails/EmailSettings.cs
+++ b/BTCPayServer/Services/Mails/EmailSettings.cs
@@ -24,7 +24,7 @@ namespace BTCPayServer.Services.Mails
         {
             get; set;
         }
-        [DataType(DataType.Password)]
+        
         public string Password
         {
             get; set;

--- a/BTCPayServer/Views/Shared/EmailsBody.cshtml
+++ b/BTCPayServer/Views/Shared/EmailsBody.cshtml
@@ -10,7 +10,7 @@
 </div>
 <div class="row">
     <div class="col-md-6">
-        <form method="post">
+        <form method="post" autocomplete="off">
             <div class="form-group">
                 <label asp-for="Settings.Server"></label>
                 <input asp-for="Settings.Server" class="form-control" />


### PR DESCRIPTION
Prevent autofilling SMTP config user and password.
Browser won't try to auto-fill the username and password anymore. This can mess up your form and your settings if you hit "save".