### PR TITLE
Bump NBXplorer.Client

### DIFF
--- a/BTCPayServer.Common/BTCPayServer.Common.csproj
+++ b/BTCPayServer.Common/BTCPayServer.Common.csproj
@@ -4,7 +4,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.9" Condition="'$(TargetFramework)' == 'netcoreapp2.1'" />
-    <FrameworkReference Include="Microsoft.AspNetCore.App"  Condition="'$(TargetFramework)' != 'netcoreapp2.1'" />
-    <PackageReference Include="NBXplorer.Client" Version="2.0.0.21" />
+    <FrameworkReference Include="Microsoft.AspNetCore.App" Condition="'$(TargetFramework)' != 'netcoreapp2.1'" />
+    <PackageReference Include="NBXplorer.Client" Version="2.0.0.23" />
   </ItemGroup>
 </Project>

--- a/BTCPayServer.Tests/UnitTest1.cs
+++ b/BTCPayServer.Tests/UnitTest1.cs
@@ -702,7 +702,7 @@ namespace BTCPayServer.Tests
                         FullNotifications = true,
                         ExtendedNotifications = true
                     });
-                    BitcoinUrlBuilder url = new BitcoinUrlBuilder(invoice.PaymentUrls.BIP21);
+                    BitcoinUrlBuilder url = new BitcoinUrlBuilder(invoice.PaymentUrls.BIP21, tester.NetworkProvider.BTC.NBitcoinNetwork);
                     bool receivedPayment = false;
                     bool paid = false;
                     bool confirmed = false;

--- a/BTCPayServer/Controllers/HomeController.cs
+++ b/BTCPayServer/Controllers/HomeController.cs
@@ -121,7 +121,7 @@ namespace BTCPayServer.Controllers
 
             try
             {
-                BitcoinUrlBuilder urlBuilder = new BitcoinUrlBuilder(vm.BitpayLink);
+                BitcoinUrlBuilder urlBuilder = new BitcoinUrlBuilder(vm.BitpayLink, Network.Main);
 #pragma warning disable CS0618 // Type or member is obsolete
                 if (!urlBuilder.PaymentRequestUrl.DnsSafeHost.EndsWith("bitpay.com", StringComparison.OrdinalIgnoreCase))
                 {


### PR DESCRIPTION
Recent changes in NBitcoin 5.0, make it mandatory to know about the network at serialization and deserialization time.