### PR TITLE
Minor README improvements

### DIFF
--- a/BTCPayServer.Tests/README.md
+++ b/BTCPayServer.Tests/README.md
@@ -1,31 +1,31 @@
 # How to be started for development
 
 BTCPay Server tests depend on having a proper environment running with Postgres, Bitcoind, NBxplorer configured.
-You can however use the `docker-compose.yml` of this folder to get it running.
+You can however use the [`BTCPayServer.Tests/docker-compose.yml`](https://github.com/btcpayserver/btcpayserver/blob/master/BTCPayServer.Tests/docker-compose.yml) to get it running.
 
 In addition, when you run a debug session of BTCPay (Hitting F5 on Visual Studio Code or Visual Studio 2017), it will run the launch profile called `Docker-Regtest`. This launch profile depends on this `docker-compose` running.
 
 This is running a bitcoind instance on regtest, a private bitcoin blockchain for testing on which you can generate blocks yourself.
 
-```
+```sh
 docker-compose up dev
 ```
 
 You can run the tests while it is running through your favorite IDE, or with
 
-```
+```sh
 dotnet test
 ```
 
 Once you want to stop
 
-```
+```sh
 docker-compose down
 ```
 
 If you want to stop, and remove all existing data
 
-```
+```sh
 docker-compose down --v
 ```
 
@@ -35,40 +35,46 @@ You can run tests on `MySql` database instead of `Postgres` by setting environne
 
 ### Using the test bitcoin-cli
 
-You can call bitcoin-cli inside the container with `docker exec`, for example, if you want to send `0.23111090` to `mohu16LH66ptoWGEL1GtP6KHTBJYXMWhEf`:
-```
+You can call bitcoin-cli inside the container with `docker exec`.
+For example, if you want to send `0.23111090` to `mohu16LH66ptoWGEL1GtP6KHTBJYXMWhEf`:
+
+```sh
 ./docker-bitcoin-cli.sh sendtoaddress "mohu16LH66ptoWGEL1GtP6KHTBJYXMWhEf" 0.23111090
 ```
 
 If you are using Powershell:
+
 ```powershell
 .\docker-bitcoin-cli.ps1 sendtoaddress "mohu16LH66ptoWGEL1GtP6KHTBJYXMWhEf" 0.23111090
 ```
 
 You can also generate blocks:
+
 ```powershell
 .\docker-bitcoin-generate.ps1 3
 ```
 
 ### Using the test litecoin-cli
 
-Same as bitcoin-cli, but with `.\docker-litecoin-cli.ps1` and `.\docker-litecoin-cli.sh` instead. 
+Same as bitcoin-cli, but with `.\docker-litecoin-cli.ps1` and `.\docker-litecoin-cli.sh` instead.
 
 ### Using the test lightning-cli
 
 If you are using Linux:
-```
+
+```sh
 ./docker-customer-lightning-cli.sh pay lnbcrt100u1pd2e6uspp5ajnadvhazjrz55twd5k6yeg9u87wpw0q2fdr7g960yl5asv5fmnqdq9d3hkccqpxmedyrk0ehw5ueqx5e0r4qrrv74cewddfcvsxaawqz7634cmjj39sqwy5tvhz0hasktkk6t9pqfdh3edmf3z09zst5y7khv3rvxh8ctqqw6mwhh
 ```
 
 If you are using Powershell:
-```
+
+```powershell
 .\docker-customer-lightning-cli.ps1 pay lnbcrt100u1pd2e6uspp5ajnadvhazjrz55twd5k6yeg9u87wpw0q2fdr7g960yl5asv5fmnqdq9d3hkccqpxmedyrk0ehw5ueqx5e0r4qrrv74cewddfcvsxaawqz7634cmjj39sqwy5tvhz0hasktkk6t9pqfdh3edmf3z09zst5y7khv3rvxh8ctqqw6mwhh
 ```
 
 If you get this message:
 
-```
+```json
 { "code" : 205, "message" : "Could not find a route", "data" : { "getroute_tries" : 1, "sendpay_tries" : 0 } }
 ```
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ After successful deployment, make sure to check our [getting started](https://do
 
 ## Documentation
 
-Please check out our [official website](https://btcpayserver.org/), our [complete documentation](https://github.com/btcpayserver/btcpayserver-doc) and [FAQ](https://docs.btcpayserver.org/FAQ/) for more details.
+Please check out our [official website](https://btcpayserver.org/), our [complete documentation](https://docs.btcpayserver.org/) and [FAQ](https://docs.btcpayserver.org/FAQ/) for more details.
 
 If you have trouble using BTCPay, consider joining [communities listed on official website](https://btcpayserver.org/#communityCTA) to get help from BTCPay community members. Only file [Github issue](https://github.com/btcpayserver/btcpayserver/issues) for technical issues you can't resolve through other channels or feature requests you've validated with other members of community.
 
@@ -79,13 +79,14 @@ If you're a developer looking to help, but you're not sure where to begin, check
 
 Contributors looking to do something a bit more challenging, before opening a pull request, please [create an issue](https://github.com/btcpayserver/btcpayserver/issues/new/choose) or join [our community chat](https://chat.btcpayserver.org/) to get early feedback, discuss best ways to tackle the problem and to ensure there is no work duplication.
 
-- [Setting up development environment on Windows](https://www.youtube.com/watch?v=ZePbMPSIvHM)
-- [Setting up development environment Linux (Ubuntu)](https://www.youtube.com/watch?v=j486T_Rk-yw&t)
-- [Setting up development environment MacOS](https://www.youtube.com/watch?v=GWR_CcMsEV0)
+* [Setting up development environment on Windows](https://www.youtube.com/watch?v=ZePbMPSIvHM)
+* [Setting up development environment Linux (Ubuntu)](https://www.youtube.com/watch?v=j486T_Rk-yw&t)
+* [Setting up development environment MacOS](https://www.youtube.com/watch?v=GWR_CcMsEV0)
 
-You also have an awesome video of our contributors which explains how to get started.[![Rockstar Dev and Britt Kelly - Btc Pay Server Code Along](https://img.youtube.com/vi/ZePbMPSIvHM/sddefault.jpg)](https://www.youtube.com/embed/VNMnd-dX9Q8)
+You also have an awesome video of our contributors which explains how to get started.
+[![Rockstar Dev and Britt Kelly - BTCPay Server Code Along](https://img.youtube.com/vi/ZePbMPSIvHM/sddefault.jpg)](https://www.youtube.com/embed/VNMnd-dX9Q8)
 
-Here is some info about [how to extend the themes](https://docs.btcpayserver.org/Theme/)
+Here is some info about [how to extend the themes](https://docs.btcpayserver.org/Theme/).
 
 ## How to build
 
@@ -94,12 +95,14 @@ While the documentation advises to use docker-compose, you may want to build BTC
 First install .NET Core SDK v3.1 as specified by [Microsoft website](https://dotnet.microsoft.com/download/dotnet-core/3.1).
 
 On Powershell:
-```
+
+```powershell
 .\build.ps1
 ```
 
 On linux:
-```
+
+```sh
 ./build.sh
 ```
 
@@ -108,12 +111,14 @@ On linux:
 Use the `run` scripts to run BTCPayServer, this example shows how to print the available command line arguments of BTCPayServer.
 
 On Powershell:
-```
+
+```powershell
 .\run.ps1 --help
 ```
 
 On linux:
-```
+
+```sh
 ./run.sh --help
 ```
 
@@ -121,7 +126,7 @@ On linux:
 
 If you want to debug, use Visual Studio Code or Visual Studio 2019.
 
-You need to run the development time docker-compose as described [in the test guide](BTCPayServer.Tests/README.md).
+You need to run the development time docker-compose as described [in the test guide](./BTCPayServer.Tests/README.md).
 
 You can then run the debugger by using the Launch Profile `Docker-Regtest` on either Visual Studio Code or Visual Studio 2017.
 
@@ -136,7 +141,8 @@ Then use the `Docker-Regtest-https` debug profile.
 
 ## Other dependencies
 
-For more information, see the documentation: [How to deploy a BTCPay server instance](https://github.com/btcpayserver/btcpayserver-doc/#deployment).
+For more information, see the documentation:
+[How to deploy a BTCPay server instance](https://docs.btcpayserver.org/Deployment/).
 
 ## Supported altcoins
 

--- a/README.md
+++ b/README.md
@@ -187,6 +187,8 @@ The BTCPay Server Project is proudly supported by these entities through the [BT
           <span>DG Lab</span>
         </a>
       </td>
+    </tr>
+    <tr>
       <td align="center" valign="middle">
         <a href="https://www.okcoin.com/" target="_blank">
           <img  src="BTCPayServer/wwwroot/img/okcoin.svg" alt="OKCoin" height=100>


### PR DESCRIPTION
I want to put the `BTCPayServer.Tests/README.md` into the docs website, here are some formatting improvements in preparation for that. 

Also updated a doc link in the main README and added the proper languages to the code samples.

A second commit puts the supporters into two rows, which makes them look less crammed. Here's a preview for that:

<img width="868" alt="supporters" src="https://user-images.githubusercontent.com/886/88263317-2259ec00-ccca-11ea-8e24-75dd3397070b.png">
 