### PR TITLE
Set noindex, nofollow to ViewPullPayment.cshtml

### DIFF
--- a/BTCPayServer/Views/PullPayment/ViewPullPayment.cshtml
+++ b/BTCPayServer/Views/PullPayment/ViewPullPayment.cshtml
@@ -12,6 +12,7 @@
 <head>
     <title>@Model.Title</title>
     <meta charset="utf-8" />
+    <meta name="robots" content="noindex, nofollow">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="apple-mobile-web-app-capable" content="yes">
     <link href="@Context.Request.GetRelativePathOrAbsolute(themeManager.BootstrapUri)" rel="stylesheet" />


### PR DESCRIPTION
We shouldn't make Google (or other search engines) index and cache these pages on SERPs.

This exposes a number of security and privacy concerns:
1. Receiver's addresses and transactions are publicly visible
2. Sender's (pull payment) balance is publicly visible
3. An attacker could take advantage of Google's dork (eg. `inurl:/pull-payments/`) to receive a list of all the websites with indexed pull payments, and attack the latter by continuously requesting fake payments.
This could cause the sender to make a mistake and approve the wrong payment.