### PR TITLE
Improve AssertLinkNotDead test output in case of exception

### DIFF
--- a/BTCPayServer.Tests/UnitTest1.cs
+++ b/BTCPayServer.Tests/UnitTest1.cs
@@ -158,9 +158,11 @@ namespace BTCPayServer.Tests
                 Assert.Equal(HttpStatusCode.OK, (await httpClient.SendAsync(request)).StatusCode);
                 Logs.Tester.LogInformation($"OK: {url} ({file})");
             }
-            catch (EqualException ex)
+            catch (Exception ex)
             {
-                Logs.Tester.LogInformation($"FAILED: {url} ({file}) {ex.Actual}");
+                var details = ex is EqualException ? (ex as EqualException).Actual : ex.Message;
+                Logs.Tester.LogInformation($"FAILED: {url} ({file}) {details}");
+                
                 throw;
             }
         }


### PR DESCRIPTION
If the test fails with an exception other than the `EqualException` the failed URL isn't logged. This general exception handler takes care of e.g. `HttpRequestException` and reports the URL that failed to be checked.

Stumbled upon this while checking why [this test run](https://app.circleci.com/pipelines/github/btcpayserver/btcpayserver/2934/workflows/0525d9fd-e4de-49dc-957b-d98b16a9abd4/jobs/7199/parallel-runs/0/steps/0-102) fails.