### PR TITLE
Rename Permission.StoreId to Permission.Scope

### DIFF
--- a/BTCPayServer.Client/Permissions.cs
+++ b/BTCPayServer.Client/Permissions.cs
@@ -57,14 +57,14 @@ namespace BTCPayServer.Client
     }
     public class Permission
     {
-        public static Permission Create(string policy, string storeId = null)
+        public static Permission Create(string policy, string scope = null)
         {
-            if (TryCreatePermission(policy, storeId, out var r))
+            if (TryCreatePermission(policy, scope, out var r))
                 return r;
             throw new ArgumentException("Invalid Permission");
         }
 
-        public static bool TryCreatePermission(string policy, string storeId, out Permission permission)
+        public static bool TryCreatePermission(string policy, string scope, out Permission permission)
         {
             permission = null;
             if (policy == null)
@@ -72,9 +72,9 @@ namespace BTCPayServer.Client
             policy = policy.Trim().ToLowerInvariant();
             if (!Policies.IsValidPolicy(policy))
                 return false;
-            if (storeId != null && !Policies.IsStorePolicy(policy))
+            if (scope != null && !Policies.IsStorePolicy(policy))
                 return false;
-            permission = new Permission(policy, storeId);
+            permission = new Permission(policy, scope);
             return true;
         }
 
@@ -108,10 +108,10 @@ namespace BTCPayServer.Client
             }
         }
 
-        internal Permission(string policy, string storeId)
+        internal Permission(string policy, string scope)
         {
             Policy = policy;
-            StoreId = storeId;
+            Scope = scope;
         }
 
         public bool Contains(Permission subpermission)
@@ -125,7 +125,7 @@ namespace BTCPayServer.Client
             }
             if (!Policies.IsStorePolicy(subpermission.Policy))
                 return true;
-            return StoreId == null || subpermission.StoreId == this.StoreId;
+            return Scope == null || subpermission.Scope == this.Scope;
         }
 
         public static IEnumerable<Permission> ToPermissions(string[] permissions)
@@ -161,14 +161,14 @@ namespace BTCPayServer.Client
             }
         }
 
-        public string StoreId { get; }
+        public string Scope { get; }
         public string Policy { get; }
 
         public override string ToString()
         {
-            if (StoreId != null)
+            if (Scope != null)
             {
-                return $"{Policy}:{StoreId}";
+                return $"{Policy}:{Scope}";
             }
             return Policy;
         }

--- a/BTCPayServer.Tests/ApiKeysTests.cs
+++ b/BTCPayServer.Tests/ApiKeysTests.cs
@@ -192,7 +192,7 @@ namespace BTCPayServer.Tests
             var canModifyAllStores = Permission.Create(Policies.CanModifyStoreSettings, null);
             var canModifyServer = Permission.Create(Policies.CanModifyServerSettings, null);
             var unrestricted = Permission.Create(Policies.Unrestricted, null);
-            var selectiveStorePermissions = permissions.Where(p => p.StoreId != null && p.Policy == Policies.CanModifyStoreSettings);
+            var selectiveStorePermissions = permissions.Where(p => p.Scope != null && p.Policy == Policies.CanModifyStoreSettings);
             if (permissions.Contains(canModifyAllStores) || selectiveStorePermissions.Any())
             {
                 var resultStores =
@@ -202,11 +202,11 @@ namespace BTCPayServer.Tests
                 foreach (var selectiveStorePermission in selectiveStorePermissions)
                 {
                     Assert.True(await TestApiAgainstAccessToken<bool>(accessToken,
-                        $"{TestApiPath}/me/stores/{selectiveStorePermission.StoreId}/can-edit",
+                        $"{TestApiPath}/me/stores/{selectiveStorePermission.Scope}/can-edit",
                         tester.PayTester.HttpClient));
 
                     Assert.Contains(resultStores,
-                        data => data.Id.Equals(selectiveStorePermission.StoreId, StringComparison.InvariantCultureIgnoreCase));
+                        data => data.Id.Equals(selectiveStorePermission.Scope, StringComparison.InvariantCultureIgnoreCase));
                 }
 
                 bool shouldBeAuthorized = false;

--- a/BTCPayServer.Tests/TestAccount.cs
+++ b/BTCPayServer.Tests/TestAccount.cs
@@ -77,8 +77,8 @@ namespace BTCPayServer.Tests
                         return p;
                     }).GroupBy(permission => permission.Policy).Select(p =>
                     {
-                        var stores = p.Where(permission => !string.IsNullOrEmpty(permission.StoreId))
-                            .Select(permission => permission.StoreId).ToList();
+                        var stores = p.Where(permission => !string.IsNullOrEmpty(permission.Scope))
+                            .Select(permission => permission.Scope).ToList();
                         return new ManageController.AddApiKeyViewModel.PermissionValueItem()
                         {
                             Permission = p.Key,

--- a/BTCPayServer/Controllers/ManageController.APIKeys.cs
+++ b/BTCPayServer/Controllers/ManageController.APIKeys.cs
@@ -128,10 +128,10 @@ namespace BTCPayServer.Controllers
                 else if (wanted?.Any()??false)
                 {
                     if (vm.SelectiveStores && Policies.IsStorePolicy(permissionValue.Permission) &&
-                        wanted.Any(permission => !string.IsNullOrEmpty(permission.StoreId)))
+                        wanted.Any(permission => !string.IsNullOrEmpty(permission.Scope)))
                     {
                         permissionValue.StoreMode = AddApiKeyViewModel.ApiKeyStoreMode.Specific;
-                        permissionValue.SpecificStores = wanted.Select(permission => permission.StoreId).ToList();
+                        permissionValue.SpecificStores = wanted.Select(permission => permission.Scope).ToList();
                     }
                     else
                     {


### PR DESCRIPTION
In future PR, a permission may have the form of `WalletPolicy:WalletId`, so it makes sense to rename what is now only StoreId to Scope.