### PR TITLE
Fix LN invoices

### DIFF
--- a/BTCPayServer/Controllers/InvoiceController.UI.cs
+++ b/BTCPayServer/Controllers/InvoiceController.UI.cs
@@ -324,6 +324,16 @@ namespace BTCPayServer.Controllers
                 cryptoPayment.Address = paymentMethodDetails.GetPaymentDestination();
                 cryptoPayment.Rate = ExchangeRate(data);
                 model.CryptoPayments.Add(cryptoPayment);
+                if (paymentMethodDetails is LightningLikePaymentMethodDetails likePaymentMethodDetails &&
+                    likePaymentMethodDetails.PreviousDestinations?.Any() is true)
+                {
+                    model.CryptoPayments.AddRange(likePaymentMethodDetails.PreviousDestinations.Select(s => new InvoiceDetailsModel.CryptoPayment()
+                    {
+                        Address = s,
+                        PaymentMethodId =  paymentMethodId,
+                        PaymentMethod = $"{paymentMethodId.ToPrettyString()} (old)"
+                    }));
+                }
             }
             return model;
         }

--- a/BTCPayServer/Controllers/InvoiceController.UI.cs
+++ b/BTCPayServer/Controllers/InvoiceController.UI.cs
@@ -300,42 +300,35 @@ namespace BTCPayServer.Controllers
             return RedirectToAction(nameof(PullPaymentController.ViewPullPayment),
                 "PullPayment",
                 new { pullPaymentId = ppId });
-
-
         }
 
         private InvoiceDetailsModel InvoicePopulatePayments(InvoiceEntity invoice)
         {
-            var model = new InvoiceDetailsModel();
-            model.Archived = invoice.Archived;
-            model.Payments = invoice.GetPayments();
-            foreach (var data in invoice.GetPaymentMethods())
+            return new InvoiceDetailsModel
             {
-                var accounting = data.Calculate();
-                var paymentMethodId = data.GetId();
-                var cryptoPayment = new InvoiceDetailsModel.CryptoPayment();
-
-                cryptoPayment.PaymentMethodId = paymentMethodId;
-                cryptoPayment.PaymentMethod = paymentMethodId.ToPrettyString();
-                cryptoPayment.Due = _CurrencyNameTable.DisplayFormatCurrency(accounting.Due.ToDecimal(MoneyUnit.BTC), paymentMethodId.CryptoCode);
-                cryptoPayment.Paid = _CurrencyNameTable.DisplayFormatCurrency(accounting.CryptoPaid.ToDecimal(MoneyUnit.BTC), paymentMethodId.CryptoCode);
-                cryptoPayment.Overpaid = _CurrencyNameTable.DisplayFormatCurrency(accounting.OverpaidHelper.ToDecimal(MoneyUnit.BTC), paymentMethodId.CryptoCode);
-                var paymentMethodDetails = data.GetPaymentMethodDetails();
-                cryptoPayment.Address = paymentMethodDetails.GetPaymentDestination();
-                cryptoPayment.Rate = ExchangeRate(data);
-                model.CryptoPayments.Add(cryptoPayment);
-                if (paymentMethodDetails is LightningLikePaymentMethodDetails likePaymentMethodDetails &&
-                    likePaymentMethodDetails.PreviousDestinations?.Any() is true)
-                {
-                    model.CryptoPayments.AddRange(likePaymentMethodDetails.PreviousDestinations.Select(s => new InvoiceDetailsModel.CryptoPayment()
+                Archived = invoice.Archived,
+                Payments = invoice.GetPayments(),
+                CryptoPayments = invoice.GetPaymentMethods().Select(
+                    data =>
                     {
-                        Address = s,
-                        PaymentMethodId =  paymentMethodId,
-                        PaymentMethod = $"{paymentMethodId.ToPrettyString()} (old)"
-                    }));
-                }
-            }
-            return model;
+                        var accounting = data.Calculate();
+                        var paymentMethodId = data.GetId();
+                        return new InvoiceDetailsModel.CryptoPayment
+                        {
+                            PaymentMethodId = paymentMethodId,
+                            PaymentMethod = paymentMethodId.ToPrettyString(),
+                            Due = _CurrencyNameTable.DisplayFormatCurrency(accounting.Due.ToDecimal(MoneyUnit.BTC),
+                                paymentMethodId.CryptoCode),
+                            Paid = _CurrencyNameTable.DisplayFormatCurrency(
+                                accounting.CryptoPaid.ToDecimal(MoneyUnit.BTC),
+                                paymentMethodId.CryptoCode),
+                            Overpaid = _CurrencyNameTable.DisplayFormatCurrency(
+                                accounting.OverpaidHelper.ToDecimal(MoneyUnit.BTC), paymentMethodId.CryptoCode),
+                            Address = data.GetPaymentMethodDetails().GetPaymentDestination(),
+                            Rate = ExchangeRate(data)
+                        };
+                    }).ToList()
+            };
         }
 
         [HttpPost("invoices/{invoiceId}/archive")]

