### PR TITLE
add additional server policy for hot wallet RPC import

### DIFF
--- a/BTCPayServer/Controllers/StoresController.BTCLike.cs
+++ b/BTCPayServer/Controllers/StoresController.BTCLike.cs
@@ -5,6 +5,7 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Net.WebSockets;
+using System.Reflection.Metadata.Ecma335;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -54,7 +55,9 @@ namespace BTCPayServer.Controllers
                 vm.Config = derivation.ToJson();
             }
             vm.Enabled = !store.GetStoreBlob().IsExcluded(new PaymentMethodId(vm.CryptoCode, PaymentTypes.BTCLike));
-            vm.CanUseHotWallet = await CanUseHotWallet();
+            var hotWallet = await CanUseHotWallet();
+            vm.CanUseHotWallet = hotWallet.HotWallet;
+            vm.CanUseRPCImport = hotWallet.RPCImport;
             return View(vm);
         }
 
@@ -332,8 +335,8 @@ namespace BTCPayServer.Controllers
             GenerateWalletRequest request)
         {
             Logs.Events.LogInformation($"GenerateNBXWallet called {storeId}, {cryptoCode}");
-
-            if (!await CanUseHotWallet())
+            var hotWallet = await CanUseHotWallet();
+            if (!hotWallet.HotWallet || (!hotWallet.RPCImport && request.ImportKeysToRPC))
             {
                 return NotFound();
             }
@@ -395,13 +398,14 @@ namespace BTCPayServer.Controllers
             return result;
         }
 
-        private async Task<bool> CanUseHotWallet()
+        private async Task<(bool HotWallet, bool RPCImport)> CanUseHotWallet()
         {
             var isAdmin = (await _authorizationService.AuthorizeAsync(User, Policies.CanModifyServerSettings)).Succeeded;
             if (isAdmin)
-                return true;
+                return (true, true);
             var policies = await _settingsRepository.GetSettingAsync<PoliciesSettings>();
-            return policies?.AllowHotWalletForAll is true;
+            var hotWallet = policies?.AllowHotWalletForAll is true;
+            return (hotWallet, hotWallet && policies?.AllowHotWalletRPCImportForAll is true);
         }
 
         private async Task<string> ReadAllText(IFormFile file)

--- a/BTCPayServer/Models/StoreViewModels/DerivationSchemeViewModel.cs
+++ b/BTCPayServer/Models/StoreViewModels/DerivationSchemeViewModel.cs
@@ -11,6 +11,7 @@ namespace BTCPayServer.Models.StoreViewModels
 {
     public class DerivationSchemeViewModel
     {
+
         public DerivationSchemeViewModel()
         {
         }
@@ -42,6 +43,7 @@ namespace BTCPayServer.Models.StoreViewModels
         public string AccountKey { get; set; }
         public BTCPayNetwork Network { get; set; }
         public bool CanUseHotWallet { get; set; }
+        public bool CanUseRPCImport { get; set; }
 
         public RootedKeyPath GetAccountKeypath()
         {

--- a/BTCPayServer/Services/PoliciesSettings.cs
+++ b/BTCPayServer/Services/PoliciesSettings.cs
@@ -25,6 +25,8 @@ namespace BTCPayServer.Services
         public bool AllowLightningInternalNodeForAll { get; set; }
         [Display(Name = "Allow non-admins to create hot wallets for their stores")]
         public bool AllowHotWalletForAll { get; set; }
+        [Display(Name = "Allow non-admins to import their hot wallets to the node wallet")]
+        public bool AllowHotWalletRPCImportForAll  { get; set; }
         
         [Display(Name = "Display app on website root")]
         public string RootAppId { get; set; }

--- a/BTCPayServer/Views/Server/Policies.cshtml
+++ b/BTCPayServer/Views/Server/Policies.cshtml
@@ -37,6 +37,11 @@
             <label asp-for="AllowHotWalletForAll" class="form-check-label"></label>
             <span asp-validation-for="AllowHotWalletForAll" class="text-danger"></span>
         </div>
+        <div class="form-check">
+            <input asp-for="AllowHotWalletRPCImportForAll" type="checkbox" class="form-check-input"/>
+            <label asp-for="AllowHotWalletRPCImportForAll" class="form-check-label"></label>
+            <span asp-validation-for="AllowHotWalletRPCImportForAll" class="text-danger"></span>
+        </div>
     </div>
     <div class="form-group">
         <label asp-for="RootAppId"></label>

--- a/BTCPayServer/Views/Stores/AddDerivationSchemes_HardwareWalletDialogs.cshtml
+++ b/BTCPayServer/Views/Stores/AddDerivationSchemes_HardwareWalletDialogs.cshtml
@@ -2,6 +2,8 @@
 @model DerivationSchemeViewModel
 @if (Model.CanUseHotWallet)
 {
+    ViewData.Add(nameof(Model.CanUseRPCImport), Model.CanUseRPCImport);
+    
     <partial name="AddDerivationSchemes_NBXWalletGenerate" model="@(new GenerateWalletRequest())"/>
 }
 <div class="modal fade" id="ledgerimport" tabindex="-1" role="dialog" aria-labelledby="ledgerimport" aria-hidden="true">

--- a/BTCPayServer/Views/Stores/AddDerivationSchemes_NBXWalletGenerate.cshtml
+++ b/BTCPayServer/Views/Stores/AddDerivationSchemes_NBXWalletGenerate.cshtml
@@ -62,14 +62,17 @@
                         If checked, each private key associated with an address generated will be stored as metadata in NBXplorer. While convenient, this means that anyone with access to your server will have access to your private keys and will be able to steal your funds.
                     </small>
                 </div>
-                <div class="form-group">
-                    <input type="checkbox" class="form-check-inline" asp-for="ImportKeysToRPC" />
-                    <label asp-for="ImportKeysToRPC">Import keys to RPC</label>
-                    <span asp-validation-for="ImportKeysToRPC" class="text-danger"></span>
-                     <small class="form-text text-muted">
-                        If checked, each address generated will be imported into the node wallet so that you can view your balance through your node. When this is enabled alongside <code>Is hot wallet</code>, you're also able to use the node wallet to spend (this works pretty well in conjunction with apps such as FullyNoded).
-                    </small>
-                </div>
+                @if (ViewData["CanUseRPCImport"] is true)
+                {
+                    <div class="form-group">
+                        <input type="checkbox" class="form-check-inline" asp-for="ImportKeysToRPC"/>
+                        <label asp-for="ImportKeysToRPC">Import keys to RPC</label>
+                        <span asp-validation-for="ImportKeysToRPC" class="text-danger"></span>
+                        <small class="form-text text-muted">
+                            If checked, each address generated will be imported into the node wallet so that you can view your balance through your node. When this is enabled alongside <code>Is hot wallet</code>, you're also able to use the node wallet to spend (this works pretty well in conjunction with apps such as FullyNoded).
+                        </small>
+                    </div>
+                }
             </div>
             <div class="modal-footer">
                 <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>


### PR DESCRIPTION
So that if you enable hot wallets for all, you can still not allow them to import to your RPC