### PR TITLE
Fix payment request template

### DIFF
--- a/BTCPayServer/Views/PaymentRequest/ViewPaymentRequest.cshtml
+++ b/BTCPayServer/Views/PaymentRequest/ViewPaymentRequest.cshtml
@@ -63,8 +63,8 @@
         </style>
     </noscript>
 </head>
-<body class="h-100">
-    <div id="app" class="h-100 d-flex flex-column">
+<body>
+    <div id="app" class="min-vh-100 d-flex flex-column">
         <nav id="mainNav" class="navbar sticky-top py-3 py-lg-4 d-print-block">
             <div class="container">
                 <div class="row align-items-center" style="width:calc(100% + 30px)">

--- a/BTCPayServer/Views/PullPayment/ViewPullPayment.cshtml
+++ b/BTCPayServer/Views/PullPayment/ViewPullPayment.cshtml
@@ -46,8 +46,8 @@
         </style>
     </noscript>
 </head>
-<body class="h-100">
-    <div class="h-100 d-flex flex-column">
+<body>
+    <div class="min-vh-100 d-flex flex-column">
         @if (Model.IsPending)
         {
             <nav id="mainNav" class="navbar sticky-top py-3 py-lg-4 d-print-none">


### PR DESCRIPTION
This will prevent the page from being vertically too small for the screen. Right now the footer will cut off and the screen will continue with the body bg on big screens. With this patch the main section will take grow vertically if space is available. 