### PR TITLE
Add API Keys Application identifier + Redirect

### DIFF
--- a/BTCPayServer.Client/BTCPayServerClient.Authorization.cs
+++ b/BTCPayServer.Client/BTCPayServerClient.Authorization.cs
@@ -7,7 +7,7 @@ namespace BTCPayServer.Client
     {
 
         public static Uri GenerateAuthorizeUri(Uri btcpayHost, string[] permissions, bool strict = true,
-            bool selectiveStores = false)
+            bool selectiveStores = false, (string ApplicationIdentifier, Uri Redirect) applicationDetails = default)
         {
             var result = new UriBuilder(btcpayHost);
             result.Path = "api-keys/authorize";
@@ -17,6 +17,15 @@ namespace BTCPayServer.Client
                 {
                     {"strict", strict}, {"selectiveStores", selectiveStores}, {"permissions", permissions}
                 });
+
+            if (applicationDetails.Redirect != null)
+            {
+                AppendPayloadToQuery(result, new KeyValuePair<string, object>("redirect", applicationDetails.Redirect));
+                if (!string.IsNullOrEmpty(applicationDetails.ApplicationIdentifier))
+                {
+                    AppendPayloadToQuery(result, new KeyValuePair<string, object>("applicationIdentifier", applicationDetails.ApplicationIdentifier));
+                }
+            }
 
             return result.Uri;
         }

--- a/BTCPayServer.Client/BTCPayServerClient.cs
+++ b/BTCPayServer.Client/BTCPayServerClient.cs
@@ -103,29 +103,37 @@ namespace BTCPayServer.Client
             return request;
         }
 
+        private static void AppendPayloadToQuery(UriBuilder uri, KeyValuePair<string, object> keyValuePair)
+        {
+            if (uri.Query.Length > 1)
+                uri.Query += "&";
+
+            UriBuilder uriBuilder = uri;
+            if (!(keyValuePair.Value is string) &&
+                keyValuePair.Value.GetType().GetInterfaces().Contains((typeof(IEnumerable))))
+            {
+                foreach (var item in (IEnumerable)keyValuePair.Value)
+                {
+                    uriBuilder.Query = uriBuilder.Query + Uri.EscapeDataString(keyValuePair.Key) + "=" +
+                                       Uri.EscapeDataString(item.ToString()) + "&";
+                }
+            }
+            else
+            {
+                uriBuilder.Query = uriBuilder.Query + Uri.EscapeDataString(keyValuePair.Key) + "=" +
+                                   Uri.EscapeDataString(keyValuePair.Value.ToString()) + "&";
+            }
+            uri.Query = uri.Query.Trim('&');
+        }
+
         private static void AppendPayloadToQuery(UriBuilder uri, Dictionary<string, object> payload)
         {
             if (uri.Query.Length > 1)
                 uri.Query += "&";
             foreach (KeyValuePair<string, object> keyValuePair in payload)
             {
-                UriBuilder uriBuilder = uri;
-                if (!(keyValuePair.Value is string) && keyValuePair.Value.GetType().GetInterfaces().Contains((typeof(IEnumerable))))
-                {
-                    foreach (var item in (IEnumerable)keyValuePair.Value)
-                    {
-                        uriBuilder.Query = uriBuilder.Query + Uri.EscapeDataString(keyValuePair.Key) + "=" +
-                                           Uri.EscapeDataString(item.ToString()) + "&";
-                    }
-                }
-                else
-                {
-                    uriBuilder.Query = uriBuilder.Query + Uri.EscapeDataString(keyValuePair.Key) + "=" +
-                                       Uri.EscapeDataString(keyValuePair.Value.ToString()) + "&";
-                }
+                AppendPayloadToQuery(uri, keyValuePair);
             }
-
-            uri.Query = uri.Query.Trim('&');
         }
     }
 }

--- a/BTCPayServer.Client/BTCPayServerClient.cs
+++ b/BTCPayServer.Client/BTCPayServerClient.cs
@@ -103,7 +103,7 @@ namespace BTCPayServer.Client
             return request;
         }
 
