### PR TITLE
Fix currentLanguage translation for a number of locales

### DIFF
--- a/BTCPayServer/wwwroot/locales/am-ET.json
+++ b/BTCPayServer/wwwroot/locales/am-ET.json
@@ -1,7 +1,7 @@
 {
   "NOTICE_WARN": "THIS CODE HAS BEEN AUTOMATICALLY GENERATED FROM TRANSIFEX, IF YOU WISH TO HELP TRANSLATION COME ON THE SLACK http://slack.btcpayserver.org TO REQUEST PERMISSION TO https://www.transifex.com/btcpayserver/btcpayserver/",
   "code": "am-ET",
-  "currentLanguage": "እንግሊዝኛ",
+  "currentLanguage": "አማርኛ",
   "lang": "ቋንቋ",
   "Awaiting Payment...": "በመጠባበቅ ላይ ያለ ክፍያ ",
   "Pay with": "ይክፈሉ",

--- a/BTCPayServer/wwwroot/locales/bs-BA.json
+++ b/BTCPayServer/wwwroot/locales/bs-BA.json
@@ -1,7 +1,7 @@
 {
   "NOTICE_WARN": "THIS CODE HAS BEEN AUTOMATICALLY GENERATED FROM TRANSIFEX, IF YOU WISH TO HELP TRANSLATION COME ON THE SLACK http://slack.btcpayserver.org TO REQUEST PERMISSION TO https://www.transifex.com/btcpayserver/btcpayserver/",
   "code": "bs-BA",
-  "currentLanguage": "Engleski",
+  "currentLanguage": "Hrvatski",
   "lang": "Jezik",
   "Awaiting Payment...": "Čekam uplatu...",
   "Pay with": "Plati sa",

--- a/BTCPayServer/wwwroot/locales/da-DK.json
+++ b/BTCPayServer/wwwroot/locales/da-DK.json
@@ -1,7 +1,7 @@
 {
   "NOTICE_WARN": "THIS CODE HAS BEEN AUTOMATICALLY GENERATED FROM TRANSIFEX, IF YOU WISH TO HELP TRANSLATION COME ON THE SLACK http://slack.btcpayserver.org TO REQUEST PERMISSION TO https://www.transifex.com/btcpayserver/btcpayserver/",
   "code": "da-DK",
-  "currentLanguage": "Engelsk",
+  "currentLanguage": "Dansk",
   "lang": "Sprog",
   "Awaiting Payment...": "Afventer betaling...",
   "Pay with": "Betal med",

--- a/BTCPayServer/wwwroot/locales/fi-FI.json
+++ b/BTCPayServer/wwwroot/locales/fi-FI.json
@@ -1,7 +1,7 @@
 {
   "NOTICE_WARN": "THIS CODE HAS BEEN AUTOMATICALLY GENERATED FROM TRANSIFEX, IF YOU WISH TO HELP TRANSLATION COME ON THE SLACK http://slack.btcpayserver.org TO REQUEST PERMISSION TO https://www.transifex.com/btcpayserver/btcpayserver/",
   "code": "fi-FI",
-  "currentLanguage": "Englanti",
+  "currentLanguage": "Suomi",
   "lang": "Kieli",
   "Awaiting Payment...": "Odotan maksua...",
   "Pay with": "Maksuvalinta",

--- a/BTCPayServer/wwwroot/locales/lv.json
+++ b/BTCPayServer/wwwroot/locales/lv.json
@@ -1,7 +1,7 @@
 {
   "NOTICE_WARN": "THIS CODE HAS BEEN AUTOMATICALLY GENERATED FROM TRANSIFEX, IF YOU WISH TO HELP TRANSLATION COME ON THE SLACK http://slack.btcpayserver.org TO REQUEST PERMISSION TO https://www.transifex.com/btcpayserver/btcpayserver/",
   "code": "lv",
-  "currentLanguage": "Angļu",
+  "currentLanguage": "Latviešu",
   "lang": "Valoda",
   "Awaiting Payment...": "Maksājuma gaidīšana...",
   "Pay with": "Maksāt ar",


### PR DESCRIPTION
For a number of locales, the translation given for `currentLanguage` was a direct translation of the word "English". It should be the name of the language in the language.


- **am-ET** እንግሊዝኛ (English) should be አማርኛ (Amharic)
- **bs-BA** Engleski (English) should be Hrvatski (Croatian)
- **da-DK** Engelsk (English) should be Dansk (Danish)
- **fi-FI** Englanti (English) should be Suomi (Finnish)
- **lv** Angļu (English) should be Latviešu (Latvian)