### PR TITLE
Require loggedin user for docs?

### DIFF
--- a/BTCPayServer.Tests/UnitTest1.cs
+++ b/BTCPayServer.Tests/UnitTest1.cs
@@ -101,9 +101,13 @@ namespace BTCPayServer.Tests
             using (var tester = ServerTester.Create())
             {
                 await tester.StartAsync();
-                var sresp = await tester.PayTester.HttpClient.GetAsync("swagger/v1/swagger.json");
+                var acc = tester.NewAccount();
 
-                JObject swagger = JObject.Parse(await sresp.Content.ReadAsStringAsync());
+                var sresp = Assert
+                    .IsType<JsonResult>(await tester.PayTester.GetController<HomeController>(acc.UserId, acc.StoreId)
+                        .Swagger()).Value.ToJson();
+
+                JObject swagger = JObject.Parse(sresp);
                 using HttpClient client = new HttpClient();
                 var resp = await client.GetAsync(
                     "https://raw.githubusercontent.com/OAI/OpenAPI-Specification/master/schemas/v3.0/schema.json");

--- a/BTCPayServer/Controllers/HomeController.cs
+++ b/BTCPayServer/Controllers/HomeController.cs
@@ -114,7 +114,7 @@ namespace BTCPayServer.Controllers
         }
 
         [Route("swagger/v1/swagger.json")]
-        [Authorize(AuthenticationSchemes = AuthenticationSchemes.Cookie)]
+        [Authorize(AuthenticationSchemes = AuthenticationSchemes.Cookie+","+ AuthenticationSchemes.Greenfield)]
         public async Task<IActionResult> Swagger()
         {
             JObject json = new JObject();

--- a/BTCPayServer/Controllers/HomeController.cs
+++ b/BTCPayServer/Controllers/HomeController.cs
@@ -114,6 +114,7 @@ namespace BTCPayServer.Controllers
         }
 
         [Route("swagger/v1/swagger.json")]
+        [Authorize(AuthenticationSchemes = AuthenticationSchemes.Cookie)]
         public async Task<IActionResult> Swagger()
         {
             JObject json = new JObject();
@@ -131,6 +132,7 @@ namespace BTCPayServer.Controllers
         }
 
         [Route("docs")]
+        [Authorize(AuthenticationSchemes = AuthenticationSchemes.Cookie)]
         public IActionResult SwaggerDocs()
         {
             return View();


### PR DESCRIPTION
We had talked before that docs should be for authorized users only. We had it in when we had Nswag but must have lost it after we switch to manual swagger files