### PR TITLE
UI: Payment request improvement

### DIFF
--- a/BTCPayServer/Views/PaymentRequest/MinimalPaymentRequest.cshtml
+++ b/BTCPayServer/Views/PaymentRequest/MinimalPaymentRequest.cshtml
@@ -8,10 +8,10 @@
                     @Model.Title
                     <span class="text-muted float-right text-center">@Model.Status</span>
                 </h1>
-                <div class="card-body px-0 pt-0">
-                    <div class="row mb-4">
+                <div class="card-body px-0 pt-0 pb-0">
+                    <div class="row">
                         <div class="col-sm-12 col-md-12 col-lg-6">
-                            <table class="table table-light">
+                            <table class="table table-light mb-0">
                                 <tbody>
                                     <tr>
                                         <td class="px-3 h2 text-muted">Request amount:</td>
@@ -27,9 +27,12 @@
                                     </tr>
                                 </tbody>
                             </table>
-                            <div class="w-100 p-2">@Safe.Raw(Model.Description)</div>
+                            @if (Model.Description != null && Model.Description != "" && Model.Description != "<br>")
+                            {
+                                <div class="w-100 px-3 pt-4 pb-3">@Safe.Raw(Model.Description)</div>
+                            }
                         </div>
-                        <div class="col-sm-12 col-md-12 col-lg-6">
+                        <div class="col-sm-12 col-md-12 col-lg-6 pt-2">
                             <div class="table-responsive">
                                 <table class="table border-top-0">
                                     <thead>

--- a/BTCPayServer/Views/PaymentRequest/MinimalPaymentRequest.cshtml
+++ b/BTCPayServer/Views/PaymentRequest/MinimalPaymentRequest.cshtml
@@ -4,45 +4,40 @@
     <div class="row w-100 p-0 m-0" style="height: 100vh">
         <div class="mx-auto my-auto w-100">
             <div class="card">
-                <h1 class="card-header">
+                <h1 class="card-header px-3">
                     @Model.Title
                     <span class="text-muted float-right text-center">@Model.Status</span>
                 </h1>
                 <div class="card-body px-0 pt-0">
                     <div class="row mb-4">
-                        <div class="col-sm-12 col-md-12 col-lg-6 ">
-                            <ul class="w-100 list-group list-group-flush">
-                                <li class="list-group-item list-group-item-light">
-                                    <div class="d-flex justify-content-between">
-                                        <span class="h2 text-muted">Request amount:</span>
-                                        <span class="h2">@Model.AmountFormatted</span>
-                                    </div>
-                                </li>
-                                <li class="list-group-item list-group-item-light">
-                                    <div class="d-flex justify-content-between">
-                                        <span class="h2 text-muted">Paid so far:</span>
-                                        <span class="h2">@Model.AmountCollectedFormatted</span>
-                                    </div>
-                                </li>
-                                <li class="list-group-item list-group-item-light">
-                                    <div class="d-flex justify-content-between">
-                                        <span class="h2 text-muted">Amount due:</span>
-                                        <span class="h2">@Model.AmountDueFormatted</span>
-                                    </div>
-                                </li>
-                            </ul>
+                        <div class="col-sm-12 col-md-12 col-lg-6">
+                            <table class="table table-light">
+                                <tbody>
+                                    <tr>
+                                        <td class="px-3 h2 text-muted">Request amount:</td>
+                                        <td class="px-3 h2 text-nowrap text-right">@Model.AmountFormatted</td>
+                                    </tr>
+                                    <tr>
+                                        <td class="px-3 h2 text-muted">Paid so far:</td>
+                                        <td class="px-3 h2 text-nowrap text-right">@Model.AmountCollectedFormatted</td>
+                                    </tr>
+                                    <tr>
+                                        <td class="px-3 h2 text-muted">Amount due:</td>
+                                        <td class="px-3 h2 text-nowrap text-right">@Model.AmountDueFormatted</td>
+                                    </tr>
+                                </tbody>
+                            </table>
                             <div class="w-100 p-2">@Safe.Raw(Model.Description)</div>
-
                         </div>
-                        <div class="col-sm-12 col-md-12  col-lg-6">
+                        <div class="col-sm-12 col-md-12 col-lg-6">
                             <div class="table-responsive">
-                                <table class="table border-top-0 ">
+                                <table class="table border-top-0">
                                     <thead>
                                     <tr>
-                                        <th class=" border-top-0" scope="col">Invoice #</th>
-                                        <th class=" border-top-0">Price</th>
-                                        <th class=" border-top-0">Expiry</th>
-                                        <th class=" border-top-0">Status</th>
+                                        <th class="border-top-0" scope="col">Invoice #</th>
+                                        <th class="border-top-0">Price</th>
+                                        <th class="border-top-0">Expiry</th>
+                                        <th class="border-top-0">Status</th>
                                     </tr>
                                     </thead>
                                     <tbody>

--- a/BTCPayServer/Views/PaymentRequest/ViewPaymentRequest.cshtml
+++ b/BTCPayServer/Views/PaymentRequest/ViewPaymentRequest.cshtml
@@ -64,10 +64,10 @@ else
                             </template>
                         </span>
                     </h1>
-                    <div class="card-body px-0 pt-0">
-                        <div class="row mb-4">
+                    <div class="card-body px-0 pt-0 pb-0">
+                        <div class="row">
                             <div class="col-sm-12 col-md-12 col-lg-6">
