### PR TITLE
Add ability to add custom CSS to pull payments

### DIFF
--- a/BTCPayServer/Controllers/WalletsController.PullPayments.cs
+++ b/BTCPayServer/Controllers/WalletsController.PullPayments.cs
@@ -30,7 +30,9 @@ namespace BTCPayServer.Controllers
             return View(new NewPullPaymentModel()
             {
                 Name = "",
-                Currency = "BTC"
+                Currency = "BTC",
+                CustomCSSLink = "",
+                EmbeddedCSS = "",
             });
         }
 
@@ -65,7 +67,9 @@ namespace BTCPayServer.Controllers
                 Amount = model.Amount,
                 Currency = model.Currency,
                 StoreId = walletId.StoreId,
-                PaymentMethodIds = new[] { paymentMethodId }
+                PaymentMethodIds = new[] { paymentMethodId },
+                EmbeddedCSS = model.EmbeddedCSS,
+                CustomCSSLink = model.CustomCSSLink
             });
             this.TempData.SetStatusMessageModel(new StatusMessageModel()
             {

--- a/BTCPayServer/HostedServices/PullPaymentHostedService.cs
+++ b/BTCPayServer/HostedServices/PullPaymentHostedService.cs
@@ -29,6 +29,8 @@ namespace BTCPayServer.HostedServices
         public string Name { get; set; }
         public decimal Amount { get; set; }
         public string Currency { get; set; }
+        public string CustomCSSLink { get; set; }
+        public string EmbeddedCSS { get; set; }
         public PaymentMethodId[] PaymentMethodIds { get; set; }
         public TimeSpan? Period { get; set; }
     }
@@ -110,9 +112,9 @@ namespace BTCPayServer.HostedServices
                 {
                     Title = create.Name ?? string.Empty,
                     Description = string.Empty,
-                    CustomCSSLink = null,
+                    CustomCSSLink = create.CustomCSSLink,
                     Email = null,
-                    EmbeddedCSS = null,
+                    EmbeddedCSS = create.EmbeddedCSS,
                 }
             });
             ctx.PullPayments.Add(o);

--- a/BTCPayServer/Models/WalletViewModels/PullPaymentsModel.cs
+++ b/BTCPayServer/Models/WalletViewModels/PullPaymentsModel.cs
@@ -42,5 +42,10 @@ namespace BTCPayServer.Models.WalletViewModels
         [Required]
         [ReadOnly(true)]
         public string Currency { get; set; }
+        [MaxLength(500)]
+        [Display(Name = "Custom bootstrap CSS file")]
+        public string CustomCSSLink { get; set; }
+        [Display(Name = "Custom CSS Code")]
+        public string EmbeddedCSS { get; set; }
     }
 }

--- a/BTCPayServer/Views/Wallets/NewPullPayment.cshtml
+++ b/BTCPayServer/Views/Wallets/NewPullPayment.cshtml
@@ -1,8 +1,7 @@
 ﻿@model NewPullPaymentModel
 @{
     Layout = "../Shared/_NavLayout.cshtml";
-    ViewData["Title"] = "Manage pull payments";
-    ViewData.SetActivePageAndTitle(WalletsNavPages.PullPayments);
+    ViewData["Title"] = "New pull payment";
 }
 <style type="text/css">
     .smMaxWidth {

--- a/BTCPayServer/Views/Wallets/NewPullPayment.cshtml
+++ b/BTCPayServer/Views/Wallets/NewPullPayment.cshtml
@@ -80,6 +80,19 @@
                 </div>
             </div>
             <div class="form-group">
+                <label asp-for="CustomCSSLink" class="control-label"></label>
+                <a href="https://docs.btcpayserver.org/Theme/#2-bootstrap-themes" target="_blank">
+                    <span class="fa fa-question-circle-o" title="More information..."></span>
+                </a>
+                <input asp-for="CustomCSSLink" class="form-control" />
+                <span asp-validation-for="CustomCSSLink" class="text-danger"></span>
+            </div>
+            <div class="form-group">
+                <label asp-for="EmbeddedCSS" class="control-label"></label>
+                <textarea asp-for="EmbeddedCSS" rows="10" cols="40" class="form-control"></textarea>
+                <span asp-validation-for="EmbeddedCSS" class="text-danger"></span>
+            </div>
+            <div class="form-group">
                 <input type="submit" value="Create" class="btn btn-primary" id="Create" />
             </div>
         </form>


### PR DESCRIPTION
Address #2108 by adding an ability to specify custom CSS for pull payments same as for payment requests.

# Screenshots

![Screen Shot 2020-12-07 at 8 22 23 PM](https://user-images.githubusercontent.com/1934678/101439746-0f873300-38ca-11eb-8fa3-08a557b480d7.png)

## Darkly theme (https://bootswatch.com/darkly/):

![Screen Shot 2020-12-07 at 7 53 06 PM](https://user-images.githubusercontent.com/1934678/101439768-1ada5e80-38ca-11eb-8307-1be01c7ee2e8.png)

## Custom CSS from example in docs:

![Screen Shot 2020-12-07 at 7 53 31 PM](https://user-images.githubusercontent.com/1934678/101439769-1c0b8b80-38ca-11eb-8a36-f1693f21ebbb.png)

## Updated page heading:

### Before
![Screen Shot 2020-12-07 at 8 16 03 PM](https://user-images.githubusercontent.com/1934678/101439997-a6ec8600-38ca-11eb-8c2c-549734294dfe.png)

### After
![Screen Shot 2020-12-07 at 8 14 56 PM](https://user-images.githubusercontent.com/1934678/101440012-aeac2a80-38ca-11eb-8ffe-684dab221fed.png)


