### PR TITLE
API: Fix behaviour after first admin signup

### DIFF
--- a/BTCPayServer/Controllers/GreenField/UsersController.cs
+++ b/BTCPayServer/Controllers/GreenField/UsersController.cs
@@ -153,6 +153,10 @@ namespace BTCPayServer.Controllers.GreenField
                 await _userManager.AddToRoleAsync(user, Roles.ServerAdmin);
                 if (!anyAdmin)
                 {
+                    var settings = await _settingsRepository.GetSettingAsync<ThemeSettings>();
+                    settings.FirstRun = false;
+                    await _settingsRepository.UpdateSetting(settings);
+
                     await _settingsRepository.FirstAdminRegistered(policies, _options.UpdateUrl != null, _options.DisableRegistration);
                 }
             }


### PR DESCRIPTION
Without updating the `FirstRun` setting it is not possible to login after signing up via the API. Otherwise the `HomeController.Index` action [always redirects](https://github.com/btcpayserver/btcpayserver/blob/master/BTCPayServer/Controllers/HomeController.cs#L96) to the Registration page.

TBD: There's some duplication of the signup logic in the [AccountController](https://github.com/btcpayserver/btcpayserver/blob/master/BTCPayServer/Controllers/AccountController.cs#L438) and [Greenfield/UsersController](https://github.com/btcpayserver/btcpayserver/blob/master/BTCPayServer/Controllers/GreenField/UsersController.cs#L147), which should get extracted to prevent something like this.
