### PR TITLE
UI: Left align admin section headings

### DIFF
--- a/BTCPayServer/wwwroot/main/site.css
+++ b/BTCPayServer/wwwroot/main/site.css
@@ -42,11 +42,6 @@ a {
     transition-property: background, color;
 }
 
-/* Admin Sections */
-.section-heading {
-    text-align: var(--btcpay-section-heading-text-align, center);
-}
-
 /* Admin Sidebar Navigation */
 a.nav-link {
     color: var(--btcpay-nav-color-link, var(--btcpay-color-neutral-600));

--- a/BTCPayServer/wwwroot/main/themes/casa.css
+++ b/BTCPayServer/wwwroot/main/themes/casa.css
@@ -55,8 +55,6 @@
   --btcpay-body-color-link: var(--btcpay-color-primary);
   --btcpay-body-color-link-accent: var(--btcpay-color-primary-accent);
 
-  --btcpay-section-heading-text-align: left;
-
   --btcpay-nav-color-link-accent: var(--btcpay-color-neutral-100);
 
   --btcpay-header-bg: var(--btcpay-brand-darker);

--- a/BTCPayServer/wwwroot/main/themes/modern.css
+++ b/BTCPayServer/wwwroot/main/themes/modern.css
@@ -46,8 +46,6 @@
   --btcpay-body-color-link: var(--btcpay-color-primary);
   --btcpay-body-color-link-accent: var(--btcpay-color-primary-accent);
 
-  --btcpay-section-heading-text-align: left;
-
   --btcpay-preformatted-text-color: var(--btcpay-color-neutral-900);
 
   --btcpay-font-size-base: 16px;


### PR DESCRIPTION
Removes the custom property and consistently align the headings left, which I agree is the better choice.

Context: https://chat.btcpayserver.org/btcpayserver/pl/upb3nzch7j8nmpbt7kfmoe6beo