### PR TITLE
Show warning when enabling Payjoin but supported payment methods are not using a hot wallet

### DIFF
--- a/BTCPayServer.Tests/docker-compose.yml
+++ b/BTCPayServer.Tests/docker-compose.yml
@@ -127,6 +127,7 @@ services:
         deprecatedrpc=signrawtransaction
     ports: 
       - "43782:43782"
+      - "39388:39388"
     expose:
       - "43782" # RPC
       - "39388" # P2P


### PR DESCRIPTION
 fixes #1474

![image](https://user-images.githubusercontent.com/1818366/80973968-5dadf280-8e20-11ea-9c27-224a3f53c738.png)
