### PR TITLE
Improve invoices list view

### DIFF
--- a/BTCPayServer/Components/Pager/Default.cshtml
+++ b/BTCPayServer/Components/Pager/Default.cshtml
@@ -26,23 +26,36 @@
             </li>
         </ul>
     }
-    <ul class="pagination float-right">
-        <li class="page-item disabled">
-            <span class="page-link">Page Size:</span>
-        </li>
-        <li class="page-item @(Model.Count == 50 ? "active" : null)">
-            <a class="page-link" href="@NavigatePages(0, 50)">50</a>
-        </li>
-        <li class="page-item @(Model.Count == 100 ? "active" : null)">
-            <a class="page-link" href="@NavigatePages(0, 100)">100</a>
-        </li>
-        <li class="page-item @(Model.Count == 250 ? "active" : null)">
-            <a class="page-link" href="@NavigatePages(0, 250)">250</a>
-        </li>
-        <li class="page-item @(Model.Count == 500 ? "active" : null)">
-            <a class="page-link" href="@NavigatePages(0, 500)">500</a>
-        </li>
-    </ul>
+
+    @if (Model.Total >= 50)
+    {
+        <ul class="pagination float-right">
+            <li class="page-item disabled">
+                <span class="page-link">Page Size:</span>
+            </li>
+            <li class="page-item @(Model.Count == 50 ? "active" : null)">
+                <a class="page-link" href="@NavigatePages(0, 50)">50</a>
+            </li>
+            @if (Model.Total >= 100)
+            {
+                <li class="page-item @(Model.Count == 100 ? "active" : null)">
+                    <a class="page-link" href="@NavigatePages(0, 100)">100</a>
+                </li>
+            }
+            @if (Model.Total >= 250)
+            {
+                <li class="page-item @(Model.Count == 250 ? "active" : null)">
+                    <a class="page-link" href="@NavigatePages(0, 250)">250</a>
+                </li>
+            }
+            @if (Model.Total >= 500)
+            {
+                <li class="page-item @(Model.Count == 500 ? "active" : null)">
+                    <a class="page-link" href="@NavigatePages(0, 500)">500</a>
+                </li>
+            }
+        </ul>
+    }
 </nav>
 @{
     string NavigatePages(int prevNext, int count)

--- a/BTCPayServer/Components/Pager/Default.cshtml
+++ b/BTCPayServer/Components/Pager/Default.cshtml
@@ -1,8 +1,8 @@
 @model BasePagingViewModel
 
-<nav aria-label="..." class="w-100">
-    @if (Model.Total != 0)
-    {
+@if (Model.Total > 0)
+{
+    <nav aria-label="..." class="w-100">
         <ul class="pagination float-left">
             <li class="page-item @(Model.Skip == 0 ? "disabled" : null)">
                 <a class="page-link" tabindex="-1" href="@NavigatePages(-1, Model.Count)">&laquo;</a>
@@ -25,38 +25,38 @@
                 <a class="page-link" href="@NavigatePages(1, Model.Count)">&raquo;</a>
             </li>
         </ul>
-    }
 
-    @if (Model.Total >= 50)
-    {
-        <ul class="pagination float-right">
-            <li class="page-item disabled">
-                <span class="page-link">Page Size:</span>
-            </li>
-            <li class="page-item @(Model.Count == 50 ? "active" : null)">
-                <a class="page-link" href="@NavigatePages(0, 50)">50</a>
-            </li>
-            @if (Model.Total >= 100)
-            {
-                <li class="page-item @(Model.Count == 100 ? "active" : null)">
-                    <a class="page-link" href="@NavigatePages(0, 100)">100</a>
+        @if (Model.Total >= 50)
+        {
+            <ul class="pagination float-right">
+                <li class="page-item disabled">
+                    <span class="page-link">Page Size:</span>
                 </li>
-            }
-            @if (Model.Total >= 250)
-            {
-                <li class="page-item @(Model.Count == 250 ? "active" : null)">
-                    <a class="page-link" href="@NavigatePages(0, 250)">250</a>
+                <li class="page-item @(Model.Count == 50 ? "active" : null)">
+                    <a class="page-link" href="@NavigatePages(0, 50)">50</a>
                 </li>
-            }
-            @if (Model.Total >= 500)
-            {
-                <li class="page-item @(Model.Count == 500 ? "active" : null)">
-                    <a class="page-link" href="@NavigatePages(0, 500)">500</a>
-                </li>
-            }
-        </ul>
-    }
-</nav>
+                @if (Model.Total >= 100)
+                {
+                    <li class="page-item @(Model.Count == 100 ? "active" : null)">
+                        <a class="page-link" href="@NavigatePages(0, 100)">100</a>
+                    </li>
+                }
+                @if (Model.Total >= 250)
+                {
+                    <li class="page-item @(Model.Count == 250 ? "active" : null)">
+                        <a class="page-link" href="@NavigatePages(0, 250)">250</a>
+                    </li>
+                }
+                @if (Model.Total >= 500)
+                {
+                    <li class="page-item @(Model.Count == 500 ? "active" : null)">
+                        <a class="page-link" href="@NavigatePages(0, 500)">500</a>
+                    </li>
+                }
+            </ul>
+        }
+    </nav>
+}
 @{
     string NavigatePages(int prevNext, int count)
     {

--- a/BTCPayServer/Controllers/InvoiceController.UI.cs
+++ b/BTCPayServer/Controllers/InvoiceController.UI.cs
@@ -623,7 +623,6 @@ namespace BTCPayServer.Controllers
                 model.Invoices.Add(new InvoiceModel()
                 {
                     Status = invoice.Status,
-                    StatusString = state.ToString(),
                     ShowCheckout = invoice.Status == InvoiceStatus.New,
                     Date = invoice.InvoiceTime,
                     InvoiceId = invoice.Id,

--- a/BTCPayServer/Models/InvoicingModels/InvoicesModel.cs
+++ b/BTCPayServer/Models/InvoicingModels/InvoicesModel.cs
@@ -19,7 +19,6 @@ namespace BTCPayServer.Models.InvoicingModels
         public string InvoiceId { get; set; }
 
         public InvoiceStatus Status { get; set; }
-        public string StatusString { get; set; }
         public bool CanMarkComplete { get; set; }
         public bool CanMarkInvalid { get; set; }
         public bool CanMarkStatus => CanMarkComplete || CanMarkInvalid;

--- a/BTCPayServer/Views/Invoice/ListInvoices.cshtml
+++ b/BTCPayServer/Views/Invoice/ListInvoices.cshtml
@@ -220,108 +220,108 @@
 
                 <table class="table table-sm table-responsive-md">
                     <thead>
-                        <tr>
-                            <th class="only-for-js">
-                                <input id="selectAllCheckbox" type="checkbox" onclick="selectAll(this);"/>
-                            </th>
-                            <th style="min-width:90px;" class="col-md-auto">
-                                Date
-                                <a href="javascript:switchTimeFormat()">
-                                    <span class="fa fa-clock-o" title="Switch date format"></span>
-                                </a>
-                            </th>
-                            <th style="max-width: 180px;">OrderId</th>
-                            <th>InvoiceId</th>
-                            <th style="min-width: 150px;">Status</th>
-                            <th style="text-align:right">Amount</th>
-                            <th style="text-align:right">Actions</th>
-                        </tr>
+                    <tr>
+                        <th class="only-for-js">
+                            <input id="selectAllCheckbox" type="checkbox" onclick="selectAll(this);"/>
+                        </th>
+                        <th style="min-width:90px;" class="col-md-auto">
+                            Date
+                            <a href="javascript:switchTimeFormat()">
+                                <span class="fa fa-clock-o" title="Switch date format"></span>
+                            </a>
+                        </th>
+                        <th style="max-width: 180px;">OrderId</th>
+                        <th>InvoiceId</th>
+                        <th style="min-width: 150px;">Status</th>
+                        <th style="text-align:right">Amount</th>
+                        <th style="text-align:right">Actions</th>
+                    </tr>
                     </thead>
                     <tbody>
-                        @foreach (var invoice in Model.Invoices)
-                        {
-                            <tr>
-                                <td class="only-for-js">
-                                    <input name="selectedItems" type="checkbox" class="selector" value="@invoice.InvoiceId"/>
-                                </td>
-                                <td>
-                                    <span class="switchTimeFormat" data-switch="@invoice.Date.ToTimeAgo()">
-                                        @invoice.Date.ToBrowserDate()
-                                    </span>
-                                </td>
-                                <td style="max-width: 180px;">
-                                    @if (invoice.RedirectUrl != string.Empty)
-                                    {
-                                        <a href="@invoice.RedirectUrl" class="wraptext200">@invoice.OrderId</a>
-                                    }
-                                    else
-                                    {
-                                        <span>@invoice.OrderId</span>
-                                    }
-                                </td>
-                                <td>@invoice.InvoiceId</td>
-                                <td>
-                                    @if (invoice.Details.Archived)
-                                    {
-                                        <span class="badge badge-warning">archived</span>
-                                    }
-                                    @if (invoice.CanMarkStatus)
-                                    {
-                                        <div id="pavpill_@invoice.InvoiceId">
-                                            <span class="dropdown-toggle dropdown-toggle-split pavpill pavpil-@invoice.Status.ToString().ToLower()"
-                                                  data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                                                @invoice.StatusString
-                                            </span>
-                                            <div class="dropdown-menu pull-right">
-                                                @if (invoice.CanMarkInvalid)
-                                                {
-                                                    <button class="dropdown-item small cursorPointer" onclick="changeInvoiceState(this, '@invoice.InvoiceId', 'invalid')">
-                                                        Mark as invalid <span class="fa fa-times"></span>
-                                                    </button>
-                                                }
-                                                @if (invoice.CanMarkComplete)
-                                                {
-                                                    <button class="dropdown-item small cursorPointer" onclick="changeInvoiceState(this, '@invoice.InvoiceId', 'complete')">
-                                                        Mark as complete <span class="fa fa-check-circle"></span>
-                                                    </button>
-                                                }
-                                            </div>
-                                        </div>
-                                    }
-                                    else
-                                    {
-                                        <span class="pavpill pavpil-@invoice.Status.ToString().ToLower()">@invoice.StatusString</span>
-                                    }
-                                </td>
-                                <td style="text-align:right">@invoice.AmountCurrency</td>
-                                <td style="text-align:right">
-                                    @if (invoice.ShowCheckout)
-                                    {
-                                        <span>
-                                            <a asp-action="Checkout" class="invoice-checkout-link" id="invoice-checkout-@invoice.InvoiceId" asp-route-invoiceId="@invoice.InvoiceId">Checkout</a>
-                                            <a href="javascript:btcpay.showInvoice('@invoice.InvoiceId')">[^]</a>
-                                            @if (!invoice.CanMarkStatus)
-                                            {
-                                                <span>-</span>
-                                            }
+                    @foreach (var invoice in Model.Invoices)
+                    {
+                        <tr>
+                            <td class="only-for-js">
+                                <input name="selectedItems" type="checkbox" class="selector" value="@invoice.InvoiceId"/>
+                            </td>
+                            <td>
+                                <span class="switchTimeFormat" data-switch="@invoice.Date.ToTimeAgo()">
+                                    @invoice.Date.ToBrowserDate()
+                                </span>
+                            </td>
+                            <td style="max-width: 180px;">
+                                @if (invoice.RedirectUrl != string.Empty)
+                                {
+                                    <a href="@invoice.RedirectUrl" class="wraptext200">@invoice.OrderId</a>
+                                }
+                                else
+                                {
+                                    <span>@invoice.OrderId</span>
+                                }
+                            </td>
+                            <td>@invoice.InvoiceId</td>
+                            <td>
+                                @if (invoice.Details.Archived)
+                                {
+                                    <span class="badge badge-warning">archived</span>
+                                }
+                                @if (invoice.CanMarkStatus)
+                                {
+                                    <div id="pavpill_@invoice.InvoiceId">
+                                        <span class="dropdown-toggle dropdown-toggle-split pavpill pavpil-@invoice.Status.ToString().ToLower()"
+                                              data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                                            @invoice.StatusString
                                         </span>
-                                    }
-                                    &nbsp;
-                                    <a asp-action="Invoice" class="invoice-details-link" asp-route-invoiceId="@invoice.InvoiceId">Details</a>
-                                    <a href="javascript:void(0);" onclick="detailsToggle(this, '@invoice.InvoiceId')">
-                                        <span title="Invoice Details Toggle" class="fa fa-1x fa-angle-double-down"></span>
-                                    </a>
-                                </td>
-                            </tr>
-                            <tr id="invoice_@invoice.InvoiceId" style="display:none;">
-                                <td colspan="99" class="border-top-0">
-                                    <div style="margin-left: 15px; margin-bottom: 0;">
-                                        @* Leaving this as partial because it abstracts complexity of Invoice Payments *@
-                                        <partial name="ListInvoicesPaymentsPartial" model="(invoice.Details, true)"/>
+                                        <div class="dropdown-menu pull-right">
+                                            @if (invoice.CanMarkInvalid)
+                                            {
+                                                <button class="dropdown-item small cursorPointer" onclick="changeInvoiceState(this, '@invoice.InvoiceId', 'invalid')">
+                                                    Mark as invalid <span class="fa fa-times"></span>
+                                                </button>
+                                            }
+                                            @if (invoice.CanMarkComplete)
+                                            {
+                                                <button class="dropdown-item small cursorPointer" onclick="changeInvoiceState(this, '@invoice.InvoiceId', 'complete')">
+                                                    Mark as complete <span class="fa fa-check-circle"></span>
+                                                </button>
+                                            }
+                                        </div>
                                     </div>
-                                </td>
-                            </tr>
-                        }
+                                }
+                                else
+                                {
+                                    <span class="pavpill pavpil-@invoice.Status.ToString().ToLower()">@invoice.StatusString</span>
+                                }
+                            </td>
+                            <td style="text-align:right">@invoice.AmountCurrency</td>
+                            <td style="text-align:right">
+                                @if (invoice.ShowCheckout)
+                                {
+                                    <span>
+                                        <a asp-action="Checkout" class="invoice-checkout-link" id="invoice-checkout-@invoice.InvoiceId" asp-route-invoiceId="@invoice.InvoiceId">Checkout</a>
+                                        <a href="javascript:btcpay.showInvoice('@invoice.InvoiceId')">[^]</a>
+                                        @if (!invoice.CanMarkStatus)
+                                        {
+                                            <span>-</span>
+                                        }
+                                    </span>
+                                }
+                                &nbsp;
+                                <a asp-action="Invoice" class="invoice-details-link" asp-route-invoiceId="@invoice.InvoiceId">Details</a>
+                                <a href="javascript:void(0);" onclick="detailsToggle(this, '@invoice.InvoiceId')">
+                                    <span title="Invoice Details Toggle" class="fa fa-1x fa-angle-double-down"></span>
+                                </a>
+                            </td>
+                        </tr>
+                        <tr id="invoice_@invoice.InvoiceId" style="display:none;">
+                            <td colspan="99" class="border-top-0">
+                                <div style="margin-left: 15px; margin-bottom: 0;">
+                                    @* Leaving this as partial because it abstracts complexity of Invoice Payments *@
+                                    <partial name="ListInvoicesPaymentsPartial" model="(invoice.Details, true)"/>
+                                </div>
+                            </td>
+                        </tr>
+                    }
                     </tbody>
                 </table>
                 @if (Model.Total > Model.Count)

--- a/BTCPayServer/Views/Invoice/ListInvoices.cshtml
+++ b/BTCPayServer/Views/Invoice/ListInvoices.cshtml
@@ -195,7 +195,7 @@
                     </div>
                 </span>
                 <span>
-                    <a class="btn btn-secondary dropdown-toggle  mb-1" href="#" role="button" id="dropdownMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                    <a class="btn btn-secondary dropdown-toggle mb-1" href="#" role="button" id="dropdownMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                         Export
                     </a>
                     <div class="dropdown-menu" aria-labelledby="dropdownMenuLink">
@@ -204,7 +204,7 @@
                     </div>
                 </span>
 
-                <a href="https://docs.btcpayserver.org/Accounting/" target="_blank">
+                <a href="https://docs.btcpayserver.org/Accounting/" class="ml-1" target="_blank">
                     <span class="fa fa-question-circle-o text-secondary" title="More information..."></span>
                 </a>
 

--- a/BTCPayServer/Views/Invoice/ListInvoices.cshtml
+++ b/BTCPayServer/Views/Invoice/ListInvoices.cshtml
@@ -1,3 +1,4 @@
+@using BTCPayServer.Payments
 @model InvoicesModel
 @{
     ViewData["Title"] = "Invoices";
@@ -264,6 +265,11 @@
                             </td>
                             <td>@invoice.InvoiceId</td>
                             <td>
+                                @{
+                                    var grouped = invoice.Details.Payments.GroupBy(payment => payment.GetPaymentMethodId()?.PaymentType).Where(entities => entities.Key!= null);
+                                    var paiOnChain = grouped.Where(g => g.Key == BitcoinPaymentType.Instance).Any();
+                                    var paidOffChain = grouped.Where(g => g.Key == LightningPaymentType.Instance).Any();
+                                }
                                 @if (invoice.Details.Archived)
                                 {
                                     <span class="badge badge-warning">archived</span>
@@ -274,6 +280,14 @@
                                         <span class="dropdown-toggle dropdown-toggle-split pavpill pavpil-@invoice.Status.ToString().ToLower()"
                                               data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                                             @invoice.StatusString
+                                            @if (paiOnChain)
+                                            {
+                                                <span class="pavpill-symbol">🔗</span>
+                                            }
+                                            @if (paidOffChain)
+                                            {
+                                                <span class="pavpill-symbol">⚡️</span>
+                                            }
                                         </span>
                                         <div class="dropdown-menu pull-right">
                                             @if (invoice.CanMarkInvalid)
@@ -293,7 +307,18 @@
                                 }
                                 else
                                 {
-                                    <span class="pavpill pavpil-@invoice.Status.ToString().ToLower()">@invoice.StatusString</span>
+                                    <span class="pavpill pavpil-@invoice.Status.ToString().ToLower()">
+                                        @invoice.Status.ToString()
+
+                                        @if (paiOnChain)
+                                        {
+                                            <span class="pavpill-symbol">🔗</span>
+                                        }
+                                        @if (paidOffChain)
+                                        {
+                                            <span class="pavpill-symbol">⚡️</span>
+                                        }
+                                    </span>
                                 }
                             </td>
                             <td style="text-align:right">@invoice.AmountCurrency</td>
@@ -416,9 +441,15 @@
             border-radius: 0.25rem;
         }
 
-            .pavpill.dropdown-toggle {
-                cursor: pointer;
-            }
+        .pavpill .pavpill-symbol {
+            display: inline-block;
+            width: .9rem;
+            height: .9rem;
+        }
+
+        .pavpill.dropdown-toggle {
+            cursor: pointer;
+        }
 
         .dropdown-item {
             cursor: pointer;
@@ -439,7 +470,8 @@
             color: #fff;
         }
 
-        .pavpil-confirmed, .pavpil-paid {
+        .pavpil-confirmed,
+        .pavpil-paid {
             background: #f1c332;
             color: #000;
         }

--- a/BTCPayServer/Views/Invoice/ListInvoices.cshtml
+++ b/BTCPayServer/Views/Invoice/ListInvoices.cshtml
@@ -324,7 +324,10 @@
                         }
                     </tbody>
                 </table>
-                <vc:pager view-model="Model"></vc:pager>
+                @if (Model.Total > Model.Count)
+                {
+                    <vc:pager view-model="Model"></vc:pager>
+                }
             </form>
         }
         else

--- a/BTCPayServer/Views/Invoice/ListInvoices.cshtml
+++ b/BTCPayServer/Views/Invoice/ListInvoices.cshtml
@@ -4,8 +4,6 @@
     ViewData["Title"] = "Invoices";
     var storeIds = string.Join("", Model.StoreIds.Select(storeId => $",storeid:{storeId}"));
     var displayList = Model.Total > 0;
-    var isFiltered = Model.Total > 0 || Model.SearchTerm.Length > 0;
-    var displaySearch = displayList || isFiltered;
 }
 @section HeadScripts {
     <script src="~/modal/btcpay.js" asp-append-version="true"></script>
@@ -37,128 +35,125 @@
                     Create an invoice
                 </a>
             </div>
-            @if (displaySearch)
-            {
-                <div class="col-12 col-sm-8 col-lg-6 mb-3">
-                    <form asp-action="ListInvoices" method="get">
-                        <input type="hidden" asp-for="Count"/>
-                        <input asp-for="TimezoneOffset" type="hidden"/>
-                        <div class="input-group">
-                            <div class="input-group-prepend">
-                                <a href="#help" class="input-group-text text-secondary text-decoration-none" data-toggle="collapse">
-                                    <span class="fa fa-filter"></span>
-                                </a>
-                            </div>
-                            <input asp-for="SearchTerm" class="form-control"/>
-                            <div class="input-group-append">
-                                <button type="submit" class="btn btn-secondary" title="Search invoice">
-                                    <span class="fa fa-search"></span> Search
-                                </button>
-                                <button type="button" class="btn btn-secondary dropdown-toggle dropdown-toggle-split" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                                    <span class="sr-only">Toggle Dropdown</span>
-                                </button>
-
-                                <div class="dropdown-menu dropdown-menu-right">
-                                    <a class="dropdown-item" href="/invoices?Count=@Model.Count&SearchTerm=status%3Ainvalid@{@storeIds}">Invalid Invoices</a>
-                                    <a class="dropdown-item" href="/invoices?Count=@Model.Count&SearchTerm=status%3Apaid%2Cstatus%3Aconfirmed%2Cstatus%3Acomplete@{@storeIds}">Paid Invoices</a>
-                                    <a class="dropdown-item" href="/invoices?Count=@Model.Count&SearchTerm=exceptionstatus%3ApaidLate@{@storeIds}s">Paid Late Invoices</a>
-                                    <a class="dropdown-item" href="/invoices?Count=@Model.Count&SearchTerm=exceptionstatus%3ApaidPartial@{@storeIds}">Paid Partial Invoices</a>
-                                    <a class="dropdown-item" href="/invoices?Count=@Model.Count&SearchTerm=exceptionstatus%3ApaidOver@{@storeIds}">Paid Over Invoices</a>
-                                    <a class="dropdown-item" href="/invoices?Count=@Model.Count&SearchTerm=unusual%3Atrue@{@storeIds}">Unusual Invoices</a>
-                                    <a class="dropdown-item" href="/invoices?Count=@Model.Count&SearchTerm=includearchived%3Atrue@{@storeIds}">Archived Invoices</a>
-                                    <div role="separator" class="dropdown-divider"></div>
-                                    <a class="dropdown-item" href="/invoices?Count=@Model.Count&timezoneoffset=0&SearchTerm=startDate%3A-24h@{@storeIds}">Last 24 hours</a>
-                                    <a class="dropdown-item" href="/invoices?Count=@Model.Count&timezoneoffset=0&SearchTerm=startDate%3A-3d@{@storeIds}">Last 3 days</a>
-                                    <a class="dropdown-item" href="/invoices?Count=@Model.Count&timezoneoffset=0&SearchTerm=startDate%3A-7d@{@storeIds}">Last 7 days</a>
-                                    <button type="button" class="dropdown-item" data-toggle="modal" data-target="#customRangeModal" data-backdrop="static">Custom Range</button>
-                                    <div role="separator" class="dropdown-divider"></div>
-                                    <a class="dropdown-item" href="/invoices?SearchTerm=">Unfiltered</a>
-                                </div>
-                            </div>
-
+            <div class="col-12 col-sm-8 col-lg-6 mb-3">
+                <form asp-action="ListInvoices" method="get">
+                    <input type="hidden" asp-for="Count"/>
+                    <input asp-for="TimezoneOffset" type="hidden"/>
+                    <div class="input-group">
+                        <div class="input-group-prepend">
+                            <a href="#help" class="input-group-text text-secondary text-decoration-none" data-toggle="collapse">
+                                <span class="fa fa-filter"></span>
+                            </a>
                         </div>
-                        <span asp-validation-for="SearchTerm" class="text-danger"></span>
-                    </form>
+                        <input asp-for="SearchTerm" class="form-control"/>
+                        <div class="input-group-append">
+                            <button type="submit" class="btn btn-secondary" title="Search invoice">
+                                <span class="fa fa-search"></span> Search
+                            </button>
+                            <button type="button" class="btn btn-secondary dropdown-toggle dropdown-toggle-split" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                                <span class="sr-only">Toggle Dropdown</span>
+                            </button>
 
-                    @* Custom Range Modal *@
-                    <div class="modal fade" id="customRangeModal" tabindex="-1" role="dialog" aria-labelledby="exampleModalCenterTitle" aria-hidden="true">
-                        <div class="modal-dialog modal-dialog-centered" role="document" style="max-width: 550px;">
-                            <div class="modal-content">
-                                <div class="modal-header">
-                                    <h5 class="modal-title" id="exampleModalLongTitle">Filter invoices by Custom Range</h5>
-                                    <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-                                        <span aria-hidden="true">&times;</span>
-                                    </button>
-                                </div>
-                                <div class="modal-body">
-                                    <div class="form-group row">
-                                        <label for="dtpStartDate" class="col-sm-3 col-form-label">Start Date</label>
-                                        <div class="col-sm-9">
-                                            <div class="input-group">
-                                                <input id="dtpStartDate" class="form-control flatdtpicker" type="datetime-local"
-                                                    data-fdtp='{ "enableTime": true, "enableSeconds": true, "dateFormat": "Y-m-d H:i:S", "time_24hr": true, "defaultHour": 0 }'
-                                                    placeholder="Start Date" />
-                                                <div class="input-group-append">
-                                                    <button type="button" class="btn btn-primary input-group-clear" title="Clear">
-                                                        <span class=" fa fa-times"></span>
-                                                    </button>
-                                                </div>
+                            <div class="dropdown-menu dropdown-menu-right">
+                                <a class="dropdown-item" href="/invoices?Count=@Model.Count&SearchTerm=status%3Ainvalid@{@storeIds}">Invalid Invoices</a>
+                                <a class="dropdown-item" href="/invoices?Count=@Model.Count&SearchTerm=status%3Apaid%2Cstatus%3Aconfirmed%2Cstatus%3Acomplete@{@storeIds}">Paid Invoices</a>
+                                <a class="dropdown-item" href="/invoices?Count=@Model.Count&SearchTerm=exceptionstatus%3ApaidLate@{@storeIds}s">Paid Late Invoices</a>
+                                <a class="dropdown-item" href="/invoices?Count=@Model.Count&SearchTerm=exceptionstatus%3ApaidPartial@{@storeIds}">Paid Partial Invoices</a>
+                                <a class="dropdown-item" href="/invoices?Count=@Model.Count&SearchTerm=exceptionstatus%3ApaidOver@{@storeIds}">Paid Over Invoices</a>
+                                <a class="dropdown-item" href="/invoices?Count=@Model.Count&SearchTerm=unusual%3Atrue@{@storeIds}">Unusual Invoices</a>
+                                <a class="dropdown-item" href="/invoices?Count=@Model.Count&SearchTerm=includearchived%3Atrue@{@storeIds}">Archived Invoices</a>
+                                <div role="separator" class="dropdown-divider"></div>
+                                <a class="dropdown-item" href="/invoices?Count=@Model.Count&timezoneoffset=0&SearchTerm=startDate%3A-24h@{@storeIds}">Last 24 hours</a>
+                                <a class="dropdown-item" href="/invoices?Count=@Model.Count&timezoneoffset=0&SearchTerm=startDate%3A-3d@{@storeIds}">Last 3 days</a>
+                                <a class="dropdown-item" href="/invoices?Count=@Model.Count&timezoneoffset=0&SearchTerm=startDate%3A-7d@{@storeIds}">Last 7 days</a>
+                                <button type="button" class="dropdown-item" data-toggle="modal" data-target="#customRangeModal" data-backdrop="static">Custom Range</button>
+                                <div role="separator" class="dropdown-divider"></div>
+                                <a class="dropdown-item" href="/invoices?SearchTerm=">Unfiltered</a>
+                            </div>
+                        </div>
+
+                    </div>
+                    <span asp-validation-for="SearchTerm" class="text-danger"></span>
+                </form>
+
+                @* Custom Range Modal *@
+                <div class="modal fade" id="customRangeModal" tabindex="-1" role="dialog" aria-labelledby="exampleModalCenterTitle" aria-hidden="true">
+                    <div class="modal-dialog modal-dialog-centered" role="document" style="max-width: 550px;">
+                        <div class="modal-content">
+                            <div class="modal-header">
+                                <h5 class="modal-title" id="exampleModalLongTitle">Filter invoices by Custom Range</h5>
+                                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                                    <span aria-hidden="true">&times;</span>
+                                </button>
+                            </div>
+                            <div class="modal-body">
+                                <div class="form-group row">
+                                    <label for="dtpStartDate" class="col-sm-3 col-form-label">Start Date</label>
+                                    <div class="col-sm-9">
+                                        <div class="input-group">
+                                            <input id="dtpStartDate" class="form-control flatdtpicker" type="datetime-local"
+                                                data-fdtp='{ "enableTime": true, "enableSeconds": true, "dateFormat": "Y-m-d H:i:S", "time_24hr": true, "defaultHour": 0 }'
+                                                placeholder="Start Date" />
+                                            <div class="input-group-append">
+                                                <button type="button" class="btn btn-primary input-group-clear" title="Clear">
+                                                    <span class=" fa fa-times"></span>
+                                                </button>
                                             </div>
                                         </div>
                                     </div>
-                                    <div class="form-group row">
-                                        <label class="col-sm-3 col-form-label">End Date</label>
-                                        <div class="col-sm-9">
-                                            <div class="input-group">
-                                                <input id="dtpEndDate" class="form-control flatdtpicker" type="datetime-local"
-                                                    data-fdtp='{ "enableTime": true, "enableSeconds": true, "dateFormat": "Y-m-d H:i:S", "time_24hr": true, "defaultHour": 0 }'
-                                                    placeholder="End Date" />
-                                                <div class="input-group-append">
-                                                    <button type="button" class="btn btn-primary input-group-clear" title="Clear">
-                                                        <span class="fa fa-times"></span>
-                                                    </button>
-                                                </div>
+                                </div>
+                                <div class="form-group row">
+                                    <label class="col-sm-3 col-form-label">End Date</label>
+                                    <div class="col-sm-9">
+                                        <div class="input-group">
+                                            <input id="dtpEndDate" class="form-control flatdtpicker" type="datetime-local"
+                                                data-fdtp='{ "enableTime": true, "enableSeconds": true, "dateFormat": "Y-m-d H:i:S", "time_24hr": true, "defaultHour": 0 }'
+                                                placeholder="End Date" />
+                                            <div class="input-group-append">
+                                                <button type="button" class="btn btn-primary input-group-clear" title="Clear">
+                                                    <span class="fa fa-times"></span>
+                                                </button>
                                             </div>
                                         </div>
                                     </div>
                                 </div>
-                                <div class="modal-footer">
-                                    <button id="btnCustomRangeDate" type="button" class="btn btn-primary">Filter</button>
-                                </div>
+                            </div>
+                            <div class="modal-footer">
+                                <button id="btnCustomRangeDate" type="button" class="btn btn-primary">Filter</button>
                             </div>
                         </div>
                     </div>
-                    <script type="text/javascript">
-                        $('#btnCustomRangeDate').on('click', function (sender) {
-                            var filterString = "";
-
-                            var dtpStartDate = $("#dtpStartDate").val();
-                            if (dtpStartDate !== null && dtpStartDate !== "") {
-                                filterString = "startDate%3A" + dtpStartDate;
-                            }
-
-                            var dtpEndDate = $("#dtpEndDate").val();
-                            if (dtpEndDate !== null && dtpEndDate !== "") {
-                                if (filterString !== "") {
-                                    filterString += ",";
-                                }
-                                filterString += "endDate%3A" + dtpEndDate;
-                            }
-
-                            if (filterString !== "") {
-                                var redirectUri = "/invoices?Count=" + $("#Count").val() +
-                                    "&timezoneoffset=" + $("#TimezoneOffset").val() +
-                                    "&SearchTerm=" + filterString;
-
-                                window.location.href = redirectUri;
-                            } else {
-                                $("#dtpStartDate").next().trigger("focus");
-                            }
-                        })
-                    </script>
-                    @* Custom Range Modal *@
                 </div>
-            }
+                <script type="text/javascript">
+                    $('#btnCustomRangeDate').on('click', function (sender) {
+                        var filterString = "";
+
+                        var dtpStartDate = $("#dtpStartDate").val();
+                        if (dtpStartDate !== null && dtpStartDate !== "") {
+                            filterString = "startDate%3A" + dtpStartDate;
+                        }
+
+                        var dtpEndDate = $("#dtpEndDate").val();
+                        if (dtpEndDate !== null && dtpEndDate !== "") {
+                            if (filterString !== "") {
+                                filterString += ",";
+                            }
+                            filterString += "endDate%3A" + dtpEndDate;
+                        }
+
+                        if (filterString !== "") {
+                            var redirectUri = "/invoices?Count=" + $("#Count").val() +
+                                "&timezoneoffset=" + $("#TimezoneOffset").val() +
+                                "&SearchTerm=" + filterString;
+
+                            window.location.href = redirectUri;
+                        } else {
+                            $("#dtpStartDate").next().trigger("focus");
+                        }
+                    })
+                </script>
+                @* Custom Range Modal *@
+            </div>
         </div>
 
         <div class="row collapse" id="help">
@@ -342,17 +337,14 @@
                     }
                     </tbody>
                 </table>
-                @if (displayList)
-                {
-                    <vc:pager view-model="Model"></vc:pager>
-                }
+
+                <vc:pager view-model="Model"></vc:pager>
             </form>
         }
         else
         {
             <p class="text-secondary mt-3">
-                There are no invoices
-                @(isFiltered ? "matching your criteria" : ", yet").
+                There are no invoices matching your criteria.
             </p>
         }
     </div>

--- a/BTCPayServer/Views/Invoice/ListInvoices.cshtml
+++ b/BTCPayServer/Views/Invoice/ListInvoices.cshtml
@@ -224,7 +224,7 @@
                 <table class="table table-sm table-responsive-md">
                     <thead>
                     <tr>
-                        <th class="only-for-js">
+                        <th style="width:2rem;" class="only-for-js">
                             <input id="selectAllCheckbox" type="checkbox" onclick="selectAll(this);"/>
                         </th>
                         <th style="min-width:90px;" class="col-md-auto">
@@ -387,6 +387,10 @@
         }
     </script>
     <style type="text/css">
+        .invoice-payments {
+            padding-left: 2rem;
+        }
+
         .invoice-payments h3 {
             font-size: 15px;
             font-weight: bold;

--- a/BTCPayServer/Views/Invoice/ListInvoices.cshtml
+++ b/BTCPayServer/Views/Invoice/ListInvoices.cshtml
@@ -2,6 +2,9 @@
 @{
     ViewData["Title"] = "Invoices";
     var storeIds = string.Join("", Model.StoreIds.Select(storeId => $",storeid:{storeId}"));
+    var displayList = Model.Total > 0;
+    var isFiltered = Model.Total > 0 || Model.SearchTerm.Length > 0;
+    var displaySearch = displayList || isFiltered;
 }
 @section HeadScripts {
     <script src="~/modal/btcpay.js" asp-append-version="true"></script>
@@ -33,7 +36,7 @@
                     Create an invoice
                 </a>
             </div>
-            @if (Model.Total > 0)
+            @if (displaySearch)
             {
                 <div class="col-12 col-sm-8 col-lg-6 mb-3">
                     <form asp-action="ListInvoices" method="get">
@@ -183,7 +186,7 @@
             </div>
         </div>
 
-        @if (Model.Total > 0)
+        @if (displayList)
         {
             <form method="post" id="MassAction" asp-action="MassAction" class="mt-3">
                 <span class="mr-2">
@@ -324,7 +327,7 @@
                     }
                     </tbody>
                 </table>
-                @if (Model.Total > Model.Count)
+                @if (displayList)
                 {
                     <vc:pager view-model="Model"></vc:pager>
                 }
@@ -332,7 +335,10 @@
         }
         else
         {
-            <p class="text-secondary mt-3">There are no invoices, yet.</p>
+            <p class="text-secondary mt-3">
+                There are no invoices
+                @(isFiltered ? "matching your criteria" : ", yet").
+            </p>
         }
     </div>
     <script type="text/javascript">
@@ -381,7 +387,6 @@
         }
     </script>
     <style type="text/css">
-
         .invoice-payments h3 {
             font-size: 15px;
             font-weight: bold;

--- a/BTCPayServer/Views/Invoice/ListInvoices.cshtml
+++ b/BTCPayServer/Views/Invoice/ListInvoices.cshtml
@@ -1,237 +1,248 @@
 @model InvoicesModel
 @{
     ViewData["Title"] = "Invoices";
+    var storeIds = string.Join("", Model.StoreIds.Select(storeId => $",storeid:{storeId}"));
 }
 @section HeadScripts {
     <script src="~/modal/btcpay.js" asp-append-version="true"></script>
 }
-
 @Html.HiddenFor(a => a.Count)
 <section>
     <div class="container">
         @if (TempData.HasStatusMessage())
         {
-        <div class="row">
-            <div class="col-lg-12 text-center">
-                <partial name="_StatusMessage" />
+            <div class="row">
+                <div class="col-lg-12 text-center">
+                    <partial name="_StatusMessage" />
+                </div>
             </div>
-        </div>
         }
 
         <div class="row">
             <div class="col-lg-12 section-heading">
                 <h2>@ViewData["Title"]</h2>
                 <hr class="primary">
-                <p>Create, search or pay an invoice. (<a href="#help" data-toggle="collapse">Help</a>)</p>
-                <div id="help" class="collapse text-left">
-                    <p>
-                        You can search for invoice Id, deposit address, price, order id, store id, any buyer information and any product information.<br />
-                        Be sure to split your search parameters with comma, for example: <code>startdate:2019-04-25 13:00:00, status:paid</code><br />
-                        You can also apply filters to your search by searching for <code>filtername:value</code>, here is a list of supported filters
-                    </p>
-                    <ul>
-                        <li><code>storeid:id</code> for filtering a specific store</li>
-                        <li><code>orderid:id</code> for filtering a specific order</li>
-                        <li><code>itemcode:code</code> for filtering a specific type of item purchased through the pos or crowdfund apps</li>
-                        <li><code>status:(expired|invalid|complete|confirmed|paid|new)</code> for filtering a specific status</li>
-                        <li><code>exceptionstatus:(paidover|paidlate|paidpartial)</code> for filtering a specific exception state</li>
-                        <li><code>unusual:(true|false)</code> for filtering invoices which might requires merchant attention (those invalid or with an exceptionstatus)</li>
-                        <li><code>startdate:yyyy-MM-dd HH:mm:ss</code> getting invoices that were created after certain date</li>
-                        <li><code>enddate:yyyy-MM-dd HH:mm:ss</code> getting invoices that were created before certain date</li>
-                    </ul>
-                    <p>
-                        If you want all confirmed and complete invoices, you can duplicate a filter <code>status:confirmed, status:complete</code>.
-                    </p>
-                </div>
+                <p>Create, search or pay an invoice.</p>
             </div>
         </div>
 
-        <form asp-action="ListInvoices" method="get" class="pull-right mb-3 col-sm-12 col-md-7 col-lg-6">
-            <input type="hidden" asp-for="Count" />
-            <div class="input-group ">
-                <input asp-for="TimezoneOffset" type="hidden" />
-                <input asp-for="SearchTerm" class="form-control" />
-                <div class="input-group-append">
-                    <button type="submit" class="btn btn-primary" title="Search invoice">
-                        <span class="fa fa-search"></span> Search
-                    </button>
-                    <button type="button" class="btn btn-primary dropdown-toggle dropdown-toggle-split" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                        <span class="sr-only">Toggle Dropdown</span>
-                    </button>
-
-                    @{
-                        var storeIds = string.Join(
-                            "",
-                            Model.StoreIds.Select(storeId => $",storeid:{storeId}")
-                        );
-                    }
-
-                    <div class="dropdown-menu dropdown-menu-right">
-                        <a class="dropdown-item" href="/invoices?Count=@Model.Count&SearchTerm=status%3Ainvalid@{@storeIds}">Invalid Invoices</a>
-                        <a class="dropdown-item" href="/invoices?Count=@Model.Count&SearchTerm=status%3Apaid%2Cstatus%3Aconfirmed%2Cstatus%3Acomplete@{@storeIds}">Paid Invoices</a>
-                        <a class="dropdown-item" href="/invoices?Count=@Model.Count&SearchTerm=exceptionstatus%3ApaidLate@{@storeIds}s">Paid Late Invoices</a>
-                        <a class="dropdown-item" href="/invoices?Count=@Model.Count&SearchTerm=exceptionstatus%3ApaidPartial@{@storeIds}">Paid Partial Invoices</a>
-                        <a class="dropdown-item" href="/invoices?Count=@Model.Count&SearchTerm=exceptionstatus%3ApaidOver@{@storeIds}">Paid Over Invoices</a>
-                        <a class="dropdown-item" href="/invoices?Count=@Model.Count&SearchTerm=unusual%3Atrue@{@storeIds}">Unusual Invoices</a>
-                        <a class="dropdown-item" href="/invoices?Count=@Model.Count&SearchTerm=includearchived%3Atrue@{@storeIds}">Archived Invoices</a>
-                        <div role="separator" class="dropdown-divider"></div>
-                        <a class="dropdown-item" href="/invoices?Count=@Model.Count&timezoneoffset=0&SearchTerm=startDate%3A-24h@{@storeIds}">Last 24 hours</a>
-                        <a class="dropdown-item" href="/invoices?Count=@Model.Count&timezoneoffset=0&SearchTerm=startDate%3A-3d@{@storeIds}">Last 3 days</a>
-                        <a class="dropdown-item" href="/invoices?Count=@Model.Count&timezoneoffset=0&SearchTerm=startDate%3A-7d@{@storeIds}">Last 7 days</a>
-                        <button type="button" class="dropdown-item" data-toggle="modal" data-target="#customRangeModal" data-backdrop="static">Custom Range</button>
-                        <div role="separator" class="dropdown-divider"></div>
-                        <a class="dropdown-item" href="/invoices?SearchTerm=">Unfiltered</a>
-                    </div>
-                </div>
+        <div class="row">
+            <div class="col-12 col-sm-4 col-lg-6 mb-3">
+                <a asp-action="CreateInvoice" class="btn btn-primary mb-1" role="button" id="CreateNewInvoice">
+                    <span class="fa fa-plus"></span>
+                    Create an invoice
+                </a>
             </div>
-            <span asp-validation-for="SearchTerm" class="text-danger"></span>
-        </form>
+            @if (Model.Total > 0)
+            {
+                <div class="col-12 col-sm-8 col-lg-6 mb-3">
+                    <form asp-action="ListInvoices" method="get">
+                        <input type="hidden" asp-for="Count"/>
+                        <input asp-for="TimezoneOffset" type="hidden"/>
+                        <div class="input-group">
+                            <div class="input-group-prepend">
+                                <a href="#help" class="input-group-text text-secondary text-decoration-none" data-toggle="collapse">
+                                    <span class="fa fa-filter"></span>
+                                </a>
+                            </div>
+                            <input asp-for="SearchTerm" class="form-control"/>
+                            <div class="input-group-append">
+                                <button type="submit" class="btn btn-secondary" title="Search invoice">
+                                    <span class="fa fa-search"></span> Search
+                                </button>
+                                <button type="button" class="btn btn-secondary dropdown-toggle dropdown-toggle-split" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                                    <span class="sr-only">Toggle Dropdown</span>
+                                </button>
 
-        <form method="post" id="MassAction" asp-action="MassAction">
-            <div class="row button-row col-sm-12 col-md-5 col-lg-6">
-                <div>
-                    <a asp-action="CreateInvoice" class="btn btn-primary mb-1" role="button" id="CreateNewInvoice"><span class="fa fa-plus"></span> Create a new invoice</a>
+                                <div class="dropdown-menu dropdown-menu-right">
+                                    <a class="dropdown-item" href="/invoices?Count=@Model.Count&SearchTerm=status%3Ainvalid@{@storeIds}">Invalid Invoices</a>
+                                    <a class="dropdown-item" href="/invoices?Count=@Model.Count&SearchTerm=status%3Apaid%2Cstatus%3Aconfirmed%2Cstatus%3Acomplete@{@storeIds}">Paid Invoices</a>
+                                    <a class="dropdown-item" href="/invoices?Count=@Model.Count&SearchTerm=exceptionstatus%3ApaidLate@{@storeIds}s">Paid Late Invoices</a>
+                                    <a class="dropdown-item" href="/invoices?Count=@Model.Count&SearchTerm=exceptionstatus%3ApaidPartial@{@storeIds}">Paid Partial Invoices</a>
+                                    <a class="dropdown-item" href="/invoices?Count=@Model.Count&SearchTerm=exceptionstatus%3ApaidOver@{@storeIds}">Paid Over Invoices</a>
+                                    <a class="dropdown-item" href="/invoices?Count=@Model.Count&SearchTerm=unusual%3Atrue@{@storeIds}">Unusual Invoices</a>
+                                    <a class="dropdown-item" href="/invoices?Count=@Model.Count&SearchTerm=includearchived%3Atrue@{@storeIds}">Archived Invoices</a>
+                                    <div role="separator" class="dropdown-divider"></div>
+                                    <a class="dropdown-item" href="/invoices?Count=@Model.Count&timezoneoffset=0&SearchTerm=startDate%3A-24h@{@storeIds}">Last 24 hours</a>
+                                    <a class="dropdown-item" href="/invoices?Count=@Model.Count&timezoneoffset=0&SearchTerm=startDate%3A-3d@{@storeIds}">Last 3 days</a>
+                                    <a class="dropdown-item" href="/invoices?Count=@Model.Count&timezoneoffset=0&SearchTerm=startDate%3A-7d@{@storeIds}">Last 7 days</a>
+                                    <button type="button" class="dropdown-item" data-toggle="modal" data-target="#customRangeModal" data-backdrop="static">Custom Range</button>
+                                    <div role="separator" class="dropdown-divider"></div>
+                                    <a class="dropdown-item" href="/invoices?SearchTerm=">Unfiltered</a>
+                                </div>
+                            </div>
 
-                    <span>
-                        <button class="btn btn-primary dropdown-toggle  mb-1" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                            Actions
-                        </button>
-                        <div class="dropdown-menu">
-                            <button type="submit" asp-action="MassAction" class="dropdown-item" name="command" value="archive"><i class="fa fa-archive"></i> Archive</button>
                         </div>
-                    </span>
+                        <span asp-validation-for="SearchTerm" class="text-danger"></span>
+                    </form>
 
-                    <span>
-                        <a class="btn btn-primary dropdown-toggle  mb-1" href="#" role="button" id="dropdownMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                            Export
-                        </a>
-                        <a href="https://docs.btcpayserver.org/Accounting/" target="_blank">
-                            <span class="fa fa-question-circle-o" title="More information..."></span>
-                        </a>
-                        <div class="dropdown-menu" aria-labelledby="dropdownMenuLink">
-                            <a asp-action="Export" asp-route-timezoneoffset="0" asp-route-format="csv" asp-route-searchTerm="@Model.SearchTerm" class="dropdown-item export-link" target="_blank">CSV</a>
-                            <a asp-action="Export" asp-route-timezoneoffset="0" asp-route-format="json" asp-route-searchTerm="@Model.SearchTerm" class="dropdown-item export-link" target="_blank">JSON</a>
-                        </div>
-                    </span>
-                </div>
-            </div>
-            <br />
-            @* Custom Range Modal *@
-            <div class="modal fade" id="customRangeModal" tabindex="-1" role="dialog" aria-labelledby="exampleModalCenterTitle" aria-hidden="true">
-                <div class="modal-dialog modal-dialog-centered" role="document" style="max-width: 550px;">
-                    <div class="modal-content">
-                        <div class="modal-header">
-                            <h5 class="modal-title" id="exampleModalLongTitle">Filter invoices by Custom Range</h5>
-                            <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-                                <span aria-hidden="true">&times;</span>
-                            </button>
-                        </div>
-                        <div class="modal-body">
-                            <div class="form-group row">
-                                <label for="dtpStartDate" class="col-sm-3 col-form-label">Start Date</label>
-                                <div class="col-sm-9">
-                                    <div class="input-group">
-                                        <input id="dtpStartDate" class="form-control flatdtpicker" type="datetime-local"
-                                               data-fdtp='{ "enableTime": true, "enableSeconds": true, "dateFormat": "Y-m-d H:i:S", "time_24hr": true, "defaultHour": 0 }'
-                                               placeholder="Start Date" />
-                                        <div class="input-group-append">
-                                            <button type="button" class="btn btn-primary input-group-clear" title="Clear">
-                                                <span class=" fa fa-times"></span>
-                                            </button>
+                    @* Custom Range Modal *@
+                    <div class="modal fade" id="customRangeModal" tabindex="-1" role="dialog" aria-labelledby="exampleModalCenterTitle" aria-hidden="true">
+                        <div class="modal-dialog modal-dialog-centered" role="document" style="max-width: 550px;">
+                            <div class="modal-content">
+                                <div class="modal-header">
+                                    <h5 class="modal-title" id="exampleModalLongTitle">Filter invoices by Custom Range</h5>
+                                    <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                                        <span aria-hidden="true">&times;</span>
+                                    </button>
+                                </div>
+                                <div class="modal-body">
+                                    <div class="form-group row">
+                                        <label for="dtpStartDate" class="col-sm-3 col-form-label">Start Date</label>
+                                        <div class="col-sm-9">
+                                            <div class="input-group">
+                                                <input id="dtpStartDate" class="form-control flatdtpicker" type="datetime-local"
+                                                    data-fdtp='{ "enableTime": true, "enableSeconds": true, "dateFormat": "Y-m-d H:i:S", "time_24hr": true, "defaultHour": 0 }'
+                                                    placeholder="Start Date" />
+                                                <div class="input-group-append">
+                                                    <button type="button" class="btn btn-primary input-group-clear" title="Clear">
+                                                        <span class=" fa fa-times"></span>
+                                                    </button>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <div class="form-group row">
+                                        <label class="col-sm-3 col-form-label">End Date</label>
+                                        <div class="col-sm-9">
+                                            <div class="input-group">
+                                                <input id="dtpEndDate" class="form-control flatdtpicker" type="datetime-local"
+                                                    data-fdtp='{ "enableTime": true, "enableSeconds": true, "dateFormat": "Y-m-d H:i:S", "time_24hr": true, "defaultHour": 0 }'
+                                                    placeholder="End Date" />
+                                                <div class="input-group-append">
+                                                    <button type="button" class="btn btn-primary input-group-clear" title="Clear">
+                                                        <span class="fa fa-times"></span>
+                                                    </button>
+                                                </div>
+                                            </div>
                                         </div>
                                     </div>
                                 </div>
-                            </div>
-                            <div class="form-group row">
-                                <label class="col-sm-3 col-form-label">End Date</label>
-                                <div class="col-sm-9">
-                                    <div class="input-group">
-                                        <input id="dtpEndDate" class="form-control flatdtpicker" type="datetime-local"
-                                               data-fdtp='{ "enableTime": true, "enableSeconds": true, "dateFormat": "Y-m-d H:i:S", "time_24hr": true, "defaultHour": 0 }'
-                                               placeholder="End Date" />
-                                        <div class="input-group-append">
-                                            <button type="button" class="btn btn-primary input-group-clear" title="Clear">
-                                                <span class=" fa fa-times"></span>
-                                            </button>
-                                        </div>
-                                    </div>
+                                <div class="modal-footer">
+                                    <button id="btnCustomRangeDate" type="button" class="btn btn-primary">Filter</button>
                                 </div>
                             </div>
                         </div>
-                        <div class="modal-footer">
-                            <button id="btnCustomRangeDate" type="button" class="btn btn-primary">Filter</button>
-                        </div>
                     </div>
+                    <script type="text/javascript">
+                        $('#btnCustomRangeDate').on('click', function (sender) {
+                            var filterString = "";
+
+                            var dtpStartDate = $("#dtpStartDate").val();
+                            if (dtpStartDate !== null && dtpStartDate !== "") {
+                                filterString = "startDate%3A" + dtpStartDate;
+                            }
+
+                            var dtpEndDate = $("#dtpEndDate").val();
+                            if (dtpEndDate !== null && dtpEndDate !== "") {
+                                if (filterString !== "") {
+                                    filterString += ",";
+                                }
+                                filterString += "endDate%3A" + dtpEndDate;
+                            }
+
+                            if (filterString !== "") {
+                                var redirectUri = "/invoices?Count=" + $("#Count").val() +
+                                    "&timezoneoffset=" + $("#TimezoneOffset").val() +
+                                    "&SearchTerm=" + filterString;
+
+                                window.location.href = redirectUri;
+                            } else {
+                                $("#dtpStartDate").next().trigger("focus");
+                            }
+                        })
+                    </script>
+                    @* Custom Range Modal *@
                 </div>
+            }
+        </div>
+
+        <div class="row collapse" id="help">
+            <div class="col">
+                <p>
+                    You can search for invoice Id, deposit address, price, order id, store id, any buyer information and any product information.
+                    Be sure to split your search parameters with comma, for example:<br />
+                    <code>startdate:2019-04-25 13:00:00, status:paid</code>
+                </p>
+                <p class="mb-2">
+                    You can also apply filters to your search by searching for <code>filtername:value</code>, supported filters are:
+                </p>
+                <ul>
+                    <li><code>storeid:id</code> for filtering a specific store</li>
+                    <li><code>orderid:id</code> for filtering a specific order</li>
+                    <li><code>itemcode:code</code> for filtering a specific type of item purchased through the pos or crowdfund apps</li>
+                    <li><code>status:(expired|invalid|complete|confirmed|paid|new)</code> for filtering a specific status</li>
+                    <li><code>exceptionstatus:(paidover|paidlate|paidpartial)</code> for filtering a specific exception state</li>
+                    <li><code>unusual:(true|false)</code> for filtering invoices which might requires merchant attention (those invalid or with an exceptionstatus)</li>
+                    <li><code>startdate:yyyy-MM-dd HH:mm:ss</code> getting invoices that were created after certain date</li>
+                    <li><code>enddate:yyyy-MM-dd HH:mm:ss</code> getting invoices that were created before certain date</li>
+                </ul>
+                <p>
+                    If you want all confirmed and complete invoices, you can duplicate a filter <code>status:confirmed, status:complete</code>.
+                </p>
             </div>
-            <script type="text/javascript">
-                $('#btnCustomRangeDate').on('click', function (sender) {
-                    var filterString = "";
+        </div>
 
-                    var dtpStartDate = $("#dtpStartDate").val();
-                    if (dtpStartDate !== null && dtpStartDate !== "") {
-                        filterString = "startDate%3A" + dtpStartDate;
-                    }
+        @if (Model.Total > 0)
+        {
+            <form method="post" id="MassAction" asp-action="MassAction" class="mt-3">
+                <span class="mr-2">
+                    <button class="btn btn-secondary dropdown-toggle  mb-1" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                        Actions
+                    </button>
+                    <div class="dropdown-menu">
+                        <button type="submit" asp-action="MassAction" class="dropdown-item" name="command" value="archive"><i class="fa fa-archive"></i> Archive</button>
+                    </div>
+                </span>
+                <span>
+                    <a class="btn btn-secondary dropdown-toggle  mb-1" href="#" role="button" id="dropdownMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                        Export
+                    </a>
+                    <div class="dropdown-menu" aria-labelledby="dropdownMenuLink">
+                        <a asp-action="Export" asp-route-timezoneoffset="0" asp-route-format="csv" asp-route-searchTerm="@Model.SearchTerm" class="dropdown-item export-link" target="_blank">CSV</a>
+                        <a asp-action="Export" asp-route-timezoneoffset="0" asp-route-format="json" asp-route-searchTerm="@Model.SearchTerm" class="dropdown-item export-link" target="_blank">JSON</a>
+                    </div>
+                </span>
 
-                    var dtpEndDate = $("#dtpEndDate").val();
-                    if (dtpEndDate !== null && dtpEndDate !== "") {
-                        if (filterString !== "") {
-                            filterString += ",";
+                <a href="https://docs.btcpayserver.org/Accounting/" target="_blank">
+                    <span class="fa fa-question-circle-o text-secondary" title="More information..."></span>
+                </a>
+
+                <script type="text/javascript">
+                    function selectAll(e)
+                    {
+                        var items = document.getElementsByClassName("selector");
+                        for (var i = 0; i < items.length; i++) {
+                            items[i].checked = e.checked;
                         }
-                        filterString += "endDate%3A" + dtpEndDate;
                     }
+                </script>
 
-                    if (filterString !== "") {
-                        var redirectUri = "/invoices?Count=" + $("#Count").val() +
-                            "&timezoneoffset=" + $("#TimezoneOffset").val() +
-                            "&SearchTerm=" + filterString;
-
-                        window.location.href = redirectUri;
-                    } else {
-                        $("#dtpStartDate").next().trigger("focus");
-                    }
-                })
-            </script>
-            @* Custom Range Modal *@
-
-            <script type="text/javascript">
-                function selectAll(e) {
-                    var items = document.getElementsByClassName("selector");
-                    for (var i = 0; i < items.length; i++) {
-                        items[i].checked = e.checked;
-                    }
-                }
-            </script>
-            <div class="row">
-                <div class="col-lg-12">
-                    <table class="table table-sm table-responsive-md">
-                        <thead>
-                            <tr>
-                                <th class="only-for-js">
-                                    @if (Model.Total > 0)
-                                    {
-                                    <input id="selectAllCheckbox" type="checkbox" onclick="selectAll(this);" />
-                                    }
-                                </th>
-                                <th style="min-width: 90px;" class="col-md-auto">
-                                    Date
-                                    <a href="javascript:switchTimeFormat()">
-                                        <span class="fa fa-clock-o" title="Switch date format"></span>
-                                    </a>
-                                </th>
-                                <th style="max-width: 180px;">OrderId</th>
-                                <th>InvoiceId</th>
-                                <th style="min-width: 150px;">Status</th>
-                                <th style="text-align:right">Amount</th>
-                                <th style="text-align:right">Actions</th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                            @foreach (var invoice in Model.Invoices)
-                            {
+                <table class="table table-sm table-responsive-md">
+                    <thead>
+                        <tr>
+                            <th class="only-for-js">
+                                <input id="selectAllCheckbox" type="checkbox" onclick="selectAll(this);"/>
+                            </th>
+                            <th style="min-width:90px;" class="col-md-auto">
+                                Date
+                                <a href="javascript:switchTimeFormat()">
+                                    <span class="fa fa-clock-o" title="Switch date format"></span>
+                                </a>
+                            </th>
+                            <th style="max-width: 180px;">OrderId</th>
+                            <th>InvoiceId</th>
+                            <th style="min-width: 150px;">Status</th>
+                            <th style="text-align:right">Amount</th>
+                            <th style="text-align:right">Actions</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @foreach (var invoice in Model.Invoices)
+                        {
                             <tr>
                                 <td class="only-for-js">
-                                    <input name="selectedItems" type="checkbox" class="selector" value="@invoice.InvoiceId" />
+                                    <input name="selectedItems" type="checkbox" class="selector" value="@invoice.InvoiceId"/>
                                 </td>
                                 <td>
                                     <span class="switchTimeFormat" data-switch="@invoice.Date.ToTimeAgo()">
@@ -240,61 +251,61 @@
                                 </td>
                                 <td style="max-width: 180px;">
                                     @if (invoice.RedirectUrl != string.Empty)
-                                        {
-                                    <a href="@invoice.RedirectUrl" class="wraptext200">@invoice.OrderId</a>
-                                        }
-                                        else
-                                        {
-                                    <span>@invoice.OrderId</span>
-                                        }
+                                    {
+                                        <a href="@invoice.RedirectUrl" class="wraptext200">@invoice.OrderId</a>
+                                    }
+                                    else
+                                    {
+                                        <span>@invoice.OrderId</span>
+                                    }
                                 </td>
                                 <td>@invoice.InvoiceId</td>
                                 <td>
-                                    @if(invoice.Details.Archived)
-                                        {
-                                    <span class="badge badge-warning">archived</span>
-                                        }
+                                    @if (invoice.Details.Archived)
+                                    {
+                                        <span class="badge badge-warning">archived</span>
+                                    }
                                     @if (invoice.CanMarkStatus)
-                                        {
-                                    <div id="pavpill_@invoice.InvoiceId">
-                                        <span class="dropdown-toggle dropdown-toggle-split pavpill pavpil-@invoice.Status.ToString().ToLower()"
-                                              data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                                            @invoice.StatusString
-                                        </span>
-                                        <div class="dropdown-menu pull-right">
-                                            @if (invoice.CanMarkInvalid)
-                                                    {
-                                            <button class="dropdown-item small cursorPointer" onclick="changeInvoiceState(this, '@invoice.InvoiceId', 'invalid')">
-                                                Mark as invalid <span class="fa fa-times"></span>
-                                            </button>
-                                                    }
-                                            @if (invoice.CanMarkComplete)
-                                                    {
-                                            <button class="dropdown-item small cursorPointer" onclick="changeInvoiceState(this, '@invoice.InvoiceId', 'complete')">
-                                                Mark as complete <span class="fa fa-check-circle"></span>
-                                            </button>
-                                                    }
+                                    {
+                                        <div id="pavpill_@invoice.InvoiceId">
+                                            <span class="dropdown-toggle dropdown-toggle-split pavpill pavpil-@invoice.Status.ToString().ToLower()"
+                                                  data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                                                @invoice.StatusString
+                                            </span>
+                                            <div class="dropdown-menu pull-right">
+                                                @if (invoice.CanMarkInvalid)
+                                                {
+                                                    <button class="dropdown-item small cursorPointer" onclick="changeInvoiceState(this, '@invoice.InvoiceId', 'invalid')">
+                                                        Mark as invalid <span class="fa fa-times"></span>
+                                                    </button>
+                                                }
+                                                @if (invoice.CanMarkComplete)
+                                                {
+                                                    <button class="dropdown-item small cursorPointer" onclick="changeInvoiceState(this, '@invoice.InvoiceId', 'complete')">
+                                                        Mark as complete <span class="fa fa-check-circle"></span>
+                                                    </button>
+                                                }
+                                            </div>
                                         </div>
-                                    </div>
-                                        }
-                                        else
-                                        {
-                                    <span class="pavpill pavpil-@invoice.Status.ToString().ToLower()">@invoice.StatusString</span>
-                                        }
+                                    }
+                                    else
+                                    {
+                                        <span class="pavpill pavpil-@invoice.Status.ToString().ToLower()">@invoice.StatusString</span>
+                                    }
                                 </td>
                                 <td style="text-align:right">@invoice.AmountCurrency</td>
                                 <td style="text-align:right">
                                     @if (invoice.ShowCheckout)
-                                        {
-                                    <span>
-                                        <a asp-action="Checkout" class="invoice-checkout-link" id="invoice-checkout-@invoice.InvoiceId" asp-route-invoiceId="@invoice.InvoiceId">Checkout</a>
-                                        <a href="javascript:btcpay.showInvoice('@invoice.InvoiceId')">[^]</a>
-                                        @if (!invoice.CanMarkStatus)
-                                                {
-                                        <span>-</span>
-                                                }
-                                    </span>
-                                        }
+                                    {
+                                        <span>
+                                            <a asp-action="Checkout" class="invoice-checkout-link" id="invoice-checkout-@invoice.InvoiceId" asp-route-invoiceId="@invoice.InvoiceId">Checkout</a>
+                                            <a href="javascript:btcpay.showInvoice('@invoice.InvoiceId')">[^]</a>
+                                            @if (!invoice.CanMarkStatus)
+                                            {
+                                                <span>-</span>
+                                            }
+                                        </span>
+                                    }
                                     &nbsp;
                                     <a asp-action="Invoice" class="invoice-details-link" asp-route-invoiceId="@invoice.InvoiceId">Details</a>
                                     <a href="javascript:void(0);" onclick="detailsToggle(this, '@invoice.InvoiceId')">
@@ -306,17 +317,20 @@
                                 <td colspan="99" class="border-top-0">
                                     <div style="margin-left: 15px; margin-bottom: 0;">
                                         @* Leaving this as partial because it abstracts complexity of Invoice Payments *@
-                                        <partial name="ListInvoicesPaymentsPartial" model="(invoice.Details, true)" />
+                                        <partial name="ListInvoicesPaymentsPartial" model="(invoice.Details, true)"/>
                                     </div>
                                 </td>
                             </tr>
-                            }
-                        </tbody>
-                    </table>
-                    <vc:pager view-model="Model"></vc:pager>
-                </div>
-            </div>
-        </form>
+                        }
+                    </tbody>
+                </table>
+                <vc:pager view-model="Model"></vc:pager>
+            </form>
+        }
+        else
+        {
+            <p class="text-secondary mt-3">There are no invoices, yet.</p>
+        }
     </div>
     <script type="text/javascript">
         $(function () {

--- a/BTCPayServer/Views/Invoice/ListInvoices.cshtml
+++ b/BTCPayServer/Views/Invoice/ListInvoices.cshtml
@@ -3,7 +3,6 @@
 @{
     ViewData["Title"] = "Invoices";
     var storeIds = string.Join("", Model.StoreIds.Select(storeId => $",storeid:{storeId}"));
-    var displayList = Model.Total > 0;
 }
 @section HeadScripts {
     <script src="~/modal/btcpay.js" asp-append-version="true"></script>
@@ -182,7 +181,7 @@
             </div>
         </div>
 
-        @if (displayList)
+        @if (Model.Total > 0)
         {
             <form method="post" id="MassAction" asp-action="MassAction" class="mt-3">
                 <span class="mr-2">

--- a/BTCPayServer/Views/Invoice/ListInvoices.cshtml
+++ b/BTCPayServer/Views/Invoice/ListInvoices.cshtml
@@ -265,29 +265,15 @@
                             </td>
                             <td>@invoice.InvoiceId</td>
                             <td>
-                                @{
-                                    var grouped = invoice.Details.Payments.GroupBy(payment => payment.GetPaymentMethodId()?.PaymentType).Where(entities => entities.Key!= null);
-                                    var paiOnChain = grouped.Where(g => g.Key == BitcoinPaymentType.Instance).Any();
-                                    var paidOffChain = grouped.Where(g => g.Key == LightningPaymentType.Instance).Any();
-                                }
                                 @if (invoice.Details.Archived)
                                 {
                                     <span class="badge badge-warning">archived</span>
                                 }
                                 @if (invoice.CanMarkStatus)
                                 {
-                                    <div id="pavpill_@invoice.InvoiceId">
-                                        <span class="dropdown-toggle dropdown-toggle-split pavpill pavpil-@invoice.Status.ToString().ToLower()"
-                                              data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                                            @invoice.StatusString
-                                            @if (paiOnChain)
-                                            {
-                                                <span class="pavpill-symbol">🔗</span>
-                                            }
-                                            @if (paidOffChain)
-                                            {
-                                                <span class="pavpill-symbol">⚡️</span>
-                                            }
+                                    <div id="pavpill_@invoice.InvoiceId" class="badge badge-@invoice.Status.ToString().ToLower()">
+                                        <span class="dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                                            @invoice.Status.ToString().ToLower()
                                         </span>
                                         <div class="dropdown-menu pull-right">
                                             @if (invoice.CanMarkInvalid)
@@ -307,18 +293,22 @@
                                 }
                                 else
                                 {
-                                    <span class="pavpill pavpil-@invoice.Status.ToString().ToLower()">
-                                        @invoice.Status.ToString()
-
-                                        @if (paiOnChain)
-                                        {
-                                            <span class="pavpill-symbol">🔗</span>
-                                        }
-                                        @if (paidOffChain)
-                                        {
-                                            <span class="pavpill-symbol">⚡️</span>
-                                        }
+                                    <span class="badge badge-@invoice.Status.ToString().ToLower()">
+                                        @invoice.Status.ToString().ToLower()
                                     </span>
+                                }
+                                @{
+                                    var grouped = invoice.Details.Payments.GroupBy(payment => payment.GetPaymentMethodId()?.PaymentType).Where(entities => entities.Key!= null);
+                                    var paiOnChain = grouped.Where(g => g.Key == BitcoinPaymentType.Instance).Any();
+                                    var paidOffChain = grouped.Where(g => g.Key == LightningPaymentType.Instance).Any();
+                                }
+                                @if (paiOnChain)
+                                {
+                                    <span class="badge">🔗</span>
+                                }
+                                @if (paidOffChain)
+                                {
+                                    <span class="badge">⚡️</span>
                                 }
                             </td>
                             <td style="text-align:right">@invoice.AmountCurrency</td>
@@ -402,8 +392,8 @@
 
             $.post("invoices/" + invoiceId + "/changestate/" + newState)
                 .done(function (data) {
-                    var statusHtml = "<span class='pavpill pavpil-" + newState + "'>" + data.statusString + " <span class='fa fa-check'></span></span>";
-                    pavpill.html(statusHtml);
+                    var statusHtml = "<span class='badge badge-" + newState + "'>" + data.statusString + " <span class='fa fa-check'></span></span>";
+                    pavpill.replaceWith(statusHtml);
                 })
                 .fail(function (data) {
                     pavpill.html(originalHtml.replace("dropdown-menu pull-right show", "dropdown-menu pull-right"));
@@ -441,42 +431,37 @@
             border-radius: 0.25rem;
         }
 
-        .pavpill .pavpill-symbol {
-            display: inline-block;
-            width: .9rem;
-            height: .9rem;
-        }
-
-        .pavpill.dropdown-toggle {
+        .badge .dropdown-toggle {
             cursor: pointer;
+            padding: 0;
         }
 
         .dropdown-item {
             cursor: pointer;
         }
 
-        .pavpil-new {
+        .badge-new {
             background: #d4edda;
             color: #000;
         }
 
-        .pavpil-expired {
+        .badge-expired {
             background: #eee;
             color: #000;
         }
 
-        .pavpil-invalid {
+        .badge-invalid {
             background: #c94a47;
             color: #fff;
         }
 
-        .pavpil-confirmed,
-        .pavpil-paid {
+        .badge-confirmed,
+        .badge-paid {
             background: #f1c332;
             color: #000;
         }
 
-        .pavpil-complete {
+        .badge-complete {
             background: #329f80;
             color: #fff;
         }

--- a/BTCPayServer/Views/PaymentRequest/GetPaymentRequests.cshtml
+++ b/BTCPayServer/Views/PaymentRequest/GetPaymentRequests.cshtml
@@ -3,6 +3,9 @@
 @{
     Layout = "_Layout";
     ViewData["Title"] = "Payment Requests";
+    var displayList = Model.Total > 0;
+    var isFiltered = Model.Total > 0 || Model.SearchTerm.Length > 0;
+    var displaySearch = displayList || isFiltered;
 }
 <section>
     <div class="container">
@@ -35,7 +38,7 @@
                 </a>
             </div>
 
-            @if (Model.Total > 0)
+            @if (displaySearch)
             {
                 <div class="col-12 col-md-8 col-lg-6 mb-3">
                     <form asp-action="GetPaymentRequests" method="get">
@@ -66,7 +69,7 @@
 
         <div class="row">
             <div class="col-lg-12">
-                @if (Model.Total > 0)
+                @if (displayList)
                 {
                     <table class="table table-sm table-responsive-md">
                         <thead>
@@ -104,14 +107,17 @@
                         </tbody>
                     </table>
 
-                    @if (Model.Total > Model.Count)
+                    @if (displayList)
                     {
                         <vc:pager view-model="Model"></vc:pager>
                     }
                 }
                 else
                 {
-                    <p class="text-secondary mt-3">There are no payment requests, yet.</p>
+                    <p class="text-secondary mt-3">
+                        There are no payment requests
+                        @(isFiltered ? "matching your criteria" : ", yet").
+                    </p>
                 }
             </div>
         </div>

--- a/BTCPayServer/Views/PaymentRequest/GetPaymentRequests.cshtml
+++ b/BTCPayServer/Views/PaymentRequest/GetPaymentRequests.cshtml
@@ -18,80 +18,101 @@
             <div class="col-lg-12 section-heading">
                 <h2>Payment Requests</h2>
                 <hr class="primary">
-                <p>Create, search or pay an payment request.</p>
+                <p>
+                    Create, search or pay a payment request.
+                    <a href="https://docs.btcpayserver.org/PaymentRequests/" class="ml-1" target="_blank">
+                        <span class="fa fa-question-circle-o text-secondary" title="More information..."></span>
+                    </a>
+                </p>
             </div>
         </div>
 
-        <form asp-action="GetPaymentRequests" method="get" class="pull-right">
-            <input type="hidden" asp-for="Count" />
-            <div class="input-group">
-                <input asp-for="TimezoneOffset" type="hidden" />
-                <input asp-for="SearchTerm" class="form-control" style="width:300px;" />
-                <div class="input-group-append">
-                    <button type="submit" class="btn btn-primary" title="Search invoice">
-                        <span class="fa fa-search"></span> Search
-                    </button>
-                    <button type="button" class="btn btn-primary dropdown-toggle dropdown-toggle-split" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                        <span class="sr-only">Toggle Dropdown</span>
-                    </button>
-
-                    <div class="dropdown-menu dropdown-menu-right">
-                        <a class="dropdown-item" href="/payment-requests?Count=@Model.Count&SearchTerm=includearchived%3Atrue">Include Archived Payment Reqs</a>
-                        <div role="separator" class="dropdown-divider"></div>
-                        <a class="dropdown-item" href="/payment-requests?SearchTerm=">Unfiltered</a>
-                    </div>
-                </div>
-            </div>
-            <span asp-validation-for="SearchTerm" class="text-danger"></span>
-        </form>
-
-        <div class="row button-row">
-            <div class="col-lg-12 pl-0">
-                <a asp-action="EditPaymentRequest" class="btn btn-primary" role="button" id="CreatePaymentRequest"><span class="fa fa-plus"></span> Create a new payment request</a>
-                <a href="https://docs.btcpayserver.org/PaymentRequests/" target="_blank">
-                    <span class="fa fa-question-circle-o" title="More information..."></span>
+        <div class="row">
+            <div class="col-12 col-md-4 col-lg-6 mb-3">
+                <a asp-action="EditPaymentRequest" class="btn btn-primary" role="button" id="CreatePaymentRequest">
+                    <span class="fa fa-plus"></span>
+                    Create a payment request
                 </a>
             </div>
+
+            @if (Model.Total > 0)
+            {
+                <div class="col-12 col-md-8 col-lg-6 mb-3">
+                    <form asp-action="GetPaymentRequests" method="get">
+                        <input type="hidden" asp-for="Count"/>
+                        <input type="hidden" asp-for="TimezoneOffset" />
+                        <div class="input-group">
+                            <input asp-for="SearchTerm" class="form-control" style="width:300px;"/>
+                            <div class="input-group-append">
+                                <button type="submit" class="btn btn-secondary" title="Search invoice">
+                                    <span class="fa fa-search"></span> Search
+                                </button>
+                                <button type="button" class="btn btn-secondary dropdown-toggle dropdown-toggle-split" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                                    <span class="sr-only">Toggle Dropdown</span>
+                                </button>
+
+                                <div class="dropdown-menu dropdown-menu-right">
+                                    <a class="dropdown-item" href="/payment-requests?Count=@Model.Count&SearchTerm=includearchived%3Atrue">Include Archived Payment Reqs</a>
+                                    <div role="separator" class="dropdown-divider"></div>
+                                    <a class="dropdown-item" href="/payment-requests?SearchTerm=">Unfiltered</a>
+                                </div>
+                            </div>
+                        </div>
+                        <span asp-validation-for="SearchTerm" class="text-danger"></span>
+                    </form>
+                </div>
+            }
         </div>
+
         <div class="row">
             <div class="col-lg-12">
-                <table class="table table-sm table-responsive-md">
-                    <thead>
-                        <tr>
-                            <th>Title</th>
-                            <th>Expiry</th>
-                            <th class="text-right">Price</th>
-                            <th class="text-right">Status</th>
-                            <th class="text-right">Actions</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        @foreach (var item in Model.Items)
-                        {
+                @if (Model.Total > 0)
+                {
+                    <table class="table table-sm table-responsive-md">
+                        <thead>
                             <tr>
-                                <td>@item.Title</td>
-                                <td>@(item.ExpiryDate?.ToString("g") ?? "No Expiry")</td>
-                                <td class="text-right">@item.Amount @item.Currency</td>
-                                <td class="text-right">@item.Status</td>
-                                <td class="text-right">
-                                    <a asp-action="EditPaymentRequest" asp-route-id="@item.Id">Edit</a>
-                                    <span> - </span>
-                                    <a asp-action="ViewPaymentRequest" asp-route-id="@item.Id">View</a>
-                                    <span> - </span>
-                                    <a target="_blank" asp-action="ListInvoices" asp-controller="Invoice" asp-route-searchterm="@($"orderid:{PaymentRequestRepository.GetOrderIdForPaymentRequest(item.Id)}")">Invoices</a>
-                                    <span> - </span>
-                                    <a target="_blank" asp-action="PayPaymentRequest" asp-route-id="@item.Id">Pay</a>
-                                    <span> - </span>
-                                    <a target="_blank" asp-action="ClonePaymentRequest" asp-route-id="@item.Id">Clone</a>
-                                    <span> - </span>
-                                    <a asp-action="TogglePaymentRequestArchival" asp-route-id="@item.Id">@(item.Archived ? "Unarchive" : "Archive")</a>
-                                </td>
+                                <th>Title</th>
+                                <th>Expiry</th>
+                                <th class="text-right">Price</th>
+                                <th class="text-right">Status</th>
+                                <th class="text-right">Actions</th>
                             </tr>
-                        }
-                    </tbody>
-                </table>
+                        </thead>
+                        <tbody>
+                            @foreach (var item in Model.Items)
+                            {
+                                <tr>
+                                    <td>@item.Title</td>
+                                    <td>@(item.ExpiryDate?.ToString("g") ?? "No Expiry")</td>
+                                    <td class="text-right">@item.Amount @item.Currency</td>
+                                    <td class="text-right">@item.Status</td>
+                                    <td class="text-right">
+                                        <a asp-action="EditPaymentRequest" asp-route-id="@item.Id">Edit</a>
+                                        <span> - </span>
+                                        <a asp-action="ViewPaymentRequest" asp-route-id="@item.Id">View</a>
+                                        <span> - </span>
+                                        <a target="_blank" asp-action="ListInvoices" asp-controller="Invoice" asp-route-searchterm="@($"orderid:{PaymentRequestRepository.GetOrderIdForPaymentRequest(item.Id)}")">Invoices</a>
+                                        <span> - </span>
+                                        <a target="_blank" asp-action="PayPaymentRequest" asp-route-id="@item.Id">Pay</a>
+                                        <span> - </span>
+                                        <a target="_blank" asp-action="ClonePaymentRequest" asp-route-id="@item.Id">Clone</a>
+                                        <span> - </span>
+                                        <a asp-action="TogglePaymentRequestArchival" asp-route-id="@item.Id">@(item.Archived ? "Unarchive" : "Archive")</a>
+                                    </td>
+                                </tr>
+                            }
+                        </tbody>
+                    </table>
 
-                <vc:pager view-model="Model"></vc:pager>
+                    @if (Model.Total > Model.Count)
+                    {
+                        <vc:pager view-model="Model"></vc:pager>
+                    }
+                }
+                else
+                {
+                    <p class="text-secondary mt-3">There are no payment requests, yet.</p>
+                }
             </div>
         </div>
     </div>

--- a/BTCPayServer/Views/PaymentRequest/GetPaymentRequests.cshtml
+++ b/BTCPayServer/Views/PaymentRequest/GetPaymentRequests.cshtml
@@ -3,7 +3,6 @@
 @{
     Layout = "_Layout";
     ViewData["Title"] = "Payment Requests";
-    var displayList = Model.Total > 0;
 }
 <section>
     <div class="container">
@@ -63,7 +62,7 @@
 
         <div class="row">
             <div class="col-lg-12">
-                @if (displayList)
+                @if (Model.Total > 0)
                 {
                     <table class="table table-sm table-responsive-md">
                         <thead>

--- a/BTCPayServer/Views/PaymentRequest/GetPaymentRequests.cshtml
+++ b/BTCPayServer/Views/PaymentRequest/GetPaymentRequests.cshtml
@@ -4,8 +4,6 @@
     Layout = "_Layout";
     ViewData["Title"] = "Payment Requests";
     var displayList = Model.Total > 0;
-    var isFiltered = Model.Total > 0 || Model.SearchTerm.Length > 0;
-    var displaySearch = displayList || isFiltered;
 }
 <section>
     <div class="container">
@@ -37,34 +35,30 @@
                     Create a payment request
                 </a>
             </div>
+            <div class="col-12 col-md-8 col-lg-6 mb-3">
+                <form asp-action="GetPaymentRequests" method="get">
+                    <input type="hidden" asp-for="Count"/>
+                    <input type="hidden" asp-for="TimezoneOffset" />
+                    <div class="input-group">
+                        <input asp-for="SearchTerm" class="form-control" style="width:300px;"/>
+                        <div class="input-group-append">
+                            <button type="submit" class="btn btn-secondary" title="Search invoice">
+                                <span class="fa fa-search"></span> Search
+                            </button>
+                            <button type="button" class="btn btn-secondary dropdown-toggle dropdown-toggle-split" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                                <span class="sr-only">Toggle Dropdown</span>
+                            </button>
 
-            @if (displaySearch)
-            {
-                <div class="col-12 col-md-8 col-lg-6 mb-3">
-                    <form asp-action="GetPaymentRequests" method="get">
-                        <input type="hidden" asp-for="Count"/>
-                        <input type="hidden" asp-for="TimezoneOffset" />
-                        <div class="input-group">
-                            <input asp-for="SearchTerm" class="form-control" style="width:300px;"/>
-                            <div class="input-group-append">
-                                <button type="submit" class="btn btn-secondary" title="Search invoice">
-                                    <span class="fa fa-search"></span> Search
-                                </button>
-                                <button type="button" class="btn btn-secondary dropdown-toggle dropdown-toggle-split" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                                    <span class="sr-only">Toggle Dropdown</span>
-                                </button>
-
-                                <div class="dropdown-menu dropdown-menu-right">
-                                    <a class="dropdown-item" href="/payment-requests?Count=@Model.Count&SearchTerm=includearchived%3Atrue">Include Archived Payment Reqs</a>
-                                    <div role="separator" class="dropdown-divider"></div>
-                                    <a class="dropdown-item" href="/payment-requests?SearchTerm=">Unfiltered</a>
-                                </div>
+                            <div class="dropdown-menu dropdown-menu-right">
+                                <a class="dropdown-item" href="/payment-requests?Count=@Model.Count&SearchTerm=includearchived%3Atrue">Include Archived Payment Reqs</a>
+                                <div role="separator" class="dropdown-divider"></div>
+                                <a class="dropdown-item" href="/payment-requests?SearchTerm=">Unfiltered</a>
                             </div>
                         </div>
-                        <span asp-validation-for="SearchTerm" class="text-danger"></span>
-                    </form>
-                </div>
-            }
+                    </div>
+                    <span asp-validation-for="SearchTerm" class="text-danger"></span>
+                </form>
+            </div>
         </div>
 
         <div class="row">
@@ -107,16 +101,12 @@
                         </tbody>
                     </table>
 
-                    @if (displayList)
-                    {
-                        <vc:pager view-model="Model"></vc:pager>
-                    }
+                    <vc:pager view-model="Model"></vc:pager>
                 }
                 else
                 {
                     <p class="text-secondary mt-3">
-                        There are no payment requests
-                        @(isFiltered ? "matching your criteria" : ", yet").
+                        There are no payment requests matching your criteria.
                     </p>
                 }
             </div>

--- a/BTCPayServer/wwwroot/main/site.css
+++ b/BTCPayServer/wwwroot/main/site.css
@@ -76,6 +76,11 @@ ul li {
     opacity: .5;
 }
 
+.dropdown-toggle-split,
+.dropdown-toggle-split:hover {
+    border-left: 1px solid var(--btcpay-color-white);
+}
+
 /* Admin Sidebar Navigation */
 a.nav-link {
     color: var(--btcpay-nav-color-link, var(--btcpay-color-neutral-600));


### PR DESCRIPTION
Sparked by [@Eskyee 's remarks](https://chat.btcpayserver.org/btcpayserver/pl/g3eqikm4r7ghmb7hm1bdxkpgoa) I took a look at the Invoices list and I'd like to propose the following changes.

Same would apply to the payment requests as well, which I'd also update if we decide all of this makes sense.

## Before

![before-lg](https://user-images.githubusercontent.com/886/89411626-06bcff80-d726-11ea-923f-632d4e852fcc.png)

![before-sm](https://user-images.githubusercontent.com/886/89411628-07ee2c80-d726-11ea-97f5-651f1a6174e7.png)

## After

As you can see there are some general layout cleanups and rearrangements.

Beyond that, these changes have been made:

- Separate the mass actions from the create button and make them secondary
- Prepend search help/filtering info to search field
- Make search button secondary

![after-lg](https://user-images.githubusercontent.com/886/89412004-a37f9d00-d726-11ea-9a0e-a3c55da3f38c.png)

With the help text expanded:

![after-lg-help](https://user-images.githubusercontent.com/886/89412015-a67a8d80-d726-11ea-923e-56430c52b835.png)

Mobile view:

![after-sm](https://user-images.githubusercontent.com/886/89412033-ad090500-d726-11ea-9655-857bad53cb15.png)

### Empty state

Let's also clean up the empty state, as the search, actions and table display make no sense if there are no items.

![no-invoices](https://user-images.githubusercontent.com/886/89411766-3ec44280-d726-11ea-9646-212f764a80ad.png)
