### PR TITLE
Invoice notification email improvements

### DIFF
--- a/BTCPayServer/HostedServices/InvoiceNotificationManager.cs
+++ b/BTCPayServer/HostedServices/InvoiceNotificationManager.cs
@@ -61,7 +61,7 @@ namespace BTCPayServer.HostedServices
             _StoreRepository = storeRepository;
         }
 
-        async void Notify(InvoiceEntity invoice, InvoiceEvent invoiceEvent, bool extendedNotification)
+        async Task Notify(InvoiceEntity invoice, InvoiceEvent invoiceEvent, bool extendedNotification)
         {
             var dto = invoice.EntityToDTO();
             var notification = new InvoicePaymentNotificationEventWrapper()

--- a/BTCPayServer/HostedServices/InvoiceNotificationManager.cs
+++ b/BTCPayServer/HostedServices/InvoiceNotificationManager.cs
@@ -13,6 +13,7 @@ using BTCPayServer.Payments;
 using BTCPayServer.Services;
 using BTCPayServer.Services.Invoices;
 using BTCPayServer.Services.Mails;
+using BTCPayServer.Services.Stores;
 using Microsoft.Extensions.Hosting;
 using NBitpayClient;
 using NBXplorer;
@@ -42,13 +43,14 @@ namespace BTCPayServer.HostedServices
         readonly EventAggregator _EventAggregator;
         readonly InvoiceRepository _InvoiceRepository;
         private readonly EmailSenderFactory _EmailSenderFactory;
+        private readonly StoreRepository _StoreRepository;
 
         public InvoiceNotificationManager(
             IHttpClientFactory httpClientFactory,
             IBackgroundJobClient jobClient,
             EventAggregator eventAggregator,
             InvoiceRepository invoiceRepository,
-            BTCPayNetworkProvider networkProvider,
+            StoreRepository storeRepository,
             EmailSenderFactory emailSenderFactory)
         {
             _Client = httpClientFactory.CreateClient();
@@ -56,9 +58,10 @@ namespace BTCPayServer.HostedServices
             _EventAggregator = eventAggregator;
             _InvoiceRepository = invoiceRepository;
             _EmailSenderFactory = emailSenderFactory;
+            _StoreRepository = storeRepository;
         }
 
-        void Notify(InvoiceEntity invoice, InvoiceEvent invoiceEvent, bool extendedNotification)
+        async void Notify(InvoiceEntity invoice, InvoiceEvent invoiceEvent, bool extendedNotification)
         {
             var dto = invoice.EntityToDTO();
             var notification = new InvoicePaymentNotificationEventWrapper()
@@ -120,11 +123,18 @@ namespace BTCPayServer.HostedServices
 
             if (invoiceEvent.Name != InvoiceEvent.Expired && !String.IsNullOrEmpty(invoice.NotificationEmail))
             {
-                var emailBody = NBitcoin.JsonConverters.Serializer.ToString(notification);
+                var json = NBitcoin.JsonConverters.Serializer.ToString(notification);
+                var store = await _StoreRepository.FindStore(invoice.StoreId);
+                var storeName = store.StoreName ?? "BTCPay Server";
+                var emailBody = $"Store: {storeName}<br>" +
+                                $"Invoice ID: {notification.Data.Id}<br>" +
+                                $"Status: {notification.Data.Status}<br>" +
+                                $"Amount: {notification.Data.Price} {notification.Data.Currency}<br>" +
+                                $"<br><details><summary>Details</summary><pre>{json}</pre></details>";
 
                 _EmailSenderFactory.GetEmailSender(invoice.StoreId).SendEmail(
                     invoice.NotificationEmail,
-                    $"BtcPayServer Invoice Notification - ${invoice.StoreId}",
+                    $"{storeName} Invoice Notification - ${invoice.StoreId}",
                     emailBody);
             }
 

--- a/BTCPayServer/HostedServices/InvoiceNotificationManager.cs
+++ b/BTCPayServer/HostedServices/InvoiceNotificationManager.cs
@@ -118,7 +118,7 @@ namespace BTCPayServer.HostedServices
 #pragma warning restore CS0618
             }
 
-            if (!String.IsNullOrEmpty(invoice.NotificationEmail))
+            if (invoiceEvent.Name != InvoiceEvent.Expired && !String.IsNullOrEmpty(invoice.NotificationEmail))
             {
                 var emailBody = NBitcoin.JsonConverters.Serializer.ToString(notification);
 
@@ -126,7 +126,6 @@ namespace BTCPayServer.HostedServices
                     invoice.NotificationEmail,
                     $"BtcPayServer Invoice Notification - ${invoice.StoreId}",
                     emailBody);
-
             }
 
             if (invoice.NotificationURL != null)


### PR DESCRIPTION
I find the invoice notification emails hard to grasp, because it's just an unformatted blob of JSON.

Here the most important information is displayed at the top, plus the option to toggle the full details JSON, which is now also formatted.
Also added the store name, so that one knows which store the invoice belongs to.

Notice: I've also deactivated email notifications for expired invoices. Maybe this needs to stay the way it was?

## Before

![before](https://user-images.githubusercontent.com/886/91590440-b66b4300-e95b-11ea-8eba-c3fc7c49f374.png)

## After

![after](https://user-images.githubusercontent.com/886/91590511-d569d500-e95b-11ea-9c17-84b6a54972d3.png)
