### PR TITLE
Prevent access to wallet features if derivation scheme isn't set

### DIFF
--- a/BTCPayServer/Controllers/WalletsController.PSBT.cs
+++ b/BTCPayServer/Controllers/WalletsController.PSBT.cs
@@ -75,9 +75,14 @@ namespace BTCPayServer.Controllers
         {
             var network = NetworkProvider.GetNetwork<BTCPayNetwork>(walletId.CryptoCode);
             vm.CryptoCode = network.CryptoCode;
+
+            var derivationSchemeSettings = GetDerivationSchemeSettings(walletId);
+            if (derivationSchemeSettings == null)
+                return NotFound();
+
             vm.NBXSeedAvailable = await CanUseHotWallet() && !string.IsNullOrEmpty(await ExplorerClientProvider.GetExplorerClient(network)
-                .GetMetadataAsync<string>(GetDerivationSchemeSettings(walletId).AccountDerivation,
-                    WellknownMetadataKeys.Mnemonic));
+                .GetMetadataAsync<string>(derivationSchemeSettings.AccountDerivation, WellknownMetadataKeys.Mnemonic));
+
             if (await vm.GetPSBT(network.NBitcoinNetwork) is PSBT psbt)
             {
                 vm.Decoded = psbt.ToString();
@@ -98,9 +103,13 @@ namespace BTCPayServer.Controllers
                 return await WalletPSBT(walletId, vm);
             var network = NetworkProvider.GetNetwork<BTCPayNetwork>(walletId.CryptoCode);
             vm.CryptoCode = network.CryptoCode;
+
+            var derivationSchemeSettings = GetDerivationSchemeSettings(walletId);
+            if (derivationSchemeSettings == null)
+                return NotFound();
+
             vm.NBXSeedAvailable = await CanUseHotWallet() && !string.IsNullOrEmpty(await ExplorerClientProvider.GetExplorerClient(network)
-                .GetMetadataAsync<string>(GetDerivationSchemeSettings(walletId).AccountDerivation,
-                    WellknownMetadataKeys.Mnemonic));
+                .GetMetadataAsync<string>(derivationSchemeSettings.AccountDerivation, WellknownMetadataKeys.Mnemonic));
             var psbt = await vm.GetPSBT(network.NBitcoinNetwork);
             if (psbt == null)
             {
@@ -127,7 +136,6 @@ namespace BTCPayServer.Controllers
                     return View(vm);
 
                 case "update":
-                    var derivationSchemeSettings = GetDerivationSchemeSettings(walletId);
                     psbt = await ExplorerClientProvider.UpdatePSBT(derivationSchemeSettings, psbt);
                     if (psbt == null)
                     {

--- a/BTCPayServer/Models/WalletViewModels/PullPaymentsModel.cs
+++ b/BTCPayServer/Models/WalletViewModels/PullPaymentsModel.cs
@@ -28,6 +28,8 @@ namespace BTCPayServer.Models.WalletViewModels
         }
 
         public List<PullPaymentModel> PullPayments { get; set; } = new List<PullPaymentModel>();
+
+        public bool HasDerivationSchemeSettings { get; set; }
     }
 
     public class NewPullPaymentModel

--- a/BTCPayServer/Views/Wallets/PullPayments.cshtml
+++ b/BTCPayServer/Views/Wallets/PullPayments.cshtml
@@ -18,14 +18,17 @@
     </div>
 }
 
-<div class="row button-row">
-    <div class="col-lg-12">
-        <a asp-action="NewPullPayment"
-           asp-route-walletId="@this.Context.GetRouteValue("walletId")"
-           class="btn btn-primary" role="button" id="NewPullPayment"><span class="fa fa-plus"></span> Create a new pull payment</a>
-        <a href="https://docs.btcpayserver.org/PullPayments/" target="_blank"><span class="fa fa-question-circle-o" title="More information..."></span></a>
+@if (Model.HasDerivationSchemeSettings)
+{
+    <div class="row button-row">
+        <div class="col-lg-12">
+            <a asp-action="NewPullPayment"
+               asp-route-walletId="@Context.GetRouteValue("walletId")"
+               class="btn btn-primary" role="button" id="NewPullPayment"><span class="fa fa-plus"></span> Create a new pull payment</a>
+            <a href="https://docs.btcpayserver.org/PullPayments/" target="_blank"><span class="fa fa-question-circle-o" title="More information..."></span></a>
+        </div>
     </div>
-</div>
+}
 
 <div class="row">
     @foreach (var pp in Model.PullPayments)


### PR DESCRIPTION
Adds checks for existing derivation scheme settings to the wallet actions that didn't have those checks yet.

Pull payment and payout list would potentially still be shown, but the link fro creating a new pull payment is removed if the wallet doesn't have a derivation scheme anymore. "Potentially" because the wallet doesn't appear in the list anymore and hence isn't really accessible via the web interface. Pav came across this, because he was using multiple tabs and deleted the derivation scheme settings in one of them and then returned to the wallet details page where he could still access the navigation sidebar … hooray to edge cases.

Thanks @pavlenex for spotting this when testing #2164.