### PR TITLE
[WIP] Switch to .netcoreapp3.0

### DIFF
--- a/BTCPayServer.Tests/BTCPayServer.Tests.csproj
+++ b/BTCPayServer.Tests/BTCPayServer.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <TargetFramework Condition="'$(TargetFrameworkOverride)' != ''">$(TargetFrameworkOverride)</TargetFramework>
     <IsPackable>false</IsPackable>
     <NoWarn>NU1701,CA1816,CA1308,CA1810,CA2208</NoWarn>

--- a/BTCPayServer.Tests/Dockerfile
+++ b/BTCPayServer.Tests/Dockerfile
@@ -1,8 +1,7 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:2.1.505-alpine3.7 AS builder
-ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT false
-RUN apk add --no-cache icu-libs
-ENV LC_ALL en_US.UTF-8
-ENV LANG en_US.UTF-8
+FROM mcr.microsoft.com/dotnet/core/sdk:3.0.100 AS builder
+
+RUN apt-get update && apt-get install -y --no-install-recommends chromium-driver \
+    && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /source
 COPY nuget.config nuget.config
@@ -11,15 +10,12 @@ COPY BTCPayServer/BTCPayServer.csproj BTCPayServer/BTCPayServer.csproj
 COPY BTCPayServer.Common/BTCPayServer.Common.csproj BTCPayServer.Common/BTCPayServer.Common.csproj
 COPY BTCPayServer.Rating/BTCPayServer.Rating.csproj BTCPayServer.Rating/BTCPayServer.Rating.csproj
 COPY BTCPayServer.Data/BTCPayServer.Data.csproj BTCPayServer.Data/BTCPayServer.Data.csproj
-COPY BTCPayServer.Tests/BTCPayServer.Tests.csproj BTCPayServer.Tests/BTCPayServer.Tests.csproj
-RUN dotnet restore BTCPayServer.Tests/BTCPayServer.Tests.csproj
-
-ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT false
-
-ENV LC_ALL en_US.UTF-8
-ENV LANG en_US.UTF-8
-
-RUN apk add --no-cache chromium chromium-chromedriver icu-libs
+RUN cd BTCPayServer && dotnet restore
+COPY BTCPayServer.Common/. BTCPayServer.Common/.
+COPY BTCPayServer.Rating/. BTCPayServer.Rating/.
+COPY BTCPayServer.Data/. BTCPayServer.Data/.
+COPY BTCPayServer/. BTCPayServer/.
+COPY Build/Version.csproj Build/Version.csproj
 
 ENV SCREEN_HEIGHT 600 \
     SCREEN_WIDTH 1200

--- a/BTCPayServer.Tests/docker-entrypoint.sh
+++ b/BTCPayServer.Tests/docker-entrypoint.sh
@@ -2,8 +2,8 @@
 set -e
 
 FILTERS=" "
-if [[ "$TEST_FILTERS" ]]; then
+if [ ! -z "$TEST_FILTERS" ]; then
 FILTERS="--filter $TEST_FILTERS"
 fi
 
-dotnet test $FILTERS --no-build -v n
+dotnet test $FILTERS --no-build -v n < /dev/null

--- a/Build/Common.csproj
+++ b/Build/Common.csproj
@@ -1,9 +1,9 @@
 <Project>
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <TargetFramework Condition="'$(TargetFrameworkOverride)' != ''">$(TargetFrameworkOverride)</TargetFramework>
     <NoWarn>NU1701,CA1816,CA1308,CA1810,CA2208</NoWarn>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1'">
     <DefineConstants>$(DefineConstants);NETCOREAPP21</DefineConstants>

--- a/amd64.Dockerfile
+++ b/amd64.Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:2.1.505-alpine3.7 AS builder
+FROM mcr.microsoft.com/dotnet/core/sdk:3.0.100 AS builder
 WORKDIR /source
 COPY nuget.config nuget.config
 COPY Build/Common.csproj Build/Common.csproj
@@ -14,16 +14,16 @@ COPY BTCPayServer/. BTCPayServer/.
 COPY Build/Version.csproj Build/Version.csproj
 RUN cd BTCPayServer && dotnet publish --output /app/ --configuration Release
 
-FROM mcr.microsoft.com/dotnet/core/aspnet:2.1.9-alpine3.7
+FROM mcr.microsoft.com/dotnet/core/aspnet:3.0.0-buster-slim
 
-ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT false
-RUN apk add --no-cache icu-libs openssh-keygen
+RUN apt-get update && apt-get install -y --no-install-recommends iproute2 openssh-client \
+    && rm -rf /var/lib/apt/lists/* 
 
 ENV LC_ALL en_US.UTF-8
 ENV LANG en_US.UTF-8
 
+WORKDIR /datadir
 WORKDIR /app
-RUN mkdir /datadir
 ENV BTCPAY_DATADIR=/datadir
 VOLUME /datadir
 

--- a/arm32v7.Dockerfile
+++ b/arm32v7.Dockerfile
@@ -1,5 +1,5 @@
 # This is a manifest image, will pull the image with the same arch as the builder machine
-FROM mcr.microsoft.com/dotnet/core/sdk:2.1.505 AS builder
+FROM mcr.microsoft.com/dotnet/core/sdk:3.0.100 AS builder
 RUN apt-get update \
 	&& apt-get install -qq --no-install-recommends qemu qemu-user-static qemu-user binfmt-support
 
@@ -19,7 +19,7 @@ COPY Build/Version.csproj Build/Version.csproj
 RUN cd BTCPayServer && dotnet publish --output /app/ --configuration Release
 
 # Force the builder machine to take make an arm runtime image. This is fine as long as the builder does not run any program
-FROM mcr.microsoft.com/dotnet/core/aspnet:2.1.9-stretch-slim-arm32v7
+FROM mcr.microsoft.com/dotnet/core/aspnet:3.0.0-buster-slim-arm32v7
 COPY --from=builder /usr/bin/qemu-arm-static /usr/bin/qemu-arm-static
 RUN apt-get update && apt-get install -y --no-install-recommends iproute2 openssh-client \
     && rm -rf /var/lib/apt/lists/* 


### PR DESCRIPTION
This build but crashes at runtime because the following dependencies are still stuck in .netcoreapp2.2:

* [x] [Pomelo.EntityFrameworkCore.MySql](https://github.com/PomeloFoundation/Pomelo.EntityFrameworkCore.MySql) (see [following issue](https://github.com/PomeloFoundation/Pomelo.EntityFrameworkCore.MySql/issues/839))
* [ ] [openiddict-core ](https://github.com/openiddict/openiddict-core)
* [ ] [BundlerMinifier PR](https://github.com/madskristensen/BundlerMinifier/pull/444)

Both library have nightly build for 3.0 support, but we should probably better wait for official release.