### PR TITLE
Update lightning-charge to v0.4.19

### DIFF
--- a/BTCPayServer.Tests/docker-compose.yml
+++ b/BTCPayServer.Tests/docker-compose.yml
@@ -163,7 +163,7 @@ services:
       - bitcoind
 
   lightning-charged:
-    image: shesek/lightning-charge:0.4.11-standalone
+    image: shesek/lightning-charge:0.4.19-standalone
     restart: unless-stopped
     environment:
       NETWORK: regtest


### PR DESCRIPTION
Changes the default units from mBTC to sats