### PR TITLE
Fix bug with already used colors being used first for new tx labels

### DIFF
--- a/BTCPayServer/Controllers/WalletsController.cs
+++ b/BTCPayServer/Controllers/WalletsController.cs
@@ -107,15 +107,21 @@ namespace BTCPayServer.Controllers
             _pullPaymentService = pullPaymentService;
         }
 
-        // Borrowed from https://github.com/ManageIQ/guides/blob/master/labels.md
+        // Borrowed from https://github.com/ManageIQ/guides/blob/master/labels.md and https://sashamaps.net/docs/resources/20-colors/
         readonly string[] LabelColorScheme = new string[]
         {
             "#fbca04",
             "#0e8a16",
             "#ff7619",
             "#84b6eb",
+            "#4363d8",
+            "#fabed4",
+            "#42d4f4",
+            "#9a6324",
+            "#800000",
+            "#808000",
             "#5319e7",
-            "#000000",
+            "#cdcdcd",
             "#cc317c",
         };
 

--- a/BTCPayServer/Controllers/WalletsController.cs
+++ b/BTCPayServer/Controllers/WalletsController.cs
@@ -179,7 +179,12 @@ namespace BTCPayServer.Controllers
                         allColors
                         .GroupBy(k => k)
                         .OrderBy(k => k.Count())
-                        .ThenBy(k => Array.IndexOf(LabelColorScheme, k.Key))
+                        .ThenBy(k => {
+                            var indexInColorScheme = Array.IndexOf(LabelColorScheme, k.Key);
+
+                            // Ensures that any label color which may not be in our label color scheme is given the least priority
+                            return indexInColorScheme == -1 ? double.PositiveInfinity : indexInColorScheme;
+                        })
                         .First().Key;
                     walletBlobInfo.LabelColors.Add(addlabel, chosenColor);
                     await WalletRepository.SetWalletInfo(walletId, walletBlobInfo);

--- a/BTCPayServer/Controllers/WalletsController.cs
+++ b/BTCPayServer/Controllers/WalletsController.cs
@@ -107,19 +107,13 @@ namespace BTCPayServer.Controllers
             _pullPaymentService = pullPaymentService;
         }
 
-        // Borrowed from https://github.com/ManageIQ/guides/blob/master/labels.md and https://sashamaps.net/docs/resources/20-colors/
+        // Borrowed from https://github.com/ManageIQ/guides/blob/master/labels.md
         readonly string[] LabelColorScheme = new string[]
         {
             "#fbca04",
             "#0e8a16",
             "#ff7619",
             "#84b6eb",
-            "#4363d8",
-            "#fabed4",
-            "#42d4f4",
-            "#9a6324",
-            "#800000",
-            "#808000",
             "#5319e7",
             "#cdcdcd",
             "#cc317c",


### PR DESCRIPTION
Close #2072.

# Before

When creating a new label sometimes an already used color is picked first before a new color is picked.

# After

New and previously unused color is always picked when creating a new label if it's available.
