### PR TITLE
API: Handle lightning invoice creation errors

### DIFF
--- a/BTCPayServer/wwwroot/swagger/v1/swagger.template.lightning.internal.json
+++ b/BTCPayServer/wwwroot/swagger/v1/swagger.template.lightning.internal.json
@@ -433,6 +433,16 @@
                             }
                         }
                     },
+                    "400": {
+                        "description": "Wellknown error codes are: `invoice-error`",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProblemDetails"
+                                }
+                            }
+                        }
+                    },
                     "503": {
                         "description": "Unable to access the lightning node"
                     },

--- a/BTCPayServer/wwwroot/swagger/v1/swagger.template.lightning.store.json
+++ b/BTCPayServer/wwwroot/swagger/v1/swagger.template.lightning.store.json
@@ -509,6 +509,16 @@
                             }
                         }
                     },
+                    "400": {
+                        "description": "Wellknown error codes are: `invoice-error`",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProblemDetails"
+                                }
+                            }
+                        }
+                    },
                     "503": {
                         "description": "Unable to access the lightning node"
                     },


### PR DESCRIPTION
Catches LightningClient exceptions and responds with a detailed API error (400) instead of a generic server failure (503).

The catch block doesn't use the `when` clause, because the check for the LightningClient namespace seemed a bit too complex to me. As the LightningClients throw their individual exception types here, I thought it'd be best to check for the namespace and handle only client errors – other exceptions should still trigger the original 503 errors. 
If there's a better way to do this check let me know …

A sample for an error thrown by the CLightningClient, which now get's handled with details included:

```json
{
    "code": "invoice-error",
    "message": "msatoshi cannot exceed 4294967295msat"
}
```