### PR TITLE
0 Amount invoices handling

### DIFF
--- a/BTCPayServer/Services/Invoices/InvoiceEntity.cs
+++ b/BTCPayServer/Services/Invoices/InvoiceEntity.cs
@@ -888,7 +888,11 @@ namespace BTCPayServer.Services.Invoices
             accounting.Due = Money.Max(accounting.TotalDue - accounting.Paid, Money.Zero);
             accounting.DueUncapped = accounting.TotalDue - accounting.Paid;
             accounting.NetworkFee = accounting.TotalDue - totalDueNoNetworkCost;
-            var minimumTotalDueSatoshi = Math.Max(1.0m, accounting.TotalDue.Satoshi * (1.0m - ((decimal)ParentEntity.PaymentTolerance / 100.0m)));
+            // If the total due is 0, there is no payment tolerance to calculate
+            var minimumTotalDueSatoshi = accounting.TotalDue.Satoshi == 0
+                ? 0
+                : Math.Max(1.0m,
+                    accounting.TotalDue.Satoshi * (1.0m - ((decimal)ParentEntity.PaymentTolerance / 100.0m)));
             accounting.MinimumTotalDue = Money.Satoshis(minimumTotalDueSatoshi);
             return accounting;
         }

--- a/BTCPayServer/Views/Invoice/Checkout-Body.cshtml
+++ b/BTCPayServer/Views/Invoice/Checkout-Body.cshtml
@@ -155,7 +155,7 @@
 </div>
 
 <div class="payment-box" v-bind:class="{ 'payment-box--with-recommended-fee': showRecommendedFee && !showEmailForm }">
-    <div class="bp-view payment manual-flow enter-contact-email" id="emailAddressView" v-bind:class="{ 'active': showEmailForm}">
+    <div class="bp-view enter-contact-email" id="emailAddressView" v-bind:class="{ 'active': showEmailForm}">
         <form class="manual__step-one refund-address-form contact-email-form" id="emailAddressForm" name="emailAddressForm" novalidate="" v-on:submit.prevent="onEmailSubmit">
             <div class="manual__step-one__header">
                 <span>{{$t("Contact and Refund Email")}}</span>
@@ -190,7 +190,7 @@
         </component>
     </div>
 
-    <div class="bp-view" id="paid" v-bind:class="{ 'active': invoicePaid}">
+    <div class="bp-view" id="paid" v-bind:class="{ 'active': invoicePaid && !showEmailForm}">
         <div class="status-block">
             <div class="success-block">
                 <div class="status-icon">

--- a/BTCPayServer/Views/Invoice/Checkout.cshtml
+++ b/BTCPayServer/Views/Invoice/Checkout.cshtml
@@ -184,7 +184,7 @@
                 return !this.showEmailForm && !this.invoiceUnpayable && !this.invoicePaid;
             },
             showEmailForm: function(){
-                return this.srvModel.requiresRefundEmail && (!this.srvModel.customerEmail || !this.validateEmail(this.srvModel.customerEmail)) && !this.invoiceUnpayable && !this.invoicePaid;
+                return this.srvModel.requiresRefundEmail && (!this.srvModel.customerEmail || !this.validateEmail(this.srvModel.customerEmail)) && !this.invoiceUnpayable;
             },
             showRecommendedFee: function(){
                 return  this.srvModel.showRecommendedFee && this.srvModel.feeRate != 0;


### PR DESCRIPTION
Let 0 amount invoices pass through(they currently get stuck on new status) and allow email to be set when required but invoice has been paid( makes sense for 0 invoices, but also for when someone displays the btc address or invoice elsewhere from the api)

Specifically requested by nodl guys but it is super useful when you combine it with the POS and want to offer free tickets/ items.
@ketominer @Askuwheteau @IAskuwheteau