### PR TITLE
Use BTCPay doc for RBF tooltip

### DIFF
--- a/BTCPayServer/Views/Wallets/WalletSend.cshtml
+++ b/BTCPayServer/Views/Wallets/WalletSend.cshtml
@@ -193,7 +193,7 @@
                         {
                             <div class="form-group">
                                 <label asp-for="AllowFeeBump"></label>
-                                <a href="https://bitcoinops.org/en/rbf-in-the-wild/" target="_blank">
+                                <a href="https://docs.btcpayserver.org/Wallet/#rbf-replace-by-fee" target="_blank">
                                     <span class="fa fa-question-circle-o" title="More information..."></span>
                                 </a>
                                 <select asp-for="AllowFeeBump" class="form-control">


### PR DESCRIPTION
Rbf was [added to btcpay docs](https://github.com/btcpayserver/btcpayserver-doc/pull/634), this updates the UI tooltip link. 