### PR TITLE
Support specifying payment method through apps

### DIFF
--- a/BTCPayServer.Tests/UnitTest1.cs
+++ b/BTCPayServer.Tests/UnitTest1.cs
@@ -2265,11 +2265,12 @@ namespace BTCPayServer.Tests
 
         [Fact]
         [Trait("Integration", "Integration")]
+        [Trait("Lightning", "Lightning")]
         public async Task CanUsePoSApp()
         {
             using (var tester = ServerTester.Create())
             {
-                tester.ActivateLBTC();
+                tester.ActivateLightning();
                 await tester.StartAsync();
                 var user = tester.NewAccount();
                 user.GrantAccess();
@@ -2447,7 +2448,7 @@ noninventoryitem:
                 
                 
                 //test payment methods option
-                user.RegisterDerivationScheme("LBTC");
+                user.RegisterLightningNode("BTC", LightningConnectionType.Charge);
                 vmpos = Assert.IsType<UpdatePointOfSaleViewModel>(Assert
                     .IsType<ViewResult>(apps.UpdatePointOfSale(appId).Result).Model);
                 vmpos.Title = "hello";
@@ -2476,7 +2477,7 @@ normal:
                 Assert.Contains(
                     invoices.Single(invoice => invoice.ItemCode == "btconly").SupportedTransactionCurrencies.Keys,
                     s => new PaymentMethodId("BTC", PaymentTypes.BTCLike) == PaymentMethodId.Parse(s) ||
-                         new PaymentMethodId("LBTC", PaymentTypes.BTCLike) == PaymentMethodId.Parse(s));
+                         new PaymentMethodId("BTC", PaymentTypes.LightningLike) == PaymentMethodId.Parse(s));
 
 
             }

--- a/BTCPayServer/Controllers/AppsPublicController.cs
+++ b/BTCPayServer/Controllers/AppsPublicController.cs
@@ -112,6 +112,7 @@ namespace BTCPayServer.Controllers
             }
             string title = null;
             var price = 0.0m;
+            Dictionary<string, InvoiceSupportedTransactionCurrency> paymentMethods = null;
             ViewPointOfSaleViewModel.Item choice = null;
             if (!string.IsNullOrEmpty(choiceKey))
             {
@@ -130,6 +131,12 @@ namespace BTCPayServer.Controllers
                     {
                         return RedirectToAction(nameof(ViewPointOfSale), new { appId = appId });
                     }
+                }
+
+                if (choice?.PaymentMethods?.Any() is true)
+                {
+                    paymentMethods = choice?.PaymentMethods.ToDictionary(s => s,
+                        s => new InvoiceSupportedTransactionCurrency() {Enabled = true});
                 }
             }
             else
@@ -183,10 +190,7 @@ namespace BTCPayServer.Controllers
                     ExtendedNotifications = true,
                     PosData = string.IsNullOrEmpty(posData) ? null : posData,
                     RedirectAutomatically = settings.RedirectAutomatically,
-                    SupportedTransactionCurrencies = !(choice?.PaymentMethods?.Any() ?? false)
-                        ? null
-                        : choice?.PaymentMethods?.ToDictionary(s => s,
-                            s => new InvoiceSupportedTransactionCurrency() {Enabled = true})
+                    SupportedTransactionCurrencies = paymentMethods,
                 }, store, HttpContext.Request.GetAbsoluteRoot(),
                     new List<string>() { AppService.GetAppInternalTag(appId) },
                     cancellationToken);
@@ -275,6 +279,7 @@ namespace BTCPayServer.Controllers
             var store = await _AppService.GetStore(app);
             var title = settings.Title;
             var price = request.Amount;
+            Dictionary<string, InvoiceSupportedTransactionCurrency> paymentMethods = null;
             ViewPointOfSaleViewModel.Item choice = null;
             if (!string.IsNullOrEmpty(request.ChoiceKey))
             {
@@ -294,6 +299,13 @@ namespace BTCPayServer.Controllers
                     {
                         return NotFound("Option was out of stock");
                     }
+                }
+                
+
+                if (choice?.PaymentMethods?.Any() is true)
+                {
+                    paymentMethods = choice?.PaymentMethods.ToDictionary(s => s,
+                        s => new InvoiceSupportedTransactionCurrency() {Enabled = true});
                 }
             }
 
@@ -316,10 +328,7 @@ namespace BTCPayServer.Controllers
                         NotificationURL = settings.NotificationUrl,
                         FullNotifications = true,
                         ExtendedNotifications = true,
-                        SupportedTransactionCurrencies = !(choice?.PaymentMethods?.Any() ?? false)
-                            ? null
-                            : choice?.PaymentMethods?.ToDictionary(s => s,
-                                s => new InvoiceSupportedTransactionCurrency() {Enabled = true}),
+                        SupportedTransactionCurrencies = paymentMethods,
                         RedirectURL = request.RedirectUrl ?? 
                                      new Uri(new Uri( new Uri(HttpContext.Request.GetAbsoluteRoot()),  _BtcPayServerOptions.RootPath), $"apps/{appId}/crowdfund").ToString()
                     }, store, HttpContext.Request.GetAbsoluteRoot(),

