### PR TITLE
LND Seed Backup service

### DIFF
--- a/BTCPayServer/BTCPayServer.csproj
+++ b/BTCPayServer/BTCPayServer.csproj
@@ -158,6 +158,9 @@
     <Content Update="Views\Server\LightningWalletServices.cshtml">
       <Pack>$(IncludeRazorContentInPack)</Pack>
     </Content>
+    <Content Update="Views\Server\LndSeedBackup.cshtml">
+      <Pack>$(IncludeRazorContentInPack)</Pack>
+    </Content>
     <Content Update="Views\Server\RPCService.cshtml">
       <Pack>$(IncludeRazorContentInPack)</Pack>
     </Content>

--- a/BTCPayServer/Configuration/ExternalConnectionString.cs
+++ b/BTCPayServer/Configuration/ExternalConnectionString.cs
@@ -144,7 +144,7 @@ namespace BTCPayServer.Configuration
         }
         public bool? IsOnion()
         {
-            if (!this.Server.IsAbsoluteUri)
+            if (this.Server == null || !this.Server.IsAbsoluteUri)
                 return null;
             return this.Server.DnsSafeHost.EndsWith(".onion", StringComparison.OrdinalIgnoreCase);
         }

--- a/BTCPayServer/Configuration/ExternalService.cs
+++ b/BTCPayServer/Configuration/ExternalService.cs
@@ -24,6 +24,10 @@ namespace BTCPayServer.Configuration
                                 "lnd server: 'server=https://lnd.example.com;macaroondirectorypath=/root/.lnd;certthumbprint=2abdf302...'" + Environment.NewLine +
                                 "Error: {1}",
                                 "LND (REST server)");
+            Load(configuration, cryptoCode, "lndseedbackup", ExternalServiceTypes.LNDSeedBackup, "Invalid setting {0}, " + Environment.NewLine +
+                                "lnd seed backup: /etc/merchant_lnd/data/chain/bitcoin/regtest/walletunlock.json'" + Environment.NewLine +
+                                "Error: {1}",
+                                "LND Seed Backup");
             Load(configuration, cryptoCode, "spark", ExternalServiceTypes.Spark, "Invalid setting {0}, " + Environment.NewLine +
                                 $"Valid example: 'server=https://btcpay.example.com/spark/btc/;cookiefile=/etc/clightning_bitcoin_spark/.cookie'" + Environment.NewLine +
                                 "Error: {1}",
@@ -73,6 +77,7 @@ namespace BTCPayServer.Configuration
     {
         LNDRest,
         LNDGRPC,
+        LNDSeedBackup,
         Spark,
         RTL,
         Charge,

--- a/BTCPayServer/Configuration/ExternalService.cs
+++ b/BTCPayServer/Configuration/ExternalService.cs
@@ -49,11 +49,17 @@ namespace BTCPayServer.Configuration
             var connStr = configuration.GetOrDefault<string>(setting, string.Empty);
             if (connStr.Length != 0)
             {
-                if (!ExternalConnectionString.TryParse(connStr, out var connectionString, out var error))
+                ExternalConnectionString serviceConnection;
+                if (type == ExternalServiceTypes.LNDSeedBackup)
+                {
+                    // just using CookieFilePath to hold variable instead of refactoring whole holder class to better conform
+                    serviceConnection = new ExternalConnectionString { CookieFilePath = connStr };
+                }
+                else if (!ExternalConnectionString.TryParse(connStr, out serviceConnection, out var error))
                 {
                     throw new ConfigException(string.Format(CultureInfo.InvariantCulture, errorMessage, setting, error));
                 }
-                this.Add(new ExternalService() { Type = type, ConnectionString = connectionString, CryptoCode = cryptoCode, DisplayName = displayName, ServiceName = serviceName });
+                this.Add(new ExternalService() { Type = type, ConnectionString = serviceConnection, CryptoCode = cryptoCode, DisplayName = displayName, ServiceName = serviceName });
             }
         }
 

--- a/BTCPayServer/Controllers/ServerController.cs
+++ b/BTCPayServer/Controllers/ServerController.cs
@@ -623,7 +623,7 @@ namespace BTCPayServer.Controllers
                 }
                 if (service.Type == ExternalServiceTypes.LNDSeedBackup)
                 {
-                    var model = new LndSeedBackupViewModel();
+                    var model = LndSeedBackupViewModel.Parse(service.ConnectionString.CookieFilePath);
                     return View("LndSeedBackup", model);
                 }
                 if (service.Type == ExternalServiceTypes.RPC)

