### PR TITLE
UI: Improve invoice view

### DIFF
--- a/BTCPayServer/Views/Invoice/Invoice.cshtml
+++ b/BTCPayServer/Views/Invoice/Invoice.cshtml
@@ -1,15 +1,16 @@
 @model InvoiceDetailsModel
 @{
-    ViewData["Title"] = "Invoice " + Model.Id;
+    ViewData["Title"] = $"Invoice {Model.Id}";
 }
+
 @section HeaderContent{
-    <META NAME="robots" CONTENT="noindex,nofollow">
+    <meta name="robots" content="noindex,nofollow">
+    <style>
+        #posData td > table:last-child { margin-bottom: 0 !important; }
+        #posData table > tbody > tr:first-child > td > h4 { margin-top: 0 !important; }
+    </style>
 }
-<style type="text/css">
-    .firstCol {
-        width: 140px;
-    }
-</style>
+
 <section class="invoice-details">
     <div class="container">
         @if (TempData.HasStatusMessage())
@@ -21,51 +22,49 @@
             </div>
         }
 
-        <div class="row">
-            <div class="col-lg-12 section-heading">
-                <div class="row">
-                    <h2 class="col-xs-12 col-lg-9">@ViewData["Title"]</h2>
-                    <div class="col-xs-12 col-lg-3 ">
-                        <div class="d-inline-flex">
-                            @if (Model.CanRefund)
+        <div class="row mb-4">
+            <h2 class="col-xs-12 col-lg-9 mb-4 mb-lg-0">@ViewData["Title"]</h2>
+            <div class="col-xs-12 col-lg-3 mb-2 mb-lg-0 text-lg-right">
+                <div class="d-inline-flex">
+                    @if (Model.CanRefund)
+                    {
+                        <a id="refundlink" class="btn btn-success text-nowrap" asp-action="Refund" asp-route-invoiceId="@Context.GetRouteValue("invoiceId")">Issue refund <span class="fa fa-undo"></span></a>
+                    }
+                    else
+                    {
+                        <button href="#" class="btn btn-secondary text-nowrap" data-toggle="tooltip" title="You can only issue refunds on invoices with confirmed payments" disabled>Issue refund <span class="fa fa-undo"></span></button>
+                    }
+                    <form class="p-0 ml-2" asp-action="ToggleArchive" asp-route-invoiceId="@Model.Id" method="post">
+                        <button type="submit" class="btn @(Model.Archived ? "btn-warning" : "btn btn-danger")" id="btn-archive-toggle">
+                            @if (Model.Archived)
                             {
-                                <a id="refundlink" class=" btn btn-success" asp-action="Refund" asp-route-invoiceId="@this.Context.GetRouteValue("invoiceId")">Issue refund <span class="fa fa-undo"></span></a>
+                                <span class="text-nowrap" data-toggle="tooltip" title="Unarchive this invoice">Archived <i class=" ml-1 fa fa-close"></i></span>
                             }
                             else
                             {
-                                <button href="#" class="btn btn-secondary" data-toggle="tooltip" title="You can only issue refunds on invoices with confirmed payments" disabled>Issue refund <span class="fa fa-undo"></span></button>
+                                <span class="text-nowrap" data-toggle="tooltip" title="Archive this invoice so that it does not appear in the invoice list by default">Archive <i class=" ml-1 fa fa-archive"></i></span>
                             }
-                            <form class="p-0 ml-1" asp-action="ToggleArchive" asp-route-invoiceId="@Model.Id" method="post">
-
-                                <button type="submit" class="btn @(Model.Archived ? "btn-warning" : "btn btn-danger")" id="btn-archive-toggle">
-                                    @if (Model.Archived)
-                                    {
-                                        <span data-toggle="tooltip" title="Unarchive this invoice">Archived <i class=" ml-1 fa fa-close"></i></span>
-                                    }
-                                    else
-                                    {
-                                        <span data-toggle="tooltip" title="Archive this invoice so that it does not appear in the invoice list by default">Archive <i class=" ml-1 fa fa-archive"></i></span>
-                                    }
-                                </button>
-                            </form>
-                        </div>
-                    </div>
+                        </button>
+                    </form>
                 </div>
-                <hr class="primary">
             </div>
         </div>
 
         <div class="row">
