### PR TITLE
Add Label and accoutKeyPath to the on chain payment methods

### DIFF
--- a/BTCPayServer.Client/Models/OnChainPaymentMethodData.cs
+++ b/BTCPayServer.Client/Models/OnChainPaymentMethodData.cs
@@ -1,3 +1,6 @@
+using NBitcoin;
+using Newtonsoft.Json;
+
 namespace BTCPayServer.Client.Models
 {
     public class OnChainPaymentMethodData
@@ -21,6 +24,11 @@ namespace BTCPayServer.Client.Models
         /// The derivation scheme
         /// </summary>
         public string DerivationScheme { get; set; }
+
+        public string Label { get; set; }
+
+        [JsonConverter(typeof(NBitcoin.JsonConverters.KeyPathJsonConverter))]
+        public RootedKeyPath AccountKeyPath { get; set; }
 
         public OnChainPaymentMethodData()
         {

--- a/BTCPayServer.Tests/GreenfieldAPITests.cs
+++ b/BTCPayServer.Tests/GreenfieldAPITests.cs
@@ -1244,9 +1244,14 @@ namespace BTCPayServer.Tests
                 new OnChainPaymentMethodData() {Default = true, Enabled = true, DerivationScheme = xpub});
             
             Assert.Equal(xpub,method.DerivationScheme);
-            
+
+            method = await client.UpdateStoreOnChainPaymentMethod(store.Id, "BTC",
+                new OnChainPaymentMethodData() { Default = true, Enabled = true, DerivationScheme = xpub, Label = "lol", AccountKeyPath = RootedKeyPath.Parse("01020304/1/2/3") });
+
             method = await client.GetStoreOnChainPaymentMethod(store.Id, "BTC");
-            
+
+            Assert.Equal("lol", method.Label);
+            Assert.Equal(RootedKeyPath.Parse("01020304/1/2/3"), method.AccountKeyPath);
             Assert.Equal(xpub,method.DerivationScheme);
             
             

--- a/BTCPayServer/Hosting/BTCPayServerServices.cs
+++ b/BTCPayServer/Hosting/BTCPayServerServices.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Security.Cryptography;
 using System.Threading;
 using BTCPayServer.Abstractions.Contracts;
 using BTCPayServer.Abstractions.Extensions;
@@ -38,6 +39,7 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.AspNetCore.Mvc.ModelBinding.Validation;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -334,7 +336,15 @@ namespace BTCPayServer.Hosting
                     logBuilder.AddProvider(new Serilog.Extensions.Logging.SerilogLoggerProvider(Log.Logger));
                 }
             });
+
+            services.AddSingleton<IObjectModelValidator, SkippableObjectValidatorProvider>();
+            services.SkipModelValidation<RootedKeyPath>();
             return services;
+        }
+
+        public static void SkipModelValidation<T>(this IServiceCollection services)
+        {
+            services.AddSingleton<SkippableObjectValidatorProvider.ISkipValidation, SkippableObjectValidatorProvider.SkipValidationType<T>>();
         }
         private const long MAX_DEBUG_LOG_FILE_SIZE = 2000000; // If debug log is in use roll it every N MB.
         private static void AddBtcPayServerAuthenticationSchemes(this IServiceCollection services)

