### PR TITLE
Detection of seed walletunlock.json LND autoinit file

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,11 @@ jobs:
       - checkout
       - run:
           command: |
-            cd .circleci && ./run-tests.sh "ExternalIntegration=ExternalIntegration"
+            if [ "$CIRCLE_PROJECT_USERNAME" == "btcpayserver" ] && [ "$CIRCLE_PROJECT_REPONAME" == "btcpayserver" ]; then
+                cd .circleci && ./run-tests.sh "ExternalIntegration=ExternalIntegration"
+            else
+              echo "Skipping running ExternalIntegration tests outside of context of main user and repository that have access to secrets"
+            fi
 
 
   # publish jobs require $DOCKERHUB_REPO, $DOCKERHUB_USER, $DOCKERHUB_PASS defined

--- a/BTCPayServer.Tests/UnitTest1.cs
+++ b/BTCPayServer.Tests/UnitTest1.cs
@@ -544,7 +544,7 @@ namespace BTCPayServer.Tests
                 user.GrantAccess();
                 var storeController = user.GetController<StoresController>();
                 Assert.IsType<ViewResult>(storeController.UpdateStore());
-                Assert.IsType<ViewResult>(storeController.AddLightningNode(user.StoreId, "BTC"));
+                Assert.IsType<ViewResult>(await storeController.AddLightningNode(user.StoreId, "BTC"));
 
                 var testResult = storeController.AddLightningNode(user.StoreId, new LightningNodeViewModel()
                 {
@@ -1702,11 +1702,11 @@ namespace BTCPayServer.Tests
                 Assert.Equal(3, invoice.CryptoInfo.Length);
 
                 var controller = user.GetController<StoresController>();
-                var lightningVM = (LightningNodeViewModel)Assert.IsType<ViewResult>(controller.AddLightningNode(user.StoreId, "BTC")).Model;
+                var lightningVM = (LightningNodeViewModel)Assert.IsType<ViewResult>(await controller.AddLightningNode(user.StoreId, "BTC")).Model;
                 Assert.True(lightningVM.Enabled);
                 lightningVM.Enabled = false;
                 controller.AddLightningNode(user.StoreId, lightningVM, "save", "BTC").GetAwaiter().GetResult();
-                lightningVM = (LightningNodeViewModel)Assert.IsType<ViewResult>(controller.AddLightningNode(user.StoreId, "BTC")).Model;
+                lightningVM = (LightningNodeViewModel)Assert.IsType<ViewResult>(await controller.AddLightningNode(user.StoreId, "BTC")).Model;
                 Assert.False(lightningVM.Enabled);
 
                 // Only Enabling/Disabling the payment method must redirect to store page

--- a/BTCPayServer.Tests/docker-compose.yml
+++ b/BTCPayServer.Tests/docker-compose.yml
@@ -223,7 +223,7 @@ services:
       - "5432"
 
   merchant_lnd:
-    image: btcpayserver/lnd:v0.7.0-beta
+    image: btcpayserver/lnd:v0.7.1-beta-withseed
     restart: unless-stopped
     environment:
       LND_CHAIN: "btc"
@@ -241,7 +241,6 @@ services:
         bitcoin.defaultchanconfs=1
         no-macaroons=1
         debuglevel=debug
-        noseedbackup=1
         trickledelay=1000
     ports:
       - "53280:8080"
@@ -254,7 +253,7 @@ services:
       - bitcoind
 
   customer_lnd:
-    image: btcpayserver/lnd:v0.7.0-beta
+    image: btcpayserver/lnd:v0.7.1-beta-withseed
     restart: unless-stopped
     environment:
       LND_CHAIN: "btc"
@@ -272,7 +271,6 @@ services:
         bitcoin.defaultchanconfs=1
         no-macaroons=1
         debuglevel=debug
-        noseedbackup=1
         trickledelay=1000
     ports:
       - "53281:8080"

--- a/BTCPayServer/Configuration/BTCPayServerOptions.cs
+++ b/BTCPayServer/Configuration/BTCPayServerOptions.cs
@@ -122,6 +122,12 @@ namespace BTCPayServer.Configuration
                 }
 
                 ExternalServices.Load(net.CryptoCode, conf);
+
+                var val = conf.GetOrDefault<string>($"{net.CryptoCode}.lndseedpath", string.Empty);
+                if (!String.IsNullOrEmpty(val))
+                {
+                    LndSeedPath.Add(net.CryptoCode, val);
+                }
             }
 
             Logs.Configuration.LogInformation("Supported chains: " + String.Join(',', supportedChains.ToArray()));
