### PR TITLE
Hide pagination & page size when not necessary 

### DIFF
--- a/BTCPayServer/Components/Pager/Default.cshtml
+++ b/BTCPayServer/Components/Pager/Default.cshtml
@@ -4,7 +4,7 @@
     var pageSizeOptions = new [] { 50, 100, 250, 500 };
 }
 
-@if (Model.Total > pageSizeOptions[0])
+@if (Model.Total > pageSizeOptions.Min())
 {
     <nav aria-label="..." class="w-100">
         @if (Model.Total > Model.Count)
@@ -33,7 +33,7 @@
             </ul>
         }
 
-        @if (Model.Total >= pageSizeOptions[0])
+        @if (Model.Total >= pageSizeOptions.Min())
         {
             <ul class="pagination float-right">
                 <li class="page-item disabled">

--- a/BTCPayServer/Components/Pager/Default.cshtml
+++ b/BTCPayServer/Components/Pager/Default.cshtml
@@ -1,57 +1,52 @@
 @model BasePagingViewModel
 
-@if (Model.Total > Model.Count)
+@{
+    var pageSizeOptions = new [] { 50, 100, 250, 500 };
+}
+
+@if (Model.Total > pageSizeOptions[0])
 {
     <nav aria-label="..." class="w-100">
-        <ul class="pagination float-left">
-            <li class="page-item @(Model.Skip == 0 ? "disabled" : null)">
-                <a class="page-link" tabindex="-1" href="@NavigatePages(-1, Model.Count)">&laquo;</a>
-            </li>
-            <li class="page-item disabled">
-                @if (Model.Total <= Model.Count)
-                {
-                    <span class="page-link">
-                        1–@Model.Total
-                    </span>
-                }
-                else
-                {
-                    <span class="page-link">
-                        @(Model.Skip + 1)–@(Model.Skip + Model.Count), Total: @Model.Total
-                    </span>
-                }
-            </li>
-            <li class="page-item @(Model.Total > (Model.Skip + Model.Count) ? null : "disabled")">
-                <a class="page-link" href="@NavigatePages(1, Model.Count)">&raquo;</a>
-            </li>
-        </ul>
+        @if (Model.Total > Model.Count)
+        {
+            <ul class="pagination float-left">
+                <li class="page-item @(Model.Skip == 0 ? "disabled" : null)">
+                    <a class="page-link" tabindex="-1" href="@NavigatePages(-1, Model.Count)">&laquo;</a>
+                </li>
+                <li class="page-item disabled">
+                    @if (Model.Total <= Model.Count)
+                    {
+                        <span class="page-link">
+                            1–@Model.Total
+                        </span>
+                    }
+                    else
+                    {
+                        <span class="page-link">
+                            @(Model.Skip + 1)–@(Model.Skip + Model.Count), Total: @Model.Total
+                        </span>
+                    }
+                </li>
+                <li class="page-item @(Model.Total > (Model.Skip + Model.Count) ? null : "disabled")">
+                    <a class="page-link" href="@NavigatePages(1, Model.Count)">&raquo;</a>
+                </li>
+            </ul>
+        }
 
-        @if (Model.Total >= 50)
+        @if (Model.Total >= pageSizeOptions[0])
         {
             <ul class="pagination float-right">
                 <li class="page-item disabled">
                     <span class="page-link">Page Size:</span>
                 </li>
-                <li class="page-item @(Model.Count == 50 ? "active" : null)">
-                    <a class="page-link" href="@NavigatePages(0, 50)">50</a>
-                </li>
-                @if (Model.Total >= 100)
+                @foreach (int pageSize in pageSizeOptions)
                 {
-                    <li class="page-item @(Model.Count == 100 ? "active" : null)">
-                        <a class="page-link" href="@NavigatePages(0, 100)">100</a>
-                    </li>
-                }
-                @if (Model.Total >= 250)
-                {
-                    <li class="page-item @(Model.Count == 250 ? "active" : null)">
-                        <a class="page-link" href="@NavigatePages(0, 250)">250</a>
-                    </li>
-                }
-                @if (Model.Total >= 500)
-                {
-                    <li class="page-item @(Model.Count == 500 ? "active" : null)">
-                        <a class="page-link" href="@NavigatePages(0, 500)">500</a>
-                    </li>
+                    if (Model.Total >= pageSize)
+                    {
+                        <li class="page-item @(Model.Count == pageSize ? "active" : null)">
+                            <a class="page-link" href="@NavigatePages(0, pageSize)">@pageSize</a>
+                        </li>
+                    }
                 }
             </ul>
         }

--- a/BTCPayServer/Components/Pager/Default.cshtml
+++ b/BTCPayServer/Components/Pager/Default.cshtml
@@ -1,6 +1,6 @@
 @model BasePagingViewModel
 
-@if (Model.Total > 0)
+@if (Model.Total > Model.Count)
 {
     <nav aria-label="..." class="w-100">
         <ul class="pagination float-left">
@@ -74,8 +74,8 @@
         {
             searchTerm = Model.SearchTerm,
             timezoneOffset = Model.TimezoneOffset,
-            skip = skip,
-            count = count,
+            skip,
+            count,
         });
 
         return act;

--- a/BTCPayServer/Components/Pager/Default.cshtml
+++ b/BTCPayServer/Components/Pager/Default.cshtml
@@ -70,14 +70,22 @@
             skip = Model.Skip + count;
         }
 
-        var act = Url.Action(null, new
+        var query = new Dictionary<string, object>
         {
-            searchTerm = Model.SearchTerm,
-            timezoneOffset = Model.TimezoneOffset,
-            skip,
-            count,
-        });
+            { "searchTerm", Model.SearchTerm },
+            { "timezoneOffset", Model.TimezoneOffset },
+            { "skip", skip },
+            { "count", count }
+        };
 