--- a/BTCPayServer/Controllers/AppsPublicController.cs
+++ b/BTCPayServer/Controllers/AppsPublicController.cs
@@ -17,6 +17,7 @@ using Microsoft.AspNetCore.Cors;
 using Microsoft.AspNetCore.Http.Extensions;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
+using NBitpayClient;
 using static BTCPayServer.Controllers.AppsController;
 
 namespace BTCPayServer.Controllers
@@ -182,6 +183,10 @@ namespace BTCPayServer.Controllers
                     ExtendedNotifications = true,
                     PosData = string.IsNullOrEmpty(posData) ? null : posData,
                     RedirectAutomatically = settings.RedirectAutomatically,
+                    SupportedTransactionCurrencies = !(choice?.PaymentMethods?.Any() ?? false)
+                        ? null
+                        : choice?.PaymentMethods?.ToDictionary(s => s,
+                            s => new InvoiceSupportedTransactionCurrency() {Enabled = true})
                 }, store, HttpContext.Request.GetAbsoluteRoot(),
                     new List<string>() { AppService.GetAppInternalTag(appId) },
                     cancellationToken);
@@ -311,6 +316,10 @@ namespace BTCPayServer.Controllers
                         NotificationURL = settings.NotificationUrl,
                         FullNotifications = true,
                         ExtendedNotifications = true,
+                        SupportedTransactionCurrencies = !(choice?.PaymentMethods?.Any() ?? false)
+                            ? null
+                            : choice?.PaymentMethods?.ToDictionary(s => s,
+                                s => new InvoiceSupportedTransactionCurrency() {Enabled = true}),
                         RedirectURL = request.RedirectUrl ?? 
                                      new Uri(new Uri( new Uri(HttpContext.Request.GetAbsoluteRoot()),  _BtcPayServerOptions.RootPath), $"apps/{appId}/crowdfund").ToString()
                     }, store, HttpContext.Request.GetAbsoluteRoot(),

--- a/BTCPayServer/Models/AppViewModels/ViewPointOfSaleViewModel.cs
+++ b/BTCPayServer/Models/AppViewModels/ViewPointOfSaleViewModel.cs
@@ -21,6 +21,7 @@ namespace BTCPayServer.Models.AppViewModels
             public string Title { get; set; }
             public bool Custom { get; set; }
             public int? Inventory { get; set; } = null;
+            public string[] PaymentMethods { get; set; } = null;
         }
 
         public class CurrencyInfoData

--- a/BTCPayServer/Models/AppViewModels/ViewPointOfSaleViewModel.cs
+++ b/BTCPayServer/Models/AppViewModels/ViewPointOfSaleViewModel.cs
@@ -21,7 +21,7 @@ namespace BTCPayServer.Models.AppViewModels
             public string Title { get; set; }
             public bool Custom { get; set; }
             public int? Inventory { get; set; } = null;
-            public string[] PaymentMethods { get; set; } = null;
+            public string[] PaymentMethods { get; set; }
         }
 
         public class CurrencyInfoData

--- a/BTCPayServer/Services/Apps/AppService.cs
+++ b/BTCPayServer/Services/Apps/AppService.cs
@@ -333,7 +333,9 @@ namespace BTCPayServer.Services.Apps
                                  Formatted = Currencies.FormatCurrency(cc.Value.Value, currency)
                              }).Single(),
                     Custom = c.GetDetailString("custom") == "true",
-                    Inventory = string.IsNullOrEmpty(c.GetDetailString("inventory")) ?(int?) null:  int.Parse(c.GetDetailString("inventory"), CultureInfo.InvariantCulture)
+                    Inventory = string.IsNullOrEmpty(c.GetDetailString("inventory")) ?(int?) null:  int.Parse(c.GetDetailString("inventory"), CultureInfo.InvariantCulture),
+                    PaymentMethods = c.GetDetailStringList("payment_methods")
+                    
                 })
                 .ToArray();
         }
@@ -410,6 +412,14 @@ namespace BTCPayServer.Services.Apps
             public string GetDetailString(string field)
             {
                 return GetDetail(field).FirstOrDefault()?.Value?.Value;
+            }
+            public string[] GetDetailStringList(string field)
+            {
+                if (!Value.Children.ContainsKey(field) || !( Value.Children[field] is YamlSequenceNode sequenceNode))
+                {
+                    return null;
+                }
+                return sequenceNode.Children.Select(node => (node as YamlScalarNode)?.Value).Where( s => s!= null).ToArray();
             }
         }
         private class PosScalar


### PR DESCRIPTION
closes #1525
This is great if you want to offer items with an incentive to use a specific payment method without messing with the rates.
For example, you can have `Item A` which costs 25$ and your store is configured for USDT and BTC. You can create two items, with different prices, where Item A costs 20$ if you pay with bitcoin or 25$ if you paid in dirty fiat pegs