### PR TITLE
fix: liquid asset usdt rate

### DIFF
--- a/BTCPayServer.Common/Altcoins/Liquid/BTCPayNetworkProvider.LiquidAssets.cs
+++ b/BTCPayServer.Common/Altcoins/Liquid/BTCPayNetworkProvider.LiquidAssets.cs
@@ -14,7 +14,7 @@ namespace BTCPayServer
                 ShowSyncSummary = false,
                 DefaultRateRules = new[]
                 {
-                    "USDT_UST = 1",
+                    "USDT_USD = 1",
                     "USDT_X = USDT_BTC * BTC_X",
                     "USDT_BTC = bitfinex(UST_BTC)",
                 },
@@ -37,7 +37,6 @@ namespace BTCPayServer
                 ShowSyncSummary = false,
                 DefaultRateRules = new[]
                 {
-
                     "ETB_X = ETB_BTC * BTC_X",
                     "ETB_BTC = bitpay(ETB_BTC)"
                 },


### PR DESCRIPTION
That typo made the USDT rate being subject to fluctuation.

**Old behavior:**
![image](https://user-images.githubusercontent.com/40615019/86840762-800af900-c079-11ea-920d-4c870491abb6.png)
![image](https://user-images.githubusercontent.com/40615019/86840812-8ac58e00-c079-11ea-83b0-1c9de400a1ac.png)

**New behavior:**
![image](https://user-images.githubusercontent.com/40615019/86840918-a7fa5c80-c079-11ea-94ef-a160cdd54967.png)
![image](https://user-images.githubusercontent.com/40615019/86840939-af216a80-c079-11ea-95bc-77ef92d08969.png)
