### PR TITLE
Refactor how we handle and validate LN ConnectionStrings

### DIFF
--- a/BTCPayServer.Tests/AltcoinTests/AltcoinTests.cs
+++ b/BTCPayServer.Tests/AltcoinTests/AltcoinTests.cs
@@ -80,7 +80,7 @@ namespace BTCPayServer.Tests
                 tester.ActivateLightning();
                 await tester.StartAsync();
                 var user = tester.NewAccount();
-                user.GrantAccess();
+                user.GrantAccess(true);
                 user.RegisterDerivationScheme("BTC");
                 user.RegisterDerivationScheme("LTC");
                 user.RegisterLightningNode("BTC", LightningConnectionType.CLightning);
@@ -287,7 +287,7 @@ namespace BTCPayServer.Tests
                 await tester.StartAsync();
                 await tester.EnsureChannelsSetup();
                 var user = tester.NewAccount();
-                user.GrantAccess();
+                user.GrantAccess(true);
                 user.RegisterLightningNode("BTC", LightningConnectionType.Charge);
                 user.RegisterDerivationScheme("BTC");
                 user.RegisterDerivationScheme("LTC");

--- a/BTCPayServer.Tests/AltcoinTests/AltcoinTests.cs
+++ b/BTCPayServer.Tests/AltcoinTests/AltcoinTests.cs
@@ -876,7 +876,7 @@ normal:
             var paymentMethodHandlerDictionary = new PaymentMethodHandlerDictionary(new IPaymentMethodHandler[]
             {
                 new BitcoinLikePaymentHandler(null, networkProvider, null, null, null),
-                new LightningLikePaymentHandler(null, null, networkProvider, null, null),
+                new LightningLikePaymentHandler(null, null, networkProvider, null, null, null),
             });
             var networkBTC = networkProvider.GetNetwork("BTC");
             var networkLTC = networkProvider.GetNetwork("LTC");

--- a/BTCPayServer.Tests/BTCPayServerTester.cs
+++ b/BTCPayServer.Tests/BTCPayServerTester.cs
@@ -112,7 +112,7 @@ namespace BTCPayServer.Tests
 
             if (UseLightning)
             {
-                config.AppendLine($"btc.lightning={IntegratedLightning.AbsoluteUri}");
+                config.AppendLine($"btc.lightning={IntegratedLightning}");
                 var localLndBackupFile = Path.Combine(_Directory, "walletunlock.json");
                 File.Copy(TestUtils.GetTestDataFullPath("LndSeedBackup/walletunlock.json"), localLndBackupFile, true);
                 config.AppendLine($"btc.external.lndseedbackup={localLndBackupFile}");
@@ -269,7 +269,7 @@ namespace BTCPayServer.Tests
         public InvoiceRepository InvoiceRepository { get; private set; }
         public StoreRepository StoreRepository { get; private set; }
         public BTCPayNetworkProvider Networks { get; private set; }
-        public Uri IntegratedLightning { get; internal set; }
+        public string IntegratedLightning { get; internal set; }
         public bool InContainer { get; internal set; }
 
         public T GetService<T>()

--- a/BTCPayServer.Tests/CheckoutUITests.cs
+++ b/BTCPayServer.Tests/CheckoutUITests.cs
@@ -109,7 +109,7 @@ namespace BTCPayServer.Tests
                 s.Server.ActivateLightning();
                 await s.StartAsync();
                 s.GoToRegister();
-                s.RegisterNewUser();
+                s.RegisterNewUser(true);
                 var store = s.CreateNewStore();
                 s.AddInternalLightningNode("BTC");
                 s.GoToStore(store.storeId, StoreNavPages.Checkout);

--- a/BTCPayServer.Tests/GreenfieldAPITests.cs
+++ b/BTCPayServer.Tests/GreenfieldAPITests.cs
@@ -540,7 +540,7 @@ namespace BTCPayServer.Tests
             }
         }
 
-        private async Task AssertValidationError(string[] fields, Func<Task> act)
+        private async Task<GreenFieldValidationException> AssertValidationError(string[] fields, Func<Task> act)
         {
             var remainingFields = fields.ToHashSet();
             var ex = await Assert.ThrowsAsync<GreenFieldValidationException>(act);
@@ -550,6 +550,7 @@ namespace BTCPayServer.Tests
                 remainingFields.Remove(field);
             }
             Assert.Empty(remainingFields);
+            return ex;
         }
 
         private async Task AssertHttpError(int code, Func<Task> act)
@@ -1287,33 +1288,85 @@ namespace BTCPayServer.Tests
             tester.ActivateLightning();
             await tester.StartAsync();
             await tester.EnsureChannelsSetup();
-            var user = tester.NewAccount();
-            await user.GrantAccessAsync(true);
-            var client = await user.CreateClient(Policies.CanModifyStoreSettings);
-            var viewOnlyClient = await user.CreateClient(Policies.CanViewStoreSettings);
+            var admin = tester.NewAccount();
+            await admin.GrantAccessAsync(true);
+            var admin2 = tester.NewAccount();
+            await admin2.GrantAccessAsync(true);
+            var adminClient = await admin.CreateClient(Policies.CanModifyStoreSettings);
+            var admin2Client = await admin2.CreateClient(Policies.CanModifyStoreSettings, Policies.CanModifyServerSettings);
+            var viewOnlyClient = await admin.CreateClient(Policies.CanViewStoreSettings);
             tester.PayTester.GetService<BTCPayServerEnvironment>().DevelopmentOverride = false;
-            var store = await client.GetStore(user.StoreId);
+            var store = await adminClient.GetStore(admin.StoreId);
 
-            Assert.Empty(await client.GetStoreLightningNetworkPaymentMethods(store.Id));
+            Assert.Empty(await adminClient.GetStoreLightningNetworkPaymentMethods(store.Id));
             await AssertHttpError(403, async () =>
             {
                 await viewOnlyClient.UpdateStoreLightningNetworkPaymentMethod(store.Id, "BTC", new LightningNetworkPaymentMethodData() { });
             });
             await AssertHttpError(404, async () =>
             {
-                await client.GetStoreLightningNetworkPaymentMethod(store.Id, "BTC");
+                await adminClient.GetStoreLightningNetworkPaymentMethod(store.Id, "BTC");
             });
-            await user.RegisterLightningNodeAsync("BTC", LightningConnectionType.CLightning, false);
+            await admin.RegisterLightningNodeAsync("BTC", false);
             
-            var method = await client.GetStoreLightningNetworkPaymentMethod(store.Id, "BTC");
+            var method = await adminClient.GetStoreLightningNetworkPaymentMethod(store.Id, "BTC");
             await AssertHttpError(403, async () =>
             {
                 await viewOnlyClient.RemoveStoreOnChainPaymentMethod(store.Id, "BTC");
             });
