### PR TITLE
Wallet view improvements

### DIFF
--- a/BTCPayServer/Views/Wallets/CoinSelection.cshtml
+++ b/BTCPayServer/Views/Wallets/CoinSelection.cshtml
@@ -23,22 +23,22 @@
         <li class="list-group-item d-flex justify-content-between align-items-center cursor-pointer"
             v-for="item of filteredItems"
             :key="item.outpoint"
-            v-bind:class="{ 'alert-success': item.selected }"
+            v-bind:class="{ 'list-group-item-secondary': item.selected }"
             v-on:click="toggleItem($event, item, !item.selected)">
-            <a v-on:click="toggleItem($event, item, !item.selected)" class="text-truncate" v-tooltip="item.outpoint" style="max-width:50%" v-bind:href="item.link" target="_blank">{{item.outpoint}}</a>
+            <a v-on:click="toggleItem($event, item, !item.selected)" class="text-truncate flex-1" v-tooltip="item.outpoint" v-bind:href="item.link" target="_blank">{{item.outpoint}}</a>
             <div :id="item.outpoint" class="d-flex justify-content-between align-items-center">
                 <div>
                     <span v-if="item.comment" data-toggle="tooltip" v-tooltip="item.comment" class="badge badge-info badge-pill" style="font-style: italic">i</span>
                     <span
                           v-if="item.labels"
-                          class="badge badge-primary badge-pill ml-1"
+                          class="badge badge-primary badge-pill ml-2"
                           v-for="label of item.labels"
                           v-bind:style="{ 'background-color': label.color}"
                           key="label.value">
                         {{label.value}}
                     </span>
                 </div>
-                <span class="text-muted ml-1">{{item.amount}}</span>
+                <span class="text-muted ml-2">{{item.amount}}</span>
             </div>
         </li>
         <li class="list-group-item">

--- a/BTCPayServer/Views/Wallets/CoinSelection.cshtml
+++ b/BTCPayServer/Views/Wallets/CoinSelection.cshtml
@@ -25,8 +25,22 @@
             :key="item.outpoint"
             v-bind:class="{ 'list-group-item-secondary': item.selected }"
             v-on:click="toggleItem($event, item, !item.selected)">
-            <a v-on:click="toggleItem($event, item, !item.selected)" class="text-truncate flex-1" v-tooltip="item.outpoint" v-bind:href="item.link" target="_blank">{{item.outpoint}}</a>
-            <div :id="item.outpoint" class="d-flex justify-content-between align-items-center">
+            <div class="d-flex justify-content-between align-items-center w-100">
+                <input class="mr-2"
+                    type="checkbox"
+                    v-bind:id="item.outpoint"
+                    v-bind:value="item.outpoint"
+                    v-bind:checked="item.selected">
+                <label
+                    class="flex-1 d-inline-block text-truncate mb-0"
+                    v-bind:for="item.outpoint">
+                    <a
+                        v-tooltip="item.outpoint"
+                        v-bind:href="item.link"
+                        target="_blank">
+                        {{item.outpoint}}
+                    </a>
+                </label>
                 <div>
                     <span v-if="item.comment" data-toggle="tooltip" v-tooltip="item.comment" class="badge badge-info badge-pill" style="font-style: italic">i</span>
                     <span

--- a/BTCPayServer/Views/Wallets/WalletSend.cshtml
+++ b/BTCPayServer/Views/Wallets/WalletSend.cshtml
@@ -43,10 +43,10 @@
             {
                 <div class="form-group hide-when-js">
                     <label asp-for="SelectedInputs"></label>
-                    <select multiple="multiple" asp-for="SelectedInputs" >
+                    <select multiple="multiple" asp-for="SelectedInputs" class="form-control">
                         @foreach (var input in Model.InputsAvailable)
                         {
-                            <option value="@input.Outpoint" asp-selected="@(Model.SelectedInputs?.Contains(input.Outpoint)??false)">@input.Outpoint (@input.Amount)</option>
+                            <option value="@input.Outpoint" class="text-truncate" asp-selected="@(Model.SelectedInputs?.Contains(input.Outpoint)??false)">(@input.Amount) @input.Outpoint</option>
                         }
                     </select>
                 </div>

--- a/BTCPayServer/Views/Wallets/WalletSend.cshtml
+++ b/BTCPayServer/Views/Wallets/WalletSend.cshtml
@@ -51,6 +51,7 @@
                     </select>
                 </div>
                 <partial name="CoinSelection"/>
+                <br>
             }
             
             @if (Model.Outputs.Count == 1)
@@ -71,7 +72,7 @@
                     <span asp-validation-for="Outputs[0].Amount" class="text-danger"></span>
                     <p class="form-text text-muted crypto-info">
                         Your current balance is
-                        <button type="button" class="crypto-balance-link btn btn-link p-0">@Model.CurrentBalance</button> <span>@Model.CryptoCode</span>.
+                        <button type="button" class="crypto-balance-link btn btn-link p-0 align-baseline">@Model.CurrentBalance</button> <span>@Model.CryptoCode</span>.
                     </p>
                 </div>
             }
@@ -101,7 +102,7 @@
                                         </div>
                                         <p class="form-text text-muted crypto-info">
                                             Your current balance is
