### PR TITLE
UI: Primary color checkmark

### DIFF
--- a/BTCPayServer/wwwroot/checkout/css/default.css
+++ b/BTCPayServer/wwwroot/checkout/css/default.css
@@ -9308,7 +9308,7 @@ strong {
 }
 
 .status-icon--error .status-icon__wrapper__outline {
-    border-color: #E5465A;
+    border-color: #51b13e;
 }
 
 .status-icon--error .status-icon__wrapper__icon {
@@ -9335,7 +9335,7 @@ strong {
     border-radius: 50%;
     height: 154px;
     width: 154px;
-    border: 2px solid #13E5B6;
+    border: 5px solid #51b13e;
 }
 
 .status-icon__wrapper__icon {

--- a/BTCPayServer/wwwroot/checkout/css/themes/legacy.css
+++ b/BTCPayServer/wwwroot/checkout/css/themes/legacy.css
@@ -9307,7 +9307,7 @@ strong {
 }
 
 .status-icon--error .status-icon__wrapper__outline {
-    border-color: #E5465A;
+    border-color: #51b13e;
 }
 
 .status-icon--error .status-icon__wrapper__icon {
@@ -9334,7 +9334,7 @@ strong {
     border-radius: 50%;
     height: 154px;
     width: 154px;
-    border: 2px solid #13E5B6;
+    border: 5px solid #51b13e;
 }
 
 .status-icon__wrapper__icon {

--- a/BTCPayServer/wwwroot/imlegacy/checkmark.svg
+++ b/BTCPayServer/wwwroot/imlegacy/checkmark.svg
@@ -1,11 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg width="64px" height="49px" viewBox="0 0 64 49" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-    <!-- Generator: Sketch 3.7 (28169) - http://www.bohemiancoding.com/sketch -->
-    <title>Shape</title>
-    <desc>Created with Sketch.</desc>
-    <defs></defs>
     <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
-        <g id="Overpaid-(Email-receipt-sent)" transform="translate(-385.000000, -270.000000)" stroke="#F5F5F7" stroke-width="4" fill="#12E5B6">
+        <g id="Overpaid-(Email-receipt-sent)" transform="translate(-385.000000, -270.000000)" stroke="transparent" stroke-width="1" fill="#51b13e">
             <g id="Invoice" transform="translate(236.000000, 86.000000)">
                 <g id="ios-checkmark-outline" transform="translate(118.000000, 150.000000)">
                     <path d="M86.5963111,36.9873548 L52.1800773,71.6517825 L39.1636812,58.6353864 L34.2549556,63.5441121 L49.6981374,78.9872939 C50.3875651,79.6767216 51.3251869,80.2282638 52.1525002,80.2282638 C52.9798135,80.2282638 53.8898582,79.6767216 54.5792859,79.014871 L91.4498825,41.9512346 L86.5963111,36.9873548 L86.5963111,36.9873548 Z" id="Shape"></path>

--- a/BTCPayServer/wwwroot/imlegacy/circle-check.svg
+++ b/BTCPayServer/wwwroot/imlegacy/circle-check.svg
@@ -1,14 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg width="21px" height="21px" viewBox="0 0 21 21" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-    <!-- Generator: Sketch 3.7 (28169) - http://www.bohemiancoding.com/sketch -->
-    <title>check</title>
-    <desc>Created with Sketch.</desc>
-    <defs></defs>
     <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
         <g id="Overpaid-(Email-receipt-sent)" transform="translate(-384.000000, -628.000000)">
             <g id="Group-2" transform="translate(384.000000, 628.000000)">
                 <g id="check">
-                    <path d="M10.5,21 C16.2989899,21 21,16.2989899 21,10.5 C21,4.70101013 16.2989899,0 10.5,0 C4.70101013,0 0,4.70101013 0,10.5 C0,16.2989899 4.70101013,21 10.5,21 Z" id="Oval-1" fill="#12E5B6"></path>
+                    <path d="M10.5,21 C16.2989899,21 21,16.2989899 21,10.5 C21,4.70101013 16.2989899,0 10.5,0 C4.70101013,0 0,4.70101013 0,10.5 C0,16.2989899 4.70101013,21 10.5,21 Z" id="Oval-1" fill="#51b13e"></path>
                     <path d="M15.5429276,6.63875598 L9.3656549,12.8605763 L7.02937868,10.5243001 L6.14832536,11.4053534 L8.92017851,14.1772066 C9.04392195,14.30095 9.21221303,14.3999448 9.36070517,14.3999448 C9.5091973,14.3999448 9.67253865,14.30095 9.79628209,14.1821563 L16.4140815,7.52970878 L15.5429276,6.63875598 L15.5429276,6.63875598 Z" id="Shape" fill="#FFFFFF"></path>
                 </g>
             </g>


### PR DESCRIPTION
Just came across this and was wondering why the checkmark doesn't use the primary/success color.
Feel free to just close this if this has been discussed beefore …

## Before

![before](https://user-images.githubusercontent.com/886/91571949-c593c600-e946-11ea-9b58-619545444577.png)

## After

![light](https://user-images.githubusercontent.com/886/91572007-ca587a00-e946-11ea-96ec-aaf65102f9ea.png)

![dark](https://user-images.githubusercontent.com/886/91572046-cc223d80-e946-11ea-95e0-4af594783555.png)
