### PR TITLE
Add nullable enable directive to HttpClientRequestMaker.MakeRequestAsync

### DIFF
--- a/BTCPayServer.Rating/Providers/HttpClientRequestMaker.cs
+++ b/BTCPayServer.Rating/Providers/HttpClientRequestMaker.cs
@@ -196,11 +196,9 @@ namespace BTCPayServer.Services.Rates
                     throw new APIException(text);
                 }
                 api.ProcessResponse(new InternalHttpWebResponse(webHttpResponse));
-                #nullable enable
-                Action<IAPIRequestMaker, RequestMakerState, object>? requestStateChanged = RequestStateChanged;
-                if (requestStateChanged != null)
+                if (RequestStateChanged != null)
                 {
-                    requestStateChanged!(this, RequestMakerState.Finished, text);
+                    RequestStateChanged(this, RequestMakerState.Finished, text);
                     return text;
                 }
                 return text;

--- a/BTCPayServer.Rating/Providers/HttpClientRequestMaker.cs
+++ b/BTCPayServer.Rating/Providers/HttpClientRequestMaker.cs
@@ -196,6 +196,7 @@ namespace BTCPayServer.Services.Rates
                     throw new APIException(text);
                 }
                 api.ProcessResponse(new InternalHttpWebResponse(webHttpResponse));
+                #nullable enable
                 Action<IAPIRequestMaker, RequestMakerState, object>? requestStateChanged = RequestStateChanged;
                 if (requestStateChanged != null)
                 {


### PR DESCRIPTION
My VSCode complains that `The annotation for nullable reference types should only be used in code within a '#nullable' annotations context. [BTCPayServer.Rating]`. To fix this I added the `#nullable enable` directive. See here for details: https://stackoverflow.com/questions/55492214/the-annotation-for-nullable-reference-types-should-only-be-used-in-code-within-a