### PR TITLE
Redesign confirm forms

### DIFF
--- a/BTCPayServer.Tests/BTCPayServer.Tests.csproj
+++ b/BTCPayServer.Tests/BTCPayServer.Tests.csproj
@@ -12,6 +12,10 @@
   <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1'">
     <DefineConstants>$(DefineConstants);NETCOREAPP21</DefineConstants>
   </PropertyGroup>
+  
+  <PropertyGroup Condition="'$(CI_TESTS)' == 'true'">
+    <DefineConstants>$(DefineConstants);SHORT_TIME</DefineConstants>
+  </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />

--- a/BTCPayServer.Tests/Dockerfile
+++ b/BTCPayServer.Tests/Dockerfile
@@ -25,6 +25,6 @@ ENV SCREEN_HEIGHT 600 \
     SCREEN_WIDTH 1200
 
 COPY . .
-RUN cd BTCPayServer.Tests && dotnet build
+RUN cd BTCPayServer.Tests && dotnet build /p:CI_TESTS=true
 WORKDIR /source/BTCPayServer.Tests
 ENTRYPOINT ["./docker-entrypoint.sh"]

--- a/BTCPayServer.Tests/TestUtils.cs
+++ b/BTCPayServer.Tests/TestUtils.cs
@@ -15,7 +15,7 @@ namespace BTCPayServer.Tests
 {
     public static class TestUtils
     {
-#if DEBUG
+#if DEBUG && !SHORT_TIMEOUT
         public const int TestTimeout = 600_000;
 #else
         public const int TestTimeout = 60_000;

--- a/BTCPayServer/Controllers/StoresController.cs
+++ b/BTCPayServer/Controllers/StoresController.cs
@@ -574,7 +574,7 @@ namespace BTCPayServer.Controllers
         {
             return View("Confirm", new ConfirmModel()
             {
-                Action = "Delete this store",
+                Action = "Delete",
                 Title = "Delete this store",
                 Description = "This action is irreversible and will remove all information related to this store. (Invoices, Apps etc...)",
                 ButtonClass = "btn-danger"
@@ -637,7 +637,7 @@ namespace BTCPayServer.Controllers
                 return NotFound();
             return View("Confirm", new ConfirmModel()
             {
-                Action = "Revoke the token",
+                Action = "Revoke",
                 Title = "Revoke the token",
                 Description = $"The access token with the label \"{token.Label}\" will be revoked, do you wish to continue?",
                 ButtonClass = "btn-danger"

--- a/BTCPayServer/Views/Shared/Confirm.cshtml
+++ b/BTCPayServer/Views/Shared/Confirm.cshtml
@@ -1,26 +1,56 @@
 ﻿@model ConfirmModel
+
+@inject BTCPayServer.HostedServices.NBXplorerDashboard dashboard
+@inject BTCPayServer.HostedServices.CssThemeManager themeManager
+@addTagHelper *, BundlerMinifier.TagHelpers
 @{
-    Layout = "_Layout.cshtml";
+    Layout = null;
 }
 
-<section>
-    <div class="container">
-        <div class="row">
-            <div class="col-lg-12 text-center">
-                <h2 class="section-heading">@Model.Title</h2>
-                <hr class="primary">
-                <p>@Model.Description</p>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="description" content="">
+    <meta name="author" content="">
+    @if (themeManager.DiscourageSearchEngines)
+    {
+        <META NAME="robots" CONTENT="noindex">
+    }
+    <title>BTCPay Server</title>
+    @* CSS *@
+    <link href="@this.Context.Request.GetRelativePathOrAbsolute(themeManager.BootstrapUri)" rel="stylesheet" />
+    <link href="@this.Context.Request.GetRelativePathOrAbsolute(themeManager.CreativeStartUri)" rel="stylesheet" />
+    <bundle name="wwwroot/bundles/main-bundle.min.css" />
+    @* JS *@
+    <bundle name="wwwroot/bundles/main-bundle.min.js" />
+</head>
+<body class="bg-light">
+    <div class="modal-dialog modal-dialog-centered">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h4 class="modal-title w-100 text-center">@Model.Title</h4>
+            </div>
+            <div class="modal-body">
+                <div class="row">
+                    <div class="col-lg-12 text-center">
+                        <p>@Model.Description</p>
+                    </div>
+                </div>
+                @if (!String.IsNullOrEmpty(Model.Action))
+                {
+                    <div class="row">
+                        <div class="col-lg-12 text-center">
+                            <form method="post">
+                                <button id="continue" type="submit" class="btn btn-secondary @Model.ButtonClass w-25">@Model.Action</button>
+                                <button type="submit" class="btn btn-secondary w-25" onclick="history.back(); return false;">Go back</button>
+                            </form>
+                        </div>
+                    </div>
+                }
             </div>
         </div>
-        @if (!String.IsNullOrEmpty(Model.Action))
-        {
-        <div class="row">
-            <div class="col-lg-12 text-center">
-                <form method="post">
-                    <button id="continue" type="submit" class="btn btn-secondary @Model.ButtonClass" title="Continue">@Model.Action</button>
-                </form>
-            </div>
-        </div>
-        }
     </div>
-</section>
+</body>
+</html>


### PR DESCRIPTION
From now, all confirm form would have this design:

![image](https://user-images.githubusercontent.com/3020646/67923256-a2966980-fbf0-11e9-8d74-4729634e8608.png)

ACK? 