### PR TITLE
Showing CheckForNewVersions checkbox only if BTCPAY_UPDATEURL is set

### DIFF
--- a/BTCPayServer/Controllers/ServerController.cs
+++ b/BTCPayServer/Controllers/ServerController.cs
@@ -254,6 +254,7 @@ namespace BTCPayServer.Controllers
         {
             var data = (await _SettingsRepository.GetSettingAsync<PoliciesSettings>()) ?? new PoliciesSettings();
             ViewBag.AppsList = await GetAppSelectList();
+            ViewBag.UpdateUrlPresent = _Options.UpdateUrl != null;
             return View(data);
         }
 

--- a/BTCPayServer/Views/Server/Policies.cshtml
+++ b/BTCPayServer/Views/Server/Policies.cshtml
@@ -1,4 +1,4 @@
-﻿@model BTCPayServer.Services.PoliciesSettings
+@model BTCPayServer.Services.PoliciesSettings
 @{
     ViewData.SetActivePageAndTitle(ServerNavPages.Policies);
 }
@@ -42,11 +42,14 @@
             <label asp-for="AllowHotWalletRPCImportForAll" class="form-check-label"></label>
             <span asp-validation-for="AllowHotWalletRPCImportForAll" class="text-danger"></span>
         </div>
+        @if (ViewBag.UpdateUrlPresent)
+        {
         <div class="form-check">
             <input asp-for="CheckForNewVersions" type="checkbox" class="form-check-input" />
             <label asp-for="CheckForNewVersions" class="form-check-label"></label>
             <span asp-validation-for="CheckForNewVersions" class="text-danger"></span>
         </div>
+        }
     </div>
     <div class="form-group">
         <label asp-for="RootAppId"></label>


### PR DESCRIPTION
Should be more intuitive this way - you first need to set `BTCPAY_UPDATEURL` env variable, and checkbox will only then show.

On new installations where `BTCPAY_UPDATEURL` is present when first admin registers `CheckForNewVersions` will be set to true. Otherwise if `BTCPAY_UPDATEURL` is added later - it'll be false.

Reference: https://github.com/btcpayserver/btcpayserver-doc/pull/737