### PR TITLE
Decouple payment type icon from UI

### DIFF
--- a/BTCPayServer/Payments/PaymentTypes.Bitcoin.cs
+++ b/BTCPayServer/Payments/PaymentTypes.Bitcoin.cs
@@ -19,10 +19,8 @@ namespace BTCPayServer.Payments
 
         public override string ToPrettyString() => "On-Chain";
         public override string GetId() => "BTCLike";
-        public override string ToStringNormalized()
-        {
-            return "OnChain";
-        }
+        public override string ToStringNormalized() => "OnChain";
+        public override string GetBadge() =>  "🔗";
 
         public override CryptoPaymentData DeserializePaymentData(BTCPayNetworkBase network, string str)
         {

--- a/BTCPayServer/Payments/PaymentTypes.Lightning.cs
+++ b/BTCPayServer/Payments/PaymentTypes.Lightning.cs
@@ -17,6 +17,8 @@ namespace BTCPayServer.Payments
 
         public override string ToPrettyString() => "Off-Chain";
         public override string GetId() => "LightningLike";
+        public override string GetBadge() =>  "⚡";
+
         public override string ToStringNormalized()
         {
             return "LightningNetwork";

--- a/BTCPayServer/Payments/PaymentTypes.cs
+++ b/BTCPayServer/Payments/PaymentTypes.cs
@@ -82,6 +82,7 @@ namespace BTCPayServer.Payments
         }
 
         public abstract string GetId();
+        public virtual string GetBadge() => null;
         public abstract CryptoPaymentData DeserializePaymentData(BTCPayNetworkBase network, string str);
         public abstract string SerializePaymentData(BTCPayNetworkBase network, CryptoPaymentData paymentData);
         public abstract IPaymentMethodDetails DeserializePaymentMethodDetails(BTCPayNetworkBase network, string str);

--- a/BTCPayServer/Views/Invoice/ListInvoices.cshtml
+++ b/BTCPayServer/Views/Invoice/ListInvoices.cshtml
@@ -291,18 +291,9 @@
                                         @invoice.Status.ToString().ToLower()
                                     </span>
                                 }
-                                @{
-                                    var grouped = invoice.Details.Payments.GroupBy(payment => payment.GetPaymentMethodId()?.PaymentType).Where(entities => entities.Key!= null);
-                                    var paiOnChain = grouped.Where(g => g.Key == BitcoinPaymentType.Instance).Any();
-                                    var paidOffChain = grouped.Where(g => g.Key == LightningPaymentType.Instance).Any();
-                                }
-                                @if (paiOnChain)
+                                @foreach (var paymentType in  invoice.Details.Payments.Select(payment => payment.GetPaymentMethodId()?.PaymentType).Distinct().Where(type => type != null && !string.IsNullOrEmpty(type.GetBadge())))
                                 {
-                                    <span class="badge">🔗</span>
-                                }
-                                @if (paidOffChain)
-                                {
-                                    <span class="badge">⚡️</span>
+                                    <span class="badge">@paymentType.GetBadge()</span>
                                 }
                             </td>
                             <td style="text-align:right">@invoice.AmountCurrency</td>


### PR DESCRIPTION
We should put an effort to not couple payment methods/types together after spending so much time decoupling things.