### PR TITLE
Authorize granular permissions 

### DIFF
--- a/BTCPayServer/Authentication/BTCPayScopes.cs
+++ b/BTCPayServer/Authentication/BTCPayScopes.cs
@@ -1,0 +1,97 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+using OpenIddict.Abstractions;
+
+namespace BTCPayServer.Authentication
+{
+    public static class RestAPIPolicies
+    {
+        public static class BTCPayScopes
+        {
+            public const string ViewStores = "view_stores";
+
+            //Create and manage stores
+            public const string StoreManagement = "store_management";
+
+            //create and manage invoices
+            public const string ViewInvoices = "view_invoices";
+
+            //create and manage invoices
+            public const string CreateInvoices = "create_invoice";
+
+            public const string InvoiceManagement = "manage_invoices";
+
+            //view apps
+            public const string ViewApps = "view_apps";
+
+            //create and manage apps
+            public const string AppManagement = "app_management";
+            public const string WalletManagement = "wallet_management";
+        }
+
+        public const string CanViewStores = nameof(CanViewStores);
+        public const string CanManageStores = nameof(CanManageStores);
+        public const string CanViewInvoices = nameof(CanViewInvoices);
+        public const string CanCreateInvoices = nameof(CanCreateInvoices);
+        public const string CanManageInvoices = nameof(CanManageInvoices);
+        public const string CanManageApps = nameof(CanManageApps);
+        public const string CanViewApps = nameof(CanViewApps);
+        public const string CanManageWallet = nameof(CanManageWallet);
+        public const string CanViewProfile = nameof(CanViewProfile);
+
+        public static AuthorizationOptions AddBTCPayRESTApiPolicies(this AuthorizationOptions options)
+        {
+            AddScopePolicy(options, CanViewStores,
+                new[] {new[] {BTCPayScopes.StoreManagement}, new[] {BTCPayScopes.ViewStores}});
+            AddScopePolicy(options, CanManageStores,
+                new[] {new[] {BTCPayScopes.StoreManagement}});
+            AddScopePolicy(options, CanViewInvoices,
+                new[] {new[] {BTCPayScopes.ViewInvoices}, new[] {BTCPayScopes.InvoiceManagement}});
+            AddScopePolicy(options, CanCreateInvoices,
+                new[] {new[] {BTCPayScopes.CreateInvoices}, new[] {BTCPayScopes.InvoiceManagement}});
+            AddScopePolicy(options, CanManageInvoices,
+                new[] {new[] {BTCPayScopes.InvoiceManagement}});
+            AddScopePolicy(options, CanManageApps,
+                new[] {new[] {BTCPayScopes.AppManagement}});
+            AddScopePolicy(options, CanViewApps,
+                new[] {new[] {BTCPayScopes.AppManagement}, new[] {BTCPayScopes.ViewApps}});
+            AddScopePolicy(options, CanManageWallet,
+                new[] {new[] {BTCPayScopes.WalletManagement}});
+            AddScopePolicy(options, CanViewProfile,
+                new[] {new[] {OpenIddictConstants.Scopes.Profile}});
+            return options;
+        }
+
+        private static void AddScopePolicy(AuthorizationOptions options, string name,
+            IEnumerable<IEnumerable<string>> scopeGroups)
+        {
+            options.AddPolicy(name,
+                builder => builder.AddRequirements(new MultipleScopeGroupsRequirement(scopeGroups)));
+        }
+    }
+
+    public class MultipleScopeGroupsRequirement :
+        AuthorizationHandler<MultipleScopeGroupsRequirement>, IAuthorizationRequirement
+    {
+        private readonly IEnumerable<IEnumerable<string>> _ScopeGroups;
+
+        public MultipleScopeGroupsRequirement(IEnumerable<IEnumerable<string>> scopeGroups)
+        {
+            _ScopeGroups = scopeGroups;
+        }
+
+        protected override Task HandleRequirementAsync(
+            AuthorizationHandlerContext context, MultipleScopeGroupsRequirement requirement)
+        {
+            if (_ScopeGroups.Any(scopeGroup =>
+                scopeGroup.All(s => context.User.HasClaim(OpenIddictConstants.Claims.Scope, s))))
+            {
+                context.Succeed(requirement);
+            }
+
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/BTCPayServer/Authentication/BTCPayScopes.cs
+++ b/BTCPayServer/Authentication/BTCPayScopes.cs
@@ -47,6 +47,8 @@ namespace BTCPayServer.Authentication
             AddScopePolicy(options, CanViewStores,
                 context => context.HasScopes(BTCPayScopes.StoreManagement) ||
                            context.HasScopes(BTCPayScopes.ViewStores));
+            AddScopePolicy(options, CanManageStores,
+                context => context.HasScopes(BTCPayScopes.StoreManagement));
             AddScopePolicy(options, CanViewInvoices,
                 context => context.HasScopes(BTCPayScopes.ViewInvoices) ||
                            context.HasScopes(BTCPayScopes.InvoiceManagement));

--- a/BTCPayServer/Controllers/AuthorizationController.cs
+++ b/BTCPayServer/Controllers/AuthorizationController.cs
@@ -78,7 +78,7 @@ namespace BTCPayServer.Controllers
             {
                 ApplicationName = await _applicationManager.GetDisplayNameAsync(application),
                 RequestId = request.RequestId,
-                Scope = request.Scope
+                Scope = request.GetScopes()
             });
         }
 

--- a/BTCPayServer/Controllers/RestApi/TestController.cs
+++ b/BTCPayServer/Controllers/RestApi/TestController.cs
@@ -66,38 +66,49 @@ namespace BTCPayServer.Controllers.RestApi
 
         [Authorize(Policy = RestAPIPolicies.CanViewStores,
             AuthenticationSchemes = OpenIddictValidationDefaults.AuthenticationScheme)]
+        [HttpGet(nameof(ScopeCanViewStores))]
         public bool ScopeCanViewStores() { return true; }
 
         [Authorize(Policy = RestAPIPolicies.CanManageStores,
             AuthenticationSchemes = OpenIddictValidationDefaults.AuthenticationScheme)]
+        [HttpGet(nameof(ScopeCanManageStores))]
         public bool ScopeCanManageStores() { return true; }
 
         [Authorize(Policy = RestAPIPolicies.CanViewInvoices,
             AuthenticationSchemes = OpenIddictValidationDefaults.AuthenticationScheme)]
+        [HttpGet(nameof(ScopeCanViewInvoices))]
         public bool ScopeCanViewInvoices() { return true; }
 
         [Authorize(Policy = RestAPIPolicies.CanCreateInvoices,
             AuthenticationSchemes = OpenIddictValidationDefaults.AuthenticationScheme)]
+        [HttpGet(nameof(ScopeCanCreateInvoices))]
         public bool ScopeCanCreateInvoices() { return true; }
 
         [Authorize(Policy = RestAPIPolicies.CanManageInvoices,
             AuthenticationSchemes = OpenIddictValidationDefaults.AuthenticationScheme)]
+        [HttpGet(nameof(ScopeCanManageInvoices))]
         public bool ScopeCanManageInvoices() { return true; }
 
         [Authorize(Policy = RestAPIPolicies.CanManageApps,
             AuthenticationSchemes = OpenIddictValidationDefaults.AuthenticationScheme)]
+        [HttpGet(nameof(ScopeCanManageApps))]
         public bool ScopeCanManageApps() { return true; }
 
         [Authorize(Policy = RestAPIPolicies.CanViewApps,
             AuthenticationSchemes = OpenIddictValidationDefaults.AuthenticationScheme)]
+        
+        [HttpGet(nameof(ScopeCanViewApps))]
         public bool ScopeCanViewApps() { return true; }
 
         [Authorize(Policy = RestAPIPolicies.CanManageWallet,
             AuthenticationSchemes = OpenIddictValidationDefaults.AuthenticationScheme)]
+        [HttpGet(nameof(ScopeCanManageWallet))]
         public bool ScopeCanManageWallet() { return true; }
 
         [Authorize(Policy = RestAPIPolicies.CanViewProfile,
             AuthenticationSchemes = OpenIddictValidationDefaults.AuthenticationScheme)]
+        
+        [HttpGet(nameof(ScopeCanViewProfile))]
         public bool ScopeCanViewProfile() { return true; }
 
         #endregion

--- a/BTCPayServer/Controllers/RestApi/TestController.cs
+++ b/BTCPayServer/Controllers/RestApi/TestController.cs
@@ -1,4 +1,5 @@
 using System.Threading.Tasks;
+using BTCPayServer.Authentication;
 using BTCPayServer.Data;
 using BTCPayServer.Models;
 using BTCPayServer.Security;
@@ -41,9 +42,10 @@ namespace BTCPayServer.Controllers.RestApi
 
         [HttpGet("me/is-admin")]
         public bool AmIAnAdmin()
-        { 
-            return  User.IsInRole(Roles.ServerAdmin);
+        {
+            return User.IsInRole(Roles.ServerAdmin);
         }
+
         [HttpGet("me/stores")]
         public async Task<StoreData[]> GetCurrentUserStores()
         {
@@ -52,10 +54,52 @@ namespace BTCPayServer.Controllers.RestApi
 
 
         [HttpGet("me/stores/{storeId}/can-edit")]
-        [Authorize(Policy = Policies.CanModifyStoreSettings.Key, AuthenticationSchemes = OpenIddictValidationDefaults.AuthenticationScheme)]
+        [Authorize(Policy = Policies.CanModifyStoreSettings.Key,
+            AuthenticationSchemes = OpenIddictValidationDefaults.AuthenticationScheme)]
         public bool CanEdit(string storeId)
         {
             return true;
         }
+
+
+        #region scopes tests
+
+        [Authorize(Policy = RestAPIPolicies.CanViewStores,
+            AuthenticationSchemes = OpenIddictValidationDefaults.AuthenticationScheme)]
+        public bool ScopeCanViewStores() { return true; }
+
+        [Authorize(Policy = RestAPIPolicies.CanManageStores,
+            AuthenticationSchemes = OpenIddictValidationDefaults.AuthenticationScheme)]
+        public bool ScopeCanManageStores() { return true; }
+
+        [Authorize(Policy = RestAPIPolicies.CanViewInvoices,
+            AuthenticationSchemes = OpenIddictValidationDefaults.AuthenticationScheme)]
+        public bool ScopeCanViewInvoices() { return true; }
+
+        [Authorize(Policy = RestAPIPolicies.CanCreateInvoices,
+            AuthenticationSchemes = OpenIddictValidationDefaults.AuthenticationScheme)]
+        public bool ScopeCanCreateInvoices() { return true; }
+
+        [Authorize(Policy = RestAPIPolicies.CanManageInvoices,
+            AuthenticationSchemes = OpenIddictValidationDefaults.AuthenticationScheme)]
+        public bool ScopeCanManageInvoices() { return true; }
+
+        [Authorize(Policy = RestAPIPolicies.CanManageApps,
+            AuthenticationSchemes = OpenIddictValidationDefaults.AuthenticationScheme)]
+        public bool ScopeCanManageApps() { return true; }
+
+        [Authorize(Policy = RestAPIPolicies.CanViewApps,
+            AuthenticationSchemes = OpenIddictValidationDefaults.AuthenticationScheme)]
+        public bool ScopeCanViewApps() { return true; }
+
+        [Authorize(Policy = RestAPIPolicies.CanManageWallet,
+            AuthenticationSchemes = OpenIddictValidationDefaults.AuthenticationScheme)]
+        public bool ScopeCanManageWallet() { return true; }
+
+        [Authorize(Policy = RestAPIPolicies.CanViewProfile,
+            AuthenticationSchemes = OpenIddictValidationDefaults.AuthenticationScheme)]
+        public bool ScopeCanViewProfile() { return true; }
+
+        #endregion
     }
 }

--- a/BTCPayServer/Hosting/BTCPayServerServices.cs
+++ b/BTCPayServer/Hosting/BTCPayServerServices.cs
@@ -237,7 +237,7 @@ namespace BTCPayServer.Hosting
             services.AddSingleton<EmailSenderFactory>();
             // bundling
 
-            services.AddAuthorization(o => Policies.AddBTCPayPolicies(o));
+            services.AddAuthorization(o => o.AddBTCPayPolicies().AddBTCPayRESTApiPolicies());
             services.AddBtcPayServerAuthenticationSchemes(configuration);
 
             services.AddSingleton<IBundleProvider, ResourceBundleProvider>();

--- a/BTCPayServer/Hosting/Startup.cs
+++ b/BTCPayServer/Hosting/Startup.cs
@@ -19,10 +19,13 @@ using Microsoft.AspNetCore.Server.Kestrel.Core;
 using OpenIddict.Abstractions;
 using OpenIddict.EntityFrameworkCore.Models;
 using System.Net;
+using BTCPayServer.Authentication;
 using BTCPayServer.Authentication.OpenId;
 using BTCPayServer.PaymentRequest;
 using BTCPayServer.Services.Apps;
 using BTCPayServer.Storage;
+using Microsoft.Extensions.Options;
+using OpenIddict.Core;
 
 namespace BTCPayServer.Hosting
 {
@@ -160,7 +163,7 @@ namespace BTCPayServer.Hosting
                     options.EnableLogoutEndpoint("/connect/logout");
 
                     //we do not care about these granular controls for now
-                    options.DisableScopeValidation();
+                    options.IgnoreScopePermissions();
                     options.IgnoreEndpointPermissions();
                     // Allow client applications various flows
                     options.AllowImplicitFlow();
@@ -176,7 +179,14 @@ namespace BTCPayServer.Hosting
                         OpenIdConnectConstants.Scopes.OfflineAccess,
                         OpenIdConnectConstants.Scopes.Email,
                         OpenIdConnectConstants.Scopes.Profile,
-                        OpenIddictConstants.Scopes.Roles);
+                        OpenIddictConstants.Scopes.Roles,
+                        RestAPIPolicies.BTCPayScopes.ViewStores,
+                        RestAPIPolicies.BTCPayScopes.CreateInvoices,
+                        RestAPIPolicies.BTCPayScopes.StoreManagement,
+                        RestAPIPolicies.BTCPayScopes.ViewApps,
+                        RestAPIPolicies.BTCPayScopes.AppManagement
+                        );
+                    
                     options.AddEventHandler<PasswordGrantTypeEventHandler>();
                     options.AddEventHandler<AuthorizationCodeGrantTypeEventHandler>();
                     options.AddEventHandler<RefreshTokenGrantTypeEventHandler>();

