### PR TITLE
Users API: Add roles

### DIFF
--- a/BTCPayServer.Client/Models/ApplicationUserData.cs
+++ b/BTCPayServer.Client/Models/ApplicationUserData.cs
@@ -21,5 +21,10 @@ namespace BTCPayServer.Client.Models
         /// whether the user needed to verify their email on account creation
         /// </summary>
         public bool RequiresEmailConfirmation { get; set; }
+
+        /// <summary>
+        /// the roles of the user
+        /// </summary>
+        public string[] Roles { get; set; }
     }
 }

--- a/BTCPayServer.Tests/GreenfieldAPITests.cs
+++ b/BTCPayServer.Tests/GreenfieldAPITests.cs
@@ -148,10 +148,13 @@ namespace BTCPayServer.Tests
                 // We have no admin, so it should work
                 var user1 = await unauthClient.CreateUser(
                     new CreateApplicationUserRequest() { Email = "test@gmail.com", Password = "abceudhqw" });
+                Assert.Empty(user1.Roles);
+                
                 // We have no admin, so it should work
                 var user2 = await unauthClient.CreateUser(
                     new CreateApplicationUserRequest() { Email = "test2@gmail.com", Password = "abceudhqw" });
-
+                Assert.Empty(user2.Roles);
+                
                 // Duplicate email
                 await AssertValidationError(new[] { "Email" },
                     async () => await unauthClient.CreateUser(
@@ -164,7 +167,8 @@ namespace BTCPayServer.Tests
                     Password = "abceudhqw",
                     IsAdministrator = true
                 });
-
+                Assert.Contains("ServerAdmin", admin.Roles);
+                
                 // Creating a new user without proper creds is now impossible (unauthorized) 
                 // Because if registration are locked and that an admin exists, we don't accept unauthenticated connection
                 await AssertHttpError(401,
@@ -560,6 +564,7 @@ namespace BTCPayServer.Tests
                 Assert.NotNull(apiKeyProfileUserData);
                 Assert.Equal(apiKeyProfileUserData.Id, user.UserId);
                 Assert.Equal(apiKeyProfileUserData.Email, user.RegisterDetails.Email);
+                Assert.Contains("ServerAdmin", apiKeyProfileUserData.Roles);
 
                 await Assert.ThrowsAsync<HttpRequestException>(async () => await clientInsufficient.GetCurrentUser());
                 await clientServer.GetCurrentUser();

--- a/BTCPayServer/Controllers/GreenField/UsersController.cs
+++ b/BTCPayServer/Controllers/GreenField/UsersController.cs
@@ -152,7 +152,7 @@ namespace BTCPayServer.Controllers.GreenField
                 }
             }
             _eventAggregator.Publish(new UserRegisteredEvent() { RequestUri = Request.GetAbsoluteRootUri(), User = user, Admin = request.IsAdministrator is true });
-            return CreatedAtAction(string.Empty, user);
+            return CreatedAtAction(string.Empty, FromModel(user));
         }
 
         private static ApplicationUserData FromModel(ApplicationUser data)

--- a/BTCPayServer/Controllers/GreenField/UsersController.cs
+++ b/BTCPayServer/Controllers/GreenField/UsersController.cs
@@ -58,7 +58,7 @@ namespace BTCPayServer.Controllers.GreenField
         public async Task<ActionResult<ApplicationUserData>> GetCurrentUser()
         {
             var user = await _userManager.GetUserAsync(User);
-            return FromModel(user);
+            return await FromModel(user);
         }
 
         [AllowAnonymous]
@@ -152,17 +152,20 @@ namespace BTCPayServer.Controllers.GreenField
                 }
             }
             _eventAggregator.Publish(new UserRegisteredEvent() { RequestUri = Request.GetAbsoluteRootUri(), User = user, Admin = request.IsAdministrator is true });
-            return CreatedAtAction(string.Empty, FromModel(user));
+            var model = await FromModel(user);
+            return CreatedAtAction(string.Empty, model);
         }
 
-        private static ApplicationUserData FromModel(ApplicationUser data)
+        private async Task<ApplicationUserData> FromModel(ApplicationUser data)
         {
+            var roles = (await _userManager.GetRolesAsync(data)).ToArray();
             return new ApplicationUserData()
             {
                 Id = data.Id,
                 Email = data.Email,
                 EmailConfirmed = data.EmailConfirmed,
-                RequiresEmailConfirmation = data.RequiresEmailConfirmation
+                RequiresEmailConfirmation = data.RequiresEmailConfirmation,
+                Roles = roles
             };
         }
     }

--- a/BTCPayServer/wwwroot/swagger/v1/swagger.template.users.json
+++ b/BTCPayServer/wwwroot/swagger/v1/swagger.template.users.json
@@ -117,12 +117,12 @@
                 "properties": {
                     "id": {
                         "type": "string",
-                        "description": "The id of the new user",
+                        "description": "The id of the user",
                         "nullable": false
                     },
                     "email": {
                         "type": "string",
-                        "description": "The email of the new user",
+                        "description": "The email of the user",
                         "nullable": false
                     },
                     "emailConfirmed": {
@@ -132,6 +132,14 @@
                     "requiresEmailConfirmation": {
                         "type": "boolean",
                         "description": "True if the email requires email confirmation to log in"
+                    },
+                    "roles": {
+                        "type": "array",
+                        "nullable": false,
+                        "items": {
+                            "type": "string"
+                        },
+                        "description": "The roles of the user"
                     }
                 }
             }


### PR DESCRIPTION
Adds the `roles` property to the `ApplicationUserData` return type. Example:

```json
{
    "id": "5ac3191d-326b-49e2-80bf-083eb175e2c9",
    "email": "mail@dennisreimann.de",
    "emailConfirmed": false,
    "requiresEmailConfirmation": false,
    "roles": [
        "ServerAdmin"
    ]
}
```

`roles` is an empty array for users that are no admins. ("ServerAdmin" is the only role there is currently)