### PR TITLE
Activate CSP

### DIFF
--- a/BTCPayServer/Controllers/AppsPublicController.cs
+++ b/BTCPayServer/Controllers/AppsPublicController.cs
@@ -57,8 +57,10 @@ namespace BTCPayServer.Controllers
         }
         
         [HttpGet]
+        [Route("/")]
         [Route("/apps/{appId}/pos/{viewType?}")]
         [XFrameOptionsAttribute(XFrameOptionsAttribute.XFrameOptions.AllowAll)]
+        [DomainMappingConstraint(AppType.PointOfSale)]
         public async Task<IActionResult> ViewPointOfSale(string appId, PosViewType? viewType = null)
         {
             var app = await _AppService.GetApp(appId, AppType.PointOfSale);
@@ -108,6 +110,7 @@ namespace BTCPayServer.Controllers
         [XFrameOptionsAttribute(XFrameOptionsAttribute.XFrameOptions.AllowAll)]
         [IgnoreAntiforgeryToken]
         [EnableCors(CorsPolicies.All)]
+        [DomainMappingConstraint(AppType.PointOfSale)]
         public async Task<IActionResult> ViewPointOfSale(string appId,
                                                         PosViewType viewType,
                                                         [ModelBinder(typeof(InvariantDecimalModelBinder))] decimal amount,
@@ -232,8 +235,10 @@ namespace BTCPayServer.Controllers
         }
 
         [HttpGet]
+        [Route("/")]
         [Route("/apps/{appId}/crowdfund")]
         [XFrameOptionsAttribute(XFrameOptionsAttribute.XFrameOptions.AllowAll)]
+        [DomainMappingConstraintAttribute(AppType.Crowdfund)]
         public async Task<IActionResult> ViewCrowdfund(string appId, string statusMessage)
         {
             var app = await _AppService.GetApp(appId, AppType.Crowdfund, true);
@@ -263,10 +268,12 @@ namespace BTCPayServer.Controllers
         }
 
         [HttpPost]
+        [Route("/")]
         [Route("/apps/{appId}/crowdfund")]
         [XFrameOptionsAttribute(XFrameOptionsAttribute.XFrameOptions.AllowAll)]
         [IgnoreAntiforgeryToken]
         [EnableCors(CorsPolicies.All)]
+        [DomainMappingConstraintAttribute(AppType.Crowdfund)]
         public async Task<IActionResult> ContributeToCrowdfund(string appId, ContributeToCrowdfund request, CancellationToken cancellationToken)
         {
             if (request.Amount <= 0)

--- a/BTCPayServer/Controllers/AppsPublicController.cs
+++ b/BTCPayServer/Controllers/AppsPublicController.cs
@@ -60,6 +60,7 @@ namespace BTCPayServer.Controllers
         [Route("/")]
         [Route("/apps/{appId}/pos/{viewType?}")]
         [XFrameOptionsAttribute(XFrameOptionsAttribute.XFrameOptions.AllowAll)]
+        [ContentSecurityPolicyAttribute(Enabled = false)]
         [DomainMappingConstraint(AppType.PointOfSale)]
         public async Task<IActionResult> ViewPointOfSale(string appId, PosViewType? viewType = null)
         {
@@ -106,6 +107,8 @@ namespace BTCPayServer.Controllers
         }
 
         [HttpPost]
+        [ContentSecurityPolicyAttribute(Enabled = false)]
+        [Route("/")]
         [Route("/apps/{appId}/pos/{viewType?}")]
         [XFrameOptionsAttribute(XFrameOptionsAttribute.XFrameOptions.AllowAll)]
         [IgnoreAntiforgeryToken]
@@ -238,6 +241,7 @@ namespace BTCPayServer.Controllers
         [Route("/")]
         [Route("/apps/{appId}/crowdfund")]
         [XFrameOptionsAttribute(XFrameOptionsAttribute.XFrameOptions.AllowAll)]
+        [ContentSecurityPolicyAttribute(Enabled = false)]
         [DomainMappingConstraintAttribute(AppType.Crowdfund)]
         public async Task<IActionResult> ViewCrowdfund(string appId, string statusMessage)
         {
@@ -273,6 +277,7 @@ namespace BTCPayServer.Controllers
         [XFrameOptionsAttribute(XFrameOptionsAttribute.XFrameOptions.AllowAll)]
         [IgnoreAntiforgeryToken]
         [EnableCors(CorsPolicies.All)]
+        [ContentSecurityPolicyAttribute(Enabled = false)]
         [DomainMappingConstraintAttribute(AppType.Crowdfund)]
         public async Task<IActionResult> ContributeToCrowdfund(string appId, ContributeToCrowdfund request, CancellationToken cancellationToken)
         {

--- a/BTCPayServer/Controllers/HomeController.cs
+++ b/BTCPayServer/Controllers/HomeController.cs
@@ -30,6 +30,7 @@ namespace BTCPayServer.Controllers
     public class HomeController : Controller
     {
         private readonly CssThemeManager _cachedServerSettings;
+        private readonly ContentSecurityPolicies _csp;
         private readonly IFileProvider _fileProvider;
 
         public IHttpClientFactory HttpClientFactory { get; }

--- a/BTCPayServer/Controllers/InvoiceController.UI.cs
+++ b/BTCPayServer/Controllers/InvoiceController.UI.cs
@@ -431,7 +431,6 @@ namespace BTCPayServer.Controllers
         [AcceptMediaTypeConstraint("application/bitcoin-paymentrequest", false)]
         [XFrameOptionsAttribute(null)]
         [ReferrerPolicyAttribute("origin")]
-        [ContentSecurityPolicyAttribute(Enabled = false)] // Disable the top level filter
         public async Task<IActionResult> Checkout(string invoiceId, string id = null, string paymentMethodId = null,
             [FromQuery] string view = null, [FromQuery] string lang = null)
         {
@@ -447,17 +446,17 @@ namespace BTCPayServer.Controllers
             if (view == "modal")
                 model.IsModal = true;
 
-            _CSP.Add(new ConsentSecurityPolicy("script-src", "'unsafe-eval'")); // Needed by Vue
             if (!string.IsNullOrEmpty(model.CustomCSSLink) &&
                 Uri.TryCreate(model.CustomCSSLink, UriKind.Absolute, out var uri))
             {
-                _CSP.Clear();
+                _CSP.Add("style-src", uri.Authority);
+                _CSP.Add("font-src", uri.Authority);
             }
 
             if (!string.IsNullOrEmpty(model.CustomLogoLink) &&
                 Uri.TryCreate(model.CustomLogoLink, UriKind.Absolute, out uri))
             {
-                _CSP.Clear();
+                _CSP.Add("img-src", uri.Authority);
             }
 
             return View(nameof(Checkout), model);

--- a/BTCPayServer/Controllers/InvoiceController.UI.cs
+++ b/BTCPayServer/Controllers/InvoiceController.UI.cs
@@ -431,6 +431,7 @@ namespace BTCPayServer.Controllers
         [AcceptMediaTypeConstraint("application/bitcoin-paymentrequest", false)]
         [XFrameOptionsAttribute(null)]
         [ReferrerPolicyAttribute("origin")]
+        [ContentSecurityPolicyAttribute(Enabled = false)] // Disable the top level filter
         public async Task<IActionResult> Checkout(string invoiceId, string id = null, string paymentMethodId = null,
             [FromQuery] string view = null, [FromQuery] string lang = null)
         {

--- a/BTCPayServer/Controllers/PaymentRequestController.cs
+++ b/BTCPayServer/Controllers/PaymentRequestController.cs
@@ -176,6 +176,7 @@ namespace BTCPayServer.Controllers
         [HttpGet]
         [Route("{id}")]
         [AllowAnonymous]
+        [ContentSecurityPolicyAttribute(Enabled = false)]
         public async Task<IActionResult> ViewPaymentRequest(string id)
         {
             var result = await _PaymentRequestService.GetPaymentRequest(id, GetUserId());
@@ -191,6 +192,7 @@ namespace BTCPayServer.Controllers
         [HttpGet]
         [Route("{id}/pay")]
         [AllowAnonymous]
+        [ContentSecurityPolicyAttribute(Enabled = false)]
         public async Task<IActionResult> PayPaymentRequest(string id, bool redirectToInvoice = true,
             decimal? amount = null, CancellationToken cancellationToken = default)
         {

--- a/BTCPayServer/Controllers/PullPaymentController.cs
+++ b/BTCPayServer/Controllers/PullPaymentController.cs
@@ -7,6 +7,7 @@ using BTCPayServer;
 using BTCPayServer.Abstractions.Extensions;
 using BTCPayServer.Abstractions.Models;
 using BTCPayServer.Data;
+using BTCPayServer.Filters;
 using BTCPayServer.HostedServices;
 using BTCPayServer.Models;
 using BTCPayServer.Payments;
@@ -40,6 +41,7 @@ namespace BTCPayServer.Controllers
             _serializerSettings = serializerSettings;
         }
         [Route("pull-payments/{pullPaymentId}")]
+        [ContentSecurityPolicyAttribute(Enabled = false)]
         public async Task<IActionResult> ViewPullPayment(string pullPaymentId)
         {
             using var ctx = _dbContextFactory.CreateContext();
@@ -90,6 +92,7 @@ namespace BTCPayServer.Controllers
 
         [Route("pull-payments/{pullPaymentId}/claim")]
         [HttpPost]
+        [ContentSecurityPolicyAttribute(Enabled = false)]
         public async Task<IActionResult> ClaimPullPayment(string pullPaymentId, ViewPullPaymentModel vm)
         {
             using var ctx = _dbContextFactory.CreateContext();

--- a/BTCPayServer/Filters/ContentSecurityPolicyAttribute.cs
+++ b/BTCPayServer/Filters/ContentSecurityPolicyAttribute.cs
@@ -22,6 +22,7 @@ namespace BTCPayServer.Filters
         public string DefaultSrc { get; set; }
         public string StyleSrc { get; set; }
         public string ScriptSrc { get; set; }
+        public string ManifestSrc { get; set; }
 
         public void OnActionExecuting(ActionExecutingContext context)
         {
@@ -41,6 +42,10 @@ namespace BTCPayServer.Filters
             if (!string.IsNullOrEmpty(FontSrc))
             {
                 policies.Add(new ConsentSecurityPolicy("font-src", FontSrc));
+            }
+            if (!string.IsNullOrEmpty(ManifestSrc))
+            {
+                policies.Add(new ConsentSecurityPolicy("manifest-src", FontSrc));
             }
 
             if (!string.IsNullOrEmpty(ImgSrc))
@@ -84,14 +89,6 @@ namespace BTCPayServer.Filters
                                            g.Value.Contains("*", StringComparison.OrdinalIgnoreCase)))
                         {
                             policies.Add(new ConsentSecurityPolicy(group.Key, "'self'"));
-                            hasSelf = true;
-                        }
-                        if (hasSelf)
-                        {
-                            foreach (var authorized in policies.Authorized)
-                            {
-                                policies.Add(new ConsentSecurityPolicy(group.Key, authorized));
-                            }
                         }
                     }
                 }

--- a/BTCPayServer/Filters/ContentSecurityPolicyAttribute.cs
+++ b/BTCPayServer/Filters/ContentSecurityPolicyAttribute.cs
@@ -13,7 +13,7 @@ namespace BTCPayServer.Filters
         {
 
         }
-
+        public bool Enabled { get; set; } = true;
         public bool AutoSelf { get; set; } = true;
         public bool UnsafeInline { get; set; } = true;
         public bool FixWebsocket { get; set; } = true;
@@ -25,80 +25,79 @@ namespace BTCPayServer.Filters
 
         public void OnActionExecuting(ActionExecutingContext context)
         {
-            if (context.IsEffectivePolicy<IContentSecurityPolicy>(this))
+            if (!context.IsEffectivePolicy<IContentSecurityPolicy>(this) || !Enabled)
+                return;
+            var policies = context.HttpContext.RequestServices.GetService(typeof(ContentSecurityPolicies)) as ContentSecurityPolicies;
+            if (policies == null)
+                return;
+            if (DefaultSrc != null)
             {
-                var policies = context.HttpContext.RequestServices.GetService(typeof(ContentSecurityPolicies)) as ContentSecurityPolicies;
-                if (policies == null)
-                    return;
-                if (DefaultSrc != null)
-                {
-                    policies.Add(new ConsentSecurityPolicy("default-src", DefaultSrc));
-                }
-                if (UnsafeInline)
-                {
-                    policies.Add(new ConsentSecurityPolicy("script-src", "'unsafe-inline'"));
-                }
-                if (!string.IsNullOrEmpty(FontSrc))
-                {
-                    policies.Add(new ConsentSecurityPolicy("font-src", FontSrc));
-                }
+                policies.Add(new ConsentSecurityPolicy("default-src", DefaultSrc));
+            }
+            if (UnsafeInline)
+            {
+                policies.Add(new ConsentSecurityPolicy("script-src", "'unsafe-inline'"));
+            }
+            if (!string.IsNullOrEmpty(FontSrc))
+            {
+                policies.Add(new ConsentSecurityPolicy("font-src", FontSrc));
+            }
 
-                if (!string.IsNullOrEmpty(ImgSrc))
-                {
-                    policies.Add(new ConsentSecurityPolicy("img-src", ImgSrc));
-                }
+            if (!string.IsNullOrEmpty(ImgSrc))
+            {
+                policies.Add(new ConsentSecurityPolicy("img-src", ImgSrc));
+            }
 
-                if (!string.IsNullOrEmpty(StyleSrc))
-                {
-                    policies.Add(new ConsentSecurityPolicy("style-src", StyleSrc));
-                }
+            if (!string.IsNullOrEmpty(StyleSrc))
+            {
+                policies.Add(new ConsentSecurityPolicy("style-src", StyleSrc));
+            }
 
-                if (!string.IsNullOrEmpty(ScriptSrc))
-                {
-                    policies.Add(new ConsentSecurityPolicy("script-src", ScriptSrc));
-                }
+            if (!string.IsNullOrEmpty(ScriptSrc))
+            {
+                policies.Add(new ConsentSecurityPolicy("script-src", ScriptSrc));
+            }
 
-                if (FixWebsocket && AutoSelf) // Self does not match wss:// and ws:// :(
-                {
-                    var request = context.HttpContext.Request;
+            if (FixWebsocket && AutoSelf) // Self does not match wss:// and ws:// :(
+            {
+                var request = context.HttpContext.Request;
 
-                    var url = string.Concat(
-                            request.Scheme.Equals("http", StringComparison.OrdinalIgnoreCase) ? "ws" : "wss",
-                            "://",
-                            request.Host.ToUriComponent(),
-                            request.PathBase.ToUriComponent());
-                    policies.Add(new ConsentSecurityPolicy("connect-src", url));
-                }
+                var url = string.Concat(
+                        request.Scheme.Equals("http", StringComparison.OrdinalIgnoreCase) ? "ws" : "wss",
+                        "://",
+                        request.Host.ToUriComponent(),
+                        request.PathBase.ToUriComponent());
+                policies.Add(new ConsentSecurityPolicy("connect-src", url));
+            }
 
-                context.HttpContext.Response.OnStarting(() =>
+            context.HttpContext.Response.OnStarting(() =>
+            {
+                if (!policies.HasRules)
+                    return Task.CompletedTask;
+                if (AutoSelf)
                 {
-                    if (!policies.HasRules)
-                        return Task.CompletedTask;
-                    if (AutoSelf)
+                    bool hasSelf = false;
+                    foreach (var group in policies.Rules.GroupBy(p => p.Name))
                     {
-                        bool hasSelf = false;
-                        foreach (var group in policies.Rules.GroupBy(p => p.Name))
+                        hasSelf = group.Any(g => g.Value.Contains("'self'", StringComparison.OrdinalIgnoreCase));
+                        if (!hasSelf && !group.Any(g => g.Value.Contains("'none'", StringComparison.OrdinalIgnoreCase) ||
+                                           g.Value.Contains("*", StringComparison.OrdinalIgnoreCase)))
                         {
-                            hasSelf = group.Any(g => g.Value.Contains("'self'", StringComparison.OrdinalIgnoreCase));
-                            if (!hasSelf && !group.Any(g => g.Value.Contains("'none'", StringComparison.OrdinalIgnoreCase) ||
-                                               g.Value.Contains("*", StringComparison.OrdinalIgnoreCase)))
+                            policies.Add(new ConsentSecurityPolicy(group.Key, "'self'"));
+                            hasSelf = true;
+                        }
+                        if (hasSelf)
+                        {
+                            foreach (var authorized in policies.Authorized)
                             {
-                                policies.Add(new ConsentSecurityPolicy(group.Key, "'self'"));
-                                hasSelf = true;
-                            }
-                            if (hasSelf)
-                            {
-                                foreach (var authorized in policies.Authorized)
-                                {
-                                    policies.Add(new ConsentSecurityPolicy(group.Key, authorized));
-                                }
+                                policies.Add(new ConsentSecurityPolicy(group.Key, authorized));
                             }
                         }
                     }
-                    context.HttpContext.Response.SetHeader("Content-Security-Policy", policies.ToString());
-                    return Task.CompletedTask;
-                });
-            }
+                }
+                context.HttpContext.Response.SetHeader("Content-Security-Policy", policies.ToString());
+                return Task.CompletedTask;
+            });
         }
     }
 }

--- a/BTCPayServer/Filters/DomainMappingConstraintAttribute.cs
+++ b/BTCPayServer/Filters/DomainMappingConstraintAttribute.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using BTCPayServer.HostedServices;
+using BTCPayServer.Services;
+using BTCPayServer.Services.Apps;
+using Microsoft.AspNetCore.Mvc.ActionConstraints;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace BTCPayServer.Filters
+{
+    public class DomainMappingConstraintAttribute : Attribute, IActionConstraint
+    {
+        public DomainMappingConstraintAttribute()
+        {
+
+        }
+        public DomainMappingConstraintAttribute(AppType appType)
+        {
+            AppType = appType;
+        }
+        public int Order => 100;
+        public AppType? AppType { get; set; }
+
+        public bool Accept(ActionConstraintContext context)
+        {
+            if (context.RouteContext.RouteData.Values.ContainsKey("appId"))
+                return true;
+            var css = context.RouteContext.HttpContext.RequestServices.GetService<CssThemeManager>();
+            if (css?.DomainToAppMapping is List<PoliciesSettings.DomainToAppMappingItem> mapping)
+            {
+                var matchedDomainMapping = css.DomainToAppMapping.FirstOrDefault(item =>
+                item.Domain.Equals(context.RouteContext.HttpContext.Request.Host.Host, StringComparison.InvariantCultureIgnoreCase));
+                if (matchedDomainMapping is PoliciesSettings.DomainToAppMappingItem)
+                {
+                    if (!(AppType is AppType appType))
+                        return false;
+                    if (appType != matchedDomainMapping.AppType)
+                        return false;
+                    context.RouteContext.RouteData.Values.Add("appId", matchedDomainMapping.AppId);
+                    return true;
+                }
+                return AppType is null;
+            }
+            else
+            {
+                return AppType is null;
+            }
+        }
+    }
+}

--- a/BTCPayServer/Hosting/Startup.cs
+++ b/BTCPayServer/Hosting/Startup.cs
@@ -11,6 +11,7 @@ using BTCPayServer.Security;
 using BTCPayServer.Services.Apps;
 using BTCPayServer.Storage;
 using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.DataProtection;
 using Microsoft.AspNetCore.Hosting;
@@ -63,6 +64,11 @@ namespace BTCPayServer.Hosting
                 opts.DefaultSignInScheme = null;
                 opts.DefaultSignOutScheme = null;
             });
+            services.PostConfigure<CookieAuthenticationOptions>(IdentityConstants.ApplicationScheme, opt =>
+            {
+                opt.LoginPath = "/login";
+            });
+
             services.Configure<SecurityStampValidatorOptions>(opts =>
             {
                 opts.ValidationInterval = TimeSpan.FromMinutes(5.0);

--- a/BTCPayServer/Hosting/Startup.cs
+++ b/BTCPayServer/Hosting/Startup.cs
@@ -84,14 +84,16 @@ namespace BTCPayServer.Hosting
                 o.Filters.Add(new XContentTypeOptionsAttribute("nosniff"));
                 o.Filters.Add(new XXSSProtectionAttribute());
                 o.Filters.Add(new ReferrerPolicyAttribute("same-origin"));
-                //o.Filters.Add(new ContentSecurityPolicyAttribute()
-                //{
-                //    FontSrc = "'self' https://fonts.gstatic.com/",
-                //    ImgSrc = "'self' data:",
-                //    DefaultSrc = "'none'",
-                //    StyleSrc = "'self' 'unsafe-inline'",
-                //    ScriptSrc = "'self' 'unsafe-inline'"
-                //});
+                o.Filters.Add(new ContentSecurityPolicyAttribute()
+                {
+                    ImgSrc = "'self' data:",
+                    DefaultSrc = "'none'",
+                    StyleSrc = "'self' 'unsafe-inline'",
+                    ScriptSrc = "'self' 'unsafe-inline'",
+                    FontSrc = "'self'",
+                    AutoSelf = true,
+                    FixWebsocket = true
+                });
             })
             .ConfigureApiBehaviorOptions(options =>
             {

--- a/BTCPayServer/Hosting/Startup.cs
+++ b/BTCPayServer/Hosting/Startup.cs
@@ -89,9 +89,11 @@ namespace BTCPayServer.Hosting
                     ImgSrc = "'self' data:",
                     DefaultSrc = "'none'",
                     StyleSrc = "'self' 'unsafe-inline'",
-                    ScriptSrc = "'self' 'unsafe-inline'",
+                    // Unsafe eval is needed by Vue
+                    ScriptSrc = "'self' 'unsafe-inline' 'unsafe-eval'",
                     FontSrc = "'self'",
                     AutoSelf = true,
+                    ManifestSrc = "'self'",
                     FixWebsocket = true
                 });
             })

