### PR TITLE
Payjoin: Fix payjoin detection in checkout UI

### DIFF
--- a/BTCPayServer/Views/Shared/Bitcoin_Lightning_LikeMethodCheckout.cshtml
+++ b/BTCPayServer/Views/Shared/Bitcoin_Lightning_LikeMethodCheckout.cshtml
@@ -228,7 +228,7 @@
             },
             computed: {
                 hasPayjoin: function(){
-                    return this.srvModel.invoiceBitcoinUrl.indexOf('@PayjoinClient.BIP21EndpointKey') === -1;
+                    return this.srvModel.invoiceBitcoinUrl.indexOf('@PayjoinClient.BIP21EndpointKey=') === -1;
                 },
                 coinswitchAmountDue: function() {
                     return this.srvModel.coinSwitchAmountMarkupPercentage


### PR DESCRIPTION
sometimes, it would think there is a payjoin enabled invoice when really, it was just the address or asset id that has `pj` in it