### PR TITLE
UI: Improve mobile store setup view

### DIFF
--- a/BTCPayServer/Views/Stores/UpdateStore.cshtml
+++ b/BTCPayServer/Views/Stores/UpdateStore.cshtml
@@ -27,27 +27,24 @@
             <ul class="list-group mb-3">
                 @foreach (var scheme in Model.DerivationSchemes.OrderBy(scheme => scheme.Collapsed))
                 {
+                    var isSetUp = !string.IsNullOrWhiteSpace(scheme.Value);
+
                     <li class="list-group-item bg-tile @(scheme.Collapsed ? "collapsed": "")">
-                        <div class="d-flex flex-wrap align-items-center">
-                            <span class="d-flex flex-wrap align-items-center flex-fill">
+                        <div class="d-flex align-items-center">
+                            <span class="d-flex flex-wrap flex-fill flex-column flex-sm-row">
                                 <strong class="mr-3">@scheme.Crypto</strong>
-                                @if (!string.IsNullOrWhiteSpace(scheme.Value))
+                                @if (isSetUp)
                                 {
                                     <span title="@scheme.Value" data-toggle="tooltip" class="d-flex mr-3">
-                                        <code class="text-truncate" style="max-width:10ch">
-                                            @scheme.Value
-                                        </code>
-                                        <code class="text-nowrap">
-                                            @if (scheme.Value.Length > 20)
-                                            {
-                                                var match = Regex.Match(scheme.Value, @"((?:-\[(?:[^\]])+\])+|\S{16})$");
-                                                @match.Value;
-                                            }
-                                        </code>
+                                        <span class="text-truncate text-secondary" style="max-width:8ch">@scheme.Value</span>
+                                        @if (scheme.Value.Length > 20)
+                                        {
+                                            <span class="text-nowrap text-secondary">@Regex.Match(scheme.Value, @"((?:-\[(?:[^\]])+\])+|\S{6})$").Value</span>
+                                        }
                                     </span>
                                     @if (scheme.WalletSupported)
                                     {
-                                        <a asp-action="WalletTransactions" asp-controller="Wallets" asp-route-walletId="@scheme.WalletId" class="text-secondary">Wallet</a>
+                                        <a asp-action="WalletTransactions" asp-controller="Wallets" asp-route-walletId="@scheme.WalletId" class="text-secondary mr-3">Manage Wallet</a>
                                     }
                                 }
                             </span>
@@ -66,12 +63,12 @@
                                         Disabled
                                     </strong>
                                 }
-                                @if (scheme.Enabled)
+                                @if (isSetUp)
                                 {
                                     <span class="text-light ml-3 mr-2">|</span>
                                 }
-                                <a asp-action="AddDerivationScheme" asp-route-cryptoCode="@scheme.Crypto" asp-route-storeId="@Context.GetRouteValue("storeId")" id="@($"Modify{scheme.Crypto}")" class="btn btn-sm btn-@(scheme.Enabled ? "link" : "primary ml-4 px-3") py-1">
-                                    @(scheme.Enabled ? "Modify" : "Setup")
+                                <a asp-action="AddDerivationScheme" asp-route-cryptoCode="@scheme.Crypto" asp-route-storeId="@Context.GetRouteValue("storeId")" id="@($"Modify{scheme.Crypto}")" class="btn btn-sm btn-@(isSetUp ? "link" : "primary ml-4 px-3") py-1">
+                                    @(isSetUp ? "Modify" : "Setup")
                                 </a>
                             </span>
                         </div>
@@ -101,13 +98,15 @@
             <ul class="list-group mb-3">
                 @foreach (var scheme in Model.LightningNodes)
                 {
+                    var isSetUp = !string.IsNullOrWhiteSpace(scheme.Address);
+
                     <li class="list-group-item bg-tile">
-                        <div class="d-flex flex-wrap align-items-center">
-                            <span class="d-flex align-items-center flex-fill">
+                        <div class="d-flex align-items-center">
+                            <span class="d-flex flex-wrap flex-fill flex-column flex-sm-row">
                                 <strong class="mr-3">@scheme.CryptoCode</strong>
-                                @if (!string.IsNullOrWhiteSpace(scheme.Address))
+                                @if (isSetUp)
                                 {
-                                    <code class="smMaxWidth text-truncate mr-3">@scheme.Address</code>
+                                    <span class="smMaxWidth text-truncate text-secondary mr-3">@scheme.Address</span>
                                 }
                             </span>
                             <span class="d-flex align-items-center">
@@ -125,12 +124,12 @@
                                         Disabled
                                     </strong>
                                 }
-                                @if (scheme.Enabled)
+                                @if (isSetUp)
                                 {
                                     <span class="text-light ml-3 mr-2">|</span>
                                 }
-                                <a asp-action="AddLightningNode" asp-route-cryptoCode="@scheme.CryptoCode" asp-route-storeId="@Context.GetRouteValue("storeId")" id="@($"Modify-Lightning{scheme.CryptoCode}")" class="btn btn-sm btn-@(scheme.Enabled ? "link" : "primary ml-4 px-3") py-1">
-                                    @(scheme.Enabled ? "Modify" : "Setup")
+                                <a asp-action="AddLightningNode" asp-route-cryptoCode="@scheme.CryptoCode" asp-route-storeId="@Context.GetRouteValue("storeId")" id="@($"Modify-Lightning{scheme.CryptoCode}")" class="btn btn-sm btn-@(isSetUp ? "link" : "primary ml-4 px-3") py-1">
+                                    @(isSetUp ? "Modify" : "Setup")
                                 </a>
                             </span>
                         </div>


### PR DESCRIPTION
According to [this comment](https://github.com/btcpayserver/btcpayserver/pull/2087#issuecomment-737672180) by @dstrukt.

Screenshot from XS and SM viewport size.

## Not set up

![setup-xs](https://user-images.githubusercontent.com/886/101497336-23cf3c80-396b-11eb-997d-037ca1cde2cd.png)
![setup-sm](https://user-images.githubusercontent.com/886/101497338-2467d300-396b-11eb-944f-6c382e286ee8.png)

## Set up, but disabled

![setup-disabled-xs](https://user-images.githubusercontent.com/886/101497235-0b5f2200-396b-11eb-847a-f3b6a20853a8.png)
![setup-disabled-sm](https://user-images.githubusercontent.com/886/101497237-0bf7b880-396b-11eb-99de-29de9fb59f0c.png)

## Enabled

![enabled-xs](https://user-images.githubusercontent.com/886/101497121-ea96cc80-396a-11eb-8c10-6bbaff6c6488.png)
![enabled-sm](https://user-images.githubusercontent.com/886/101497120-e9fe3600-396a-11eb-817c-f3d9e09c4b46.png)
