### PR TITLE
Fix possible view exception in pos app

### DIFF
--- a/BTCPayServer/Views/AppsPublic/PointOfSale/Cart.cshtml
+++ b/BTCPayServer/Views/AppsPublic/PointOfSale/Cart.cshtml
@@ -249,7 +249,7 @@
                         </div>
                         <div class="card-footer pt-0 bg-transparent border-0">
 
-                            <span class="text-muted small">@String.Format(Model.ButtonText, @item.Price.Formatted)</span>
+                            <span class="text-muted small">@Model.ButtonText.Replace("{0}",item.Price.Formatted).Replace("{Price}",item.Price.Formatted)</span>
                              @if (item.Inventory.HasValue)
                              {
 

--- a/BTCPayServer/Views/AppsPublic/PointOfSale/Static.cshtml
+++ b/BTCPayServer/Views/AppsPublic/PointOfSale/Static.cshtml
@@ -55,7 +55,7 @@
                                 {
                                     <form method="post" asp-controller="AppsPublic" asp-action="ViewPointOfSale" asp-route-appId="@Model.AppId" asp-antiforgery="false">
                                         <button type="submit" name="choiceKey" class="js-add-cart btn btn-primary" value="@item.Id">
-                                            @String.Format(Model.ButtonText, @item.Price.Formatted)
+                                            @Model.ButtonText.Replace("{0}",item.Price.Formatted).Replace("{Price}",item.Price.Formatted)
                                         </button>
                                     </form>
                                 }


### PR DESCRIPTION
Replaced string.format with a simpler replace and also allow `{Price}` instead of `{0}` as it's obscure to non c# devs

error described at https://chat.btcpayserver.org/btcpayserver/pl/dgir7z1e43897da4cga69he86o