### PR TITLE
Update invoice log row styling

### DIFF
--- a/BTCPayServer/Views/Invoice/Invoice.cshtml
+++ b/BTCPayServer/Views/Invoice/Invoice.cshtml
@@ -290,7 +290,7 @@
                     <tbody>
                         @foreach (var evt in Model.Events)
                         {
-                            <tr class="alert alert-@evt.GetCssClass()">
+                            <tr class="text-@evt.GetCssClass()">
                                 <td>@evt.Timestamp.ToBrowserDate()</td>
                                 <td>@evt.Message</td>
                             </tr>


### PR DESCRIPTION
**Before:**

![Screen Shot 2021-03-06 at 10 08 09 PM](https://user-images.githubusercontent.com/1934678/110230816-79fb3f80-7ec8-11eb-977a-9d9d96d23d47.png)

**After:**

![Screen Shot 2021-03-06 at 9 58 23 PM](https://user-images.githubusercontent.com/1934678/110230822-85e70180-7ec8-11eb-95c3-50ef701f0c91.png)


Because the `alert` CSS class is not intended to be used to style table rows it ends up looking weird in some cases when you hover over the table row and default table row hover styling is applied. Styling just the text in the table prevents this issue.

**Standard table (before):**

![Screen Shot 2021-03-06 at 10 04 37 PM](https://user-images.githubusercontent.com/1934678/110230875-d8c0b900-7ec8-11eb-8b73-0331cc866d20.png)

**Standard table (after):**

![Screen Shot 2021-03-06 at 10 01 51 PM](https://user-images.githubusercontent.com/1934678/110230882-e413e480-7ec8-11eb-811a-cd44207111c9.png)

closes #2328