### PR TITLE
Specify QR code error correction level explicitly

### DIFF
--- a/BTCPayServer/Views/Home/BitpayTranslator.cshtml
+++ b/BTCPayServer/Views/Home/BitpayTranslator.cshtml
@@ -55,7 +55,8 @@
                 text: @Safe.Json(Model.BitcoinUri),
                 width: 200,
                 height: 200,
-                useSVG: true
+                useSVG: true,
+                correctLevel : QRCode.CorrectLevel.M
             });
         $("#qrCode > img").css({ "margin": "auto" });
     </script>

--- a/BTCPayServer/Views/Manage/EnableAuthenticator.cshtml
+++ b/BTCPayServer/Views/Manage/EnableAuthenticator.cshtml
@@ -56,7 +56,8 @@
                 text: @Safe.Json(Model.AuthenticatorUri),
                 width: 200,
                 height: 200,
-                useSVG: true
+                useSVG: true,
+                correctLevel : QRCode.CorrectLevel.M
             });
         $("#qrCode > img").css({ "margin": "auto" });
     </script>

--- a/BTCPayServer/Views/Server/CLightningRestServices.cshtml
+++ b/BTCPayServer/Views/Server/CLightningRestServices.cshtml
@@ -158,7 +158,8 @@
                 text: @Safe.Json(Model.QRCode),
                 width: 200,
                 height: 200,
-                useSVG: true
+                useSVG: true,
+                correctLevel : QRCode.CorrectLevel.M
             });
         </script>
     }

--- a/BTCPayServer/Views/Server/LightningWalletServices.cshtml
+++ b/BTCPayServer/Views/Server/LightningWalletServices.cshtml
@@ -73,7 +73,8 @@
                 text: @Safe.Json(Model.ServiceLink),
                 width: 200,
                 height: 200,
-                useSVG: true
+                useSVG: true,
+                correctLevel : QRCode.CorrectLevel.M
             });
         </script>
     }

--- a/BTCPayServer/Views/Server/LndServices.cshtml
+++ b/BTCPayServer/Views/Server/LndServices.cshtml
@@ -187,7 +187,8 @@
                 text: @Safe.Json(Model.QRCode),
                 width: 200,
                 height: 200,
-                useSVG: true
+                useSVG: true,
+                correctLevel : QRCode.CorrectLevel.M
             });
         </script>
     }

--- a/BTCPayServer/Views/Server/P2PService.cshtml
+++ b/BTCPayServer/Views/Server/P2PService.cshtml
@@ -101,7 +101,8 @@
                 text: @Safe.Json(Model.ServiceLink),
                 width: 200,
                 height: 200,
-                useSVG: true
+                useSVG: true,
+                correctLevel : QRCode.CorrectLevel.M
             });
         </script>
     }

--- a/BTCPayServer/Views/Server/RPCService.cshtml
+++ b/BTCPayServer/Views/Server/RPCService.cshtml
@@ -98,7 +98,8 @@
                 text: @Safe.Json(Model.ServiceLink),
                 width: 200,
                 height: 200,
-                useSVG: true
+                useSVG: true,
+                correctLevel : QRCode.CorrectLevel.M
             });
         </script>
     }


### PR DESCRIPTION
fix #1332

The issue here was that our QR code strings were getting really long and longer than what could be reliably encoded in the generated QR code with default error correction level applied.

I now specify the `M` (medium - 15%) error correction level instead of the default `H` (high - 30%) level to avoid this issue wherever we render a QR code. This should be more than enough since these QR codes are only rendered on screen and generally not damaged in any way. See details about error correction levels here: https://en.wikipedia.org/wiki/QR_code#Error_correction