### PR TITLE
Fixing modal Open Wallet click on iOS Safari by targeting iframe parent

### DIFF
--- a/BTCPayServer/Views/Shared/Bitcoin_Lightning_LikeMethodCheckout.cshtml
+++ b/BTCPayServer/Views/Shared/Bitcoin_Lightning_LikeMethodCheckout.cshtml
@@ -27,7 +27,7 @@
                 </div>
             </div>
             <div class="payment__details__instruction__open-wallet" v-if="srvModel.invoiceBitcoinUrl">
-                <a class="payment__details__instruction__open-wallet__btn action-button" v-bind:href="srvModel.invoiceBitcoinUrl">
+                <a class="payment__details__instruction__open-wallet__btn action-button" target="_top" v-bind:href="srvModel.invoiceBitcoinUrl">
                     <span>{{$t("Open in wallet")}}</span>
                 </a>
             </div>


### PR DESCRIPTION
Fixes: #931 