-                                            <button type="button" class="crypto-balance-link btn btn-link p-0">@Model.CurrentBalance</button> <span>@Model.CryptoCode</span>.
+                                            <button type="button" class="crypto-balance-link btn btn-link p-0 align-baseline">@Model.CurrentBalance</button> <span>@Model.CryptoCode</span>.
                                         </p>
                                         <span asp-validation-for="Outputs[index].Amount" class="text-danger"></span>
                                     </div>
@@ -132,7 +133,7 @@
                 <span id="FeeRate-Error" class="text-danger"></span>
                 <p class="form-text text-muted crypto-info">
                     The recommended value is
-                    <button type="button" id="crypto-fee-link" class="btn btn-link p-0">@Model.RecommendedSatoshiPerByte</button> satoshi per byte.
+                    <button type="button" id="crypto-fee-link" class="btn btn-link p-0 align-baseline">@Model.RecommendedSatoshiPerByte</button> satoshi per byte.
                 </p>
             </div>
             @if (Model.Outputs.Count == 1)

--- a/BTCPayServer/Views/Wallets/WalletTransactions.cshtml
+++ b/BTCPayServer/Views/Wallets/WalletTransactions.cshtml
@@ -15,7 +15,7 @@
         }
     }
 
-    .unconf {
+    .unconf > * {
         opacity: 0.5;
     }
 
@@ -102,10 +102,10 @@
                                     "
                                 >
                                     @label.Value
-                                    <form 
+                                    <form
                                         asp-route-walletId="@this.Context.GetRouteValue("walletId")"
                                         asp-action="ModifyTransaction"
-                                        method="post" 
+                                        method="post"
                                         class="removeTransactionLabelForm"
                                     >
                                         <input type="hidden" name="transactionId" value="@transaction.Id" />
@@ -137,7 +137,7 @@
                             <div class="dropdown" style="display:inline-block;">
                                 <span class="fa fa-tags" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"></span>
                                 <div class="dropdown-menu">
-                                    <form asp-action="ModifyTransaction" method="post" 
+                                    <form asp-action="ModifyTransaction" method="post"
                                         asp-route-walletId="@this.Context.GetRouteValue("walletId")">
                                         <input type="hidden" name="transactionId" value="@transaction.Id" />
                                         <div class="dropdown-item input-group">
@@ -171,7 +171,7 @@
                                     <span class="fa fa-commenting" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"></span>
                                 }
                                 <div class="dropdown-menu">
-                                    <form asp-action="ModifyTransaction" method="post" 
+                                    <form asp-action="ModifyTransaction" method="post"
                                         asp-route-walletId="@this.Context.GetRouteValue("walletId")">
                                         <input type="hidden" name="transactionId" value="@transaction.Id" />
                                         <textarea name="addcomment" class="dropdown-item" maxlength="200" rows="2" cols="20">@transaction.Comment</textarea>

--- a/BTCPayServer/wwwroot/js/vaultbridge.ui.js
+++ b/BTCPayServer/wwwroot/js/vaultbridge.ui.js
@@ -28,7 +28,7 @@ var vaultui = (function () {
         vaultLoading: new VaultFeedback("?", "Checking BTCPayServer Vault is running...", "vault-feedback1", "vault-loading"),
         vaultDenied: new VaultFeedback("failed", "The user declined access to the vault.", "vault-feedback1", "vault-denied"),
         vaultGranted: new VaultFeedback("ok", "Access to vault granted by owner.", "vault-feedback1", "vault-granted"),
-        noVault: new VaultFeedback("failed", "BTCPayServer Vault does not seems running, you can download it on <a target=\"_blank\" href=\"https://github.com/btcpayserver/BTCPayServer.Vault/releases/latest\">Github</a>.", "vault-feedback1", "no-vault"),
+        noVault: new VaultFeedback("failed", "BTCPayServer Vault does not seem to be running, you can download it on <a target=\"_blank\" href=\"https://github.com/btcpayserver/BTCPayServer.Vault/releases/latest\">Github</a>.", "vault-feedback1", "no-vault"),
         noWebsockets: new VaultFeedback("failed", "Web sockets are not supported by the browser.", "vault-feedback1", "no-websocket"),
         errorWebsockets: new VaultFeedback("failed", "Error of the websocket while connecting to the backend.", "vault-feedback1", "error-websocket"),
         bridgeConnected: new VaultFeedback("ok", "BTCPayServer successfully connected to the vault.", "vault-feedback1", "bridge-connected"),

--- a/BTCPayServer/wwwroot/main/site.css
+++ b/BTCPayServer/wwwroot/main/site.css
@@ -146,3 +146,7 @@ pre {
 .cursor-pointer{
     cursor: pointer;
 }
+
+.list-group-item a {
+  color: inherit;
+}


### PR DESCRIPTION
As brought up by @kukks with [this comment](https://github.com/btcpayserver/btcpayserver/pull/1434#issuecomment-609724703). These improvements can be applied across themes, so these fixes are separated from the originating PR.
Pure visual finetunings for the Coin Selection form and amount/fee rate links.

![wallet](https://user-images.githubusercontent.com/886/78693524-ab0b7280-78fb-11ea-9c37-a8660133d926.png)