### PR TITLE
Add an approval state to pull payments

### DIFF
--- a/BTCPayServer.Client/BTCPayServerClient.PullPayments.cs
+++ b/BTCPayServer.Client/BTCPayServerClient.PullPayments.cs
@@ -54,5 +54,10 @@ namespace BTCPayServer.Client
             var response = await _httpClient.SendAsync(CreateHttpRequest($"api/v1/stores/{HttpUtility.UrlEncode(storeId)}/payouts/{HttpUtility.UrlEncode(payoutId)}", method: HttpMethod.Delete), cancellationToken);
             await HandleResponse(response);
         }
+        public async Task<PayoutData> ApprovePayout(string storeId, string payoutId, ApprovePayoutRequest request, CancellationToken cancellationToken = default)
+        {
+            var response = await _httpClient.SendAsync(CreateHttpRequest($"api/v1/stores/{HttpUtility.UrlEncode(storeId)}/payouts/{HttpUtility.UrlEncode(payoutId)}", bodyPayload: request, method: HttpMethod.Post), cancellationToken);
+            return await HandleResponse<PayoutData>(response);
+        }
     }
 }

--- a/BTCPayServer.Client/Models/ApprovePayoutRequest.cs
+++ b/BTCPayServer.Client/Models/ApprovePayoutRequest.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace BTCPayServer.Client.Models
+{
+    public class ApprovePayoutRequest
+    {
+        public int Revision { get; set; }
+        public string RateRule { get; set; }
+    }
+}

--- a/BTCPayServer.Client/Models/PayoutData.cs
+++ b/BTCPayServer.Client/Models/PayoutData.cs
@@ -9,6 +9,7 @@ namespace BTCPayServer.Client.Models
 {
     public enum PayoutState
     {
+        AwaitingApproval,
         AwaitingPayment,
         InProgress,
         Completed,
@@ -25,8 +26,9 @@ namespace BTCPayServer.Client.Models
         [JsonConverter(typeof(DecimalStringJsonConverter))]
         public decimal Amount { get; set; }
         [JsonConverter(typeof(DecimalStringJsonConverter))]
-        public decimal PaymentMethodAmount { get; set; }
+        public decimal? PaymentMethodAmount { get; set; }
         [JsonConverter(typeof(StringEnumConverter))]
         public PayoutState State { get; set; }
+        public int Revision { get; set; }
     }
 }

