### PR TITLE
Improve information structure on Lightning page

### DIFF
--- a/BTCPayServer/Controllers/StoresController.LightningLike.cs
+++ b/BTCPayServer/Controllers/StoresController.LightningLike.cs
@@ -159,7 +159,7 @@ namespace BTCPayServer.Controllers
                                 await handler.TestConnection(info, cts.Token);
                             }
                         }
-                        TempData[WellKnownTempData.SuccessMessage] = $"Connection to the lightning node succeeded ({info})";
+                        TempData[WellKnownTempData.SuccessMessage] = $"Connection to the lightning node succeeded. Your node address: {info}";
                     }
                     catch (Exception ex)
                     {

--- a/BTCPayServer/Models/StoreViewModels/LightningNodeViewModel.cs
+++ b/BTCPayServer/Models/StoreViewModels/LightningNodeViewModel.cs
@@ -23,6 +23,8 @@ namespace BTCPayServer.Models.StoreViewModels
         }
         public string InternalLightningNode { get; internal set; }
         public bool SkipPortTest { get; set; }
+
+        [Display(Name="Lightning enabled")]
         public bool Enabled { get; set; } = true;
 
         public string StoreId { get; set; }

--- a/BTCPayServer/Views/Stores/AddLightningNode.cshtml
+++ b/BTCPayServer/Views/Stores/AddLightningNode.cshtml
@@ -1,24 +1,22 @@
 ﻿@model LightningNodeViewModel
 @{
     Layout = "../Shared/_NavLayout.cshtml";
-    ViewData.SetActivePageAndTitle(StoreNavPages.Index, "Add lightning node (Experimental)");
+    ViewData.SetActivePageAndTitle(StoreNavPages.Index, "Add lightning node");
 }
 
 <partial name="_StatusMessage" />
 
-<div class="alert alert-warning alert-dismissible" role="alert">
-    <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+<div class="alert alert-warning alert-dismissible mb-5" role="alert">
+    <h4 class="alert-heading">Warning</h4>
     <p>
         <span>Before you proceed, please understand that the Lightning Network is still considered experimental and is under active development.</span>
     </p>
     <p><strong>Do not add money that you can't afford to lose - there's a high risk of loss of funds.</strong></p>
-    <p>
-        Take time to familiarize yourself with the risks, some of which are:
-    </p>
-    <ul>
+    <p class="mb-2">Take time to familiarize yourself with the risks, some of which are:</p>
+    <ul class="mb-4">
         <li>Most BTCPay Server deployments run on a pruned node which, while working, is not officially supported by lightning network implementations.</li>
         <li>
-            Lightning keys are NOT automatically backed up by BTCPay Server; your keys are in a hot-wallet. This means:
+            Lightning keys are NOT automatically backed up by BTCPay Server. Your keys are in a hot-wallet. This means:
             <ul>
                 <li>If you erase your BTCPay Server virtual machine: you lose all the funds.</li>
                 <li>If your server gets hacked: a hacker can take all of your funds by accessing your keys.</li>
@@ -26,84 +24,109 @@
             </ul>
         </li>
     </ul>
-
-    <p>To proceed, please ensure that:</p>
+    <hr>
+    <p class="mb-2">To proceed, please ensure that:</p>
     <ul>
         <li>You accept being #reckless and being the sole responsible party for any loss of funds.</li>
         <li>You agree to keep on your lightning node only what you can afford to lose.</li>
     </ul>
+    <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+        <span aria-hidden="true">&times;</span>
+    </button>
 </div>
 
 <div class="row">
-    <div class="col-md-10">
+    <div class="col">
+        <h3 class="mb-3">Lightning Node Connection</h3>
         <form method="post">
             <div class="form-group">
-                <p>This connection string encapsulates the necessary information BTCPay needs to connect to your lightning node, we currently support:</p>
+                <p class="mb-2">The connection string encapsulates the configuration for connecting to your lightning node. We currently support:</p>
                 <ul>