--- a/BTCPayServer/Payments/Lightning/LightningLikePaymentMethodDetails.cs
+++ b/BTCPayServer/Payments/Lightning/LightningLikePaymentMethodDetails.cs
@@ -2,6 +2,7 @@ namespace BTCPayServer.Payments.Lightning
 {
     public class LightningLikePaymentMethodDetails : IPaymentMethodDetails
     {
+        public string[] PreviousDestinations { get; set; } = System.Array.Empty<string>();
         public string BOLT11 { get; set; }
         public string InvoiceId { get; set; }
         public string NodeInfo { get; set; }
@@ -24,11 +25,6 @@ namespace BTCPayServer.Payments.Lightning
         public decimal GetFeeRate()
         {
             return 0.0m;
-        }
-
-        public void SetPaymentDetails(IPaymentMethodDetails newPaymentMethodDetails)
-        {
-            BOLT11 = newPaymentMethodDetails.GetPaymentDestination();
         }
     }
 }

--- a/BTCPayServer/Payments/Lightning/LightningLikePaymentMethodDetails.cs
+++ b/BTCPayServer/Payments/Lightning/LightningLikePaymentMethodDetails.cs
@@ -2,7 +2,6 @@ namespace BTCPayServer.Payments.Lightning
 {
     public class LightningLikePaymentMethodDetails : IPaymentMethodDetails
     {
-        public string[] PreviousDestinations { get; set; } = System.Array.Empty<string>();
         public string BOLT11 { get; set; }
         public string InvoiceId { get; set; }
         public string NodeInfo { get; set; }

--- a/BTCPayServer/Payments/Lightning/LightningListener.cs
+++ b/BTCPayServer/Payments/Lightning/LightningListener.cs
@@ -204,12 +204,6 @@ namespace BTCPayServer.Payments.Lightning
                             (LightningLikePaymentMethodDetails)(await _lightningLikePaymentHandler
                                 .CreatePaymentMethodDetails(logs, supportedMethod, paymentMethod, store,
                                     paymentMethod.Network, prepObj));
-                        if (paymentMethod.GetPaymentMethodDetails() is LightningLikePaymentMethodDetails
-                            oldPaymentMethodDetails)
-                        {
-                            newPaymentMethodDetails.PreviousDestinations = oldPaymentMethodDetails.PreviousDestinations
-                                .Concat(new[] {oldPaymentMethodDetails.GetPaymentDestination()}).ToArray();
-                        }
 
                         var instanceListenerKey = (paymentMethod.Network.CryptoCode,
                             supportedMethod.GetLightningUrl().ToString());

--- a/BTCPayServer/Services/Invoices/InvoiceRepository.cs
+++ b/BTCPayServer/Services/Invoices/InvoiceRepository.cs
@@ -327,15 +327,14 @@ retry:
             PaymentMethodId paymentMethodId)
         {
             var paymentMethodIdStr = paymentMethodId?.ToString();
-            context.HistoricalAddressInvoices.Where(data =>
-                    data.InvoiceDataId == invoiceId && paymentMethodIdStr == null ||
-                    data.CryptoCode == paymentMethodIdStr &&
-                    data.UnAssigned == null)
-                .ForEachAsync(
-                    data =>
-                    {
-                        data.UnAssigned = DateTimeOffset.UtcNow;
-                    });
+            var addresses = context.HistoricalAddressInvoices.Where(data =>
+                (data.InvoiceDataId == invoiceId && paymentMethodIdStr == null ||
+                 data.CryptoCode == paymentMethodIdStr) &&
+                data.UnAssigned == null);
+            foreach (var historicalAddressInvoiceData in addresses)
+            {
+                historicalAddressInvoiceData.UnAssigned = DateTimeOffset.UtcNow;   
+            }
         }
 
         public async Task UnaffectAddress(string invoiceId)

--- a/BTCPayServer/Views/Invoice/Invoice.cshtml
+++ b/BTCPayServer/Views/Invoice/Invoice.cshtml
@@ -205,8 +205,7 @@
             </div>
         }
 
-        <partial name="ListInvoicesPaymentsPartial" model="(Model, false)" />
-
+        <partial name="ListInvoicesPaymentsPartial" model="(Model, true)" />
 
         <div class="row">
             <div class="col-md-12">


### PR DESCRIPTION
This commit adds more to the previous LN fix in the case of a partial payment to an invoice. While it generated a new LN invoice after 1 partial payment was made, there were some new issues uncovered:
* Any other subsequent partial payments was not listened to  and did not generate an invoice ( fixed by listeneing to received payment event and makng sure that the status was already set `to partialPaid`)
* Any other subsequent partial payments caused a DbConcurrency error and did not generate an invoice ( Fixed in `MarkUnassigned`)
* ~The UI did not show previous BOLT11 invoices that were generated (a user may have paid them) (fixed by storing all previous bolt11 in the payment method details and displaying in the invoice details)~