### PR TITLE
Update launchSettings.json

### DIFF
--- a/BTCPayServer/Properties/launchSettings.json
+++ b/BTCPayServer/Properties/launchSettings.json
@@ -46,35 +46,6 @@
                 "BTCPAY_SSHPASSWORD": "opD3i2282D"
             },
             "applicationUrl": "https://localhost:14142/"
-        },
-        "Docker-Regtest-https-monero": {
-            "commandName": "Project",
-            "launchBrowser": true,
-            "environmentVariables": {
-                "BTCPAY_NETWORK": "regtest",
-                "BTCPAY_LAUNCHSETTINGS": "true",
-                "BTCPAY_PORT": "14142",
-                "BTCPAY_HttpsUseDefaultCertificate": "true",
-                "BTCPAY_BUNDLEJSCSS": "false",
-                "BTCPAY_LTCEXPLORERURL": "http://127.0.0.1:32838/",
-                "BTCPAY_BTCLIGHTNING": "type=charge;server=http://127.0.0.1:54938/;api-token=foiewnccewuify",
-                "BTCPAY_BTCEXTERNALLNDGRPC": "type=lnd-grpc;server=https://lnd:lnd@127.0.0.1:53280/;allowinsecure=true",
-                "BTCPAY_BTCEXTERNALLNDREST": "type=lnd-rest;server=https://lnd:lnd@127.0.0.1:53280/lnd-rest/btc/;allowinsecure=true",
-                "BTCPAY_BTCEXTERNALSPARK": "server=/spark/btc/;cookiefile=fake",
-                "BTCPAY_BTCEXTERNALCHARGE": "server=https://127.0.0.1:53280/mycharge/btc/;cookiefilepath=fake",
-                "BTCPAY_BTCEXPLORERURL": "http://127.0.0.1:32838/",
-                "BTCPAY_ALLOW-ADMIN-REGISTRATION": "true",
-                "BTCPAY_DISABLE-REGISTRATION": "false",
-                "ASPNETCORE_ENVIRONMENT": "Development",
-                "BTCPAY_CHAINS": "btc,ltc,xmr",
-                "BTCPAY_POSTGRES": "User ID=postgres;Host=127.0.0.1;Port=39372;Database=btcpayserver",
-                "BTCPAY_EXTERNALSERVICES": "totoservice:totolink;",
-                "BTCPAY_XMR_DAEMON_URI": "http://127.0.0.1:18081",
-                "BTCPAY_XMR_WALLET_DAEMON_URI": "http://127.0.0.1:18082",
-                "BTCPAY_XMR_WALLET_DAEMON_WALLETDIR": "C:/ProgramData/bitmonero/wallet"
-                
-            },
-            "applicationUrl": "https://localhost:14142/"
         }
     }
 }


### PR DESCRIPTION
I`m  the Removing Docker-Regtest-https-monero as this loads as a default, which I didn't ask for, it  default in my builds config, launchSettings json, also I think since this json was changed, it gave my Mac VS a indent bug somehow, ?? But i may be wrong there, 
can Nicolas please review ?? this is the correct way I would remove Docker-Regtest-https-monero from my folk ?? thanks