### PR TITLE
Adding private route hints based on store settings

### DIFF
--- a/BTCPayServer/BTCPayServer.csproj
+++ b/BTCPayServer/BTCPayServer.csproj
@@ -31,7 +31,8 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="BTCPayServer.Hwi" Version="1.1.3" />
-    <PackageReference Include="BTCPayServer.Lightning.All" Version="1.1.13" />
+    <PackageReference Include="BTCPayServer.Lightning.All" Version="1.1.14" />
+    <PackageReference Include="BTCPayServer.Lightning.Common" Version="1.1.0.23" />
     <PackageReference Include="BuildBundlerMinifier" Version="3.2.435" />
     <PackageReference Include="BundlerMinifier.Core" Version="3.2.435" />
     <PackageReference Include="BundlerMinifier.TagHelpers" Version="3.2.435" />

--- a/BTCPayServer/BTCPayServer.csproj
+++ b/BTCPayServer/BTCPayServer.csproj
@@ -31,8 +31,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="BTCPayServer.Hwi" Version="1.1.3" />
-    <PackageReference Include="BTCPayServer.Lightning.All" Version="1.1.14" />
-    <PackageReference Include="BTCPayServer.Lightning.Common" Version="1.1.0.23" />
+    <PackageReference Include="BTCPayServer.Lightning.All" Version="1.1.15" />
     <PackageReference Include="BuildBundlerMinifier" Version="3.2.435" />
     <PackageReference Include="BundlerMinifier.Core" Version="3.2.435" />
     <PackageReference Include="BundlerMinifier.TagHelpers" Version="3.2.435" />

--- a/BTCPayServer/Controllers/StoresController.cs
+++ b/BTCPayServer/Controllers/StoresController.cs
@@ -381,6 +381,7 @@ namespace BTCPayServer.Controllers
             vm.OnChainMinValue = storeBlob.OnChainMinValue?.ToString() ?? "";
             vm.LightningMaxValue = storeBlob.LightningMaxValue?.ToString() ?? "";
             vm.LightningAmountInSatoshi = storeBlob.LightningAmountInSatoshi;
+            vm.LightningPrivateRouteHints = storeBlob.LightningPrivateRouteHints;
             vm.RedirectAutomatically = storeBlob.RedirectAutomatically;
             return View(vm);
         }
@@ -441,6 +442,7 @@ namespace BTCPayServer.Controllers
             blob.OnChainMinValue = onchainMinValue;
             blob.LightningMaxValue = lightningMaxValue;
             blob.LightningAmountInSatoshi = model.LightningAmountInSatoshi;
+            blob.LightningPrivateRouteHints = model.LightningPrivateRouteHints;
             blob.RedirectAutomatically = model.RedirectAutomatically;
             if (CurrentStore.SetStoreBlob(blob))
             {

--- a/BTCPayServer/Data/StoreBlob.cs
+++ b/BTCPayServer/Data/StoreBlob.cs
@@ -92,6 +92,7 @@ namespace BTCPayServer.Data
         [JsonConverter(typeof(CurrencyValueJsonConverter))]
         public CurrencyValue LightningMaxValue { get; set; }
         public bool LightningAmountInSatoshi { get; set; }
+        public bool LightningPrivateRouteHints { get; set; }
 
         public string CustomCSS { get; set; }
         public string CustomLogo { get; set; }

--- a/BTCPayServer/Models/StoreViewModels/CheckoutExperienceViewModel.cs
+++ b/BTCPayServer/Models/StoreViewModels/CheckoutExperienceViewModel.cs
@@ -63,7 +63,10 @@ namespace BTCPayServer.Models.StoreViewModels
 
         [Display(Name = "Display lightning payment amounts in Satoshis")]
         public bool LightningAmountInSatoshi { get; set; }
-        
+
+        [Display(Name = "Add hop hints for private channels to the lightning invoice")]
+        public bool LightningPrivateRouteHints { get; set; }
+
         [Display(Name = "Redirect invoice to redirect url automatically after paid")]
         public bool  RedirectAutomatically { get; set; }
     }

--- a/BTCPayServer/Payments/Lightning/LightningLikePaymentHandler.cs
+++ b/BTCPayServer/Payments/Lightning/LightningLikePaymentHandler.cs
@@ -65,7 +65,9 @@ namespace BTCPayServer.Payments.Lightning
             {
                 try
                 {
-                    lightningInvoice = await client.CreateInvoice(new LightMoney(due, LightMoneyUnit.BTC), description, expiry, cts.Token);
+                    var request = new CreateInvoiceParams(new LightMoney(due, LightMoneyUnit.BTC), description, expiry);
+                    request.PrivateRouteHints = storeBlob.LightningPrivateRouteHints;
+                    lightningInvoice = await client.CreateInvoice(request, cts.Token);
                 }
                 catch (OperationCanceledException) when (cts.IsCancellationRequested)
                 {

--- a/BTCPayServer/Views/Stores/CheckoutExperience.cshtml
+++ b/BTCPayServer/Views/Stores/CheckoutExperience.cshtml
@@ -82,6 +82,12 @@
                     <span asp-validation-for="LightningAmountInSatoshi" class="text-danger"></span>
                 </div>
                 <div class="form-check">
+                    <input asp-for="LightningPrivateRouteHints" type="checkbox" class="form-check-input" />
+                    <label asp-for="LightningPrivateRouteHints" class="form-check-label"></label>
+                    <span asp-validation-for="LightningPrivateRouteHints" class="text-danger"></span>
+                </div>
+
+                <div class="form-check">
                     <input asp-for="RedirectAutomatically" type="checkbox" class="form-check-input" />
                     <label asp-for="RedirectAutomatically" class="form-check-label"></label>
                     <span asp-validation-for="RedirectAutomatically" class="text-danger"></span>


### PR DESCRIPTION
Resolves: #1480

Note that this only works for LND. I need to look if other lightning implementations have similar setting and enable it; but that will work through BtcPayServer.Lightning libarary update.