-            await  client.RemoveStoreOnChainPaymentMethod(store.Id, "BTC");
+            await  adminClient.RemoveStoreOnChainPaymentMethod(store.Id, "BTC");
             await AssertHttpError(404, async () =>
             {
-                await client.GetStoreOnChainPaymentMethod(store.Id, "BTC");
+                await adminClient.GetStoreOnChainPaymentMethod(store.Id, "BTC");
+            });
+
+
+            // Let's verify that the admin client can't change LN to unsafe connection strings without modify server settings rights
+            foreach (var forbidden in new string[]
+            {
+                "type=clightning;server=tcp://127.0.0.1",
+                "type=clightning;server=tcp://test",
+                "type=clightning;server=tcp://test.lan",
+                "type=clightning;server=tcp://test.local",
+                "type=clightning;server=tcp://192.168.1.2",
+                "type=clightning;server=unix://8.8.8.8",
+            })
+            {
+                var ex = await AssertValidationError(new[] { "ConnectionString" }, async () =>
+                {
+                    await adminClient.UpdateStoreLightningNetworkPaymentMethod(store.Id, "BTC", new LightningNetworkPaymentMethodData()
+                    {
+                        ConnectionString = forbidden,
+                        CryptoCode = "BTC",
+                        Enabled = true
+                    });
+                });
+                Assert.Contains("btcpay.server.canmodifyserversettings", ex.Message);
+                // However, the other client should work because he has `btcpay.server.canmodifyserversettings`
+                await admin2Client.UpdateStoreLightningNetworkPaymentMethod(admin2.StoreId, "BTC", new LightningNetworkPaymentMethodData()
+                {
+                    ConnectionString = forbidden,
+                    CryptoCode = "BTC",
+                    Enabled = true
+                });
+            }
+            // Allowed ip should be ok
+            await adminClient.UpdateStoreLightningNetworkPaymentMethod(store.Id, "BTC", new LightningNetworkPaymentMethodData()
+            {
+                ConnectionString = "type=clightning;server=tcp://8.8.8.8",
+                CryptoCode = "BTC",
+                Enabled = true
+            });
+            // If we strip the admin's right, he should not be able to set unsafe anymore, even if the API key is still valid
+            await admin2.MakeAdmin(false);
+            await AssertValidationError(new[] { "ConnectionString" }, async () =>
+            {
+                await admin2Client.UpdateStoreLightningNetworkPaymentMethod(admin2.StoreId, "BTC", new LightningNetworkPaymentMethodData()
+                {
+                    ConnectionString = "type=clightning;server=tcp://127.0.0.1",
+                    CryptoCode = "BTC",
+                    Enabled = true
+                });
             });
 
             var settings = (await tester.PayTester.GetService<SettingsRepository>().GetSettingAsync<PoliciesSettings>())?? new PoliciesSettings();

--- a/BTCPayServer.Tests/GreenfieldAPITests.cs
+++ b/BTCPayServer.Tests/GreenfieldAPITests.cs
@@ -1109,7 +1109,6 @@ namespace BTCPayServer.Tests
                 merchant.RegisterLightningNode("BTC", LightningConnectionType.LndREST);
                 var merchantClient = await merchant.CreateClient($"{Policies.CanUseLightningNodeInStore}:{merchant.StoreId}");
                 var merchantInvoice = await merchantClient.CreateLightningInvoice(merchant.StoreId, "BTC", new CreateLightningInvoiceRequest(LightMoney.Satoshis(1_000), "hey", TimeSpan.FromSeconds(60)));
-                tester.PayTester.GetService<BTCPayServerEnvironment>().DevelopmentOverride = false;
                 // The default client is using charge, so we should not be able to query channels
                 var client = await user.CreateClient(Policies.CanUseInternalLightningNode);
 
@@ -1295,7 +1294,6 @@ namespace BTCPayServer.Tests
             var adminClient = await admin.CreateClient(Policies.CanModifyStoreSettings);
             var admin2Client = await admin2.CreateClient(Policies.CanModifyStoreSettings, Policies.CanModifyServerSettings);
             var viewOnlyClient = await admin.CreateClient(Policies.CanViewStoreSettings);
-            tester.PayTester.GetService<BTCPayServerEnvironment>().DevelopmentOverride = false;
             var store = await adminClient.GetStore(admin.StoreId);
 
             Assert.Empty(await adminClient.GetStoreLightningNetworkPaymentMethods(store.Id));
@@ -1330,6 +1328,8 @@ namespace BTCPayServer.Tests
                 "type=clightning;server=tcp://test.local",
                 "type=clightning;server=tcp://192.168.1.2",
                 "type=clightning;server=unix://8.8.8.8",
+                "type=clightning;server=unix://[::1]",
+                "type=clightning;server=unix://[0:0:0:0:0:0:0:1]",
             })
             {
                 var ex = await AssertValidationError(new[] { "ConnectionString" }, async () =>

--- a/BTCPayServer.Tests/TestAccount.cs
+++ b/BTCPayServer.Tests/TestAccount.cs
@@ -256,40 +256,18 @@ namespace BTCPayServer.Tests
         {
             RegisterLightningNodeAsync(cryptoCode, connectionType, isMerchant).GetAwaiter().GetResult();
         }
-
-        public async Task RegisterLightningNodeAsync(string cryptoCode, LightningConnectionType connectionType, bool isMerchant = true, string storeId = null)
+        public Task RegisterLightningNodeAsync(string cryptoCode, bool isMerchant = true, string storeId = null)
+        {
+            return RegisterLightningNodeAsync(cryptoCode, null, isMerchant, storeId);
+        }
+        public async Task RegisterLightningNodeAsync(string cryptoCode, LightningConnectionType? connectionType, bool isMerchant = true, string storeId = null)
         {
             var storeController = this.GetController<StoresController>();
 
-            string connectionString = null;
-            if (connectionType == LightningConnectionType.Charge)
-            {
-                if (isMerchant)
-                    connectionString = $"type=charge;server={parent.MerchantCharge.Client.Uri.AbsoluteUri};allowinsecure=true";
-                else
-                    throw new NotSupportedException();
-            }
-            else if (connectionType == LightningConnectionType.CLightning)
-            {
-                if (isMerchant)
-                    connectionString = "type=clightning;server=" +
-                                       ((CLightningClient)parent.MerchantLightningD).Address.AbsoluteUri;
-                else
-                    connectionString = "type=clightning;server=" +
-                                   ((CLightningClient)parent.CustomerLightningD).Address.AbsoluteUri;
-            }
-            else if (connectionType == LightningConnectionType.LndREST)
-            {
-                if (isMerchant)
-                    connectionString = $"type=lnd-rest;server={parent.MerchantLnd.Swagger.BaseUrl};allowinsecure=true";
-                else
-                    throw new NotSupportedException();
-            }
-            else
-                throw new NotSupportedException(connectionType.ToString());
+            string connectionString = parent.GetLightningConnectionString(connectionType, isMerchant);
 
             await storeController.AddLightningNode(storeId ?? StoreId,
-                new LightningNodeViewModel() {ConnectionString = connectionString, SkipPortTest = true}, "save", "BTC");
+                new LightningNodeViewModel() { ConnectionString = connectionString, SkipPortTest = true }, "save", "BTC");
             if (storeController.ModelState.ErrorCount != 0)
                 Assert.False(true, storeController.ModelState.FirstOrDefault().Value.Errors[0].ErrorMessage);
         }

--- a/BTCPayServer.Tests/UnitTest1.cs
+++ b/BTCPayServer.Tests/UnitTest1.cs
@@ -411,7 +411,7 @@ namespace BTCPayServer.Tests
             var paymentMethodHandlerDictionary = new PaymentMethodHandlerDictionary(new IPaymentMethodHandler[]
             {
                 new BitcoinLikePaymentHandler(null, networkProvider, null, null, null),
-                new LightningLikePaymentHandler(null, null, networkProvider, null, null),
+                new LightningLikePaymentHandler(null, null, networkProvider, null, null, null),
             });
             var entity = new InvoiceEntity();
             entity.Networks = networkProvider;
@@ -699,7 +699,7 @@ namespace BTCPayServer.Tests
             var paymentMethodHandlerDictionary = new PaymentMethodHandlerDictionary(new IPaymentMethodHandler[]
             {
                 new BitcoinLikePaymentHandler(null, networkProvider, null, null, null),
-                new LightningLikePaymentHandler(null, null, networkProvider, null, null),
+                new LightningLikePaymentHandler(null, null, networkProvider, null, null, null),
             });
             var entity = new InvoiceEntity();
             entity.Networks = networkProvider;

--- a/BTCPayServer/Controllers/GreenField/LightningNodeApiController.Internal.cs
+++ b/BTCPayServer/Controllers/GreenField/LightningNodeApiController.Internal.cs
@@ -28,8 +28,9 @@ namespace BTCPayServer.Controllers.GreenField
         public InternalLightningNodeApiController(
             BTCPayNetworkProvider btcPayNetworkProvider, BTCPayServerEnvironment btcPayServerEnvironment,
             CssThemeManager cssThemeManager, LightningClientFactoryService lightningClientFactory,  
-            IOptions<LightningNetworkOptions> lightningNetworkOptions ) : base(
-            btcPayNetworkProvider, btcPayServerEnvironment, cssThemeManager)
+            IOptions<LightningNetworkOptions> lightningNetworkOptions,
+            IAuthorizationService authorizationService) : base(
+            btcPayNetworkProvider, btcPayServerEnvironment, cssThemeManager, authorizationService)
         {
             _btcPayNetworkProvider = btcPayNetworkProvider;
             _lightningClientFactory = lightningClientFactory;
@@ -100,17 +101,17 @@ namespace BTCPayServer.Controllers.GreenField
             return base.CreateInvoice(cryptoCode, request);
         }
 
