### PR TITLE
Mark Shopify orders paid on invoice payment confirmed

### DIFF
--- a/BTCPayServer/Services/Shopify/ShopifyOrderMarkerHostedService.cs
+++ b/BTCPayServer/Services/Shopify/ShopifyOrderMarkerHostedService.cs
@@ -41,7 +41,7 @@ namespace BTCPayServer.Services.Shopify
         {
             if (evt is InvoiceEvent invoiceEvent && !new[]
             {
-                InvoiceEvent.Created, InvoiceEvent.Confirmed, InvoiceEvent.ExpiredPaidPartial,
+                InvoiceEvent.Created, InvoiceEvent.ExpiredPaidPartial,
                 InvoiceEvent.ReceivedPayment, InvoiceEvent.PaidInFull
             }.Contains(invoiceEvent.Name))
             {


### PR DESCRIPTION
Small fix, right now only `InvoiceStatus.Complete` will trigger Shopify order marking as paid... 

This gives those who enable integration faster marking of order paid and ability to configure it through confirmation setting in store.