### PR TITLE
Rename UiExtensionPoint folder to fix build crash

### DIFF
--- a/BTCPayServer/Components/UiExtensionPoint/Default.cshtml
+++ b/BTCPayServer/Components/UiExtensionPoint/Default.cshtml
@@ -1,0 +1,6 @@
+@model IEnumerable<string> 
+
+@foreach (var partial in Model)
+{
+    await Html.RenderPartialAsync(partial);
+}

--- a/BTCPayServer/Components/UiExtensionPoint/UIExtensionPoint.cs
+++ b/BTCPayServer/Components/UiExtensionPoint/UIExtensionPoint.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using BTCPayServer.Abstractions.Contracts;
+using Microsoft.AspNetCore.Mvc;
+
+namespace BTCPayServer.Components.UIExtensionPoint
+{
+    public class UiExtensionPoint : ViewComponent
+    {
+        private readonly IEnumerable<IUIExtension> _uiExtensions;
+
+        public UiExtensionPoint(IEnumerable<IUIExtension> uiExtensions)
+        {
+            _uiExtensions = uiExtensions;
+        }
+
+        public IViewComponentResult Invoke(string location)
+        {
+            return View(_uiExtensions.Where(extension => extension.Location.Equals(location, StringComparison.InvariantCultureIgnoreCase)).Select(extension => extension.Partial));
+        }
+    }
+}


### PR DESCRIPTION
When building on Ubuntu I got the following error:

```
System.InvalidOperationException: The view 'Components/UiExtensionPoint/Default' was not found. The following locations were searched:
/Views/Home/Components/UiExtensionPoint/Default.cshtml
/Views/Shared/Components/UiExtensionPoint/Default.cshtml
/Pages/Shared/Components/UiExtensionPoint/Default.cshtml
/Components/UiExtensionPoint/Default.cshtml
   at Microsoft.AspNetCore.Mvc.ViewEngines.ViewEngineResult.EnsureSuccessful(IEnumerable`1 originalLocations)
   at Microsoft.AspNetCore.Mvc.ViewComponents.ViewViewComponentResult.ExecuteAsync(ViewComponentContext context)
   at Microsoft.AspNetCore.Mvc.ViewComponents.DefaultViewComponentInvoker.InvokeAsync(ViewComponentContext context)
   at Microsoft.AspNetCore.Mvc.ViewComponents.DefaultViewComponentHelper.InvokeCoreAsync(ViewComponentDescriptor descriptor, Object arguments)
   at AspNetCore.Views_Shared__Layout.__Generated__UiExtensionPointViewComponentTagHelper.ProcessAsync(TagHelperContext __context, TagHelperOutput __output)
   at Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner.<RunAsync>g__Awaited|0_0(Task task, TagHelperExecutionContext executionContext, Int32 i, Int32 count)
   at AspNetCore.Views_Shared__Layout.<ExecuteAsync>b__50_1() in /home/pavle/Documents/GitHub/btcpayserver/BTCPayServer/Views/Shared/_Layout.cshtml:line 28
   at Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperExecutionContext.SetOutputContentAsync()
   at AspNetCore.Views_Shared__Layout.ExecuteAsync() in /home/pavle/Documents/GitHub/btcpayserver/BTCPayServer/Views/Shared/_Layout.cshtml:line 8
   at Microsoft.AspNetCore.Mvc.Razor.RazorView.RenderPageCoreAsync(IRazorPage page, ViewContext context)
   at Microsoft.AspNetCore.Mvc.Razor.RazorView.RenderPageAsync(IRazorPage page, ViewContext context, Boolean invokeViewStarts)
   at Microsoft.AspNetCore.Mvc.Razor.RazorView.RenderLayoutAsync(ViewContext context, ViewBufferTextWriter bodyWriter)
   at Microsoft.AspNetCore.Mvc.Razor.RazorView.RenderAsync(ViewContext context)
   at Microsoft.AspNetCore.Mvc.ViewFeatures.ViewExecutor.ExecuteAsync(ViewContext viewContext, String contentType, Nullable`1 statusCode)
   at Microsoft.AspNetCore.Mvc.ViewFeatures.ViewExecutor.ExecuteAsync(ViewContext viewContext, String contentType, Nullable`1 statusCode)
   at Microsoft.AspNetCore.Mvc.ViewFeatures.ViewExecutor.ExecuteAsync(ActionContext actionContext, IView view, ViewDataDictionary viewData, ITempDataDictionary tempData, String contentType, Nullable`1 statusCode)
   at Microsoft.AspNetCore.Mvc.ViewFeatures.ViewResultExecutor.ExecuteAsync(ActionContext context, ViewResult result)
   at Microsoft.AspNetCore.Mvc.ViewResult.ExecuteResultAsync(ActionContext context)
   at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeNextResultFilterAsync>g__Awaited|29_0[TFilter,TFilterAsync](ResourceInvoker invoker, Task lastTask, State next, Scope scope, Object state, Boolean isCompleted)
   at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.Rethrow(ResultExecutedContextSealed context)
   at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.ResultNext[TFilter,TFilterAsync](State& next, Scope& scope, Object& state, Boolean& isCompleted)
   at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.InvokeResultFilters()
--- End of stack trace from previous location where exception was thrown ---
   at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeNextResourceFilter>g__Awaited|24_0(ResourceInvoker invoker, Task lastTask, State next, Scope scope, Object state, Boolean isCompleted)
   at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.Rethrow(ResourceExecutedContextSealed context)
   at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.Next(State& next, Scope& scope, Object& state, Boolean& isCompleted)
   at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.InvokeFilterPipelineAsync()
--- End of stack trace from previous location where exception was thrown ---
   at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeAsync>g__Awaited|17_0(ResourceInvoker invoker, Task task, IDisposable scope)
   at Microsoft.AspNetCore.Routing.EndpointMiddleware.<Invoke>g__AwaitRequestTask|6_0(Endpoint endpoint, Task requestTask, ILogger logger)
   at Microsoft.AspNetCore.Session.SessionMiddleware.Invoke(HttpContext context)
   at Microsoft.AspNetCore.Session.SessionMiddleware.Invoke(HttpContext context)
   at Microsoft.AspNetCore.Authorization.AuthorizationMiddleware.Invoke(HttpContext context)
   at Microsoft.AspNetCore.Authentication.AuthenticationMiddleware.Invoke(HttpContext context)
   at BTCPayServer.Hosting.BTCPayMiddleware.Invoke(HttpContext httpContext) in /home/pavle/Documents/GitHub/btcpayserver/BTCPayServer/Hosting/BTCpayMiddleware.cs:line 84
   at Microsoft.AspNetCore.Diagnostics.StatusCodePagesMiddleware.Invoke(HttpContext context)
   at BTCPayServer.Hosting.HeadersOverrideMiddleware.Invoke(HttpContext httpContext) in /home/pavle/Documents/GitHub/btcpayserver/BTCPayServer/Hosting/HeadersOverrideMiddleware.cs:line 29
```

![Screenshot from 2020-12-19 14-00-34](https://user-images.githubusercontent.com/36959754/102690470-e8076300-4205-11eb-8a36-70dbaafe586d.png)

Another community member reported this.

Kukks suggested that folder should be renamed from `UIExtensionPoint` to `UiExtensionPoint`

And that's what this PR does. 