-            <div class="col-md-6">
-                <h3 class="mb-3">Information</h3>
+            <div class="col-md-6 mb-4">
+                <h3 class="mb-3">Invoice Information</h3>
                 <table class="table table-sm table-responsive-md removetopborder">
                     <tr>
                         <th>Store</th>
                         <td><a href="@Model.StoreLink">@Model.StoreName</a></td>
                     </tr>
                     <tr>
-                        <th>Id</th>
+                        <th>Internal Id</th>
                         <td>@Model.Id</td>
+                    </tr>
+                    <tr>
+                        <th>Order Id</th>
+                        <td>@Model.TypedMetadata.OrderId</td>
                     </tr>
                     <tr>
                         <th>State</th>
@@ -88,29 +87,34 @@
                         <td>@Model.TransactionSpeed</td>
                     </tr>
                     <tr>
-                        <th>Refund email</th>
-                        <td><a href="mailto:@Model.RefundEmail">@Model.RefundEmail</a></td>
-                    </tr>
-                    <tr>
-                        <th>Order Id</th>
-                        <td>@Model.TypedMetadata.OrderId</td>
-                    </tr>
-                    <tr>
                         <th>Total fiat due</th>
                         <td>@Model.Fiat</td>
                     </tr>
-                    <tr>
-                        <th>Notification Url</th>
-                        <td>@Model.NotificationUrl</td>
-                    </tr>
-                    <tr>
-                        <th>Redirect Url</th>
-                        <td><a href="@Model.RedirectUrl">@Model.RedirectUrl</a></td>
-                    </tr>
+                    @if (!string.IsNullOrEmpty(Model.RefundEmail))
+                    {
+                        <tr>
+                            <th>Refund email</th>
+                            <td><a href="mailto:@Model.RefundEmail">@Model.RefundEmail</a></td>
+                        </tr>
+                    }
+                    @if (!string.IsNullOrEmpty(Model.NotificationUrl))
+                    {
+                        <tr>
+                            <th>Notification Url</th>
+                            <td>@Model.NotificationUrl</td>
+                        </tr>
+                    }
+                    @if (!string.IsNullOrEmpty(Model.RedirectUrl))
+                    {
+                        <tr>
+                            <th>Redirect Url</th>
+                            <td><a href="@Model.RedirectUrl">@Model.RedirectUrl</a></td>
+                        </tr>
+                    }
                 </table>
             </div>
-            <div class="col-md-6">
-                <h3 class="mb-3">Buyer information</h3>
+            <div class="col-md-6 mb-4">
+                <h3 class="mb-3">Buyer Information</h3>
                 <table class="table table-sm table-responsive-md removetopborder">
                     <tr>
                         <th>Name</th>
