### PR TITLE
fix forgot password

### DIFF
--- a/BTCPayServer/Controllers/AccountController.cs
+++ b/BTCPayServer/Controllers/AccountController.cs
@@ -537,7 +537,7 @@ namespace BTCPayServer.Controllers
             if (ModelState.IsValid)
             {
                 var user = await _userManager.FindByEmailAsync(model.Email);
-                if (user == null || !(await _userManager.IsEmailConfirmedAsync(user)))
+                if (user == null || (user.RequiresEmailConfirmation && !(await _userManager.IsEmailConfirmedAsync(user))))
                 {
                     // Don't reveal that the user does not exist or is not confirmed
                     return RedirectToAction(nameof(ForgotPasswordConfirmation));


### PR DESCRIPTION
If Email verification is turned off but you requested a forgot password form, it would ignore the request internally. Seems like it has been this way since the beginning