### PR TITLE
Fix failing generateaddress when address contains escape sequences in docker-bitcoin-generate.sh

### DIFF
--- a/BTCPayServer.Tests/docker-bitcoin-generate.sh
+++ b/BTCPayServer.Tests/docker-bitcoin-generate.sh
@@ -2,4 +2,5 @@
 
 bitcoind_container_id="$(docker ps -q --filter label=com.docker.compose.project=btcpayservertests --filter label=com.docker.compose.service=bitcoind)"
 address=$(docker exec -ti $bitcoind_container_id bitcoin-cli -datadir="/data" getnewaddress)
-docker exec -ti $bitcoind_container_id bitcoin-cli -datadir="/data" generatetoaddress "$@" "$address"
+clean_address="${address//[$'\t\r\n']}"
+docker exec $bitcoind_container_id bitcoin-cli -datadir="/data" generatetoaddress "$@" "$clean_address"


### PR DESCRIPTION
# Description

This PR fixes an issue on some environments where `docker-bitcoin-generate.sh` script fails while running `docker exec ... generateaddress ...` succeeds.

## To Reproduce

```bash
$ ./docker-bitcoin-generate.sh 1
f5eafc96f054 # echo "$bitcoind_container_id"
bcrt1qendwwd8dmxp6zr0v7ku4vxmwlqjnnkyvjxnry2 # echo "$address"
error code: -5
error message:
Error: Invalid address

$ docker exec -ti f5eafc96f054 bitcoin-cli -datadir="/data" generatetoaddress 1 bcrt1qendwwd8dmxp6zr0v7ku4vxmwlqjnnkyvjxnry2
[
  "5d6c3041004abf1de991f1b7d4097253f3d1b76c562c08f24478fa445a18dfbb"
]
```

# Solution

The problem is that `bitcoin-cli` fails to decode the `address` variable if it contains escape sequences.

```bash
$ sudo bash docker-bitcoin-generate.sh 1
f5eafc96f054 # echo "$bitcoind_container_id"
bcrt1qendwwd8dmxp6zr0v7ku4vxmwlqjnnkyvjxnry2 # echo "$address"

# echo "$address" | hd -b
00000000  62 63 72 74 31 71 7a 7a  68 73 79 79 75 76 6b 34  |bcrt1qzzhsyyuvk4|
0000000 142 143 162 164 061 161 172 172 150 163 171 171 165 166 153 064
00000010  68 30 34 70 71 68 6c 67  75 66 72 66 6d 63 71 38  |h04pqhlgufrfmcq8|
0000010 150 060 064 160 161 150 154 147 165 146 162 146 155 143 161 070
00000020  30 77 77 77 64 76 67 6e  76 33 64 75 0d 0a        |0wwwdvgnv3du..|
0000020 060 167 167 167 144 166 147 156 166 063 144 165 015 012
000002e

error code: -5
error message:
Error: Invalid address

# using this address would work,
# see the difference in the last char
$ echo "bcrt1qzzhsyyuvk4h04pqhlgufrfmcq80wwwdvgnv3du" | hd -b
00000000  62 63 72 74 31 71 7a 7a  68 73 79 79 75 76 6b 34  |bcrt1qzzhsyyuvk4|
0000000 142 143 162 164 061 161 172 172 150 163 171 171 165 166 153 064
00000010  68 30 34 70 71 68 6c 67  75 66 72 66 6d 63 71 38  |h04pqhlgufrfmcq8|
0000010 150 060 064 160 161 150 154 147 165 146 162 146 155 143 161 070
00000020  30 77 77 77 64 76 67 6e  76 33 64 75 0a           |0wwwdvgnv3du.|
0000020 060 167 167 167 144 166 147 156 166 063 144 165 012
000002d
```

If `address` is stripped of any whitespace characters `bitcoin-cli` can decode it without errors.
This solution should preserve behavior in environments where this script did not fail.

Shout out to @slapec for helping me with this issue!