@@ -151,16 +155,22 @@
                 </table>
                 @if (Model.PosData.Count == 0)
                 {
-                    <h3 class="mb-3">Product information</h3>
+                    <h3 class="mb-3">Product Information</h3>
                     <table class="table table-sm table-responsive-md removetopborder">
-                        <tr>
-                            <th>Item code</th>
-                            <td>@Model.TypedMetadata.ItemCode</td>
-                        </tr>
-                        <tr>
-                            <th>Item Description</th>
-                            <td>@Model.TypedMetadata.ItemDesc</td>
-                        </tr>
+                        @if (!string.IsNullOrEmpty(Model.TypedMetadata.ItemCode))
+                        {
+                            <tr>
+                                <th>Item code</th>
+                                <td>@Model.TypedMetadata.ItemCode</td>
+                            </tr>
+                        }
+                        @if (!string.IsNullOrEmpty(Model.TypedMetadata.ItemDesc))
+                        {
+                            <tr>
+                                <th>Item Description</th>
+                                <td>@Model.TypedMetadata.ItemDesc</td>
+                            </tr>
+                        }
                         <tr>
                             <th>Price</th>
                             <td>@Model.Fiat</td>
@@ -177,17 +187,23 @@
         @if (Model.PosData.Count != 0)
         {
             <div class="row">
-                <div class="col-md-6">
+                <div class="col-md-6 mb-4">
                     <h3 class="mb-3">Product information</h3>
                     <table class="table table-sm table-responsive-md removetopborder">
-                        <tr>
-                            <th>Item code</th>
-                            <td>@Model.TypedMetadata.ItemCode</td>
-                        </tr>
-                        <tr>
-                            <th>Item Description</th>
-                            <td>@Model.TypedMetadata.ItemDesc</td>
-                        </tr>
+                        @if (!string.IsNullOrEmpty(Model.TypedMetadata.ItemCode))
+                        {
+                            <tr>
+                                <th>Item code</th>
+                                <td>@Model.TypedMetadata.ItemCode</td>
+                            </tr>
+                        }
+                        @if (!string.IsNullOrEmpty(Model.TypedMetadata.ItemDesc))
+                        {
+                            <tr>
+                                <th>Item Description</th>
+                                <td>@Model.TypedMetadata.ItemDesc</td>
+                            </tr>
+                        }
                         <tr>
                             <th>Price</th>
                             <td>@Model.Fiat</td>
@@ -198,14 +214,16 @@
                         </tr>
                     </table>
                 </div>
-                <div class="col-md-6">
+                <div class="col-md-6 mb-4" id="posData">
                     <h3 class="mb-3">Point of Sale Data</h3>
-                    <partial name="PosData" model="@Model.PosData" />
+
+                    <partial name="PosData" model="(Model.PosData, 1)" />
                 </div>
             </div>
         }
 
         <partial name="ListInvoicesPaymentsPartial" model="(Model, true)" />
+
         @if (Model.Deliveries.Count != 0)
         {
             <h3 class="mb-3">Webhook deliveries</h3>
@@ -261,7 +279,7 @@
 
         <div class="row">
             <div class="col-md-12">
-                <h3 class="mb-3">Events</h3>
+                <h3 class="mb-0">Events</h3>
                 <table class="table table-sm table-responsive-md">
                     <thead class="thead-inverse">
                         <tr>

--- a/BTCPayServer/Views/Invoice/Invoice.cshtml
+++ b/BTCPayServer/Views/Invoice/Invoice.cshtml
@@ -59,7 +59,7 @@
                         <td><a href="@Model.StoreLink">@Model.StoreName</a></td>
                     </tr>
                     <tr>
-                        <th>Internal Id</th>
+                        <th>Invoice Id</th>
                         <td>@Model.Id</td>
                     </tr>
                     <tr>

--- a/BTCPayServer/Views/Invoice/ListInvoicesPaymentsPartial.cshtml
+++ b/BTCPayServer/Views/Invoice/ListInvoicesPaymentsPartial.cshtml
@@ -3,9 +3,9 @@
 @{ var invoice = Model.Invoice; }
 @inject PaymentMethodHandlerDictionary PaymentMethodHandlerDictionary
 
-<div class="row">
+<div class="row mb-4">
     <div class="col-md-12 invoice-payments">
-        <h3>Invoice Summary</h3>
+        <h3 class="mb-0">Invoice Summary</h3>
         <table class="table table-sm table-responsive-md">
             <thead class="thead-inverse">
             <tr>

--- a/BTCPayServer/Views/Invoice/PosData.cshtml
+++ b/BTCPayServer/Views/Invoice/PosData.cshtml
@@ -1,46 +1,52 @@
 @model (Dictionary<string, object> Items, int Level)
 
+@functions{
+    void DisplayValue(object value)
+    {
+        if (value is string str && str.StartsWith("http"))
+        {
+            <a href="@str" target="_blank">@str</a>
+        }
+        else
+        {
+            @value
+        }
+    }
+}
+
 <table class="table table-sm table-responsive-md removetopborder">
     @foreach (var (key, value) in Model.Items)
     {
         <tr>
-            @if (value is Dictionary<string, object>subItems)
+            @if (value is string)
             {
-                <td colspan="2">
-                    @if (key == "_urls")
-                    {
-                        @Html.Raw($"<h{Model.Level + 3} class='mt-3'>Links</h{Model.Level + 3}>")
-                        <ul>
-                            @foreach (var (title, url) in subItems)
-                            {
-                                <li>
-                                    <a href="@url" target="_blank">@title</a>
-                                </li>
-                            }
-                        </ul>
-
-                    }
-                    else
-                    {
-                        @Html.Raw($"<h{Model.Level + 3} class='mt-3 mb-n3'>{key}</h{Model.Level + 3}>")
-                        <partial name="PosData" model="(subItems, Model.Level + 1)"/>
-                    }
+                if (!string.IsNullOrEmpty(key))
+                {
+                    <th class="w-150px">@key</th>
+                }
+                <td>
+                    @{ DisplayValue(value); }
                 </td>
             }
-            else
+            else if (value is Dictionary<string, object>subItems)
             {
-                <th class="w-150px">@key</th>
-                <td>
-                    @if (value is string && ((string) value).StartsWith("http"))
-                    {
-                        <a href="@value" target="_blank">@value</a>
-                    }
-                    else
-                    {
-                        @value
-                    }
-                </td>
+                @* This is the array case *@
+                if (subItems.Count == 1 && subItems.First().Value is string)
+                {
+                    <th class="w-150px">@key</th>
+                    <td>
+                        @{ DisplayValue(subItems.First().Value); }
+                    </td>
+                }
+                else
+                {
+                    <td colspan="2">
+                        @Html.Raw($"<h{Model.Level + 3} class='mt-3'>{key}</h{Model.Level + 3}>")
+                        <partial name="PosData" model="(subItems, Model.Level + 1)"/>
+                    </td>
+                }
             }
         </tr>
     }
 </table>
+

--- a/BTCPayServer/Views/Invoice/PosData.cshtml
+++ b/BTCPayServer/Views/Invoice/PosData.cshtml
@@ -1,34 +1,43 @@
-@model Dictionary<string, object>
+@model (Dictionary<string, object> Items, int Level)
 
-<table class="table table-sm table-responsive-md">
-    @foreach (var posDataItem in Model)
+<table class="table table-sm table-responsive-md removetopborder">
+    @foreach (var (key, value) in Model.Items)
     {
         <tr>
-            @if (!string.IsNullOrEmpty(posDataItem.Key))
+            @if (value is Dictionary<string, object>subItems)
             {
-                <th>@posDataItem.Key</th>
-                <td>
-                    @if (posDataItem.Value is string)
+                <td colspan="2">
+                    @if (key == "_urls")
                     {
-                        @posDataItem.Value
+                        @Html.Raw($"<h{Model.Level + 3} class='mt-3'>Links</h{Model.Level + 3}>")
+                        <ul>
+                            @foreach (var (title, url) in subItems)
+                            {
+                                <li>
+                                    <a href="@url" target="_blank">@title</a>
+                                </li>
+                            }
+                        </ul>
+
                     }
                     else
                     {
-                        <partial name="PosData" model="@posDataItem.Value"/>
+                        @Html.Raw($"<h{Model.Level + 3} class='mt-3 mb-n3'>{key}</h{Model.Level + 3}>")
+                        <partial name="PosData" model="(subItems, Model.Level + 1)"/>
                     }
-
                 </td>
             }
             else
             {
-                <td colspan="2">
-                    @if (posDataItem.Value is string)
+                <th class="w-150px">@key</th>
+                <td>
+                    @if (value is string && ((string) value).StartsWith("http"))
                     {
-                        @posDataItem.Value
+                        <a href="@value" target="_blank">@value</a>
                     }
                     else
                     {
-                        <partial name="PosData" model="@posDataItem.Value"/>
+                        @value
                     }
                 </td>
             }

--- a/BTCPayServer/Views/Shared/Lightning/ViewLightningLikePaymentData.cshtml
+++ b/BTCPayServer/Views/Shared/Lightning/ViewLightningLikePaymentData.cshtml
@@ -27,7 +27,7 @@
             <table class="table table-sm table-responsive-md">
                 <thead class="thead-inverse">
                     <tr>
-                        <th class="firstCol">Crypto</th>
+                        <th class="w-150px">Crypto</th>
                         <th>BOLT11</th>
                     </tr>
                 </thead>


### PR DESCRIPTION
- General improvements for the spacings on the page
- Hides rows of data in case they aren't present
- Improved the PoS data view so that it renders complex objects nicely and adds links for URLs

![url-list](https://user-images.githubusercontent.com/886/102252030-de2fe800-3f05-11eb-9e2c-d3c771c947d3.png)

This stems from the [recent updates to the woocommerce plugin](https://github.com/btcpayserver/woocommerce-plugin/pull/53#issuecomment-744456557), where we are now adding structured data to the PoS data field.

### Sample data from screenshot

```json
{
    "Woocommerce": {
        "Order Number": "ORDR-2",
        "Order Link": "https://d11n.net",
        "URLs": [
            "https://btcpayserver.org",
            "https://d11n.net/ORDR-2"
        ]
    }
}