### PR TITLE
Improve static asset caching

### DIFF
--- a/BTCPayServer/Hosting/Startup.cs
+++ b/BTCPayServer/Hosting/Startup.cs
@@ -18,6 +18,7 @@ using System.IO;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using BTCPayServer.Security;
 using Microsoft.AspNetCore.Server.Kestrel.Core;
+using Microsoft.Net.Http.Headers;
 using System.Net;
 using BTCPayServer.PaymentRequest;
 using BTCPayServer.Services.Apps;
@@ -189,7 +190,17 @@ namespace BTCPayServer.Hosting
             app.UseRouting();
             app.UseCors();
 
-            app.UseStaticFiles();
+            app.UseStaticFiles(new StaticFileOptions
+            {
+                OnPrepareResponse = ctx =>
+                {
+                    // Cache static assets for one year, set asp-append-version="true" on references to update on change.
+                    // https://andrewlock.net/adding-cache-control-headers-to-static-files-in-asp-net-core/
+                    const int durationInSeconds = 60 * 60 * 24 * 365;
+                    ctx.Context.Response.Headers[HeaderNames.CacheControl] = "public,max-age=" + durationInSeconds;
+                }
+            });
+            
             app.UseProviderStorage(options);
             app.UseAuthentication();
             app.UseAuthorization();

--- a/BTCPayServer/Views/Account/LoginWithU2F.cshtml
+++ b/BTCPayServer/Views/Account/LoginWithU2F.cshtml
@@ -29,7 +29,7 @@
     </div>
 </section>
 
-<script src="~/vendor/u2f/u2f-api-1.1.js"></script>
+<script src="~/vendor/u2f/u2f-api-1.1.js" asp-append-version="true"></script>
 <script type="text/javascript">
     var errorMap = {
         1: 'Unknown error, try again',

--- a/BTCPayServer/Views/Apps/UpdateCrowdfund.cshtml
+++ b/BTCPayServer/Views/Apps/UpdateCrowdfund.cshtml
@@ -227,9 +227,9 @@
     </div>
 </section>
 @section Scripts {
-    <script src="~/vendor/moment/moment.js"></script>
-    <bundle name="wwwroot/bundles/crowdfund-admin-bundle.min.js"></bundle>
-    <bundle name="wwwroot/bundles/crowdfund-admin-bundle.min.css"></bundle>
+    <script src="~/vendor/moment/moment.js" asp-append-version="true"></script>
+    <bundle name="wwwroot/bundles/crowdfund-admin-bundle.min.js" asp-append-version="true"></bundle>
+    <bundle name="wwwroot/bundles/crowdfund-admin-bundle.min.css" asp-append-version="true"></bundle>
     <script id="template-product-item" type="text/template">
         <div class="col-sm-4 col-md-3 mb-3">
             <div class="card">

--- a/BTCPayServer/Views/Apps/UpdatePointOfSale.cshtml
+++ b/BTCPayServer/Views/Apps/UpdatePointOfSale.cshtml
@@ -225,8 +225,8 @@
     </div>
 </section>
 @section Scripts {
-    <link rel="stylesheet" href="~/vendor/highlightjs/default.min.css">
-    <script src="~/vendor/highlightjs/highlight.min.js"></script>
+    <link rel="stylesheet" href="~/vendor/highlightjs/default.min.css" asp-append-version="true">
+    <script src="~/vendor/highlightjs/highlight.min.js" asp-append-version="true"></script>
     <script>hljs.initHighlightingOnLoad();</script>
     <script id="template-product-item" type="text/template">
         <div class="col-sm-4 col-md-3 mb-3">
@@ -285,6 +285,6 @@
         </div>
     </script>
 
-    <bundle name="wwwroot/bundles/pos-admin-bundle.min.js"></bundle>
-    <bundle name="wwwroot/bundles/pos-admin-bundle.min.css"></bundle>
+    <bundle name="wwwroot/bundles/pos-admin-bundle.min.js" asp-append-version="true"></bundle>
+    <bundle name="wwwroot/bundles/pos-admin-bundle.min.css" asp-append-version="true"></bundle>
 }

--- a/BTCPayServer/Views/AppsPublic/Crowdfund/ContributeForm.cshtml
+++ b/BTCPayServer/Views/AppsPublic/Crowdfund/ContributeForm.cshtml
@@ -10,7 +10,7 @@
             }
             @if (!string.IsNullOrEmpty(item.Image))
             {
-                <img class="card-img-top" src="@item.Image"/>
+                <img class="card-img-top" src="@item.Image" asp-append-version="true" />
             }
             <div class="card-body">
                 <div class="card-title d-flex justify-content-between">

--- a/BTCPayServer/Views/AppsPublic/Crowdfund/MinimalCrowdfund.cshtml
+++ b/BTCPayServer/Views/AppsPublic/Crowdfund/MinimalCrowdfund.cshtml
@@ -8,7 +8,7 @@
         <div class="card w-100 p-0 mx-0">
             @if (!string.IsNullOrEmpty(Model.MainImageUrl))
             {
-                <img class="card-img-top" src="@Model.MainImageUrl"/>
+                <img class="card-img-top" src="@Model.MainImageUrl" asp-append-version="true" />
             }
             <div class="d-flex justify-content-between px-2">
                 <h1>

--- a/BTCPayServer/Views/AppsPublic/ViewCrowdfund.cshtml
+++ b/BTCPayServer/Views/AppsPublic/ViewCrowdfund.cshtml
@@ -24,13 +24,13 @@
         <script type="text/javascript">
             var srvModel = @Safe.Json(Model);
         </script>
-        <bundle name="wwwroot/bundles/crowdfund-bundle-1.min.js"></bundle>
-        <bundle name="wwwroot/bundles/crowdfund-bundle-2.min.js"></bundle>
+        <bundle name="wwwroot/bundles/crowdfund-bundle-1.min.js" asp-append-version="true"></bundle>
+        <bundle name="wwwroot/bundles/crowdfund-bundle-2.min.js" asp-append-version="true"></bundle>
         @*We need to make sure btcpay.js is not bundled, else it will not work if there is a RootPath*@
-        <script src="~/modal/btcpay.js"></script>
+        <script src="~/modal/btcpay.js" asp-append-version="true"></script>
     }
 
