### PR TITLE
Readme overhaul

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@
 
 ## 🚀 Getting Started
 
-Firstly, decide if you want to host an instance yourself or use a [third-party host](https://docs.btcpayserver.org/ThirdPartyHosting/). If you've chosen to self-host, we documented plenty of [ways to deploy BTCPay Server](https://docs.btcpayserver.org/Deployment/).
+Firstly, decide if you want to host an instance yourself or use a [third-party host](https://docs.btcpayserver.org/ThirdPartyHosting/). If you've chosen to self-host, there are plenty of documented [ways to deploy BTCPay Server](https://docs.btcpayserver.org/Deployment/).
 
 After successful deployment, make sure to check our [getting started](https://docs.btcpayserver.org/RegisterAccount/) and [walkthrough](https://docs.btcpayserver.org/Walkthrough/) guides. In case you would like to use Lightning Network, see [Lightning guide](https://docs.btcpayserver.org/LightningNetwork/).
 
@@ -113,7 +113,7 @@ After successful deployment, make sure to check our [getting started](https://do
 
 Please check out our [official website](https://btcpayserver.org/), [complete documentation](https://docs.btcpayserver.org/) and [FAQ](https://docs.btcpayserver.org/FAQ/) for more details.
 
-If you have trouble using BTCPay Server, consider joining [communities listed on the official website](https://btcpayserver.org/#communityCTA) to get help from the members. Only file [Github issue](https://github.com/btcpayserver/btcpayserver/issues/new/choose) for technical issues you can't resolve through other channels or feature requests you've validated with other members of the community.
+If you have trouble using BTCPay Server, consider joining [communities listed on the official website](https://btcpayserver.org/#communityCTA) to get help from other contributors. Only create a [GitHub issue](https://github.com/btcpayserver/btcpayserver/issues/new/choose) for technical issues you can't resolve through other channels or feature requests you've validated with other members of the community.
 
 ## 🤝 Contributing
 
@@ -197,7 +197,7 @@ BTCPay Server has two API's:
   - [Greenfield API examples with CURL](https://docs.btcpayserver.org/GreenFieldExample/)
 - **Legacy API**
 
-The **Greenfield API** is our brand-new API which is still in development. Once complete, it will allow you to run BTCPay Server heedlessly.
+The **Greenfield API** is our brand-new API which is still in development. Once complete, it will allow you to run BTCPay Server headlessly.
 The **Legacy API**, is fully compatible with [BitPay's API](https://bitpay.com/api/). It has limited features, but allows instant migration from BitPay.
 
 ## 💚 Community

--- a/README.md
+++ b/README.md
@@ -117,8 +117,6 @@ Please check out our [official website](https://btcpayserver.org/), our [complet
 
 If you have trouble using BTCPay, consider joining [communities listed on the official website](https://btcpayserver.org/#communityCTA) to get help from the BTCPay community members. Only file [Github issue](https://github.com/btcpayserver/btcpayserver/issues) for technical issues you can't resolve through other channels or feature requests you've validated with other members of the community.
 
-The main community chat is located on [Mattermost](https://chat.btcpayserver.org/).
-
 ## 🤝 Contributing
 
 BTCPay Server is built and maintained entirely by volunteer contributors around the internet. We welcome and appreciate new contributions.

--- a/README.md
+++ b/README.md
@@ -97,13 +97,11 @@
 * SegWit support
 * Lightning Network support (LND, c-lightning, Eclair, and Ptarmigan)
 * Tor support
-* Bitcoin-only build
 * Share your instance with friends (multi-tenant)
-* Invoice management
-* Point of sale $ crowdfunding app
-* Payment requests and donation button
-* Full-node reliant wallet with [hardware wallet integration](https://docs.btcpayserver.org/Vault/)
-* Separate community-maintained altcoin build (when supported [altcoins](https://docs.btcpayserver.org/FAQ/FAQ-Altcoin/) are enabled)
+* Invoice management and Payment requests
+* Apps: Point of sale, crowdfunding, donation button
+* Full-node reliant wallet with [hardware wallet integration](https://docs.btcpayserver.org/Vault/) and SegWit support
+* Bitcoin-only build, separate community-maintained altcoin build ([supported altcoins](https://docs.btcpayserver.org/FAQ/FAQ-Altcoin/))
 
 ## 🚀 Getting Started
 

--- a/README.md
+++ b/README.md
@@ -1,98 +1,147 @@
+# BTCPay Server
 
 ![BTCPay Server](BTCPayServer/wwwroot/img/btc_pay_BG_twitter.png)
 
-[![Docker Automated build](https://img.shields.io/docker/automated/jrottenberg/ffmpeg.svg)](https://hub.docker.com/r/btcpayserver/btcpayserver/)
-[![Deploy to Azure](https://azuredeploy.net/deploybutton.svg)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fbtcpayserver%2Fbtcpayserver-azure%2Fmaster%2Fazuredeploy.json)
-[![CircleCI](https://circleci.com/gh/btcpayserver/btcpayserver.svg?style=svg)](https://circleci.com/gh/btcpayserver/btcpayserver)
+<h3 align="center">
+  Accept Bitcoin payments ₿
+</h3>
+<p align="center"> BTCPay Server is a free and open-source Bitcoin payment processor which allows you to accept bitcoin without fees or intermediary.
+</p>
+<p align="center">
+  <a href="https://circleci.com/gh/btcpayserver/btcpayserver">
+    <img src="https://img.shields.io/circleci/build/github/btcpayserver/btcpayserver"/>
+  </a>
+  <a href="https://github.com/btcpayserver/btcpayserver/releases/">
+    <img src="https://img.shields.io/github/v/release/btcpayserver/btcpayserver"/>
+  </a>
+  <a href="https://github.com/btcpayserver/btcpayserver/blob/master/LICENSE">
+      <img src="https://img.shields.io/github/license/btcpayserver/btcpayserver"/>
+  </a>     
+  <a href="https://docs.btcpayserver.org/Contribute/">
+    <img src="https://img.shields.io/badge/PRs-welcome-brightgreen.svg"/>
+  </a>
+  <a href="https://chat.btcpayserver.org/">
+    <img src="https://img.shields.io/badge/Community%20Chat-Mattermost-%230058cc"/>
+  </a>
+  <a href="https://twitter.com/intent/follow?screen_name=btcpayserver">
+    <img src="https://img.shields.io/twitter/follow/btcpayserver.svg?label=Follow%20@btcpayserver"/>
+  </a>
+</p>
 
-# BTCPay Server
+<div align="center">
+  <h3>
+    <a href="https://btcpayserver.org">
+      Website
+    </a>
+    <span> | </span>
+    <a href="https://docs.btcpayserver.org">
+      Documentation
+    </a>
+    <span> | </span>
+    <a href="https://docs.btcpayserver.org/API/Greenfield/v1/">
+      API
+    </a>
+    <span> | </span>
+    <a href="https://docs.btcpayserver.org/Contribute/>"
+      Contribute
+    </a>
+    <span> | </span>
+    <a href="https://www.youtube.com/btcpayserver/">
+      YouTube
+    </a>
+    <span> | </span>
+    <a href="https://chat.btcpayserver.org/">
+      Chat
+    </a>
+  </h3>
+</div>
 
-## Introduction
+<div align="center">
+  <sub>"This is lies, my trust in you is broken, I will make you obsolete" 💚
+  </a>
+</div>
+<br/>
 
-BTCPay Server is a free and open-source cryptocurrency payment processor which allows you to receive payments in Bitcoin and altcoins directly, with no fees, transaction cost or a middleman.
+<p align="center">
+  <a href="https://mainnet.demo.btcpayserver.org">View Demo</a>
+  ·
+  <a href="https://github.com/btcpayserver/btcpayserver/issues/new/choose">Report a bug</a>
+  ·
+  <a href="https://github.com/btcpayserver/btcpayserver/discussions/new">Request a feature</a>
+  ·
+  <a href="https://docs.btcpayserver.org/FAQ/">FAQ</a>
+</p>
 
-BTCPay Server is a non-custodial invoicing system which eliminates the involvement of a third-party. Payments with BTCPay Server go directly to your wallet, which increases the privacy and security. Your private keys are never uploaded to the server. There is no address re-use, since each invoice generates a new address deriving from your xpubkey.
+## 💼 Table of Contents
 
-The software is built in C# and conforms to the invoice [API of BitPay](https://bitpay.com/api). It allows for your website to be easily migrated from BitPay and configured as a self-hosted payment processor.
+* [Features](#-features)
+* [Getting Started](#-getting-started)
+* [Documentation](#-documentation)
+* [Contributing](#-contributing)
+* [Developing](#-developing)
+  * [API](#-api)
+* [Community](#-community)
+* [License](#-license)
+* [Supporters](#-supporters)
 
-You can run BTCPay Server as a self-hosted solution on your own server, or use a [third-party host](https://docs.btcpayserver.org/ThirdPartyHosting/).
+![](https://raw.githubusercontent.com/btcpayserver/btcpayserver-doc/master/docs/img/BTCPayServerScreenshot.png)
 
-The self-hosted solution allows you not only to attach an unlimited number of stores and use the Lightning Network but also become the payment processor for others.
-
-Thanks to the [apps](https://docs.btcpayserver.org/Apps/) built on top of it, you can use BTCPay to receive donations, start a crowdfunding campaign or have an in-store Point of Sale.
-
-[![What is BTCPay](https://img.youtube.com/vi/q7xJMno_B3U/sddefault.jpg)](https://www.youtube.com/watch?v=q7xJMno_B3U "What is BTCPay")
-
-## Table of Contents
-
-* [Features](#features)
-* [Getting Started](#getting-started)
-* [Documentation](#documentation)
-* [Contributing](#Contributing)
-* [How to build](#how-to-build)
-* [How to run](#how-to-run)
-* [How to debug](#how-to-debug)
-* [Dependencies](#other-dependencies)
-
-## Features
+## 🎨 Features
 
 * Direct, peer-to-peer Bitcoin payments
 * No transaction fees (other than the [network fee](https://en.bitcoin.it/wiki/Miner_fees))
-* No processing fees
-* No middleman
-* No KYC
+* No fees, middleman or KYC
 * Non-custodial (complete control over the private key)
-* Enhanced privacy
-* Enhanced security
+* Enhanced privacy & privacy
 * Self-hosted
 * SegWit support
-* Lightning Network support (LND, c-lightning, Eclair and Ptarmigan)
+* Lightning Network support (LND, c-lightning, Eclair, and Ptarmigan)
 * Tor support
-* Opt-in [altcoin](https://docs.btcpayserver.org/FAQ/FAQ-Altcoin/) integrations
-* Full compatibility with BitPay API (easy migration)
-* Process payments for others
-* Easy-embeddable Payment buttons
-* Point of sale app
-* Crowdfunding app
-* Payment Requests
-* Internal, full-node reliant wallet with [hardware wallet integration](https://docs.btcpayserver.org/Vault/)
+* Bitcoin-only build
+* Share your instance with friends
+* Invoice management
+* Point of sale $ crowdfunding app
+* Payment requests and donation button
+* Full-node reliant wallet with [hardware wallet integration](https://docs.btcpayserver.org/Vault/)
+* Separate community-maintained altcoin build (when supported [altcoins](https://docs.btcpayserver.org/FAQ/FAQ-Altcoin/) are enabled)
 
-## Getting Started
+## 🚀 Getting Started
 
 Firstly, decide if you want to host an instance yourself or use a [third-party host](https://docs.btcpayserver.org/ThirdPartyHosting/). If you've chosen to self-host, we documented plenty [ways to deploy BTCPay Server](https://docs.btcpayserver.org/Deployment/).
 
 After successful deployment, make sure to check our [getting started](https://docs.btcpayserver.org/RegisterAccount/) and [walkthrough](https://docs.btcpayserver.org/Walkthrough/) guides. In case you would like to use Lightning Network, see [Lightning guide](https://docs.btcpayserver.org/LightningNetwork/).
 
-## Documentation
+## 📗 Documentation
 
 Please check out our [official website](https://btcpayserver.org/), our [complete documentation](https://docs.btcpayserver.org/) and [FAQ](https://docs.btcpayserver.org/FAQ/) for more details.
 
-If you have trouble using BTCPay, consider joining [communities listed on official website](https://btcpayserver.org/#communityCTA) to get help from BTCPay community members. Only file [Github issue](https://github.com/btcpayserver/btcpayserver/issues) for technical issues you can't resolve through other channels or feature requests you've validated with other members of community.
+If you have trouble using BTCPay, consider joining [communities listed on the official website](https://btcpayserver.org/#communityCTA) to get help from the BTCPay community members. Only file [Github issue](https://github.com/btcpayserver/btcpayserver/issues) for technical issues you can't resolve through other channels or feature requests you've validated with other members of the community.
 
-Main community chat is located on [Mattermost](https://chat.btcpayserver.org/).
+The main community chat is located on [Mattermost](https://chat.btcpayserver.org/).
 
-## Contributing
+## 🤝 Contributing
 
-BTCPay is built and maintained entirely by volunteer contributors around the internet. We welcome and appreciate new contributions.
+BTCPay Server is built and maintained entirely by volunteer contributors around the internet. We welcome and appreciate new contributions.
 
 If you're a developer looking to help, but you're not sure where to begin, check the [good first issue label](https://github.com/btcpayserver/btcpayserver/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22), which contains small pieces of work that have been specifically flagged as being friendly to new contributors.
 
-Contributors looking to do something a bit more challenging, before opening a pull request, please [create an issue](https://github.com/btcpayserver/btcpayserver/issues/new/choose) or join [our community chat](https://chat.btcpayserver.org/) to get early feedback, discuss best ways to tackle the problem and to ensure there is no work duplication.
+Contributors looking to do something a bit more challenging, before opening a pull request, please join [our community chat](https://chat.btcpayserver.org/) or [start a GitHub discussion](https://github.com/btcpayserver/btcpayserver/discussions) to get early feedback, discuss best ways to tackle the problem and ensure there is no work duplication.
+
+There are many other ways to get involved with the project. Check our [contribution guidelines](https://docs.btcpayserver.org/Contribute/). To get the big-picture of the project development, visit our [evolving roadmap](https://github.com/orgs/btcpayserver/projects/9). We organize different types of community calls several times a month. [Subscribe to our calendar](https://github.com/btcpayserver/organization#calendar) and feel free to join our calls to discuss development, design, documentation and more.
+
+## 🧑‍💻 Developing
+
+To begin developing locally, visit [local development guide](https://docs.btcpayserver.org/LocalDevelopment/). There are also several video-tutorials:
 
 * [Setting up development environment on Windows](https://www.youtube.com/watch?v=ZePbMPSIvHM)
 * [Setting up development environment Linux (Ubuntu)](https://www.youtube.com/watch?v=j486T_Rk-yw&t)
 * [Setting up development environment MacOS](https://www.youtube.com/watch?v=GWR_CcMsEV0)
 
-You also have an awesome video of our contributors which explains how to get started.
-[![Rockstar Dev and Britt Kelly - BTCPay Server Code Along](https://img.youtube.com/vi/ZePbMPSIvHM/sddefault.jpg)](https://www.youtube.com/embed/VNMnd-dX9Q8)
+### How to build
 
-Here is some info about [how to extend the themes](https://docs.btcpayserver.org/Theme/).
+While the documentation advises using docker-compose, you may want to build BTCPay Server yourself.
 
-## How to build
-
-While the documentation advises to use docker-compose, you may want to build BTCPay Server yourself.
-
-First install .NET Core SDK v3.1 as specified by [Microsoft website](https://dotnet.microsoft.com/download/dotnet-core/3.1).
+First, install .NET Core SDK v3.1 as specified by [Microsoft website](https://dotnet.microsoft.com/download/dotnet-core/3.1).
 
 On Powershell:
 
@@ -106,9 +155,9 @@ On linux:
 ./build.sh
 ```
 
-## How to run
+### How to run
 
-Use the `run` scripts to run BTCPayServer, this example shows how to print the available command line arguments of BTCPayServer.
+Use the `run` scripts to run BTCPay Server, this example shows how to print the available command-line arguments of BTCPay Server.
 
 On Powershell:
 
@@ -122,7 +171,7 @@ On linux:
 ./run.sh --help
 ```
 
-## How to debug
+### How to debug
 
 If you want to debug, use Visual Studio Code or Visual Studio 2019.
 
@@ -136,23 +185,34 @@ If you need to debug ledger wallet interaction, install the development time cer
 # Install development time certificate in the trust store
 dotnet dev-certs https --trust
 ```
-
 Then use the `Docker-Regtest-https` debug profile.
 
-## Other dependencies
+### Other dependencies
 
 For more information, see the documentation:
-[How to deploy a BTCPay server instance](https://docs.btcpayserver.org/Deployment/).
+[How to deploy a BTCPay Server instance](https://docs.btcpayserver.org/Deployment/).
 
-## Supported altcoins
+### 🧪 API
 
-Bitcoin is the only focus of the project and its core developers. However, opt in integrations are present for [several altcoins](https://docs.btcpayserver.org/FAQ/FAQ-Altcoin/). Altcoins are maintained by their respective communities.
+BTCPay Server has two API:
 
-## License
+- **Greenfield API (New)**
+  - [Greenfield API documentation](https://docs.btcpayserver.org/API/Greenfield/v1/)
+  - [Greenfield API examples with CURL](https://docs.btcpayserver.org/GreenFieldExample/)
+- **Legacy API**
+
+The **Greenfield API** is our brand-new API which is still in development. Once complete, it will allow you to run BTCPay Server heedlessly.
+The **legacy API**, is fully compatible with [BitPay's API](https://bitpay.com/api/). It has limited features, but allows instant migration from BitPay.
+
+## 💚 Community
+
+Our community is ❤️ of the project. To chat with other community members in real-time, join our [Mattermost chat](https://chat.btcpayserver.org). We're also on [GitHub discussions](https://github.com/btcpayserver/btcpayserver/discussions).
+
+## 📝 License
 
 BTCPay Server software, logo and designs are provided under [MIT License](https://github.com/btcpayserver/btcpayserver/blob/master/LICENSE).
 
-## Supporters
+## 🙏 Supporters
 
 The BTCPay Server Project is proudly supported by these entities through the [BTCPay Server Foundation](https://foundation.btcpayserver.org/).
 

--- a/README.md
+++ b/README.md
@@ -105,13 +105,13 @@
 
 ## 🚀 Getting Started
 
-Firstly, decide if you want to host an instance yourself or use a [third-party host](https://docs.btcpayserver.org/ThirdPartyHosting/). If you've chosen to self-host, we documented plenty [ways to deploy BTCPay Server](https://docs.btcpayserver.org/Deployment/).
+Firstly, decide if you want to host an instance yourself or use a [third-party host](https://docs.btcpayserver.org/ThirdPartyHosting/). If you've chosen to self-host, we documented plenty of [ways to deploy BTCPay Server](https://docs.btcpayserver.org/Deployment/).
 
 After successful deployment, make sure to check our [getting started](https://docs.btcpayserver.org/RegisterAccount/) and [walkthrough](https://docs.btcpayserver.org/Walkthrough/) guides. In case you would like to use Lightning Network, see [Lightning guide](https://docs.btcpayserver.org/LightningNetwork/).
 
 ## 📗 Documentation
 
-Please check out our [official website](https://btcpayserver.org/), our [complete documentation](https://docs.btcpayserver.org/) and [FAQ](https://docs.btcpayserver.org/FAQ/) for more details.
+Please check out our [official website](https://btcpayserver.org/), [complete documentation](https://docs.btcpayserver.org/) and [FAQ](https://docs.btcpayserver.org/FAQ/) for more details.
 
 If you have trouble using BTCPay Server, consider joining [communities listed on the official website](https://btcpayserver.org/#communityCTA) to get help from the members. Only file [Github issue](https://github.com/btcpayserver/btcpayserver/issues/new/choose) for technical issues you can't resolve through other channels or feature requests you've validated with other members of the community.
 

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ After successful deployment, make sure to check our [getting started](https://do
 
 Please check out our [official website](https://btcpayserver.org/), our [complete documentation](https://docs.btcpayserver.org/) and [FAQ](https://docs.btcpayserver.org/FAQ/) for more details.
 
-If you have trouble using BTCPay, consider joining [communities listed on the official website](https://btcpayserver.org/#communityCTA) to get help from the BTCPay community members. Only file [Github issue](https://github.com/btcpayserver/btcpayserver/issues) for technical issues you can't resolve through other channels or feature requests you've validated with other members of the community.
+If you have trouble using BTCPay Server, consider joining [communities listed on the official website](https://btcpayserver.org/#communityCTA) to get help from the members. Only file [Github issue](https://github.com/btcpayserver/btcpayserver/issues/new/choose) for technical issues you can't resolve through other channels or feature requests you've validated with other members of the community.
 
 ## 🤝 Contributing
 
@@ -127,7 +127,7 @@ There are many other ways to get involved with the project. Check our [contribut
 
 ## 🧑‍💻 Developing
 
-To begin developing locally, visit [local development guide](https://docs.btcpayserver.org/LocalDevelopment/). There are also several video-tutorials:
+To begin developing locally, visit our [local development guide](https://docs.btcpayserver.org/LocalDevelopment/). There are also several video-tutorials:
 
 * [Setting up development environment on Windows](https://www.youtube.com/watch?v=ZePbMPSIvHM)
 * [Setting up development environment Linux (Ubuntu)](https://www.youtube.com/watch?v=j486T_Rk-yw&t)
@@ -137,7 +137,7 @@ To begin developing locally, visit [local development guide](https://docs.btcpay
 
 While the documentation advises using docker-compose, you may want to build BTCPay Server yourself.
 
-First, install .NET Core SDK v3.1 as specified by [Microsoft website](https://dotnet.microsoft.com/download/dotnet-core/3.1).
+First, install .NET Core SDK v3.1 as specified by the [Microsoft website](https://dotnet.microsoft.com/download/dotnet-core/3.1).
 
 On Powershell:
 
@@ -190,7 +190,7 @@ For more information, see the documentation:
 
 ### 🧪 API
 
-BTCPay Server has two APIs:
+BTCPay Server has two API's:
 
 - **Greenfield API (New)**
   - [Greenfield API documentation](https://docs.btcpayserver.org/API/Greenfield/v1/)
@@ -198,11 +198,11 @@ BTCPay Server has two APIs:
 - **Legacy API**
 
 The **Greenfield API** is our brand-new API which is still in development. Once complete, it will allow you to run BTCPay Server heedlessly.
-The **legacy API**, is fully compatible with [BitPay's API](https://bitpay.com/api/). It has limited features, but allows instant migration from BitPay.
+The **Legacy API**, is fully compatible with [BitPay's API](https://bitpay.com/api/). It has limited features, but allows instant migration from BitPay.
 
 ## 💚 Community
 
-Our community is ❤️ of the project. To chat with other community members in real-time, join our [Mattermost chat](https://chat.btcpayserver.org). We're also on [GitHub discussions](https://github.com/btcpayserver/btcpayserver/discussions).
+Our community is the ❤️ of the project. To chat with other community members in real-time, join our [Mattermost chat](https://chat.btcpayserver.org). We're also on [GitHub discussions](https://github.com/btcpayserver/btcpayserver/discussions).
 
 ## 📝 License
 


### PR DESCRIPTION
I've noticed that our readme has a bit of outdated information and doesn't really link to all relevant places. Since our readme is our GitHub landing page, this PR attempts to organize things and clean things up.

**Preview here** https://github.com/pavlenex/btcpayserver/tree/readme-improvements

Here's what's added:
- Navigation header with links to demo, bug reports, and important places (docs, site, yt API)
- Software screenshot (important to preview how  software looks)
- Adds Developing section, nests (build, run, debug) and adds API section that clarifies our two API's (hopefully)
- Adds new badges (PR welcome, Twitter, Chat, etc) and aligns them properly 
- Simplifies features section
- Adds emoji in headings for more fun :tada: 
 
Here's what's removed:
- YouTube video (we can add a new one once it's done)
- Removes introduction section as it was too wordy, instead adds simple sentence and links to docs
- Removes Azure deploy badge since it'll be added in the azure readme (azure no longer recommended deployment method)