### PR TITLE
Fix empty GetLightningClient return value

### DIFF
--- a/BTCPayServer/Controllers/GreenField/LightningNodeApiController.Internal.cs
+++ b/BTCPayServer/Controllers/GreenField/LightningNodeApiController.Internal.cs
@@ -107,7 +107,7 @@ namespace BTCPayServer.Controllers.GreenField
             var network = _btcPayNetworkProvider.GetNetwork<BTCPayNetwork>(cryptoCode);
             if (network == null || !CanUseInternalLightning(doingAdminThings) || internalLightningNode == null)
             {
-                return null;
+                return Task.FromResult<ILightningClient>(null);
             }
 
             return Task.FromResult(_lightningClientFactory.Create(internalLightningNode, network));

--- a/BTCPayServer/Controllers/GreenField/LightningNodeApiController.Store.cs
+++ b/BTCPayServer/Controllers/GreenField/LightningNodeApiController.Store.cs
@@ -120,7 +120,7 @@ namespace BTCPayServer.Controllers.GreenField
             if (existing == null || (existing.GetLightningUrl().IsInternalNode(internalLightningNode) &&
                                      !CanUseInternalLightning(doingAdminThings)))
             {
-                return null;
+                return Task.FromResult<ILightningClient>(null);
             }
 
             return Task.FromResult(_lightningClientFactory.Create(existing.GetLightningUrl(), network));


### PR DESCRIPTION
Fixes an [issue brought up the chat](https://chat.btcpayserver.org/btcpayserver/pl/y5813qcodtgitnpa8qur18upew): In case the LN node of a store isn't configured, the endpoint returned an error `503` instead of `404`, because the code crashed with an `System.NullReferenceException` before reaching [the `null` check](https://github.com/btcpayserver/btcpayserver/blob/master/BTCPayServer/Controllers/GreenField/LightningNodeApiController.cs#L46).