-                                <table class="table table-light">
+                                <table class="table table-light mb-0">
                                     <tbody>
                                         <tr>
                                             <td class="px-3 h2 text-muted">Request amount:</td>
@@ -83,9 +83,13 @@ else
                                         </tr>
                                     </tbody>
                                 </table>
-                                <div v-html="srvModel.description" class="w-100 p-2"></div>
+                                <div
+                                    v-if="srvModel.description && srvModel.description !== '' && srvModel.description !== '<br>'"
+                                    v-html="srvModel.description"
+                                    class="w-100 px-3 pt-4 pb-3"
+                                ></div>
                             </div>
-                            <div class="col-sm-12 col-md-12  col-lg-6">
+                            <div class="col-sm-12 col-md-12 col-lg-6 pt-2">
                                 <div class="table-responsive">
                                     <table class="table border-top-0 ">
                                         <thead>

--- a/BTCPayServer/Views/PaymentRequest/ViewPaymentRequest.cshtml
+++ b/BTCPayServer/Views/PaymentRequest/ViewPaymentRequest.cshtml
@@ -52,7 +52,7 @@ else
         <div class="row w-100 p-0 m-0" style="height: 100vh">
             <div class="mx-auto my-auto w-100">
                 <div class="card">
-                    <h1 class="card-header">
+                    <h1 class="card-header px-3">
                         {{srvModel.title}}
 
                         <span class="text-muted float-right text-center">
@@ -66,39 +66,34 @@ else
                     </h1>
                     <div class="card-body px-0 pt-0">
                         <div class="row mb-4">
-                            <div class="col-sm-12 col-md-12 col-lg-6 ">
-                                <ul class="w-100 list-group list-group-flush">
-                                    <li class="list-group-item list-group-item-light">
-                                        <div class="d-flex justify-content-between">
-                                            <span class="h2 text-muted">Request amount:</span>
-                                            <span class="h2">{{srvModel.amountFormatted}}</span>
-                                        </div>
-                                    </li>
-                                    <li class="list-group-item list-group-item-light">
-                                        <div class="d-flex justify-content-between">
-                                            <span class="h2 text-muted">Paid so far:</span>
-                                            <span class="h2">{{srvModel.amountCollectedFormatted}}</span>
-                                        </div>
-                                    </li>
-                                    <li class="list-group-item list-group-item-light">
-                                        <div class="d-flex justify-content-between">
-                                            <span class="h2 text-muted">Amount due:</span>
-                                            <span class="h2">{{srvModel.amountDueFormatted}}</span>
-                                        </div>
-                                    </li>
-                                </ul>
+                            <div class="col-sm-12 col-md-12 col-lg-6">
+                                <table class="table table-light">
+                                    <tbody>
+                                        <tr>
+                                            <td class="px-3 h2 text-muted">Request amount:</td>
+                                            <td class="px-3 h2 text-nowrap text-right">{{srvModel.amountFormatted}}</td>
+                                        </tr>
+                                        <tr>
+                                            <td class="px-3 h2 text-muted">Paid so far:</td>
+                                            <td class="px-3 h2 text-nowrap text-right">{{srvModel.amountCollectedFormatted}}</td>
+                                        </tr>
+                                        <tr>
+                                            <td class="px-3 h2 text-muted">Amount due:</td>
+                                            <td class="px-3 h2 text-nowrap text-right">{{srvModel.amountDueFormatted}}</td>
+                                        </tr>
+                                    </tbody>
+                                </table>
                                 <div v-html="srvModel.description" class="w-100 p-2"></div>
-
                             </div>
                             <div class="col-sm-12 col-md-12  col-lg-6">
                                 <div class="table-responsive">
                                     <table class="table border-top-0 ">
                                         <thead>
                                         <tr>
-                                            <th class=" border-top-0" scope="col">Invoice #</th>
-                                            <th class=" border-top-0">Price</th>
-                                            <th class=" border-top-0">Expiry</th>
-                                            <th class=" border-top-0">Status</th>
+                                            <th class="border-top-0" scope="col">Invoice #</th>
+                                            <th class="border-top-0">Price</th>
+                                            <th class="border-top-0">Expiry</th>
+                                            <th class="border-top-0">Status</th>
                                         </tr>
                                         </thead>
                                         <tbody>


### PR DESCRIPTION
## List vs. table

Uses a table instead of list group items, so that the columns properly align (rows use the same grid). Also aligns the values on the right.

**Before:**

<img width="431" alt="list-before" src="https://user-images.githubusercontent.com/886/68999991-fed3db80-08c8-11ea-994f-ca49afa4d889.png">


**After:** 

<img width="430" alt="table-after" src="https://user-images.githubusercontent.com/886/69000000-1a3ee680-08c9-11ea-844f-788fe8840b46.png">


## Description: Empty vs. present

There appears an unnecessary area of white space, when the description is not set. The second commit handles the different cases.

**Empty:**

<img width="1141" alt="description-empty" src="https://user-images.githubusercontent.com/886/69000010-5d995500-08c9-11ea-9472-756c8a5d9112.png">


**Present:**

<img width="1132" alt="description-present png" src="https://user-images.githubusercontent.com/886/69000017-6e49cb00-08c9-11ea-8a14-c348dfe4c670.png">
