### PR TITLE
UI: Improve mobile login views

### DIFF
--- a/BTCPayServer/Views/Account/Login.cshtml
+++ b/BTCPayServer/Views/Account/Login.cshtml
@@ -29,7 +29,7 @@
                 @if (env.OnionUrl != null)
                 {
                     <div class="text-center">
-                        <a href="@env.OnionUrl" target="_onion" class="btn btn-sm btn-outline-onion d-inline-flex align-items-center p-2" data-clipboard="@env.OnionUrl">
+                        <a href="@env.OnionUrl" target="_onion" class="btn btn-sm btn-outline-onion d-inline-flex align-items-center text-nowrap p-2" data-clipboard="@env.OnionUrl">
                             <img src="~/img/icons/onion-purple.svg" height="20" class="mr-2" asp-append-version="true" />
                             Copy Tor URL
                         </a>

--- a/BTCPayServer/Views/Account/Register.cshtml
+++ b/BTCPayServer/Views/Account/Register.cshtml
@@ -33,7 +33,7 @@
                 @if (env.OnionUrl != null)
                 {
                     <div class="text-center">
-                        <a href="@env.OnionUrl" target="_onion" class="btn btn-sm btn-outline-onion d-inline-flex align-items-center p-2" data-clipboard="@env.OnionUrl">
+                        <a href="@env.OnionUrl" target="_onion" class="btn btn-sm btn-outline-onion d-inline-flex align-items-center text-nowrap p-2" data-clipboard="@env.OnionUrl">
                             <img src="~/img/icons/onion-purple.svg" height="20" class="mr-2" asp-append-version="true" />
                             Copy Tor URL
                         </a>

--- a/BTCPayServer/Views/Shared/_BTCPaySupporters.cshtml
+++ b/BTCPayServer/Views/Shared/_BTCPaySupporters.cshtml
@@ -2,37 +2,37 @@
     Our Supporters
 </h5>
 <div class="row justify-content-center mb-2">
-    <div class="p-3 text-center">
+    <div class="p-3 text-center" style="flex-basis:105px;">
         <a href="https://kraken.com" target="_blank" class="text-muted small">
             <img src="~/img/kraken.svg" alt="Sponsor Kraken" height="50" asp-append-version="true"/>
             <span class="d-block mt-3">Kraken</span>
         </a>
     </div>
-    <div class="p-3 text-center">
+    <div class="p-3 text-center" style="flex-basis:105px;">
         <a href="https://twitter.com/sqcrypto" target="_blank" class="text-muted small">
             <img src="~/img/squarecrypto.svg" alt="Sponsor Square Crypto" height="50" asp-append-version="true"/>
             <span class="d-block mt-3">Square Crypto</span>
         </a>
     </div>
-    <div class="p-3 text-center">
+    <div class="p-3 text-center" style="flex-basis:105px;">
         <a href="https://www.btse.com" target="_blank" class="text-muted small">
             <img src="~/img/btse.svg" alt="Sponsor BTSE" height="50" asp-append-version="true"/>
             <span class="d-block mt-3">BTSE</span>
         </a>
     </div>
-    <div class="p-3 text-center">
+    <div class="p-3 text-center" style="flex-basis:105px;">
         <a href="https://www.dglab.com/en/" target="_blank" class="text-muted small">
             <img src="~/img/dglab.svg" alt="Sponsor DG lab" height="50" asp-append-version="true"/>
             <span class="d-block mt-3">DG Lab</span>
         </a>
     </div>
-    <div class="p-3 text-center">
+    <div class="p-3 text-center" style="flex-basis:105px;">
         <a href="https://www.okcoin.com/" target="_blank" class="text-muted small">
             <img src="~/img/okcoin.svg" alt="Sponsor OKCoin" height="50" asp-append-version="true"/>
             <span class="d-block mt-3">OKCoin</span>
         </a>
     </div>
-    <div class="p-3 text-center">
+    <div class="p-3 text-center" style="flex-basis:105px;">
         <a href="https://acinq.co/" target="_blank" class="text-muted small">
             <img src="~/img/acinq-logo.svg" alt="Sponsor ACINQ" height="50" asp-append-version="true"/>
             <span class="d-block mt-3">ACINQ</span>


### PR DESCRIPTION
Some improvements that make the login/register pages look nicer on mobile screens:

- The "Copy Tor URL" text got wrapped, which is now fixed
- The supporters weren't spaced and aligned correctly

## Before
![before](https://user-images.githubusercontent.com/886/89761392-92e87180-daee-11ea-8c92-4abf11e6e1f7.png)

## After
![after](https://user-images.githubusercontent.com/886/89761393-94b23500-daee-11ea-8e06-3df9b278d132.png)