### PR TITLE
Greenfield API: God Mode

### DIFF
--- a/BTCPayServer.Tests/ApiKeysTests.cs
+++ b/BTCPayServer.Tests/ApiKeysTests.cs
@@ -224,6 +224,12 @@ namespace BTCPayServer.Tests
                         tester.PayTester.HttpClient);
                 });
             }
+            else
+            {
+                await TestApiAgainstAccessToken<bool>(accessToken,
+                    $"{TestApiPath}/me/stores/{testAccount.StoreId}/can-edit",
+                    tester.PayTester.HttpClient);
+            }
 
             if (!permissions.Contains(Permissions.ServerManagement))
             {
@@ -233,12 +239,26 @@ namespace BTCPayServer.Tests
                         tester.PayTester.HttpClient);
                 });
             }
+            else
+            {
+                await TestApiAgainstAccessToken<bool>(accessToken, $"{TestApiPath}/me/stores/{secondUser.StoreId}/can-edit",
+                    tester.PayTester.HttpClient);
+            }
 
             if (permissions.Contains(Permissions.ServerManagement))
             {
                 Assert.True(await TestApiAgainstAccessToken<bool>(accessToken,
                     $"{TestApiPath}/me/is-admin",
                     tester.PayTester.HttpClient));
+            }
+            else
+            {
+                await Assert.ThrowsAnyAsync<HttpRequestException>(async () =>
+                {
+                    await TestApiAgainstAccessToken<bool>(accessToken,
+                        $"{TestApiPath}/me/is-admin",
+                        tester.PayTester.HttpClient);
+                });
             }
         }
 

--- a/BTCPayServer.Tests/ApiKeysTests.cs
+++ b/BTCPayServer.Tests/ApiKeysTests.cs
@@ -214,8 +214,9 @@ namespace BTCPayServer.Tests
                 Assert.DoesNotContain(resultStores,
                     data => data.Id.Equals(secondUser.StoreId, StringComparison.InvariantCultureIgnoreCase));
             }
-            else
+            else if(!permissions.Contains(Permissions.ServerManagement))
             {
+                
                 await Assert.ThrowsAnyAsync<HttpRequestException>(async () =>
                 {
                     await TestApiAgainstAccessToken<bool>(accessToken,
@@ -224,11 +225,14 @@ namespace BTCPayServer.Tests
                 });
             }
 
-            await Assert.ThrowsAnyAsync<HttpRequestException>(async () =>
+            if (!permissions.Contains(Permissions.ServerManagement))
             {
-                await TestApiAgainstAccessToken<bool>(accessToken, $"{TestApiPath}/me/stores/{secondUser.StoreId}/can-edit",
-                    tester.PayTester.HttpClient);
-            });
+                await Assert.ThrowsAnyAsync<HttpRequestException>(async () =>
+                {
+                    await TestApiAgainstAccessToken<bool>(accessToken, $"{TestApiPath}/me/stores/{secondUser.StoreId}/can-edit",
+                        tester.PayTester.HttpClient);
+                });
+            }
 
             if (permissions.Contains(Permissions.ServerManagement))
             {

--- a/BTCPayServer.Tests/GreenfieldAPITests.cs
+++ b/BTCPayServer.Tests/GreenfieldAPITests.cs
@@ -62,8 +62,10 @@ namespace BTCPayServer.Tests
                 user.GrantAccess();
                 await user.MakeAdmin();
                 string apiKeyProfile = await GenerateAPIKey(tester, user, Permissions.ProfileManagement);
+                string apiKeyServer = await GenerateAPIKey(tester, user, Permissions.ServerManagement);
                 string apiKeyInsufficient = await GenerateAPIKey(tester, user, Permissions.StoreManagement);
                 var clientProfile = new BTCPayServerClient(tester.PayTester.ServerUri, apiKeyProfile);
+                var clientServer = new BTCPayServerClient(tester.PayTester.ServerUri, apiKeyServer);
                 var clientInsufficient= new BTCPayServerClient(tester.PayTester.ServerUri, apiKeyInsufficient);
                 
                 var apiKeyProfileUserData = await clientProfile.GetCurrentUser();
@@ -72,6 +74,7 @@ namespace BTCPayServer.Tests
                 Assert.Equal(apiKeyProfileUserData.Email, user.RegisterDetails.Email);
 
                 await Assert.ThrowsAsync<HttpRequestException>(async () => await clientInsufficient.GetCurrentUser());
+                await clientServer.GetCurrentUser();
             }
         }
 


### PR DESCRIPTION
When the `ServerManagement` permission is granted, you should be able to do everything in the system.
Maybe I should rename it to GodMode as a permission to not have any confusion with managing server settings (currently `ServerManagement`)?