-        return act;
+        if (Model.PaginationQuery != null)
+        {
+            // merge both, prefering the `query` properties in case of duplicate keys
+            query = query.Concat(Model.PaginationQuery)
+                .GroupBy(e => e.Key)
+                .ToDictionary(g => g.Key, g => g.First().Value);
+        }
+
+        return Url.Action(null, query);
     }
 }

--- a/BTCPayServer/Controllers/WalletsController.cs
+++ b/BTCPayServer/Controllers/WalletsController.cs
@@ -289,6 +289,13 @@ namespace BTCPayServer.Controllers
                 Count = count,
                 Total = 0
             };
+            if (labelFilter != null)
+            {
+                model.PaginationQuery = new Dictionary<string, object>
+                {
+                    {"labelFilter", labelFilter}
+                };
+            }
             if (transactions == null)
             {
                 TempData.SetStatusMessageModel(new StatusMessageModel()

--- a/BTCPayServer/Models/BasePagingViewModel.cs
+++ b/BTCPayServer/Models/BasePagingViewModel.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 
 namespace BTCPayServer.Models
@@ -10,5 +11,6 @@ namespace BTCPayServer.Models
         [DisplayFormat(ConvertEmptyStringToNull = false)]
         public string SearchTerm { get; set; }
         public int? TimezoneOffset { get; set; }
+        public Dictionary<string, object> PaginationQuery { get; set; }
     }
 }

--- a/BTCPayServer/Models/NotificationViewModels/IndexViewModel.cs
+++ b/BTCPayServer/Models/NotificationViewModels/IndexViewModel.cs
@@ -3,13 +3,8 @@ using BTCPayServer.Abstractions.Contracts;
 
 namespace BTCPayServer.Models.NotificationViewModels
 {
-    public class IndexViewModel
+    public class IndexViewModel : BasePagingViewModel
     {
-        public int Skip { get; set; }
-        public int Count { get; set; }
-        public int Total { get; set; }
         public List<NotificationViewModel> Items { get; set; }
     }
-
-
 }

--- a/BTCPayServer/Models/WalletViewModels/ListTransactionsViewModel.cs
+++ b/BTCPayServer/Models/WalletViewModels/ListTransactionsViewModel.cs
@@ -4,7 +4,7 @@ using BTCPayServer.Services.Labels;
 
 namespace BTCPayServer.Models.WalletViewModels
 {
-    public class ListTransactionsViewModel
+    public class ListTransactionsViewModel : BasePagingViewModel
     {
         public class TransactionViewModel
         {
@@ -19,8 +19,5 @@ namespace BTCPayServer.Models.WalletViewModels
         }
         public HashSet<Label> Labels { get; set; } = new HashSet<Label>();
         public List<TransactionViewModel> Transactions { get; set; } = new List<TransactionViewModel>();
-        public int Skip { get; set; }
-        public int Count { get; set; }
-        public int Total { get; set; }
     }
 }