-    <bundle name="wwwroot/bundles/crowdfund-bundle.min.css"></bundle>
+    <bundle name="wwwroot/bundles/crowdfund-bundle.min.css" asp-append-version="true"></bundle>
     @if (!string.IsNullOrEmpty(Model.EmbeddedCSS))
     {
         @Safe.Raw($"<style>{Model.EmbeddedCSS}</style>");

--- a/BTCPayServer/Views/AppsPublic/ViewPointOfSale.cshtml
+++ b/BTCPayServer/Views/AppsPublic/ViewPointOfSale.cshtml
@@ -21,21 +21,21 @@
 
     <link rel="manifest" href="~/manifest.json">
 
-    <link href="@this.Context.Request.GetRelativePathOrAbsolute(themeManager.BootstrapUri)" rel="stylesheet" />
-    <link href="@this.Context.Request.GetRelativePathOrAbsolute(themeManager.ThemeUri)" rel="stylesheet" />
+    <link href="@this.Context.Request.GetRelativePathOrAbsolute(themeManager.BootstrapUri)" rel="stylesheet" asp-append-version="true" />
+    <link href="@this.Context.Request.GetRelativePathOrAbsolute(themeManager.ThemeUri)" rel="stylesheet" asp-append-version="true" />
     @if (Model.CustomCSSLink != null)
     {
         <link href="@Model.CustomCSSLink" rel="stylesheet" />
     }
-    <link href="~/vendor/font-awesome/css/font-awesome.min.css" rel="stylesheet" />
+    <link href="~/vendor/font-awesome/css/font-awesome.min.css" rel="stylesheet" asp-append-version="true" />
 
     @if (Model.EnableShoppingCart)
     {
-        <link rel="stylesheet" href="~/cart/css/style.css">
+        <link rel="stylesheet" href="~/cart/css/style.css" asp-append-version="true">
         <script type="text/javascript">
             var srvModel = @Safe.Json(Model);
         </script>
-        <bundle name="wwwroot/bundles/cart-bundle.min.js" />
+        <bundle name="wwwroot/bundles/cart-bundle.min.js" asp-append-version="true" />
     }
     <style>
         .card-deck {
@@ -320,7 +320,7 @@
                             <div class="js-add-cart card my-2 card-wrapper" data-index="@index">
                                 @if (!String.IsNullOrWhiteSpace(image))
                                 {
-                                    @:<img class="card-img-top" src="@image" alt="Card image cap">
+                                    @:<img class="card-img-top" src="@image" alt="Card image cap" asp-append-version="true">
                                 }
                                 <div class="card-body p-3">
                                     <h6 class="card-title mb-0">@item.Title</h6>
@@ -414,7 +414,7 @@
                         <div class="card my-2" data-id="@x">
                             @if (!String.IsNullOrWhiteSpace(item.Image))
                             {
-                                <img class="card-img-top" src="@item.Image" alt="Card image cap">
+                                <img class="card-img-top" src="@item.Image" alt="Card image cap" asp-append-version="true">
                             }
                             <div class="card-body pb-0">
                                 <h5 class="card-title">@item.Title</h5>

--- a/BTCPayServer/Views/Error/404.cshtml
+++ b/BTCPayServer/Views/Error/404.cshtml
@@ -6,7 +6,7 @@
     This is like searching for a person more beautiful than <a href="https://twitter.com/NicolasDorier" target="_blank">Nicolas Dorier</a>.
     <br /><br />
     <a href="https://twitter.com/NicolasDorier" target="_blank">
-        <img src="~/img/errorpages/404_nicolas.jpg" alt="Nicolas Dorier beauty" title="Slowly stroke the image" />
+        <img src="~/img/errorpages/404_nicolas.jpg" alt="Nicolas Dorier beauty" title="Slowly stroke the image" asp-append-version="true" />
     </a>
     <br /><br />
     It doesn't exist.

--- a/BTCPayServer/Views/Error/429.cshtml
+++ b/BTCPayServer/Views/Error/429.cshtml
@@ -6,7 +6,7 @@
     Please send requests slower. Or face the wrath of <a href="https://twitter.com/r0ckstardev" target="_blank">Vin Diesel</a>.
     <br /><br />
     <a href="https://twitter.com/r0ckstardev" target="_blank">
-        <img src="~/img/errorpages/429_rockstardev.jpg" alt="Vin is angry because you caused 429" title="Move away that cursor" />
+        <img src="~/img/errorpages/429_rockstardev.jpg" alt="Vin is angry because you caused 429" title="Move away that cursor" asp-append-version="true" />
     </a>
     <br /><br />
     You sure you want to risk that?

--- a/BTCPayServer/Views/Error/500.cshtml
+++ b/BTCPayServer/Views/Error/500.cshtml
@@ -6,7 +6,7 @@
     Whoops, something really went wrong! <a href="https://twitter.com/mrkukks">Mr Kukks</a> is so sorry.
     <br /><br />
     <a href="https://twitter.com/mrkukks" target="_blank">
-        <img src="~/img/errorpages/500_mrkukks.jpg" alt="Mr Kukks puppy eyes" title="The most innocent look you'll ever see" />
+        <img src="~/img/errorpages/500_mrkukks.jpg" alt="Mr Kukks puppy eyes" title="The most innocent look you'll ever see" asp-append-version="true" />
     </a>
     <br /><br />
     Consult server log and consider submitting issue on BTCPayServer GitHub.

--- a/BTCPayServer/Views/Error/_LayoutError.cshtml
+++ b/BTCPayServer/Views/Error/_LayoutError.cshtml
@@ -7,7 +7,7 @@
 <head>
     <partial name="Header" />
 
-    <link href="~/main/fonts/Montserrat.css" rel="stylesheet">
+    <link href="~/main/fonts/Montserrat.css" rel="stylesheet" asp-append-version="true">
     <style>
         .content-wrapper {
             padding: 20px 0;
@@ -95,7 +95,9 @@
             <div class="container">
                 <div class="row">
                     <div class="col-12 col-head" style="justify-content:center;">
-                        <a asp-controller="Home" asp-action="Index"><img src="~/img/btcpay-logo.svg" alt="BTCPay Server" class="head-logo" /></a>
+                        <a asp-controller="Home" asp-action="Index">
+                            <img src="~/img/btcpay-logo.svg" alt="BTCPay Server" class="head-logo" asp-append-version="true" />
+                        </a>
                         <h1 class="lead-title text-uppercase">@ViewData["ErrorTitle"]</h1>
                     </div>
                 </div>

--- a/BTCPayServer/Views/Home/BitpayTranslator.cshtml
+++ b/BTCPayServer/Views/Home/BitpayTranslator.cshtml
@@ -48,7 +48,7 @@
 
 @section Scripts {
     @await Html.PartialAsync("_ValidationScriptsPartial")
-    <script type="text/javascript" src="~/js/qrcode.js"></script>
+    <script type="text/javascript" src="~/js/qrcode.js" asp-append-version="true"></script>
     <script type="text/javascript">
         new QRCode(document.getElementById("qrCode"),
             {

--- a/BTCPayServer/Views/Home/Home.cshtml
+++ b/BTCPayServer/Views/Home/Home.cshtml
@@ -27,21 +27,21 @@
         <div class="row">
             <div class="col-lg-4 col-md-6 text-center">
                 <div class="service-box">
-                    <img src="~/img/lock-logo.png" alt="" />
+                    <img src="~/img/lock-logo.png" alt="" asp-append-version="true" />
                     <h3>Secure</h3>
                     <p class="text-muted">The payment server does not need to know your private keys, so your money can't be stolen.</p>
                 </div>
             </div>
             <div class="col-lg-4 col-md-6 text-center">
                 <div class="service-box">
-                    <img src="~/img/qr-logo.png" alt="" />
+                    <img src="~/img/qr-logo.png" alt="" asp-append-version="true" />
                     <h3>Easy</h3>
                     <p class="text-muted">A user-friendly Bitcoin checkout page for your customers.</p>
                 </div>
             </div>
             <div class="col-lg-4 col-md-6 text-center">
                 <div class="service-box">
-                    <img src="~/img/money-logo.png" alt="" />
+                    <img src="~/img/money-logo.png" alt="" asp-append-version="true" />
                     <h3>Visibility</h3>
                     <p class="text-muted">Manage, generate reports, and search for your invoices easily.</p>
                 </div>
@@ -56,7 +56,7 @@
         <div class="row">
             <div class="col-lg-12 text-center">
                 <a href="https://www.youtube.com/channel/UCpG9WL6TJuoNfFVkaDMp9ug" target="_blank">
-                    <img src="~/img/youtube.png" class="img-fluid" />
+                    <img src="~/img/youtube.png" class="img-fluid" asp-append-version="true" />
                 </a>
             </div>
         </div>
@@ -118,25 +118,25 @@
     <div class="row social-row">
         <div class="col-6 col-md-3 ml-auto text-center">
             <a href="https://chat.btcpayserver.org/" target="_blank">
-                <img src="~/img/mattermost.svg" alt="Mattermost" class="social-logo" />
+                <img src="~/img/mattermost.svg" alt="Mattermost" class="social-logo" asp-append-version="true" />
                 <span>On Mattermost</span>
             </a>
         </div>
         <div class="col-6 col-md-3 ml-auto text-center">
             <a href="https://slack.btcpayserver.org/" target="_blank">
-                <img src="~/img/slack.svg" alt="Slack" class="social-logo" />
+                <img src="~/img/slack.svg" alt="Slack" class="social-logo" asp-append-version="true" />
                 <span>On Slack</span>
             </a>
         </div>
         <div class="col-6 col-md-3 mr-auto text-center">
             <a href="https://twitter.com/BtcpayServer" target="_blank">
-                <img src="~/img/twitter.svg" alt="Twitter" class="social-logo" />
+                <img src="~/img/twitter.svg" alt="Twitter" class="social-logo" asp-append-version="true" />
                 <span>On Twitter</span>
             </a>
         </div>
         <div class="col-6 col-md-3 mr-auto text-center">
             <a href="https://github.com/btcpayserver/btcpayserver" target="_blank">
-                <img src="~/img/github.svg" alt="Github" class="social-logo" />
+                <img src="~/img/github.svg" alt="Github" class="social-logo" asp-append-version="true" />
                 <span>On Github</span>
             </a>
         </div>

--- a/BTCPayServer/Views/Invoice/Checkout-Body.cshtml
+++ b/BTCPayServer/Views/Invoice/Checkout-Body.cshtml
@@ -5,7 +5,7 @@
         @if (!string.IsNullOrEmpty(Model.CustomLogoLink))
         {
             <div class="header__icon">
-                <img class="header__icon__img" src="@Model.CustomLogoLink" height="40">
+                <img class="header__icon__img" src="@Model.CustomLogoLink" height="40" asp-append-version="true">
             </div>
         }
         else
@@ -61,7 +61,7 @@
                         {
                             <li class="vexmenuitem">
                                 <a href="@crypto.Link" onclick="closePaymentMethodDialog('@crypto.PaymentMethodId');return false;">
-                                    <img alt="@crypto.PaymentMethodName" src="@crypto.CryptoImage" />
+                                    <img alt="@crypto.PaymentMethodName" src="@crypto.CryptoImage" asp-append-version="true" />
                                     @crypto.PaymentMethodName
                                     @(crypto.IsLightning ? Html.Raw("&#9889;") : null)
                                     <span>@crypto.CryptoCode</span>
@@ -197,7 +197,7 @@
                     <div class="status-icon__wrapper">
                         <div class="inner-wrapper">
                             <div class="status-icon__wrapper__icon">
-                                <img src="~/imlegacy/checkmark.svg">
+                                <img src="~/imlegacy/checkmark.svg" asp-append-version="true">
                             </div>
                             <div class="status-icon__wrapper__outline"></div>
                         </div>

--- a/BTCPayServer/Views/Invoice/Checkout.cshtml
+++ b/BTCPayServer/Views/Invoice/Checkout.cshtml
@@ -15,13 +15,13 @@
     <META NAME="robots" CONTENT="noindex,nofollow">
     <title>@Model.HtmlTitle</title>
 
-    <bundle name="wwwroot/bundles/checkout-bundle.min.css" />
+    <bundle name="wwwroot/bundles/checkout-bundle.min.css" asp-append-version="true" />
 
     <script type="text/javascript">
         var initialSrvModel = @Safe.Json(Model);
     </script>
 
-    <bundle name="wwwroot/bundles/checkout-bundle.min.js" />
+    <bundle name="wwwroot/bundles/checkout-bundle.min.js" asp-append-version="true" />
     <script>vex.defaultOptions.className = 'vex-theme-btcpay'</script>
 
     @if (!string.IsNullOrEmpty(Model.CustomCSSLink))

--- a/BTCPayServer/Views/Invoice/CheckoutNoScript.cshtml
+++ b/BTCPayServer/Views/Invoice/CheckoutNoScript.cshtml
@@ -34,7 +34,7 @@
                     {
                         <li style="height: 32px; line-height: 32px;">
                             <a href="/invoice-noscript?id=@Model.InvoiceId&paymentMethodId=@crypto.PaymentMethodId">
-                            <img alt="@crypto.PaymentMethodName" src="@crypto.CryptoImage" style="vertical-align:middle; height:24px; text-decoration:none; margin-top: -3px;" /></a>
+                            <img alt="@crypto.PaymentMethodName" src="@crypto.CryptoImage" style="vertical-align:middle; height:24px; text-decoration:none; margin-top: -3px;" asp-append-version="true" /></a>
                             <a href="/invoice-noscript?id=@Model.InvoiceId&paymentMethodId=@crypto.PaymentMethodId" style="padding-top: 2px;">
                                 @crypto.PaymentMethodName
                                 @(crypto.IsLightning ? Html.Raw("&#9889;") : null)

--- a/BTCPayServer/Views/Invoice/ListInvoices.cshtml
+++ b/BTCPayServer/Views/Invoice/ListInvoices.cshtml
@@ -3,7 +3,7 @@
     ViewData["Title"] = "Invoices";
 }
 @section HeadScripts {
-    <script src="~/modal/btcpay.js"></script>
+    <script src="~/modal/btcpay.js" asp-append-version="true"></script>
 }
 @Html.HiddenFor(a => a.Count)
 <section>

--- a/BTCPayServer/Views/Manage/AddU2FDevice.cshtml
+++ b/BTCPayServer/Views/Manage/AddU2FDevice.cshtml
@@ -34,7 +34,7 @@
 
 @section Scripts {
 
-    <script src="~/vendor/u2f/u2f-api-1.1.js"></script>
+    <script src="~/vendor/u2f/u2f-api-1.1.js" asp-append-version="true"></script>
     <script type="text/javascript">
         var errorMap = {
             1: 'Unknown error, try again',

--- a/BTCPayServer/Views/Manage/EnableAuthenticator.cshtml
+++ b/BTCPayServer/Views/Manage/EnableAuthenticator.cshtml
@@ -48,7 +48,7 @@
 
 @section Scripts {
     @await Html.PartialAsync("_ValidationScriptsPartial")
-    <script type="text/javascript" src="~/js/qrcode.js"></script>
+    <script type="text/javascript" src="~/js/qrcode.js" asp-append-version="true"></script>
     <script type="text/javascript">
         new QRCode(document.getElementById("qrCode"),
             {

--- a/BTCPayServer/Views/PaymentRequest/EditPaymentRequest.cshtml
+++ b/BTCPayServer/Views/PaymentRequest/EditPaymentRequest.cshtml
@@ -116,7 +116,7 @@
     </div>
 </section>
 @section Scripts {
-    <script src="~/vendor/moment/moment.js"></script>
-    <bundle name="wwwroot/bundles/payment-request-admin-bundle.min.js"></bundle>
-    <bundle name="wwwroot/bundles/payment-request-admin-bundle.min.css"></bundle>
+    <script src="~/vendor/moment/moment.js" asp-append-version="true"></script>
+    <bundle name="wwwroot/bundles/payment-request-admin-bundle.min.js" asp-append-version="true"></bundle>
+    <bundle name="wwwroot/bundles/payment-request-admin-bundle.min.css" asp-append-version="true"></bundle>
 }

--- a/BTCPayServer/Views/PaymentRequest/ViewPaymentRequest.cshtml
+++ b/BTCPayServer/Views/PaymentRequest/ViewPaymentRequest.cshtml
@@ -25,13 +25,13 @@
         <script type="text/javascript">
             var srvModel = @Safe.Json(Model);
         </script>
-        <bundle name="wwwroot/bundles/payment-request-bundle-1.min.js"></bundle>
-        <bundle name="wwwroot/bundles/payment-request-bundle-2.min.js"></bundle>
+        <bundle name="wwwroot/bundles/payment-request-bundle-1.min.js" asp-append-version="true"></bundle>
+        <bundle name="wwwroot/bundles/payment-request-bundle-2.min.js" asp-append-version="true"></bundle>
         @*We need to make sure btcpay.js is not bundled, else it will not work if there is a RootPath*@
-        <script src="~/modal/btcpay.js"></script>
+        <script src="~/modal/btcpay.js" asp-append-version="true"></script>
     }
 
-    <bundle name="wwwroot/bundles/payment-request-bundle.min.css"></bundle>
+    <bundle name="wwwroot/bundles/payment-request-bundle.min.css" asp-append-version="true"></bundle>
 
     @Safe.Raw(Model.EmbeddedCSS)
 </head>

--- a/BTCPayServer/Views/PublicLightningNodeInfo/ShowLightningNodeInfo.cshtml
+++ b/BTCPayServer/Views/PublicLightningNodeInfo/ShowLightningNodeInfo.cshtml
@@ -13,16 +13,16 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="apple-mobile-web-app-capable" content="yes">
-    <link rel="apple-touch-icon" href="~/img/icons/icon-512x512.png">
-    <link rel="apple-touch-startup-image" href="~/img/splash.png">
+    <link rel="apple-touch-icon" href="~/img/icons/icon-512x512.png" asp-append-version="true">
+    <link rel="apple-touch-startup-image" href="~/img/splash.png" asp-append-version="true">
 
     <link rel="manifest" href="~/manifest.json">
 
-    <link href="@this.Context.Request.GetRelativePathOrAbsolute(themeManager.BootstrapUri)" rel="stylesheet" />
-    <link href="@this.Context.Request.GetRelativePathOrAbsolute(themeManager.ThemeUri)" rel="stylesheet" />
-    <link href="~/vendor/font-awesome/css/font-awesome.min.css" rel="stylesheet" />
+    <link href="@this.Context.Request.GetRelativePathOrAbsolute(themeManager.BootstrapUri)" rel="stylesheet" asp-append-version="true" />
+    <link href="@this.Context.Request.GetRelativePathOrAbsolute(themeManager.ThemeUri)" rel="stylesheet" asp-append-version="true" />
+    <link href="~/vendor/font-awesome/css/font-awesome.min.css" rel="stylesheet" asp-append-version="true" />
 
-    <bundle name="wwwroot/bundles/lightning-node-info-bundle.min.js" />
+    <bundle name="wwwroot/bundles/lightning-node-info-bundle.min.js" asp-append-version="true" />
     <script type="text/javascript">
         var srvModel = @Safe.Json(Model);
 

--- a/BTCPayServer/Views/Server/CLightningRestServices.cshtml
+++ b/BTCPayServer/Views/Server/CLightningRestServices.cshtml
@@ -27,7 +27,7 @@
             <div class="row">
                 <div class="col-lg-3 ml-auto text-center">
                     <a href="https://github.com/ZeusLN/zeus" target="_blank">
-                        <img src="~/img/zeus.jpg" height="100" />
+                        <img src="~/img/zeus.jpg" height="100" asp-append-version="true" />
                     </a>
                     <p><a href="https://github.com/ZeusLN/zeus" target="_blank">Zeus</a></p>
                 </div>
@@ -151,7 +151,7 @@
 
     @if(Model.QRCode != null)
     {
-        <script type="text/javascript" src="~/js/qrcode.js"></script>
+        <script type="text/javascript" src="~/js/qrcode.js" asp-append-version="true"></script>
         <script type="text/javascript">
         new QRCode(document.getElementById("qrCode"),
             {

--- a/BTCPayServer/Views/Server/LightningWalletServices.cshtml
+++ b/BTCPayServer/Views/Server/LightningWalletServices.cshtml
@@ -66,7 +66,7 @@
 
     @if (Model.ShowQR)
     {
-        <script type="text/javascript" src="~/js/qrcode.js"></script>
+        <script type="text/javascript" src="~/js/qrcode.js" asp-append-version="true"></script>
         <script type="text/javascript">
         new QRCode(document.getElementById("qrCode"),
             {

--- a/BTCPayServer/Views/Server/LndServices.cshtml
+++ b/BTCPayServer/Views/Server/LndServices.cshtml
@@ -29,13 +29,13 @@
             <div class="row">
                 <div class="col-lg-3 ml-auto text-center">
                     <a href="https://www.pebble.indiesquare.me/" target="_blank">
-                        <img src="~/img/pebblewallet.jpg" height="100" />
+                        <img src="~/img/pebblewallet.jpg" height="100" asp-append-version="true" />
                     </a>
                     <p><a href="https://www.pebble.indiesquare.me/" target="_blank">Pebble</a></p>
                 </div>
                 <div class="col-lg-3 ml-auto text-center">
                     <a href="https://zap.jackmallers.com/" target="_blank">
-                        <img src="~/img/zapwallet.jpg" height="100" />
+                        <img src="~/img/zapwallet.jpg" height="100" asp-append-version="true" />
                     </a>
                     <p><a href="https://zap.jackmallers.com/" target="_blank">Zap</a></p>
                 </div>
@@ -52,13 +52,13 @@
             <div class="row">
                 <div class="col-lg-3 ml-auto text-center">
                     <a href="https://lightningjoule.com/" target="_blank">
-                        <img src="~/img/joule.png" height="100" />
+                        <img src="~/img/joule.png" height="100" asp-append-version="true" />
                     </a>
                     <p><a href="https://lightningjoule.com/" target="_blank">Joule</a></p>
                 </div>
                 <div class="col-lg-3 ml-auto text-center">
                     <a href="https://github.com/ZeusLN/zeus" target="_blank">
-                        <img src="~/img/zeus.jpg" height="100" />
+                        <img src="~/img/zeus.jpg" height="100" asp-append-version="true" />
                     </a>
                     <p><a href="https://github.com/ZeusLN/zeus" target="_blank">Zeus</a></p>
                 </div>
@@ -180,7 +180,7 @@
 
     @if(Model.QRCode != null)
     {
-        <script type="text/javascript" src="~/js/qrcode.js"></script>
+        <script type="text/javascript" src="~/js/qrcode.js" asp-append-version="true"></script>
         <script type="text/javascript">
         new QRCode(document.getElementById("qrCode"),
             {

--- a/BTCPayServer/Views/Server/P2PService.cshtml
+++ b/BTCPayServer/Views/Server/P2PService.cshtml
@@ -38,13 +38,13 @@
         <div class="row">
             <div class="col-lg-3 ml-auto text-center">
                 <a href="https://play.google.com/store/apps/details?id=com.greenaddress.greenbits_android_wallet" target="_blank">
-                    <img src="~/img/GreenWallet.png" height="100" />
+                    <img src="~/img/GreenWallet.png" height="100" asp-append-version="true" />
                 </a>
                 <p><a href="https://play.google.com/store/apps/details?id=com.greenaddress.greenbits_android_wallet" target="_blank">Blockstream Green Wallet</a></p>
             </div>
             <div class="col-lg-3 mr-auto text-center">
                 <a href="https://www.wasabiwallet.io/" target="_blank">
-                    <img src="~/img/wasabi.png" height="100" />
+                    <img src="~/img/wasabi.png" height="100" asp-append-version="true" />
                 </a>
                 <p><a href="https://www.wasabiwallet.io/" target="_blank">Wasabi Wallet</a> <a href="https://www.reddit.com/r/WasabiWallet/comments/aqlyia/how_to_connect_wasabi_wallet_to_my_own_full/" target="_blank"><span class="fa fa-question-circle-o" title="More information..."></span></a></p>
             </div>
@@ -94,7 +94,7 @@
 
     @if (Model.ShowQR)
     {
-        <script type="text/javascript" src="~/js/qrcode.js"></script>
+        <script type="text/javascript" src="~/js/qrcode.js" asp-append-version="true"></script>
         <script type="text/javascript">
         new QRCode(document.getElementById("qrCode"),
             {

--- a/BTCPayServer/Views/Server/RPCService.cshtml
+++ b/BTCPayServer/Views/Server/RPCService.cshtml
@@ -38,7 +38,7 @@
         <div class="row">
             <div class="col-lg-3 ml-auto text-center">
                 <a href="https://apps.apple.com/us/app/fully-noded/id1436425586" target="_blank">
-                    <img src="~/img/fullynoded.png" height="100" />
+                    <img src="~/img/fullynoded.png" height="100" asp-append-version="true" />
                 </a>
                 <p><a href="https://apps.apple.com/us/app/fully-noded/id1436425586" target="_blank">Fully Noded</a></p>
             </div>
@@ -91,7 +91,7 @@
 
     @if (Model.ShowQR)
     {
-        <script type="text/javascript" src="~/js/qrcode.js"></script>
+        <script type="text/javascript" src="~/js/qrcode.js" asp-append-version="true"></script>
         <script type="text/javascript">
         new QRCode(document.getElementById("qrCode"),
             {

--- a/BTCPayServer/Views/Server/Services.cshtml
+++ b/BTCPayServer/Views/Server/Services.cshtml
@@ -38,7 +38,7 @@
                             @if (s.ConnectionString.IsOnion() == true || 
                                 (s.ConnectionString.IsOnion() == false && this.Context.Request.IsOnion()))
                             {
-                            <span><img style="display:inline; margin-top:-8px;" src="~/img/icons/Onion_Color.svg" height="20" /></span>
+                            <span><img style="display:inline; margin-top:-8px;" src="~/img/icons/Onion_Color.svg" height="20" asp-append-version="true" /></span>
                             }
                         </td>
                         <td style="text-align: right">

--- a/BTCPayServer/Views/Shared/Header.cshtml
+++ b/BTCPayServer/Views/Shared/Header.cshtml
@@ -11,13 +11,13 @@
 }
 <title>@ViewData["Title"]</title>
 @* CSS *@
-<link href="@this.Context.Request.GetRelativePathOrAbsolute(themeManager.BootstrapUri)" rel="stylesheet" />
-<link href="@this.Context.Request.GetRelativePathOrAbsolute(themeManager.CreativeStartUri)" rel="stylesheet" />
-<link href="@this.Context.Request.GetRelativePathOrAbsolute(themeManager.ThemeUri)" rel="stylesheet" />
+<link href="@this.Context.Request.GetRelativePathOrAbsolute(themeManager.BootstrapUri)" rel="stylesheet" asp-append-version="true" />
+<link href="@this.Context.Request.GetRelativePathOrAbsolute(themeManager.CreativeStartUri)" rel="stylesheet" asp-append-version="true" />
+<link href="@this.Context.Request.GetRelativePathOrAbsolute(themeManager.ThemeUri)" rel="stylesheet" asp-append-version="true" />
 @if (!String.IsNullOrWhiteSpace(themeManager.CustomThemeUri))
 {
-<link href="@this.Context.Request.GetRelativePathOrAbsolute(themeManager.CustomThemeUri)" rel="stylesheet" />
+<link href="@this.Context.Request.GetRelativePathOrAbsolute(themeManager.CustomThemeUri)" rel="stylesheet" asp-append-version="true" />
 }
-<bundle name="wwwroot/bundles/main-bundle.min.css" />
+<bundle name="wwwroot/bundles/main-bundle.min.css" asp-append-version="true" />
 @* JS *@
-<bundle name="wwwroot/bundles/main-bundle.min.js" />
+<bundle name="wwwroot/bundles/main-bundle.min.js" asp-append-version="true" />

--- a/BTCPayServer/Views/Shared/SyncModal.cshtml
+++ b/BTCPayServer/Views/Shared/SyncModal.cshtml
@@ -84,7 +84,7 @@
 
 </div>
 
-@*<link href="~/vendor/animatecss/animate.css" rel="stylesheet" />*@
+@*<link href="~/vendor/animatecss/animate.css" rel="stylesheet" asp-append-version="true" />*@
 <script type="text/javascript">
     function dismissSyncModal() {
         $("#modalDialog").addClass('animated bounceOutRight')

--- a/BTCPayServer/Views/Shared/_BTCPaySupporters.cshtml
+++ b/BTCPayServer/Views/Shared/_BTCPaySupporters.cshtml
@@ -2,7 +2,7 @@
 <div class="row justify-content-@(ViewData["Justify"] ?? "start")">
     <div class="figure p-3">
         <a href="https://twitter.com/sqcrypto" target="_blank">
-            <img src="~/img/squarecrypto.svg" alt="Sponsor Square Crypto" height="75" />
+            <img src="~/img/squarecrypto.svg" alt="Sponsor Square Crypto" height="75" asp-append-version="true" />
         </a>
         <div class="figure-caption text-center">
             <a href="https://twitter.com/sqcrypto" class="text-muted small" target="_blank">Square Crypto</a>
@@ -10,7 +10,7 @@
     </div>
     <div class="figure p-3">
         <a href="https://www.btse.com" target="_blank">
-            <img src="~/img/btse.svg" alt="Sponsor BTSE" height="75" />
+            <img src="~/img/btse.svg" alt="Sponsor BTSE" height="75" asp-append-version="true" />
         </a>
         <div class="figure-caption text-center">
             <a href="https://www.btse.com/" class="text-muted small" target="_blank">BTSE</a>
@@ -18,7 +18,7 @@
     </div>
     <div class="figure p-3">
         <a href="https://www.dglab.com/en/" target="_blank">
-            <img src="~/img/dglab.svg" alt="Sponsor DG lab" height="75" />
+            <img src="~/img/dglab.svg" alt="Sponsor DG lab" height="75" asp-append-version="true" />
         </a>
         <div class="figure-caption text-center">
             <a href="https://www.dglab.com/en/" class="text-muted small" target="_blank">DG Lab</a>
@@ -26,7 +26,7 @@
     </div>
     <div class="figure p-3">
         <a href="https://acinq.co/" target="_blank">
-            <img src="~/img/acinq-logo.svg" alt="Sponsor ACINQ" height="75" />
+            <img src="~/img/acinq-logo.svg" alt="Sponsor ACINQ" height="75" asp-append-version="true" />
         </a>
         <div class="figure-caption text-center">
             <a href="https://acinq.co/" class="text-muted small" target="_blank">ACINQ</a>
@@ -34,7 +34,7 @@
     </div>
     <div class="figure p-3">
         <a href="https://lunanode.com/" target="_blank">
-            <img src="~/img/lunanode.svg" alt="Sponsor LunaNode" height="75" />
+            <img src="~/img/lunanode.svg" alt="Sponsor LunaNode" height="75" asp-append-version="true" />
         </a>
         <div class="figure-caption text-center">
             <a href="https://lunanode.com/" class="text-muted small" target="_blank">LunaNode</a>
@@ -42,7 +42,7 @@
     </div>
     <div class="figure p-3">
         <a href="https://walletofsatoshi.com/" target="_blank">
-            <img src="~/img/walletofsatoshi.svg" alt="Sponsor Wallet of Satoshi" height="75" />
+            <img src="~/img/walletofsatoshi.svg" alt="Sponsor Wallet of Satoshi" height="75" asp-append-version="true" />
         </a>
         <div class="figure-caption text-center">
             <a href="https://walletofsatoshi.com/" class="text-muted small" target="_blank">Wallet of Satoshi</a>

--- a/BTCPayServer/Views/Shared/_Layout.cshtml
+++ b/BTCPayServer/Views/Shared/_Layout.cshtml
@@ -52,7 +52,7 @@
             @if (env.OnionUrl != null)
             {
                 <a class="onion" href="@env.OnionUrl" target="_blank">
-                    <img src="~/img/icons/onion.svg" width="26" height="32" />
+                    <img src="~/img/icons/onion.svg" width="26" height="32" asp-append-version="true" />
                 </a>
             }
             <button class="navbar-toggler navbar-toggler-right" type="button" data-toggle="collapse" data-target="#navbarResponsive" aria-controls="navbarResponsive" aria-expanded="false" aria-label="Toggle navigation">

--- a/BTCPayServer/Views/Shared/_LayoutWelcome.cshtml
+++ b/BTCPayServer/Views/Shared/_LayoutWelcome.cshtml
@@ -7,7 +7,7 @@
 <head>
     <partial name="Header" />
 
-    <link href="~/main/fonts/Montserrat.css" rel="stylesheet">
+    <link href="~/main/fonts/Montserrat.css" rel="stylesheet" asp-append-version="true">
     <style>
         .content-wrapper {
             padding: 70px 0;
@@ -94,7 +94,7 @@
         <div class="container">
             <div class="row">
                 <div class="col-12 col-head">
-                    <a asp-controller="Home" asp-action="Index"><img src="~/img/btcpay-logo.svg" alt="BTCPay Server" class="head-logo" /></a>
+                    <a asp-controller="Home" asp-action="Index"><img src="~/img/btcpay-logo.svg" alt="BTCPay Server" class="head-logo" asp-append-version="true" /></a>
                     <h1 class="lead-title text-uppercase">Welcome to your BTCPay Server</h1>
                 </div>
             </div>
@@ -113,7 +113,7 @@
                             <div class="input-group-prepend">
                                 <a href="@env.OnionUrl" class="input-group-text">
                                     <span class="input-group-addon"></span>
-                                    <img src="~/img/icons/Onion_Color.svg" height="16" />
+                                    <img src="~/img/icons/Onion_Color.svg" height="16" asp-append-version="true" />
                                 </a>
                             </div>
                             <input class="form-control" onClick="this.select();" type="text" style="font-size:0.75em;" value="@env.OnionUrl" readonly>

--- a/BTCPayServer/Views/Shared/_ValidationScriptsPartial.cshtml
+++ b/BTCPayServer/Views/Shared/_ValidationScriptsPartial.cshtml
@@ -1,3 +1,3 @@
 @addTagHelper *, BundlerMinifier.TagHelpers
 
-<bundle name="wwwroot/bundles/jqueryvalidate-bundle.min.js" />
+<bundle name="wwwroot/bundles/jqueryvalidate-bundle.min.js" asp-append-version="true" />

--- a/BTCPayServer/Views/Stores/AddDerivationScheme.cshtml
+++ b/BTCPayServer/Views/Stores/AddDerivationScheme.cshtml
@@ -209,10 +209,10 @@
 </div>
 @section Scripts {
     @await Html.PartialAsync("_ValidationScriptsPartial")
-    <script src="~/js/ledgerwebsocket.js" type="text/javascript" defer="defer"></script>
-    <script src="~/js/StoreAddDerivationScheme.js" type="text/javascript" defer="defer"></script>
-    <script src="~/js/vaultbridge.js" type="text/javascript" defer="defer"></script>
-    <script src="~/js/vaultbridge.ui.js" type="text/javascript" defer="defer"></script>
+    <script src="~/js/ledgerwebsocket.js" type="text/javascript" defer="defer" asp-append-version="true"></script>
+    <script src="~/js/StoreAddDerivationScheme.js" type="text/javascript" defer="defer" asp-append-version="true"></script>
+    <script src="~/js/vaultbridge.js" type="text/javascript" defer="defer" asp-append-version="true"></script>
+    <script src="~/js/vaultbridge.ui.js" type="text/javascript" defer="defer" asp-append-version="true"></script>
     <script>
         window.coinName = "@Model.Network.DisplayName.ToLowerInvariant()";
     </script>

--- a/BTCPayServer/Views/Stores/PayButton.cshtml
+++ b/BTCPayServer/Views/Stores/PayButton.cshtml
@@ -254,15 +254,15 @@
 </div>
 
 @section HeadScripts {
-    <link rel="stylesheet" href="~/vendor/highlightjs/default.min.css">
-    <script src="~/vendor/highlightjs/highlight.min.js"></script>
+    <link rel="stylesheet" href="~/vendor/highlightjs/default.min.css" asp-append-version="true">
+    <script src="~/vendor/highlightjs/highlight.min.js" asp-append-version="true"></script>
 
-    <script src="~/vendor/vuejs/vue.js"></script>
-    <script src="~/vendor/vuejs-vee-validate/vee-validate.js"></script>
+    <script src="~/vendor/vuejs/vue.js" asp-append-version="true"></script>
+    <script src="~/vendor/vuejs-vee-validate/vee-validate.js" asp-append-version="true"></script>
 
-    <script src="~/vendor/clipboard.js/clipboard.js"></script>
+    <script src="~/vendor/clipboard.js/clipboard.js" asp-append-version="true"></script>
 
-    <script src="~/paybutton/paybutton.js"></script>
+    <script src="~/paybutton/paybutton.js" asp-append-version="true"></script>
 }
 
 @section Scripts {

--- a/BTCPayServer/Views/Wallets/CoinSelection.cshtml
+++ b/BTCPayServer/Views/Wallets/CoinSelection.cshtml
@@ -78,7 +78,7 @@
     </ul>
 </div>
 
-<script src="~/bundles/wallet-coin-selection-bundle.min.js" type="text/javascript"></script>
+<script src="~/bundles/wallet-coin-selection-bundle.min.js" type="text/javascript" asp-append-version="true"></script>
 <script>
 $(function() {
 

--- a/BTCPayServer/Views/Wallets/WalletCameraScanner.cshtml
+++ b/BTCPayServer/Views/Wallets/WalletCameraScanner.cshtml
@@ -1,6 +1,6 @@
 @model WalletSendModel
 
-<link href="~/vendor/vue-qrcode-reader/vue-qrcode-reader.css" rel="stylesheet"/>
+<link href="~/vendor/vue-qrcode-reader/vue-qrcode-reader.css" rel="stylesheet" asp-append-version="true" />
 <div id="wallet-camera-app" v-cloak class="only-for-js">
     <div class="modal fade" data-backdrop="static" id="scanModal">
 

--- a/BTCPayServer/Views/Wallets/WalletPSBT.cshtml
+++ b/BTCPayServer/Views/Wallets/WalletPSBT.cshtml
@@ -81,7 +81,7 @@
 </div>
 
 @section Scripts {
-    <link rel="stylesheet" href="~/vendor/highlightjs/default.min.css">
-    <script src="~/vendor/highlightjs/highlight.min.js"></script>
+    <link rel="stylesheet" href="~/vendor/highlightjs/default.min.css" asp-append-version="true">
+    <script src="~/vendor/highlightjs/highlight.min.js" asp-append-version="true"></script>
     <script>hljs.initHighlightingOnLoad();</script>
 }

--- a/BTCPayServer/Views/Wallets/WalletReceive.cshtml
+++ b/BTCPayServer/Views/Wallets/WalletReceive.cshtml
@@ -66,7 +66,7 @@
 @section HeadScripts
 
 {
-    <script src="~/bundles/lightning-node-info-bundle.min.js" type="text/javascript"></script>
+    <script src="~/bundles/lightning-node-info-bundle.min.js" type="text/javascript" asp-append-version="true"></script>
     <script type="text/javascript">
         var srvModel = @Safe.Json(Model);
         window.onload = function() {

--- a/BTCPayServer/Views/Wallets/WalletSend.cshtml
+++ b/BTCPayServer/Views/Wallets/WalletSend.cshtml
@@ -212,7 +212,7 @@
 
 @section HeadScripts
 {
-    <bundle name="wwwroot/bundles/wallet-send-bundle.min.js"></bundle>
+    <bundle name="wwwroot/bundles/wallet-send-bundle.min.js" asp-append-version="true"></bundle>
     <style>
         .remove-destination-btn{
             font-size: 1.5rem;

--- a/BTCPayServer/Views/Wallets/WalletSendLedger.cshtml
+++ b/BTCPayServer/Views/Wallets/WalletSendLedger.cshtml
@@ -44,6 +44,6 @@
 
 @section Scripts
 {
-    <script src="~/js/ledgerwebsocket.js" type="text/javascript" defer="defer"></script>
-    <script src="~/js/WalletSendLedger.js" type="text/javascript" defer="defer"></script>
+    <script src="~/js/ledgerwebsocket.js" type="text/javascript" defer="defer" asp-append-version="true"></script>
+    <script src="~/js/WalletSendLedger.js" type="text/javascript" defer="defer" asp-append-version="true"></script>
 }

--- a/BTCPayServer/Views/Wallets/WalletSendVault.cshtml
+++ b/BTCPayServer/Views/Wallets/WalletSendVault.cshtml
@@ -36,8 +36,8 @@
 <partial name="VaultElements" />
 @section Scripts
 {
-    <script src="~/js/vaultbridge.js" type="text/javascript" defer="defer"></script>
-    <script src="~/js/vaultbridge.ui.js" type="text/javascript" defer="defer"></script>
+    <script src="~/js/vaultbridge.js" type="text/javascript" defer="defer" asp-append-version="true"></script>
+    <script src="~/js/vaultbridge.ui.js" type="text/javascript" defer="defer" asp-append-version="true"></script>
     <script type="text/javascript">
         async function askSign() {
             var websocketPath = $("#WebsocketPath").val();

--- a/BTCPayServer/wwwroot/_bootstrap_kitchensink.html
+++ b/BTCPayServer/wwwroot/_bootstrap_kitchensink.html
@@ -19,11 +19,11 @@
     <script src="bundles/main-bundle.min.js"></script>
 </head>
 <body>
-    <nav class="navbar sticky-top navbar-dark bg-dark text-white navbar-expand-lg mb-3">
+    <nav id="mainNav" class="navbar navbar-expand-lg sticky-top">
         <div class="container">
             <a class="navbar-brand" href="#">Bootstrap 4 Kitchen Sink</a>
             <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
-                <span class="navbar-toggler-icon"></span>
+                <svg class="navbar-toggler-icon" viewBox='0 0 30 30' xmlns='http://www.w3.org/2000/svg'><path stroke='currentColor' stroke-width='2' stroke-linecap='round' stroke-miterlimit='10' d='M4 7h22M4 15h22M4 23h22'/></svg>
             </button>
 
             <div class="collapse navbar-collapse" id="navbarSupportedContent">


### PR DESCRIPTION
Cache static assets for one year and set the correct cache control header. Adds the cache busting version based on file content to asset references to invalidate the cache on change. ([further details on the approach](https://andrewlock.net/adding-cache-control-headers-to-static-files-in-asp-net-core/) and [why one year](https://ashton.codes/set-cache-control-max-age-1-year/))

Most of the changes are the additions of the `asp-append-version="true"` attribute, the main configuration change is in `Startup.cs`.