-        protected override Task<ILightningClient> GetLightningClient(string cryptoCode, bool doingAdminThings)
+        protected override async Task<ILightningClient> GetLightningClient(string cryptoCode, bool doingAdminThings)
         {
-            _lightningNetworkOptions.Value.InternalLightningByCryptoCode.TryGetValue(cryptoCode,
-                out var internalLightningNode);
             var network = _btcPayNetworkProvider.GetNetwork<BTCPayNetwork>(cryptoCode);
-            if (network == null || !CanUseInternalLightning(doingAdminThings) || internalLightningNode == null)
+            if (network == null ||
+                !_lightningNetworkOptions.Value.InternalLightningByCryptoCode.TryGetValue(network.CryptoCode,
+                out var internalLightningNode) ||
+                !await CanUseInternalLightning(doingAdminThings))
             {
-                return Task.FromResult<ILightningClient>(null);
+                return null;
             }
-
-            return Task.FromResult(_lightningClientFactory.Create(internalLightningNode, network));
+            return _lightningClientFactory.Create(internalLightningNode, network);
         }
     }
 }

--- a/BTCPayServer/Controllers/GreenField/LightningNodeApiController.Store.cs
+++ b/BTCPayServer/Controllers/GreenField/LightningNodeApiController.Store.cs
@@ -31,8 +31,9 @@ namespace BTCPayServer.Controllers.GreenField
         public StoreLightningNodeApiController(
             IOptions<LightningNetworkOptions> lightningNetworkOptions,
             LightningClientFactoryService lightningClientFactory, BTCPayNetworkProvider btcPayNetworkProvider,
-            BTCPayServerEnvironment btcPayServerEnvironment, CssThemeManager cssThemeManager) : base(
-            btcPayNetworkProvider, btcPayServerEnvironment, cssThemeManager)
+            BTCPayServerEnvironment btcPayServerEnvironment, CssThemeManager cssThemeManager,
+            IAuthorizationService authorizationService) : base(
+            btcPayNetworkProvider, btcPayServerEnvironment, cssThemeManager, authorizationService)
         {
             _lightningNetworkOptions = lightningNetworkOptions;
             _lightningClientFactory = lightningClientFactory;
@@ -100,11 +101,10 @@ namespace BTCPayServer.Controllers.GreenField
             return base.CreateInvoice(cryptoCode, request);
         }
 
-        protected override Task<ILightningClient> GetLightningClient(string cryptoCode,
+        protected override async Task<ILightningClient> GetLightningClient(string cryptoCode,
             bool doingAdminThings)
         {
-            _lightningNetworkOptions.Value.InternalLightningByCryptoCode.TryGetValue(cryptoCode,
-                out var internalLightningNode);
+            
             var network = _btcPayNetworkProvider.GetNetwork<BTCPayNetwork>(cryptoCode);
 
             var store = HttpContext.GetStoreData();
@@ -117,13 +117,20 @@ namespace BTCPayServer.Controllers.GreenField
             var existing = store.GetSupportedPaymentMethods(_btcPayNetworkProvider)
                 .OfType<LightningSupportedPaymentMethod>()
                 .FirstOrDefault(d => d.PaymentId == id);
-            if (existing == null || (existing.GetLightningUrl().IsInternalNode(internalLightningNode) &&
-                                     !CanUseInternalLightning(doingAdminThings)))
+            if (existing == null)
+                return null;
+            if (existing.GetExternalLightningUrl() is LightningConnectionString connectionString)
             {
-                return Task.FromResult<ILightningClient>(null);
+                return _lightningClientFactory.Create(connectionString, network);
             }
-
-            return Task.FromResult(_lightningClientFactory.Create(existing.GetLightningUrl(), network));
+            else if (
+                await CanUseInternalLightning(doingAdminThings) && 
+                _lightningNetworkOptions.Value.InternalLightningByCryptoCode.TryGetValue(network.CryptoCode,
+                out var internalLightningNode))
+            {
+                return _lightningClientFactory.Create(internalLightningNode, network);
+            }
+            return null;
         }
     }
 }

--- a/BTCPayServer/Controllers/GreenField/StoreLightningNetworkPaymentMethodsController.cs
+++ b/BTCPayServer/Controllers/GreenField/StoreLightningNetworkPaymentMethodsController.cs
@@ -151,7 +151,7 @@ namespace BTCPayServer.Controllers.GreenField
                     }
                     if (!await CanManageServer() && !connectionString.IsSafe())
                     {
-                        ModelState.AddModelError(nameof(paymentMethodData.ConnectionString), $"You do not have 'btcpay.server.canmodifyserversettings' rights, so the connection string should not contains 'cookiefilepath', 'macaroondirectorypath', 'macaroonfilepath', and should not point to a local ip or to a dns name ending with '.internal', '.local', '.lan' or '.'.");
+                        ModelState.AddModelError(nameof(paymentMethodData.ConnectionString), $"You do not have 'btcpay.server.canmodifyserversettings' rights, so the connection string should not contain 'cookiefilepath', 'macaroondirectorypath', 'macaroonfilepath', and should not point to a local ip or to a dns name ending with '.internal', '.local', '.lan' or '.'.");
                         return this.CreateValidationError(ModelState);
                     }
                     paymentMethod = new Payments.Lightning.LightningSupportedPaymentMethod()