-                    <li><code>clightning</code> via TCP or unix domain socket connection</li>
-                    <li><code>lightning charge</code> via HTTPS</li>
-                    <li><code>lnd</code> via the REST proxy</li>
+                    <li class="mb-2">
+                        <strong>c-lightning</strong> via TCP or unix domain socket connection:
+                        <ul>
+                            <li>
+                                <code><b>type=</b>clightning;<b>server=</b>unix://root/.lightning/lightning-rpc</code>
+                            </li>
+                            <li>
+                                <code><b>type=</b>clightning;<b>server=</b>tcp://1.1.1.1:27743/</code>
+                            </li>
+                        </ul>
+                    </li>
+                    <li class="mb-2">
+                        <strong>Lightning Charge</strong> via HTTPS:
+                        <ul>
+                            <li>
+                                <code><b>type=</b>charge;<b>server=</b>https://charge:8080/;<b>api-token=</b>myapitoken...</code>
+                            </li>
+                        </ul>
+                    </li>
+                    <li class="mb-2">
+                        <strong>Eclair</strong> via HTTPS:
+                        <ul>
+                            <li>
+                                <code><b>type=</b>eclair;<b>server=</b>https://eclair:8080/;<b>password=</b>eclairpassword...</code>
+                            </li>
+                        </ul>
+                    </li>
+                    <li class="mb-2">
+                        <strong>LND</strong> via the REST proxy:
+                        <ul>
+                            <li>
+                                <code><b>type=</b>lnd-rest;<b>server=</b>https://mylnd:8080/;<b>macaroon=</b>abef263adfe...</code>
+                            </li>
+                            <li>
+                                <code><b>type=</b>lnd-rest;<b>server=</b>https://mylnd:8080/;<b>macaroon=</b>abef263adfe...;<b>certthumbprint=</b>abef263adfe...</code>
+                            </li>
+                            <li>
+                                <code><b>type=</b>lnd-rest;<b>server=</b>http://mylnd:8080/;<b>macaroonfilepath=</b>/root/.lnd/admin.macaroon;<b>allowinsecure=</b>true</code>
+                            </li>
+                        </ul>
+                        <a class="d-inline-block my-2 text-secondary text-decoration-none" data-toggle="collapse" href="#lnd-notes" role="button" aria-expanded="false" aria-controls="lnd-notes">
+                            <span class="fa fa-question-circle-o" title="More information..."></span> More information on the LND settings
+                        </a>
+                        <div class="collapse" id="lnd-notes">
+                            <div class="card card-body">
+                                <p>For the macaroon options you need to provide the <code>admin.macaroon</code>.</p>
+                                <p>The path to the LND data directory may vary, the following example assume <code>/root/.lnd</code>.</p>
+                                <p class="mb-2">The <code>macaroon</code> parameter expects the HEX value, it can be obtained using this command:</p>
+                                <pre class="mb-4">xxd -plain /root/.lnd/data/chain/bitcoin/mainnet/admin.macaroon | tr -d '\n'</pre>
+                                <p>You can omit <code>certthumbprint</code> if the certificate is trusted by your machine.</p>
+                                <p class="mb-2">The <code>certthumbprint</code> can be obtained using this command:</p>
+                                <pre class="mb-4">openssl x509 -noout -fingerprint -sha256 -in /root/.lnd/tls.cert | sed -e 's/.*=//;s/://g'</pre>
+                                <p class="mb-0">If your LND REST server is using HTTP or HTTPS with an untrusted certificate, you can set <code>allowinsecure=true</code> as a fallback.</p>
+                            </div>
+                        </div>
+                    </li>
                 </ul>
-                <table class="table table-sm table-responsive-md">
-                    <thead>
-                        <tr>
-                            <th>Examples</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-
-                        <tr>
-                            <th class="small"><b>type=</b>clightning;<b>server=</b>unix://root/.lightning/lightning-rpc</th>
-                        </tr>
-                        <tr>
-                            <th class="small"><b>type=</b>clightning;<b>server=</b>tcp://1.1.1.1:27743/</th>
-                        </tr>
-                        <tr>
-                            <th class="small"><b>type=</b>lnd-rest;<b>server=</b>http://mylnd:8080/;<b>macaroonfilepath=</b>/root/.lnd/admin.macaroon;<b>allowinsecure=</b>true</th>
-                        </tr>
-                        <tr>
-                            <th class="small"><b>type=</b>lnd-rest;<b>server=</b>https://mylnd:8080/;<b>macaroon=</b>abef263adfe...</th>
-                        </tr>
-                        <tr>
-                            <th class="small"><b>type=</b>lnd-rest;<b>server=</b>https://mylnd:8080/;<b>macaroon=</b>abef263adfe...;<b>certthumbprint=</b>abef263adfe...</th>
-                        </tr>
-                        <tr>
-                            <th class="small"><b>type=</b>charge;<b>server=</b>https://charge:8080/;<b>api-token=</b>myapitoken...</th>
-                        </tr>
-                        <tr>
-                            <th class="small"><b>type=</b>eclair;<b>server=</b>https://eclair:8080/;<b>password=</b>eclairpassword...</th>
-                        </tr>
-                    </tbody>
-                </table>
-                <p>Note that the <code>certthumbprint</code> to connect to your LND node can be obtained through this command line:</p>
-                <p><pre><code>openssl x509 -noout -fingerprint -sha256 -inform pem -in /root/.lnd/tls.cert | sed -e 's/.*=//' -e 's/://g'</code></pre></p>
-                <p>You can omit <code>certthumbprint</code> if the certificate is trusted by your machine</p>
-                <p>You can set <code>allowinsecure</code> to <code>true</code> if your LND REST server is using HTTP or HTTPS with an untrusted certificate which you don't know the <code>certthumbprint</code></p>
             </div>
+
             <div class="form-group">
                 <label asp-for="ConnectionString"></label>
