### PR TITLE
[WIP] The tests in btcpayserver should use only the services they use

### DIFF
--- a/BTCPayServer.Tests/BTCPayServerTester.cs
+++ b/BTCPayServer.Tests/BTCPayServerTester.cs
@@ -94,7 +94,9 @@ namespace BTCPayServer.Tests
 
         public bool MockRates { get; set; } = true;
 
-        public List<string> Chains { get; set; } = new List<string>(){"BTC", "LTC"};
+        public HashSet<string> Chains { get; set; } = new HashSet<string>(){"BTC"};
+        public bool UseLightning { get; set; }
+
         public async Task StartAsync()
         {
             if (!Directory.Exists(_Directory))
@@ -116,6 +118,10 @@ namespace BTCPayServer.Tests
             {
                 config.AppendLine($"btc.explorer.url={NBXplorerUri.AbsoluteUri}");
                 config.AppendLine($"btc.explorer.cookiefile=0");
+            }
+
+            if (UseLightning)
+            {
                 config.AppendLine($"btc.lightning={IntegratedLightning.AbsoluteUri}");
                 var localLndBackupFile = Path.Combine(_Directory, "walletunlock.json");
                 File.Copy(TestUtils.GetTestDataFullPath("LndSeedBackup/walletunlock.json"), localLndBackupFile, true);

--- a/BTCPayServer.Tests/CheckoutUITests.cs
+++ b/BTCPayServer.Tests/CheckoutUITests.cs
@@ -106,10 +106,14 @@ namespace BTCPayServer.Tests
         }
         
         [Fact(Timeout = TestTimeout)]
+        [Trait("Altcoins", "Altcoins")]
+        [Trait("Lightning", "Lightning")]
         public async Task CanUsePaymentMethodDropdown()
         {
             using (var s = SeleniumTester.Create())
             {
+                s.Server.ActivateLTC();
+                s.Server.ActivateLightning();
                 await s.StartAsync();
                 s.GoToRegister();
                 s.RegisterNewUser();
@@ -150,10 +154,12 @@ namespace BTCPayServer.Tests
         }
         
         [Fact(Timeout = TestTimeout)]
+        [Trait("Lightning", "Lightning")]
         public async Task CanUseLightningSatsFeature()
         {
             using (var s = SeleniumTester.Create())
             {
+                s.Server.ActivateLightning();
                 await s.StartAsync();
                 s.GoToRegister();
                 s.RegisterNewUser();

--- a/BTCPayServer.Tests/ElementsTests.cs
+++ b/BTCPayServer.Tests/ElementsTests.cs
@@ -29,11 +29,12 @@ namespace BTCPayServer.Tests
         }
         
         [Fact]
+        [Trait("Altcoins", "Altcoins")]
         public async Task OnlyShowSupportedWallets()
         {
             using (var tester = ServerTester.Create())
             {
-                tester.PayTester.Chains.Add("LBTC");
+                tester.ActivateLBTC();
                 await tester.StartAsync();
                 await tester.EnsureChannelsSetup();
                 var user = tester.NewAccount();
@@ -67,11 +68,12 @@ namespace BTCPayServer.Tests
         }
 
         [Fact]
+        [Trait("Altcoins", "Altcoins")]
         public async Task ElementsAssetsAreHandledCorrectly()
         {
             using (var tester = ServerTester.Create())
             {
-                tester.PayTester.Chains.Add("LBTC");
+                tester.ActivateLBTC();
                 await tester.StartAsync();
                 var user = tester.NewAccount();
                 user.GrantAccess();

--- a/BTCPayServer.Tests/PaymentHandlerTest.cs
+++ b/BTCPayServer.Tests/PaymentHandlerTest.cs
@@ -13,6 +13,7 @@ using BTCPayServer.Rating;
 
 namespace BTCPayServer.Tests
 {
+    [Trait("Fast", "Fast")]
     public class PaymentHandlerTest
     {
         private BitcoinLikePaymentHandler handlerBTC;

--- a/BTCPayServer.Tests/SeleniumTests.cs
+++ b/BTCPayServer.Tests/SeleniumTests.cs
@@ -34,6 +34,27 @@ namespace BTCPayServer.Tests
                 s.ClickOnAllSideMenus();
                 s.Driver.FindElement(By.LinkText("Services")).Click();
 
+                Logs.Tester.LogInformation("Let's check if we can access the logs");
+                s.Driver.FindElement(By.LinkText("Logs")).Click();
+                s.Driver.FindElement(By.PartialLinkText(".log")).Click();
+                Assert.Contains("Starting listening NBXplorer", s.Driver.PageSource);
+                s.Driver.Quit();
+            }
+        }
+
+        [Fact(Timeout = TestTimeout)]
+        [Trait("Lightning", "Lightning")]
+        public async Task CanUseLndSeedBackup()
+        {
+            using (var s = SeleniumTester.Create())
+            {
+                s.Server.ActivateLightning();
+                await s.StartAsync();
+                s.RegisterNewUser(true);
+                s.Driver.FindElement(By.Id("ServerSettings")).Click();
+                s.Driver.AssertNoError();
+                s.Driver.FindElement(By.LinkText("Services")).Click();
+
                 Logs.Tester.LogInformation("Let's if we can access LND's seed");
                 Assert.Contains("server/services/lndseedbackup/BTC", s.Driver.PageSource);
                 s.Driver.Navigate().GoToUrl(s.Link("/server/services/lndseedbackup/BTC"));
@@ -49,12 +70,6 @@ namespace BTCPayServer.Tests
                 s.AssertHappyMessage();
                 seedEl = s.Driver.FindElement(By.Id("SeedTextArea"));
                 Assert.Contains("Seed removed", seedEl.Text, StringComparison.OrdinalIgnoreCase);
-
-                Logs.Tester.LogInformation("Let's check if we can access the logs");
-                s.Driver.FindElement(By.LinkText("Logs")).Click();
-                s.Driver.FindElement(By.PartialLinkText(".log")).Click();
-                Assert.Contains("Starting listening NBXplorer", s.Driver.PageSource);
-                s.Driver.Quit();
             }
         }
 

--- a/BTCPayServer.Tests/ServerTester.cs
+++ b/BTCPayServer.Tests/ServerTester.cs
@@ -46,31 +46,15 @@ namespace BTCPayServer.Tests
             NetworkProvider = new BTCPayNetworkProvider(NetworkType.Regtest);
             ExplorerNode = new RPCClient(RPCCredentialString.Parse(GetEnvironment("TESTS_BTCRPCCONNECTION", "server=http://127.0.0.1:43782;ceiwHEbqWI83:DwubwWsoo3")), NetworkProvider.GetNetwork<BTCPayNetwork>("BTC").NBitcoinNetwork);
             ExplorerNode.ScanRPCCapabilities();
-            LTCExplorerNode = new RPCClient(RPCCredentialString.Parse(GetEnvironment("TESTS_LTCRPCCONNECTION", "server=http://127.0.0.1:43783;ceiwHEbqWI83:DwubwWsoo3")), NetworkProvider.GetNetwork<BTCPayNetwork>("LTC").NBitcoinNetwork);
-            LBTCExplorerNode = new RPCClient(RPCCredentialString.Parse(GetEnvironment("TESTS_LBTCRPCCONNECTION", "server=http://127.0.0.1:19332;liquid:liquid")), NetworkProvider.GetNetwork<BTCPayNetwork>("LBTC").NBitcoinNetwork);
 
             ExplorerClient = new ExplorerClient(NetworkProvider.GetNetwork<BTCPayNetwork>("BTC").NBXplorerNetwork, new Uri(GetEnvironment("TESTS_BTCNBXPLORERURL", "http://127.0.0.1:32838/")));
-            LTCExplorerClient = new ExplorerClient(NetworkProvider.GetNetwork<BTCPayNetwork>("LTC").NBXplorerNetwork, new Uri(GetEnvironment("TESTS_LTCNBXPLORERURL", "http://127.0.0.1:32838/")));
-            LBTCExplorerClient = new ExplorerClient(NetworkProvider.GetNetwork<BTCPayNetwork>("LBTC").NBXplorerNetwork, new Uri(GetEnvironment("TESTS_LBTCNBXPLORERURL", "http://127.0.0.1:32838/")));
-
-            var btc = NetworkProvider.GetNetwork<BTCPayNetwork>("BTC").NBitcoinNetwork;
-            CustomerLightningD = LightningClientFactory.CreateClient(GetEnvironment("TEST_CUSTOMERLIGHTNINGD", "type=clightning;server=tcp://127.0.0.1:30992/"), btc);
-            MerchantLightningD = LightningClientFactory.CreateClient(GetEnvironment("TEST_MERCHANTLIGHTNINGD", "type=clightning;server=tcp://127.0.0.1:30993/"), btc);
-
-            MerchantCharge = new ChargeTester(this, "TEST_MERCHANTCHARGE", "type=charge;server=http://127.0.0.1:54938/;api-token=foiewnccewuify", "merchant_lightningd", btc);
-
-            MerchantLnd = new LndMockTester(this, "TEST_MERCHANTLND", "https://lnd:lnd@127.0.0.1:53280/", "merchant_lnd", btc);
 
             PayTester = new BTCPayServerTester(Path.Combine(_Directory, "pay"))
             {
-                
                 NBXplorerUri = ExplorerClient.Address,
-                LTCNBXplorerUri = LTCExplorerClient.Address,
-                LBTCNBXplorerUri = LTCExplorerClient.Address,
                 TestDatabase = Enum.Parse<TestDatabases>(GetEnvironment("TESTS_DB", TestDatabases.Postgres.ToString()), true),
                 Postgres = GetEnvironment("TESTS_POSTGRES", "User ID=postgres;Host=127.0.0.1;Port=39372;Database=btcpayserver"),
-                MySQL = GetEnvironment("TESTS_MYSQL", "User ID=root;Host=127.0.0.1;Port=33036;Database=btcpayserver"),
-                IntegratedLightning = MerchantCharge.Client.Uri
+                MySQL = GetEnvironment("TESTS_MYSQL", "User ID=root;Host=127.0.0.1;Port=33036;Database=btcpayserver")
             };
             PayTester.Port = int.Parse(GetEnvironment("TESTS_PORT", Utils.FreeTcpPort().ToString(CultureInfo.InvariantCulture)), CultureInfo.InvariantCulture);
             PayTester.HostName = GetEnvironment("TESTS_HOSTNAME", "127.0.0.1");
@@ -81,6 +65,31 @@ namespace BTCPayServer.Tests
             PayTester.SSHConnection = GetEnvironment("TESTS_SSHCONNECTION", "root@127.0.0.1:21622");
         }
 
+        public void ActivateLTC()
+        {
+            LTCExplorerNode = new RPCClient(RPCCredentialString.Parse(GetEnvironment("TESTS_LTCRPCCONNECTION", "server=http://127.0.0.1:43783;ceiwHEbqWI83:DwubwWsoo3")), NetworkProvider.GetNetwork<BTCPayNetwork>("LTC").NBitcoinNetwork);
+            LTCExplorerClient = new ExplorerClient(NetworkProvider.GetNetwork<BTCPayNetwork>("LTC").NBXplorerNetwork, new Uri(GetEnvironment("TESTS_LTCNBXPLORERURL", "http://127.0.0.1:32838/")));
+            PayTester.Chains.Add("LTC");
+            PayTester.LTCNBXplorerUri = LTCExplorerClient.Address;
+        }
+        public void ActivateLBTC()
+        {
+            LBTCExplorerNode = new RPCClient(RPCCredentialString.Parse(GetEnvironment("TESTS_LBTCRPCCONNECTION", "server=http://127.0.0.1:19332;liquid:liquid")), NetworkProvider.GetNetwork<BTCPayNetwork>("LBTC").NBitcoinNetwork);
+            LBTCExplorerClient = new ExplorerClient(NetworkProvider.GetNetwork<BTCPayNetwork>("LBTC").NBXplorerNetwork, new Uri(GetEnvironment("TESTS_LBTCNBXPLORERURL", "http://127.0.0.1:32838/")));
+            PayTester.Chains.Add("LBTC");
+            PayTester.LBTCNBXplorerUri = LBTCExplorerClient.Address;
+        }
+
+        public void ActivateLightning()
+        {
+            var btc = NetworkProvider.GetNetwork<BTCPayNetwork>("BTC").NBitcoinNetwork;
+            CustomerLightningD = LightningClientFactory.CreateClient(GetEnvironment("TEST_CUSTOMERLIGHTNINGD", "type=clightning;server=tcp://127.0.0.1:30992/"), btc);
+            MerchantLightningD = LightningClientFactory.CreateClient(GetEnvironment("TEST_MERCHANTLIGHTNINGD", "type=clightning;server=tcp://127.0.0.1:30993/"), btc);
+            MerchantCharge = new ChargeTester(this, "TEST_MERCHANTCHARGE", "type=charge;server=http://127.0.0.1:54938/;api-token=foiewnccewuify", "merchant_lightningd", btc);
+            MerchantLnd = new LndMockTester(this, "TEST_MERCHANTLND", "https://lnd:lnd@127.0.0.1:53280/", "merchant_lnd", btc);
+            PayTester.UseLightning = true;
+            PayTester.IntegratedLightning = MerchantCharge.Client.Uri;
+        }
 
         public bool Dockerized
         {


### PR DESCRIPTION
The goal of this PR is to properly separate tests which need Bitcoin/Altcoins/Lightning so that developer working on btcpayserver eventually do not need to fire up tons resource consuming software in the docker-compose.