--- a/BTCPayServer/Controllers/GreenField/StoreLightningNetworkPaymentMethodsController.cs
+++ b/BTCPayServer/Controllers/GreenField/StoreLightningNetworkPaymentMethodsController.cs
@@ -185,7 +185,7 @@ namespace BTCPayServer.Controllers.GreenField
             return paymentMethod == null
                 ? null
                 : new LightningNetworkPaymentMethodData(paymentMethod.PaymentId.CryptoCode,
-                    paymentMethod.GetExternalLightningUrl()?.ToString() ?? LightningSupportedPaymentMethod.InternalNode, !excluded);
+                    paymentMethod.GetDisplayableConnectionString(), !excluded);
         }
 
         private bool GetNetwork(string cryptoCode, out BTCPayNetwork network)

--- a/BTCPayServer/Controllers/GreenField/StoreLightningNetworkPaymentMethodsController.cs
+++ b/BTCPayServer/Controllers/GreenField/StoreLightningNetworkPaymentMethodsController.cs
@@ -57,7 +57,7 @@ namespace BTCPayServer.Controllers.GreenField
                 .OfType<LightningSupportedPaymentMethod>()
                 .Select(paymentMethod =>
                     new LightningNetworkPaymentMethodData(paymentMethod.PaymentId.CryptoCode,
-                        paymentMethod.GetLightningUrl().ToString(), !excludedPaymentMethods.Match(paymentMethod.PaymentId)))
+                        paymentMethod.GetExternalLightningUrl().ToString(), !excludedPaymentMethods.Match(paymentMethod.PaymentId)))
                 .Where((result) => !enabledOnly || result.Enabled)
                 .ToList()
             );
@@ -110,8 +110,6 @@ namespace BTCPayServer.Controllers.GreenField
                 return NotFound();
             }
 
-            var internalLightning = await GetInternalLightningNode(network.CryptoCode);
-
             if (string.IsNullOrEmpty(paymentMethodData?.ConnectionString))
             {
                 ModelState.AddModelError(nameof(LightningNetworkPaymentMethodData.ConnectionString),
@@ -124,66 +122,44 @@ namespace BTCPayServer.Controllers.GreenField
             LightningSupportedPaymentMethod paymentMethod = null;
             if (!string.IsNullOrEmpty(paymentMethodData.ConnectionString))
             {
-                if (!LightningConnectionString.TryParse(paymentMethodData.ConnectionString, false,
-                    out var connectionString, out var error))
-                {
-                    ModelState.AddModelError(nameof(paymentMethodData.ConnectionString), $"Invalid URL ({error})");
-                    return this.CreateValidationError(ModelState);
-                }
-
-                if (connectionString.ConnectionType == LightningConnectionType.LndGRPC)
-                {
-                    ModelState.AddModelError(nameof(paymentMethodData.ConnectionString),
-                        $"BTCPay does not support gRPC connections");
-                    return this.CreateValidationError(ModelState);
-                }
-
-                bool isInternalNode = connectionString.IsInternalNode(internalLightning);
-
-                if (connectionString.BaseUri.Scheme == "http")
-                {
-                    if (!isInternalNode && !connectionString.AllowInsecure)
-                    {
-                        ModelState.AddModelError(nameof(paymentMethodData.ConnectionString), "The url must be HTTPS");
-                        return this.CreateValidationError(ModelState);
-                    }
-                }
-
-                if (connectionString.MacaroonFilePath != null)
+                if (paymentMethodData.ConnectionString == LightningSupportedPaymentMethod.InternalNode)
                 {
                     if (!await CanUseInternalLightning())
                     {
-                        ModelState.AddModelError(nameof(paymentMethodData.ConnectionString),
-                            "You are not authorized to use macaroonfilepath");
+                        ModelState.AddModelError(nameof(paymentMethodData.ConnectionString), $"You are not authorized to use the internal lightning node");
                         return this.CreateValidationError(ModelState);
                     }
-
-                    if (!System.IO.File.Exists(connectionString.MacaroonFilePath))
+                    paymentMethod = new Payments.Lightning.LightningSupportedPaymentMethod()
+                    {
+                        CryptoCode = paymentMethodId.CryptoCode
+                    };
+                    paymentMethod.SetInternalNode();
+                }
+                else
+                {
+                    if (!LightningConnectionString.TryParse(paymentMethodData.ConnectionString, false,
+                        out var connectionString, out var error))
+                    {
+                        ModelState.AddModelError(nameof(paymentMethodData.ConnectionString), $"Invalid URL ({error})");
+                        return this.CreateValidationError(ModelState);
+                    }
+                    if (connectionString.ConnectionType == LightningConnectionType.LndGRPC)
                     {
                         ModelState.AddModelError(nameof(paymentMethodData.ConnectionString),
-                            "The macaroonfilepath file does not exist");
+                            $"BTCPay does not support gRPC connections");
                         return this.CreateValidationError(ModelState);
                     }
-
-                    if (!System.IO.Path.IsPathRooted(connectionString.MacaroonFilePath))
+                    if (!await CanManageServer() && !connectionString.IsSafe())
                     {
-                        ModelState.AddModelError(nameof(paymentMethodData.ConnectionString),
-                            "The macaroonfilepath should be fully rooted");
+                        ModelState.AddModelError(nameof(paymentMethodData.ConnectionString), $"You do not have 'btcpay.server.canmodifyserversettings' rights, so the connection string should not contains 'cookiefilepath', 'macaroondirectorypath', 'macaroonfilepath', and should not point to a local ip or to a dns name ending with '.internal', '.local', '.lan' or '.'.");
                         return this.CreateValidationError(ModelState);
                     }
+                    paymentMethod = new Payments.Lightning.LightningSupportedPaymentMethod()
+                    {
+                        CryptoCode = paymentMethodId.CryptoCode
+                    };
+                    paymentMethod.SetLightningUrl(connectionString);
                 }
-
-                if (isInternalNode && !await CanUseInternalLightning())
-                {
-                    ModelState.AddModelError(nameof(paymentMethodData.ConnectionString), "Unauthorized url");
-                    return this.CreateValidationError(ModelState);
-                }
-
-                paymentMethod = new Payments.Lightning.LightningSupportedPaymentMethod()
-                {
-                    CryptoCode = paymentMethodId.CryptoCode
-                };
-                paymentMethod.SetLightningUrl(connectionString);
             }
 
             var store = Store;
@@ -209,7 +185,7 @@ namespace BTCPayServer.Controllers.GreenField
             return paymentMethod == null
                 ? null
                 : new LightningNetworkPaymentMethodData(paymentMethod.PaymentId.CryptoCode,
-                    paymentMethod.GetLightningUrl().ToString(), !excluded);
+                    paymentMethod.GetExternalLightningUrl()?.ToString() ?? LightningSupportedPaymentMethod.InternalNode, !excluded);
         }
 
         private bool GetNetwork(string cryptoCode, out BTCPayNetwork network)
@@ -219,20 +195,17 @@ namespace BTCPayServer.Controllers.GreenField
             return network != null;
         }
         
-        private async Task<LightningConnectionString> GetInternalLightningNode(string cryptoCode)
-        {
-            if (_lightningNetworkOptions.Value.InternalLightningByCryptoCode.TryGetValue(cryptoCode, out var connectionString))
-            {
-                return await CanUseInternalLightning() ? connectionString : null;
-            }
-            return null;
-        }
-        
         private async Task<bool> CanUseInternalLightning()
         {
             return _cssThemeManager.AllowLightningInternalNodeForAll ||
                 (await _authorizationService.AuthorizeAsync(User, null,
                     new PolicyRequirement(Policies.CanUseInternalLightningNode))).Succeeded;
+        }
+        private async Task<bool> CanManageServer()
+        {
+            return 
+                (await _authorizationService.AuthorizeAsync(User, null,
+                    new PolicyRequirement(Policies.CanModifyServerSettings))).Succeeded;
         }
     }
 }

