### PR TITLE
Add payment link in checkout with payjoin indicator

### DIFF
--- a/BTCPayServer/Views/Shared/Bitcoin_Lightning_LikeMethodCheckout.cshtml
+++ b/BTCPayServer/Views/Shared/Bitcoin_Lightning_LikeMethodCheckout.cshtml
@@ -1,3 +1,4 @@
+@using BTCPayServer.Services
 @model BTCPayServer.Models.InvoicingModels.PaymentModel
 
 <script type="text/x-template" id="bitcoin-lightning-method-checkout-template">
@@ -57,6 +58,15 @@
                 </div>
             </nav>
             <nav v-else class="copyBox">
+                <div class="copySectionBox bottomBorder" :title="$t(hasPayjoin? 'BIP21 payment link' : 'BIP21 payment link with payjoin support') " >
+                    <label>{{$t("Payment link")}}</label>
+                    <div class="inputWithIcon _copyInput">
+                        <input type="text" class="checkoutTextbox" v-bind:value="srvModel.invoiceBitcoinUrl" readonly="readonly"/>
+                        <img v-bind:src="srvModel.cryptoImage" v-if="hasPayjoin"/>
+                        <i class="fa fa-user-secret" v-else/>
+                    </div>
+                </div>
+                <div class="separatorGem"></div>
                 <div class="copySectionBox bottomBorder">
                     <label>{{$t("Amount")}}</label>
                     <div class="copyAmountText copy-cursor _copySpan">
@@ -217,6 +227,9 @@
                 }
             },
             computed: {
+                hasPayjoin: function(){
+                    return this.srvModel.invoiceBitcoinUrl.indexOf('@PayjoinClient.BIP21EndpointKey') === -1;
+                },
                 coinswitchAmountDue: function() {
                     return this.srvModel.coinSwitchAmountMarkupPercentage
                         ? this.srvModel.btcDue * (1 + (this.srvModel.coinSwitchAmountMarkupPercentage / 100))

--- a/BTCPayServer/Views/Shared/Bitcoin_Lightning_LikeMethodCheckout.cshtml
+++ b/BTCPayServer/Views/Shared/Bitcoin_Lightning_LikeMethodCheckout.cshtml
@@ -58,15 +58,6 @@
                 </div>
             </nav>
             <nav v-else class="copyBox">
-                <div class="copySectionBox bottomBorder" :title="$t(hasPayjoin? 'BIP21 payment link' : 'BIP21 payment link with payjoin support') " >
-                    <label>{{$t("Payment link")}}</label>
-                    <div class="inputWithIcon _copyInput">
-                        <input type="text" class="checkoutTextbox" v-bind:value="srvModel.invoiceBitcoinUrl" readonly="readonly"/>
-                        <img v-bind:src="srvModel.cryptoImage" v-if="hasPayjoin"/>
-                        <i class="fa fa-user-secret" v-else/>
-                    </div>
-                </div>
-                <div class="separatorGem"></div>
                 <div class="copySectionBox bottomBorder">
                     <label>{{$t("Amount")}}</label>
                     <div class="copyAmountText copy-cursor _copySpan">
@@ -74,11 +65,20 @@
                     </div>
                 </div>
                 <div class="separatorGem"></div>
-                <div class="copySectionBox">
+                <div class="copySectionBox bottomBorder">
                     <label>{{$t("Address")}}</label>
                     <div class="inputWithIcon _copyInput">
                         <input type="text" class="checkoutTextbox" v-bind:value="srvModel.btcAddress" readonly="readonly"/>
                         <img v-bind:src="srvModel.cryptoImage"/>
+                    </div>
+                </div>
+                <div class="separatorGem"></div>
+                <div class="copySectionBox" :title="$t(hasPayjoin? 'BIP21 payment link' : 'BIP21 payment link with payjoin support') " >
+                    <label>{{$t("Payment link")}}</label>
+                    <div class="inputWithIcon _copyInput">
+                        <input type="text" class="checkoutTextbox" v-bind:value="srvModel.invoiceBitcoinUrl" readonly="readonly"/>
+                        <img v-bind:src="srvModel.cryptoImage" v-if="hasPayjoin"/>
+                        <i class="fa fa-user-secret" v-else/>
                     </div>
                 </div>
             </nav>

--- a/BTCPayServer/wwwroot/checkout/css/default.css
+++ b/BTCPayServer/wwwroot/checkout/css/default.css
@@ -11448,7 +11448,7 @@ low-fee-timeline {
     position: relative;
 }
 
-    .inputWithIcon img {
+    .inputWithIcon img, .inputWithIcon i {
         position: absolute;
         left: 2px;
         top: 9px;
@@ -11458,7 +11458,7 @@ low-fee-timeline {
         border-right: 1px solid #e0e0e0;
     }
 
-    .inputWithIcon.inputIconBg img {
+    .inputWithIcon.inputIconBg img, .inputWithIcon.inputIconBg i {
         background-color: #aaa;
         color: #fff;
         padding: 9px 4px;

--- a/BTCPayServer/wwwroot/checkout/css/themes/legacy.css
+++ b/BTCPayServer/wwwroot/checkout/css/themes/legacy.css
@@ -11447,7 +11447,7 @@ low-fee-timeline {
     position: relative;
 }
 
-    .inputWithIcon img {
+    .inputWithIcon img, .inputWithIcon i  {
         position: absolute;
         left: 2px;
         top: 9px;
@@ -11457,7 +11457,7 @@ low-fee-timeline {
         border-right: 1px solid #e0e0e0;
     }
 
-    .inputWithIcon.inputIconBg img {
+    .inputWithIcon.inputIconBg img, .inputWithIcon.inputIconBg i {
         background-color: #aaa;
         color: #fff;
         padding: 9px 4px;


### PR DESCRIPTION
This shows the BIP21 in the Copy tab in the invoice checkout. If the link is payjoin enabled, it shows the `user-secret` icon. Else, it shows the coin image.
![image](https://user-images.githubusercontent.com/1818366/78866533-d7300c00-7a3f-11ea-96ba-1ede3bfd8a45.png)
