### PR TITLE
UI: Improve mobile store setup view

### DIFF
--- a/BTCPayServer/Views/Stores/UpdateStore.cshtml
+++ b/BTCPayServer/Views/Stores/UpdateStore.cshtml
@@ -48,26 +48,26 @@
                                     }
                                 }
                             </span>
-                            <span class="d-flex align-items-center">
+                            <span class="d-flex align-items-center fw-semibold">
                                 @if (scheme.Enabled)
                                 {
-                                    <strong class="d-flex align-items-center text-success">
+                                    <span class="d-flex align-items-center text-success">
                                         <span class="mr-2 btcpay-status btcpay-status--enabled"></span>
                                         Enabled
-                                    </strong>
+                                    </span>
                                 }
                                 else
                                 {
-                                    <strong class="d-flex align-items-center text-danger">
+                                    <span class="d-flex align-items-center text-danger">
                                         <span class="mr-2 btcpay-status btcpay-status--disabled"></span>
                                         Disabled
-                                    </strong>
+                                    </span>
                                 }
                                 @if (isSetUp)
                                 {
                                     <span class="text-light ml-3 mr-2">|</span>
                                 }
-                                <a asp-action="AddDerivationScheme" asp-route-cryptoCode="@scheme.Crypto" asp-route-storeId="@Context.GetRouteValue("storeId")" id="@($"Modify{scheme.Crypto}")" class="btn btn-sm btn-@(isSetUp ? "link" : "primary ml-4 px-3") py-1">
+                                <a asp-action="AddDerivationScheme" asp-route-cryptoCode="@scheme.Crypto" asp-route-storeId="@Context.GetRouteValue("storeId")" id="@($"Modify{scheme.Crypto}")" class="btn btn-@(isSetUp ? "link px-1" : "primary btn-sm ml-4 px-3") py-1 fw-semibold">
                                     @(isSetUp ? "Modify" : "Setup")
                                 </a>
                             </span>
@@ -109,26 +109,26 @@
                                     <span class="smMaxWidth text-truncate text-secondary mr-3">@scheme.Address</span>
                                 }
                             </span>
-                            <span class="d-flex align-items-center">
+                            <span class="d-flex align-items-center fw-semibold">
                                 @if (scheme.Enabled)
                                 {
-                                    <strong class="d-flex align-items-center text-success">
+                                    <span class="d-flex align-items-center text-success">
                                         <span class="mr-2 btcpay-status btcpay-status--enabled"></span>
                                         Enabled
-                                    </strong>
+                                    </span>
                                 }
                                 else
                                 {
-                                    <strong class="d-flex align-items-center text-danger">
+                                    <span class="d-flex align-items-center text-danger">
                                         <span class="mr-2 btcpay-status btcpay-status--disabled"></span>
                                         Disabled
-                                    </strong>
+                                    </span>
                                 }
                                 @if (isSetUp)
                                 {
                                     <span class="text-light ml-3 mr-2">|</span>
                                 }
-                                <a asp-action="AddLightningNode" asp-route-cryptoCode="@scheme.CryptoCode" asp-route-storeId="@Context.GetRouteValue("storeId")" id="@($"Modify-Lightning{scheme.CryptoCode}")" class="btn btn-sm btn-@(isSetUp ? "link" : "primary ml-4 px-3") py-1">
+                                <a asp-action="AddLightningNode" asp-route-cryptoCode="@scheme.CryptoCode" asp-route-storeId="@Context.GetRouteValue("storeId")" id="@($"Modify-Lightning{scheme.CryptoCode}")" class="btn btn-@(isSetUp ? "link px-1" : "primary btn-sm ml-4 px-3") py-1 fw-semibold">
                                     @(isSetUp ? "Modify" : "Setup")
                                 </a>
                             </span>

--- a/BTCPayServer/wwwroot/main/site.css
+++ b/BTCPayServer/wwwroot/main/site.css
@@ -261,6 +261,10 @@ pre {
 .w-175px { width: 175px; }
 .w-200px { width: 200px; }
 
+.fw-semibold {
+    font-weight: 600;
+}
+
 /* Chrome, Safari, Edge, Opera */
 input[type=number].hide-number-spin::-webkit-outer-spin-button,
 input[type=number].hide-number-spin::-webkit-inner-spin-button {


### PR DESCRIPTION
Follow up to #2117, according to [this comment](https://github.com/btcpayserver/btcpayserver/pull/2117#issuecomment-741255465).

Improved font weights on the right side – semibold instead of bold:

![1](https://user-images.githubusercontent.com/886/101606302-8542ea00-3a03-11eb-8878-9dfb9206a24a.png)
![2](https://user-images.githubusercontent.com/886/101606306-85db8080-3a03-11eb-9dc7-5ee6d114ab6e.png)
