### PR TITLE
Place status message in correct positions for cart and static versions of POS app

### DIFF
--- a/BTCPayServer/Views/AppsPublic/PointOfSale/Cart.cshtml
+++ b/BTCPayServer/Views/AppsPublic/PointOfSale/Cart.cshtml
@@ -202,6 +202,10 @@
     <div id="content">
         <div class="p-2 p-sm-4">
             <div class="row">
+                @if (this.TempData.HasStatusMessage())
+                {
+                    <partial name="_StatusMessage" />
+                }
                 <div class="col-sm-4 col-lg-2 order-sm-last text-right mb-2">
                     <a class="js-cart btn btn-lg btn-outline-primary" href="#">
                         <i class="fa fa-shopping-basket"></i>&nbsp;

--- a/BTCPayServer/Views/AppsPublic/PointOfSale/Static.cshtml
+++ b/BTCPayServer/Views/AppsPublic/PointOfSale/Static.cshtml
@@ -6,6 +6,10 @@
 
 <div class="container d-flex h-100">
     <div class="justify-content-center align-self-center text-center mx-auto px-2 py-3 w-100" style="margin: auto;">
+        @if (this.TempData.HasStatusMessage())
+        {
+            <partial name="_StatusMessage" />
+        }
         <h1 class="mb-4">@Model.Title</h1>
         @if (!string.IsNullOrEmpty(Model.Description))
         {

--- a/BTCPayServer/Views/Shared/_LayoutPos.cshtml
+++ b/BTCPayServer/Views/Shared/_LayoutPos.cshtml
@@ -80,11 +80,6 @@
 </head>
 
 <body class="h-100">
-    @if (this.TempData.HasStatusMessage())
-    {
-        <partial name="_StatusMessage" />
-    }
-    
     @RenderBody()
 </body>
 </html>


### PR DESCRIPTION
Before:
![Screen Shot 2020-07-20 at 8 34 20 PM](https://user-images.githubusercontent.com/1934678/88009871-6aa9bc00-cac8-11ea-80b7-80be265b147f.png)

After (cart):
![Screen Shot 2020-07-20 at 8 29 39 PM](https://user-images.githubusercontent.com/1934678/88009889-739a8d80-cac8-11ea-86e6-5c2fb071617a.png)

After (static):

![Screen Shot 2020-07-20 at 8 29 01 PM](https://user-images.githubusercontent.com/1934678/88009926-8745f400-cac8-11ea-87c0-18c3214dae23.png)

fix #1758