### PR TITLE
Update classic theme for payment requests

### DIFF
--- a/BTCPayServer/Views/PaymentRequest/ViewPaymentRequest.cshtml
+++ b/BTCPayServer/Views/PaymentRequest/ViewPaymentRequest.cshtml
@@ -250,7 +250,7 @@
                                                 <tr class="table-borderless">
                                                     <th class="font-weight-normal text-secondary" scope="col">Invoice Id</th>
                                                     <th class="font-weight-normal text-secondary w-175px">Expiry</th>
-                                                    <th class="font-weight-normal text-secondary text-right w-100px">Amount</th>
+                                                    <th class="font-weight-normal text-secondary text-right w-125px">Amount</th>
                                                     <th class="font-weight-normal text-secondary text-right w-125px"></th>
                                                     <th class="font-weight-normal text-secondary text-right">Status</th>
                                                 </tr>
@@ -309,7 +309,7 @@
                                             <tr class="table-borderless">
                                                 <th class="font-weight-normal text-secondary" scope="col">Invoice Id</th>
                                                 <th class="font-weight-normal text-secondary w-175px">Expiry</th>
-                                                <th class="font-weight-normal text-secondary text-right w-100px">Amount</th>
+                                                <th class="font-weight-normal text-secondary text-right w-125px">Amount</th>
                                                 <th class="font-weight-normal text-secondary text-right w-125px"></th>
                                                 <th class="font-weight-normal text-secondary text-right">Status</th>
                                             </tr>

--- a/BTCPayServer/wwwroot/main/themes/classic.css
+++ b/BTCPayServer/wwwroot/main/themes/classic.css
@@ -59,11 +59,17 @@
   --btcpay-bg-tile: var(--btcpay-color-white);
   --btcpay-bg-cta:  var(--btcpay-bg-dark);
 
-  --btcpay-footer-color: var(--btcpay-color-neutral-400);
-
   --btcpay-body-color: var(--btcpay-color-neutral-900);
   --btcpay-body-color-link: var(--btcpay-color-primary);
   --btcpay-body-color-link-accent: var(--btcpay-color-primary-accent);
+
+  --btcpay-header-bg: var(--btcpay-bg-dark);
+  --btcpay-header-color: var(--btcpay-color-white);
+  --btcpay-header-color-link: var(--btcpay-color-white);
+  --btcpay-header-color-link-accent: var(--btcpay-color-white);
+
+  --btcpay-footer-bg: var(--btcpay-bg-dark);
+  --btcpay-footer-color: var(--btcpay-color-neutral-400);
 
   --btcpay-bg-nav-link-active: #d9f7ef;
 
@@ -113,4 +119,8 @@
 .removetopborder tr:first-child th,
 .removetopborder tr:first-child td {
   border-top: none;
+}
+
+#mainNav:not(.navbar-shrink) {
+  background: var(--btcpay-color-white);
 }


### PR DESCRIPTION
Fixes #2084. The classic theme was missing the background color for the header – hence the content overlap. Also checked the Casa theme, which worked fine.

![classic](https://user-images.githubusercontent.com/886/100883894-246e5b80-34b1-11eb-913f-6d8faa95fe8e.png)
