### PR TITLE
Add API Keys Application identifier

### DIFF
--- a/BTCPayServer.Data/Data/APIKeyData.cs
+++ b/BTCPayServer.Data/Data/APIKeyData.cs
@@ -20,6 +20,7 @@ namespace BTCPayServer.Data
         [MaxLength(50)] public string StoreId { get; set; }
 
         [MaxLength(50)] public string UserId { get; set; }
+        public string ApplicationIdentifier { get; set; }
 
         public APIKeyType Type { get; set; } = APIKeyType.Legacy;
         public string Permissions { get; set; }

--- a/BTCPayServer.Data/Migrations/20200228183226_Add_ApiKeys_ApplicationIdentifier.cs
+++ b/BTCPayServer.Data/Migrations/20200228183226_Add_ApiKeys_ApplicationIdentifier.cs
@@ -1,0 +1,26 @@
+﻿using BTCPayServer.Data;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace BTCPayServer.Migrations
+{
+    [DbContext(typeof(ApplicationDbContext))]
+    [Migration("20200228183226_Add_ApiKeys_ApplicationIdentifier")]
+    public partial class Add_ApiKeys_ApplicationIdentifier : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "ApplicationIdentifier",
+                table: "ApiKeys",
+                nullable: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "ApplicationIdentifier",
+                table: "ApiKeys");
+        }
+    }
+}

--- a/BTCPayServer.Data/Migrations/ApplicationDbContextModelSnapshot.cs
+++ b/BTCPayServer.Data/Migrations/ApplicationDbContextModelSnapshot.cs
@@ -22,6 +22,9 @@ namespace BTCPayServer.Migrations
                         .HasColumnType("TEXT")
                         .HasMaxLength(50);
 
+                    b.Property<string>("ApplicationIdentifier")
+                        .HasColumnType("TEXT");
+
                     b.Property<string>("Label")
                         .HasColumnType("TEXT");
 

--- a/BTCPayServer/Security/APIKeys/APIKeyRepository.cs
+++ b/BTCPayServer/Security/APIKeys/APIKeyRepository.cs
@@ -30,9 +30,18 @@ namespace BTCPayServer.Security.APIKeys
             using (var context = _applicationDbContextFactory.CreateContext())
             {
                 var queryable = context.ApiKeys.AsQueryable();
-                if (query?.UserId != null && query.UserId.Any())
+                if (query != null)
                 {
-                    queryable = queryable.Where(data => query.UserId.Contains(data.UserId));
+                    if (query.UserId != null && query.UserId.Any())
+                    {
+                        queryable = queryable.Where(data => query.UserId.Contains(data.UserId));
+                    }
+
+                    if (query.ApplicationIdentifier != null && query.ApplicationIdentifier.Any())
+                    {
+                        queryable = queryable.Where(data =>
+                            query.ApplicationIdentifier.Contains(data.ApplicationIdentifier));
+                    }
                 }
 
                 return await queryable.ToListAsync();
@@ -67,6 +76,7 @@ namespace BTCPayServer.Security.APIKeys
         public class APIKeyQuery
         {
             public string[] UserId { get; set; }
+            public string[] ApplicationIdentifier { get; set; }
         }
     }
 }

--- a/BTCPayServer/Views/Manage/AuthorizeAPIKey.cshtml
+++ b/BTCPayServer/Views/Manage/AuthorizeAPIKey.cshtml
@@ -19,10 +19,12 @@
 
 <partial name="_StatusMessage"/>
 <form method="post" asp-action="AuthorizeAPIKey">
+    <input type="hidden" asp-for="RedirectUrl" value="@Model.RedirectUrl"/>
     <input type="hidden" asp-for="Permissions" value="@Model.Permissions"/>
     <input type="hidden" asp-for="Strict" value="@Model.Strict"/>
     <input type="hidden" asp-for="ApplicationName" value="@Model.ApplicationName"/>
     <input type="hidden" asp-for="SelectiveStores" value="@Model.SelectiveStores"/>
+    <input type="hidden" asp-for="ApplicationIdentifier" value="@Model.ApplicationIdentifier"/>
     <section>
         <div class="card container">
             <div class="row">
@@ -30,6 +32,12 @@
                     <h2>Authorization Request</h2>
                     <hr class="primary">
                     <p class="mb-1">@(Model.ApplicationName ?? "An application") is requesting access to your account.</p>
+                    @if (Model.RedirectUrl != null)
+                    {
+                        <p class="mb-1 alert alert-info">
+                        If authorized, the generated API key will be provided to <strong>@Model.RedirectUrl.AbsoluteUri</strong>
+                        </p>
+                    }
                 </div>
             </div>
             <div class="row">


### PR DESCRIPTION
This lets the authorize api key screen redirect to the defined url  and provide it with the user id, permissions granted and the key.

This also allows apps to match existing api keys generated for it specifically using the application identifier, and if matched, presented with a confirmation page before redirection.