### PR TITLE
Update .gitignore all the .DS_Store files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -294,3 +294,4 @@ BTCPayServer/wwwroot/bundles/*
 
 .vscode
 BTCPayServer/testpwd
+.DS_Store


### PR DESCRIPTION
.gitignore all the .DS_Store files in every folder and subfolder - improves UX
If you are using macOS, visual studio, visual code, rider, your system appends the .DS_Store file in your directories. It’s not a big issue, but often you need to exclude these files explicitly in your .gitignore file, to prevent any unnecessary files in your commit. 

DS_Store file creation for network connected volumes, shares, and drives, but it is rarely necessary for most users situations. These DS_Store files exist in all versions of OS X, from the oldest versions to the latest releases of Mac OS X, as they are a critical component of file system metadata storage and info.

notice for btcpay Mac dev users..
This will never allow the .DS_Store file to sneak in your git.
But, if it's already there, you can write in your project terminal:

find . -name .DS_Store -print0 | xargs -0 git rm -f --ignore-unmatch
then commit and push the changes to remove the .DS_Store from your remote repo:

git commit -m "Remove .DS_Store from everywhere"

git push origin master