### PR TITLE
Updating referenced lnd to 0.8.2-beta

### DIFF
--- a/BTCPayServer.Tests/docker-compose.yml
+++ b/BTCPayServer.Tests/docker-compose.yml
@@ -257,7 +257,7 @@ services:
       - "5432"
 
   merchant_lnd:
-    image: btcpayserver/lnd:v0.7.1-beta-withseed
+    image: btcpayserver/lnd:v0.8.2-beta
     restart: unless-stopped
     environment:
       LND_CHAIN: "btc"
@@ -287,7 +287,7 @@ services:
       - bitcoind
 
   customer_lnd:
-    image: btcpayserver/lnd:v0.7.1-beta-withseed
+    image: btcpayserver/lnd:v0.8.2-beta
     restart: unless-stopped
     environment:
       LND_CHAIN: "btc"


### PR DESCRIPTION
This updates LND in our dev environments to 0.8.2-beta. Please test if things keep working for you in local dev envs... if they do we can update `btcpayserver-docker` repository to reference this version.