### PR TITLE
turn of autocomplete for PrivKey input

### DIFF
--- a/BTCPayServer/Views/Wallets/SignWithSeed.cshtml
+++ b/BTCPayServer/Views/Wallets/SignWithSeed.cshtml
@@ -30,7 +30,7 @@
             <partial name="SigningContext" for="SigningContext" />
             <div class="form-group">
                 <label asp-for="SeedOrKey"></label>
-                <input asp-for="SeedOrKey" class="form-control" />
+                <input asp-for="SeedOrKey" class="form-control" autocomplete="off" autocorrect="off" autocapitalize="off"/>
                 <span asp-validation-for="SeedOrKey" class="text-danger"></span>
             </div>
             <div class="form-group">


### PR DESCRIPTION
turn of autocomplete for "BIP39 Seed (12/24 word mnemonic phrase) or HD private key" input

autocomplete not pretend to be safe store for your wallet key.

Done according to https://css-tricks.com/snippets/html/autocomplete-off/