### PR TITLE
Add Security.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,7 @@
+Security issues and bugs should be reported privately, via email. To report security a security issue, please send an email to **security@btcpayserver.org** (not for support).
+
+You will receive a reply indicating the next steps in handling your report. If for some reason you do not receive a reply within 24 hours, please follow up via email to ensure the original message was received.
+
+After the initial reply to your report, you will be informed of the progress towards a fix and full announcement. You may be asked to provide additional information or guidance.
+
+We appreciate your efforts to responsibly disclose your findings, and will make every effort to acknowledge your contributions.


### PR DESCRIPTION
This PR adds security.md file and closes #1031 so that security researches can have proper guidance on how to report their findings.