### PR TITLE
Fix MySQL support (fixed width columns instead of blobs)

### DIFF
--- a/BTCPayServer.Data/Migrations/20170913143004_Init.cs
+++ b/BTCPayServer.Data/Migrations/20170913143004_Init.cs
@@ -114,8 +114,8 @@ namespace BTCPayServer.Migrations
                 name: "AspNetUserLogins",
                 columns: table => new
                 {
-                    LoginProvider = table.Column<string>(nullable: false),
-                    ProviderKey = table.Column<string>(nullable: false),
+                    LoginProvider = table.Column<string>(nullable: false, maxLength: 255),
+                    ProviderKey = table.Column<string>(nullable: false, maxLength: 255),
                     ProviderDisplayName = table.Column<string>(nullable: true),
                     UserId = table.Column<string>(nullable: false, maxLength: maxLength)
                 },
@@ -159,8 +159,8 @@ namespace BTCPayServer.Migrations
                 columns: table => new
                 {
                     UserId = table.Column<string>(nullable: false, maxLength: maxLength),
-                    LoginProvider = table.Column<string>(nullable: false),
-                    Name = table.Column<string>(nullable: false),
+                    LoginProvider = table.Column<string>(nullable: false, maxLength: 64),
+                    Name = table.Column<string>(nullable: false, maxLength: 64),
                     Value = table.Column<string>(nullable: true)
                 },
                 constraints: table =>

--- a/BTCPayServer.Data/Migrations/20171010082424_Tokens.cs
+++ b/BTCPayServer.Data/Migrations/20171010082424_Tokens.cs
@@ -22,7 +22,7 @@ namespace BTCPayServer.Migrations
                     Label = table.Column<string>(nullable: true),
                     Name = table.Column<string>(nullable: true),
                     PairingTime = table.Column<DateTimeOffset>(nullable: false),
-                    SIN = table.Column<string>(nullable: true),
+                    SIN = table.Column<string>(nullable: true, maxLength: maxLength),
                     StoreDataId = table.Column<string>(nullable: true, maxLength: maxLength)
                 },
                 constraints: table =>

--- a/BTCPayServer.Data/Migrations/20171024163354_RenewUsedAddresses.cs
+++ b/BTCPayServer.Data/Migrations/20171024163354_RenewUsedAddresses.cs
@@ -23,7 +23,7 @@ namespace BTCPayServer.Migrations
                 columns: table => new
                 {
                     InvoiceDataId = table.Column<string>(nullable: false, maxLength: maxLength),
-                    Address = table.Column<string>(nullable: false),
+                    Address = table.Column<string>(nullable: false, maxLength: 250),
                     Assigned = table.Column<DateTimeOffset>(nullable: false),
                     UnAssigned = table.Column<DateTimeOffset>(nullable: true)
                 },


### PR DESCRIPTION
This is an attempt to fix MySQL support (works for me, probably requires further testing). Some columns didn't have fixed width but keys so creation was failing. It's also taking into account the max key size (767 Bytes) so the total of the columns from one key shouldn't exceed that.