--- a/BTCPayServer/Controllers/StoresController.LightningLike.cs
+++ b/BTCPayServer/Controllers/StoresController.LightningLike.cs
@@ -25,7 +25,6 @@ namespace BTCPayServer.Controllers
             LightningNodeViewModel vm = new LightningNodeViewModel
             {
                 CryptoCode = cryptoCode,
-                InternalLightningNode = GetInternalLighningNode(cryptoCode)?.ToString(),
                 StoreId = storeId
             };
             SetExistingValues(store, vm);
@@ -34,8 +33,12 @@ namespace BTCPayServer.Controllers
 
         private void SetExistingValues(StoreData store, LightningNodeViewModel vm)
         {
-            vm.ConnectionString = GetExistingLightningSupportedPaymentMethod(vm.CryptoCode, store)?.GetLightningUrl()?.ToString();
+            if (GetExistingLightningSupportedPaymentMethod(vm.CryptoCode, store) is LightningSupportedPaymentMethod paymentMethod)
+            {
+                vm.ConnectionString = paymentMethod.GetExternalLightningUrl()?.ToString() ?? LightningSupportedPaymentMethod.InternalNode;
+            }
             vm.Enabled = !store.GetStoreBlob().IsExcluded(new PaymentMethodId(vm.CryptoCode, PaymentTypes.LightningLike));
+            vm.CanUseInternalNode = CanUseInternalLightning();
         }
         private LightningSupportedPaymentMethod GetExistingLightningSupportedPaymentMethod(string cryptoCode, StoreData store)
         {
@@ -45,16 +48,6 @@ namespace BTCPayServer.Controllers
                 .FirstOrDefault(d => d.PaymentId == id);
             return existing;
         }
-
-        private LightningConnectionString GetInternalLighningNode(string cryptoCode)
-        {
-            if (_lightningNetworkOptions.Value.InternalLightningByCryptoCode.TryGetValue(cryptoCode, out var connectionString))
-            {
-                return CanUseInternalLightning() ? connectionString : null;
-            }
-            return null;
-        }
-
         [HttpPost]
         [Route("{storeId}/lightning/{cryptoCode}")]
         public async Task<IActionResult> AddLightningNode(string storeId, LightningNodeViewModel vm, string command, string cryptoCode)
@@ -65,8 +58,6 @@ namespace BTCPayServer.Controllers
                 return NotFound();
             var network = vm.CryptoCode == null ? null : _ExplorerProvider.GetNetwork(vm.CryptoCode);
 
-            var internalLightning = GetInternalLighningNode(network.CryptoCode);
-            vm.InternalLightningNode = internalLightning?.ToString();
             if (network == null)
             {
                 ModelState.AddModelError(nameof(vm.CryptoCode), "Invalid network");
@@ -75,7 +66,20 @@ namespace BTCPayServer.Controllers
 
             PaymentMethodId paymentMethodId = new PaymentMethodId(network.CryptoCode, PaymentTypes.LightningLike);
             Payments.Lightning.LightningSupportedPaymentMethod paymentMethod = null;
-            if (!string.IsNullOrEmpty(vm.ConnectionString))
+            if (vm.ConnectionString == LightningSupportedPaymentMethod.InternalNode)
+            {
+                if (!CanUseInternalLightning())
+                {
+                    ModelState.AddModelError(nameof(vm.ConnectionString), $"You are not authorized to use the internal lightning node");
+                    return View(vm);
+                }
+                paymentMethod = new Payments.Lightning.LightningSupportedPaymentMethod()
+                {
+                    CryptoCode = paymentMethodId.CryptoCode
+                };
+                paymentMethod.SetInternalNode();
+            }
+            else if (!string.IsNullOrEmpty(vm.ConnectionString))
             {
                 if (!LightningConnectionString.TryParse(vm.ConnectionString, false, out var connectionString, out var error))
                 {
@@ -88,40 +92,9 @@ namespace BTCPayServer.Controllers
                     ModelState.AddModelError(nameof(vm.ConnectionString), $"BTCPay does not support gRPC connections");
                     return View(vm);
                 }
-
-                bool isInternalNode = connectionString.IsInternalNode(internalLightning);
-
-                if (connectionString.BaseUri.Scheme == "http")
+                if (!User.IsInRole(Roles.ServerAdmin) && !connectionString.IsSafe())
                 {
-                    if (!isInternalNode && !connectionString.AllowInsecure)
-                    {
-                        ModelState.AddModelError(nameof(vm.ConnectionString), "The url must be HTTPS");
-                        return View(vm);
-                    }
-                }
-
-                if (connectionString.MacaroonFilePath != null)
-                {
-                    if (!CanUseInternalLightning())
-                    {
-                        ModelState.AddModelError(nameof(vm.ConnectionString), "You are not authorized to use macaroonfilepath");
-                        return View(vm);
-                    }
-                    if (!System.IO.File.Exists(connectionString.MacaroonFilePath))
-                    {
-                        ModelState.AddModelError(nameof(vm.ConnectionString), "The macaroonfilepath file does not exist");
-                        return View(vm);
-                    }
-                    if (!System.IO.Path.IsPathRooted(connectionString.MacaroonFilePath))
-                    {
-                        ModelState.AddModelError(nameof(vm.ConnectionString), "The macaroonfilepath should be fully rooted");
-                        return View(vm);
-                    }
-                }
-
-                if (isInternalNode && !CanUseInternalLightning())
-                {
-                    ModelState.AddModelError(nameof(vm.ConnectionString), "Unauthorized url");
+                    ModelState.AddModelError(nameof(vm.ConnectionString), $"You are not admin, so the connection string should not contains 'cookiefilepath', 'macaroondirectorypath', 'macaroonfilepath', and should not point to a local ip or to a dns name ending with '.internal', '.local', '.lan' or '.'.");
                     return View(vm);
                 }
 
@@ -170,10 +143,9 @@ namespace BTCPayServer.Controllers
                     return View(vm);
             }
         }
-
         private bool CanUseInternalLightning()
         {
-            return (_BTCPayEnv.IsDeveloping || User.IsInRole(Roles.ServerAdmin) || _CssThemeManager.AllowLightningInternalNodeForAll);
+            return User.IsInRole(Roles.ServerAdmin) || _CssThemeManager.AllowLightningInternalNodeForAll;
         }
     }
 }

--- a/BTCPayServer/Controllers/StoresController.LightningLike.cs
+++ b/BTCPayServer/Controllers/StoresController.LightningLike.cs
@@ -35,7 +35,7 @@ namespace BTCPayServer.Controllers
         {
             if (GetExistingLightningSupportedPaymentMethod(vm.CryptoCode, store) is LightningSupportedPaymentMethod paymentMethod)
             {
-                vm.ConnectionString = paymentMethod.GetExternalLightningUrl()?.ToString() ?? LightningSupportedPaymentMethod.InternalNode;
+                vm.ConnectionString = paymentMethod.GetDisplayableConnectionString();
             }
             vm.Enabled = !store.GetStoreBlob().IsExcluded(new PaymentMethodId(vm.CryptoCode, PaymentTypes.LightningLike));
             vm.CanUseInternalNode = CanUseInternalLightning();

--- a/BTCPayServer/Controllers/StoresController.LightningLike.cs
+++ b/BTCPayServer/Controllers/StoresController.LightningLike.cs
@@ -94,7 +94,7 @@ namespace BTCPayServer.Controllers
                 }
                 if (!User.IsInRole(Roles.ServerAdmin) && !connectionString.IsSafe())
                 {
-                    ModelState.AddModelError(nameof(vm.ConnectionString), $"You are not admin, so the connection string should not contains 'cookiefilepath', 'macaroondirectorypath', 'macaroonfilepath', and should not point to a local ip or to a dns name ending with '.internal', '.local', '.lan' or '.'.");
+                    ModelState.AddModelError(nameof(vm.ConnectionString), $"You are not a server admin, so the connection string should not contain 'cookiefilepath', 'macaroondirectorypath', 'macaroonfilepath', and should not point to a local ip or to a dns name ending with '.internal', '.local', '.lan' or '.'.");
                     return View(vm);
                 }
 

