### PR TITLE
add config yaml to issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yaml
+++ b/.github/ISSUE_TEMPLATE/config.yaml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Community Support Chat 
+    url: https://chat.btcpayserver.org/
+    about: Ask general questions and get community support in real-time.


### PR DESCRIPTION
This PR shows what will be done after #1893
After #1893 is merged in Repository settings we need to set up issue templates again, there's no other way that it'll work with config.yaml for some weird reason.
This PR:

- adds support chat link
- disable blank issues

![Capture](https://user-images.githubusercontent.com/36959754/89892348-cd2d3e00-dbd6-11ea-91c5-24d9777c4d2b.PNG)
