### PR TITLE
Fixing returned version string, trimming leading v

### DIFF
--- a/BTCPayServer/HostedServices/NewVersionCheckerHostedService.cs
+++ b/BTCPayServer/HostedServices/NewVersionCheckerHostedService.cs
@@ -106,7 +106,14 @@ namespace BTCPayServer.HostedServices
                     var tag = jobj["tag_name"].ToString();
 
                     var isReleaseVersionTag = _releaseVersionTag.IsMatch(tag);
-                    return isReleaseVersionTag ? tag : null;
+                    if (isReleaseVersionTag)
+                    {
+                        return tag.TrimStart('v');
+                    }
+                    else
+                    {
+                        return null;
+                    }
                 }
                 else
                 {


### PR DESCRIPTION
The version string fetched from GitHub (example `v1.0.5.6`) was not stripped of leading `v`. PR fixes this.