### PR TITLE
Update vaultbridge.js

### DIFF
--- a/BTCPayServer/wwwroot/js/vaultbridge.js
+++ b/BTCPayServer/wwwroot/js/vaultbridge.js
@@ -35,7 +35,7 @@
                         }
                     };
                     request.overrideMimeType("text/plain");
-                    request.open('POST', 'http://localhost:65092/hwi-bridge/v1');
+                    request.open('POST', 'http://127.0.0.1:65092/hwi-bridge/v1');
                     request.send(JSON.stringify(jsonObject));
                 }
                 else {
@@ -87,7 +87,7 @@
                 }
             };
             request.overrideMimeType("text/plain");
-            request.open('GET', 'http://localhost:65092/hwi-bridge/v1/request-permission');
+            request.open('GET', 'http://127.0.0.1:65092/hwi-bridge/v1/request-permission');
             request.send();
         });
     }


### PR DESCRIPTION
replace localhost with 127.0.0.1 fixes BTCPay Vault in Apple Safari browser Version 13.0.3 macOS Catalina 10.15.1 (19B88)
thanks to Nicolas