### PR TITLE
Ensure submitting empty currency does not break update PoS page

### DIFF
--- a/BTCPayServer/Controllers/AppsController.PointOfSale.cs
+++ b/BTCPayServer/Controllers/AppsController.PointOfSale.cs
@@ -161,6 +161,11 @@ namespace BTCPayServer.Controllers
         [Route("{appId}/settings/pos")]
         public async Task<IActionResult> UpdatePointOfSale(string appId, UpdatePointOfSaleViewModel vm)
         {
+            if (!ModelState.IsValid)
+            {
+                return View(vm);
+            }
+            
             if (_currencies.GetCurrencyData(vm.Currency, false) == null)
                 ModelState.AddModelError(nameof(vm.Currency), "Invalid currency");
             try


### PR DESCRIPTION
This PR fixes a bug with the "Update Point of Sale" page breaking if a user empties out the required "Currency" field.

**Before:**
![Screen Shot 2021-03-17 at 6 49 50 PM](https://user-images.githubusercontent.com/1934678/111562359-4f747680-8753-11eb-8b7d-56eb175157c2.png)

**After:**
![Screen Shot 2021-03-17 at 7 01 34 PM](https://user-images.githubusercontent.com/1934678/111562380-5602ee00-8753-11eb-836d-a8614dc82c41.png)
