### PR TITLE
Randomize RBF if the user does not care

### DIFF
--- a/BTCPayServer/Controllers/WalletsController.PSBT.cs
+++ b/BTCPayServer/Controllers/WalletsController.PSBT.cs
@@ -40,7 +40,10 @@ namespace BTCPayServer.Controllers
            
             if (network.SupportRBF)
             {
-                psbtRequest.RBF = !sendModel.DisableRBF;
+                if (sendModel.AllowFeeBump is WalletSendModel.ThreeStateBool.Yes)
+                    psbtRequest.RBF = true;
+                if (sendModel.AllowFeeBump is WalletSendModel.ThreeStateBool.No)
+                    psbtRequest.RBF = false;
             }
            
             psbtRequest.FeePreference = new FeePreference();

--- a/BTCPayServer/Models/WalletViewModels/WalletSendModel.cs
+++ b/BTCPayServer/Models/WalletViewModels/WalletSendModel.cs
@@ -7,6 +7,12 @@ namespace BTCPayServer.Models.WalletViewModels
 {
     public class WalletSendModel
     {
+        public enum ThreeStateBool
+        {
+            Maybe,
+            Yes,
+            No
+        }
         public class FeeRateOption
         {
             public TimeSpan Target { get; set; }
@@ -45,8 +51,8 @@ namespace BTCPayServer.Models.WalletViewModels
         public string Fiat { get; set; }
         public string RateError { get; set; }
         public bool SupportRBF { get; set; }
-        [Display(Name = "Disable RBF")]
-        public bool DisableRBF { get; set; }
+        [Display(Name = "Allow fee increase (RBF)")]
+        public ThreeStateBool AllowFeeBump { get; set; }
 
         public bool NBXSeedAvailable { get; set; }
         [Display(Name = "PayJoin Endpoint Url")]

--- a/BTCPayServer/Views/Wallets/WalletSend.cshtml
+++ b/BTCPayServer/Views/Wallets/WalletSend.cshtml
@@ -171,21 +171,27 @@
                 </button>
                 <div id="accordian-advanced" class="collapse" aria-labelledby="accordian-advanced-header" data-parent="#accordian-advanced">
                     <div class="card-body">
-                        <div class="form-check">
-                            <input asp-for="NoChange" class="form-check-input" />
-                            <label asp-for="NoChange" class="form-check-label"></label>
-                            <a href="https://docs.btcpayserver.org/features/wallet#make-sure-no-change-utxo-is-created-expert-mode" target="_blank">
-                                <span class="fa fa-question-circle-o" title="More information..."></span>
-                            </a>
+                        <div class="form-group">
+                            <div class="form-check">
+                                <input asp-for="NoChange" class="form-check-input" />
+                                <label asp-for="NoChange" class="form-check-label"></label>
+                                <a href="https://docs.btcpayserver.org/features/wallet#make-sure-no-change-utxo-is-created-expert-mode" target="_blank">
+                                    <span class="fa fa-question-circle-o" title="More information..."></span>
+                                </a>
+                            </div>
                         </div>
                         @if (Model.SupportRBF)
                         {
-                            <div class="form-check">
-                                <input asp-for="DisableRBF" class="form-check-input" />
-                                <label asp-for="DisableRBF" class="form-check-label"></label>
-                                <a href="https://bitcoin.org/en/glossary/rbf" target="_blank">
+                            <div class="form-group">
+                                <label asp-for="AllowFeeBump"></label>
+                                <a href="https://bitcoinops.org/en/rbf-in-the-wild/" target="_blank">
                                     <span class="fa fa-question-circle-o" title="More information..."></span>
                                 </a>
+                                <select asp-for="AllowFeeBump" class="form-control">
+                                    <option value="Maybe">Randomize for higher privacy</option>
+                                    <option value="Yes">Yes</option>
+                                    <option value="No">No</option>
+                                </select>
                             </div>
                         }
                         @if (!string.IsNullOrEmpty(Model.PayJoinEndpointUrl))


### PR DESCRIPTION
NBXplorer will start randomizing the fingerprint of transactions.
To accomodate this change, I removed the checkbox in advanced settings of the wallet and replaced by a tri state.

![image](https://user-images.githubusercontent.com/3020646/82753800-7d26b280-9e03-11ea-99ed-e5c97c4c1637.png)