-        private static void AppendPayloadToQuery(UriBuilder uri, KeyValuePair<string, object> keyValuePair)
+        public static void AppendPayloadToQuery(UriBuilder uri, KeyValuePair<string, object> keyValuePair)
         {
             if (uri.Query.Length > 1)
                 uri.Query += "&";
@@ -126,7 +126,7 @@ namespace BTCPayServer.Client
             uri.Query = uri.Query.Trim('&');
         }
 
-        private static void AppendPayloadToQuery(UriBuilder uri, Dictionary<string, object> payload)
+        public static void AppendPayloadToQuery(UriBuilder uri, Dictionary<string, object> payload)
         {
             if (uri.Query.Length > 1)
                 uri.Query += "&";

--- a/BTCPayServer.Data/Data/APIKeyData.cs
+++ b/BTCPayServer.Data/Data/APIKeyData.cs
@@ -15,7 +15,6 @@ namespace BTCPayServer.Data
         [MaxLength(50)] public string StoreId { get; set; }
 
         [MaxLength(50)] public string UserId { get; set; }
-        public string ApplicationIdentifier { get; set; }
 
         public APIKeyType Type { get; set; } = APIKeyType.Legacy;
 

--- a/BTCPayServer.Data/Data/APIKeyData.cs
+++ b/BTCPayServer.Data/Data/APIKeyData.cs
@@ -15,6 +15,7 @@ namespace BTCPayServer.Data
         [MaxLength(50)] public string StoreId { get; set; }
 
         [MaxLength(50)] public string UserId { get; set; }
+        public string ApplicationIdentifier { get; set; }
 
         public APIKeyType Type { get; set; } = APIKeyType.Legacy;
 
@@ -43,6 +44,8 @@ namespace BTCPayServer.Data
     public class APIKeyBlob
     {
         public string[] Permissions { get; set; }
+        public string ApplicationIdentifier { get; set; }
+        public string ApplicationAuthority { get; set; }
 
     }
 

--- a/BTCPayServer.Tests/ApiKeysTests.cs
+++ b/BTCPayServer.Tests/ApiKeysTests.cs
@@ -117,10 +117,13 @@ namespace BTCPayServer.Tests
                 //permissions
                 //strict
                 //selectiveStores
+                //redirect
+                //appidentifier
+                var appidentifier = "testapp";
                 var authUrl = BTCPayServerClient.GenerateAuthorizeUri(tester.PayTester.ServerUri,
-                    new[] { Policies.CanModifyStoreSettings, Policies.CanModifyServerSettings }).ToString();
+                    new[] { Policies.CanModifyStoreSettings, Policies.CanModifyServerSettings }, applicationDetails: (appidentifier, new Uri("https://local.local/callback"))).ToString();
                 s.Driver.Navigate().GoToUrl(authUrl);
-                s.Driver.PageSource.Contains("kukksappname");
+                Assert.True(s.Driver.PageSource.Contains(appidentifier));
                 Assert.Equal("hidden", s.Driver.FindElement(By.Id("btcpay.store.canmodifystoresettings")).GetAttribute("type").ToLowerInvariant());
                 Assert.Equal("true", s.Driver.FindElement(By.Id("btcpay.store.canmodifystoresettings")).GetAttribute("value").ToLowerInvariant());
                 Assert.Equal("hidden", s.Driver.FindElement(By.Id("btcpay.server.canmodifyserversettings")).GetAttribute("type").ToLowerInvariant());
@@ -138,7 +141,7 @@ namespace BTCPayServer.Tests
                     (await apiKeyRepo.GetKey(results.Single(pair => pair.Key == "key").Value)).GetBlob().Permissions);
 
                 authUrl = BTCPayServerClient.GenerateAuthorizeUri(tester.PayTester.ServerUri,
-                    new[] { Policies.CanModifyStoreSettings, Policies.CanModifyServerSettings }, false, true).ToString();
+                    new[] { Policies.CanModifyStoreSettings, Policies.CanModifyServerSettings }, false, true,  applicationDetails: (null, new Uri("https://local.local/callback"))).ToString();
 
                 s.Driver.Navigate().GoToUrl(authUrl);
                 Assert.DoesNotContain("kukksappname", s.Driver.PageSource);
