### PR TITLE
Fix: 1 DOGE "absurdly high" fee was trapping DOGE.

### DIFF
--- a/BTCPayServer/Controllers/WalletsController.cs
+++ b/BTCPayServer/Controllers/WalletsController.cs
@@ -641,17 +641,6 @@ namespace BTCPayServer.Controllers
                     vm.AddModelError(model => model.FeeSatoshiPerByte,
                             "The fee rate should be above 0", this);
                 }
-                if (fee > 5_000m)
-                {
-                    vm.AddModelError(model => model.FeeSatoshiPerByte,
-                            "The fee rate is absurdly high", this);
-                }
-                if (_dashboard.Get(network.CryptoCode).Status?.BitcoinStatus?.MinRelayTxFee?.SatoshiPerByte is decimal minFee)
-                {
-                    if (vm.FeeSatoshiPerByte < minFee)
-                        vm.AddModelError(model => model.FeeSatoshiPerByte,
-                            $"The fee rate is lower than the minimum relay fee ({vm.FeeSatoshiPerByte} < {minFee})", this);
-                }
             }
 
             if (!ModelState.IsValid)


### PR DESCRIPTION
Removing wallet send model checks. For some shitcoin, those are problematics, and I don't think those checks are really useful anyway, since an absurdly high fee or low fee will be stopped during broadcast.

![image](https://user-images.githubusercontent.com/3020646/95428577-2c63c080-0984-11eb-9151-52d4c27d7641.png)
