### PR TITLE
Invoices list: Remove icon indicator for onchain

### DIFF
--- a/BTCPayServer/Payments/PaymentTypes.Bitcoin.cs
+++ b/BTCPayServer/Payments/PaymentTypes.Bitcoin.cs
@@ -17,7 +17,7 @@ namespace BTCPayServer.Payments
 
         public override string ToPrettyString() => "On-Chain";
         public override string GetId() => "BTCLike";
-        public override string GetBadge() => "🔗";
+        public override string GetBadge() => "";
         public override string ToStringNormalized() => "OnChain";
         public override CryptoPaymentData DeserializePaymentData(BTCPayNetworkBase network, string str)
         {

--- a/BTCPayServer/Views/Invoice/ListInvoices.cshtml
+++ b/BTCPayServer/Views/Invoice/ListInvoices.cshtml
@@ -292,7 +292,7 @@
                                         @invoice.Status.ToString().ToLower()
                                     </span>
                                 }
-                                @foreach (var paymentType in  invoice.Details.Payments.Select(payment => payment.GetPaymentMethodId()?.PaymentType).Distinct().Where(type => type != null && !string.IsNullOrEmpty(type.GetBadge())))
+                                @foreach (var paymentType in invoice.Details.Payments.Select(payment => payment.GetPaymentMethodId()?.PaymentType).Distinct().Where(type => type != null && !string.IsNullOrEmpty(type.GetBadge())))
                                 {
                                     <span class="badge">@paymentType.GetBadge()</span>
                                 }


### PR DESCRIPTION
As [discussed on the chat](https://chat.btcpayserver.org/btcpayserver/pl/tcjy5ornhbd8i8jm4yj9y3maie) the icon feels unnecessary and isn't clear to users. Leaving it off and only indicating Lightning transactions avoids confusion.