### PR TITLE
Check for Double Spends

### DIFF
--- a/BTCPayServer.Tests/ServerTester.cs
+++ b/BTCPayServer.Tests/ServerTester.cs
@@ -138,6 +138,19 @@ namespace BTCPayServer.Tests
             await CustomerLightningD.Pay(bolt11);
         }
 
+        public async Task<T> WaitForEvent<T>(Func<Task> action)
+        {
+            var tcs = new TaskCompletionSource<T>();
+            var sub = PayTester.GetService<EventAggregator>().Subscribe<T>(evt =>
+            {
+                tcs.SetResult(evt);
+            });
+            await action.Invoke();
+            var result = await tcs.Task;
+            sub.Dispose();
+            return result;
+        }
+        
         public ILightningClient CustomerLightningD { get; set; }
 
         public ILightningClient MerchantLightningD { get; private set; }

--- a/BTCPayServer.Tests/docker-compose.yml
+++ b/BTCPayServer.Tests/docker-compose.yml
@@ -102,6 +102,7 @@ services:
       NBXPLORER_MAXGAPSIZE: 10
       NBXPLORER_VERBOSE: 1
       NBXPLORER_NOAUTH: 1
+      NBXPLORER_EXPOSERPC: 1
     links:
       - bitcoind
       - litecoind

--- a/BTCPayServer/Payments/Bitcoin/NBXplorerListener.cs
+++ b/BTCPayServer/Payments/Bitcoin/NBXplorerListener.cs
@@ -241,7 +241,7 @@ namespace BTCPayServer.Payments.Bitcoin
                 {
                     // we should check the mempool and see if it's still available as NBX does not know of txs that double spend to external addresses
                     var explorerClient = _ExplorerClients.GetExplorerClient(wallet.Network);
-                    accounted = (await explorerClient.RPCClient.GetMempoolEntryAsync(paymentData.Outpoint.Hash)) != null;
+                    accounted = (await explorerClient.RPCClient.GetMempoolEntryAsync(paymentData.Outpoint.Hash, false)) != null;
                 }
                 
                 bool updated = false;
@@ -275,7 +275,7 @@ namespace BTCPayServer.Payments.Bitcoin
             return invoice;
         }
 
-        async Task CheckForDoubleSpends()
+        public async Task CheckForDoubleSpends()
         {
             var pendingInvoices = await _InvoiceRepository.GetPendingInvoices();
             var invoices = await _InvoiceRepository.GetInvoices(new InvoiceQuery() {InvoiceId = pendingInvoices});
@@ -303,9 +303,9 @@ namespace BTCPayServer.Payments.Bitcoin
                 }
 
                 var explorerClient = _ExplorerClients.GetExplorerClient(network);
-                RPCClient rpcClient = null;//explorerClient.RPCClient
+                
 
-                var batchClient = rpcClient.PrepareBatch();
+                var batchClient = explorerClient.RPCClient.PrepareBatch();
                 var z = y.Select(tuple => (tuple.Id, tuple.paymentEntity, tuple.Item3,
                     batchClient.GetMempoolEntryAsync(tuple.Item3.Outpoint.Hash, false)));
 


### PR DESCRIPTION
~~Blocked by https://github.com/dgarage/NBXplorer/pull/247~~
fixes #1371
potentially helps #1330
needed for #1321

Currently, BTCPay can only handle double spends on incoming txs when at least 1 output is still pointing to the store derivation. Of course, the invoice would never get marked as confirmed, but it does stay stuck in the `paid` state. This PR introduces a checker that runs every minute that verifies that any unconfirmed, RBF enabled transaction has not been double spent by calling `getmempoolentry`.