### PR TITLE
[GreenField] Add additional data to allow roundtrip of upper version fields

### DIFF
--- a/BTCPayServer.Client/Models/PaymentRequestBaseData.cs
+++ b/BTCPayServer.Client/Models/PaymentRequestBaseData.cs
@@ -1,6 +1,8 @@
 using System;
+using System.Collections.Generic;
 using BTCPayServer.JsonConverters;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 
 namespace BTCPayServer.Client.Models
 {
@@ -17,5 +19,8 @@ namespace BTCPayServer.Client.Models
         public string EmbeddedCSS { get; set; }
         public string CustomCSSLink { get; set; }
         public bool AllowCustomPaymentAmounts { get; set; }
+
+        [JsonExtensionData]
+        public IDictionary<string, JToken> AdditionalData { get; set; }
     }
 }

--- a/BTCPayServer.Client/Models/StoreBaseData.cs
+++ b/BTCPayServer.Client/Models/StoreBaseData.cs
@@ -1,8 +1,10 @@
 using System;
+using System.Collections.Generic;
 using System.ComponentModel;
 using BTCPayServer.Client.JsonConverters;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
+using Newtonsoft.Json.Linq;
 
 namespace BTCPayServer.Client.Models
 {
@@ -54,6 +56,9 @@ namespace BTCPayServer.Client.Models
         public bool PayJoinEnabled { get; set; }
         public bool LightningPrivateRouteHints { get; set; }
 
+
+        [JsonExtensionData]
+        public IDictionary<string, JToken> AdditionalData { get; set; }
     }
     
     public enum NetworkFeeMode


### PR DESCRIPTION
Ping @rockstardev @Kukks in the future, think about adding this field to JSON data that may have roundtrips.

Imagine a store in btcpayserver V1 have only a field "name" and "defaultLang" and btcpayserver client lib is also V1.

The client wants to change the name
First the client would do a GET
```json
{
  "name": "Hello",
  "defaultLang": "fr"
}
```

Then client would do a POST
```json
{
  "name": "NEW NAME",
  "defaultLang": "fr"
}
```

Then imagine the server update to V2, and a new field, enablePayjoin is added, but the client library is still V1. Without the AdditionalData field, here what would happen.

GET
```json
{
  "name": "Hello",
  "defaultLang": "fr",
  "payjoinEnabled": true
}
```

During deserialization, without AdditionalData, `payjoinEnabled` is simply thrown away. So when the client is running the same code than before on V2, his update on the name will actually disable payjoinEnabled because this default to `false`!

POST
```json
{
  "name": "NEW NAME",
  "defaultLang": "fr"
}
```

Adding AdditionalData make sure that the payjoinEnabled value is correctly roundtripping even for V1 clients.