@@ -158,6 +161,26 @@ namespace BTCPayServer.Tests
 
                 await TestApiAgainstAccessToken(results.Single(pair => pair.Key == "key").Value, tester, user,
                     (await apiKeyRepo.GetKey(results.Single(pair => pair.Key == "key").Value)).GetBlob().Permissions);
+                
+                
+                //let's test the app identifier system
+                authUrl = BTCPayServerClient.GenerateAuthorizeUri(tester.PayTester.ServerUri,
+                    new[] { Policies.CanModifyStoreSettings, Policies.CanModifyServerSettings }, false, true, (appidentifier, new Uri("https://local.local/callback"))).ToString();
+
+
+                //if it's the same, go to the confirm page
+                s.Driver.Navigate().GoToUrl(authUrl);
+                s.Driver.FindElement(By.Id("continue")).Click();
+                url = s.Driver.Url;
+                Assert.StartsWith("https://local.local/callback", url);
+                
+                //same app but different redirect = nono
+                authUrl = BTCPayServerClient.GenerateAuthorizeUri(tester.PayTester.ServerUri,
+                    new[] { Policies.CanModifyStoreSettings, Policies.CanModifyServerSettings }, false, true, (appidentifier, new Uri("https://international.local/callback"))).ToString();
+                
+                s.Driver.Navigate().GoToUrl(authUrl);
+                url = s.Driver.Url;
+                Assert.False(url.StartsWith("https://international.com/callback"));
 
             }
         }

--- a/BTCPayServer.Tests/ApiKeysTests.cs
+++ b/BTCPayServer.Tests/ApiKeysTests.cs
@@ -128,6 +128,7 @@ namespace BTCPayServer.Tests
                 Assert.DoesNotContain("change-store-mode", s.Driver.PageSource);
                 s.Driver.FindElement(By.Id("consent-yes")).Click();
                 var url = s.Driver.Url;
+                Assert.StartsWith("https://local.local/callback", url);
                 IEnumerable<KeyValuePair<string, string>> results = url.Split("?").Last().Split("&")
                     .Select(s1 => new KeyValuePair<string, string>(s1.Split("=")[0], s1.Split("=")[1]));
 
@@ -151,6 +152,7 @@ namespace BTCPayServer.Tests
                 Assert.Contains("change-store-mode", s.Driver.PageSource);
                 s.Driver.FindElement(By.Id("consent-yes")).Click();
                 url = s.Driver.Url;
+                Assert.StartsWith("https://local.local/callback", url);
                 results = url.Split("?").Last().Split("&")
                     .Select(s1 => new KeyValuePair<string, string>(s1.Split("=")[0], s1.Split("=")[1]));
 

--- a/BTCPayServer/Security/GreenField/APIKeyRepository.cs
+++ b/BTCPayServer/Security/GreenField/APIKeyRepository.cs
@@ -36,12 +36,6 @@ namespace BTCPayServer.Security.GreenField
                     {
                         queryable = queryable.Where(data => query.UserId.Contains(data.UserId));
                     }
-
-                    if (query.ApplicationIdentifier != null && query.ApplicationIdentifier.Any())
-                    {
-                        queryable = queryable.Where(data =>
-                            query.ApplicationIdentifier.Contains(data.ApplicationIdentifier));
-                    }
                 }
 
                 return await queryable.ToListAsync();