--- a/BTCPayServer/Controllers/StoresController.cs
+++ b/BTCPayServer/Controllers/StoresController.cs
@@ -546,8 +546,8 @@ namespace BTCPayServer.Controllers
                         vm.LightningNodes.Add(new StoreViewModel.LightningNode()
                         {
                             CryptoCode = paymentMethodId.CryptoCode,
-                            Address = lightning?.GetLightningUrl()?.BaseUri.AbsoluteUri ?? string.Empty,
-                            Enabled = !excludeFilters.Match(paymentMethodId) && lightning?.GetLightningUrl() != null
+                            Address = lightning?.GetExternalLightningUrl()?.BaseUri.AbsoluteUri ?? "Internal node",
+                            Enabled = !excludeFilters.Match(paymentMethodId)
                         });
                         break;
                 }

--- a/BTCPayServer/Data/StoreDataExtensions.cs
+++ b/BTCPayServer/Data/StoreDataExtensions.cs
@@ -69,14 +69,6 @@ namespace BTCPayServer.Data
 #pragma warning disable CS0618
             bool btcReturned = false;
 
-            // Legacy stuff which should go away
-            if (!string.IsNullOrEmpty(storeData.DerivationStrategy))
-            {
-                btcReturned = true;
-                yield return DerivationSchemeSettings.Parse(storeData.DerivationStrategy, networks.BTC);
-            }
-
-
             if (!string.IsNullOrEmpty(storeData.DerivationStrategies))
             {
                 JObject strategies = JObject.Parse(storeData.DerivationStrategies);
@@ -130,11 +122,6 @@ namespace BTCPayServer.Data
             foreach (var strat in strategies.Properties().ToList())
             {
                 var stratId = PaymentMethodId.Parse(strat.Name);
-                if (stratId.IsBTCOnChain)
-                {
-                    // Legacy stuff which should go away
-                    storeData.DerivationStrategy = null;
-                }
                 if (stratId == paymentMethodId)
                 {
                     if (supportedPaymentMethod == null)
@@ -149,12 +136,7 @@ namespace BTCPayServer.Data
                     break;
                 }
             }
-
-            if (!existing && supportedPaymentMethod == null && paymentMethodId.IsBTCOnChain)
-            {
-                storeData.DerivationStrategy = null;
-            }
-            else if (!existing && supportedPaymentMethod != null)
+            if (!existing && supportedPaymentMethod != null)
                 strategies.Add(new JProperty(supportedPaymentMethod.PaymentId.ToString(), PaymentMethodExtensions.Serialize(supportedPaymentMethod)));
             storeData.DerivationStrategies = strategies.ToString();
 #pragma warning restore CS0618

--- a/BTCPayServer/Extensions.cs
+++ b/BTCPayServer/Extensions.cs
@@ -46,13 +46,20 @@ namespace BTCPayServer
             endpoint = bip21.UnknowParameters.TryGetValue($"{PayjoinClient.BIP21EndpointKey}", out var uri) ? new Uri(uri, UriKind.Absolute) : null;
             return endpoint != null;
         }
