### PR TITLE
Improve payment print styles

### DIFF
--- a/BTCPayServer/Controllers/PaymentRequestController.cs
+++ b/BTCPayServer/Controllers/PaymentRequestController.cs
@@ -235,7 +235,7 @@ namespace BTCPayServer.Controllers
 
             var statusesAllowedToDisplay = new List<InvoiceStatus>() { InvoiceStatus.New };
             var validInvoice = result.Invoices.FirstOrDefault(invoice =>
-                Enum.TryParse<InvoiceStatus>(invoice.Status, true, out var status) &&
+                Enum.TryParse<InvoiceStatus>(invoice.StatusFormatted, true, out var status) &&
                 statusesAllowedToDisplay.Contains(status));
 
             if (validInvoice != null)
@@ -297,7 +297,7 @@ namespace BTCPayServer.Controllers
             }
 
             var invoices = result.Invoices.Where(requestInvoice =>
-                requestInvoice.Status.Equals(InvoiceState.ToString(InvoiceStatus.New),
+                requestInvoice.StatusFormatted.Equals(InvoiceState.ToString(InvoiceStatus.New),
                     StringComparison.InvariantCulture) && !requestInvoice.Payments.Any());
 
             if (!invoices.Any())

--- a/BTCPayServer/Controllers/PaymentRequestController.cs
+++ b/BTCPayServer/Controllers/PaymentRequestController.cs
@@ -234,9 +234,7 @@ namespace BTCPayServer.Controllers
             }
 
             var statusesAllowedToDisplay = new List<InvoiceStatus>() { InvoiceStatus.New };