--- a/BTCPayServer.Data/Data/PayoutData.cs
+++ b/BTCPayServer.Data/Data/PayoutData.cs
@@ -56,6 +56,7 @@ namespace BTCPayServer.Data
 
     public enum PayoutState
     {
+        AwaitingApproval,
         AwaitingPayment,
         InProgress,
         Completed,

--- a/BTCPayServer.Rating/RateRules.cs
+++ b/BTCPayServer.Rating/RateRules.cs
@@ -494,6 +494,12 @@ namespace BTCPayServer.Rating
         private SyntaxNode expression;
         FlattenExpressionRewriter flatten;
 
+        public static RateRule CreateFromExpression(string expression, CurrencyPair currencyPair)
+        {
+            var ex = RateRules.CreateExpression(expression);
+            RateRules.TryParse("", out var rules);
+            return new RateRule(rules, currencyPair, ex);
+        }
         public RateRule(RateRules parent, CurrencyPair currencyPair, SyntaxNode candidate)
         {
             _CurrencyPair = currencyPair;

--- a/BTCPayServer.Tests/SeleniumTests.cs
+++ b/BTCPayServer.Tests/SeleniumTests.cs
@@ -738,7 +738,7 @@ namespace BTCPayServer.Tests
                 s.Driver.FindElement(By.Id("ClaimedAmount")).Clear();
                 s.Driver.FindElement(By.Id("ClaimedAmount")).SendKeys("20" + Keys.Enter);
                 s.AssertHappyMessage();
-                Assert.Contains("AwaitingPayment", s.Driver.PageSource);
+                Assert.Contains("AwaitingApproval", s.Driver.PageSource);
 
                 var viewPullPaymentUrl = s.Driver.Url;
                 // This one should have nothing

--- a/BTCPayServer/Controllers/GreenField/PullPaymentController.cs
+++ b/BTCPayServer/Controllers/GreenField/PullPaymentController.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.CompilerServices;
+using System.Threading;
 using System.Threading.Tasks;
 using BTCPayServer;
 using BTCPayServer.Client;
@@ -81,13 +82,12 @@ namespace BTCPayServer.Controllers.GreenField
             {
                 ModelState.AddModelError(nameof(request.Name), "The name should be maximum 50 characters.");
             }
-            BTCPayNetwork network = null;
             if (request.Currency is String currency)
             {
-                network = _networkProvider.GetNetwork<BTCPayNetwork>(currency);
-                if (network is null)
+                request.Currency = currency.ToUpperInvariant().Trim();
+                if (_currencyNameTable.GetCurrencyData(request.Currency, false) is null)
                 {
-                    ModelState.AddModelError(nameof(request.Currency), $"Only crypto currencies are supported this field. (More will be supported soon)");
+                    ModelState.AddModelError(nameof(request.Currency), "Invalid currency");
                 }
             }
             else
@@ -102,12 +102,12 @@ namespace BTCPayServer.Controllers.GreenField
             {
                 ModelState.AddModelError(nameof(request.Period), $"The period should be positive");
             }
-            if (request.PaymentMethods is string[] paymentMethods)
+            PaymentMethodId[] paymentMethods = null;
+            if (request.PaymentMethods is string[] paymentMethodsStr)
             {
-                if (paymentMethods.Length != 1 && paymentMethods[0] != request.Currency)
-                {
-                    ModelState.AddModelError(nameof(request.PaymentMethods), "We expect this array to only contains the same element as the `currency` field. (More will be supported soon)");
-                }
+                paymentMethods = paymentMethodsStr.Select(p => new PaymentMethodId(p, PaymentTypes.BTCLike)).ToArray();
+                if (paymentMethods.Any(p => _networkProvider.GetNetwork<BTCPayNetwork>(p.CryptoCode) is null))
+                    ModelState.AddModelError(nameof(request.PaymentMethods), "Invalid payment method");
             }
             else
             {
@@ -122,9 +122,9 @@ namespace BTCPayServer.Controllers.GreenField
                 Period = request.Period,
                 Name = request.Name,
                 Amount = request.Amount,
-                Currency = network.CryptoCode,
+                Currency = request.Currency,
                 StoreId = storeId,
-                PaymentMethodIds = new[] { new PaymentMethodId(network.CryptoCode, PaymentTypes.BTCLike) }
+                PaymentMethodIds = paymentMethods
             });
             var pp = await _pullPaymentService.GetPullPayment(ppId);
             return this.Ok(CreatePullPaymentData(pp));
@@ -193,7 +193,9 @@ namespace BTCPayServer.Controllers.GreenField
                 Date = p.Date,
                 Amount = blob.Amount,
                 PaymentMethodAmount = blob.CryptoAmount,
+                Revision = blob.Revision,
                 State = p.State == Data.PayoutState.AwaitingPayment ? Client.Models.PayoutState.AwaitingPayment :
+                                            p.State == Data.PayoutState.AwaitingApproval ? Client.Models.PayoutState.AwaitingApproval :
                                             p.State == Data.PayoutState.Cancelled ? Client.Models.PayoutState.Cancelled :
                                             p.State == Data.PayoutState.Completed ? Client.Models.PayoutState.Completed :
                                             p.State == Data.PayoutState.InProgress ? Client.Models.PayoutState.InProgress :
@@ -289,6 +291,62 @@ namespace BTCPayServer.Controllers.GreenField
                 return NotFound();
             await _pullPaymentService.Cancel(new PullPaymentHostedService.CancelRequest(new[] { payoutId }));
             return Ok();
+        }
+
+        [HttpPost("~/api/v1/stores/{storeId}/payouts/{payoutId}")]
+        [Authorize(Policy = Policies.CanManagePullPayments, AuthenticationSchemes = AuthenticationSchemes.Greenfield)]
+        public async Task<IActionResult> ApprovePayout(string storeId, string payoutId, ApprovePayoutRequest approvePayoutRequest, CancellationToken cancellationToken = default)
+        {
+            using var ctx = _dbContextFactory.CreateContext();
+            ctx.ChangeTracker.QueryTrackingBehavior = QueryTrackingBehavior.NoTracking;
+            var revision = approvePayoutRequest?.Revision;
+            if (revision is null)
+            {
+                ModelState.AddModelError(nameof(approvePayoutRequest.Revision), "The `revision` property is required");
+            }
+            if (!ModelState.IsValid)
+                return this.CreateValidationError(ModelState);
+            var payout = await ctx.Payouts.GetPayout(payoutId, storeId, true, true);
+            if (payout is null)
+                return NotFound();
+            RateResult rateResult = null;
+            try
+            {
+                rateResult = await _pullPaymentService.GetRate(payout, approvePayoutRequest?.RateRule, cancellationToken);
+                if (rateResult.BidAsk == null)
+                {
+                    return this.CreateAPIError("rate-unavailable", $"Rate unavailable: {rateResult.EvaluatedRule}");
+                }
+            }
+            catch (FormatException)
+            {
+                ModelState.AddModelError(nameof(approvePayoutRequest.RateRule), "Invalid RateRule");
+                return this.CreateValidationError(ModelState);
+            }
+            var ppBlob = payout.PullPaymentData.GetBlob();
+            var cd = _currencyNameTable.GetCurrencyData(ppBlob.Currency, false);
+            var result = await _pullPaymentService.Approve(new PullPaymentHostedService.PayoutApproval()
+            {
+                PayoutId = payoutId,
+                Revision = revision.Value,
+                Rate = rateResult.BidAsk.Ask
+            });
+            var errorMessage = PullPaymentHostedService.PayoutApproval.GetErrorMessage(result);
+            switch (result)
+            {
+                case PullPaymentHostedService.PayoutApproval.Result.Ok:
+                    return Ok(ToModel(await ctx.Payouts.GetPayout(payoutId, storeId, true), cd));
+                case PullPaymentHostedService.PayoutApproval.Result.InvalidState:
+                    return this.CreateAPIError("invalid-state", errorMessage);
+                case PullPaymentHostedService.PayoutApproval.Result.TooLowAmount:
+                    return this.CreateAPIError("amount-too-low", errorMessage);
+                case PullPaymentHostedService.PayoutApproval.Result.OldRevision:
+                    return this.CreateAPIError("old-revision", errorMessage);
+                case PullPaymentHostedService.PayoutApproval.Result.NotFound:
+                    return NotFound();
+                default:
+                    throw new NotSupportedException();
+            }
         }
     }
 }