--- a/BTCPayServer/Security/ContentSecurityPolicies.cs
+++ b/BTCPayServer/Security/ContentSecurityPolicies.cs
@@ -9,6 +9,8 @@ namespace BTCPayServer.Security
     {
         public ConsentSecurityPolicy(string name, string value)
         {
+            if (value.Contains(';', StringComparison.OrdinalIgnoreCase))
+                throw new FormatException();
             _Value = value;
             _Name = name;
         }
@@ -67,6 +69,10 @@ namespace BTCPayServer.Security
         }
 
         readonly HashSet<ConsentSecurityPolicy> _Policies = new HashSet<ConsentSecurityPolicy>();
+        public void Add(string name, string value)
+        {
+            Add(new ConsentSecurityPolicy(name, value));
+        }
         public void Add(ConsentSecurityPolicy policy)
         {
             if (_Policies.Any(p => p.Name == policy.Name && p.Value == policy.Name))
@@ -87,15 +93,11 @@ namespace BTCPayServer.Security
                 {
                     value.Append(';');
                 }
-                List<string> values = new List<string>();
+                HashSet<string> values = new HashSet<string>();
                 values.Add(group.Key);
                 foreach (var v in group)
                 {
                     values.Add(v.Value);
-                }
-                foreach (var i in authorized)
-                {
-                    values.Add(i);
                 }
                 value.Append(String.Join(" ", values.OfType<object>().ToArray()));
                 firstGroup = false;
@@ -105,16 +107,7 @@ namespace BTCPayServer.Security
 
         internal void Clear()
         {
-            authorized.Clear();
             _Policies.Clear();
         }
-
-        readonly HashSet<string> authorized = new HashSet<string>();
-        internal void AddAllAuthorized(string v)
-        {
-            authorized.Add(v);
-        }
-
-        public IEnumerable<string> Authorized => authorized;
     }
 }

--- a/BTCPayServer/Views/Home/SwaggerDocs.cshtml
+++ b/BTCPayServer/Views/Home/SwaggerDocs.cshtml
@@ -1,5 +1,7 @@
+@inject BTCPayServer.Security.ContentSecurityPolicies csp
 @{
     Layout = null;
+    csp.Add("script-src", "cdn.jsdelivr.net blob:");
 }
 <!DOCTYPE html>
 <html>


### PR DESCRIPTION
Attempt to activate some limited CSP to prevent XSS vulnerabilities to escalate too much.
This also fix a bug with the previous root domain mapping, where HTTP headers were not properly set if using root domain mapping to a crowdfund or pos app.