### PR TITLE
Bump LND version to 0.10.1-beta

### DIFF
--- a/BTCPayServer.Tests/docker-compose.yml
+++ b/BTCPayServer.Tests/docker-compose.yml
@@ -262,7 +262,7 @@ services:
       - "5432"
 
   merchant_lnd:
-    image: btcpayserver/lnd:v0.9.2-beta
+    image: btcpayserver/lnd:v0.10.1-beta
     restart: unless-stopped
     environment:
       LND_CHAIN: "btc"
@@ -292,7 +292,7 @@ services:
       - bitcoind
 
   customer_lnd:
-    image: btcpayserver/lnd:v0.9.2-beta
+    image: btcpayserver/lnd:v0.10.1-beta
     restart: unless-stopped
     environment:
       LND_CHAIN: "btc"


### PR DESCRIPTION
If after merge it works well for you @NicolasDorier and @Kukks during your development, I'll bump the version in btcpayserver-docker repository.

All works well for me + btcpayserver.lightning tests.