--- a/BTCPayServer/Hosting/SkippableObjectValidatorProvider.cs
+++ b/BTCPayServer/Hosting/SkippableObjectValidatorProvider.cs
@@ -1,0 +1,78 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.AspNetCore.Mvc.ModelBinding.Validation;
+using Microsoft.Extensions.Options;
+using NBitcoin;
+
+namespace BTCPayServer.Hosting
+{
+    public class SkippableObjectValidatorProvider : ObjectModelValidator
+    {
+        public interface ISkipValidation
+        {
+            bool SkipValidation(object obj);
+        }
+        public class SkipValidationType<T> : ISkipValidation
+        {
+            public bool SkipValidation(object obj)
+            {
+                return obj is T;
+            }
+        }
+        public SkippableObjectValidatorProvider(
+           IModelMetadataProvider modelMetadataProvider,
+           IEnumerable<ISkipValidation> skipValidations,
+           IOptions<MvcOptions> mvcOptions)
+           : base(modelMetadataProvider, mvcOptions.Value.ModelValidatorProviders)
+        {
+            _mvcOptions = mvcOptions.Value;
+            SkipValidations = skipValidations.ToList();
+        }
+
+        class OverrideValidationVisitor : ValidationVisitor
+        {
+            public OverrideValidationVisitor(IEnumerable<ISkipValidation> skipValidations, ActionContext actionContext, IModelValidatorProvider validatorProvider, ValidatorCache validatorCache, IModelMetadataProvider metadataProvider, ValidationStateDictionary validationState) : base(actionContext, validatorProvider, validatorCache, metadataProvider, validationState)
+            {
+                SkipValidations = skipValidations;
+            }
+
+            public IEnumerable<ISkipValidation> SkipValidations { get; }
+
+            protected override bool VisitComplexType(IValidationStrategy defaultStrategy)
+            {
+                if (SkipValidations.Any(v => v.SkipValidation(Model)))
+                    return true;
+                return base.VisitComplexType(defaultStrategy);
+            }
+        }
+
+        public MvcOptions _mvcOptions { get; }
+        IEnumerable<ISkipValidation> SkipValidations { get; }
+
+        public override ValidationVisitor GetValidationVisitor(
+            ActionContext actionContext,
+            IModelValidatorProvider validatorProvider,
+            ValidatorCache validatorCache,
+            IModelMetadataProvider metadataProvider,
+            ValidationStateDictionary validationState)
+        {
+            var visitor = new OverrideValidationVisitor(
+                SkipValidations,
+                actionContext,
+                validatorProvider,
+                validatorCache,
+                metadataProvider,
+                validationState)
+            {
+                MaxValidationDepth = _mvcOptions.MaxValidationDepth,
+                ValidateComplexTypesIfChildValidationFails = _mvcOptions.ValidateComplexTypesIfChildValidationFails,
+            };
+
+            return visitor;
+        }
+    }
+}

--- a/BTCPayServer/Hosting/Startup.cs
+++ b/BTCPayServer/Hosting/Startup.cs
@@ -22,6 +22,7 @@ using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Net.Http.Headers;
+using NBitcoin;
 
 namespace BTCPayServer.Hosting
 {
@@ -75,7 +76,6 @@ namespace BTCPayServer.Hosting
             .ConfigureApiBehaviorOptions(options =>
             {
                 var builtInFactory = options.InvalidModelStateResponseFactory;
-
                 options.InvalidModelStateResponseFactory = context =>
                 {
                     context.HttpContext.Response.StatusCode = (int)HttpStatusCode.UnprocessableEntity;

--- a/BTCPayServer/wwwroot/swagger/v1/swagger.template.stores-payment-methods.on-chain.json
+++ b/BTCPayServer/wwwroot/swagger/v1/swagger.template.stores-payment-methods.on-chain.json
@@ -403,7 +403,17 @@
                     },
                     "derivationScheme": {
                         "type": "string",
-                        "description": "The derivation scheme"
+                        "description": "The derivation scheme",
+                        "example": "xpub..."
+                    },
+                    "label": {
+                        "type": "string",
+                        "description": "A label that will be shown in the UI"
+                    },
+                    "accountKeyPath": {
+                        "type": "string",
+                        "description": "The wallet fingerprint followed by the keypath to derive the account key used for signing operation or creating PSBTs",
+                        "example": "abcd82a1/84'/0'/0'"
                     }
                 }
             },


### PR DESCRIPTION
This add a way to specify some fields of the on-chain payment methods such as `Label` and `AccountKeyPath`.

I wanted to use non-primitive (`RootedKeyPath`) types to make the greenfield library easier to use.
However, this caused problem as the default `ObjectModelValidator` would try to visit all the members of the `RootKeyPath` to validate everything. But those were sending back exception.

So I create a new `SkippableObjectModelValidator` which is like the `DefaultObjectModelValidator` of MVC, except that it is possible to register types to skip validations.

I initially wanted to remove all validations, but we rely on it for the UI and there is no way to allow it only for UI and not for API.