### PR TITLE
API: Fix for invoice not found

### DIFF
--- a/BTCPayServer/Controllers/GreenField/InvoiceController.cs
+++ b/BTCPayServer/Controllers/GreenField/InvoiceController.cs
@@ -263,7 +263,7 @@ namespace BTCPayServer.Controllers.GreenField
             }
 
             var invoice = await _invoiceRepository.GetInvoice(invoiceId, true);
-            if (invoice.StoreId != store.Id)
+            if (invoice?.StoreId != store.Id)
             {
                 return NotFound();
             }


### PR DESCRIPTION
In case the invoice ID was invalid, this resulted in an exception instead of a 404.