### PR TITLE
Remove the next address to pay to from Invoice details page (Fix #1056)

### DIFF
--- a/BTCPayServer/Controllers/InvoiceController.UI.cs
+++ b/BTCPayServer/Controllers/InvoiceController.UI.cs
@@ -104,7 +104,6 @@ namespace BTCPayServer.Controllers
                 cryptoPayment.Paid = _CurrencyNameTable.DisplayFormatCurrency(accounting.CryptoPaid.ToDecimal(MoneyUnit.BTC), paymentMethodId.CryptoCode);
                 cryptoPayment.Overpaid = _CurrencyNameTable.DisplayFormatCurrency(accounting.OverpaidHelper.ToDecimal(MoneyUnit.BTC), paymentMethodId.CryptoCode);
                 var paymentMethodDetails = data.GetPaymentMethodDetails();
-                cryptoPayment.Address = paymentMethodDetails.GetPaymentDestination();
                 cryptoPayment.Rate = ExchangeRate(data);
                 model.CryptoPayments.Add(cryptoPayment);
             }

--- a/BTCPayServer/Models/InvoicingModels/InvoiceDetailsModel.cs
+++ b/BTCPayServer/Models/InvoicingModels/InvoiceDetailsModel.cs
@@ -36,7 +36,6 @@ namespace BTCPayServer.Models.InvoicingModels
             public string PaymentMethod { get; set; }
             public string Due { get; set; }
             public string Paid { get; set; }
-            public string Address { get; internal set; }
             public string Rate { get; internal set; }
             public string PaymentUrl { get; internal set; }
             public string Overpaid { get; set; }

--- a/BTCPayServer/Views/Invoice/InvoicePaymentsPartial.cshtml
+++ b/BTCPayServer/Views/Invoice/InvoicePaymentsPartial.cshtml
@@ -3,12 +3,11 @@
 
 <div class="row">
     <div class="col-md-12 invoice-payments">
-        <h3>Paid summary</h3>
+        <h3>Current status</h3>
         <table class="table table-sm table-responsive-md">
             <thead class="thead-inverse">
             <tr>
                 <th>Payment method</th>
-                <th>Address</th>
                 <th class="text-right">Rate</th>
                 <th class="text-right">Paid</th>
                 <th class="text-right">Due</th>
@@ -23,9 +22,6 @@
             {
                 <tr>
                     <td>@payment.PaymentMethod</td>
-                    <td title="@payment.Address">
-                        <span  class="text-truncate d-block" style="max-width: 400px">@payment.Address</span>
-                    </td>
                     <td class="text-right">@payment.Rate</td>
                     <td class="text-right">@payment.Paid</td>
                     <td class="text-right">@payment.Due</td>


### PR DESCRIPTION
This address was confusing. It represent the next address to pay to, but could easily confuse users as #1056 shows.

Before
![image](https://user-images.githubusercontent.com/3020646/72504085-7d74d700-3880-11ea-981a-f215b542e142.png)


Now
![image](https://user-images.githubusercontent.com/3020646/72504017-5b7b5480-3880-11ea-8e1d-5540b35ffb2b.png)

