### PR TITLE
Add AlwaysIncludeNonWitnessUTXO to Wallet Send

### DIFF
--- a/BTCPayServer.Common/BTCPayServer.Common.csproj
+++ b/BTCPayServer.Common/BTCPayServer.Common.csproj
@@ -4,6 +4,6 @@
 
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="NBXplorer.Client" Version="3.0.15" />
+    <PackageReference Include="NBXplorer.Client" Version="3.0.16" />
   </ItemGroup>
 </Project>

--- a/BTCPayServer/Controllers/WalletsController.PSBT.cs
+++ b/BTCPayServer/Controllers/WalletsController.PSBT.cs
@@ -45,6 +45,8 @@ namespace BTCPayServer.Controllers
                 if (sendModel.AllowFeeBump is WalletSendModel.ThreeStateBool.No)
                     psbtRequest.RBF = false;
             }
+
+            psbtRequest.AlwaysIncludeNonWitnessUTXO = sendModel.AlwaysIncludeNonWitnessUTXO;
            
             psbtRequest.FeePreference = new FeePreference();
             if (sendModel.FeeSatoshiPerByte is decimal v &&

--- a/BTCPayServer/Models/WalletViewModels/WalletSendModel.cs
+++ b/BTCPayServer/Models/WalletViewModels/WalletSendModel.cs
@@ -51,6 +51,8 @@ namespace BTCPayServer.Models.WalletViewModels
         public string Fiat { get; set; }
         public string RateError { get; set; }
         public bool SupportRBF { get; set; }
+        [Display(Name = "Always include non-witness UTXO if available")]
+        public bool AlwaysIncludeNonWitnessUTXO  { get; set; }
         [Display(Name = "Allow fee increase (RBF)")]
         public ThreeStateBool AllowFeeBump { get; set; }
 

--- a/BTCPayServer/Views/Wallets/WalletSend.cshtml
+++ b/BTCPayServer/Views/Wallets/WalletSend.cshtml
@@ -180,6 +180,13 @@
                                 </a>
                             </div>
                         </div>
+                        
+                        <div class="form-group">
+                            <div class="form-check">
+                                <input asp-for="AlwaysIncludeNonWitnessUTXO" class="form-check-input"/>
+                                <label asp-for="AlwaysIncludeNonWitnessUTXO" class="form-check-label"></label>
+                            </div>
+                        </div>    
                         @if (Model.SupportRBF)
                         {
                             <div class="form-group">

--- a/BTCPayServer/Views/Wallets/WalletSend.cshtml
+++ b/BTCPayServer/Views/Wallets/WalletSend.cshtml
@@ -179,12 +179,14 @@
                                     <span class="fa fa-question-circle-o" title="More information..."></span>
                                 </a>
                             </div>
-                        </div>
-                        
+                        </div>                        
                         <div class="form-group">
                             <div class="form-check">
                                 <input asp-for="AlwaysIncludeNonWitnessUTXO" class="form-check-input"/>
                                 <label asp-for="AlwaysIncludeNonWitnessUTXO" class="form-check-label"></label>
+                                <a href="https://medium.com/@jmacato/wasabi-wallets-advisory-for-trezor-users-7d942c727f92" target="_blank">
+                                    <span class="fa fa-question-circle-o" title="More information..."></span>
+                                </a>
                             </div>
                         </div>    
                         @if (Model.SupportRBF)


### PR DESCRIPTION
Band-aid fix for trezor support. if a BTCPay wallet is restored and the bitcoind node is not running txindex=1, this will fail either way on trezor

We will need to document this 