-        public static bool IsInternalNode(this LightningConnectionString connectionString, LightningConnectionString internalLightning)
-        {
-            var internalDomain = internalLightning?.BaseUri?.DnsSafeHost;
 
-            return connectionString.ConnectionType == LightningConnectionType.CLightning ||
-                                  connectionString.BaseUri.DnsSafeHost == internalDomain ||
-                                  (internalDomain == "127.0.0.1" || internalDomain == "localhost");
+        public static bool IsSafe(this LightningConnectionString connectionString)
+        {
+            if (connectionString.CookieFilePath != null ||
+                connectionString.MacaroonDirectoryPath != null ||
+                connectionString.MacaroonFilePath != null)
+                return false;
+
+            var uri = connectionString.BaseUri;
+            if (uri.Scheme.Equals("unix", StringComparison.OrdinalIgnoreCase))
+                return false;
+            if (!NBitcoin.Utils.TryParseEndpoint(uri.DnsSafeHost, 80, out var endpoint))
+                return false;
+            return !Extensions.IsLocalNetwork(uri.DnsSafeHost);
         }
 
         public static IQueryable<TEntity> Where<TEntity>(this Microsoft.EntityFrameworkCore.DbSet<TEntity> obj, System.Linq.Expressions.Expression<Func<TEntity, bool>> predicate) where TEntity : class

--- a/BTCPayServer/Hosting/MigrationStartupTask.cs
+++ b/BTCPayServer/Hosting/MigrationStartupTask.cs
@@ -21,6 +21,7 @@ using Microsoft.Extensions.Options;
 using NBitcoin.DataEncoders;
 using NBXplorer;
 using Newtonsoft.Json.Linq;
+using Newtonsoft.Json.Serialization;
 
 namespace BTCPayServer.Hosting
 {
@@ -206,6 +207,12 @@ namespace BTCPayServer.Hosting
                     {
                         updated = true;
                         ln.Value = null;
+                        if (!(method.Property("InternalNodeRef", StringComparison.OrdinalIgnoreCase) is JProperty internalNode))
+                        {
+                            internalNode = new JProperty("InternalNodeRef", null);
+                            method.Add(internalNode);
+                        }
+                        internalNode.Value = new JValue(LightningSupportedPaymentMethod.InternalNode);
                     }
                 }
 

--- a/BTCPayServer/Hosting/MigrationStartupTask.cs
+++ b/BTCPayServer/Hosting/MigrationStartupTask.cs
@@ -342,8 +342,8 @@ retry:
                 {
                     foreach (var method in store.GetSupportedPaymentMethods(_NetworkProvider).OfType<Payments.Lightning.LightningSupportedPaymentMethod>())
                     {
-                        var lightning = method.GetLightningUrl();
-                        if (lightning.IsLegacy)
+                        var lightning = method.GetExternalLightningUrl();
+                        if (lightning?.IsLegacy is true)
                         {
                             method.SetLightningUrl(lightning);
                             store.SetSupportedPaymentMethod(method);

--- a/BTCPayServer/Models/StoreViewModels/LightningNodeViewModel.cs
+++ b/BTCPayServer/Models/StoreViewModels/LightningNodeViewModel.cs
@@ -16,7 +16,8 @@ namespace BTCPayServer.Models.StoreViewModels
             get;
             set;
         }
-        public string InternalLightningNode { get; internal set; }
+        public bool CanUseInternalNode { get; set; }
+
         public bool SkipPortTest { get; set; }
 
         [Display(Name="Lightning enabled")]

--- a/BTCPayServer/Payments/Lightning/LightningSupportedPaymentMethod.cs
+++ b/BTCPayServer/Payments/Lightning/LightningSupportedPaymentMethod.cs
@@ -1,6 +1,8 @@
 using System;
+using System.Collections.Generic;
 using BTCPayServer.Lightning;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 
 namespace BTCPayServer.Payments.Lightning
 {
@@ -9,16 +11,8 @@ namespace BTCPayServer.Payments.Lightning
         public const string InternalNode = "Internal Node";
         public string CryptoCode { get; set; }
 
-        [Obsolete("Use Get/SetLightningUrl")]
-        public string Username { get; set; }
-        [Obsolete("Use Get/SetLightningUrl")]
-        public string Password { get; set; }
-
-        // This property MUST be after CryptoCode or else JSON serialization fails
+        [JsonIgnore]
         public PaymentMethodId PaymentId => new PaymentMethodId(CryptoCode, PaymentTypes.LightningLike);
-
-        [Obsolete("Use Get/SetLightningUrl")]
-        public string LightningChargeUrl { get; set; }
 
         [Obsolete("Use Get/SetLightningUrl")]
         public string LightningConnectionString { get; set; }
@@ -26,25 +20,9 @@ namespace BTCPayServer.Payments.Lightning
         public LightningConnectionString GetExternalLightningUrl()
         {
 #pragma warning disable CS0618 // Type or member is obsolete
-            return GetLightningUrl();
-#pragma warning restore CS0618 // Type or member is obsolete
-        }
-        [Obsolete("TODO")]
-        public LightningConnectionString GetLightningUrl()
-        {
-#pragma warning disable CS0618 // Type or member is obsolete
             if (!string.IsNullOrEmpty(LightningConnectionString))
             {
                 if (!BTCPayServer.Lightning.LightningConnectionString.TryParse(LightningConnectionString, false, out var connectionString, out var error))
-                {
-                    throw new FormatException(error);
-                }
-                return connectionString;
-            }
-            else if (LightningChargeUrl != null)
-            {
-                var fullUri = new UriBuilder(LightningChargeUrl) { UserName = Username, Password = Password }.Uri.AbsoluteUri;
-                if (!BTCPayServer.Lightning.LightningConnectionString.TryParse(fullUri, true, out var connectionString, out var error))
                 {
                     throw new FormatException(error);
                 }
@@ -61,9 +39,6 @@ namespace BTCPayServer.Payments.Lightning
                 throw new ArgumentNullException(nameof(connectionString));
 #pragma warning disable CS0618 // Type or member is obsolete
             LightningConnectionString = connectionString.ToString();
-            Username = null;
-            Password = null;
-            LightningChargeUrl = null;
 #pragma warning restore CS0618 // Type or member is obsolete
         }
 
@@ -71,9 +46,6 @@ namespace BTCPayServer.Payments.Lightning
         {
 #pragma warning disable CS0618 // Type or member is obsolete
             LightningConnectionString = null;
-            Username = null;
-            Password = null;
-            LightningChargeUrl = null;
 #pragma warning restore CS0618 // Type or member is obsolete
         }
 
@@ -83,7 +55,7 @@ namespace BTCPayServer.Payments.Lightning
             get
             {
 #pragma warning disable CS0618 // Type or member is obsolete
-                return GetLightningUrl() is null;
+                return GetExternalLightningUrl() is null;
 #pragma warning restore CS0618 // Type or member is obsolete
             }
         }

--- a/BTCPayServer/Payments/Lightning/LightningSupportedPaymentMethod.cs
+++ b/BTCPayServer/Payments/Lightning/LightningSupportedPaymentMethod.cs
@@ -15,6 +15,7 @@ namespace BTCPayServer.Payments.Lightning
         public PaymentMethodId PaymentId => new PaymentMethodId(CryptoCode, PaymentTypes.LightningLike);
 
         [Obsolete("Use Get/SetLightningUrl")]
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
         public string LightningConnectionString { get; set; }
 
         public LightningConnectionString GetExternalLightningUrl()
@@ -42,20 +43,35 @@ namespace BTCPayServer.Payments.Lightning
 #pragma warning restore CS0618 // Type or member is obsolete
         }
 
+        public string GetDisplayableConnectionString()
+        {
+#pragma warning disable CS0618 // Type or member is obsolete
+            if (!string.IsNullOrEmpty(LightningConnectionString) &&
+                BTCPayServer.Lightning.LightningConnectionString.TryParse(LightningConnectionString, false, out var conn))
+                return conn.ToString();
+#pragma warning restore CS0618 // Type or member is obsolete
+            if (InternalNodeRef is string s)
+                return s;
+            return "Invalid connection string";
+        }
+
         public void SetInternalNode()
         {
 #pragma warning disable CS0618 // Type or member is obsolete
             LightningConnectionString = null;
+            InternalNodeRef = InternalNode;
 #pragma warning restore CS0618 // Type or member is obsolete
         }
 
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public string InternalNodeRef { get; set; }
         [JsonIgnore]
         public bool IsInternalNode
         {
             get
             {
 #pragma warning disable CS0618 // Type or member is obsolete
-                return GetExternalLightningUrl() is null;
+                return InternalNodeRef == InternalNode;
 #pragma warning restore CS0618 // Type or member is obsolete
             }
         }

--- a/BTCPayServer/Payments/Lightning/LightningSupportedPaymentMethod.cs
+++ b/BTCPayServer/Payments/Lightning/LightningSupportedPaymentMethod.cs
@@ -1,10 +1,12 @@
 using System;
 using BTCPayServer.Lightning;
+using Newtonsoft.Json;
 
 namespace BTCPayServer.Payments.Lightning
 {
     public class LightningSupportedPaymentMethod : ISupportedPaymentMethod
     {
+        public const string InternalNode = "Internal Node";
         public string CryptoCode { get; set; }
 
         [Obsolete("Use Get/SetLightningUrl")]
@@ -21,6 +23,13 @@ namespace BTCPayServer.Payments.Lightning
         [Obsolete("Use Get/SetLightningUrl")]
         public string LightningConnectionString { get; set; }
 
+        public LightningConnectionString GetExternalLightningUrl()
+        {
+#pragma warning disable CS0618 // Type or member is obsolete
+            return GetLightningUrl();
+#pragma warning restore CS0618 // Type or member is obsolete
+        }
+        [Obsolete("TODO")]
         public LightningConnectionString GetLightningUrl()
         {
 #pragma warning disable CS0618 // Type or member is obsolete
@@ -32,7 +41,7 @@ namespace BTCPayServer.Payments.Lightning
                 }
                 return connectionString;
             }
-            else
+            else if (LightningChargeUrl != null)
             {
                 var fullUri = new UriBuilder(LightningChargeUrl) { UserName = Username, Password = Password }.Uri.AbsoluteUri;
                 if (!BTCPayServer.Lightning.LightningConnectionString.TryParse(fullUri, true, out var connectionString, out var error))
@@ -41,6 +50,8 @@ namespace BTCPayServer.Payments.Lightning
                 }
                 return connectionString;
             }
+            else
+                return null;
 #pragma warning restore CS0618 // Type or member is obsolete
         }
 
@@ -48,13 +59,33 @@ namespace BTCPayServer.Payments.Lightning
         {
             if (connectionString == null)
                 throw new ArgumentNullException(nameof(connectionString));
-
 #pragma warning disable CS0618 // Type or member is obsolete
             LightningConnectionString = connectionString.ToString();
             Username = null;
             Password = null;
             LightningChargeUrl = null;
 #pragma warning restore CS0618 // Type or member is obsolete
+        }
+
+        public void SetInternalNode()
+        {
+#pragma warning disable CS0618 // Type or member is obsolete
+            LightningConnectionString = null;
+            Username = null;
+            Password = null;
+            LightningChargeUrl = null;
+#pragma warning restore CS0618 // Type or member is obsolete
+        }
+
+        [JsonIgnore]
+        public bool IsInternalNode
+        {
+            get
+            {
+#pragma warning disable CS0618 // Type or member is obsolete
+                return GetLightningUrl() is null;
+#pragma warning restore CS0618 // Type or member is obsolete
+            }
         }
     }
 }