--- a/BTCPayServer/Controllers/ServerController.cs
+++ b/BTCPayServer/Controllers/ServerController.cs
@@ -621,6 +621,11 @@ namespace BTCPayServer.Controllers
                         ServiceLink = service.ConnectionString.Server.AbsoluteUri.WithoutEndingSlash()
                     });
                 }
+                if (service.Type == ExternalServiceTypes.LNDSeedBackup)
+                {
+                    var model = new LndSeedBackupViewModel();
+                    return View("LndSeedBackup", model);
+                }
                 if (service.Type == ExternalServiceTypes.RPC)
                 {
                     return View("RPCService", new LightningWalletServices()

--- a/BTCPayServer/Models/ServerViewModels/LndSeedBackupViewModel.cs
+++ b/BTCPayServer/Models/ServerViewModels/LndSeedBackupViewModel.cs
@@ -1,0 +1,13 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace BTCPayServer.Models.ServerViewModels
+{
+    public class LndSeedBackupViewModel
+    {
+        public bool IsWalletUnlockPresent { get; set; }
+
+        public string WalletPassword { get; set; }
+
+        public string[] Seed { get; set; }
+    }
+}

--- a/BTCPayServer/Models/ServerViewModels/LndSeedBackupViewModel.cs
+++ b/BTCPayServer/Models/ServerViewModels/LndSeedBackupViewModel.cs
@@ -1,4 +1,8 @@
-﻿using System.ComponentModel.DataAnnotations;
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.IO;
+using Newtonsoft.Json;
 
 namespace BTCPayServer.Models.ServerViewModels
 {
@@ -8,6 +12,39 @@ namespace BTCPayServer.Models.ServerViewModels
 
         public string WalletPassword { get; set; }
 
-        public string[] Seed { get; set; }
+        public List<string> Seed { get; set; }
+
+        public static LndSeedBackupViewModel Parse(string lndSeedFilePath)
+        {
+            try
+            {
+                if (!String.IsNullOrEmpty(lndSeedFilePath) && File.Exists(lndSeedFilePath))
+                {
+                    var unlockFileContents = File.ReadAllText(lndSeedFilePath);
+                    var unlockFile = JsonConvert.DeserializeObject<LndSeedFile>(unlockFileContents);
+
+                    if (!String.IsNullOrEmpty(unlockFile.wallet_password))
+                    {
+                        return new LndSeedBackupViewModel
+                        {
+                            WalletPassword = unlockFile.wallet_password,
+                            Seed = unlockFile.cipher_seed_mnemonic,
+                            IsWalletUnlockPresent = true,
+                        };
+                    }
+                }
+            }
+            catch
+            {
+            }
+
+            return new LndSeedBackupViewModel();
+        }
+
+        private class LndSeedFile
+        {
+            public string wallet_password { get; set; }
+            public List<string> cipher_seed_mnemonic { get; set; }
+        }
     }
 }

--- a/BTCPayServer/Models/ServerViewModels/LndSeedBackupViewModel.cs
+++ b/BTCPayServer/Models/ServerViewModels/LndSeedBackupViewModel.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
+using System.Globalization;
 using System.IO;
+using System.Threading.Tasks;
 using Newtonsoft.Json;
 
 namespace BTCPayServer.Models.ServerViewModels
@@ -13,6 +15,29 @@ namespace BTCPayServer.Models.ServerViewModels
         public string WalletPassword { get; set; }
 
         public List<string> Seed { get; set; }
+
+
+        public async Task<bool> RemoveSeedAndWrite(string lndSeedFilePath)
+        {
+            var removedDate = DateTime.UtcNow.ToString("yyyy-MM-dd HH:mm:ssZ", CultureInfo.InvariantCulture);
+            var seedFile = new LndSeedFile
+            {
+                wallet_password = WalletPassword,
+                cipher_seed_mnemonic = new List<string> { $"Seed removed on {removedDate}" }
+            };
+            var json = JsonConvert.SerializeObject(seedFile);
+            try
+            {
+                await File.WriteAllTextAsync(lndSeedFilePath, json);
+                return true;
+            }
+            catch
+            {
+                // file access exception and such
+                return false;
+            }
+        }
+
 
         public static LndSeedBackupViewModel Parse(string lndSeedFilePath)
         {

--- a/BTCPayServer/Properties/launchSettings.json
+++ b/BTCPayServer/Properties/launchSettings.json
@@ -11,7 +11,7 @@
                 "BTCPAY_BTCLIGHTNING": "type=charge;server=http://127.0.0.1:54938/;api-token=foiewnccewuify",
                 "BTCPAY_BTCEXTERNALLNDGRPC": "type=lnd-grpc;server=https://lnd:lnd@127.0.0.1:53280/;allowinsecure=true",
                 "BTCPAY_BTCEXTERNALLNDREST": "type=lnd-rest;server=https://lnd:lnd@127.0.0.1:53280/lnd-rest/btc/;allowinsecure=true;macaroonfilepath=D:\\admin.macaroon",
-                "BTCPAY_BTCEXTERNALLNDSEEDBACKUP": "/etc/merchant_lnd/data/chain/bitcoin/regtest/walletunlock.json",
+                "BTCPAY_BTCEXTERNALLNDSEEDBACKUP": "D:\\walletunlock.json",
                 "BTCPAY_BTCEXPLORERURL": "http://127.0.0.1:32838/",
                 "BTCPAY_ALLOW-ADMIN-REGISTRATION": "true",
                 "BTCPAY_DISABLE-REGISTRATION": "false",

--- a/BTCPayServer/Properties/launchSettings.json
+++ b/BTCPayServer/Properties/launchSettings.json
@@ -11,7 +11,7 @@
                 "BTCPAY_BTCLIGHTNING": "type=charge;server=http://127.0.0.1:54938/;api-token=foiewnccewuify",
                 "BTCPAY_BTCEXTERNALLNDGRPC": "type=lnd-grpc;server=https://lnd:lnd@127.0.0.1:53280/;allowinsecure=true",
                 "BTCPAY_BTCEXTERNALLNDREST": "type=lnd-rest;server=https://lnd:lnd@127.0.0.1:53280/lnd-rest/btc/;allowinsecure=true;macaroonfilepath=D:\\admin.macaroon",
-                "BTCPAY_BTCLNDSEEDPATH": "/etc/merchant_lnd/data/chain/bitcoin/regtest/walletunlock.json",
+                "BTCPAY_BTCEXTERNALLNDSEEDBACKUP": "/etc/merchant_lnd/data/chain/bitcoin/regtest/walletunlock.json",
                 "BTCPAY_BTCEXPLORERURL": "http://127.0.0.1:32838/",
                 "BTCPAY_ALLOW-ADMIN-REGISTRATION": "true",
                 "BTCPAY_DISABLE-REGISTRATION": "false",

--- a/BTCPayServer/Views/Server/LndSeedBackup.cshtml
+++ b/BTCPayServer/Views/Server/LndSeedBackup.cshtml
@@ -1,0 +1,38 @@
+﻿@model LndSeedBackupViewModel
+@{
+    ViewData.SetActivePageAndTitle(ServerNavPages.Services);
+}
+
+
+<h4>LND Seed Backup</h4>
+<partial name="_StatusMessage" />
+<div class="row">
+    <div class="col-md-6">
+        <div asp-validation-summary="All" class="text-danger"></div>
+    </div>
+</div>
+
+<div class="row">
+
+    <div class="col-md-8">
+        <div class="form-group">
+            @if (Model.IsWalletUnlockPresent)
+            {
+                <p>Unlock file is present... here are details</p>
+                <p>Wallet Password: @Model.WalletPassword</p>
+                <p>Seed: @String.Join(',', Model.Seed)</p>
+            }
+            else
+            {
+                <p>
+                    You don't have LND unlock file, which means you need to migrate to new version of LND docker container.
+                    <a href="https://github.com/btcpayserver/lnd/pull/4" target="_blank">More information</a>
+                </p>
+            }
+        </div>
+    </div>
+
+</div>
+
+@section Scripts {
+}

--- a/BTCPayServer/Views/Server/LndSeedBackup.cshtml
+++ b/BTCPayServer/Views/Server/LndSeedBackup.cshtml
@@ -18,16 +18,27 @@
         <div class="form-group">
             @if (Model.IsWalletUnlockPresent)
             {
-                <p>Unlock file is present... here are details</p>
-                <p>Wallet Password: @Model.WalletPassword</p>
-                <p>Seed: @String.Join(',', Model.Seed)</p>
+                <p>Wallet Password: <b>@Model.WalletPassword</b></p>
+                @if (Model.Seed.Count > 1)
+                {
+                    <p>
+                        <div><a href="#details" data-toggle="collapse">Reveal Seed Information</a></div>
+                        <div id="details" class="collapse">
+                            @String.Join(", ", Model.Seed)
+                        </div>
+                    </p>
+                }
+                else
+                {
+                    <p>Seed information was deleted on <b>@Model.Seed.First()</b></p>
+                }
             }
             else
             {
-                <p>
-                    You don't have LND unlock file, which means you need to migrate to new version of LND docker container.
-                    <a href="https://github.com/btcpayserver/lnd/pull/4" target="_blank">More information</a>
-                </p>
+                <p class="text-danger">Unlock file is NOT present</p>
+                <p>You have old version of LND deployment that was auto-initialized using `noseedbackup=1`.</p>
+                <p>Please migrate to new version of LND deployment that is auto-initialized through script which creates seed backup file as part of the startup process.</p>
+                <p><a href="https://github.com/btcpayserver/lnd/pull/4" target="_blank">Visit this link for more information</a></p>
             }
         </div>
     </div>
@@ -35,4 +46,15 @@
 </div>
 
 @section Scripts {
+    <script type="text/javascript">
+        function confirmSeedDelete() {
+            var conf = confirm('This operation is not undoable. Are you sure you want to proceed with deleting seed from LND container?');
+            if (conf) {
+                return true;
+            }
+            else {
+                return false;
+            }
+        }
+    </script>
 }

--- a/BTCPayServer/Views/Server/LndSeedBackup.cshtml
+++ b/BTCPayServer/Views/Server/LndSeedBackup.cshtml
@@ -24,13 +24,20 @@
                     <p>
                         <div><a href="#details" data-toggle="collapse">Reveal Seed Information</a></div>
                         <div id="details" class="collapse">
-                            @String.Join(", ", Model.Seed)
+                            @foreach (var item in Model.Seed)
+                            {
+                                <span>@item</span>
+                            }
+                            <br /><br />
+                            <form method="post" action="@Context.Request.Path/removelndseed">
+                                <button class="btn btn-primary" type="submit" onclick="return confirmSeedDelete();">Remove Seed from server</button>
+                            </form>
                         </div>
                     </p>
                 }
                 else
                 {
-                    <p>Seed information was deleted on <b>@Model.Seed.First()</b></p>
+                    <p><b>@Model.Seed.First()</b></p>
                 }
             }
             else