--- a/BTCPayServer/Views/Invoice/ListInvoices.cshtml
+++ b/BTCPayServer/Views/Invoice/ListInvoices.cshtml
@@ -329,7 +329,7 @@
                     </tbody>
                 </table>
 
-                <vc:pager view-model="Model"></vc:pager>
+                <vc:pager view-model="Model" />
             </form>
         }
         else

--- a/BTCPayServer/Views/Notifications/Index.cshtml
+++ b/BTCPayServer/Views/Notifications/Index.cshtml
@@ -86,73 +86,7 @@
                         </tbody>
                     </table>
 
-                    <nav aria-label="..." class="w-100">
-                        @if (Model.Total != 0)
-                        {
-                            <ul class="pagination float-left">
-                                <li class="page-item @(Model.Skip == 0 ? "disabled" : null)">
-                                    <a class="page-link" tabindex="-1" href="@ListItemsPage(-1, Model.Count)">&laquo;</a>
-                                </li>
-                                <li class="page-item disabled">
-                                    @if (Model.Total <= Model.Count)
-                                    {
-                                        <span class="page-link">
-                                            1–@Model.Items.Count
-                                        </span>
-                                    }
-                                    else
-                                    {
-                                        <span class="page-link">
-                                            @(Model.Skip + 1)–@(Model.Skip + Model.Items.Count), Total: @Model.Total
-                                        </span>
-                                    }
-                                </li>
-                                <li class="page-item @(Model.Total > (Model.Skip + Model.Items.Count) ? null : "disabled")">
-                                    <a class="page-link" href="@ListItemsPage(1, Model.Count)">&raquo;</a>
-                                </li>
-                            </ul>
-                        }
-                        <ul class="pagination float-right">
-                            <li class="page-item disabled">
-                                <span class="page-link">Page Size:</span>
-                            </li>
-                            <li class="page-item @(Model.Count == 50 ? "active" : null)">
-                                <a class="page-link" href="@ListItemsPage(0, 50)">50</a>
-                            </li>
-                            <li class="page-item @(Model.Count == 100 ? "active" : null)">
-                                <a class="page-link" href="@ListItemsPage(0, 100)">100</a>
-                            </li>
-                            <li class="page-item @(Model.Count == 250 ? "active" : null)">
-                                <a class="page-link" href="@ListItemsPage(0, 250)">250</a>
-                            </li>
-                            <li class="page-item @(Model.Count == 500 ? "active" : null)">
-                                <a class="page-link" href="@ListItemsPage(0, 500)">500</a>
-                            </li>
-                        </ul>
-                    </nav>
-                    @{
-                        string ListItemsPage(int prevNext, int count)
-                        {
-                            var skip = Model.Skip;
-                            if (prevNext == -1)
-                            {
-                                skip = Math.Max(0, Model.Skip - Model.Count);
-                            }
-                            else if (prevNext == 1)
-                            {
-                                skip = Model.Skip + count;
-                            }
-
-                            var act = Url.Action("Index", new
-                            {
-                                skip = skip,
-                                count = count,
-                            });
-
-                            return act;
-                        }
-                    }
-
+                    <vc:pager view-model="Model" />
                 </div>
             </div>
 

--- a/BTCPayServer/Views/Wallets/WalletTransactions.cshtml
+++ b/BTCPayServer/Views/Wallets/WalletTransactions.cshtml
@@ -68,7 +68,7 @@
 }
 <div class="row">
     <div class="col-md-12">
-        If BTCPay Server shows you an invalid balance, <a asp-action="WalletRescan" asp-route-walletId="@this.Context.GetRouteValue("walletId")">rescan your wallet</a>. <br />
+        If BTCPay Server shows you an invalid balance, <a asp-action="WalletRescan" asp-route-walletId="@Context.GetRouteValue("walletId")">rescan your wallet</a>. <br />
         If some transactions appear in BTCPay Server, but are missing on Electrum or another wallet, <a href="https://docs.btcpayserver.org/FAQ/FAQ-Wallet/#missing-payments-in-my-software-or-hardware-wallet">follow those instructions</a>.
     </div>
 </div>
@@ -126,7 +126,7 @@
                                         <a asp-route-labelFilter="@label.Value" class="text-white">@label.Value</a>
 
                                         <form
-                                            asp-route-walletId="@this.Context.GetRouteValue("walletId")"
+                                            asp-route-walletId="@Context.GetRouteValue("walletId")"
                                             asp-action="ModifyTransaction"
                                             method="post"
                                             class="removeTransactionLabelForm">