@@ -252,6 +258,7 @@ namespace BTCPayServer.Configuration
 
         public string RootPath { get; set; }
         public Dictionary<string, LightningConnectionString> InternalLightningByCryptoCode { get; set; } = new Dictionary<string, LightningConnectionString>();
+        public Dictionary<string, string> LndSeedPath { get; set; } = new Dictionary<string, string>();
 
         public Dictionary<string, Uri> OtherExternalServices { get; set; } = new Dictionary<string, Uri>();
         public ExternalServices ExternalServices { get; set; } = new ExternalServices();

--- a/BTCPayServer/Controllers/StoresController.LightningLike.cs
+++ b/BTCPayServer/Controllers/StoresController.LightningLike.cs
@@ -37,8 +37,12 @@ namespace BTCPayServer.Controllers
                 (vm.ConnectionString.Contains("lnd-rest", StringComparison.OrdinalIgnoreCase) ||
                 vm.ConnectionString.Contains("lnd-grpc", StringComparison.OrdinalIgnoreCase)))
             {
-                await _lndMigrationHelper.PerformDetection();
-                vm.IsSeedlessLnd = _lndMigrationHelper.IsSeedlessLnd;
+                if (_serverOptions.LndSeedPath.ContainsKey(cryptoCode))
+                {
+                    var lndSeedFilePath = _serverOptions.LndSeedPath[cryptoCode];
+                    await _lndMigrationHelper.PerformDetection(lndSeedFilePath);
+                    vm.IsSeedlessLnd = _lndMigrationHelper.IsSeedlessLnd;
+                }
             }
 
             return View(vm);

--- a/BTCPayServer/Controllers/StoresController.cs
+++ b/BTCPayServer/Controllers/StoresController.cs
@@ -65,7 +65,8 @@ namespace BTCPayServer.Controllers
             IWebHostEnvironment env, IHttpClientFactory httpClientFactory,
             PaymentMethodHandlerDictionary paymentMethodHandlerDictionary,
             CssThemeManager cssThemeManager,
-            LndMigrationHelper lndMigrationHelper)
+            LndMigrationHelper lndMigrationHelper,
+            BTCPayServerOptions serverOptions)
         {
             _RateFactory = rateFactory;
             _Repo = repo;
@@ -80,6 +81,7 @@ namespace BTCPayServer.Controllers
             _paymentMethodHandlerDictionary = paymentMethodHandlerDictionary;
             _CssThemeManager = cssThemeManager;
             _lndMigrationHelper = lndMigrationHelper;
+            _serverOptions = serverOptions;
             _NetworkProvider = networkProvider;
             _ExplorerProvider = explorerProvider;
             _FeeRateProvider = feeRateProvider;
@@ -105,6 +107,7 @@ namespace BTCPayServer.Controllers
         private readonly PaymentMethodHandlerDictionary _paymentMethodHandlerDictionary;
         private readonly CssThemeManager _CssThemeManager;
         private readonly LndMigrationHelper _lndMigrationHelper;
+        private readonly BTCPayServerOptions _serverOptions;
 
         [TempData]
         public string StatusMessage

--- a/BTCPayServer/Controllers/StoresController.cs
+++ b/BTCPayServer/Controllers/StoresController.cs
@@ -65,8 +65,7 @@ namespace BTCPayServer.Controllers
             IWebHostEnvironment env, IHttpClientFactory httpClientFactory,
             PaymentMethodHandlerDictionary paymentMethodHandlerDictionary,
             CssThemeManager cssThemeManager,
-            LndMigrationHelper lndMigrationHelper,
-            BTCPayServerOptions serverOptions)
+            LndMigrationHelper lndMigrationHelper)
         {
             _RateFactory = rateFactory;
             _Repo = repo;
@@ -80,14 +79,13 @@ namespace BTCPayServer.Controllers
             _httpClientFactory = httpClientFactory;
             _paymentMethodHandlerDictionary = paymentMethodHandlerDictionary;
             _CssThemeManager = cssThemeManager;
-            _lndMigrationHelper = lndMigrationHelper;
-            _serverOptions = serverOptions;
             _NetworkProvider = networkProvider;
             _ExplorerProvider = explorerProvider;
             _FeeRateProvider = feeRateProvider;
             _ServiceProvider = serviceProvider;
             _BtcpayServerOptions = btcpayServerOptions;
             _BTCPayEnv = btcpayEnv;
+            _lndMigrationHelper = lndMigrationHelper;
         }
         BTCPayServerOptions _BtcpayServerOptions;
         BTCPayServerEnvironment _BTCPayEnv;