--- a/BTCPayServer/Views/Server/Services.cshtml
+++ b/BTCPayServer/Views/Server/Services.cshtml
@@ -35,9 +35,8 @@
                         <td>@s.CryptoCode</td>
                         <td>
                             <span>@s.DisplayName</span>
-                            @if ((s.ConnectionString.IsOnion() is true) ||
-                                (s.ConnectionString.IsOnion() is false &&
-                                this.Context.Request.IsOnion()))
+                            @if (s.ConnectionString.IsOnion() == true || 
+                                (s.ConnectionString.IsOnion() == false && this.Context.Request.IsOnion()))
                             {
                             <span><img style="display:inline; margin-top:-8px;" src="~/img/icons/Onion_Color.svg" height="20" /></span>
                             }


### PR DESCRIPTION
This PR (continuation of #1092) makes use of auto-init and unlock functionality and displays information fetched from LND docker container in UI. When tested and merged it'll allow us to migrate from `noseedbackup=1` setting.

LND Seed Backup service is now displayed in Server Settings

![01-services](https://user-images.githubusercontent.com/5191402/68452022-b9bbf500-01b6-11ea-8e86-28009dedfb1a.jpg)

Legacy deployments will show warning and provide link that explains the migration process (sweeping funds from legacy deployment to on-chain address, starting new LND instance, sending funds back)

![02-legacy-deployments](https://user-images.githubusercontent.com/5191402/68452108-0bfd1600-01b7-11ea-834d-0822b89bd9af.jpg)

New deployments will show wallet password, provide option to reveal the seed and delete it

![03-with-seed](https://user-images.githubusercontent.com/5191402/68452148-2a631180-01b7-11ea-921b-0835537bce26.jpg)

Seed can be deleted from the server, since all we need is wallet unlock password for subsequent restarts

![04-seed-deleted](https://user-images.githubusercontent.com/5191402/68452183-45358600-01b7-11ea-9bff-69002176be91.jpg)

Deleting the seed can be problem in situations where BTCPayServer doesn't have write permission on the path... in that case error message will be shown and server admin can delete the password 