### PR TITLE
fixed mysql support

### DIFF
--- a/BTCPayServer.Data/Migrations/20200625064111_refundnotificationpullpayments.cs
+++ b/BTCPayServer.Data/Migrations/20200625064111_refundnotificationpullpayments.cs
@@ -11,13 +11,16 @@ namespace BTCPayServer.Migrations
     {
         protected override void Up(MigrationBuilder migrationBuilder)
         {
+            int? maxLength = this.IsMySql(migrationBuilder.ActiveProvider) ? (int?)255 : null;
+
             migrationBuilder.DropTable(
                 name: "RefundAddresses");
 
             migrationBuilder.AddColumn<string>(
                 name: "CurrentRefundId",
                 table: "Invoices",
-                nullable: true);
+                nullable: true,
+		maxLength: maxLength);
 
             migrationBuilder.CreateTable(
                 name: "Notifications",
@@ -73,7 +76,7 @@ namespace BTCPayServer.Migrations
                     PullPaymentDataId = table.Column<string>(maxLength: 30, nullable: true),
                     State = table.Column<string>(maxLength: 20, nullable: false),
                     PaymentMethodId = table.Column<string>(maxLength: 20, nullable: false),
-                    Destination = table.Column<string>(nullable: true),
+                    Destination = table.Column<string>(maxLength: maxLength, nullable: true),
                     Blob = table.Column<byte[]>(nullable: true),
                     Proof = table.Column<byte[]>(nullable: true)
                 },
@@ -92,8 +95,8 @@ namespace BTCPayServer.Migrations
                 name: "Refunds",
                 columns: table => new
                 {
-                    InvoiceDataId = table.Column<string>(nullable: false),
-                    PullPaymentDataId = table.Column<string>(nullable: false)
+                    InvoiceDataId = table.Column<string>(maxLength: maxLength, nullable: false),
+                    PullPaymentDataId = table.Column<string>(maxLength: maxLength, nullable: false)
                 },
                 constraints: table =>
                 {

--- a/BTCPayServer.Data/Migrations/20201108054749_webhooks.cs
+++ b/BTCPayServer.Data/Migrations/20201108054749_webhooks.cs
@@ -27,8 +27,8 @@ namespace BTCPayServer.Migrations
                 name: "StoreWebhooks",
                 columns: table => new
                 {
-                    StoreId = table.Column<string>(nullable: false),
-                    WebhookId = table.Column<string>(nullable: false)
+                    StoreId = table.Column<string>(maxLength: 50, nullable: false),
+                    WebhookId = table.Column<string>(maxLength: 25, nullable: false)
                 },
                 constraints: table =>
                 {
@@ -71,8 +71,8 @@ namespace BTCPayServer.Migrations
                 name: "InvoiceWebhookDeliveries",
                 columns: table => new
                 {
-                    InvoiceId = table.Column<string>(nullable: false),
-                    DeliveryId = table.Column<string>(nullable: false)
+                    InvoiceId = table.Column<string>(maxLength: 255, nullable: false),
+                    DeliveryId = table.Column<string>(maxLength: 100, nullable: false)
                 },
                 constraints: table =>
                 {

--- a/BTCPayServer.Data/Migrations/20201208054211_invoicesorderindex.cs
+++ b/BTCPayServer.Data/Migrations/20201208054211_invoicesorderindex.cs
@@ -10,14 +10,17 @@ namespace BTCPayServer.Migrations
     {
         protected override void Up(MigrationBuilder migrationBuilder)
         {
-        migrationBuilder.AlterColumn<string>(
-            name: "OrderId",
-            table: "Invoices",
-            maxLength: 100,
-            nullable: true,
-            oldClrType: typeof(string));
+            if (!migrationBuilder.IsSqlite())
+            {
+                migrationBuilder.AlterColumn<string>(
+                    name: "OrderId",
+                    table: "Invoices",
+                    maxLength: 100,
+                    nullable: true,
+                    oldClrType: typeof(string));
+            }
 
-	    migrationBuilder.CreateIndex(
+	        migrationBuilder.CreateIndex(
                 name: "IX_Invoices_OrderId",
                 table: "Invoices",
                 column: "OrderId");

--- a/BTCPayServer.Data/Migrations/20201208054211_invoicesorderindex.cs
+++ b/BTCPayServer.Data/Migrations/20201208054211_invoicesorderindex.cs
@@ -10,7 +10,14 @@ namespace BTCPayServer.Migrations
     {
         protected override void Up(MigrationBuilder migrationBuilder)
         {
-            migrationBuilder.CreateIndex(
+        migrationBuilder.AlterColumn<string>(
+            name: "OrderId",
+            table: "Invoices",
+            maxLength: 100,
+            nullable: true,
+            oldClrType: typeof(string));
+
+	    migrationBuilder.CreateIndex(
                 name: "IX_Invoices_OrderId",
                 table: "Invoices",
                 column: "OrderId");

--- a/BTCPayServer.Data/Migrations/20201228225040_AddingInvoiceSearchesTable.cs
+++ b/BTCPayServer.Data/Migrations/20201228225040_AddingInvoiceSearchesTable.cs
@@ -21,8 +21,8 @@ namespace BTCPayServer.Migrations
                         .Annotation("MySql:ValueGeneratedOnAdd", true)
                         .Annotation("Sqlite:Autoincrement", true),
                         // eof manually added
-                    InvoiceDataId = table.Column<string>(nullable: true),
-                    Value = table.Column<string>(nullable: true)
+                    InvoiceDataId = table.Column<string>(maxLength: 255, nullable: true),
+                    Value = table.Column<string>(maxLength: 512, nullable: true)
                 },
                 constraints: table =>
                 {


### PR DESCRIPTION
Various fixes for mysql support, mainly columns without length parameter ending up in longtext (4GB) columns that can't be used for indexes. Also had to alter an old table that initially didn't have a length but  is now used in an index (see 20201208054211_invoicesorderindex.cs)