### PR TITLE
Update AddDerivationSchemes_HardwareWalletDialogs.cshtml

### DIFF
--- a/BTCPayServer/Views/Stores/AddDerivationSchemes_HardwareWalletDialogs.cshtml
+++ b/BTCPayServer/Views/Stores/AddDerivationSchemes_HardwareWalletDialogs.cshtml
@@ -39,7 +39,7 @@
                         </tr>
                         <tr>
                             <td>Electrum</td>
-                            <td><kbd>File ❯ Save Copy</kbd></td>
+                            <td><kbd>File ❯ Save backup</kbd></td>
                         </tr>
                         <tr>
                             <td>Wasabi</td>


### PR DESCRIPTION
Minor change for Electrum where menu choice is `Save backup`, not `Save Copy`