### PR TITLE
Widen destination address field and make it monospace

### DIFF
--- a/BTCPayServer/Views/Wallets/WalletSend.cshtml
+++ b/BTCPayServer/Views/Wallets/WalletSend.cshtml
@@ -18,7 +18,7 @@
 <partial name="WalletCameraScanner"/>
 <div class="row">
    
-    <div class="@(!Model.InputSelection && Model.Outputs.Count==1? "col-lg-6 transaction-output-form": "col-lg-8")">
+    <div class="@(!Model.InputSelection && Model.Outputs.Count==1? "col-lg-7 transaction-output-form": "col-lg-8")">
         <form method="post" asp-action="WalletSend" asp-route-walletId="@this.Context.GetRouteValue("walletId")">
             <input type="hidden" asp-for="InputSelection" />
             <input type="hidden" asp-for="Divisibility" />
@@ -58,7 +58,7 @@
             {
                 <div class="form-group">
                     <label asp-for="Outputs[0].DestinationAddress"></label>
-                    <input asp-for="Outputs[0].DestinationAddress" class="form-control" />
+                    <input asp-for="Outputs[0].DestinationAddress" class="form-control text-monospace" />
                     <span asp-validation-for="Outputs[0].DestinationAddress" class="text-danger"></span>
                 </div>
                 <div class="form-group">


### PR DESCRIPTION
fix #1723

All coins in the screenshots below are fake regtest coins so don't get too excited and don't try to five-dollar-wrench-attack me.

# Before

Address doesn't fit fully in the input field, also notice how buttons on the bottom are too tall
![Screen Shot 2020-07-08 at 7 49 05 PM](https://user-images.githubusercontent.com/1934678/86992083-8cfd1a80-c155-11ea-9ba8-d7f4c8ad60cd.png)

# After

**After:** address fits in the input field, buttons on the bottom are all on one line
![Screen Shot 2020-07-08 at 7 53 02 PM](https://user-images.githubusercontent.com/1934678/86992093-91c1ce80-c155-11ea-9192-872a38bd74c5.png)
