### PR TITLE
Docker: Add Lightning channel setup/teardown scripts

### DIFF
--- a/BTCPayServer.Tests/README.md
+++ b/BTCPayServer.Tests/README.md
@@ -52,6 +52,9 @@ If you get this message:
 
 Please, run the test `CanSetLightningServer`, this will establish a channel between the customer and the merchant, then, retry.
 
+Alternatively you can run the `./docker-lightning-channel-setup.sh` script to establish the channel connection.
+The `./docker-lightning-channel-teardown.sh` script closes any existing lightning channels.
+
 ## FAQ
 
 `docker-compose up dev` failed or tests are not passing, what should I do?

--- a/BTCPayServer.Tests/docker-lightning-channel-setup.sh
+++ b/BTCPayServer.Tests/docker-lightning-channel-setup.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+
+# Commands
+BCMD=./docker-bitcoin-cli.sh
+GCMD=./docker-bitcoin-generate.sh
+CCMD=./docker-customer-lightning-cli.sh
+MCMD=./docker-merchant-lightning-cli.sh
+
+function channel_count () {
+  local cmd=$1; local id=$2;
+  local count=$($cmd listchannels | jq -r ".channels | map(select(.destination == \"$id\")) | length | tonumber") 2>/dev/null
+  return $count
+}
+
+function create_channel () {
+  local cmd=$1; local id=$2;
+  local btcaddr=$($cmd newaddr | jq -r '.address')
+  $BCMD sendtoaddress $btcaddr 0.15 >/dev/null
+  $GCMD 10 >/dev/null
+  local fundres=$($cmd fundchannel $id 14500000 5000 | jq -r '.channel_id')
+  $GCMD 20 >/dev/null
+  sleep 2
+  channel_count $cmd $id
+  local count=$?
+  return $count
+}
+
+# General information
+cinfo=$($CCMD getinfo | jq '.' 2>/dev/null)
+minfo=$($MCMD getinfo | jq '.' 2>/dev/null)
+cid=$(echo $cinfo | jq -r '.id')
+mid=$(echo $minfo | jq -r '.id')
+caddr=$(echo $cinfo | jq -r '.address[] | "\(.address):\(.port)"')
+maddr=$(echo $minfo | jq -r '.address[] | "\(.address):\(.port)"')
+
+printf "Customer ID: %s@%s\n\r" $cid $caddr
+printf "Merchant ID: %s@%s\n\r" $mid $maddr
+
+# Connections
+printf "\n\rConnecting both parties …\n\r"
+
+cconnid=$($CCMD connect "$mid@$maddr" | jq -r '.id' 2>/dev/null)
+mconnid=$($MCMD connect "$cid@$caddr" | jq -r '.id' 2>/dev/null)
+
+printf "Customer to merchant %s\n\r" $([[ $cconnid == $mid ]] && echo "succeeded" || echo "failed")
+printf "Merchant to customer %s\n\r" $([[ $mconnid == $cid ]] && echo "succeeded" || echo "failed")
+
+# Channels
+printf "\n\rChecking channels …\n\r"
+channel_count $CCMD $mid
+cchanscount=$?
+channel_count $MCMD $cid
+mchanscount=$?
+
+printf "Customer channel count to merchant: %d\n\r" $cchanscount
+printf "Merchant channel count to customer: %d\n\r" $mchanscount
+
+# Open channels if there are none, details: https://github.com/ElementsProject/lightning#opening-a-channel
+if [[ $cchanscount -eq 0 ]]; then
+  create_channel $CCMD $mid
+  cchanres=$?
+  printf "Establishing channel from customer to merchant %s\n\r" $([[ $cchanres -gt 0 ]] && echo "succeeded" || echo "failed")
+fi
+
+if [[ $mchanscount -eq 0 ]]; then
+  create_channel $MCMD $cid
+  mchanres=$?
+  printf "Establishing channel from merchant to customer %s\n\r" $([[ $mchanres -gt 0 ]] && echo "succeeded" || echo "failed")
+fi

--- a/BTCPayServer.Tests/docker-lightning-channel-teardown.sh
+++ b/BTCPayServer.Tests/docker-lightning-channel-teardown.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -e
+
+channels=$(./docker-merchant-lightning-cli.sh listchannels | jq -cr '.channels | map(.short_channel_id) | unique')
+printf "Channels: %s\n\r" $channels
+
+for chanid in $(echo "${channels}" | jq -cr '.[]')
+do
+    printf "Closing channel ID: %s\n\r" $chanid
+    ./docker-merchant-lightning-cli.sh close $chanid
+    ./docker-bitcoin-generate.sh 20 > /dev/null
+done


### PR DESCRIPTION
An alternative for establishing the customer-merchant channel connection.

## Setup: First run

No channels yet -> Setup the connection

```bash
BTCPayServer.Tests ➜ ./docker-lightning-channel-setup.sh
Customer ID: 02544752c76e766b494966d8c8eda4638573c86ea06f6c55609cd405828fde8494@172.20.0.8:9735
Merchant ID: 026d4f0c04e5ebb535820dc76f5ef901af29cb282e59091c941df58fd2c8306dd5@172.20.0.6:9735

Connecting both parties …
Customer to merchant succeeded
Merchant to customer succeeded

Checking channels …
Customer channel count to merchant: 0
Merchant channel count to customer: 0
Establishing channel from customer to merchant succeeded
Establishing channel from merchant to customer succeeded
```

## Setup: Second run 

Channels exist -> Skip setup

```bash
BTCPayServer.Tests ➜ ./docker-lightning-channel-setup.sh
Customer ID: 02544752c76e766b494966d8c8eda4638573c86ea06f6c55609cd405828fde8494@172.20.0.8:9735
Merchant ID: 026d4f0c04e5ebb535820dc76f5ef901af29cb282e59091c941df58fd2c8306dd5@172.20.0.6:9735

Connecting both parties …
Customer to merchant succeeded
Merchant to customer succeeded

Checking channels …
Customer channel count to merchant: 1
Merchant channel count to customer: 1
```

## Teardown 

Remove existing channels -> Cleanup

```bash
BTCPayServer.Tests ➜ ./docker-lightning-channel-teardown.sh
Channels: ["5438x1x1"]
Closing channel ID: 5438x1x1
{
   "tx": "02000000018c43f9d97316f5ec82c752e13969b37545ba52f49daaceb74777718ce83a86c40100000000ffffffff01dc3edd0000000000160014aedd4c1d6cff17a321a9fcb68543e4b3caf0e09200000000",
   "txid": "b8a6e1cd964e7826ff32a42b62b7ec909ee05cb5fd204941c52d5a3725f8b7e0",
   "type": "mutual"
}
```