### PR TITLE
Fix issue around new bech uppercase + vault supported flag

### DIFF
--- a/BTCPayServer.Common/Altcoins/BTCPayNetworkProvider.Groestlcoin.cs
+++ b/BTCPayServer.Common/Altcoins/BTCPayNetworkProvider.Groestlcoin.cs
@@ -26,7 +26,8 @@ namespace BTCPayServer
                 DefaultSettings = BTCPayDefaultSettings.GetDefaultSettings(NetworkType),
                 CoinType = NetworkType == ChainName.Mainnet ? new KeyPath("17'") : new KeyPath("1'"),
                 SupportRBF = true,
-                SupportPayJoin = true
+                SupportPayJoin = true,
+                VaultSupported = true
             });
         }
     }

--- a/BTCPayServer.Common/BTCPayNetwork.cs
+++ b/BTCPayServer.Common/BTCPayNetwork.cs
@@ -63,7 +63,7 @@ namespace BTCPayServer
 
         public virtual bool WalletSupported { get; set; } = true;
         public virtual bool ReadonlyWallet { get; set; } = false;
-
+        public virtual bool VaultSupported { get; set; } = false;
         public int MaxTrackedConfirmation { get; internal set; } = 6;
         public string UriScheme { get; internal set; }
         public bool SupportPayJoin { get; set; } = false;

--- a/BTCPayServer.Common/BTCPayNetworkProvider.Bitcoin.cs
+++ b/BTCPayServer.Common/BTCPayNetworkProvider.Bitcoin.cs
@@ -24,6 +24,7 @@ namespace BTCPayServer
                 CoinType = NetworkType == ChainName.Mainnet ? new KeyPath("0'") : new KeyPath("1'"),
                 SupportRBF = true,
                 SupportPayJoin = true,
+                VaultSupported = true,
                 //https://github.com/spesmilo/electrum/blob/11733d6bc271646a00b69ff07657119598874da4/electrum/constants.py
                 ElectrumMapping = NetworkType == ChainName.Mainnet
                     ? new Dictionary<uint, DerivationType>()

--- a/BTCPayServer/Views/Stores/ImportWalletOptions.cshtml
+++ b/BTCPayServer/Views/Stores/ImportWalletOptions.cshtml
@@ -1,4 +1,5 @@
 @model WalletSetupViewModel
+@inject BTCPayNetworkProvider BTCPayNetworkProvider
 @addTagHelper *, BundlerMinifier.TagHelpers
 @{
     Layout = "_LayoutWalletSetup";
@@ -16,7 +17,7 @@
     <p class="lead text-secondary mt-3">The following methods assume that you already have an existing&nbsp;wallet created and backed up.</p>
 </header>
 
-@if (Model.CryptoCode == "BTC")
+@if (BTCPayNetworkProvider.GetNetwork<BTCPayNetwork>(Model.CryptoCode).VaultSupported)
 {
     <div class="mt-5">
         <div class="list-group">

--- a/BTCPayServer/Views/Wallets/WalletSigningMenu.cshtml
+++ b/BTCPayServer/Views/Wallets/WalletSigningMenu.cshtml
@@ -1,3 +1,4 @@
+@inject BTCPayNetworkProvider BTCPayNetworkProvider
 @model (string CryptoCode, bool NBXSeedAvailable)
 
 
@@ -6,7 +7,7 @@
         Sign with...
     </button>
     <div class="dropdown-menu" aria-labelledby="SendMenu">
-        @if (Model.CryptoCode == "BTC")
+        @if (BTCPayNetworkProvider.GetNetwork<BTCPayNetwork>(Model.CryptoCode).VaultSupported)
         {
             <button name="command" type="submit" class="dropdown-item" value="vault">... a hardware wallet</button>
         }


### PR DESCRIPTION
This adds a flag to the BTCPayNetwork to show it supports Vault. Additionally, it also fixes an issue in the bech32 prefix detection code if BTC is not available in the instance