### PR TITLE
Autofocus 2FA-code input on page load

### DIFF
--- a/BTCPayServer/Views/Account/LoginWith2fa.cshtml
+++ b/BTCPayServer/Views/Account/LoginWith2fa.cshtml
@@ -14,7 +14,7 @@
                 <input asp-for="RememberMe" type="hidden"/>
                 <div class="form-group">
                     <label asp-for="TwoFactorCode"></label>
-                    <input asp-for="TwoFactorCode" class="form-control" autocomplete="off"/>
+                    <input asp-for="TwoFactorCode" class="form-control" autocomplete="off" autofocus/>
                     <span asp-validation-for="TwoFactorCode" class="text-danger"></span>
                 </div>
                 <div class="form-group">


### PR DESCRIPTION
UX improvement that allows you to directly paste the 2FA-code. Useful when you are using e.g. the 1Password browser extension.