### PR TITLE
Checkout dark theme improvements

### DIFF
--- a/BTCPayServer/wwwroot/checkout/css/themes/dark.css
+++ b/BTCPayServer/wwwroot/checkout/css/themes/dark.css
@@ -38,8 +38,13 @@ html {
     background-color: #333333; /* messes up bottom border radius */
 }
 
-.expired__body {
+.expired__body,
+.success-message {
     color: #fff;
+}
+
+line-items .line-items__item {
+    color: #8D8D8F;
 }
 
 .currency-selection {
@@ -85,7 +90,7 @@ canvas {
 }
 
 #prettydropdown-DefaultLang ul {
-    color: #565d6e !important;
+    color: #818a91 !important;
     background-color: #191919;
 }
 


### PR DESCRIPTION
Increase the contrast for some elements. Closes #1508.

<img width="447" alt="checkout-dark" src="https://user-images.githubusercontent.com/886/80316941-1365b980-8801-11ea-85a3-c956093e1f90.png">
