### PR TITLE
GreenField: Remove requirement for permissions >= 1 when creating key

### DIFF
--- a/BTCPayServer/Controllers/GreenField/ApiKeysController.cs
+++ b/BTCPayServer/Controllers/GreenField/ApiKeysController.cs
@@ -45,11 +45,7 @@ namespace BTCPayServer.Controllers.GreenField
         {
             if (request is null)
                 return NotFound();
-            if (request.Permissions is null || request.Permissions.Length == 0)
-            {
-                ModelState.AddModelError(nameof(request.Permissions), "One or more permissions are required");
-                return this.CreateValidationError(ModelState);
-            }
+            request.Permissions ??= System.Array.Empty<Permission>();
             var key = new APIKeyData()
             {
                 Id = Encoders.Hex.EncodeData(RandomUtils.GetBytes(20)),


### PR DESCRIPTION
Sometimes you just want to have an api key to verify a user still exists periodically on a server and do not need any permissions