--- a/BTCPayServer/Controllers/PullPaymentController.cs
+++ b/BTCPayServer/Controllers/PullPaymentController.cs
@@ -11,6 +11,7 @@ using BTCPayServer.Models;
 using BTCPayServer.Payments;
 using BTCPayServer.Services;
 using BTCPayServer.Services.Rates;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.ModelBinding.Validation;
 using Microsoft.EntityFrameworkCore;
@@ -18,6 +19,7 @@ using Microsoft.EntityFrameworkCore.Internal;
 
 namespace BTCPayServer.Controllers
 {
+    [AllowAnonymous]
     public class PullPaymentController : Controller
     {
         private readonly ApplicationDbContextFactory _dbContextFactory;

--- a/BTCPayServer/Views/Wallets/NewPullPayment.cshtml
+++ b/BTCPayServer/Views/Wallets/NewPullPayment.cshtml
@@ -72,7 +72,7 @@
             </div>
             <div class="form-group">
                 <label asp-for="Currency" class="control-label"></label>
-                <input asp-for="Currency" class="form-control" readonly />
+                <input asp-for="Currency" class="form-control" />
                 <span asp-validation-for="Currency" class="text-danger"></span>
             </div>
             <div class="form-group">

--- a/BTCPayServer/WalletId.cs
+++ b/BTCPayServer/WalletId.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
+using BTCPayServer.Payments;
 
 namespace BTCPayServer
 {
@@ -35,7 +36,10 @@ namespace BTCPayServer
         public string StoreId { get; set; }
         public string CryptoCode { get; set; }
 
-
+        public PaymentMethodId GetPaymentMethodId()
+        {
+            return new PaymentMethodId(CryptoCode, PaymentTypes.BTCLike);
+        }
         public override bool Equals(object obj)
         {
             WalletId item = obj as WalletId;

--- a/BTCPayServer/wwwroot/swagger/v1/swagger.template.pull-payments.json
+++ b/BTCPayServer/wwwroot/swagger/v1/swagger.template.pull-payments.json
@@ -307,6 +307,65 @@
                     "schema": { "type": "string" }
                 }
             ],
+            "post": {
+                "description": "Approve a payout",
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "revision": {
+                                        "type": "integer",
+                                        "description": "The revision number of the payout being modified"
+                                    },
+                                    "rateRule": {
+                                        "type": "string",
+                                        "nullable": true,
+                                        "example": "kraken(BTC_USD)",
+                                        "description": "The rate rule to calculate the rate of the payout. This can also be a fixed decimal. (if null or unspecified, will use the same rate setting as the store's settings)"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "The payout has been approved, transitioning to `AwaitingPayment` state.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/PayoutData"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Unable to validate the request",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ValidationProblemDetails"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Wellknown error codes are: `rate-unavailable`, `invalid-state`, `amount-too-low`, `old-revision`",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProblemDetails"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "The payout is not found"
+                    }
+                }
+            },
             "delete": {
                 "description": "Cancel the payout",
                 "responses": {
@@ -350,6 +409,10 @@
                         "type": "string",
                         "description": "The id of the payout"
                     },
+                    "revision": {
+                        "type": "integer",
+                        "description": "The revision number of the payout. This revision number is incremented when the payout amount or destination is modified before the approval."
+                    },
                     "pullPaymentId": {
                         "type": "string",
                         "description": "The id of the pull payment this payout belongs to"
@@ -367,7 +430,7 @@
                         "type": "string",
                         "format": "decimal",
                         "example": "10399.18",
-                        "description": "The amount of the payout in the currency of the pull payment (eg. USD). In this current release, `amount` is the same as `paymentMethodAmount`."
+                        "description": "The amount of the payout in the currency of the pull payment (eg. USD)."
                     },
                     "paymentMethod": {
                         "type": "string",
@@ -377,20 +440,23 @@
                     "paymentMethodAmount": {
                         "type": "string",
                         "format": "decimal",
+                        "nullable": true,
                         "example": "1.12300000",
-                        "description": "The amount of the payout in the currency of the payment method (eg. BTC). In this current release, `paymentMethodAmount` is the same as `amount`."
+                        "description": "The amount of the payout in the currency of the payment method (eg. BTC). This is only available from the `AwaitingPayment` state."
                     },
                     "state": {
                         "type": "string",
                         "example": "AwaitingPayment",
-                        "description": "The state of the payout (`AwaitingPayment`, `InProgress`, `Completed`, `Cancelled`)",
+                        "description": "The state of the payout (`AwaitingApproval`, `AwaitingPayment`, `InProgress`, `Completed`, `Cancelled`)",
                         "x-enumNames": [
+                            "AwaitingApproval",
                             "AwaitingPayment",
                             "InProgress",
                             "Completed",
                             "Cancelled"
                         ],
                         "enum": [
+                            "AwaitingApproval",
                             "AwaitingPayment",
                             "InProgress",
                             "Completed",


### PR DESCRIPTION
The add an Approval step to the payouts. No change from UI/UX perspective for now, only API.

This allow several things:
* Allow a pull payment in Currency (say USD), during approval of a payout, you can set a rate rule to calculate the rate to use with the payout's crypto currency. (default to store settings)
* TODO: Allow somebody claiming a payout to modify the claim amount or address until the payer is actually approving.
* Make sure that the payer can't pay at the same time as a the receiver modify the payout.
