### PR TITLE
New Feature: Storage Drop Folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -293,3 +293,4 @@ BTCPayServer/wwwroot/bundles/*
 !BTCPayServer/wwwroot/bundles/.gitignore
 
 .vscode
+BTCPayServer/DropFolder

--- a/BTCPayServer/Configuration/BTCPayServerOptions.cs
+++ b/BTCPayServer/Configuration/BTCPayServerOptions.cs
@@ -42,6 +42,11 @@ namespace BTCPayServer.Configuration
             get;
             private set;
         }
+        public string StorageDropFolder
+        {
+            get;
+            private set;
+        }
         public EndPoint SocksEndpoint { get; set; }
         
         public List<NBXplorerConnectionSetting> NBXplorerConnectionSettings
@@ -70,6 +75,7 @@ namespace BTCPayServer.Configuration
         {
             NetworkType = DefaultConfiguration.GetNetworkType(conf);
             DataDir = conf.GetDataDir(NetworkType);
+            StorageDropFolder = conf.GetOrDefault<string>("storage.dropfolder", null);
             Logs.Configuration.LogInformation("Network: " + NetworkType.ToString());
 
             if (conf.GetOrDefault<bool>("launchsettings", false) && NetworkType != NetworkType.Regtest)

--- a/BTCPayServer/Properties/launchSettings.json
+++ b/BTCPayServer/Properties/launchSettings.json
@@ -43,7 +43,8 @@
                 "BTCPAY_POSTGRES": "User ID=postgres;Host=127.0.0.1;Port=39372;Database=btcpayserver",
                 "BTCPAY_EXTERNALSERVICES": "totoservice:totolink;",
                 "BTCPAY_SSHCONNECTION": "root@127.0.0.1:21622",
-                "BTCPAY_SSHPASSWORD": "opD3i2282D"
+                "BTCPAY_SSHPASSWORD": "opD3i2282D",
+                "BTCPAY_STORAGEDROPFOLDER": "DropFolder"
             },
             "applicationUrl": "https://localhost:14142/"
         }

--- a/BTCPayServer/Storage/Services/DropFolderHostedService.cs
+++ b/BTCPayServer/Storage/Services/DropFolderHostedService.cs
@@ -1,0 +1,137 @@
+using System;
+using System.Collections.Concurrent;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using BTCPayServer.Configuration;
+using BTCPayServer.Data;
+using BTCPayServer.Services;
+using BTCPayServer.Storage.Models;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace BTCPayServer.Storage.Services
+{
+    public class DropFolderHostedService : IHostedService
+    {
+        private readonly BTCPayServerOptions _BTCPayServerOptions;
+        private readonly SettingsRepository _SettingsRepository;
+        private readonly FileService _FileService;
+        private readonly UserManager<ApplicationUser> _UserManager;
+        private ConcurrentQueue<string> uploadQueue = new ConcurrentQueue<string>();
+        private StorageSettings _StorageSettings;
+        private string adminId;
+        private readonly ILogger<DropFolderHostedService> _Logger;
+
+        public DropFolderHostedService(BTCPayServerOptions btcPayServerOptions, SettingsRepository settingsRepository,
+            FileService fileService, UserManager<ApplicationUser> userManager, ILogger<DropFolderHostedService> logger)
+        {
+            _BTCPayServerOptions = btcPayServerOptions;
+            _SettingsRepository = settingsRepository;
+            _FileService = fileService;
+            _UserManager = userManager;
+            _Logger = logger;
+        }
+
+        public Task StartAsync(CancellationToken cancellationToken)
+        {
+            var folder = _BTCPayServerOptions.StorageDropFolder;
+            if (string.IsNullOrEmpty(folder))
+            {
+                return Task.CompletedTask;
+            }
+
+            var dir = !Directory.Exists(folder) ? Directory.CreateDirectory(folder) : new DirectoryInfo(folder);
+
+            _Logger.LogInformation(
+                $"Drop folder configured at {dir.FullName}. Anything moved within it will be uploaded to the configured storage provider.");
+            _ = ListenInOnStorageSettings(cancellationToken);
+            var watcher = new FileSystemWatcher(folder) {IncludeSubdirectories = true, EnableRaisingEvents = true};
+            watcher.Created += WatcherOnCreated;
+            UploadAll();
+            _ = ProcessQueue(cancellationToken);
+            return Task.CompletedTask;
+        }
+
+        private async Task ProcessQueue(CancellationToken token)
+        {
+            while (!token.IsCancellationRequested)
+            {
+                if (adminId == null)
+                {
+                    adminId = (await _UserManager.GetUsersInRoleAsync(Roles.ServerAdmin)).FirstOrDefault()?.Id;
+                    continue;
+                }
+
+                if (!uploadQueue.IsEmpty && (_StorageSettings == null || adminId == null))
+                {
+                    _Logger.LogInformation(
+                        "There are queued files in the drop folder but a storage provider is not configured or else there is no server admin registered yet.");
+                    await Task.Delay(TimeSpan.FromMinutes(1), token);
+                    continue;
+                }
+
+                if (!uploadQueue.TryDequeue(out var file)) continue;
+                if (!File.Exists(file))
+                {
+                    continue;
+                }
+
+                try
+                {
+                    var storedFile = await _FileService.AddFile(new FileInfo(file), adminId);
+                    if (storedFile != null)
+                    {
+                        File.Delete(file);
+                    }
+                }
+                catch (Exception e)
+                {
+                    _Logger.LogWarning($"Could not upload {file} in drop folder because {e.Message}. Queuing again for later.");
+                    uploadQueue.Enqueue(file);
+                }
+            }
+        }
+
+
+        private async Task ListenInOnStorageSettings(CancellationToken cancellationToken)
+        {
+            _StorageSettings = await _SettingsRepository.GetSettingAsync<StorageSettings>();
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                _StorageSettings = await _SettingsRepository.WaitSettingsChanged<StorageSettings>(cancellationToken);
+            }
+        }
+
+        private void UploadAll()
+        {
+            foreach (var file in new DirectoryInfo(_BTCPayServerOptions.StorageDropFolder).GetFiles())
+            {
+                if (uploadQueue.Contains(file.FullName))
+                {
+                    continue;
+                }
+
+                uploadQueue.Enqueue(file.FullName);
+            }
+        }
+
+        private void WatcherOnCreated(object sender, FileSystemEventArgs e)
+        {
+            if (uploadQueue.Contains(e.FullPath))
+            {
+                return;
+            }
+
+            uploadQueue.Enqueue(e.FullPath);
+            _Logger.LogInformation($"new file({e.Name}) in drop folder. Queued for upload.");
+        }
+
+        public Task StopAsync(CancellationToken cancellationToken)
+        {
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/BTCPayServer/Storage/Services/FileService.cs
+++ b/BTCPayServer/Storage/Services/FileService.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using BTCPayServer.Data;
@@ -25,6 +26,17 @@ namespace BTCPayServer.Storage.Services
         }
 
         public async Task<StoredFile> AddFile(IFormFile file, string userId)
+        {
+            var settings = await _SettingsRepository.GetSettingAsync<StorageSettings>();
+            var provider = GetProvider(settings);
+
+            var storedFile = await provider.AddFile(file, settings);
+            storedFile.ApplicationUserId = userId;
+            await _FileRepository.AddFile(storedFile);
+            return storedFile;
+        }
+        
+        public async Task<StoredFile> AddFile(FileInfo file, string userId)
         {
             var settings = await _SettingsRepository.GetSettingAsync<StorageSettings>();
             var provider = GetProvider(settings);

--- a/BTCPayServer/Storage/Services/Providers/IStorageProviderService.cs
+++ b/BTCPayServer/Storage/Services/Providers/IStorageProviderService.cs
@@ -1,4 +1,5 @@
 using System;
+using System.IO;
 using System.Threading.Tasks;
 using BTCPayServer.Data;
 using BTCPayServer.Storage.Models;
@@ -15,5 +16,6 @@ namespace BTCPayServer.Storage.Services.Providers
         Task<string> GetTemporaryFileUrl(Uri baseUri, StoredFile storedFile, StorageSettings configuration,
             DateTimeOffset expiry, bool isDownload, BlobUrlAccess access = BlobUrlAccess.Read);
         StorageProvider StorageProvider();
+        Task<StoredFile> AddFile(FileInfo formFile, StorageSettings configuration);
     }
 }

--- a/BTCPayServer/Storage/StorageExtensions.cs
+++ b/BTCPayServer/Storage/StorageExtensions.cs
@@ -21,6 +21,7 @@ namespace BTCPayServer.Storage
         {
             serviceCollection.AddSingleton<StoredFileRepository>();
             serviceCollection.AddSingleton<FileService>();
+            serviceCollection.AddHostedService<DropFolderHostedService>();
 //            serviceCollection.AddSingleton<IStorageProviderService, AmazonS3FileProviderService>();
             serviceCollection.AddSingleton<IStorageProviderService, AzureBlobStorageFileProviderService>();
             serviceCollection.AddSingleton<IStorageProviderService, FileSystemFileProviderService>();


### PR DESCRIPTION
Closes #1011

if btcpay_storagedropfolder is set to a directory path, any file moved or created there will be uploaded to the configured storage provider and then removed from the drop folder. If there is no configured provider, it will wait until one is configured. If you put files in the folder when btcpay is not running, it will queue all files on startup