--- a/BTCPayServer/Models/Authorization/AuthorizeViewModel.cs
+++ b/BTCPayServer/Models/Authorization/AuthorizeViewModel.cs
@@ -1,4 +1,5 @@
-﻿using System.ComponentModel.DataAnnotations;
+﻿using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 
 namespace BTCPayServer.Models.Authorization
@@ -9,6 +10,6 @@ namespace BTCPayServer.Models.Authorization
 
         [BindNever] public string RequestId { get; set; }
 
-        [Display(Name = "Scope")] public string Scope { get; set; }
+        [Display(Name = "Scope")] public IEnumerable<string> Scope { get; set; }
     }
 }

--- a/BTCPayServer/Views/Authorization/Authorize.cshtml
+++ b/BTCPayServer/Views/Authorization/Authorize.cshtml
@@ -1,4 +1,23 @@
-﻿@model BTCPayServer.Models.Authorization.AuthorizeViewModel
+﻿@using BTCPayServer.Authentication
+@using OpenIddict.Abstractions
+@model BTCPayServer.Models.Authorization.AuthorizeViewModel
+@{
+
+    var scopeMappings = new Dictionary<string, (string Title, string Description)>()
+    {
+        {RestAPIPolicies.BTCPayScopes.AppManagement, ("manage your apps", "The app will be able to create, modify and delete all your apps.")},
+        {RestAPIPolicies.BTCPayScopes.ViewApps, ("view your apps", "The app will be able to list and view all your apps.")},
+        {RestAPIPolicies.BTCPayScopes.CreateInvoices, ("create invoices", "The app will be able to create new invoices.")},
+        {RestAPIPolicies.BTCPayScopes.InvoiceManagement, ("manage invoices", "The app will be able to create new invoices and mark existing invoices as complete or invalid.")},
+        {RestAPIPolicies.BTCPayScopes.StoreManagement, ("manage your stores", "The app will be able to create, modify and delete all your stores.")},
+        {RestAPIPolicies.BTCPayScopes.ViewStores, ("view your stores", "The app will be able to list and view all your stores.")},
+        {RestAPIPolicies.BTCPayScopes.WalletManagement, ("manage your wallet", "The app will be able to manage your wallet associate to stores. This includes configuring it, transaction creation and transaction signing")},
+        {RestAPIPolicies.BTCPayScopes.ViewInvoices, ("view your invoices", "The app will be able to list and view all your apps.")},
+        {OpenIddictConstants.Scopes.Email, ("view your email", "The app will have access to your email")},
+        {OpenIddictConstants.Scopes.Profile, ("view your account", "The app will have access to your account")},
+        {OpenIddictConstants.Scopes.Roles, ("view your roles", "The app will know if you are a server admin")},
+       };
+}
 <form method="post">
     <input type="hidden" name="request_id" value="@Model.RequestId"/>
     <section>
