### PR TITLE
Decode item description on POS app page

### DIFF
--- a/BTCPayServer/Views/AppsPublic/ViewPointOfSale.cshtml
+++ b/BTCPayServer/Views/AppsPublic/ViewPointOfSale.cshtml
@@ -420,7 +420,7 @@
                                 <h5 class="card-title">@item.Title</h5>
                                 @if (!String.IsNullOrWhiteSpace(item.Description))
                                 {
-                                    <p class="card-text">@item.Description</p>
+                                    <p class="card-text">@System.Net.WebUtility.HtmlDecode(item.Description)</p>
                                 }
 
                             </div>


### PR DESCRIPTION
fix #938

In the POS editor characters get unescaped so they show up correctly. See line 376 in `TemplateEditor.cshtml`. However, this is not done when outputting the item description on the actual POS app page. This PR changes that.