--- a/BTCPayServer/Security/GreenField/APIKeyRepository.cs
+++ b/BTCPayServer/Security/GreenField/APIKeyRepository.cs
@@ -30,9 +30,18 @@ namespace BTCPayServer.Security.GreenField
             using (var context = _applicationDbContextFactory.CreateContext())
             {
                 var queryable = context.ApiKeys.AsQueryable();
-                if (query?.UserId != null && query.UserId.Any())
+                if (query != null)
                 {
-                    queryable = queryable.Where(data => query.UserId.Contains(data.UserId));
+                    if (query.UserId != null && query.UserId.Any())
+                    {
+                        queryable = queryable.Where(data => query.UserId.Contains(data.UserId));
+                    }
+
+                    if (query.ApplicationIdentifier != null && query.ApplicationIdentifier.Any())
+                    {
+                        queryable = queryable.Where(data =>
+                            query.ApplicationIdentifier.Contains(data.ApplicationIdentifier));
+                    }
                 }
 
                 return await queryable.ToListAsync();

--- a/BTCPayServer/Views/Manage/AuthorizeAPIKey.cshtml
+++ b/BTCPayServer/Views/Manage/AuthorizeAPIKey.cshtml
@@ -11,10 +11,12 @@
 
 <partial name="_StatusMessage"/>
 <form method="post" asp-action="AuthorizeAPIKey">
+    <input type="hidden" asp-for="RedirectUrl" value="@Model.RedirectUrl"/>
     <input type="hidden" asp-for="Permissions" value="@Model.Permissions"/>
     <input type="hidden" asp-for="Strict" value="@Model.Strict"/>
     <input type="hidden" asp-for="ApplicationName" value="@Model.ApplicationName"/>
     <input type="hidden" asp-for="SelectiveStores" value="@Model.SelectiveStores"/>
+    <input type="hidden" asp-for="ApplicationIdentifier" value="@Model.ApplicationIdentifier"/>
     <section>
         <div class="card container">
             <div class="row">
@@ -22,6 +24,12 @@
                     <h2>Authorization Request</h2>
                     <hr class="primary">
                     <p class="mb-1">@(Model.ApplicationName ?? "An application") is requesting access to your account.</p>
+                    @if (Model.RedirectUrl != null)
+                    {
+                        <p class="mb-1 alert alert-info">
+                        If authorized, the generated API key will be provided to <strong>@Model.RedirectUrl.AbsoluteUri</strong>
+                        </p>
+                    }
                 </div>
             </div>
             <div class="row">

--- a/BTCPayServer/wwwroot/swagger/v1/swagger.template.authorization.json
+++ b/BTCPayServer/wwwroot/swagger/v1/swagger.template.authorization.json
@@ -54,6 +54,27 @@
                             "nullable": true
                         },
                         "x-position": 4
+                    },
+                    {
+                        "name": "redirect",
+                        "description": "The url to redirect to after the user consents, with the query parameters appended to it: permissions, user-id, api-key. If not specified, user is redirected to their API Key list.",
+                        "in": "query",
+                        "schema": {
+                            "type": "string",
+                            "format": "url",
+                            "nullable": true
+                        },
+                        "x-position": 5
+                    },
+                    {
+                        "name": "applicationIdentifier",
+                        "description": "If specified, BTCPay Server will check if there is an existing API key associated with the user that also has this application identifier, redirect host AND the permissions required match(takes selectiveStores and strict into account). `applicationIdentifier` is ignored if redirect is not specified.",
+                        "in": "query",
+                        "schema": {
+                            "type": "string",
+                            "nullable": true
+                        },
+                        "x-position": 6
                     }
                 ],
                 "responses": {
@@ -63,6 +84,9 @@
                             "text/html": {
                             }
                         }
+                    },
+                    "307": {
+                        "description": "Redirects to the specified url in `redirect` with query string values for `key` (the api key created or matched), `permissions` (the permissions the user consented to), and `user` (the id of the user that consented) upon consent"
                     }
                 },
                 "security": []


### PR DESCRIPTION
This lets the authorize api key screen redirect to the defined url and provide it with the user id, permissions granted and the key.

This also allows apps to match existing api keys generated for it specifically using the application identifier, and if matched, presented with a confirmation page before redirection.