### PR TITLE
FIx Pay Button Link preview when app mode chosen

### DIFF
--- a/BTCPayServer/Views/Stores/PayButton.cshtml
+++ b/BTCPayServer/Views/Stores/PayButton.cshtml
@@ -153,9 +153,11 @@
         <div class="col-lg-5">
             <h4>Preview</h4>
             <div id="preview"></div>
-            <h4 class="mt-2">Link</h4>
-            <span>Alternatively, you can share this link or encode it in a QR code</span>
-            <div id="preview-link"></div>
+            <div v-show="!srvModel.appIdEndpoint">
+                <h4 class="mt-2">Link</h4>
+                <span>Alternatively, you can share this link or encode it in a QR code</span>
+                <div id="preview-link"></div>
+            </div>
         </div>
     </div>
     <hr />

--- a/BTCPayServer/wwwroot/paybutton/paybutton.js
+++ b/BTCPayServer/wwwroot/paybutton/paybutton.js
@@ -197,7 +197,7 @@ function inputChanges(event, buttonSize) {
         }
     });
     url = url.href;
-    $("#preview-link").append(`<a href="${url}">${url}</a>`)
+    $("#preview-link").html(`<a href="${url}">${url}</a>`)
     
     $('pre code').each(function (i, block) {
         hljs.highlightBlock(block);


### PR DESCRIPTION
Apps cannot have a link as they only have a POST action.
fixes #2112  (i think)