### PR TITLE
Reverting uppercasing of Bech32 addresses in QR code

### DIFF
--- a/BTCPayServer.Tests/UnitTest1.cs
+++ b/BTCPayServer.Tests/UnitTest1.cs
@@ -2094,7 +2094,11 @@ namespace BTCPayServer.Tests
                 Assert.Contains("&lightning=", paymentMethodSecond.InvoiceBitcoinUrlQR);
                 Assert.StartsWith("BITCOIN:", paymentMethodSecond.InvoiceBitcoinUrlQR);
                 var split = paymentMethodSecond.InvoiceBitcoinUrlQR.Split('?')[0];
-                Assert.True($"BITCOIN:{paymentMethodSecond.BtcAddress.ToUpperInvariant()}" == split);
+
+                // Standard for uppercase Bech32 addresses in QR codes is still not implemented in all wallets
+                // When it is widely propagated consider uncommenting these lines
+                //Assert.True($"BITCOIN:{paymentMethodSecond.BtcAddress.ToUpperInvariant()}" == split);
+                Assert.True($"BITCOIN:{paymentMethodSecond.BtcAddress}" == split);
             }
         }
 

--- a/BTCPayServer/Payments/Bitcoin/BitcoinLikePaymentHandler.cs
+++ b/BTCPayServer/Payments/Bitcoin/BitcoinLikePaymentHandler.cs
@@ -71,15 +71,17 @@ namespace BTCPayServer.Payments.Bitcoin
                 .Replace("bitcoin:", "BITCOIN:", StringComparison.OrdinalIgnoreCase)
                 + lightningFallback.ToUpperInvariant().Replace("LIGHTNING=", "lightning=", StringComparison.OrdinalIgnoreCase);
 
-            if (bech32Prefixes.Any(a => model.BtcAddress.StartsWith(a, StringComparison.OrdinalIgnoreCase)))
-            {
-                model.InvoiceBitcoinUrlQR = model.InvoiceBitcoinUrlQR.Replace(
-                    $"BITCOIN:{model.BtcAddress}", $"BITCOIN:{model.BtcAddress.ToUpperInvariant()}", 
-                    StringComparison.OrdinalIgnoreCase
-                );
-            }
+            // Standard for uppercase Bech32 addresses in QR codes is still not implemented in all wallets
+            // When it is widely propagated consider uncommenting these lines
+            //if (bech32Prefixes.Any(a => model.BtcAddress.StartsWith(a, StringComparison.OrdinalIgnoreCase)))
+            //{
+            //    model.InvoiceBitcoinUrlQR = model.InvoiceBitcoinUrlQR.Replace(
+            //        $"BITCOIN:{model.BtcAddress}", $"BITCOIN:{model.BtcAddress.ToUpperInvariant()}", 
+            //        StringComparison.OrdinalIgnoreCase
+            //    );
+            //}
         }
-        private static string[] bech32Prefixes = new[] { "bc1", "tb1", "bcrt1" };
+        //private static string[] bech32Prefixes = new[] { "bc1", "tb1", "bcrt1" };
 
         public override string GetCryptoImage(PaymentMethodId paymentMethodId)
         {


### PR DESCRIPTION
Resolves: #2099

Linked issue contains all the details and great discussion. For reasons on why we decided to uppercase bech32 address in QR codes in the first place see: https://github.com/btcpayserver/btcpayserver/pull/2060#issuecomment-723828348