### PR TITLE
Pull payments claim & payout notification rewording

### DIFF
--- a/BTCPayServer/Controllers/PullPaymentController.cs
+++ b/BTCPayServer/Controllers/PullPaymentController.cs
@@ -133,7 +133,7 @@ namespace BTCPayServer.Controllers
             {
                 TempData.SetStatusMessageModel(new StatusMessageModel()
                 {
-                    Message = $"You posted a claim of {_currencyNameTable.DisplayFormatCurrency(vm.ClaimedAmount, ppBlob.Currency)} to {vm.Destination}, this will get fullfilled later.",
+                    Message = $"Your claim request of {_currencyNameTable.DisplayFormatCurrency(vm.ClaimedAmount, ppBlob.Currency)} to {vm.Destination} has been submitted and is awaiting approval.",
                     Severity = StatusMessageModel.StatusSeverity.Success
                 });
             }

--- a/BTCPayServer/Services/Notifications/Blobs/PayoutNotification.cs
+++ b/BTCPayServer/Services/Notifications/Blobs/PayoutNotification.cs
@@ -20,7 +20,7 @@ namespace BTCPayServer.Services.Notifications.Blobs
             public override string NotificationType => "payout";
             protected override void FillViewModel(PayoutNotification notification, NotificationViewModel vm)
             {
-                vm.Body = "A new payout is awaiting for payment";
+                vm.Body = "A new payout is awaiting for approval";
                 vm.ActionLink = _linkGenerator.GetPathByAction(nameof(WalletsController.Payouts),
                     "Wallets",
                     new { walletId = new WalletId(notification.StoreId, notification.PaymentMethod) }, _options.RootPath);


### PR DESCRIPTION
3dbb8a0 Consists of a little rewording of the _claim-success-message_ that make it clear that it needs approval from the OP of the PullPayment.
Closes #1824 

ea9836a Changes the term `payment` to `approval` in the _payout-notification_, as to make it clear that it needs approval from the server admin receiving the notification.
Relates to https://github.com/btcpayserver/btcpayserver/issues/1824#issuecomment-670632759 .

