### PR TITLE
Fix Payjoin p2sh

### DIFF
--- a/BTCPayServer.Client/BTCPayServer.Client.csproj
+++ b/BTCPayServer.Client/BTCPayServer.Client.csproj
@@ -5,7 +5,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="NBitcoin" Version="5.0.29" />
+      <PackageReference Include="NBitcoin" Version="5.0.30" />
       <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     </ItemGroup>
 

--- a/BTCPayServer.Tests/PayJoinTests.cs
+++ b/BTCPayServer.Tests/PayJoinTests.cs
@@ -141,8 +141,14 @@ namespace BTCPayServer.Tests
                         var receiverCoin = await receiverUser.ReceiveUTXO(Money.Satoshis(810), network);
 
                         var clientShouldError = unsupportedFormats.Contains(senderAddressType);
-                        var errorCode = ( unsupportedFormats.Contains( receiverAddressType) || receiverAddressType != senderAddressType)? "unsupported-inputs"  : null;
-
+                        string errorCode = null;
+                        if (unsupportedFormats.Contains(receiverAddressType))
+                        {
+                            errorCode = "unsupported-inputs";
+                        }else if (receiverAddressType != senderAddressType)
+                        {
+                            errorCode = "out-of-utxos";
+                        }
                         var invoice = receiverUser.BitPay.CreateInvoice(new Invoice() {Price = 50000, Currency = "sats", FullNotifications = true});
                         
                         var invoiceAddress = BitcoinAddress.Create(invoice.BitcoinAddress, cashCow.Network);

--- a/BTCPayServer/Payments/PayJoin/PayJoinEndpointController.cs
+++ b/BTCPayServer/Payments/PayJoin/PayJoinEndpointController.cs
@@ -451,8 +451,11 @@ namespace BTCPayServer.Payments.PayJoin
             foreach (var selectedUtxo in selectedUTXOs.Select(o => o.Value))
             {
                 var signedInput = newPsbt.Inputs.FindIndexedInput(selectedUtxo.Outpoint);
-                signedInput.UpdateFromCoin(selectedUtxo.AsCoin());
+                var coin = selectedUtxo.AsCoin(derivationSchemeSettings.AccountDerivation);
+                signedInput.UpdateFromCoin(coin);
                 var privateKey = accountKey.Derive(selectedUtxo.KeyPath).PrivateKey;
+                //hack until UpdateFromCoin is fixed in NBitcoin when the coin is p2sh
+                signedInput.WitnessUtxo = coin.TxOut;
                 signedInput.Sign(privateKey);
                 signedInput.FinalizeInput();
                 newTx.Inputs[signedInput.Index].WitScript = newPsbt.Inputs[(int)signedInput.Index].FinalScriptWitness;

--- a/BTCPayServer/Services/PayjoinClient.cs
+++ b/BTCPayServer/Services/PayjoinClient.cs
@@ -34,7 +34,7 @@ namespace BTCPayServer.Services
             if (i.WitnessUtxo.ScriptPubKey.IsScriptType(ScriptType.P2WPKH))
                 return ScriptPubKeyType.Segwit;
             if (i.WitnessUtxo.ScriptPubKey.IsScriptType(ScriptType.P2SH) &&
-                i.FinalScriptWitness.ToScript().IsScriptType(ScriptType.P2WPKH))
+                i.FinalScriptWitness.GetSigner().ScriptPubKey.IsScriptType(ScriptType.P2WPKH))
                 return ScriptPubKeyType.SegwitP2SH;
             return null as ScriptPubKeyType?;
         }

