### PR TITLE
Add "vertical-align: middle;" to pay button image CSS

### DIFF
--- a/BTCPayServer/wwwroot/paybutton/paybutton.js
+++ b/BTCPayServer/wwwroot/paybutton/paybutton.js
@@ -181,7 +181,7 @@ function inputChanges(event, buttonSize) {
     }else{
         var numheight = parseInt(height.replace("px", ""));
         html+= '<button type="submit" class="submit" name="submit" style="min-width:' + width + '; min-height:' + height + '; border-radius: 4px;border-style: none;background-color: #0f3b21;" alt="Pay with BtcPay, Self-Hosted Bitcoin Payment Processor"><span style="color:#fff">'+esc(srvModel.payButtonText)+'</span>\n' +
-            (srvModel.payButtonImageUrl? '<img src="'+esc(srvModel.payButtonImageUrl)+'" style="height:'+numheight+'px;display:inline-block;padding: 5% 0 5% 5px;">\n' : '')+
+            (srvModel.payButtonImageUrl? '<img src="'+esc(srvModel.payButtonImageUrl)+'" style="height:'+numheight+'px;display:inline-block;padding: 5% 0 5% 5px;vertical-align: middle;">\n' : '')+
             '</button>'
     }
     html += '</form>';


### PR DESCRIPTION
closes #2311

**Before:** https://www.w3schools.com/code/tryit.asp?filename=GNYGNYETZQV0
**After:** https://www.w3schools.com/code/tryit.asp?filename=GNYGNFX0MOE1

Notice the CSS in the bottom right corner that comes from `bootstrap.css`. If you embed the pay button code into a site which does not have a Bootstrap CSS file this CSS won't be present so the text will not be aligned vertically.

![Screen Shot 2021-02-23 at 7 24 10 PM](https://user-images.githubusercontent.com/1934678/108943316-6a990e00-760d-11eb-84d7-556b1bfb2541.png)
