### PR TITLE
Add "allow insecure" check

### DIFF
--- a/BTCPayServer/Controllers/StoresController.LightningLike.cs
+++ b/BTCPayServer/Controllers/StoresController.LightningLike.cs
@@ -93,7 +93,7 @@ namespace BTCPayServer.Controllers
 
                 if (connectionString.BaseUri.Scheme == "http")
                 {
-                    if (!isInternalNode)
+                    if (!isInternalNode && !connectionString.AllowInsecure)
                     {
                         ModelState.AddModelError(nameof(vm.ConnectionString), "The url must be HTTPS");
                         return View(vm);


### PR DESCRIPTION
Check if "allow insecure" is set for ligthning node connection string before throwing error for http connection.

fix #1880