### PR TITLE
delete files on user delete

### DIFF
--- a/BTCPayServer/Controllers/ServerController.cs
+++ b/BTCPayServer/Controllers/ServerController.cs
@@ -348,6 +348,14 @@ namespace BTCPayServer.Controllers
             var user = userId == null ? null : await _UserManager.FindByIdAsync(userId);
             if (user == null)
                 return NotFound();
+            
+            var files = await _StoredFileRepository.GetFiles(new StoredFileRepository.FilesQuery()
+            {
+                UserIds = new[] {userId},
+            });
+
+            await Task.WhenAll(files.Select(file => _FileService.RemoveFile(file.Id, userId)));
+            
             await _UserManager.DeleteAsync(user);
             await _StoreRepository.CleanUnreachableStores();
             TempData[WellKnownTempData.SuccessMessage] = "User deleted";


### PR DESCRIPTION
fixes #1451
(I did not do a cascade delete for 2 reasons: Sqlite does not support the migration easily to alter a foreign key AND files would be orphaned in the storage with no record in the db)