### PR TITLE
Add policy to allow internal lightning node for non-admins

### DIFF
--- a/BTCPayServer/Controllers/StoresController.LightningLike.cs
+++ b/BTCPayServer/Controllers/StoresController.LightningLike.cs
@@ -178,7 +178,7 @@ namespace BTCPayServer.Controllers
 
         private bool CanUseInternalLightning()
         {
-            return (_BTCPayEnv.IsDevelopping || User.IsInRole(Roles.ServerAdmin));
+            return (_BTCPayEnv.IsDevelopping || User.IsInRole(Roles.ServerAdmin) || _CssThemeManager.AllowLightningInternalNodeForAll);
         }
     }
 }

--- a/BTCPayServer/Controllers/StoresController.cs
+++ b/BTCPayServer/Controllers/StoresController.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using BTCPayServer.Authentication;
 using BTCPayServer.Configuration;
 using BTCPayServer.Data;
+using BTCPayServer.HostedServices;
 using BTCPayServer.Models;
 using BTCPayServer.Models.AppViewModels;
 using BTCPayServer.Models.StoreViewModels;
@@ -58,7 +59,8 @@ namespace BTCPayServer.Controllers
             ChangellyClientProvider changellyClientProvider,
             IOptions<MvcJsonOptions> mvcJsonOptions,
             IHostingEnvironment env, IHttpClientFactory httpClientFactory,
-            PaymentMethodHandlerDictionary paymentMethodHandlerDictionary)
+            PaymentMethodHandlerDictionary paymentMethodHandlerDictionary,
+            CssThemeManager cssThemeManager)
         {
             _RateFactory = rateFactory;
             _Repo = repo;
@@ -72,6 +74,7 @@ namespace BTCPayServer.Controllers
             _Env = env;
             _httpClientFactory = httpClientFactory;
             _paymentMethodHandlerDictionary = paymentMethodHandlerDictionary;
+            _CssThemeManager = cssThemeManager;
             _NetworkProvider = networkProvider;
             _ExplorerProvider = explorerProvider;
             _FeeRateProvider = feeRateProvider;
@@ -95,6 +98,7 @@ namespace BTCPayServer.Controllers
         IHostingEnvironment _Env;
         private IHttpClientFactory _httpClientFactory;
         private readonly PaymentMethodHandlerDictionary _paymentMethodHandlerDictionary;
+        private readonly CssThemeManager _CssThemeManager;
 
         [TempData]
         public string StatusMessage

--- a/BTCPayServer/HostedServices/CssThemeManager.cs
+++ b/BTCPayServer/HostedServices/CssThemeManager.cs
@@ -62,7 +62,10 @@ namespace BTCPayServer.HostedServices
             RootAppType = data.RootAppType;
             RootAppId = data.RootAppId;
             DomainToAppMapping = data.DomainToAppMapping;
+            AllowLightningInternalNodeForAll = data.AllowLightningInternalNodeForAll;
         }
+
+        public bool AllowLightningInternalNodeForAll { get; set; }
     }
 
     public class ContentSecurityPolicyCssThemeManager : Attribute, IActionFilter, IOrderedFilter

--- a/BTCPayServer/Services/PoliciesSettings.cs
+++ b/BTCPayServer/Services/PoliciesSettings.cs
@@ -21,6 +21,8 @@ namespace BTCPayServer.Services
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.Populate)]
         [Display(Name = "Discourage search engines from indexing this site")]
         public bool DiscourageSearchEngines { get; set; }
+        [Display(Name = "Allow non-admins to use the internal lightning node in their stores")]
+        public bool AllowLightningInternalNodeForAll { get; set; }
 
         [Display(Name = "Display app on website root")]
         public string RootAppId { get; set; }


### PR DESCRIPTION
Partially related to #204 (but no actual management and accounting of funds in different stores occurs)