### PR TITLE
Order files list by descending timestamp

### DIFF
--- a/BTCPayServer/Storage/Services/StoredFileRepository.cs
+++ b/BTCPayServer/Storage/Services/StoredFileRepository.cs
@@ -36,6 +36,7 @@ namespace BTCPayServer.Storage.Services
                     .Where(file =>
                         (!filesQuery.Id.Any() || filesQuery.Id.Contains(file.Id)) &&
                         (!filesQuery.UserIds.Any() || filesQuery.UserIds.Contains(file.ApplicationUserId)))
+                    .OrderByDescending(file => file.Timestamp)
                     .ToListAsync();
             }
         }


### PR DESCRIPTION
This PR orders files in the files list view by descending timestamp so that the files are shown from newest to oldest always.

closes #2273
