### PR TITLE
Prettify wallet receive tab screen

### DIFF
--- a/BTCPayServer/Views/Wallets/WalletReceive.cshtml
+++ b/BTCPayServer/Views/Wallets/WalletReceive.cshtml
@@ -14,21 +14,39 @@
     </div>
 }
 <div class="row no-gutters">
-    <div class="col-lg-6  mx-auto my-auto ">
+    <div class="col-lg-7  mx-auto my-auto ">
         <form method="post" asp-action="WalletReceive" class="card text-center">
-            @if (string.IsNullOrEmpty(Model.Address))
-            {
+            <div class="card-body">
+                @if (string.IsNullOrEmpty(Model.Address))
+                {
 
-                <h2 class="card-title">Receive @Model.CryptoCode</h2>
-                <button class="btn btn-lg btn-primary m-2" type="submit" name="command" value="generate-new-address">Generate @Model.CryptoCode address</button>
-            }
-            else
-            {
-                <h2 class="card-title">Next available @Model.CryptoCode address</h2>
-                <noscript>
-                    <div class="card-body m-sm-0 p-sm-0">
-                        <div class="input-group">
-                            <input type="text" class="form-control " readonly="readonly" asp-for="Address" id="address" />
+                    <h3 class="card-title mb-3">Receive @Model.CryptoCode</h3>
+                    <button class="btn btn-lg btn-primary" type="submit" name="command" value="generate-new-address">Generate @Model.CryptoCode address</button>
+                }
+                else
+                {
+                    <h3 class="card-title mb-4">Next available @Model.CryptoCode address</h3>
+                    <noscript>
+                        <div class="card-body m-sm-0 p-sm-0">
+                            <div class="input-group">
+                                <input type="text" class="form-control " readonly="readonly" asp-for="Address" id="address" />
+                                <div class="input-group-append">
+                                    <span class="input-group-text fa fa-copy"> </span>
+                                </div>
+                            </div>
+
+                            <button type="submit" name="command" value="unreserve-current-address" class="btn btn-link">Unreserve this address</button>
+
+                        </div>
+                    </noscript>
+                    <div class="only-for-js card-body m-sm-0 p-sm-0" id="app">
+                        <div class="qr-container mb-4">
+                            <img v-bind:src="srvModel.cryptoImage" class="qr-icon" />
+                            <qrcode v-bind:value="srvModel.address" :options="{ width: 256, margin: 0, color: {dark:'#000', light:'#fff'} }" tag="svg">
+                            </qrcode>
+                        </div>
+                        <div class="input-group copy" data-clipboard-target="#vue-address">
+                            <input type="text" class=" form-control " readonly="readonly" :value="srvModel.address" id="vue-address" />
                             <div class="input-group-append">
                                 <span class="input-group-text fa fa-copy"> </span>
                             </div>
@@ -37,25 +55,8 @@
                         <button type="submit" name="command" value="unreserve-current-address" class="btn btn-link">Unreserve this address</button>
 
                     </div>
-                </noscript>
-                <div class="only-for-js card-body m-sm-0 p-sm-0" id="app">
-                    <div class="qr-container mb-2">
-                        <img v-bind:src="srvModel.cryptoImage" class="qr-icon" />
-                        <qrcode v-bind:value="srvModel.address" :options="{ width: 256, margin: 0, color: {dark:'#000', light:'#fff'} }" tag="svg">
-                        </qrcode>
-                    </div>
-                    <div class="input-group copy" data-clipboard-target="#vue-address">
-                        <input type="text" class=" form-control " readonly="readonly" :value="srvModel.address" id="vue-address" />
-                        <div class="input-group-append">
-                            <span class="input-group-text fa fa-copy"> </span>
-                        </div>
-                    </div>
-
-                    <button type="submit" name="command" value="unreserve-current-address" class="btn btn-link">Unreserve this address</button>
-
-                </div>
-            }
-
+                }
+            </div>
         </form>
     </div>
 </div>


### PR DESCRIPTION
I saw that we now have a new "Receive" tab for the wallet and decided to prettify it a bit.

Before:
![Screen Shot 2020-03-03 at 9 13 55 PM](https://user-images.githubusercontent.com/1934678/75847788-00041800-5d95-11ea-855f-0efdcb869dc8.png)

After:
![Screen Shot 2020-03-03 at 8 58 27 PM](https://user-images.githubusercontent.com/1934678/75847793-05616280-5d95-11ea-8c42-7609d67cdd9b.png)

Before:
![Screen Shot 2020-03-03 at 9 14 21 PM](https://user-images.githubusercontent.com/1934678/75847811-101bf780-5d95-11ea-835d-79df8406b3f6.png)

After:
![Screen Shot 2020-03-03 at 8 58 03 PM](https://user-images.githubusercontent.com/1934678/75847826-18743280-5d95-11ea-9d30-2db4d26980a8.png)

Also, one thing that's not clear to me is as someone who has never seen this screen before is this:
1. Is there a reason you need to click on "Generate BTC address" instead of just showing the QR code with the address right away?
2. What does "unreserve this address" button do? Once you click on it you get a success message like: `Address bcrt1qkjr980k3mnswq02mpnn627njuswycul0q9sgj2 was unreserved.`. It's not clear what "unreserve" means in this context and there is no explanation provided. I'm guessing this means that this address will never be used again but it's not entirely clear to me.

I'm anticipating that other users who are not familiar with this screen will probably have the same questions in their head as me when they first use this feature.
