### PR TITLE
Fix liquid asset BIP21 decimal precision

### DIFF
--- a/BTCPayServer.Common/Altcoins/Liquid/ElementsLikeBtcPayNetwork.cs
+++ b/BTCPayServer.Common/Altcoins/Liquid/ElementsLikeBtcPayNetwork.cs
@@ -25,7 +25,7 @@ namespace BTCPayServer
 
         public override string GenerateBIP21(string cryptoInfoAddress, Money cryptoInfoDue)
         {
-            return $"{base.GenerateBIP21(cryptoInfoAddress, cryptoInfoDue)}&assetid={AssetId}";
+            return $"{base.GenerateBIP21(cryptoInfoAddress, new Money(long.Parse(cryptoInfoDue.ToString(false, true).Replace(".", ""))))}&assetid={AssetId}";
         }
     }
 }

--- a/BTCPayServer.Common/Altcoins/Liquid/ElementsLikeBtcPayNetwork.cs
+++ b/BTCPayServer.Common/Altcoins/Liquid/ElementsLikeBtcPayNetwork.cs
@@ -25,7 +25,11 @@ namespace BTCPayServer
 
         public override string GenerateBIP21(string cryptoInfoAddress, Money cryptoInfoDue)
         {
-            return $"{base.GenerateBIP21(cryptoInfoAddress, new Money(long.Parse(cryptoInfoDue.ToString(false, true).Replace(".", ""))))}&assetid={AssetId}";
+            //precision 0: 10 = 0.00000010
+            //precision 2: 10 = 0.00001000
+            //precision 8: 10 = 10
+            var money = new Money(cryptoInfoDue.ToDecimal(MoneyUnit.BTC) / decimal.Parse("1".PadRight(1 + 8 - Divisibility, '0')), MoneyUnit.BTC);
+            return $"{base.GenerateBIP21(cryptoInfoAddress, money)}&assetid={AssetId}";
         }
     }
 }

--- a/BTCPayServer.Tests/BTCPayServerTester.cs
+++ b/BTCPayServer.Tests/BTCPayServerTester.cs
@@ -223,6 +223,10 @@ namespace BTCPayServer.Tests
                 var bitfinex = new MockRateProvider();
                 bitfinex.ExchangeRates.Add(new PairRate(CurrencyPair.Parse("UST_BTC"), new BidAsk(0.000136m)));
                 rateProvider.Providers.Add("bitfinex", bitfinex);
+                
+                var bitpay = new MockRateProvider();
+                bitpay.ExchangeRates.Add(new PairRate(CurrencyPair.Parse("ETB_BTC"), new BidAsk(0.1m)));
+                rateProvider.Providers.Add("bitpay", bitpay);
             }
 
 


### PR DESCRIPTION
The way liquid assets decimal precision works is just an ui layer. Each unit of an asset is actually 1sat.
Fixes https://github.com/Blockstream/green_android/issues/86