### PR TITLE
Returning 0 for NextNetworkFee if it's null

### DIFF
--- a/BTCPayServer/Payments/Bitcoin/BitcoinLikeOnChainPaymentMethod.cs
+++ b/BTCPayServer/Payments/Bitcoin/BitcoinLikeOnChainPaymentMethod.cs
@@ -17,7 +17,8 @@ namespace BTCPayServer.Payments.Bitcoin
 
         public decimal GetNextNetworkFee()
         {
-            return NextNetworkFee.ToDecimal(MoneyUnit.BTC);
+            // NextNetworkFee is sometimes not initialized properly, so we return 0 in that case
+            return NextNetworkFee?.ToDecimal(MoneyUnit.BTC) ?? 0;
         }
 
         public decimal GetFeeRate()

--- a/BTCPayServer/Payments/Bitcoin/BitcoinLikePaymentHandler.cs
+++ b/BTCPayServer/Payments/Bitcoin/BitcoinLikePaymentHandler.cs
@@ -143,9 +143,11 @@ namespace BTCPayServer.Payments.Bitcoin
             if (!_ExplorerProvider.IsAvailable(network))
                 throw new PaymentMethodUnavailableException($"Full node not available");
             var prepare = (Prepare)preparePaymentObject;
-            Payments.Bitcoin.BitcoinLikeOnChainPaymentMethod onchainMethod =
-                new Payments.Bitcoin.BitcoinLikeOnChainPaymentMethod();
+            var onchainMethod = new BitcoinLikeOnChainPaymentMethod();
             var blob = store.GetStoreBlob();
+
+            // TODO: this needs to be refactored to move this logic into BitcoinLikeOnChainPaymentMethod
+            // This is likely a constructor code
             onchainMethod.NetworkFeeMode = blob.NetworkFeeMode;
             onchainMethod.FeeRate = await prepare.GetFeeRate;
             switch (onchainMethod.NetworkFeeMode)
@@ -154,8 +156,6 @@ namespace BTCPayServer.Payments.Bitcoin
                     onchainMethod.NetworkFeeRate = (await prepare.GetNetworkFeeRate);
                     onchainMethod.NextNetworkFee =
                         onchainMethod.NetworkFeeRate.GetFee(100); // assume price for 100 bytes
-                    if (onchainMethod.NextNetworkFee == null)
-                        onchainMethod.NextNetworkFee = Money.Zero;
                     break;
                 case NetworkFeeMode.Never:
                     onchainMethod.NetworkFeeRate = FeeRate.Zero;

--- a/BTCPayServer/Payments/Bitcoin/BitcoinLikePaymentHandler.cs
+++ b/BTCPayServer/Payments/Bitcoin/BitcoinLikePaymentHandler.cs
@@ -154,6 +154,8 @@ namespace BTCPayServer.Payments.Bitcoin
                     onchainMethod.NetworkFeeRate = (await prepare.GetNetworkFeeRate);
                     onchainMethod.NextNetworkFee =
                         onchainMethod.NetworkFeeRate.GetFee(100); // assume price for 100 bytes
+                    if (onchainMethod.NextNetworkFee == null)
+                        onchainMethod.NextNetworkFee = Money.Zero;
                     break;
                 case NetworkFeeMode.Never:
                     onchainMethod.NetworkFeeRate = FeeRate.Zero;


### PR DESCRIPTION
I've ran into this problem several times when testing locally, with NextNetworkFee throwing null:

![image](https://user-images.githubusercontent.com/5191402/109520173-8ec37780-7a71-11eb-9933-21c5fa4f1fcf.png)

This usually happens in the tests, specifically try running `UnitTest1.CanSetUnifiedQrCode` without this PR.

I've left comments on places of improvements in the code... how we can refactor initialization of `NextNetworkFee`.

