### PR TITLE
Prevent layout from breaking on hyperlinks with very long URLs as the visible text

### DIFF
--- a/BTCPayServer/Views/Invoice/Invoice.cshtml
+++ b/BTCPayServer/Views/Invoice/Invoice.cshtml
@@ -15,7 +15,7 @@
         width: 140px;
     }
 </style>
-<section>
+<section class="invoice-details">
     <div class="container">
         @if (!string.IsNullOrEmpty(Model.StatusMessage))
         {

--- a/BTCPayServer/wwwroot/main/css/site.css
+++ b/BTCPayServer/wwwroot/main/css/site.css
@@ -114,3 +114,8 @@ a.nav-link {
         max-width: 600px;
     }
 }
+
+.invoice-details a{
+    /* Prevent layout from breaking on hyperlinks with very long URLs as the visible text */
+    word-break: break-word;
+}


### PR DESCRIPTION
Fixes broken layout like this.
The link text should be word wrapped so the table doesn't stretch wider.

![image](https://user-images.githubusercontent.com/71019/62421992-526c4180-b6ab-11e9-9392-dce42056cf5c.png)
