### PR TITLE
Make sure documentation tooltip link stays inline with label

### DIFF
--- a/BTCPayServer/Views/PaymentRequest/EditPaymentRequest.cshtml
+++ b/BTCPayServer/Views/PaymentRequest/EditPaymentRequest.cshtml
@@ -38,9 +38,9 @@
                         <input asp-for="Currency" class="form-control" />
                         <span asp-validation-for="Currency" class="text-danger"></span>
                     </div>
-                    <div class="form-group">
-                        <label asp-for="AllowCustomPaymentAmounts"></label>
-                        <input asp-for="AllowCustomPaymentAmounts" type="checkbox" class="form-check" />
+                    <div class="form-group form-check">
+                        <input asp-for="AllowCustomPaymentAmounts" type="checkbox" class="form-check-input" />
+                        <label asp-for="AllowCustomPaymentAmounts" class="form-check-label"></label>
                         <span asp-validation-for="AllowCustomPaymentAmounts" class="text-danger"></span>
                     </div>
                     <div class="form-group">

--- a/BTCPayServer/Views/Stores/UpdateStore.cshtml
+++ b/BTCPayServer/Views/Stores/UpdateStore.cshtml
@@ -45,26 +45,34 @@
                 </div>
             </div>
             <div class="form-group">
-                <label asp-for="InvoiceExpiration"></label>
-                <a href="https://docs.btcpayserver.org/faq-and-common-issues/faq-stores#invoice-expires-if-the-full-amount-has-not-been-paid-after-minutes" target="_blank"><span class="fa fa-question-circle-o" title="More information..."></span></a>
+                <div class="mb-2">
+                    <label asp-for="InvoiceExpiration" class="d-inline"></label>
+                    <a href="https://docs.btcpayserver.org/faq-and-common-issues/faq-stores#invoice-expires-if-the-full-amount-has-not-been-paid-after-minutes" target="_blank"><span class="fa fa-question-circle-o" title="More information..."></span></a>
+                </div>
                 <input asp-for="InvoiceExpiration" class="form-control" />
                 <span asp-validation-for="InvoiceExpiration" class="text-danger"></span>
             </div>
             <div class="form-group">
-                <label asp-for="MonitoringExpiration"></label>
-                <a href="https://docs.btcpayserver.org/faq-and-common-issues/faq-stores#payment-invalid-if-transactions-fails-to-confirm-minutes-after-invoice-expiration" target="_blank"><span class="fa fa-question-circle-o" title="More information..."></span></a>
+                <div class="mb-2">
+                    <label asp-for="MonitoringExpiration" class="d-inline"></label>
+                    <a href="https://docs.btcpayserver.org/faq-and-common-issues/faq-stores#payment-invalid-if-transactions-fails-to-confirm-minutes-after-invoice-expiration" target="_blank"><span class="fa fa-question-circle-o" title="More information..."></span></a>
+                </div>
                 <input asp-for="MonitoringExpiration" class="form-control" />
                 <span asp-validation-for="MonitoringExpiration" class="text-danger"></span>
             </div>
             <div class="form-group">
-                <label asp-for="PaymentTolerance"></label>
-                <a href="https://docs.btcpayserver.org/faq-and-common-issues/faq-stores#consider-the-invoice-paid-even-if-the-paid-amount-is-less-than-expected" target="_blank"><span class="fa fa-question-circle-o" title="More information..."></span></a>
+                <div class="mb-2">
+                    <label asp-for="PaymentTolerance" class="d-inline"></label>
+                    <a href="https://docs.btcpayserver.org/faq-and-common-issues/faq-stores#consider-the-invoice-paid-even-if-the-paid-amount-is-less-than-expected" target="_blank"><span class="fa fa-question-circle-o" title="More information..."></span></a>
+                </div>
                 <input asp-for="PaymentTolerance" class="form-control" />
                 <span asp-validation-for="PaymentTolerance" class="text-danger"></span>
             </div>
             <div class="form-group">
-                <label asp-for="SpeedPolicy"></label>
-                <a href="https://docs.btcpayserver.org/faq-and-common-issues/faq-stores#consider-the-invoice-confirmed-when-the-payment-transaction" target="_blank"><span class="fa fa-question-circle-o" title="More information..."></span></a>
+                <div class="mb-2">
+                    <label asp-for="SpeedPolicy" class="d-inline"></label>
+                    <a href="https://docs.btcpayserver.org/faq-and-common-issues/faq-stores#consider-the-invoice-confirmed-when-the-payment-transaction" target="_blank"><span class="fa fa-question-circle-o" title="More information..."></span></a>
+                </div>
                 <select asp-for="SpeedPolicy" class="form-control">
                     <option value="0">Is unconfirmed</option>
                     <option value="1">Has at least 1 confirmation</option>


### PR DESCRIPTION
Close #1129

Before:
![Screen Shot 2019-11-07 at 7 52 55 PM](https://user-images.githubusercontent.com/1934678/68448511-941ff300-0198-11ea-8320-a608aa8e78d2.png)

After:
![Screen Shot 2019-11-07 at 7 53 20 PM](https://user-images.githubusercontent.com/1934678/68448522-9da95b00-0198-11ea-855f-5f5654016abe.png)