-                <input id="lightningurl" asp-for="ConnectionString" class="form-control" />
+                <input asp-for="ConnectionString" class="form-control"/>
                 <span asp-validation-for="ConnectionString" class="text-danger"></span>
                 @if (Model.InternalLightningNode != null)
                 {
                     <p class="form-text text-muted">
-                        You can use the internal lightning node by <a href="#" id="internal-ln-node-setter" onclick="$('#lightningurl').val('@Model.InternalLightningNode'); return false;">clicking here</a>
+                        Use the internal lightning node of this BTCPay Server instance by
+                        <a href="#" id="internal-ln-node-setter" onclick="$('#ConnectionString').val('@Model.InternalLightningNode');return false;">clicking here</a>.
                     </p>
                 }
             </div>
-            <div class="form-group">
-                <label asp-for="Enabled"></label>
-                <input asp-for="Enabled" type="checkbox" class="form-check" />
+            <div class="form-group form-check">
+                <input asp-for="Enabled" type="checkbox" class="form-check-input"/>
+                <label asp-for="Enabled" class="form-check-label"></label>
             </div>
             <button id="save" name="command" type="submit" value="save" class="btn btn-primary">Submit</button>
-            <button name="command" type="submit" value="test" class="btn btn-secondary">Test connection</button>
-            <a 
-                class="btn btn-secondary"
-                asp-controller="PublicLightningNodeInfo" 
-               asp-action="ShowLightningNodeInfo" 
-               asp-route-cryptoCode="@Model.CryptoCode" 
-               asp-route-storeId="@Model.StoreId"
-               target="_blank">
+            <button name="command" type="submit" value="test" class="btn btn-secondary mr-3">Test connection</button>
+            <a
+                class="text-secondary"
+                asp-controller="PublicLightningNodeInfo"
+                asp-action="ShowLightningNodeInfo"
+                asp-route-cryptoCode="@Model.CryptoCode"
+                asp-route-storeId="@Model.StoreId"
+                target="_blank">
+                <span class="fa fa-info-circle" title="More information..."></span>
                 Open Public Node Info Page
             </a>
         </form>

--- a/BTCPayServer/Views/Stores/AddLightningNode.cshtml
+++ b/BTCPayServer/Views/Stores/AddLightningNode.cshtml
@@ -40,7 +40,7 @@
         <h3 class="mb-3">Lightning Node Connection</h3>
         <form method="post">
             <div class="form-group">
-                <p class="mb-2">The connection string encapsulates the configuration for connecting to your lightning node. We currently support:</p>
+                <p class="mb-2">The connection string encapsulates the configuration for connecting to your lightning node. BTCPay Server currently supports:</p>
                 <ul>
                     <li class="mb-2">
                         <strong>c-lightning</strong> via TCP or unix domain socket connection:

--- a/BTCPayServer/wwwroot/_bootstrap_kitchensink.html
+++ b/BTCPayServer/wwwroot/_bootstrap_kitchensink.html
@@ -9,6 +9,7 @@
     <!-- Bootstrap -->
     <link href="main/bootstrap/bootstrap.css" rel="stylesheet" />
     <link href="main/bootstrap4-creativestart/creative.css" rel="stylesheet" />
+    <link href="main/site.css" rel="stylesheet" />
     <script>
         const theme = window.location.search.replace('?theme=','') || 'default';
         document.write(`<link href="main/themes/${theme}.css" rel="stylesheet" />`)

--- a/BTCPayServer/wwwroot/main/site.css
+++ b/BTCPayServer/wwwroot/main/site.css
@@ -47,6 +47,15 @@ a {
     transition-property: background, color;
 }
 
+ul {
+    padding-left: 1em;
+}
+
+ul li {
+    padding-top: .2em;
+    padding-bottom: .2em;
+}
+
 .navbar .onion {
     margin-right: auto;
 }
@@ -173,4 +182,11 @@ pre {
   position: absolute;
   margin-top: -36px;
   margin-left: 16px;
+}
+
+.alert hr {
+    display: block;
+    width: unset;
+    height: 1px;
+    background: none;
 }


### PR DESCRIPTION
There is quite a lot of information on the Lightning setup page. With this PR I'd like to propose a bit more clarity, by restructuring the information a bit and also by doing some UI tweaks to the content.

To make it easy to follow along, here's [the original version](https://user-images.githubusercontent.com/886/86021764-c1702880-ba29-11ea-9119-789f7048fc5a.png).

## The high-level changes

- Warning box: Visual content tweaks to allow for better reading experience
- Divide warning and main content with a proper headline of what's the form is about
- Group examples by supported implementation so that the user is guided better
- Move additional details for the LND config to a separate and toggleable info box
- Improve "Connection String" hint and "Enabled" label.

Here's how it looks like with these changes: 

![after](https://user-images.githubusercontent.com/886/86021806-d2209e80-ba29-11ea-9ee7-e349985791b6.png)

---

## LND Info Box

This is the content of the LND info box, to which I also added some more details about the `macaroon` parameter:

![lnd-details](https://user-images.githubusercontent.com/886/86021817-d5b42580-ba29-11ea-9bf6-6062ebae6bea.png)
