### PR TITLE
Improving styling of error pages in preparation for adding new ones

### DIFF
--- a/BTCPayServer/Views/Error/404.cshtml
+++ b/BTCPayServer/Views/Error/404.cshtml
@@ -1,16 +1,20 @@
-﻿@{
+@{
     ViewData["Title"] = "404 - Page not found";
 }
 
-<div class="row justify-content-center mb-2">
-    <div class="col text-center">
+<div class="row">
+    <div class="col-12 col-head" style="justify-content:center; flex-direction: row; display:flex; flex-direction:row; text-align:center;">
         <a asp-controller="Home" asp-action="Index">
-            <img src="~/img/btcpay-logo.svg" alt="BTCPay Server" class="mb-4" height="70" asp-append-version="true"/>
+            <img src="~/img/btcpay-logo.svg" alt="BTCPay Server" class="head-logo" height="70" asp-append-version="true" />
         </a>
 
-        <h1 class="h2 mb-3">@ViewData["Title"]</h1>
+        <h1 class="text-uppercase mt-3 ml-4">@ViewData["Title"]</h1>
     </div>
 </div>
+
+<center>
+    <hr class="primary" />
+</center>
 
 <p class="lead text-center">
     This is like searching for a person more beautiful than <a href="https://twitter.com/NicolasDorier" target="_blank">Nicolas Dorier</a>.
@@ -24,8 +28,12 @@
     You can always try <a href="/">navigating back to home</a>.
 </p>
 
+<center>
+    <hr class="primary" />
+</center>
+
 <div class="row justify-content-center mt-5">
     <div class="col">
-        <partial name="_BTCPaySupporters"/>
+        <partial name="_BTCPaySupporters" />
     </div>
 </div>

--- a/BTCPayServer/Views/Error/429.cshtml
+++ b/BTCPayServer/Views/Error/429.cshtml
@@ -1,16 +1,20 @@
-﻿@{
+@{
     ViewData["Title"] = "429 - Too Many Requests";
 }
 
-<div class="row justify-content-center mb-2">
-    <div class="col text-center">
+<div class="row">
+    <div class="col-12 col-head" style="justify-content:center; flex-direction: row; display:flex; flex-direction:row; text-align:center;">
         <a asp-controller="Home" asp-action="Index">
-            <img src="~/img/btcpay-logo.svg" alt="BTCPay Server" class="mb-4" height="70" asp-append-version="true"/>
+            <img src="~/img/btcpay-logo.svg" alt="BTCPay Server" class="head-logo" height="70" asp-append-version="true" />
         </a>
 
-        <h1 class="h2 mb-3">@ViewData["Title"]</h1>
+        <h1 class="text-uppercase mt-3 ml-4">@ViewData["Title"]</h1>
     </div>
 </div>
+
+<center>
+    <hr class="primary" />
+</center>
 
 <p class="lead text-center">
     Please send requests slower. Or face the wrath of <a href="https://twitter.com/r0ckstardev" target="_blank">Vin Diesel</a>.
@@ -24,8 +28,12 @@
     Slowly <a href="/">navigate back to home</a>.
 </p>
 
+<center>
+    <hr class="primary" />
+</center>
+
 <div class="row justify-content-center mt-5">
     <div class="col">
-        <partial name="_BTCPaySupporters"/>
+        <partial name="_BTCPaySupporters" />
     </div>
 </div>

--- a/BTCPayServer/Views/Error/500.cshtml
+++ b/BTCPayServer/Views/Error/500.cshtml
@@ -1,16 +1,20 @@
-﻿@{
+@{
     ViewData["Title"] = "500 - Internal Server Error";
 }
 
-<div class="row justify-content-center mb-2">
-    <div class="col text-center">
+<div class="row">
+    <div class="col-12 col-head" style="justify-content:center; flex-direction: row; display:flex; flex-direction:row; text-align:center;">
         <a asp-controller="Home" asp-action="Index">
-            <img src="~/img/btcpay-logo.svg" alt="BTCPay Server" class="mb-4" height="70" asp-append-version="true"/>
+            <img src="~/img/btcpay-logo.svg" alt="BTCPay Server" class="head-logo" height="70" asp-append-version="true" />
         </a>
 
-        <h1 class="h2 mb-3">@ViewData["Title"]</h1>
+        <h1 class="text-uppercase mt-3 ml-4">@ViewData["Title"]</h1>
     </div>
 </div>
+
+<center>
+    <hr class="primary" />
+</center>
 
 <p class="lead text-center">
     Whoops, something really went wrong! <a href="https://twitter.com/mrkukks">Mr Kukks</a> is so sorry.
@@ -24,8 +28,12 @@
     <a href="/">Navigate back to home</a>.
 </p>
 
+<center>
+    <hr class="primary" />
+</center>
+
 <div class="row justify-content-center mt-5">
     <div class="col">
-        <partial name="_BTCPaySupporters"/>
+        <partial name="_BTCPaySupporters" />
     </div>
 </div>

--- a/BTCPayServer/Views/Error/_ViewStart.cshtml
+++ b/BTCPayServer/Views/Error/_ViewStart.cshtml
@@ -1,3 +1,4 @@
-﻿@{
+@{
     Layout = "_LayoutSimple";
+    ViewBag.TopSmallMargin = true;
 }

--- a/BTCPayServer/Views/Shared/_BTCPaySupporters.cshtml
+++ b/BTCPayServer/Views/Shared/_BTCPaySupporters.cshtml
@@ -1,5 +1,5 @@
 <h5 class="text-center font-weight-normal mb-2">
-    BTCPayServer Supporters
+    BTCPay Server Supporters
 </h5>
 <div class="row justify-content-center mb-2">
     <div class="p-3 text-center" style="flex-basis:105px;">

--- a/BTCPayServer/Views/Shared/_BTCPaySupporters.cshtml
+++ b/BTCPayServer/Views/Shared/_BTCPaySupporters.cshtml
@@ -1,5 +1,5 @@
-﻿<h5 class="text-center font-weight-normal mb-2">
-    Our Supporters
+<h5 class="text-center font-weight-normal mb-2">
+    BTCPayServer Supporters
 </h5>
 <div class="row justify-content-center mb-2">
     <div class="p-3 text-center" style="flex-basis:105px;">

--- a/BTCPayServer/Views/Shared/_LayoutSimple.cshtml
+++ b/BTCPayServer/Views/Shared/_LayoutSimple.cshtml
@@ -1,4 +1,4 @@
-﻿@{
+@{
     Layout = null;
 }
 <!DOCTYPE html>
@@ -7,7 +7,7 @@
     <partial name="Header" />
 </head>
 <body>
-    <section class="content-wrapper">
+    <section class="content-wrapper @(ViewBag.TopSmallMargin != null ? "pt-4" : "")">
         <!-- Dummy navbar-brand, hackish way to keep test AssertNoError passing -->
         <div class="navbar-brand d-none"></div>
         <div class="container">


### PR DESCRIPTION
There were some styling inconsistencies when switch to unified layout page was made. Restored original layout and look where it doesn't conflict with new styling.

Final, improved _look_:

![image](https://user-images.githubusercontent.com/5191402/104824513-da022d80-5817-11eb-88a4-263b44eb249c.png)
