### PR TITLE
Update LND to 0.11.0-beta

### DIFF
--- a/BTCPayServer.Tests/docker-compose.altcoins.yml
+++ b/BTCPayServer.Tests/docker-compose.altcoins.yml
@@ -265,7 +265,7 @@ services:
       - "5432"
 
   merchant_lnd:
-    image: btcpayserver/lnd:v0.10.2-beta
+    image: btcpayserver/lnd:v0.11.0-beta
     restart: unless-stopped
     environment:
       LND_CHAIN: "btc"
@@ -295,7 +295,7 @@ services:
       - bitcoind
 
   customer_lnd:
-    image: btcpayserver/lnd:v0.10.2-beta
+    image: btcpayserver/lnd:v0.11.0-beta
     restart: unless-stopped
     environment:
       LND_CHAIN: "btc"

--- a/BTCPayServer.Tests/docker-compose.yml
+++ b/BTCPayServer.Tests/docker-compose.yml
@@ -207,7 +207,7 @@ services:
       - "5432"
 
   merchant_lnd:
-    image: btcpayserver/lnd:v0.10.2-beta
+    image: btcpayserver/lnd:v0.11.0-beta
     restart: unless-stopped
     environment:
       LND_CHAIN: "btc"
@@ -237,7 +237,7 @@ services:
       - bitcoind
 
   customer_lnd:
-    image: btcpayserver/lnd:v0.10.2-beta
+    image: btcpayserver/lnd:v0.11.0-beta
     restart: unless-stopped
     environment:
       LND_CHAIN: "btc"


### PR DESCRIPTION
If it works well for you locally, I'll open PR to update `btcpayserver-docker`

I've already updated [BTCPayServer.Lightning](https://github.com/btcpayserver/BTCPayServer.Lightning/runs/1047083744) and everything runs well.