@@ -8,6 +27,23 @@
                     <h2 class="section-heading">Authorization Request</h2>
                     <hr class="primary">
                     <p>@Model.ApplicationName is requesting access to your account.</p>
+                </div>
+            </div>
+            <div class="row">
+                <div class="col-lg-12">
+                    <div class="list-group list-group-flush">
+                        @foreach (var scope in Model.Scope)
+                        {
+                            @if (scopeMappings.TryGetValue(scope, out var text))
+                             {
+                                 <li class="list-group-item">
+                                     <h5 class="mb-1">@text.Title</h5>
+                                     <p class="mb-1">@text.Description.</p>
+                                 </li>
+                             }
+                        }
+                    </div>
+
                 </div>
             </div>
             <div class="row">

--- a/BTCPayServer/Views/Authorization/Authorize.cshtml
+++ b/BTCPayServer/Views/Authorization/Authorize.cshtml
@@ -5,23 +5,23 @@
 
     var scopeMappings = new Dictionary<string, (string Title, string Description)>()
     {
-        {RestAPIPolicies.BTCPayScopes.AppManagement, ("manage your apps", "The app will be able to create, modify and delete all your apps.")},
-        {RestAPIPolicies.BTCPayScopes.ViewApps, ("view your apps", "The app will be able to list and view all your apps.")},
-        {RestAPIPolicies.BTCPayScopes.CreateInvoices, ("create invoices", "The app will be able to create new invoices.")},
-        {RestAPIPolicies.BTCPayScopes.InvoiceManagement, ("manage invoices", "The app will be able to create new invoices and mark existing invoices as complete or invalid.")},
-        {RestAPIPolicies.BTCPayScopes.StoreManagement, ("manage your stores", "The app will be able to create, modify and delete all your stores.")},
-        {RestAPIPolicies.BTCPayScopes.ViewStores, ("view your stores", "The app will be able to list and view all your stores.")},
-        {RestAPIPolicies.BTCPayScopes.WalletManagement, ("manage your wallet", "The app will be able to manage your wallet associate to stores. This includes configuring it, transaction creation and transaction signing")},
-        {RestAPIPolicies.BTCPayScopes.ViewInvoices, ("view your invoices", "The app will be able to list and view all your apps.")},
-        {OpenIddictConstants.Scopes.Email, ("view your email", "The app will have access to your email")},
-        {OpenIddictConstants.Scopes.Profile, ("view your account", "The app will have access to your account")},
-        {OpenIddictConstants.Scopes.Roles, ("view your roles", "The app will know if you are a server admin")},
+        {RestAPIPolicies.BTCPayScopes.AppManagement, ("Manage your apps", "The app will be able to create, modify and delete all your apps.")},
+        {RestAPIPolicies.BTCPayScopes.ViewApps, ("View your apps", "The app will be able to list and view all your apps.")},
+        {RestAPIPolicies.BTCPayScopes.CreateInvoices, ("Create invoices", "The app will be able to create new invoices.")},
+        {RestAPIPolicies.BTCPayScopes.InvoiceManagement, ("Manage invoices", "The app will be able to create new invoices and mark existing invoices as complete or invalid.")},
+        {RestAPIPolicies.BTCPayScopes.StoreManagement, ("Manage your stores", "The app will be able to create, modify and delete all your stores.")},
+        {RestAPIPolicies.BTCPayScopes.ViewStores, ("View your stores", "The app will be able to list and view all your stores.")},
+        {RestAPIPolicies.BTCPayScopes.WalletManagement, ("Manage your wallet", "The app will be able to manage your wallet associate to stores. This includes configuring it, transaction creation and signing.")},
+        {RestAPIPolicies.BTCPayScopes.ViewInvoices, ("View your invoices", "The app will be able to list and view all your apps.")},
+        {OpenIddictConstants.Scopes.Email, ("View your email", "The app will have access to your email.")},
+        {OpenIddictConstants.Scopes.Profile, ("View your account", "The app will have access to your account details.")},
+        {OpenIddictConstants.Scopes.Roles, ("View your roles", "The app will know if you are a server admin.")},
        };
 }
 <form method="post">
     <input type="hidden" name="request_id" value="@Model.RequestId"/>
     <section>