@@ -107,7 +105,6 @@ namespace BTCPayServer.Controllers
         private readonly PaymentMethodHandlerDictionary _paymentMethodHandlerDictionary;
         private readonly CssThemeManager _CssThemeManager;
         private readonly LndMigrationHelper _lndMigrationHelper;
-        private readonly BTCPayServerOptions _serverOptions;
 
         [TempData]
         public string StatusMessage

--- a/BTCPayServer/Controllers/StoresController.cs
+++ b/BTCPayServer/Controllers/StoresController.cs
@@ -19,6 +19,7 @@ using BTCPayServer.Security;
 using BTCPayServer.Security.Bitpay;
 using BTCPayServer.Services;
 using BTCPayServer.Services.Invoices;
+using BTCPayServer.Services.Lightning;
 using BTCPayServer.Services.Rates;
 using BTCPayServer.Services.Stores;
 using BTCPayServer.Services.Wallets;
@@ -63,7 +64,8 @@ namespace BTCPayServer.Controllers
             ChangellyClientProvider changellyClientProvider,
             IWebHostEnvironment env, IHttpClientFactory httpClientFactory,
             PaymentMethodHandlerDictionary paymentMethodHandlerDictionary,
-            CssThemeManager cssThemeManager)
+            CssThemeManager cssThemeManager,
+            LndMigrationHelper lndMigrationHelper)
         {
             _RateFactory = rateFactory;
             _Repo = repo;
@@ -77,6 +79,7 @@ namespace BTCPayServer.Controllers
             _httpClientFactory = httpClientFactory;
             _paymentMethodHandlerDictionary = paymentMethodHandlerDictionary;
             _CssThemeManager = cssThemeManager;
+            _lndMigrationHelper = lndMigrationHelper;
             _NetworkProvider = networkProvider;
             _ExplorerProvider = explorerProvider;
             _FeeRateProvider = feeRateProvider;
@@ -101,6 +104,7 @@ namespace BTCPayServer.Controllers
         private IHttpClientFactory _httpClientFactory;
         private readonly PaymentMethodHandlerDictionary _paymentMethodHandlerDictionary;
         private readonly CssThemeManager _CssThemeManager;
+        private readonly LndMigrationHelper _lndMigrationHelper;
 
         [TempData]
         public string StatusMessage

--- a/BTCPayServer/Hosting/BTCPayServerServices.cs
+++ b/BTCPayServer/Hosting/BTCPayServerServices.cs
@@ -55,6 +55,7 @@ using Microsoft.AspNetCore.Routing;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authorization;
 using BTCPayServer.Security.Bitpay;
+using BTCPayServer.Services.Lightning;
 
 namespace BTCPayServer.Hosting
 {
@@ -83,6 +84,7 @@ namespace BTCPayServer.Hosting
             services.TryAddSingleton<TorServices>();
             services.TryAddSingleton<SocketFactory>();
             services.TryAddSingleton<LightningClientFactoryService>();
+            services.AddSingleton<LndMigrationHelper>();
             services.TryAddSingleton<InvoicePaymentNotification>();
             services.TryAddSingleton<BTCPayServerOptions>(o =>
                 o.GetRequiredService<IOptions<BTCPayServerOptions>>().Value);

--- a/BTCPayServer/Models/StoreViewModels/LightningNodeViewModel.cs
+++ b/BTCPayServer/Models/StoreViewModels/LightningNodeViewModel.cs
@@ -10,22 +10,17 @@ namespace BTCPayServer.Models.StoreViewModels
     public class LightningNodeViewModel
     {
         [Display(Name = "Connection string")]
-        public string ConnectionString
-        {
-            get;
-            set;
-        }
+        public string ConnectionString { get; set; }
 
-        public string CryptoCode
-        {
-            get;
-            set;
-        }
+        public string CryptoCode { get; set; }
         public string StatusMessage { get; set; }
         public string InternalLightningNode { get; internal set; }
         public bool SkipPortTest { get; set; }
         public bool Enabled { get; set; } = true;
 
         public string StoreId { get; set; }
+        
+        // obsolete and remove down the road when Seedless LND is no longer issue
+        public bool IsSeedlessLnd { get; set; }
     }
 }

--- a/BTCPayServer/Properties/launchSettings.json
+++ b/BTCPayServer/Properties/launchSettings.json
@@ -11,7 +11,7 @@
                 "BTCPAY_BTCLIGHTNING": "type=charge;server=http://127.0.0.1:54938/;api-token=foiewnccewuify",
                 "BTCPAY_BTCEXTERNALLNDGRPC": "type=lnd-grpc;server=https://lnd:lnd@127.0.0.1:53280/;allowinsecure=true",
                 "BTCPAY_BTCEXTERNALLNDREST": "type=lnd-rest;server=https://lnd:lnd@127.0.0.1:53280/lnd-rest/btc/;allowinsecure=true;macaroonfilepath=D:\\admin.macaroon",
-                "BTCPAY_BTCLNDSEEDPATH": "D:\\walletunlock.json",
+                "BTCPAY_BTCLNDSEEDPATH": "/etc/merchant_lnd/data/chain/bitcoin/regtest/walletunlock.json",
                 "BTCPAY_BTCEXPLORERURL": "http://127.0.0.1:32838/",
                 "BTCPAY_ALLOW-ADMIN-REGISTRATION": "true",
                 "BTCPAY_DISABLE-REGISTRATION": "false",

--- a/BTCPayServer/Properties/launchSettings.json
+++ b/BTCPayServer/Properties/launchSettings.json
@@ -11,7 +11,7 @@
                 "BTCPAY_BTCLIGHTNING": "type=charge;server=http://127.0.0.1:54938/;api-token=foiewnccewuify",
                 "BTCPAY_BTCEXTERNALLNDGRPC": "type=lnd-grpc;server=https://lnd:lnd@127.0.0.1:53280/;allowinsecure=true",
                 "BTCPAY_BTCEXTERNALLNDREST": "type=lnd-rest;server=https://lnd:lnd@127.0.0.1:53280/lnd-rest/btc/;allowinsecure=true;macaroonfilepath=D:\\admin.macaroon",
-                "BTCPAY_LND_SEEDPATH": "D:\\walletunlock.json",
+                "BTCPAY_BTCLNDSEEDPATH": "D:\\walletunlock.json",
                 "BTCPAY_BTCEXPLORERURL": "http://127.0.0.1:32838/",
                 "BTCPAY_ALLOW-ADMIN-REGISTRATION": "true",
                 "BTCPAY_DISABLE-REGISTRATION": "false",

--- a/BTCPayServer/Properties/launchSettings.json
+++ b/BTCPayServer/Properties/launchSettings.json
@@ -11,6 +11,7 @@
                 "BTCPAY_BTCLIGHTNING": "type=charge;server=http://127.0.0.1:54938/;api-token=foiewnccewuify",
                 "BTCPAY_BTCEXTERNALLNDGRPC": "type=lnd-grpc;server=https://lnd:lnd@127.0.0.1:53280/;allowinsecure=true",
                 "BTCPAY_BTCEXTERNALLNDREST": "type=lnd-rest;server=https://lnd:lnd@127.0.0.1:53280/lnd-rest/btc/;allowinsecure=true;macaroonfilepath=D:\\admin.macaroon",
+                "BTCPAY_LND_SEEDPATH": "D:\\walletunlock.json",
                 "BTCPAY_BTCEXPLORERURL": "http://127.0.0.1:32838/",
                 "BTCPAY_ALLOW-ADMIN-REGISTRATION": "true",
                 "BTCPAY_DISABLE-REGISTRATION": "false",

--- a/BTCPayServer/Services/Lightning/LndMigrationHelper.cs
+++ b/BTCPayServer/Services/Lightning/LndMigrationHelper.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using BTCPayServer.Lightning;
+using NBitcoin;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace BTCPayServer.Services.Lightning
+{
+    public class LndMigrationHelper
+    {
+        private readonly LightningClientFactoryService _lightningClientFactory;
+
+        public LndMigrationHelper(LightningClientFactoryService lightningClientFactory,
+            BTCPayNetworkProvider networkProvider)
+        {
+            _lightningClientFactory = lightningClientFactory;
+        }
+
+        public LndSeedFile UnlockFile { get; set; }
+
+        public bool IsSeedlessLnd { get; set; }
+        public async Task PerformDetection()
+        {
+            // by default all LND instalations were started as seedless
+            IsSeedlessLnd = true;
+
+            try
+            {
+                // with new setting we'll try to check if unlock file existits and is in right format
+                // if that's true and parsing passes, we know this is not seedless LND
+                var seedFilePath = Environment.GetEnvironmentVariable("BTCPAY_LND_SEEDPATH");
+                if (!String.IsNullOrEmpty(seedFilePath) && File.Exists(seedFilePath))
+                {
+                    var unlockFile = File.ReadAllText(seedFilePath);
+                    UnlockFile = JsonConvert.DeserializeObject<LndSeedFile>(unlockFile);
+
+                    if (!String.IsNullOrEmpty(UnlockFile.wallet_password))
+                    {
+                        IsSeedlessLnd = false;
+                        return;
+                    }
+                }
+            }
+            catch
+            {
+            }
+        }
+
+        public class LndSeedFile
+        {
+            public string wallet_password { get; set; }
+            public List<string> cipher_seed_mnemonic { get; set; }
+        }
+    }
+}

--- a/BTCPayServer/Services/Lightning/LndMigrationHelper.cs
+++ b/BTCPayServer/Services/Lightning/LndMigrationHelper.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using BTCPayServer.Configuration;
 using BTCPayServer.Lightning;
 using NBitcoin;
 using Newtonsoft.Json;
@@ -13,27 +14,26 @@ namespace BTCPayServer.Services.Lightning
 {
     public class LndMigrationHelper
     {
-        private readonly LightningClientFactoryService _lightningClientFactory;
-
-        public LndMigrationHelper(LightningClientFactoryService lightningClientFactory,
-            BTCPayNetworkProvider networkProvider)
+        public LndMigrationHelper()
         {
-            _lightningClientFactory = lightningClientFactory;
         }
 
         public LndSeedFile UnlockFile { get; set; }
 
         public bool IsSeedlessLnd { get; set; }
-        public async Task PerformDetection()
+        public async Task PerformDetection(string seedFilePath)
         {
+            // if seed file path is empty, show no warning
+            if (String.IsNullOrEmpty(seedFilePath))
+                IsSeedlessLnd = false;
+
             // by default all LND instalations were started as seedless
             IsSeedlessLnd = true;
-
+            
             try
             {
                 // with new setting we'll try to check if unlock file existits and is in right format
                 // if that's true and parsing passes, we know this is not seedless LND
-                var seedFilePath = Environment.GetEnvironmentVariable("BTCPAY_LND_SEEDPATH");
                 if (!String.IsNullOrEmpty(seedFilePath) && File.Exists(seedFilePath))
                 {
                     var unlockFile = File.ReadAllText(seedFilePath);

--- a/BTCPayServer/Services/LightningClientFactoryService.cs
+++ b/BTCPayServer/Services/LightningClientFactoryService.cs
@@ -22,7 +22,7 @@ namespace BTCPayServer.Services
                 throw new ArgumentNullException(nameof(lightningConnectionString));
             if (network == null)
                 throw new ArgumentNullException(nameof(network));
-            return new Lightning.LightningClientFactory(network.NBitcoinNetwork)
+            return new LightningClientFactory(network.NBitcoinNetwork)
             {
                 HttpClient = _httpClientFactory.CreateClient($"{network.CryptoCode}: Lightning client")
             }.Create(lightningConnectionString);

--- a/BTCPayServer/Views/Stores/AddLightningNode.cshtml
+++ b/BTCPayServer/Views/Stores/AddLightningNode.cshtml
@@ -69,6 +69,16 @@
                 <p><pre><code>openssl x509 -noout -fingerprint -sha256 -inform pem -in /root/.lnd/tls.cert</code></pre></p>
                 <p>You can omit <code>certthumbprint</code> if you the certificate is trusted by your machine</p>
                 <p>You can set <code>allowinsecure</code> to <code>true</code> if your LND REST server is using HTTP or HTTPS with an untrusted certificate which you don't know the <code>certthumbprint</code></p>
+
+                @if (Model.IsSeedlessLnd)
+                {
+                <div class="alert alert-danger alert-dismissible" role="alert">
+                    <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                    <p>You have old version of LND deployment that was auto-initialized using `noseedbackup=1`.</p>
+                    <p>Please migrate to new version of LND deployment that is auto-initialized through script which creates seed backup file as part of the startup process.</p>
+                    <p><a href="https://github.com/btcpayserver/lnd/pull/4" target="_blank">Click here for more information</a></p>
+                </div>
+                }
             </div>
             <div class="form-group">
                 <label asp-for="ConnectionString"></label>
@@ -87,11 +97,10 @@
             </div>
             <button id="save" name="command" type="submit" value="save" class="btn btn-primary">Submit</button>
             <button name="command" type="submit" value="test" class="btn btn-secondary">Test connection</button>
-            <a 
-                class="btn btn-secondary"
-                asp-controller="PublicLightningNodeInfo" 
-               asp-action="ShowLightningNodeInfo" 
-               asp-route-cryptoCode="@Model.CryptoCode" 
+            <a class="btn btn-secondary"
+               asp-controller="PublicLightningNodeInfo"
+               asp-action="ShowLightningNodeInfo"
+               asp-route-cryptoCode="@Model.CryptoCode"
                asp-route-storeId="@Model.StoreId"
                target="_blank">
                 Open Public Node Info Page


### PR DESCRIPTION
New deployments of LND will be auto initialized and have `walletunlock.json` file that will preserve seed and wallet unlock password. See this PR: https://github.com/btcpayserver/lnd/pull/4

BTCPayServer's detection of whether LND has seed backup / auto-unlock file will depend on new setting `BTCPAY_LND_SEEDPATH`. If setting is present we'll try to check if file exists and read it to parse & ensure format is right. If everything is correct we won't show warning about seedless LND deployment.

Otherwise user will be presented with big warning dialog explaining the migration path from legacy deployment with `noseedbackup=1` to new deployment that auto-inits the seed and auto-unlocks the wallet.

![image](https://user-images.githubusercontent.com/5191402/67023889-2288e380-f0c9-11e9-8048-c04b2613c1ab.png)
