### PR TITLE
Fix view payment request loading spinner alignment

### DIFF
--- a/BTCPayServer/Views/PaymentRequest/ViewPaymentRequest.cshtml
+++ b/BTCPayServer/Views/PaymentRequest/ViewPaymentRequest.cshtml
@@ -157,8 +157,8 @@
                                             </div>
                                         </div>
                                         <div class="col mt-2 col-12 col-sm-6 mt-sm-0 col-md-12 mt-md-2">
-                                            <button class="btn btn-primary w-100 text-nowrap" v-bind:class="{ 'btn-disabled': loading}" :disabled="loading" type="submit">
-                                                <div v-if="loading" class="spinner-grow spinner-grow-sm" role="status">
+                                            <button class="btn btn-primary w-100 d-flex d-print-none align-items-center justify-content-center text-nowrap" v-bind:class="{ 'btn-disabled': loading}" :disabled="loading" type="submit">
+                                                <div v-if="loading" class="spinner-grow spinner-grow-sm mr-2" role="status">
                                                     <span class="sr-only">Loading...</span>
                                                 </div>
                                                 Pay Invoice


### PR DESCRIPTION
This patch will align the loading spinner for the pay invoice button vertically centered to the text.