### PR TITLE
Fix for classic theme header CSS

### DIFF
--- a/BTCPayServer/wwwroot/main/themes/classic.css
+++ b/BTCPayServer/wwwroot/main/themes/classic.css
@@ -121,6 +121,6 @@
   border-top: none;
 }
 
-#mainNav:not(.navbar-shrink) {
+#mainNav.sticky-top {
   background: var(--btcpay-color-white);
 }


### PR DESCRIPTION
Fixes #2155.

![header](https://user-images.githubusercontent.com/886/102783112-bc69b180-439a-11eb-9b38-ed6f8d3cb8c4.png)