@@ -169,7 +169,7 @@
                                 <span class="fa fa-tags cursor-pointer" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"></span>
                                 <div class="dropdown-menu">
                                     <form asp-action="ModifyTransaction" method="post"
-                                        asp-route-walletId="@this.Context.GetRouteValue("walletId")">
+                                        asp-route-walletId="@Context.GetRouteValue("walletId")">
                                         <input type="hidden" name="transactionId" value="@transaction.Id" />
                                         <div class="input-group p-2">
                                             <input name="addlabel" placeholder="Label name" maxlength="20" type="text" class="form-control form-control-sm" />
@@ -206,7 +206,7 @@
                                 }
                                 <div class="dropdown-menu">
                                     <form asp-action="ModifyTransaction" method="post"
-                                        asp-route-walletId="@this.Context.GetRouteValue("walletId")">
+                                        asp-route-walletId="@Context.GetRouteValue("walletId")">
                                         <input type="hidden" name="transactionId" value="@transaction.Id" />
                                         <div class="input-group p-2">
                                             <textarea name="addcomment" maxlength="200" rows="2" cols="20" class="form-control form-control-sm">@transaction.Comment</textarea>
@@ -222,72 +222,6 @@
                 }
             </tbody>
         </table>
-        <nav class="w-100">
-            @if (Model.Total != 0)
-            {
-                <ul class="pagination float-left">
-                    <li class="page-item @(Model.Skip == 0 ? "disabled" : null)">
-                        <a class="page-link" tabindex="-1" href="@ListTransactionsPage(-1, Model.Count)">&laquo;</a>
-                    </li>
-                    <li class="page-item disabled">
-                        @if (Model.Total <= Model.Count)
-                        {
-                            <span class="page-link">
-                                1–@Model.Transactions.Count
-                            </span>
-                        }
-                        else
-                        {
-                            <span class="page-link">
-                                @(Model.Skip + 1)–@(Model.Skip + Model.Transactions.Count), Total: @Model.Total
-                            </span>
-                        }
-                    </li>
-                    <li class="page-item @(Model.Total > (Model.Skip + Model.Transactions.Count) ? null : "disabled")">
-                        <a class="page-link" href="@ListTransactionsPage(1, Model.Count)">&raquo;</a>
-                    </li>
-                </ul>
-            }
-            <ul class="pagination float-right">
-                <li class="page-item disabled">
-                    <span class="page-link">Page Size:</span>
-                </li>
-                <li class="page-item @(Model.Count == 50 ? "active" : null)">
-                    <a class="page-link" href="@ListTransactionsPage(0, 50)">50</a>
-                </li>
-                <li class="page-item @(Model.Count == 100 ? "active" : null)">
-                    <a class="page-link" href="@ListTransactionsPage(0, 100)">100</a>
-                </li>
-                <li class="page-item @(Model.Count == 250 ? "active" : null)">
-                    <a class="page-link" href="@ListTransactionsPage(0, 250)">250</a>
-                </li>
-                <li class="page-item @(Model.Count == 500 ? "active" : null)">
-                    <a class="page-link" href="@ListTransactionsPage(0, 500)">500</a>
-                </li>
-            </ul>
-        </nav>
-        @{
-            string ListTransactionsPage(int prevNext, int count)
-            {
-                var skip = Model.Skip;
-                if (prevNext == -1)
-                {
-                    skip = Math.Max(0, Model.Skip - Model.Count);
-                }
-                else if (prevNext == 1)
-                {
-                    skip = Model.Skip + count;
-                }
-
-                var act = Url.Action("WalletTransactions", new
-                {
-                    labelFilter = Context.Request.Query["labelFilter"],
-                    skip = skip,
-                    count = count,
-                });
-
-                return act;
-            }
-        }
+        <vc:pager view-model="Model" />
     </div>
 </div>


### PR DESCRIPTION
As proposed by @dstrukt in [this issue](https://github.com/btcpayserver/btcpayserver/issues/2121). Closes #2121.

I saw that the pager component wasn't used for the notifications list and wallet transactions. The former was straight forward to integrate – for the latter I had to introduce the `PaginationQuery` property in the `BasePagingViewModel`: This list has the custom `labelFilter` query param, which we need to pass through on the pagination links.

I've talked to @kukks about this and we decided that using a `Dictionary` here would be a good choice, because it allows for easy query customizability like in this case.