### PR TITLE
Changed display date format on View Pull Payments screen

### DIFF
--- a/BTCPayServer/Controllers/PullPaymentController.cs
+++ b/BTCPayServer/Controllers/PullPaymentController.cs
@@ -70,7 +70,8 @@ namespace BTCPayServer.Controllers
                 ClaimedAmount = amountDue,
                 AmountDueFormatted = _currencyNameTable.FormatCurrency(amountDue, blob.Currency),
                 CurrencyData = cd,
-                LastUpdated = DateTime.Now,
+                StartDate = pp.StartDate,
+                LastRefreshed = DateTime.Now,
                 Payouts = payouts
                           .Select(entity => new ViewPullPaymentModel.PayoutLine
                           {

--- a/BTCPayServer/Models/ViewPullPaymentModel.cs
+++ b/BTCPayServer/Models/ViewPullPaymentModel.cs
@@ -76,7 +76,8 @@ namespace BTCPayServer.Models
         public string EmbeddedCSS { get; set; }
         public string CustomCSSLink { get; set; }
         public List<PayoutLine> Payouts { get; set; } = new List<PayoutLine>();
-        public DateTime LastUpdated { get; set; }
+        public DateTimeOffset StartDate { get; set; }
+        public DateTime LastRefreshed { get; set; }
         public CurrencyData CurrencyData { get; set; }
         public string AmountCollectedFormatted { get; set; }
         public string AmountFormatted { get; set; }

--- a/BTCPayServer/Views/PullPayment/ViewPullPayment.cshtml
+++ b/BTCPayServer/Views/PullPayment/ViewPullPayment.cshtml
@@ -89,9 +89,14 @@
                                 <h2 class="h4 mb-3">@Model.Title</h2>
                             }
                             <div class="d-flex align-items-center">
-                                <span class="text-muted text-nowrap">Last Updated</span>
+                                <span class="text-muted text-nowrap">Start Date</span>
                                 &nbsp;
-                                <span class="text-nowrap">@Model.LastUpdated.ToString("g")</span>
+                                <span class="text-nowrap">@Model.StartDate.ToBrowserDate()</span>
+                            </div>
+                            <div class="d-flex align-items-center">
+                                <span class="text-muted text-nowrap">Last Refreshed</span>
+                                &nbsp;
+                                <span class="text-nowrap">@Model.LastRefreshed.ToBrowserDate()</span>
                                 <button type="button" class="btn btn-link d-none d-lg-inline-block d-print-none border-0 p-0 ml-4 only-for-js" id="copyLink">
                                     Copy Link
                                 </button>

--- a/BTCPayServer/Views/PullPayment/ViewPullPayment.cshtml
+++ b/BTCPayServer/Views/PullPayment/ViewPullPayment.cshtml
@@ -94,7 +94,7 @@
                                 <span class="text-nowrap">@Model.StartDate.ToBrowserDate()</span>
                             </div>
                             <div class="d-flex align-items-center">
-                                <span class="text-muted text-nowrap">Last Refreshed</span>
+                                <span class="text-muted text-nowrap">Last Updated</span>
                                 &nbsp;
                                 <span class="text-nowrap">@Model.LastRefreshed.ToBrowserDate()</span>
                                 <button type="button" class="btn btn-link d-none d-lg-inline-block d-print-none border-0 p-0 ml-4 only-for-js" id="copyLink">

--- a/BTCPayServer/Views/Server/Files.cshtml
+++ b/BTCPayServer/Views/Server/Files.cshtml
@@ -28,7 +28,7 @@
             {
                 <tr>
                     <td>@file.FileName</td>
-                    <td>@file.Timestamp.ToBrowserDate2()</td>
+                    <td>@file.Timestamp.ToBrowserDate()</td>
                     <td>@file.ApplicationUser.UserName</td>
                     <td>
                         <a asp-action="Files" asp-route-fileId="@file.Id">Get Link</a>

--- a/BTCPayServer/Views/ViewsRazor.cs
+++ b/BTCPayServer/Views/ViewsRazor.cs
@@ -28,15 +28,16 @@ namespace BTCPayServer.Views
 
         public static HtmlString ToBrowserDate(this DateTimeOffset date)
         {
-            var hello = date.ToString("o", CultureInfo.InvariantCulture);
-            return new HtmlString($"<span class='localizeDate'>{hello}</span>");
+            var displayDate = date.ToString("g", CultureInfo.InvariantCulture);
+            return new HtmlString($"<span class='localizeDate'>{displayDate}</span>");
         }
 
-        public static HtmlString ToBrowserDate2(this DateTime date)
+        public static HtmlString ToBrowserDate(this DateTime date)
         {
-            var hello = date.ToString("o", CultureInfo.InvariantCulture);
-            return new HtmlString($"<span class='localizeDate'>{hello}</span>");
+            var displayDate = date.ToString("g", CultureInfo.InvariantCulture);
+            return new HtmlString($"<span class='localizeDate'>{displayDate}</span>");
         }
+        
         public static string ToTimeAgo(this DateTimeOffset date)
         {
             var formatted = (DateTimeOffset.UtcNow - date).TimeString() + " ago";

--- a/BTCPayServer/Views/ViewsRazor.cs
+++ b/BTCPayServer/Views/ViewsRazor.cs
@@ -28,13 +28,13 @@ namespace BTCPayServer.Views
 
         public static HtmlString ToBrowserDate(this DateTimeOffset date)
         {
-            var displayDate = date.ToString("g", CultureInfo.InvariantCulture);
+            var displayDate = date.ToString("g");
             return new HtmlString($"<span class='localizeDate'>{displayDate}</span>");
         }
 
         public static HtmlString ToBrowserDate(this DateTime date)
         {
-            var displayDate = date.ToString("g", CultureInfo.InvariantCulture);
+            var displayDate = date.ToString("g");
             return new HtmlString($"<span class='localizeDate'>{displayDate}</span>");
         }
         


### PR DESCRIPTION
Closes #1725 by:

- Adding "Start Date" to View Pull Payments screen
- "Last Updated" relabelled to "Last Refreshed"
- "Last Refreshed" to display in local timezone

Note: Date times are formatted based on the server's date time culture info 


----
Before:
![image](https://user-images.githubusercontent.com/8363987/110258910-cdd75880-7f9c-11eb-8247-837444d78046.png)

----
After:
![image](https://user-images.githubusercontent.com/8363987/110258832-75a05680-7f9c-11eb-832c-b922d19ab54b.png)
