### PR TITLE
Allow sorting apps by store, name or app type

### DIFF
--- a/BTCPayServer/Controllers/AppsController.cs
+++ b/BTCPayServer/Controllers/AppsController.cs
@@ -60,11 +60,11 @@ namespace BTCPayServer.Controllers
                     {
                         switch (sortOrderColumn)
                         {
-                            case "Name":
+                            case nameof(app.AppName):
                                 return app.AppName;
-                            case "Store":
+                            case nameof(app.StoreName):
                                 return app.StoreName;
-                            case "AppType":
+                            case nameof(app.AppType):
                                 return app.AppType;
                             default:
                                 return app.Id;

--- a/BTCPayServer/Controllers/AppsController.cs
+++ b/BTCPayServer/Controllers/AppsController.cs
@@ -47,9 +47,42 @@ namespace BTCPayServer.Controllers
 
         public string CreatedAppId { get; set; }
 
-        public async Task<IActionResult> ListApps()
+        public async Task<IActionResult> ListApps(
+            string sortOrder = null,
+            string sortOrderColumn = null
+        )
         {
             var apps = await _AppService.GetAllApps(GetUserId());
+
+            if (sortOrder != null && sortOrderColumn != null) 
+            {
+                apps = apps.OrderByDescending(app => 
+                    {
+                        switch (sortOrderColumn)
+                        {
+                            case "Name":
+                                return app.AppName;
+                            case "Store":
+                                return app.StoreName;
+                            case "AppType":
+                                return app.AppType;
+                            default:
+                                return app.Id;
+                        }
+                    }).ToArray();
+
+                switch (sortOrder)
+                {
+                    case "desc":
+                        ViewData[$"{sortOrderColumn}SortOrder"] = "asc";
+                        break;
+                    case "asc":
+                        apps = apps.Reverse().ToArray();
+                        ViewData[$"{sortOrderColumn}SortOrder"] = "desc";
+                        break;
+                }
+            }
+            
             return View(new ListAppsViewModel()
             {
                 Apps = apps

--- a/BTCPayServer/Views/Apps/ListApps.cshtml
+++ b/BTCPayServer/Views/Apps/ListApps.cshtml
@@ -31,9 +31,48 @@
                 <table class="table table-sm table-responsive-md">
                     <thead>
                         <tr>
-                            <th>Store</th>
-                            <th>Name</th>
-                            <th>App type</th>
+                            <th>
+                                <a
+                                    asp-action="ListApps"
+                                    asp-route-sortOrder="@(ViewData["StoreSortOrder"] ?? "asc")"
+                                    asp-route-sortOrderColumn="Store"
+                                    class="text-nowrap"
+                                    title="@((string)ViewData["StoreSortOrder"] == "desc" ? "Sort by descending..." : "Sort by ascending...")"
+                                >
+                                    Store  @if (ViewData["StoreSortOrder"] != null)
+                                    {
+                                        <span class="fa @((string)ViewData["StoreSortOrder"] == "asc" ? "fa-arrow-down": "fa-arrow-up")" />
+                                    }
+                                </a>
+                            </th>
+                            <th>
+                                <a
+                                    asp-action="ListApps"
+                                    asp-route-sortOrder="@(ViewData["NameSortOrder"] ?? "asc")"
+                                    asp-route-sortOrderColumn="Name"
+                                    class="text-nowrap"
+                                    title="@((string)ViewData["NameSortOrder"] == "desc" ? "Sort by descending..." : "Sort by ascending...")"
+                                >
+                                    Name  @if (ViewData["NameSortOrder"] != null)
+                                    {
+                                        <span class="fa @((string)ViewData["NameSortOrder"] == "asc" ? "fa-arrow-down": "fa-arrow-up")" />
+                                    }
+                                </a>
+                            </th>
+                            <th>
+                                <a
+                                    asp-action="ListApps"
+                                    asp-route-sortOrder="@(ViewData["AppTypeSortOrder"] ?? "asc")"
+                                    asp-route-sortOrderColumn="AppType"
+                                    class="text-nowrap"
+                                    title="@((string)ViewData["AppTypeSortOrder"] == "desc" ? "Sort by descending..." : "Sort by ascending...")"
+                                >
+                                    App Type  @if (ViewData["AppTypeSortOrder"] != null)
+                                    {
+                                        <span class="fa @((string)ViewData["AppTypeSortOrder"] == "asc" ? "fa-arrow-down": "fa-arrow-up")" />
+                                    }
+                                </a>
+                            </th>
                             <th style="text-align:right">Actions</th>
                         </tr>
                     </thead>

--- a/BTCPayServer/Views/Apps/ListApps.cshtml
+++ b/BTCPayServer/Views/Apps/ListApps.cshtml
@@ -34,28 +34,28 @@
                             <th>
                                 <a
                                     asp-action="ListApps"
-                                    asp-route-sortOrder="@(ViewData["StoreSortOrder"] ?? "asc")"
-                                    asp-route-sortOrderColumn="Store"
+                                    asp-route-sortOrder="@(ViewData["StoreNameSortOrder"] ?? "asc")"
+                                    asp-route-sortOrderColumn="StoreName"
                                     class="text-nowrap"
-                                    title="@((string)ViewData["StoreSortOrder"] == "desc" ? "Sort by descending..." : "Sort by ascending...")"
+                                    title="@((string)ViewData["StoreNameSortOrder"] == "desc" ? "Sort by descending..." : "Sort by ascending...")"
                                 >
-                                    Store  @if (ViewData["StoreSortOrder"] != null)
+                                    Store  @if (ViewData["StoreNameSortOrder"] != null)
                                     {
-                                        <span class="fa @((string)ViewData["StoreSortOrder"] == "asc" ? "fa-arrow-down": "fa-arrow-up")" />
+                                        <span class="fa @((string)ViewData["StoreNameSortOrder"] == "asc" ? "fa-arrow-down": "fa-arrow-up")" />
                                     }
                                 </a>
                             </th>
                             <th>
                                 <a
                                     asp-action="ListApps"
-                                    asp-route-sortOrder="@(ViewData["NameSortOrder"] ?? "asc")"
-                                    asp-route-sortOrderColumn="Name"
+                                    asp-route-sortOrder="@(ViewData["AppNameSortOrder"] ?? "asc")"
+                                    asp-route-sortOrderColumn="AppName"
                                     class="text-nowrap"
-                                    title="@((string)ViewData["NameSortOrder"] == "desc" ? "Sort by descending..." : "Sort by ascending...")"
+                                    title="@((string)ViewData["AppNameSortOrder"] == "desc" ? "Sort by descending..." : "Sort by ascending...")"
                                 >
-                                    Name  @if (ViewData["NameSortOrder"] != null)
+                                    Name  @if (ViewData["AppNameSortOrder"] != null)
                                     {
-                                        <span class="fa @((string)ViewData["NameSortOrder"] == "asc" ? "fa-arrow-down": "fa-arrow-up")" />
+                                        <span class="fa @((string)ViewData["AppNameSortOrder"] == "asc" ? "fa-arrow-down": "fa-arrow-up")" />
                                     }
                                 </a>
                             </th>


### PR DESCRIPTION
See in action:

![Jul-19-2020 14-14-25](https://user-images.githubusercontent.com/1934678/87885486-53d16f80-c9cb-11ea-9ed2-795c8b85952e.gif)

Also has helpful tooltips on hover:

![Screen Shot 2020-07-19 at 2 08 07 PM](https://user-images.githubusercontent.com/1934678/87885509-7b283c80-c9cb-11ea-9c76-9e421d523418.png)
![Screen Shot 2020-07-19 at 2 08 29 PM](https://user-images.githubusercontent.com/1934678/87885511-7d8a9680-c9cb-11ea-99ae-52b9ac44d56f.png)

I modelled the behavior after the macOS sort functionality in Finder:

![Screen Shot 2020-07-19 at 2 25 26 PM](https://user-images.githubusercontent.com/1934678/87885577-f12ca380-c9cb-11ea-86cd-d3e8ec558140.png)


close #1568