### PR TITLE
Use different close button color variable

### DIFF
--- a/BTCPayServer/wwwroot/main/bootstrap/bootstrap.css
+++ b/BTCPayServer/wwwroot/main/bootstrap/bootstrap.css
@@ -3766,11 +3766,11 @@ input[type="button"].btn-block {
   font-size: 1.5rem;
   font-weight: 700;
   line-height: 1;
-  color: var(--btcpay-color-black);
+  color: var(--btcpay-color-dark-accent);
   text-shadow: 0 1px 0 var(--btcpay-color-white);
   opacity: .5; }
   .close:hover {
-    color: var(--btcpay-color-black);
+    color: var(--btcpay-color-dark-accent);
     text-decoration: none; }
   .close:not(:disabled):not(.disabled):hover, .close:not(:disabled):not(.disabled):focus {
     opacity: .75; }


### PR DESCRIPTION
fix #1579

Old:
![Screen Shot 2020-05-18 at 10 58 29 AM](https://user-images.githubusercontent.com/1934678/82247273-fd787f80-98fa-11ea-877b-9ca465d91ad6.png)

"Close" icon look fine in all themes now:
![Screen Shot 2020-05-18 at 11 27 46 AM](https://user-images.githubusercontent.com/1934678/82247320-0c5f3200-98fb-11ea-9de2-1e37f3b6d836.png)
![Screen Shot 2020-05-18 at 11 27 54 AM](https://user-images.githubusercontent.com/1934678/82247322-0cf7c880-98fb-11ea-872f-62e4393e4d0b.png)
![Screen Shot 2020-05-18 at 11 28 01 AM](https://user-images.githubusercontent.com/1934678/82247324-0d905f00-98fb-11ea-8b80-b5fe237a0579.png)
![Screen Shot 2020-05-18 at 11 28 07 AM](https://user-images.githubusercontent.com/1934678/82247325-0d905f00-98fb-11ea-9d1d-e04c90fd535e.png)