-            var validInvoice = result.Invoices.FirstOrDefault(invoice =>
-                Enum.TryParse<InvoiceStatus>(invoice.StatusFormatted, true, out var status) &&
-                statusesAllowedToDisplay.Contains(status));
+            var validInvoice = result.Invoices.FirstOrDefault(invoice => statusesAllowedToDisplay.Contains(invoice.Status));
 
             if (validInvoice != null)
             {

--- a/BTCPayServer/Models/PaymentRequestViewModels/ListPaymentRequestsViewModel.cs
+++ b/BTCPayServer/Models/PaymentRequestViewModels/ListPaymentRequestsViewModel.cs
@@ -1,7 +1,9 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
+using BTCPayServer.Client.Models;
 using BTCPayServer.Data;
+using BTCPayServer.Services.Invoices;
 using BTCPayServer.Services.Rates;
 using Microsoft.AspNetCore.Mvc.Rendering;
 using PaymentRequestData = BTCPayServer.Data.PaymentRequestData;
@@ -137,9 +139,14 @@ namespace BTCPayServer.Models.PaymentRequestViewModels
         {
             public string Id { get; set; }
             public DateTime ExpiryDate { get; set; }
+            public decimal Rate { get; set; }
             public decimal Amount { get; set; }
             public string AmountFormatted { get; set; }
-            public string Status { get; set; }
+            public decimal AmountPaid { get; set; }
+            public string AmountPaidFormatted { get; set; }
+            public InvoiceState State { get; set; }
+            public InvoiceStatus Status { get; set; }
+            public string StatusFormatted { get; set; }
 
             public List<PaymentRequestInvoicePayment> Payments { get; set; }
             public string Currency { get; set; }
@@ -149,6 +156,7 @@ namespace BTCPayServer.Models.PaymentRequestViewModels
         {
             public string PaymentMethod { get; set; }
             public decimal Amount { get; set; }
+            public string RateFormatted { get; set; }
             public string Link { get; set; }
             public string Id { get; set; }
         }

--- a/BTCPayServer/Models/PaymentRequestViewModels/ListPaymentRequestsViewModel.cs
+++ b/BTCPayServer/Models/PaymentRequestViewModels/ListPaymentRequestsViewModel.cs
@@ -156,6 +156,7 @@ namespace BTCPayServer.Models.PaymentRequestViewModels
             public string RateFormatted { get; set; }
             public decimal Paid { get; set; }
             public string PaidFormatted { get; set; }
+            public DateTime ReceivedDate { get; set; }
             public string Link { get; set; }
             public string Id { get; set; }
         }

--- a/BTCPayServer/Models/PaymentRequestViewModels/ListPaymentRequestsViewModel.cs
+++ b/BTCPayServer/Models/PaymentRequestViewModels/ListPaymentRequestsViewModel.cs
@@ -139,9 +139,9 @@ namespace BTCPayServer.Models.PaymentRequestViewModels
         {
             public string Id { get; set; }
             public DateTime ExpiryDate { get; set; }
-            public decimal Rate { get; set; }
             public decimal Amount { get; set; }
             public string AmountFormatted { get; set; }
+            public string RateFormatted { get; set; }
             public decimal AmountPaid { get; set; }
             public string AmountPaidFormatted { get; set; }
             public InvoiceState State { get; set; }
@@ -156,7 +156,6 @@ namespace BTCPayServer.Models.PaymentRequestViewModels
         {
             public string PaymentMethod { get; set; }
             public decimal Amount { get; set; }
-            public string RateFormatted { get; set; }
             public string Link { get; set; }
             public string Id { get; set; }
         }

--- a/BTCPayServer/Models/PaymentRequestViewModels/ListPaymentRequestsViewModel.cs
+++ b/BTCPayServer/Models/PaymentRequestViewModels/ListPaymentRequestsViewModel.cs
@@ -141,9 +141,6 @@ namespace BTCPayServer.Models.PaymentRequestViewModels
             public DateTime ExpiryDate { get; set; }
             public decimal Amount { get; set; }
             public string AmountFormatted { get; set; }
-            public string RateFormatted { get; set; }
-            public decimal AmountPaid { get; set; }
-            public string AmountPaidFormatted { get; set; }
             public InvoiceState State { get; set; }
             public InvoiceStatus Status { get; set; }
             public string StatusFormatted { get; set; }
@@ -156,6 +153,9 @@ namespace BTCPayServer.Models.PaymentRequestViewModels
         {
             public string PaymentMethod { get; set; }
             public decimal Amount { get; set; }
+            public string RateFormatted { get; set; }
+            public decimal Paid { get; set; }
+            public string PaidFormatted { get; set; }
             public string Link { get; set; }
             public string Id { get; set; }
         }

--- a/BTCPayServer/PaymentRequest/PaymentRequestService.cs
+++ b/BTCPayServer/PaymentRequest/PaymentRequestService.cs
@@ -125,13 +125,13 @@ namespace BTCPayServer.PaymentRequest
                                 string txId = paymentData.GetPaymentId();
                                 string link = GetTransactionLink(paymentMethodId, txId);
                                 var paymentMethod = entity.GetPaymentMethod(paymentMethodId);
+                                var amount = paymentData.GetValue();
                                 var rate = paymentMethod.Rate;
-                                var paid = paymentMethod.Calculate().Paid
-                                    .GetValue(paymentMethod.Network as BTCPayNetwork) * rate;
+                                var paid = (amount - paymentEntity.NetworkFee) * rate;
 
                                 return new ViewPaymentRequestViewModel.PaymentRequestInvoicePayment
                                 {
-                                    Amount = paymentData.GetValue(),
+                                    Amount = amount,
                                     Paid = paid,
                                     ReceivedDate = paymentEntity.ReceivedTime.DateTime,
                                     PaidFormatted = _currencies.FormatCurrency(paid, blob.Currency),

--- a/BTCPayServer/PaymentRequest/PaymentRequestService.cs
+++ b/BTCPayServer/PaymentRequest/PaymentRequestService.cs
@@ -105,9 +105,9 @@ namespace BTCPayServer.PaymentRequest
                     return new ViewPaymentRequestViewModel.PaymentRequestInvoice()
                     {
                         Id = entity.Id,
-                        Rate = entity.Rate,
                         Amount = entity.Price,
                         AmountFormatted = _currencies.FormatCurrency(entity.Price, blob.Currency),
+                        RateFormatted = _currencies.FormatCurrency(entity.Rate, blob.Currency),
                         AmountPaid = amountPaid,
                         AmountPaidFormatted = _currencies.FormatCurrency(amountPaid, blob.Currency),
                         Currency = entity.Currency,
@@ -126,14 +126,12 @@ namespace BTCPayServer.PaymentRequest
                                     return null;
                                 }
 
-                                var paymentMethod = entity.GetPaymentMethod(paymentMethodId);
                                 string txId = paymentData.GetPaymentId();
                                 string link = GetTransactionLink(paymentMethodId, txId);
                                 return new ViewPaymentRequestViewModel.PaymentRequestInvoicePayment()
                                 {
                                     Amount = paymentData.GetValue(),
                                     PaymentMethod = paymentMethodId.ToString(),
-                                    RateFormatted = _currencies.FormatCurrency(paymentMethod.Rate, entity.Currency),
                                     Link = link,
                                     Id = txId
                                 };

--- a/BTCPayServer/PaymentRequest/PaymentRequestService.cs
+++ b/BTCPayServer/PaymentRequest/PaymentRequestService.cs
@@ -133,6 +133,7 @@ namespace BTCPayServer.PaymentRequest
                                 {
                                     Amount = paymentData.GetValue(),
                                     Paid = paid,
+                                    ReceivedDate = paymentEntity.ReceivedTime.DateTime,
                                     PaidFormatted = _currencies.FormatCurrency(paid, blob.Currency),
                                     RateFormatted = _currencies.FormatCurrency(rate, blob.Currency),
                                     PaymentMethod = paymentMethodId.ToPrettyString(),

--- a/BTCPayServer/Views/PaymentRequest/ViewPaymentRequest.cshtml
+++ b/BTCPayServer/Views/PaymentRequest/ViewPaymentRequest.cshtml
@@ -239,7 +239,7 @@
                                                     if (invoice.Payments != null && invoice.Payments.Any())
                                                     {
                                                         <tr class="table-borderless table-light">
-                                                            <th colspan="2" class="pl-3 font-weight-normal text-secondary">TX Id</th>
+                                                            <th colspan="2" class="pl-3 font-weight-normal text-secondary">Transaction Id</th>
                                                             <th class="font-weight-normal text-secondary w-150px">Payment Method</th>
                                                             <th class="font-weight-normal text-secondary text-right w-150px">Amount</th>
                                                         </tr>
@@ -290,7 +290,7 @@
                                                 </tr>
                                                 <template v-if="invoice.payments && invoice.payments.length > 0">
                                                     <tr class="table-borderless table-light">
-                                                        <th colspan="2" class="pl-3 font-weight-normal text-secondary">TX Id</th>
+                                                        <th colspan="2" class="pl-3 font-weight-normal text-secondary">Transaction Id</th>
                                                         <th class="font-weight-normal text-secondary w-150px">Payment Method</th>
                                                         <th class="font-weight-normal text-secondary text-right w-150px">Amount</th>
                                                     </tr>

--- a/BTCPayServer/Views/PaymentRequest/ViewPaymentRequest.cshtml
+++ b/BTCPayServer/Views/PaymentRequest/ViewPaymentRequest.cshtml
@@ -215,7 +215,7 @@
                             <h2 class="h4 mb-3">Payment Details</h2>
                             <dl class="mb-0 mt-md-4">
                                 <div class="d-flex d-print-inline-block flex-column mb-4 mr-5">
-                                    <dt class="h4 font-weight-normal text-nowrap text-primary order-2 order-sm-1 mb-0" v-text="srvModel.amountDueFormatted">@Model.AmountDueFormatted</dt>
+                                    <dt class="h4 font-weight-normal text-nowrap text-primary text-print-default order-2 order-sm-1 mb-0" v-text="srvModel.amountDueFormatted">@Model.AmountDueFormatted</dt>
                                     <dd class="text-muted order-1 order-sm-2 mb-1">Amount due</dd>
                                 </div>
                                 <div class="progress bg-light d-none d-sm-flex mb-sm-4 d-print-none" style="height:5px">
@@ -265,7 +265,7 @@
                                                         <td class="text-right">@invoice.AmountFormatted</td>
                                                         <td class="text-right">@invoice.RateFormatted</td>
                                                         <td class="text-right">@invoice.AmountPaidFormatted</td>
-                                                        <td class="text-right @StatusTextClass(invoice.State)">@invoice.StatusFormatted</td>
+                                                        <td class="text-right text-print-default @StatusTextClass(invoice.State)">@invoice.StatusFormatted</td>
                                                     </tr>
                                                     if (invoice.Payments != null && invoice.Payments.Any())
                                                     {
@@ -280,7 +280,7 @@
                                                                 <td colspan="4" class="pl-3 text-break">
                                                                     @if (!string.IsNullOrEmpty(payment.Link))
                                                                     {
-                                                                        <a href="@payment.Link" target="_blank">@payment.Id</a>
+                                                                        <a href="@payment.Link" class="text-print-default" target="_blank">@payment.Id</a>
                                                                     }
                                                                     else
                                                                     {
@@ -321,7 +321,7 @@
                                                     <td class="text-right">{{invoice.amountFormatted}}</td>
                                                     <td class="text-right">{{invoice.rateFormatted}}</td>
                                                     <td class="text-right">{{invoice.amountPaidFormatted}}</td>
-                                                    <td class="text-right" :class="statusTextClass(invoice.statusFormatted)">{{invoice.statusFormatted}}</td>
+                                                    <td class="text-right text-print-default" :class="statusTextClass(invoice.statusFormatted)">{{invoice.statusFormatted}}</td>
                                                 </tr>
                                                 <template v-if="invoice.payments && invoice.payments.length > 0">
                                                     <tr class="table-borderless table-light">
@@ -331,7 +331,7 @@
                                                     </tr>
                                                     <tr v-for="payment of invoice.payments" class="table-borderless table-light">
                                                         <td colspan="4" class="pl-3 text-break">
-                                                            <a v-if="payment.link" :href="payment.link" target="_blank">{{payment.id}}</a>
+                                                            <a v-if="payment.link" :href="payment.link" class="text-print-default" target="_blank">{{payment.id}}</a>
                                                             <span v-else>{{payment.id}}</span>
                                                         </td>
                                                         <td class="text-right">{{payment.amount.noExponents()}}</td>

--- a/BTCPayServer/Views/PaymentRequest/ViewPaymentRequest.cshtml
+++ b/BTCPayServer/Views/PaymentRequest/ViewPaymentRequest.cshtml
@@ -269,7 +269,8 @@
                                                     if (invoice.Payments != null && invoice.Payments.Any())
                                                     {
                                                         <tr class="table-borderless table-light">
-                                                            <th colspan="2" class="pl-3 font-weight-normal text-secondary">Transaction Id</th>
+                                                            <th class="pl-3 font-weight-normal text-secondary">Transaction Id</th>
+                                                            <th class="font-weight-normal text-secondary">Received</th>
                                                             <th class="font-weight-normal text-secondary text-right">Paid</th>
                                                             <th class="font-weight-normal text-secondary text-right">Rate</th>
                                                             <th class="font-weight-normal text-secondary text-right">Payment</th>
@@ -277,7 +278,7 @@
                                                         @foreach (var payment in invoice.Payments)
                                                         {
                                                             <tr class="table-borderless table-light">
-                                                                <td colspan="2" class="pl-3 text-break">
+                                                                <td class="pl-3 text-break">
                                                                     @if (!string.IsNullOrEmpty(payment.Link))
                                                                     {
                                                                         <a href="@payment.Link" class="text-print-default" target="_blank">@payment.Id</a>
@@ -287,6 +288,7 @@
                                                                         <span>@payment.Id</span>
                                                                     }
                                                                 </td>
+                                                                <td>@payment.ReceivedDate.ToString("g")</td>
                                                                 <td class="text-right">@payment.PaidFormatted</td>
                                                                 <td class="text-right">@payment.RateFormatted</td>
                                                                 <td class="text-right text-nowrap">@payment.Amount @payment.PaymentMethod</td>
@@ -324,16 +326,18 @@
                                                 </tr>
                                                 <template v-if="invoice.payments && invoice.payments.length > 0">
                                                     <tr class="table-borderless table-light">
-                                                        <th colspan="2" class="pl-3 font-weight-normal text-secondary">Transaction Id</th>
+                                                        <th class="pl-3 font-weight-normal text-secondary">Transaction Id</th>
+                                                        <th class="font-weight-normal text-secondary">Received</th>
                                                         <th class="font-weight-normal text-secondary text-right">Paid</th>
                                                         <th class="font-weight-normal text-secondary text-right">Rate</th>
                                                         <th class="font-weight-normal text-secondary text-right">Payment</th>
                                                     </tr>
                                                     <tr v-for="payment of invoice.payments" class="table-borderless table-light">
-                                                        <td colspan="2" class="pl-3 text-break">
+                                                        <td class="pl-3 text-break">
                                                             <a v-if="payment.link" :href="payment.link" class="text-print-default" target="_blank">{{payment.id}}</a>
                                                             <span v-else>{{payment.id}}</span>
                                                         </td>
+                                                        <td v-text="formatDate(payment.receivedDate)"></td>
                                                         <td class="text-right">{{payment.paidFormatted}}</td>
                                                         <td class="text-right">{{payment.rateFormatted}}</td>
                                                         <td class="text-right text-nowrap">{{payment.amount.noExponents()}} {{payment.paymentMethod}}</td>

--- a/BTCPayServer/Views/PaymentRequest/ViewPaymentRequest.cshtml
+++ b/BTCPayServer/Views/PaymentRequest/ViewPaymentRequest.cshtml
@@ -78,7 +78,7 @@
                                 <span class="text-muted text-nowrap">Last Updated</span>
                                 &nbsp;
                                 <span class="text-nowrap d-print-none" v-text="lastUpdated" v-cloak>@Model.LastUpdated.ToString("g")</span>
-                                <span class="text-nowrap d-none d-print-block" v-text="lastUpdatedDate" v-cloak>@Model.LastUpdated.ToString("g")</span>
+                                <span class="text-nowrap d-none d-print-block" v-text="lastUpdatedDate">@Model.LastUpdated.ToString("g")</span>
                                 <button type="button" class="btn btn-link d-none d-lg-inline-block d-print-none border-0 p-0 ml-4 only-for-js" v-on:click="window.print" v-cloak>
                                     Print
                                 </button>
@@ -250,11 +250,10 @@
                                             <thead>
                                                 <tr class="table-borderless">
                                                     <th class="font-weight-normal text-secondary" scope="col">Invoice Id</th>
-                                                    <th class="font-weight-normal text-secondary w-150px">Expiry</th>
+                                                    <th class="font-weight-normal text-secondary w-175px">Expiry</th>
                                                     <th class="font-weight-normal text-secondary text-right w-100px">Amount</th>
-                                                    <th class="font-weight-normal text-secondary text-right w-125px">Rate</th>
-                                                    <th class="font-weight-normal text-secondary text-right w-125px">Paid</th>
-                                                    <th class="font-weight-normal text-secondary text-right w-150px">Status</th>
+                                                    <th class="font-weight-normal text-secondary text-right w-125px"></th>
+                                                    <th class="font-weight-normal text-secondary text-right">Status</th>
                                                 </tr>
                                             </thead>
                                             <tbody>
@@ -264,21 +263,21 @@
                                                         <td>@invoice.Id</td>
                                                         <td>@invoice.ExpiryDate.ToString("g")</td>
                                                         <td class="text-right">@invoice.AmountFormatted</td>
-                                                        <td class="text-right">@invoice.RateFormatted</td>
-                                                        <td class="text-right">@invoice.AmountPaidFormatted</td>
+                                                        <td class="text-right"></td>
                                                         <td class="text-right text-print-default @StatusTextClass(invoice.State)">@invoice.StatusFormatted</td>
                                                     </tr>
                                                     if (invoice.Payments != null && invoice.Payments.Any())
                                                     {
                                                         <tr class="table-borderless table-light">
-                                                            <th colspan="4" class="pl-3 font-weight-normal text-secondary">Transaction Id</th>
+                                                            <th colspan="2" class="pl-3 font-weight-normal text-secondary">Transaction Id</th>
                                                             <th class="font-weight-normal text-secondary text-right">Paid</th>
-                                                            <th class="font-weight-normal text-secondary text-right">Payment Method</th>
+                                                            <th class="font-weight-normal text-secondary text-right">Rate</th>
+                                                            <th class="font-weight-normal text-secondary text-right">Payment</th>
                                                         </tr>
                                                         @foreach (var payment in invoice.Payments)
                                                         {
                                                             <tr class="table-borderless table-light">
-                                                                <td colspan="4" class="pl-3 text-break">
+                                                                <td colspan="2" class="pl-3 text-break">
                                                                     @if (!string.IsNullOrEmpty(payment.Link))
                                                                     {
                                                                         <a href="@payment.Link" class="text-print-default" target="_blank">@payment.Id</a>
@@ -288,8 +287,9 @@
                                                                         <span>@payment.Id</span>
                                                                     }
                                                                 </td>
-                                                                <td class="text-right">@payment.Amount</td>
-                                                                <td class="text-right">@payment.PaymentMethod</td>
+                                                                <td class="text-right">@payment.PaidFormatted</td>
+                                                                <td class="text-right">@payment.RateFormatted</td>
+                                                                <td class="text-right text-nowrap">@payment.Amount @payment.PaymentMethod</td>
                                                             </tr>
                                                         }
                                                     }
@@ -307,36 +307,36 @@
                                         <thead>
                                             <tr class="table-borderless">
                                                 <th class="font-weight-normal text-secondary" scope="col">Invoice Id</th>
-                                                <th class="font-weight-normal text-secondary w-150px">Expiry</th>
+                                                <th class="font-weight-normal text-secondary w-175px">Expiry</th>
                                                 <th class="font-weight-normal text-secondary text-right w-100px">Amount</th>
-                                                <th class="font-weight-normal text-secondary text-right w-125px">Rate</th>
-                                                <th class="font-weight-normal text-secondary text-right w-125px">Paid</th>
-                                                <th class="font-weight-normal text-secondary text-right w-150px">Status</th>
+                                                <th class="font-weight-normal text-secondary text-right w-125px"></th>
+                                                <th class="font-weight-normal text-secondary text-right">Status</th>
                                             </tr>
                                         </thead>
                                         <tbody>
                                             <template v-for="invoice of srvModel.invoices" :key="invoice.id">
                                                 <tr>
                                                     <td>{{invoice.id}}</td>
-                                                    <td>{{moment(invoice.expiryDate).format('L HH:mm')}}</td>
+                                                    <td v-text="formatDate(invoice.expiryDate)"></td>
                                                     <td class="text-right">{{invoice.amountFormatted}}</td>
-                                                    <td class="text-right">{{invoice.rateFormatted}}</td>
-                                                    <td class="text-right">{{invoice.amountPaidFormatted}}</td>
+                                                    <td class="text-right"></td>
                                                     <td class="text-right text-print-default" :class="statusTextClass(invoice.statusFormatted)">{{invoice.statusFormatted}}</td>
                                                 </tr>
                                                 <template v-if="invoice.payments && invoice.payments.length > 0">
                                                     <tr class="table-borderless table-light">
-                                                        <th colspan="4" class="pl-3 font-weight-normal text-secondary">Transaction Id</th>
+                                                        <th colspan="2" class="pl-3 font-weight-normal text-secondary">Transaction Id</th>
                                                         <th class="font-weight-normal text-secondary text-right">Paid</th>
-                                                        <th class="font-weight-normal text-secondary text-right">Payment Method</th>
+                                                        <th class="font-weight-normal text-secondary text-right">Rate</th>
+                                                        <th class="font-weight-normal text-secondary text-right">Payment</th>
                                                     </tr>
                                                     <tr v-for="payment of invoice.payments" class="table-borderless table-light">
-                                                        <td colspan="4" class="pl-3 text-break">
+                                                        <td colspan="2" class="pl-3 text-break">
                                                             <a v-if="payment.link" :href="payment.link" class="text-print-default" target="_blank">{{payment.id}}</a>
                                                             <span v-else>{{payment.id}}</span>
                                                         </td>
-                                                        <td class="text-right">{{payment.amount.noExponents()}}</td>
-                                                        <td class="text-right">{{formatPaymentMethod(payment.paymentMethod)}}</td>
+                                                        <td class="text-right">{{payment.paidFormatted}}</td>
+                                                        <td class="text-right">{{payment.rateFormatted}}</td>
+                                                        <td class="text-right text-nowrap">{{payment.amount.noExponents()}} {{payment.paymentMethod}}</td>
                                                     </tr>
                                                 </template>
                                             </template>

--- a/BTCPayServer/Views/PaymentRequest/ViewPaymentRequest.cshtml
+++ b/BTCPayServer/Views/PaymentRequest/ViewPaymentRequest.cshtml
@@ -1,4 +1,6 @@
-﻿@model BTCPayServer.Models.PaymentRequestViewModels.ViewPaymentRequestViewModel
+﻿@using BTCPayServer.Services.Invoices
+@using BTCPayServer.Client.Models
+@model BTCPayServer.Models.PaymentRequestViewModels.ViewPaymentRequestViewModel
 
 @addTagHelper *, BundlerMinifier.TagHelpers
 @inject BTCPayServer.Services.BTCPayServerEnvironment env
@@ -6,6 +8,31 @@
 @{
     ViewData["Title"] = Model.Title;
     Layout = null;
+
+    string StatusTextClass(InvoiceState state)
+    {
+        switch (state.Status)
+        {
+            case InvoiceStatus.Confirmed:
+            case InvoiceStatus.Complete:
+            case InvoiceStatus.Paid:
+                return "text-success";
+            case InvoiceStatus.Expired:
+                switch (state.ExceptionStatus)
+                {
+                    case InvoiceExceptionStatus.PaidLate:
+                    case InvoiceExceptionStatus.PaidPartial:
+                    case InvoiceExceptionStatus.PaidOver:
+                        return "text-warning";
+                    default:
+                        return "text-danger";
+                }
+            case InvoiceStatus.Invalid:
+                return "text-danger";
+            default:
+                return "text-warning";
+        }
+    }
 }
 
 <!DOCTYPE html>
@@ -222,8 +249,9 @@
                                             <thead>
                                                 <tr class="table-borderless">
                                                     <th class="font-weight-normal text-secondary" scope="col">Invoice Id</th>
-                                                    <th class="font-weight-normal text-secondary w-150px">Price</th>
-                                                    <th class="font-weight-normal text-secondary w-100px">Expiry</th>
+                                                    <th class="font-weight-normal text-secondary w-150px">Expiry</th>
+                                                    <th class="font-weight-normal text-secondary text-right w-100px">Amount</th>
+                                                    <th class="font-weight-normal text-secondary text-right w-100px">Paid</th>
                                                     <th class="font-weight-normal text-secondary text-right w-150px">Status</th>
                                                 </tr>
                                             </thead>
@@ -232,16 +260,18 @@
                                                 {
                                                     <tr>
                                                         <td>@invoice.Id</td>
-                                                        <td>@invoice.AmountFormatted</td>
                                                         <td>@invoice.ExpiryDate.ToString("g")</td>
-                                                        <td class="text-right">@invoice.Status</td>
+                                                        <td class="text-right">@invoice.AmountFormatted</td>
+                                                        <td class="text-right">@invoice.AmountPaidFormatted</td>
+                                                        <td class="text-right @StatusTextClass(invoice.State)">@invoice.StatusFormatted</td>
                                                     </tr>
                                                     if (invoice.Payments != null && invoice.Payments.Any())
                                                     {
                                                         <tr class="table-borderless table-light">
                                                             <th colspan="2" class="pl-3 font-weight-normal text-secondary">Transaction Id</th>
-                                                            <th class="font-weight-normal text-secondary w-150px">Payment Method</th>
-                                                            <th class="font-weight-normal text-secondary text-right w-150px">Amount</th>
+                                                            <th class="font-weight-normal text-secondary text-right">Rate</th>
+                                                            <th class="font-weight-normal text-secondary text-right">Paid</th>
+                                                            <th class="font-weight-normal text-secondary text-right">Payment Method</th>
                                                         </tr>
                                                         @foreach (var payment in invoice.Payments)
                                                         {
@@ -256,8 +286,9 @@
                                                                         <span>@payment.Id</span>
                                                                     }
                                                                 </td>
-                                                                <td>@payment.PaymentMethod</td>
+                                                                <td class="text-right">@payment.RateFormatted</td>
                                                                 <td class="text-right">@payment.Amount</td>
+                                                                <td class="text-right">@payment.PaymentMethod</td>
                                                             </tr>
                                                         }
                                                     }
@@ -275,8 +306,9 @@
                                         <thead>
                                             <tr class="table-borderless">
                                                 <th class="font-weight-normal text-secondary" scope="col">Invoice Id</th>
-                                                <th class="font-weight-normal text-secondary w-100px">Price</th>
                                                 <th class="font-weight-normal text-secondary w-150px">Expiry</th>
+                                                <th class="font-weight-normal text-secondary text-right w-100px">Amount</th>
+                                                <th class="font-weight-normal text-secondary text-right w-100px">Paid</th>
                                                 <th class="font-weight-normal text-secondary text-right w-150px">Status</th>
                                             </tr>
                                         </thead>
@@ -284,23 +316,26 @@
                                             <template v-for="invoice of srvModel.invoices" :key="invoice.id">
                                                 <tr>
                                                     <td>{{invoice.id}}</td>
-                                                    <td>{{invoice.amountFormatted}}</td>
                                                     <td>{{moment(invoice.expiryDate).format('L HH:mm')}}</td>
-                                                    <td class="text-right">{{invoice.status}}</td>
+                                                    <td class="text-right">{{invoice.amountFormatted}}</td>
+                                                    <td class="text-right">{{invoice.amountPaidFormatted}}</td>
+                                                    <td class="text-right" :class="statusTextClass(invoice.statusFormatted)">{{invoice.statusFormatted}}</td>
                                                 </tr>
                                                 <template v-if="invoice.payments && invoice.payments.length > 0">
                                                     <tr class="table-borderless table-light">
                                                         <th colspan="2" class="pl-3 font-weight-normal text-secondary">Transaction Id</th>
-                                                        <th class="font-weight-normal text-secondary w-150px">Payment Method</th>
-                                                        <th class="font-weight-normal text-secondary text-right w-150px">Amount</th>
+                                                        <th class="font-weight-normal text-secondary text-right">Rate</th>
+                                                        <th class="font-weight-normal text-secondary text-right">Paid</th>
+                                                        <th class="font-weight-normal text-secondary text-right">Payment Method</th>
                                                     </tr>
                                                     <tr v-for="payment of invoice.payments" class="table-borderless table-light">
                                                         <td colspan="2" class="pl-3 text-break">
                                                             <a v-if="payment.link" :href="payment.link" target="_blank">{{payment.id}}</a>
                                                             <span v-else>{{payment.id}}</span>
                                                         </td>
-                                                        <td>{{formatPaymentMethod(payment.paymentMethod)}}</td>
+                                                        <td class="text-right">{{payment.rateFormatted}}</td>
                                                         <td class="text-right">{{payment.amount.noExponents()}}</td>
+                                                        <td class="text-right">{{formatPaymentMethod(payment.paymentMethod)}}</td>
                                                     </tr>
                                                 </template>
                                             </template>

--- a/BTCPayServer/Views/PaymentRequest/ViewPaymentRequest.cshtml
+++ b/BTCPayServer/Views/PaymentRequest/ViewPaymentRequest.cshtml
@@ -77,7 +77,8 @@
                             <div class="col col-12 col-sm-6 col-lg-8 d-flex align-items-center">
                                 <span class="text-muted text-nowrap">Last Updated</span>
                                 &nbsp;
-                                <span class="text-nowrap" v-text="lastUpdated" v-cloak>@Model.LastUpdated.ToString("g")</span>
+                                <span class="text-nowrap d-print-none" v-text="lastUpdated" v-cloak>@Model.LastUpdated.ToString("g")</span>
+                                <span class="text-nowrap d-none d-print-block" v-text="lastUpdatedDate" v-cloak>@Model.LastUpdated.ToString("g")</span>
                                 <button type="button" class="btn btn-link d-none d-lg-inline-block d-print-none border-0 p-0 ml-4 only-for-js" v-on:click="window.print" v-cloak>
                                     Print
                                 </button>

--- a/BTCPayServer/Views/PaymentRequest/ViewPaymentRequest.cshtml
+++ b/BTCPayServer/Views/PaymentRequest/ViewPaymentRequest.cshtml
@@ -69,13 +69,13 @@
                             </div>
                         </div>
                     </div>
-                    <div class="col-12 pt-3 pb-2 col-md-4 py-md-0 col-lg-3 d-print-none">
+                    <div class="col-12 pt-3 pb-2 col-md-4 py-md-0 col-lg-3">
                         <noscript>
                             @if (Model.IsPending && !Model.Archived)
                             {
                                 @if (Model.AllowCustomPaymentAmounts && !Model.AnyPendingInvoice)
                                 {
-                                    <form method="get" asp-action="PayPaymentRequest" asp-route-id="@Model.Id">
+                                    <form method="get" asp-action="PayPaymentRequest" asp-route-id="@Model.Id" class="d-print-none">
                                         <div class="row">
                                             <div class="col col-12 col-sm-6 col-md-12">
                                                 <div class="input-group">
@@ -93,12 +93,12 @@
                                 }
                                 else
                                 {
-                                    <a class="btn btn-primary d-inline-block w-100 text-nowrap @if (!(Model.AnyPendingInvoice && !Model.PendingInvoiceHasPayments)) { @("btn-lg") }" asp-action="PayPaymentRequest" asp-route-id="@Model.Id">
+                                    <a class="btn btn-primary d-inline-block d-print-none w-100 text-nowrap @if (!(Model.AnyPendingInvoice && !Model.PendingInvoiceHasPayments)) { @("btn-lg") }" asp-action="PayPaymentRequest" asp-route-id="@Model.Id">
                                         Pay Invoice
                                     </a>
                                     if (Model.AnyPendingInvoice && !Model.PendingInvoiceHasPayments)
                                     {
-                                        <form method="get" asp-action="CancelUnpaidPendingInvoice" asp-route-id="@Model.Id" class="mt-2">
+                                        <form method="get" asp-action="CancelUnpaidPendingInvoice" asp-route-id="@Model.Id" class="mt-2 d-print-none">
                                             <button class="btn btn-outline-secondary w-100 text-nowrap" type="submit">Cancel Invoice</button>
                                         </form>
                                     }
@@ -119,7 +119,7 @@
                         </noscript>
                         <template v-if="srvModel.isPending && !srvModel.archived" class="d-print-none">
                             <template v-if="srvModel.allowCustomPaymentAmounts && !srvModel.anyPendingInvoice">
-                                <form v-on:submit="submitCustomAmountForm">
+                                <form v-on:submit="submitCustomAmountForm" class="d-print-none">
                                     <div class="row">
                                         <div class="col col-12 col-sm-6 col-md-12">
                                             <div class="input-group">
@@ -141,13 +141,13 @@
                                 </form>
                             </template>
                             <template v-else>
-                                <button class="btn btn-primary w-100 d-flex align-items-center justify-content-center text-nowrap" :class="{ 'btn-lg': !(srvModel.anyPendingInvoice && !srvModel.pendingInvoiceHasPayments)}" v-on:click="pay(null)" :disabled="loading">
+                                <button class="btn btn-primary w-100 d-flex d-print-none align-items-center justify-content-center text-nowrap" :class="{ 'btn-lg': !(srvModel.anyPendingInvoice && !srvModel.pendingInvoiceHasPayments)}" v-on:click="pay(null)" :disabled="loading">
                                     <div v-if="loading" class="spinner-grow spinner-grow-sm mr-2" role="status">
                                         <span class="sr-only">Loading...</span>
                                     </div>
                                     <span>Pay Invoice</span>
                                 </button>
-                                <button class="btn btn-outline-secondary mt-2 w-100 d-flex align-items-center justify-content-center text-nowrap" v-if="srvModel.anyPendingInvoice && !srvModel.pendingInvoiceHasPayments" v-on:click="cancelPayment()" :disabled="loading">
+                                <button class="btn btn-outline-secondary mt-2 w-100 d-flex d-print-none align-items-center justify-content-center text-nowrap" v-if="srvModel.anyPendingInvoice && !srvModel.pendingInvoiceHasPayments" v-on:click="cancelPayment()" :disabled="loading">
                                     <span v-if="loading" class="spinner-grow spinner-grow-sm mr-2" role="status">
                                         <span class="sr-only">Loading...</span>
                                     </span>
@@ -187,19 +187,19 @@
                         <div class="jumbotron h-100 m-0 p-sm-5">
                             <h2 class="h4 mb-3">Payment Details</h2>
                             <dl class="mb-0 mt-md-4">
-                                <div class="d-flex flex-column mb-4">
+                                <div class="d-flex d-print-inline-block flex-column mb-4 mr-5">
                                     <dt class="h4 font-weight-normal text-nowrap text-primary order-2 order-sm-1 mb-0" v-text="srvModel.amountDueFormatted">@Model.AmountDueFormatted</dt>
                                     <dd class="text-muted order-1 order-sm-2 mb-1">Amount due</dd>
                                 </div>
                                 <div class="progress bg-light d-none d-sm-flex mb-sm-4 d-print-none" style="height:5px">
                                   <div class="progress-bar bg-primary" role="progressbar" style="width:@((Model.AmountCollected/Model.Amount)*100)%" v-bind:style="{ width: (srvModel.amountCollected/srvModel.amount*100) + '%' }"></div>
                                 </div>
-                                <div class="d-flex flex-column mb-4 d-sm-inline-flex mb-sm-0">
+                                <div class="d-flex d-print-inline-block flex-column mb-4 mr-5 d-sm-inline-flex mb-sm-0">
                                     <dt class="h4 font-weight-normal text-nowrap order-2 order-sm-1 mb-0" v-text="srvModel.amountCollectedFormatted">@Model.AmountCollectedFormatted</dt>
                                     <dd class="text-muted order-1 order-sm-2 mb-1">Amount paid</dd>
                                 </div>
-                                <div class="d-flex flex-column mb-0 d-sm-inline-flex float-sm-right">
-                                    <dt class="h4 font-weight-normal text-nowrap order-2 order-sm-1 mb-0" v-text="srvModel.amountFormatted">@Model.AmountFormatted</dt>
+                                <div class="d-flex d-print-inline-block flex-column mb-0 d-sm-inline-flex float-sm-right">
+                                    <dt class="h4 text-sm-right font-weight-normal text-nowrap order-2 order-sm-1 mb-0" v-text="srvModel.amountFormatted">@Model.AmountFormatted</dt>
                                     <dd class="text-muted text-sm-right order-1 order-sm-2 mb-1">Total requested</dd>
                                 </div>
                             </dl>
@@ -222,9 +222,9 @@
                                             <thead>
                                                 <tr class="table-borderless">
                                                     <th class="font-weight-normal text-secondary" scope="col">Invoice Id</th>
-                                                    <th class="font-weight-normal text-secondary">Price</th>
-                                                    <th class="font-weight-normal text-secondary">Expiry</th>
-                                                    <th class="font-weight-normal text-secondary text-right">Status</th>
+                                                    <th class="font-weight-normal text-secondary w-150px">Price</th>
+                                                    <th class="font-weight-normal text-secondary w-150px">Expiry</th>
+                                                    <th class="font-weight-normal text-secondary text-right w-150px">Status</th>
                                                 </tr>
                                             </thead>
                                             <tbody>
@@ -240,8 +240,8 @@
                                                     {
                                                         <tr class="table-borderless table-light">
                                                             <th colspan="2" class="pl-3 font-weight-normal text-secondary">TX Id</th>
-                                                            <th class="font-weight-normal text-secondary">Payment Method</th>
-                                                            <th class="font-weight-normal text-secondary text-right">Amount</th>
+                                                            <th class="font-weight-normal text-secondary w-150px">Payment Method</th>
+                                                            <th class="font-weight-normal text-secondary text-right w-150px">Amount</th>
                                                         </tr>
                                                         @foreach (var payment in invoice.Payments)
                                                         {
@@ -270,37 +270,39 @@
                                 <template v-if="!srvModel.invoices || srvModel.invoices.length == 0">
                                     <p class="text-muted">No payments made yet.</p>
                                 </template>
-                                <template v-else v-for="invoice of srvModel.invoices" :key="invoice.id">
+                                <template v-else>
                                     <table class="table my-0">
                                         <thead>
                                             <tr class="table-borderless">
                                                 <th class="font-weight-normal text-secondary" scope="col">Invoice Id</th>
-                                                <th class="font-weight-normal text-secondary">Price</th>
-                                                <th class="font-weight-normal text-secondary">Expiry</th>
-                                                <th class="font-weight-normal text-secondary text-right">Status</th>
+                                                <th class="font-weight-normal text-secondary w-150px">Price</th>
+                                                <th class="font-weight-normal text-secondary w-150px">Expiry</th>
+                                                <th class="font-weight-normal text-secondary text-right w-150px">Status</th>
                                             </tr>
                                         </thead>
                                         <tbody>
-                                            <tr>
-                                                <td>{{invoice.id}}</td>
-                                                <td>{{invoice.amountFormatted}}</td>
-                                                <td>{{moment(invoice.expiryDate).format('L HH:mm')}}</td>
-                                                <td class="text-right">{{invoice.status}}</td>
-                                            </tr>
-                                            <template v-if="invoice.payments && invoice.payments.length > 0">
-                                                <tr class="table-borderless table-light">
-                                                    <th colspan="2" class="pl-3 font-weight-normal text-secondary">TX Id</th>
-                                                    <th class="font-weight-normal text-secondary">Payment Method</th>
-                                                    <th class="font-weight-normal text-secondary text-right">Amount</th>
+                                            <template v-for="invoice of srvModel.invoices" :key="invoice.id">
+                                                <tr>
+                                                    <td>{{invoice.id}}</td>
+                                                    <td>{{invoice.amountFormatted}}</td>
+                                                    <td>{{moment(invoice.expiryDate).format('L HH:mm')}}</td>
+                                                    <td class="text-right">{{invoice.status}}</td>
                                                 </tr>
-                                                <tr v-for="payment of invoice.payments" class="table-borderless table-light">
-                                                    <td colspan="2" class="pl-3 text-break">
-                                                        <a v-if="payment.link" :href="payment.link" target="_blank">{{payment.id}}</a>
-                                                        <span v-else>{{payment.id}}</span>
-                                                    </td>
-                                                    <td>{{formatPaymentMethod(payment.paymentMethod)}}</td>
-                                                    <td class="text-right">{{payment.amount.noExponents()}}</td>
-                                                </tr>
+                                                <template v-if="invoice.payments && invoice.payments.length > 0">
+                                                    <tr class="table-borderless table-light">
+                                                        <th colspan="2" class="pl-3 font-weight-normal text-secondary">TX Id</th>
+                                                        <th class="font-weight-normal text-secondary w-150px">Payment Method</th>
+                                                        <th class="font-weight-normal text-secondary text-right w-150px">Amount</th>
+                                                    </tr>
+                                                    <tr v-for="payment of invoice.payments" class="table-borderless table-light">
+                                                        <td colspan="2" class="pl-3 text-break">
+                                                            <a v-if="payment.link" :href="payment.link" target="_blank">{{payment.id}}</a>
+                                                            <span v-else>{{payment.id}}</span>
+                                                        </td>
+                                                        <td>{{formatPaymentMethod(payment.paymentMethod)}}</td>
+                                                        <td class="text-right">{{payment.amount.noExponents()}}</td>
+                                                    </tr>
+                                                </template>
                                             </template>
                                         </tbody>
                                     </table>

--- a/BTCPayServer/Views/PaymentRequest/ViewPaymentRequest.cshtml
+++ b/BTCPayServer/Views/PaymentRequest/ViewPaymentRequest.cshtml
@@ -223,7 +223,7 @@
                                                 <tr class="table-borderless">
                                                     <th class="font-weight-normal text-secondary" scope="col">Invoice Id</th>
                                                     <th class="font-weight-normal text-secondary w-150px">Price</th>
-                                                    <th class="font-weight-normal text-secondary w-150px">Expiry</th>
+                                                    <th class="font-weight-normal text-secondary w-100px">Expiry</th>
                                                     <th class="font-weight-normal text-secondary text-right w-150px">Status</th>
                                                 </tr>
                                             </thead>
@@ -232,7 +232,7 @@
                                                 {
                                                     <tr>
                                                         <td>@invoice.Id</td>
-                                                        <td>@invoice.Amount @invoice.Currency</td>
+                                                        <td>@invoice.AmountFormatted</td>
                                                         <td>@invoice.ExpiryDate.ToString("g")</td>
                                                         <td class="text-right">@invoice.Status</td>
                                                     </tr>
@@ -275,7 +275,7 @@
                                         <thead>
                                             <tr class="table-borderless">
                                                 <th class="font-weight-normal text-secondary" scope="col">Invoice Id</th>
-                                                <th class="font-weight-normal text-secondary w-150px">Price</th>
+                                                <th class="font-weight-normal text-secondary w-100px">Price</th>
                                                 <th class="font-weight-normal text-secondary w-150px">Expiry</th>
                                                 <th class="font-weight-normal text-secondary text-right w-150px">Status</th>
                                             </tr>

--- a/BTCPayServer/Views/PaymentRequest/ViewPaymentRequest.cshtml
+++ b/BTCPayServer/Views/PaymentRequest/ViewPaymentRequest.cshtml
@@ -251,7 +251,8 @@
                                                     <th class="font-weight-normal text-secondary" scope="col">Invoice Id</th>
                                                     <th class="font-weight-normal text-secondary w-150px">Expiry</th>
                                                     <th class="font-weight-normal text-secondary text-right w-100px">Amount</th>
-                                                    <th class="font-weight-normal text-secondary text-right w-100px">Paid</th>
+                                                    <th class="font-weight-normal text-secondary text-right w-125px">Rate</th>
+                                                    <th class="font-weight-normal text-secondary text-right w-125px">Paid</th>
                                                     <th class="font-weight-normal text-secondary text-right w-150px">Status</th>
                                                 </tr>
                                             </thead>
@@ -262,21 +263,21 @@
                                                         <td>@invoice.Id</td>
                                                         <td>@invoice.ExpiryDate.ToString("g")</td>
                                                         <td class="text-right">@invoice.AmountFormatted</td>
+                                                        <td class="text-right">@invoice.RateFormatted</td>
                                                         <td class="text-right">@invoice.AmountPaidFormatted</td>
                                                         <td class="text-right @StatusTextClass(invoice.State)">@invoice.StatusFormatted</td>
                                                     </tr>
                                                     if (invoice.Payments != null && invoice.Payments.Any())
                                                     {
                                                         <tr class="table-borderless table-light">
-                                                            <th colspan="2" class="pl-3 font-weight-normal text-secondary">Transaction Id</th>
-                                                            <th class="font-weight-normal text-secondary text-right">Rate</th>
+                                                            <th colspan="4" class="pl-3 font-weight-normal text-secondary">Transaction Id</th>
                                                             <th class="font-weight-normal text-secondary text-right">Paid</th>
                                                             <th class="font-weight-normal text-secondary text-right">Payment Method</th>
                                                         </tr>
                                                         @foreach (var payment in invoice.Payments)
                                                         {
                                                             <tr class="table-borderless table-light">
-                                                                <td colspan="2" class="pl-3 text-break">
+                                                                <td colspan="4" class="pl-3 text-break">
                                                                     @if (!string.IsNullOrEmpty(payment.Link))
                                                                     {
                                                                         <a href="@payment.Link" target="_blank">@payment.Id</a>
@@ -286,7 +287,6 @@
                                                                         <span>@payment.Id</span>
                                                                     }
                                                                 </td>
-                                                                <td class="text-right">@payment.RateFormatted</td>
                                                                 <td class="text-right">@payment.Amount</td>
                                                                 <td class="text-right">@payment.PaymentMethod</td>
                                                             </tr>
@@ -308,7 +308,8 @@
                                                 <th class="font-weight-normal text-secondary" scope="col">Invoice Id</th>
                                                 <th class="font-weight-normal text-secondary w-150px">Expiry</th>
                                                 <th class="font-weight-normal text-secondary text-right w-100px">Amount</th>
-                                                <th class="font-weight-normal text-secondary text-right w-100px">Paid</th>
+                                                <th class="font-weight-normal text-secondary text-right w-125px">Rate</th>
+                                                <th class="font-weight-normal text-secondary text-right w-125px">Paid</th>
                                                 <th class="font-weight-normal text-secondary text-right w-150px">Status</th>
                                             </tr>
                                         </thead>
@@ -318,22 +319,21 @@
                                                     <td>{{invoice.id}}</td>
                                                     <td>{{moment(invoice.expiryDate).format('L HH:mm')}}</td>
                                                     <td class="text-right">{{invoice.amountFormatted}}</td>
+                                                    <td class="text-right">{{invoice.rateFormatted}}</td>
                                                     <td class="text-right">{{invoice.amountPaidFormatted}}</td>
                                                     <td class="text-right" :class="statusTextClass(invoice.statusFormatted)">{{invoice.statusFormatted}}</td>
                                                 </tr>
                                                 <template v-if="invoice.payments && invoice.payments.length > 0">
                                                     <tr class="table-borderless table-light">
-                                                        <th colspan="2" class="pl-3 font-weight-normal text-secondary">Transaction Id</th>
-                                                        <th class="font-weight-normal text-secondary text-right">Rate</th>
+                                                        <th colspan="4" class="pl-3 font-weight-normal text-secondary">Transaction Id</th>
                                                         <th class="font-weight-normal text-secondary text-right">Paid</th>
                                                         <th class="font-weight-normal text-secondary text-right">Payment Method</th>
                                                     </tr>
                                                     <tr v-for="payment of invoice.payments" class="table-borderless table-light">
-                                                        <td colspan="2" class="pl-3 text-break">
+                                                        <td colspan="4" class="pl-3 text-break">
                                                             <a v-if="payment.link" :href="payment.link" target="_blank">{{payment.id}}</a>
                                                             <span v-else>{{payment.id}}</span>
                                                         </td>
-                                                        <td class="text-right">{{payment.rateFormatted}}</td>
                                                         <td class="text-right">{{payment.amount.noExponents()}}</td>
                                                         <td class="text-right">{{formatPaymentMethod(payment.paymentMethod)}}</td>
                                                     </tr>

--- a/BTCPayServer/Views/PullPayment/ViewPullPayment.cshtml
+++ b/BTCPayServer/Views/PullPayment/ViewPullPayment.cshtml
@@ -50,7 +50,7 @@
     <div class="h-100 d-flex flex-column">
         @if (Model.IsPending)
         {
-            <nav id="mainNav" class="navbar sticky-top py-3 py-lg-4 d-print-block">
+            <nav id="mainNav" class="navbar sticky-top py-3 py-lg-4 d-print-none">
                 <div class="container">
                     <form asp-action="ClaimPullPayment" asp-route-pullPaymentId="@Model.Id" class="w-100">
                         <div class="row align-items-center" style="width:calc(100% + 30px)">
@@ -115,7 +115,7 @@
                             <h2 class="h4 mb-3">Payment Details</h2>
                             <dl class="mb-0 mt-md-4">
                                 <div class="d-flex d-print-inline-block flex-column mb-4 mr-5">
-                                    <dt class="h4 font-weight-normal text-nowrap text-primary order-2 order-sm-1 mb-0">@Model.AmountDueFormatted</dt>
+                                    <dt class="h4 font-weight-normal text-nowrap text-primary text-print-default order-2 order-sm-1 mb-0">@Model.AmountDueFormatted</dt>
                                     <dd class="text-muted order-1 order-sm-2 mb-1">Available claim</dd>
                                 </div>
                                 <div class="progress bg-light d-none d-sm-flex mb-sm-4 d-print-none" style="height:5px">
@@ -159,11 +159,11 @@
                                                 <td class="text-right text-nowrap">
                                                     @if (!string.IsNullOrEmpty(invoice.Link))
                                                     {
-                                                        <a class="transaction-link @StatusTextClass(invoice.Status)" href="@invoice.Link">@invoice.Status</a>
+                                                        <a class="transaction-link text-print-default @StatusTextClass(invoice.Status)" href="@invoice.Link">@invoice.Status</a>
                                                     }
                                                     else
                                                     {
-                                                        <span class="@StatusTextClass(invoice.Status)">@invoice.Status</span>
+                                                        <span class="text-print-default @StatusTextClass(invoice.Status)">@invoice.Status</span>
                                                     }
                                                 </td>
                                             </tr>

--- a/BTCPayServer/Views/PullPayment/ViewPullPayment.cshtml
+++ b/BTCPayServer/Views/PullPayment/ViewPullPayment.cshtml
@@ -114,19 +114,19 @@
                         <div class="jumbotron h-100 m-0 p-sm-5">
                             <h2 class="h4 mb-3">Payment Details</h2>
                             <dl class="mb-0 mt-md-4">
-                                <div class="d-flex flex-column mb-4">
+                                <div class="d-flex d-print-inline-block flex-column mb-4 mr-5">
                                     <dt class="h4 font-weight-normal text-nowrap text-primary order-2 order-sm-1 mb-0">@Model.AmountDueFormatted</dt>
                                     <dd class="text-muted order-1 order-sm-2 mb-1">Available claim</dd>
                                 </div>
                                 <div class="progress bg-light d-none d-sm-flex mb-sm-4 d-print-none" style="height:5px">
                                     <div class="progress-bar bg-primary" role="progressbar" style="width:@((Model.AmountCollected / Model.Amount) * 100)%"></div>
                                 </div>
-                                <div class="d-flex flex-column mb-4 d-sm-inline-flex mb-sm-0">
+                                <div class="d-flex d-print-inline-block flex-column mb-4 mr-5 d-sm-inline-flex mb-sm-0">
                                     <dt class="h4 font-weight-normal text-nowrap order-2 order-sm-1 mb-0">@Model.AmountCollectedFormatted</dt>
                                     <dd class="text-muted order-1 order-sm-2 mb-1">Already claimed</dd>
                                 </div>
-                                <div class="d-flex flex-column mb-0 d-sm-inline-flex float-sm-right">
-                                    <dt class="h4 font-weight-normal text-nowrap order-2 order-sm-1 mb-0">@Model.AmountFormatted</dt>
+                                <div class="d-flex d-print-inline-block flex-column mb-0 d-sm-inline-flex float-sm-right">
+                                    <dt class="h4 text-sm-right font-weight-normal text-nowrap order-2 order-sm-1 mb-0">@Model.AmountFormatted</dt>
                                     <dd class="text-muted text-sm-right order-1 order-sm-2 mb-1">Claim limit</dd>
                                 </div>
                             </dl>

--- a/BTCPayServer/wwwroot/main/site.css
+++ b/BTCPayServer/wwwroot/main/site.css
@@ -252,6 +252,9 @@ pre {
 .w-100px {
     width: 100px;
 }
+.w-125px {
+    width: 125px;
+}
 .w-150px {
     width: 150px;
 }

--- a/BTCPayServer/wwwroot/main/site.css
+++ b/BTCPayServer/wwwroot/main/site.css
@@ -249,6 +249,10 @@ pre {
     margin-top: .5rem;
 }
 
+.w-150px {
+    width: 150px;
+}
+
 /* Chrome, Safari, Edge, Opera */
 input[type=number].hide-number-spin::-webkit-outer-spin-button,
 input[type=number].hide-number-spin::-webkit-inner-spin-button {
@@ -285,8 +289,15 @@ html[data-devenv]:before {
 
 /* Print */
 @media print {
+    .table td,
+    .table th {
+        background: transparent;
+    }
     .jumbotron {
         padding: 1rem 0 !important;
+    }
+    a {
+        text-decoration: none !important;
     }
 }
 

--- a/BTCPayServer/wwwroot/main/site.css
+++ b/BTCPayServer/wwwroot/main/site.css
@@ -302,6 +302,9 @@ html[data-devenv]:before {
     .jumbotron {
         padding: 1rem 0 !important;
     }
+    .text-print-default {
+        color: inherit !important;
+    }
     a {
         text-decoration: none !important;
     }

--- a/BTCPayServer/wwwroot/main/site.css
+++ b/BTCPayServer/wwwroot/main/site.css
@@ -249,15 +249,11 @@ pre {
     margin-top: .5rem;
 }
 
-.w-100px {
-    width: 100px;
-}
-.w-125px {
-    width: 125px;
-}
-.w-150px {
-    width: 150px;
-}
+.w-100px { width: 100px; }
+.w-125px { width: 125px; }
+.w-150px { width: 150px; }
+.w-175px { width: 175px; }
+.w-200px { width: 200px; }
 
 /* Chrome, Safari, Edge, Opera */
 input[type=number].hide-number-spin::-webkit-outer-spin-button,

--- a/BTCPayServer/wwwroot/main/site.css
+++ b/BTCPayServer/wwwroot/main/site.css
@@ -249,6 +249,9 @@ pre {
     margin-top: .5rem;
 }
 
+.w-100px {
+    width: 100px;
+}
 .w-150px {
     width: 150px;
 }
@@ -272,8 +275,8 @@ html[data-devenv]:before {
     z-index: 1000;
     right: 0;
     bottom: 0;
-    background: var(--btcpay-bg-dark);
-    color: var(--btcpay-color-dark-text);
+    background: var(--btcpay-color-secondary-backdrop);
+    color: var(--btcpay-color-secondary-text);
     opacity: .7;
     padding: 4px 5px 3px 7px;
     font-size: 10px;

--- a/BTCPayServer/wwwroot/payment-request/app.js
+++ b/BTCPayServer/wwwroot/payment-request/app.js
@@ -43,6 +43,9 @@ addLoadEvent(function (ev) {
             lastUpdated: function () {
                 return this.srvModel.lastUpdated && moment(this.srvModel.lastUpdated).calendar();
             },
+            lastUpdatedDate: function () {
+                return this.srvModel.lastUpdated && moment(this.srvModel.lastUpdated).format('MMMM Do YYYY, h:mm:ss a');
+            },
             active: function () {
                 return !this.ended;
             }

--- a/BTCPayServer/wwwroot/payment-request/app.js
+++ b/BTCPayServer/wwwroot/payment-request/app.js
@@ -95,12 +95,8 @@ addLoadEvent(function (ev) {
                 }, 5000);
                 eventAggregator.$emit("cancel-invoice", amount);
             },
-            formatPaymentMethod: function (str) {
-                if (str.endsWith("LightningLike")) {
-                    return str.replace("LightningLike", "Lightning")
-                }
-                return str;
-
+            formatDate: function (date) {
+                return moment(date).format('L h:mm A')
             },
             submitCustomAmountForm: function(e) {
                 if (e) {
@@ -114,7 +110,6 @@ addLoadEvent(function (ev) {
             },
             statusTextClass: function (state) {
                 var [, status,, exceptionStatus] = state.match(/(\w*)\s?(\((\w*)\))?/) || [];
-                console.log(status, exceptionStatus)
                 switch (status) {
                     case "confirmed":
                     case "complete":

--- a/BTCPayServer/wwwroot/payment-request/app.js
+++ b/BTCPayServer/wwwroot/payment-request/app.js
@@ -90,25 +90,46 @@ addLoadEvent(function (ev) {
                 self.timeoutState = setTimeout(function () {
                     self.setLoading(false);
                 }, 5000);
-
                 eventAggregator.$emit("cancel-invoice", amount);
             },
             formatPaymentMethod: function (str) {
-
                 if (str.endsWith("LightningLike")) {
                     return str.replace("LightningLike", "Lightning")
                 }
                 return str;
 
             },
-            submitCustomAmountForm : function(e){
+            submitCustomAmountForm: function(e) {
                 if (e) {
                     e.preventDefault();
                 }
-                if(this.srvModel.allowCustomPaymentAmounts && parseFloat(this.customAmount) < this.srvModel.amountDue){
+                if (this.srvModel.allowCustomPaymentAmounts && parseFloat(this.customAmount) < this.srvModel.amountDue){
                     this.pay(parseFloat(this.customAmount));
-                }else{
+                } else {
                     this.pay();
+                }
+            },
+            statusTextClass: function (state) {
+                var [, status,, exceptionStatus] = state.match(/(\w*)\s?(\((\w*)\))?/) || [];
+                console.log(status, exceptionStatus)
+                switch (status) {
+                    case "confirmed":
+                    case "complete":
+                    case "paid":
+                        return "text-success";
+                    case "expired":
+                        switch (exceptionStatus) {
+                            case "paidLate":
+                            case "paidPartial":
+                            case "paidOver":
+                                return "text-warning";
+                            default:
+                                return "text-danger";
+                        }
+                    case "invalid":
+                        return "text-danger";
+                    default:
+                        return "text-warning";
                 }
             }
         },


### PR DESCRIPTION
Allows for export as invoice PDF to be used in accounting. Closes #1957.

The main option for providing additional information and styling it is the description field. This isn't available for the pull payment, that's why that PDF is rather sparse.

