### PR TITLE
Add "Mark all as seen" button to notification dropdown

### DIFF
--- a/BTCPayServer/Components/NotificationsDropdown/Default.cshtml
+++ b/BTCPayServer/Components/NotificationsDropdown/Default.cshtml
@@ -2,6 +2,7 @@
 @inject UserManager<ApplicationUser> UserManager
 @inject CssThemeManager CssThemeManager
 @using BTCPayServer.HostedServices
+@using Microsoft.AspNetCore.Http.Extensions
 @model BTCPayServer.Components.NotificationsDropdown.NotificationSummaryViewModel
 
 @if (Model.UnseenCount > 0)
@@ -24,6 +25,9 @@
                 </a>
             }
             <a class="dropdown-item text-secondary" asp-controller="Notifications" asp-action="Index">See All</a>
+            <form asp-controller="Notifications" asp-action="MarkAllAsSeen" asp-route-returnUrl="@Context.Request.GetDisplayUrl()" method="post">
+                <button class="dropdown-item text-secondary" type="submit"><i class="fa fa-eye"></i> Mark all as seen</button>
+            </form>
         </div>
     </li>
 }

--- a/BTCPayServer/Controllers/NotificationsController.cs
+++ b/BTCPayServer/Controllers/NotificationsController.cs
@@ -206,6 +206,17 @@ namespace BTCPayServer.Controllers
             return RedirectToAction(nameof(Index));
         }
 
+        [HttpPost]
+        public async Task<IActionResult> MarkAllAsSeen(string returnUrl)
+        {
+            if (!ValidUserClaim(out var userId))
+            {
+                return NotFound();
+            }
+            await _notificationManager.ToggleSeen(new NotificationsQuery() {Seen = false, UserId = userId}, true);
+            return Redirect(returnUrl);
+        }
+
         private bool ValidUserClaim(out string userId)
         {
             userId = _userManager.GetUserId(User);

--- a/BTCPayServer/Services/Notifications/NotificationSender.cs
+++ b/BTCPayServer/Services/Notifications/NotificationSender.cs
@@ -13,6 +13,10 @@ namespace BTCPayServer.Services.Notifications
     public class UserNotificationsUpdatedEvent
     {
         public string UserId { get; set; }
+        public override string ToString()
+        {
+            return string.Empty;
+        }
     }
     public class NotificationSender
     {


### PR DESCRIPTION
## Motivation

I often find myself wanting to just clear all notifications after I have seen them. In order to do this I need to go to the "Notifications" page, mass-select them and then perform a batch action. This takes four clicks to do. I would like to be able to do this quicker.

## Solution

Added a "Mark all as seen" button in the notification dropdown which allows me to accomplish the goal of marking all notifications as seen in two clicks instead of four.

![Screen Shot 2020-12-03 at 7 54 20 PM](https://user-images.githubusercontent.com/1934678/101120875-91621e00-35a3-11eb-91a1-f15ccfba77ef.png)
