### PR TITLE
Fixing ocassional CanManageWallet Selenium test fails

### DIFF
--- a/BTCPayServer.Tests/SeleniumTester.cs
+++ b/BTCPayServer.Tests/SeleniumTester.cs
@@ -126,7 +126,8 @@ namespace BTCPayServer.Tests
             Driver.FindElement(By.Id($"Modify{cryptoCode}")).ForceClick();
             Driver.FindElement(By.Id("import-from-btn")).ForceClick();
             Driver.FindElement(By.Id("nbxplorergeneratewalletbtn")).ForceClick();
-            Driver.FindElement(By.Id("ExistingMnemonic")).SendKeys(seed);
+            Thread.Sleep(200); // allow for modal to fade in
+            Driver.WaitForElement(By.Id("ExistingMnemonic")).SendKeys(seed);
             SetCheckbox(Driver.FindElement(By.Id("SavePrivateKeys")), privkeys);
             SetCheckbox(Driver.FindElement(By.Id("ImportKeysToRPC")), importkeys);
             Driver.FindElement(By.Id("btn-generate")).ForceClick();


### PR DESCRIPTION
Looking through logs it seems like Generate button is never clicked, which can happen if modal is not yet displayed (it has 150ms of fade in).

Example of CanManageWallet CI [FAIL]:
https://circleci.com/gh/btcpayserver/btcpayserver/6167