--- a/BTCPayServer/Services/BTCPayServerEnvironment.cs
+++ b/BTCPayServer/Services/BTCPayServerEnvironment.cs
@@ -58,7 +58,7 @@ namespace BTCPayServer.Services
         {
             get
             {
-                return DevelopmentOverride?? NetworkType == ChainName.Regtest && Environment.IsDevelopment();
+                return NetworkType == ChainName.Regtest && Environment.IsDevelopment();
             }
         }
 
@@ -87,7 +87,5 @@ namespace BTCPayServer.Services
             }
             return txt.ToString();
         }
-
-        public bool? DevelopmentOverride;
     }
 }

--- a/BTCPayServer/Services/MigrationSettings.cs
+++ b/BTCPayServer/Services/MigrationSettings.cs
@@ -11,6 +11,7 @@ namespace BTCPayServer.Services
         public bool CheckedFirstRun { get; set; }
         public bool PaymentMethodCriteria { get; set; }
         public bool TransitionToStoreBlobAdditionalData { get; set; }
+        public bool TransitionInternalNodeConnectionString { get; set; }
 
         public override string ToString()
         {

--- a/BTCPayServer/Views/Stores/AddLightningNode.cshtml
+++ b/BTCPayServer/Views/Stores/AddLightningNode.cshtml
@@ -1,4 +1,4 @@
-﻿@model LightningNodeViewModel
+@model LightningNodeViewModel
 @{
     Layout = "../Shared/_NavLayout.cshtml";
     ViewData.SetActivePageAndTitle(StoreNavPages.Index, "Add lightning node");
@@ -43,6 +43,14 @@
                 <p class="mb-2">The connection string encapsulates the configuration for connecting to your lightning node. BTCPay Server currently supports:</p>
                 <ul>
                     <li class="mb-2">
+                        <strong>Internal node</strong>, if you are administrator of the server:
+                        <ul>
+                            <li>
+                                <code>Internal Node</code>
+                            </li>
+                        </ul>
+                    </li>
+                    <li class="mb-2">
                         <strong>c-lightning</strong> via TCP or unix domain socket connection:
                         <ul>
                             <li>
@@ -78,9 +86,6 @@
                             <li>
                                 <code><b>type=</b>lnd-rest;<b>server=</b>https://mylnd:8080/;<b>macaroon=</b>abef263adfe...;<b>certthumbprint=</b>abef263adfe...</code>
                             </li>
-                            <li>
-                                <code><b>type=</b>lnd-rest;<b>server=</b>http://mylnd:8080/;<b>macaroonfilepath=</b>/root/.lnd/admin.macaroon;<b>allowinsecure=</b>true</code>
-                            </li>
                         </ul>
                         <a class="d-inline-block my-2 text-secondary text-decoration-none" data-toggle="collapse" href="#lnd-notes" role="button" aria-expanded="false" aria-controls="lnd-notes">
                             <span class="fa fa-question-circle-o" title="More information..."></span> More information on the LND settings
@@ -103,29 +108,28 @@
 
             <div class="form-group">
                 <label asp-for="ConnectionString"></label>
-                <input asp-for="ConnectionString" class="form-control"/>
+                <input asp-for="ConnectionString" class="form-control" />
                 <span asp-validation-for="ConnectionString" class="text-danger"></span>
-                @if (Model.InternalLightningNode != null)
+                @if (Model.CanUseInternalNode)
                 {
                     <p class="form-text text-muted">
                         Use the internal lightning node of this BTCPay Server instance by
-                        <a href="#" id="internal-ln-node-setter" onclick="$('#ConnectionString').val('@Model.InternalLightningNode');return false;">clicking here</a>.
+                        <a href="#" id="internal-ln-node-setter" onclick="$('#ConnectionString').val('Internal Node');return false;">clicking here</a>.
                     </p>
                 }
             </div>
             <div class="form-group form-check">
-                <input asp-for="Enabled" type="checkbox" class="form-check-input"/>
+                <input asp-for="Enabled" type="checkbox" class="form-check-input" />
                 <label asp-for="Enabled" class="form-check-label"></label>
             </div>
             <button id="save" name="command" type="submit" value="save" class="btn btn-primary">Submit</button>
             <button name="command" type="submit" value="test" class="btn btn-secondary mr-3">Test connection</button>
-            <a
-                class="text-secondary"
-                asp-controller="PublicLightningNodeInfo"
-                asp-action="ShowLightningNodeInfo"
-                asp-route-cryptoCode="@Model.CryptoCode"
-                asp-route-storeId="@Model.StoreId"
-                target="_blank">
+            <a class="text-secondary"
+               asp-controller="PublicLightningNodeInfo"
+               asp-action="ShowLightningNodeInfo"
+               asp-route-cryptoCode="@Model.CryptoCode"
+               asp-route-storeId="@Model.StoreId"
+               target="_blank">
                 <span class="fa fa-info-circle" title="More information..."></span>
                 Open Public Node Info Page
             </a>

--- a/BTCPayServer/wwwroot/swagger/v1/swagger.template.stores-payment-methods.lightning-network.json
+++ b/BTCPayServer/wwwroot/swagger/v1/swagger.template.stores-payment-methods.lightning-network.json
@@ -241,7 +241,7 @@
                     },
                     "connectionString": {
                         "type": "string",
-                        "description": "The lightning connection string",
+                        "description": "The lightning connection string. Set to 'Internal Node' to use the internal node. (See [this doc](https://github.com/btcpayserver/BTCPayServer.Lightning/blob/master/README.md#examples) for some example)",
                         "example": "type=clightning;server=..."
                     }
                 }


### PR DESCRIPTION
This PR is refactoring how we handle and validate connection strings for LN payment methods.

Because connection string can read the file system, we must be sure that a malicious party can't leverage lightning connection string to read and steal arbitrary file on the host.

While the original code was doing this successfully, it was hard to read and hard to understand.

I simplified the code in the following way: Now a Lightning Payment Method can be either an external connection string (as before), but some fields forbidden (such as macaroonfilepath).
If the user wants to use the internal node, then the connection string should be the string "Internal Node".

The nice thing about it is that if the user change his internal lightning implementation, he won't need to re-set the connection string to the new internal node.

I am also migrating all stores which used the internal node before to the new connection string "Internal Node".

long story short:
1. The connection strings are now strictly limited to a subset if you are not admin "IsSafe()"
2. For using internal node, you need to set the connection string to "Internal Node"
3. A migration has been done so connection strings that match internal node are converted to "Internal Node"
4. Some cleanup of old fields in the DB that we don't use anymore
5. The new design means that it is possible to set lightning network's payment method to internal in the greenfield API @Kukks 