### PR TITLE
add enviroment configuration to issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -14,10 +14,8 @@ A clear and concise description of what the bug is.
 **Logs (if applicable)**
 Basic logs can be found in Server Settings > Logs.
 
-**Profile Configuration**
-If you're reporting a deployment issue, paste your configuration:
-
-`cat /etc/profile.d/btcpay-env.sh`
+**Setup Parameters**
+If you're reporting a deployment issue run `. btcpay-setup.sh -i` and paste your the paremeters by obscuring private information.
 
 **To Reproduce**
 Steps to reproduce the behavior:

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -14,6 +14,11 @@ A clear and concise description of what the bug is.
 **Logs (if applicable)**
 Basic logs can be found in Server Settings > Logs.
 
+**Profile Configuration**
+If you're reporting a deployment issue, paste your configuration:
+
+`cat /etc/profile.d/btcpay-env.sh`
+
 **To Reproduce**
 Steps to reproduce the behavior:
 1. Go to '...'


### PR DESCRIPTION
This PR adds `cat /etc/profile.d/btcpay-env.sh` in the bug report issue template that will help us better with deployment issues. I've noticed it's important info we often ask people to provide.

Unsure if wording was the best here so if there are better ideas, let me know.