### PR TITLE
Page title fixes

### DIFF
--- a/BTCPayServer/Views/PaymentRequest/EditPaymentRequest.cshtml
+++ b/BTCPayServer/Views/PaymentRequest/EditPaymentRequest.cshtml
@@ -2,11 +2,14 @@
 @using System.Globalization
 @model BTCPayServer.Models.PaymentRequestViewModels.UpdatePaymentRequestViewModel
 @addTagHelper *, BundlerMinifier.TagHelpers
+@{
+    ViewData["Title"] = (string.IsNullOrEmpty(Model.Id) ? "Create" : "Edit") + " Payment Request";
+}
 <section>
     <div class="container">
         <div class="row">
             <div class="col-lg-12 section-heading">
-                <h2>@(string.IsNullOrEmpty(Model.Id) ? "Create" : "Edit") Payment Request</h2>
+                <h2>@ViewData["Title"]</h2>
                 <hr class="primary">
             </div>
         </div>

--- a/BTCPayServer/Views/PaymentRequest/GetPaymentRequests.cshtml
+++ b/BTCPayServer/Views/PaymentRequest/GetPaymentRequests.cshtml
@@ -2,6 +2,7 @@
 @model BTCPayServer.Models.PaymentRequestViewModels.ListPaymentRequestsViewModel
 @{
     Layout = "_Layout";
+    ViewData["Title"] = "Payment Requests";
 }
 <section>
     <div class="container">

--- a/BTCPayServer/Views/Stores/PayButton.cshtml
+++ b/BTCPayServer/Views/Stores/PayButton.cshtml
@@ -2,7 +2,7 @@
 @{
     Layout = "../Shared/_NavLayout.cshtml";
     ViewData.SetActivePageAndTitle(StoreNavPages.PayButton);
-    ViewBag.MainTitle = "Pay Button";
+    ViewData["Title"] = "Pay Button";
 }
 
 <div class="container" id="payButtonCtrl">


### PR DESCRIPTION
The missing page titles should be uncontroversial. The Pay Button title fix turns "Pay Button: PayButton" into "Manage store: Pay Button" (consistent with the rest of the Store area page titles).