### PR TITLE
Remove QuadrigaCX references

### DIFF
--- a/BTCPayServer.Tests/BTCPayServerTester.cs
+++ b/BTCPayServer.Tests/BTCPayServerTester.cs
@@ -206,9 +206,9 @@ namespace BTCPayServer.Tests
                 bitflyerMock.ExchangeRates.Add(new PairRate(CurrencyPair.Parse("BTC_JPY"), new BidAsk(700000m)));
                 rateProvider.Providers.Add("bitflyer", bitflyerMock);
 
-                var quadrigacx = new MockRateProvider();
-                quadrigacx.ExchangeRates.Add(new PairRate(CurrencyPair.Parse("BTC_CAD"), new BidAsk(6000m)));
-                rateProvider.Providers.Add("quadrigacx", quadrigacx);
+                var ndax = new MockRateProvider();
+                ndax.ExchangeRates.Add(new PairRate(CurrencyPair.Parse("BTC_CAD"), new BidAsk(6000m)));
+                rateProvider.Providers.Add("ndax", ndax);
 
                 var bittrex = new MockRateProvider();
                 bittrex.ExchangeRates.Add(new PairRate(CurrencyPair.Parse("DOGE_BTC"), new BidAsk(0.004m)));

--- a/BTCPayServer.Tests/UnitTest1.cs
+++ b/BTCPayServer.Tests/UnitTest1.cs
@@ -1893,7 +1893,7 @@ namespace BTCPayServer.Tests
 
                 rateVm.ScriptTest = "BTC_USD,BTC_CAD,DOGE_USD,DOGE_CAD";
                 rateVm.Script = "DOGE_X = bittrex(DOGE_BTC) * BTC_X;\n" +
-                                "X_CAD = quadrigacx(X_CAD);\n" +
+                                "X_CAD = ndax(X_CAD);\n" +
                                 "X_X = coingecko(X_X);";
                 rateVm.Spread = 50;
                 rateVm = Assert.IsType<RatesViewModel>(Assert.IsType<ViewResult>(await store.Rates(rateVm, "Test"))

--- a/BTCPayServer/Views/Stores/Rates.cshtml
+++ b/BTCPayServer/Views/Stores/Rates.cshtml
@@ -105,10 +105,10 @@
                             X_X = kraken(X_X);
                         </code>
                     </pre>
-                    <p>However, <code>kraken</code> does not support the <code>BTC_CAD</code> pair. For this reason you can add a rule mapping all <code>X_CAD</code> to <code>quadrigacx</code>, a Canadian exchange.</p>
+                    <p>However, <code>kraken</code> does not support the <code>BTC_CAD</code> pair. For this reason you can add a rule mapping all <code>X_CAD</code> to <code>ndax</code>, a Canadian exchange.</p>
                     <pre>
                     <code>
-                            X_CAD = quadrigacx(X_CAD);
+                            X_CAD = ndax(X_CAD);
                             X_X = kraken(X_X);
                         </code>
                     </pre>
@@ -120,19 +120,19 @@
                     <pre>
                     <code>
                             DOGE_X = bittrex(DOGE_BTC) * BTC_X
-                            X_CAD = quadrigacx(X_CAD);
+                            X_CAD = ndax(X_CAD);
                             X_X = kraken(X_X);
                         </code>
                     </pre>
                     <p>
-                        With <code>DOGE_USD</code> will be expanded to <code>bittrex(DOGE_BTC) * kraken(BTC_USD)</code>. And <code>DOGE_CAD</code> will be expanded to <code>bittrex(DOGE_BTC) * quadrigacx(BTC_CAD)</code>. <br />
+                        With <code>DOGE_USD</code> will be expanded to <code>bittrex(DOGE_BTC) * kraken(BTC_USD)</code>. And <code>DOGE_CAD</code> will be expanded to <code>bittrex(DOGE_BTC) * ndax(BTC_CAD)</code>. <br />
                         However, we advise you to write it that way to increase coverage so that <code>DOGE_BTC</code> is also supported:
                     </p>
                     <pre>
                     <code>
                             DOGE_X = DOGE_BTC * BTC_X
                             DOGE_BTC = bittrex(DOGE_BTC)
-                            X_CAD = quadrigacx(X_CAD);
+                            X_CAD = ndax(X_CAD);
                             X_X = kraken(X_X);
                         </code>
                     </pre>


### PR DESCRIPTION
Quadriga has been dead for years. I've removed the references to them and replaced them with a different Canadian exchange (ndax) for example. 

The whole set of instructions could probably use an overhaul, but for now, at least let's get rid of Gerry's presence.