-        <div class="container">
+        <div class="card container">
             <div class="row">
                 <div class="col-lg-12 text-center">
                     <h2 class="section-heading">Authorization Request</h2>
@@ -46,10 +46,10 @@
 
                 </div>
             </div>
-            <div class="row">
+            <div class="row mb-2">
                 <div class="col-lg-12 text-center">
                     <div class="btn-group">
-                        <button class="btn btn-lg btn-success" name="consent" id="consent-yes" type="submit" value="Yes">Authorize app</button>
+                        <button class="btn btn-lg btn-primary" name="consent" id="consent-yes" type="submit" value="Yes">Authorize app</button>
                         <button type="button" class="btn btn-primary dropdown-toggle dropdown-toggle-split" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                             <span class="sr-only">Toggle Dropdown</span>
                         </button>

--- a/BTCPayServer/Views/Stores/_Nav.cshtml
+++ b/BTCPayServer/Views/Stores/_Nav.cshtml
@@ -11,3 +11,4 @@
         <partial name="@extension.Partial"/>
     }
 </div>
+


### PR DESCRIPTION
This PR makes the new API authorization require integrations to specify what they would like to be allowed to do once the user authorizes it. Controller action protection is already in place and tested :)
![image](https://user-images.githubusercontent.com/1818366/65406429-cf7c8300-dddf-11e9-90a5-0a61987fcac1.png)