--- a/BTCPayServer/Services/PayjoinClient.cs
+++ b/BTCPayServer/Services/PayjoinClient.cs
@@ -213,31 +213,8 @@ namespace BTCPayServer.Services
             {
                 var overPaying = sentAfter - sentBefore;
                
-                //hack until GetAllCoins is fixed in NBitcoin when the coin is p2sh (redeem needs to be loaded from RedeemScript and fallback to i.FinalScriptSig extraction)
-                int newVirtualSize = 0;
-                if (type == ScriptPubKeyType.SegwitP2SH)
-                {
-                    if (!newPSBT.TryGetFee(out var fee))
-                    {
-                        throw new PayjoinSenderException("The payjoin receiver did not included UTXO information to calculate fee correctly");
-                    }
-                    var transactionBuilder = originalTx.Network.CreateTransactionBuilder();
-                    transactionBuilder.AddCoins(newPSBT.Inputs.Select(i =>i.GetCoin().ToScriptCoin(i.RedeemScript??PayToScriptHashTemplate.Instance.ExtractScriptSigParameters(i.FinalScriptSig).RedeemScript)));
-                    try
-                    {
-                        newVirtualSize = transactionBuilder.EstimateSize(newPSBT.GetGlobalTransaction(), true);
-                    }
-                    catch
-                    {
-                        throw new PayjoinSenderException("The payjoin receiver did not included UTXO information to calculate fee correctly");
-                    }
-                    
-                }
-                else
-                {
-                    if (!newPSBT.TryGetEstimatedFeeRate(out var newFeeRate) || !newPSBT.TryGetVirtualSize(out newVirtualSize))
-                        throw new PayjoinSenderException("The payjoin receiver did not included UTXO information to calculate fee correctly");
-                }
+                if (!newPSBT.TryGetEstimatedFeeRate(out var newFeeRate) || !newPSBT.TryGetVirtualSize(out var newVirtualSize))
+                    throw new PayjoinSenderException("The payjoin receiver did not included UTXO information to calculate fee correctly");
                 
                 var additionalFee = newPSBT.GetFee() - originalFee;
                 if (overPaying > additionalFee)

--- a/BTCPayServer/Services/PayjoinClient.cs
+++ b/BTCPayServer/Services/PayjoinClient.cs
@@ -34,9 +34,9 @@ namespace BTCPayServer.Services
             if (i.WitnessUtxo.ScriptPubKey.IsScriptType(ScriptType.P2WPKH))
                 return ScriptPubKeyType.Segwit;
             if (i.WitnessUtxo.ScriptPubKey.IsScriptType(ScriptType.P2SH) &&
-                i.FinalScriptWitness.GetSigner().ScriptPubKey.IsScriptType(ScriptType.P2WPKH))
+                PayToWitPubKeyHashTemplate.Instance.ExtractWitScriptParameters(i.FinalScriptWitness) is {})
                 return ScriptPubKeyType.SegwitP2SH;
-            return null as ScriptPubKeyType?;
+            return null;
         }
     }
 
@@ -212,8 +212,33 @@ namespace BTCPayServer.Services
             if (sentAfter > sentBefore)
             {
                 var overPaying = sentAfter - sentBefore;
-                if (!newPSBT.TryGetEstimatedFeeRate(out var newFeeRate) || !newPSBT.TryGetVirtualSize(out var newVirtualSize))
-                    throw new PayjoinSenderException("The payjoin receiver did not included UTXO information to calculate fee correctly");
+               
+                //hack until GetAllCoins is fixed in NBitcoin when the coin is p2sh (redeem needs to be loaded from RedeemScript and fallback to i.FinalScriptSig extraction)
+                int newVirtualSize = 0;
+                if (type == ScriptPubKeyType.SegwitP2SH)
+                {
+                    if (!newPSBT.TryGetFee(out var fee))
+                    {
+                        throw new PayjoinSenderException("The payjoin receiver did not included UTXO information to calculate fee correctly");
+                    }
+                    var transactionBuilder = originalTx.Network.CreateTransactionBuilder();
+                    transactionBuilder.AddCoins(newPSBT.Inputs.Select(i =>i.GetCoin().ToScriptCoin(i.RedeemScript??PayToScriptHashTemplate.Instance.ExtractScriptSigParameters(i.FinalScriptSig).RedeemScript)));
+                    try
+                    {
+                        newVirtualSize = transactionBuilder.EstimateSize(newPSBT.GetGlobalTransaction(), true);
+                    }
+                    catch
+                    {
+                        throw new PayjoinSenderException("The payjoin receiver did not included UTXO information to calculate fee correctly");
+                    }
+                    
+                }
+                else
+                {
+                    if (!newPSBT.TryGetEstimatedFeeRate(out var newFeeRate) || !newPSBT.TryGetVirtualSize(out newVirtualSize))
+                        throw new PayjoinSenderException("The payjoin receiver did not included UTXO information to calculate fee correctly");
+                }
+                
                 var additionalFee = newPSBT.GetFee() - originalFee;
                 if (overPaying > additionalFee)
                     throw new PayjoinSenderException("The payjoin receiver is sending more money to himself");


### PR DESCRIPTION
Since the test was not correct and that p2sh was never being enabled before, we missed these issues

Also having this on the payjoin receiver when adding p2sh inputs. 
```
System.InvalidOperationException: You need to provide P2WSH or P2SH redeem script with Coin.ToScriptCoin()
   at NBitcoin.Coin.GetScriptCode()
   at NBitcoin.TransactionBuilder.EstimateScriptSigSize(ICoin coin, Int32& witSize, Int32& baseSize)
   at NBitcoin.TransactionBuilder.EstimateSizes(Transaction tx, Int32& witSize, Int32& baseSize)
   at NBitcoin.TransactionBuilder.EstimateSize(Transaction tx, Boolean virtualSize)
   at NBitcoin.TransactionBuilder.EstimateFees(Transaction tx, FeeRate feeRate)
   at BTCPayServer.Payments.PayJoin.PayJoinEndpointController.Submit(String cryptoCode) in C:\Git\btcpayserver\BTCPayServer\Payments\PayJoin\PayJoinEndpointController.cs:line 391

```

