### PR TITLE
Fix sync modal styles

### DIFF
--- a/BTCPayServer/Views/Shared/LayoutPartials/SyncModal.cshtml
+++ b/BTCPayServer/Views/Shared/LayoutPartials/SyncModal.cshtml
@@ -7,7 +7,7 @@
         <div class="modal-content">
             <a class="modal-header btn-link border-0 text-decoration-none cursor-pointer align-items-center" data-toggle="collapse" data-target="#syncModalContent">
                 <h4 class="modal-title">Your nodes are synching...</h4>
-                <span class="fa fa-chevron-down" style="font-size:1em;"></span>
+                <span class="fa fa-chevron-down"></span>
             </a>
             <div id="syncModalContent" class="collapse show">
                 <div class="modal-body pt-0">
@@ -40,7 +40,7 @@
     <style type="text/css">
         #syncModal {
             position: fixed;
-            bottom: 10px;
+            bottom: 40px;
             right: 10px;
             margin: 0;
             z-index: 1000;
@@ -52,6 +52,8 @@
             overflow-y: scroll;
         }
         #syncModal .fa-chevron-down {
+            font-size: 1em;
+            text-decoration: none;
             transition: transform .35s;
         }
         #syncModal .collapsed .fa-chevron-down {


### PR DESCRIPTION
Do not overlap the footer. Also removed the underline for the toggle button in chrome. 
Fixes #1941.

![collapsed](https://user-images.githubusercontent.com/886/95168154-2c5f9700-07b1-11eb-9f37-4998ac0f5ad2.png)

![expanded](https://user-images.githubusercontent.com/886/95168156-2d90c400-07b1-11eb-8cdd-3a5e16f00b7d.png)
