### PR TITLE
API Keys: Add usage examples link to docs

### DIFF
--- a/BTCPayServer/Views/Manage/APIKeys.cshtml
+++ b/BTCPayServer/Views/Manage/APIKeys.cshtml
@@ -6,7 +6,11 @@
 
 <partial name="_StatusMessage" />
 
-<p>The <a asp-controller="Home" asp-action="SwaggerDocs" target="_blank">BTCPay Server Greenfield API</a> offers programmatic access to your instance. You can manage your BTCPay Server (e.g. stores, invoices, users) as well as automate workflows and integrations (see some use case examples). For that you need the API keys, which can be generated here. Find more information in the <a href="@Url.Action("SwaggerDocs", "Home")#section/Authentication" target="_blank">API authentication docs</a>.</p>
+<p>
+    The <a asp-controller="Home" asp-action="SwaggerDocs" target="_blank">BTCPay Server Greenfield API</a> offers programmatic access to your instance. You can manage your BTCPay
+    Server (e.g. stores, invoices, users) as well as automate workflows and integrations (see <a href="https://docs.btcpayserver.org/GreenFieldExample/">use case examples</a>). 
+    For that you need the API keys, which can be generated here. Find more information in the <a href="@Url.Action("SwaggerDocs", "Home")#section/Authentication" target="_blank">API authentication docs</a>.
+</p>
 <table class="table table-lg">
     <thead>
         <tr>


### PR DESCRIPTION
Just adding the link to the docs page. If that's superfluous then we should remove the text in parenthesis alltogether, because without the link it's a bit confusing :)