### PR TITLE
do not crash when importing a non-json based QR code

### DIFF
--- a/BTCPayServer/DerivationSchemeSettings.cs
+++ b/BTCPayServer/DerivationSchemeSettings.cs
@@ -81,6 +81,8 @@ namespace BTCPayServer
                     settings.Network = network;
                     return true;
                 }
+
+                return false;
             }
 
             //electrum


### PR DESCRIPTION
fixes #2098