### PR TITLE
Do not ask for address confirmation if a new wallet is generated

### DIFF
--- a/BTCPayServer.Tests/SeleniumTester.cs
+++ b/BTCPayServer.Tests/SeleniumTester.cs
@@ -138,8 +138,6 @@ namespace BTCPayServer.Tests
             {
                 seed = Driver.FindElements(By.ClassName("alert-success")).First().FindElement(By.TagName("code")).Text;
             }
-            Driver.FindElement(By.Id("Confirm")).ForceClick();
-            AssertHappyMessage();
             return new Mnemonic(seed);
         }
 


### PR DESCRIPTION
The current UX is very error prone, as many user forget to confirm the new derivation scheme of the hotwallet. They may then backup the wrong seed and lose money.

This PR is skipping the address confirmation step when a new wallet is generated.