### PR TITLE
Local Greenfield Client for Plugins

### DIFF
--- a/BTCPayServer.Abstractions/BTCPayServer.Abstractions.csproj
+++ b/BTCPayServer.Abstractions/BTCPayServer.Abstractions.csproj
@@ -36,4 +36,7 @@
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="3.1.4" />
     <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="3.1.1" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\BTCPayServer.Client\BTCPayServer.Client.csproj" />
+  </ItemGroup>
 </Project>

--- a/BTCPayServer.Abstractions/Contracts/IBTCPayServerClientFactory.cs
+++ b/BTCPayServer.Abstractions/Contracts/IBTCPayServerClientFactory.cs
@@ -1,0 +1,10 @@
+using System.Threading.Tasks;
+using BTCPayServer.Client;
+
+namespace BTCPayServer.Abstractions.Contracts
+{
+    public interface IBTCPayServerClientFactory
+    {
+        Task<BTCPayServerClient> Create(string userId, params string[] storeIds);
+    }
+}

--- a/BTCPayServer.Client/BTCPayServerClient.Invoices.cs
+++ b/BTCPayServer.Client/BTCPayServerClient.Invoices.cs
@@ -11,12 +11,13 @@ namespace BTCPayServer.Client
 {
     public partial class BTCPayServerClient
     {
-        public virtual async Task<IEnumerable<InvoiceData>> GetInvoices(string storeId, string orderId = null, InvoiceStatus[] status = null,
+        public virtual async Task<IEnumerable<InvoiceData>> GetInvoices(string storeId, string[] orderId = null,
+            InvoiceStatus[] status = null,
             DateTimeOffset? startDate = null,
             DateTimeOffset? endDate = null,
             string textSearch = null,
             bool includeArchived = false,
-            CancellationToken token = default)
+            CancellationToken token = bad)
         {
             Dictionary<string, object> queryPayload = new Dictionary<string, object>();
             queryPayload.Add(nameof(includeArchived), includeArchived);

--- a/BTCPayServer.Client/BTCPayServerClient.Invoices.cs
+++ b/BTCPayServer.Client/BTCPayServerClient.Invoices.cs
@@ -17,7 +17,7 @@ namespace BTCPayServer.Client
             DateTimeOffset? endDate = null,
             string textSearch = null,
             bool includeArchived = false,
-            CancellationToken token = bad)
+            CancellationToken token = default)
         {
             Dictionary<string, object> queryPayload = new Dictionary<string, object>();
             queryPayload.Add(nameof(includeArchived), includeArchived);

--- a/BTCPayServer.Client/BTCPayServerClient.Lightning.Internal.cs
+++ b/BTCPayServer.Client/BTCPayServerClient.Lightning.Internal.cs
@@ -9,7 +9,7 @@ namespace BTCPayServer.Client
 {
     public partial class BTCPayServerClient
     {
-        public async Task<LightningNodeInformationData> GetLightningNodeInfo(string cryptoCode,
+        public virtual async Task<LightningNodeInformationData> GetLightningNodeInfo(string cryptoCode,
             CancellationToken token = default)
         {
             var response = await _httpClient.SendAsync(
@@ -18,7 +18,7 @@ namespace BTCPayServer.Client
             return await HandleResponse<LightningNodeInformationData>(response);
         }
 
-        public async Task ConnectToLightningNode(string cryptoCode, ConnectToNodeRequest request,
+        public virtual async Task ConnectToLightningNode(string cryptoCode, ConnectToNodeRequest request,
             CancellationToken token = default)
         {
             if (request == null)
@@ -29,7 +29,7 @@ namespace BTCPayServer.Client
             await HandleResponse(response);
         }
 
-        public async Task<IEnumerable<LightningChannelData>> GetLightningNodeChannels(string cryptoCode,
+        public virtual async Task<IEnumerable<LightningChannelData>> GetLightningNodeChannels(string cryptoCode,
             CancellationToken token = default)
         {
             var response = await _httpClient.SendAsync(
@@ -38,16 +38,16 @@ namespace BTCPayServer.Client
             return await HandleResponse<IEnumerable<LightningChannelData>>(response);
         }
 
-        public async Task<string> OpenLightningChannel(string cryptoCode, OpenLightningChannelRequest request,
+        public virtual async Task OpenLightningChannel(string cryptoCode, OpenLightningChannelRequest request,
             CancellationToken token = default)
         {
             var response = await _httpClient.SendAsync(
                 CreateHttpRequest($"api/v1/server/lightning/{cryptoCode}/channels", bodyPayload: request,
                     method: HttpMethod.Post), token);
-            return await HandleResponse<string>(response);
+            await HandleResponse(response);
         }
 
-        public async Task<string> GetLightningDepositAddress(string cryptoCode, CancellationToken token = default)
+        public virtual async Task<string> GetLightningDepositAddress(string cryptoCode, CancellationToken token = default)
         {
             var response = await _httpClient.SendAsync(
                 CreateHttpRequest($"api/v1/server/lightning/{cryptoCode}/address", method: HttpMethod.Post), token);
@@ -55,7 +55,7 @@ namespace BTCPayServer.Client
         }
 
 
-        public async Task PayLightningInvoice(string cryptoCode, PayLightningInvoiceRequest request,
+        public virtual async Task PayLightningInvoice(string cryptoCode, PayLightningInvoiceRequest request,
             CancellationToken token = default)
         {
             if (request == null)
@@ -66,7 +66,7 @@ namespace BTCPayServer.Client
             await HandleResponse(response);
         }
 
-        public async Task<LightningInvoiceData> GetLightningInvoice(string cryptoCode,
+        public virtual async Task<LightningInvoiceData> GetLightningInvoice(string cryptoCode,
             string invoiceId, CancellationToken token = default)
         {
             if (invoiceId == null)
@@ -77,7 +77,7 @@ namespace BTCPayServer.Client
             return await HandleResponse<LightningInvoiceData>(response);
         }
 
-        public async Task<LightningInvoiceData> CreateLightningInvoice(string cryptoCode, CreateLightningInvoiceRequest request,
+        public virtual async Task<LightningInvoiceData> CreateLightningInvoice(string cryptoCode, CreateLightningInvoiceRequest request,
             CancellationToken token = default)
         {
             if (request == null)

--- a/BTCPayServer.Client/BTCPayServerClient.Lightning.Store.cs
+++ b/BTCPayServer.Client/BTCPayServerClient.Lightning.Store.cs
@@ -9,7 +9,7 @@ namespace BTCPayServer.Client
 {
     public partial class BTCPayServerClient
     {
-        public async Task<LightningNodeInformationData> GetLightningNodeInfo(string storeId, string cryptoCode,
+        public virtual async Task<LightningNodeInformationData> GetLightningNodeInfo(string storeId, string cryptoCode,
             CancellationToken token = default)
         {
             var response = await _httpClient.SendAsync(
@@ -18,7 +18,7 @@ namespace BTCPayServer.Client
             return await HandleResponse<LightningNodeInformationData>(response);
         }
 
-        public async Task ConnectToLightningNode(string storeId, string cryptoCode, ConnectToNodeRequest request,
+        public virtual async Task ConnectToLightningNode(string storeId, string cryptoCode, ConnectToNodeRequest request,
             CancellationToken token = default)
         {
             if (request == null)
@@ -29,7 +29,7 @@ namespace BTCPayServer.Client
             await HandleResponse(response);
         }
 
-        public async Task<IEnumerable<LightningChannelData>> GetLightningNodeChannels(string storeId, string cryptoCode,
+        public virtual async Task<IEnumerable<LightningChannelData>> GetLightningNodeChannels(string storeId, string cryptoCode,
             CancellationToken token = default)
         {
             var response = await _httpClient.SendAsync(
@@ -38,16 +38,16 @@ namespace BTCPayServer.Client
             return await HandleResponse<IEnumerable<LightningChannelData>>(response);
         }
 
-        public async Task<string> OpenLightningChannel(string storeId, string cryptoCode, OpenLightningChannelRequest request,
+        public virtual async Task OpenLightningChannel(string storeId, string cryptoCode, OpenLightningChannelRequest request,
             CancellationToken token = default)
         {
             var response = await _httpClient.SendAsync(
                 CreateHttpRequest($"api/v1/stores/{storeId}/lightning/{cryptoCode}/channels", bodyPayload: request,
                     method: HttpMethod.Post), token);
-            return await HandleResponse<string>(response);
+            await HandleResponse(response);
         }
 
-        public async Task<string> GetLightningDepositAddress(string storeId, string cryptoCode,
+        public virtual async Task<string> GetLightningDepositAddress(string storeId, string cryptoCode,
             CancellationToken token = default)
         {
             var response = await _httpClient.SendAsync(
@@ -56,7 +56,7 @@ namespace BTCPayServer.Client
             return await HandleResponse<string>(response);
         }
 
-        public async Task PayLightningInvoice(string storeId, string cryptoCode, PayLightningInvoiceRequest request,
+        public virtual async Task PayLightningInvoice(string storeId, string cryptoCode, PayLightningInvoiceRequest request,
             CancellationToken token = default)
         {
             if (request == null)
@@ -67,7 +67,7 @@ namespace BTCPayServer.Client
             await HandleResponse(response);
         }
 
-        public async Task<LightningInvoiceData> GetLightningInvoice(string storeId, string cryptoCode,
+        public virtual async Task<LightningInvoiceData> GetLightningInvoice(string storeId, string cryptoCode,
             string invoiceId, CancellationToken token = default)
         {
             if (invoiceId == null)
@@ -78,7 +78,7 @@ namespace BTCPayServer.Client
             return await HandleResponse<LightningInvoiceData>(response);
         }
 
-        public async Task<LightningInvoiceData> CreateLightningInvoice(string storeId, string cryptoCode,
+        public virtual async Task<LightningInvoiceData> CreateLightningInvoice(string storeId, string cryptoCode,
             CreateLightningInvoiceRequest request, CancellationToken token = default)
         {
             if (request == null)

--- a/BTCPayServer.Client/BTCPayServerClient.PullPayments.cs
+++ b/BTCPayServer.Client/BTCPayServerClient.PullPayments.cs
@@ -9,18 +9,18 @@ namespace BTCPayServer.Client
 {
     public partial class BTCPayServerClient
     {
-        public async Task<PullPaymentData> CreatePullPayment(string storeId, CreatePullPaymentRequest request, CancellationToken cancellationToken = default)
+        public virtual async Task<PullPaymentData> CreatePullPayment(string storeId, CreatePullPaymentRequest request, CancellationToken cancellationToken = default)
         {
             var response = await _httpClient.SendAsync(CreateHttpRequest($"api/v1/stores/{HttpUtility.UrlEncode(storeId)}/pull-payments", bodyPayload: request, method: HttpMethod.Post), cancellationToken);
             return await HandleResponse<PullPaymentData>(response);
         }
-        public async Task<PullPaymentData> GetPullPayment(string pullPaymentId, CancellationToken cancellationToken = default)
+        public virtual async Task<PullPaymentData> GetPullPayment(string pullPaymentId, CancellationToken cancellationToken = default)
         {
             var response = await _httpClient.SendAsync(CreateHttpRequest($"api/v1/pull-payments/{HttpUtility.UrlEncode(pullPaymentId)}", method: HttpMethod.Get), cancellationToken);
             return await HandleResponse<PullPaymentData>(response);
         }
 
-        public async Task<PullPaymentData[]> GetPullPayments(string storeId, bool includeArchived = false, CancellationToken cancellationToken = default)
+        public virtual async Task<PullPaymentData[]> GetPullPayments(string storeId, bool includeArchived = false, CancellationToken cancellationToken = default)
         {
             Dictionary<string, object> query = new Dictionary<string, object>();
             query.Add("includeArchived", includeArchived);
@@ -28,31 +28,31 @@ namespace BTCPayServer.Client
             return await HandleResponse<PullPaymentData[]>(response);
         }
 
-        public async Task ArchivePullPayment(string storeId, string pullPaymentId, CancellationToken cancellationToken = default)
+        public virtual async Task ArchivePullPayment(string storeId, string pullPaymentId, CancellationToken cancellationToken = default)
         {
             var response = await _httpClient.SendAsync(CreateHttpRequest($"api/v1/stores/{HttpUtility.UrlEncode(storeId)}/pull-payments/{HttpUtility.UrlEncode(pullPaymentId)}", method: HttpMethod.Delete), cancellationToken);
             await HandleResponse(response);
         }
 
-        public async Task<PayoutData[]> GetPayouts(string pullPaymentId, bool includeCancelled = false, CancellationToken cancellationToken = default)
+        public virtual async Task<PayoutData[]> GetPayouts(string pullPaymentId, bool includeCancelled = false, CancellationToken cancellationToken = default)
         {
             Dictionary<string, object> query = new Dictionary<string, object>();
             query.Add("includeCancelled", includeCancelled);
             var response = await _httpClient.SendAsync(CreateHttpRequest($"api/v1/pull-payments/{HttpUtility.UrlEncode(pullPaymentId)}/payouts", queryPayload: query, method: HttpMethod.Get), cancellationToken);
             return await HandleResponse<PayoutData[]>(response);
         }
-        public async Task<PayoutData> CreatePayout(string pullPaymentId, CreatePayoutRequest payoutRequest, CancellationToken cancellationToken = default)
+        public virtual async Task<PayoutData> CreatePayout(string pullPaymentId, CreatePayoutRequest payoutRequest, CancellationToken cancellationToken = default)
         {
             var response = await _httpClient.SendAsync(CreateHttpRequest($"api/v1/pull-payments/{HttpUtility.UrlEncode(pullPaymentId)}/payouts", bodyPayload: payoutRequest, method: HttpMethod.Post), cancellationToken);
             return await HandleResponse<PayoutData>(response);
         }
 
-        public async Task CancelPayout(string storeId, string payoutId, CancellationToken cancellationToken = default)
+        public virtual async Task CancelPayout(string storeId, string payoutId, CancellationToken cancellationToken = default)
         {
             var response = await _httpClient.SendAsync(CreateHttpRequest($"api/v1/stores/{HttpUtility.UrlEncode(storeId)}/payouts/{HttpUtility.UrlEncode(payoutId)}", method: HttpMethod.Delete), cancellationToken);
             await HandleResponse(response);
         }
-        public async Task<PayoutData> ApprovePayout(string storeId, string payoutId, ApprovePayoutRequest request, CancellationToken cancellationToken = default)
+        public virtual async Task<PayoutData> ApprovePayout(string storeId, string payoutId, ApprovePayoutRequest request, CancellationToken cancellationToken = default)
         {
             var response = await _httpClient.SendAsync(CreateHttpRequest($"api/v1/stores/{HttpUtility.UrlEncode(storeId)}/payouts/{HttpUtility.UrlEncode(payoutId)}", bodyPayload: request, method: HttpMethod.Post), cancellationToken);
             return await HandleResponse<PayoutData>(response);

--- a/BTCPayServer.Client/BTCPayServerClient.Webhooks.cs
+++ b/BTCPayServer.Client/BTCPayServerClient.Webhooks.cs
@@ -1,60 +1,56 @@
-using System;
-using System.Collections.Generic;
 using System.Net.Http;
-using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using BTCPayServer.Client.Models;
-using Newtonsoft.Json.Linq;
 
 namespace BTCPayServer.Client
 {
     public partial class BTCPayServerClient
     {
-        public async Task<StoreWebhookData> CreateWebhook(string storeId, Client.Models.CreateStoreWebhookRequest create, CancellationToken token = default)
+        public virtual async Task<StoreWebhookData> CreateWebhook(string storeId, Client.Models.CreateStoreWebhookRequest create, CancellationToken token = default)
         {
             var response = await _httpClient.SendAsync(CreateHttpRequest($"api/v1/stores/{storeId}/webhooks", bodyPayload: create, method: HttpMethod.Post), token);
             return await HandleResponse<StoreWebhookData>(response);
         }
-        public async Task<StoreWebhookData> GetWebhook(string storeId, string webhookId, CancellationToken token = default)
+        public virtual async Task<StoreWebhookData> GetWebhook(string storeId, string webhookId, CancellationToken token = default)
         {
             var response = await _httpClient.SendAsync(CreateHttpRequest($"api/v1/stores/{storeId}/webhooks/{webhookId}"), token);
             if (response.StatusCode == System.Net.HttpStatusCode.NotFound)
                 return null;
             return await HandleResponse<StoreWebhookData>(response);
         }
-        public async Task<StoreWebhookData> UpdateWebhook(string storeId, string webhookId, Models.UpdateStoreWebhookRequest update, CancellationToken token = default)
+        public virtual async Task<StoreWebhookData> UpdateWebhook(string storeId, string webhookId, Models.UpdateStoreWebhookRequest update, CancellationToken token = default)
         {
             var response = await _httpClient.SendAsync(CreateHttpRequest($"api/v1/stores/{storeId}/webhooks/{webhookId}", bodyPayload: update, method: HttpMethod.Put), token);
             return await HandleResponse<StoreWebhookData>(response);
         }
-        public async Task<bool> DeleteWebhook(string storeId, string webhookId, CancellationToken token = default)
+        public virtual async Task<bool> DeleteWebhook(string storeId, string webhookId, CancellationToken token = default)
         {
             var response = await _httpClient.SendAsync(CreateHttpRequest($"api/v1/stores/{storeId}/webhooks/{webhookId}", method: HttpMethod.Delete), token);
             return response.IsSuccessStatusCode;
         }
-        public async Task<StoreWebhookData[]> GetWebhooks(string storeId, CancellationToken token = default)
+        public virtual async Task<StoreWebhookData[]> GetWebhooks(string storeId, CancellationToken token = default)
         {
             var response = await _httpClient.SendAsync(CreateHttpRequest($"api/v1/stores/{storeId}/webhooks"), token);
             return await HandleResponse<StoreWebhookData[]>(response);
         }
-        public async Task<WebhookDeliveryData[]> GetWebhookDeliveries(string storeId, string webhookId, CancellationToken token = default)
+        public virtual async Task<WebhookDeliveryData[]> GetWebhookDeliveries(string storeId, string webhookId, CancellationToken token = default)
         {
             var response = await _httpClient.SendAsync(CreateHttpRequest($"api/v1/stores/{storeId}/webhooks/{webhookId}/deliveries"), token);
             return await HandleResponse<WebhookDeliveryData[]>(response);
         }
-        public async Task<WebhookDeliveryData> GetWebhookDelivery(string storeId, string webhookId, string deliveryId, CancellationToken token = default)
+        public virtual async Task<WebhookDeliveryData> GetWebhookDelivery(string storeId, string webhookId, string deliveryId, CancellationToken token = default)
         {
             var response = await _httpClient.SendAsync(CreateHttpRequest($"api/v1/stores/{storeId}/webhooks/{webhookId}/deliveries/{deliveryId}"), token);
             return await HandleResponse<WebhookDeliveryData>(response);
         }
-        public async Task<string> RedeliverWebhook(string storeId, string webhookId, string deliveryId, CancellationToken token = default)
+        public virtual async Task<string> RedeliverWebhook(string storeId, string webhookId, string deliveryId, CancellationToken token = default)
         {
             var response = await _httpClient.SendAsync(CreateHttpRequest($"api/v1/stores/{storeId}/webhooks/{webhookId}/deliveries/{deliveryId}/redeliver", null, HttpMethod.Post), token);
             return await HandleResponse<string>(response);
         }
 
-        public async Task<WebhookEvent> GetWebhookDeliveryRequest(string storeId, string webhookId, string deliveryId, CancellationToken token = default)
+        public virtual async Task<WebhookEvent> GetWebhookDeliveryRequest(string storeId, string webhookId, string deliveryId, CancellationToken token = default)
         {
             var response = await _httpClient.SendAsync(CreateHttpRequest($"api/v1/stores/{storeId}/webhooks/{webhookId}/deliveries/{deliveryId}/request"), token);
             if (response.StatusCode == System.Net.HttpStatusCode.NotFound)

--- a/BTCPayServer.Tests/GreenfieldAPITests.cs
+++ b/BTCPayServer.Tests/GreenfieldAPITests.cs
@@ -1117,14 +1117,14 @@ namespace BTCPayServer.Tests
 
                 //list Existing OrderId
                 var invoicesExistingOrderId =
-                     await viewOnly.GetInvoices(user.StoreId, orderId: newInvoice.Metadata["orderId"].ToString());
+                     await viewOnly.GetInvoices(user.StoreId, orderId: new []{newInvoice.Metadata["orderId"].ToString()});
                  Assert.NotNull(invoicesExistingOrderId);
                  Assert.Single(invoicesFiltered);
                  Assert.Equal(newInvoice.Id, invoicesFiltered.First().Id);
 
                  //list NonExisting OrderId
                  var invoicesNonExistingOrderId =
-                     await viewOnly.GetInvoices(user.StoreId, orderId: "NonExistingOrderId");
+                     await viewOnly.GetInvoices(user.StoreId, orderId: new []{"NonExistingOrderId"});
                  Assert.NotNull(invoicesNonExistingOrderId);
                  Assert.Empty(invoicesNonExistingOrderId);
 

--- a/BTCPayServer.Tests/GreenfieldAPITests.cs
+++ b/BTCPayServer.Tests/GreenfieldAPITests.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
+using BTCPayServer.Abstractions.Contracts;
 using BTCPayServer.Client;
 using BTCPayServer.Client.Models;
 using BTCPayServer.Controllers;
@@ -20,8 +21,6 @@ using BTCPayServer.Tests.Logging;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using NBitcoin;
-using NBitcoin.OpenAsset;
-using NBitcoin.Payment;
 using NBitpayClient;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -40,6 +39,23 @@ namespace BTCPayServer.Tests
             Logs.Tester = new XUnitLog(helper) { Name = "Tests" };
             Logs.LogProvider = new XUnitLogProvider(helper);
         }
+
+        [Fact(Timeout = TestTimeout)]
+        [Trait("Integration", "Integration")]
+        public async Task LocalClientTests()
+        {
+            using var tester = ServerTester.Create();
+            await tester.StartAsync();
+            var user = tester.NewAccount();
+            await user.GrantAccessAsync();
+            await user.MakeAdmin();
+            var factory = tester.PayTester.GetService<IBTCPayServerClientFactory>();
+            Assert.NotNull(factory);
+            var client = await factory.Create(user.UserId);
+            var u = await client.GetCurrentUser();
+            var s = await client.GetStores();
+        }
+
 
         [Fact(Timeout = TestTimeout)]
         [Trait("Integration", "Integration")]

--- a/BTCPayServer.Tests/GreenfieldAPITests.cs
+++ b/BTCPayServer.Tests/GreenfieldAPITests.cs
@@ -1082,26 +1082,31 @@ namespace BTCPayServer.Tests
                 Assert.Empty(invoices);
 
                 //list Filtered
-                var invoicesFiltered = await viewOnly.GetInvoices(user.StoreId,
-                    orderId: null, status: null, DateTimeOffset.Now.AddHours(-1),
-                    DateTimeOffset.Now.AddHours(1));
+                 var invoicesFiltered = await viewOnly.GetInvoices(user.StoreId,
+                     orderId: null, status: null, startDate: DateTimeOffset.Now.AddHours(-1),
+                     endDate: DateTimeOffset.Now.AddHours(1));
+
+                 Assert.NotNull(invoicesFiltered);
+                 Assert.Single(invoicesFiltered);
+                 Assert.Equal(newInvoice.Id, invoicesFiltered.First().Id);
+
 
                 Assert.NotNull(invoicesFiltered);
                 Assert.Single(invoicesFiltered);
                 Assert.Equal(newInvoice.Id, invoicesFiltered.First().Id);
 
-                //list Yesterday
-                var invoicesYesterday = await viewOnly.GetInvoices(user.StoreId,
-                    orderId: null, status: null, DateTimeOffset.Now.AddDays(-2),
-                    DateTimeOffset.Now.AddDays(-1));
-                Assert.NotNull(invoicesYesterday);
-                Assert.Empty(invoicesYesterday);
+                 //list Yesterday
+                 var invoicesYesterday = await viewOnly.GetInvoices(user.StoreId,
+                     orderId: null, status: null, startDate: DateTimeOffset.Now.AddDays(-2),
+                     endDate: DateTimeOffset.Now.AddDays(-1));
+                 Assert.NotNull(invoicesYesterday);
+                 Assert.Empty(invoicesYesterday);
 
                 // Error, startDate and endDate inverted
                 await AssertValidationError(new[] { "startDate", "endDate" },
                     () => viewOnly.GetInvoices(user.StoreId,
-                    orderId: null, status: null, DateTimeOffset.Now.AddDays(-1),
-                    DateTimeOffset.Now.AddDays(-2)));
+                    orderId: null, status: null, startDate: DateTimeOffset.Now.AddDays(-1),
+                    endDate: DateTimeOffset.Now.AddDays(-2)));
 
                 await AssertValidationError(new[] { "startDate" },
                     () => viewOnly.SendHttpRequest<Client.Models.InvoiceData[]>($"api/v1/stores/{user.StoreId}/invoices", new Dictionary<string, object>()
@@ -1113,30 +1118,30 @@ namespace BTCPayServer.Tests
                 //list Existing OrderId
                 var invoicesExistingOrderId =
                      await viewOnly.GetInvoices(user.StoreId, orderId: newInvoice.Metadata["orderId"].ToString());
-                Assert.NotNull(invoicesExistingOrderId);
-                Assert.Single(invoicesFiltered);
-                Assert.Equal(newInvoice.Id, invoicesFiltered.First().Id);
+                 Assert.NotNull(invoicesExistingOrderId);
+                 Assert.Single(invoicesFiltered);
+                 Assert.Equal(newInvoice.Id, invoicesFiltered.First().Id);
 
-                //list NonExisting OrderId
-                var invoicesNonExistingOrderId =
-                    await viewOnly.GetInvoices(user.StoreId, orderId: "NonExistingOrderId");
-                Assert.NotNull(invoicesNonExistingOrderId);
-                Assert.Empty(invoicesNonExistingOrderId);
+                 //list NonExisting OrderId
+                 var invoicesNonExistingOrderId =
+                     await viewOnly.GetInvoices(user.StoreId, orderId: "NonExistingOrderId");
+                 Assert.NotNull(invoicesNonExistingOrderId);
+                 Assert.Empty(invoicesNonExistingOrderId);
 
-                //list Existing Status
-                var invoicesExistingStatus =
-                    await viewOnly.GetInvoices(user.StoreId, status: new[] { newInvoice.Status });
-                Assert.NotNull(invoicesExistingStatus);
-                Assert.Single(invoicesExistingStatus);
-                Assert.Equal(newInvoice.Id, invoicesExistingStatus.First().Id);
+                 //list Existing Status
+                 var invoicesExistingStatus =
+                     await viewOnly.GetInvoices(user.StoreId, status: new []{newInvoice.Status});
+                 Assert.NotNull(invoicesExistingStatus);
+                 Assert.Single(invoicesExistingStatus);
+                 Assert.Equal(newInvoice.Id, invoicesExistingStatus.First().Id);
 
-                //list NonExisting Status
-                var invoicesNonExistingStatus = await viewOnly.GetInvoices(user.StoreId,
-                    status: new[] { BTCPayServer.Client.Models.InvoiceStatus.Invalid });
-                Assert.NotNull(invoicesNonExistingStatus);
-                Assert.Empty(invoicesNonExistingStatus);
-
-
+                 //list NonExisting Status
+                 var invoicesNonExistingStatus = await viewOnly.GetInvoices(user.StoreId,
+                     status: new []{BTCPayServer.Client.Models.InvoiceStatus.Invalid});
+                 Assert.NotNull(invoicesNonExistingStatus);
+                 Assert.Empty(invoicesNonExistingStatus);
+                 
+                 
                 //get
                 var invoice = await viewOnly.GetInvoice(user.StoreId, newInvoice.Id);
                 Assert.Equal(newInvoice.Metadata, invoice.Metadata);

--- a/BTCPayServer/Controllers/GreenField/HealthController.cs
+++ b/BTCPayServer/Controllers/GreenField/HealthController.cs
@@ -10,13 +10,19 @@ namespace BTCPayServer.Controllers.GreenField
     [EnableCors(CorsPolicies.All)]
     public class HealthController : ControllerBase
     {
+        private readonly NBXplorerDashboard _dashBoard;
+
+        public HealthController(NBXplorerDashboard dashBoard )
+        {
+            _dashBoard = dashBoard;
+        }
         [AllowAnonymous]
         [HttpGet("~/api/v1/health")]
-        public ActionResult GetHealth(NBXplorerDashboard dashBoard)
+        public ActionResult GetHealth()
         {
             ApiHealthData model = new ApiHealthData()
             {
-                Synchronized = dashBoard.IsFullySynched()
+                Synchronized = _dashBoard.IsFullySynched()
             };
             return Ok(model);
         }

--- a/BTCPayServer/Controllers/GreenField/LocalBTCPayServerClient.cs
+++ b/BTCPayServer/Controllers/GreenField/LocalBTCPayServerClient.cs
@@ -21,8 +21,74 @@ using StoreData = BTCPayServer.Client.Models.StoreData;
 
 namespace BTCPayServer.Controllers.GreenField
 {
-
-    public class BTCPayServerClientFactory
+    //
+    // public class BTCPayServerClientFactory
+    // {
+    //     private readonly StoreRepository _storeRepository;
+    //     private readonly IOptionsMonitor<IdentityOptions> _identityOptions;
+    //     private readonly StoreOnChainPaymentMethodsController _chainPaymentMethodsController;
+    //     private readonly StoreOnChainWalletsController _storeOnChainWalletsController;
+    //     private readonly HealthController _healthController;
+    //     private readonly GreenFieldPaymentRequestsController _paymentRequestController;
+    //     private readonly ApiKeysController _apiKeysController;
+    //     private readonly NotificationsController _notificationsController;
+    //     private readonly UsersController _usersController;
+    //     private readonly GreenFieldStoresController _storesController;
+    //     private readonly StoreLightningNodeApiController _storeLightningNodeApiController;
+    //     private readonly UserManager<ApplicationUser> _userManager;
+    //     private readonly IHttpContextAccessor _httpContextAccessor;
+    //
+    //     public BTCPayServerClientFactory(StoreRepository storeRepository,
+    //         IOptionsMonitor<IdentityOptions> identityOptions,
+    //         StoreOnChainPaymentMethodsController chainPaymentMethodsController,
+    //         StoreOnChainWalletsController storeOnChainWalletsController,
+    //         HealthController healthController, 
+    //         GreenFieldPaymentRequestsController paymentRequestController,
+    //         ApiKeysController apiKeysController,
+    //         NotificationsController notificationsController, 
+    //         UsersController usersController,
+    //         GreenFieldStoresController storesController,
+    //         StoreLightningNodeApiController storeLightningNodeApiController,
+    //         UserManager<ApplicationUser> userManager,
+    //         IHttpContextAccessor httpContextAccessor )
+    //     {
+    //         _storeRepository = storeRepository;
+    //         _identityOptions = identityOptions;
+    //         _chainPaymentMethodsController = chainPaymentMethodsController;
+    //         _storeOnChainWalletsController = storeOnChainWalletsController;
+    //         _healthController = healthController;
+    //         _paymentRequestController = paymentRequestController;
+    //         _apiKeysController = apiKeysController;
+    //         _notificationsController = notificationsController;
+    //         _usersController = usersController;
+    //         _storesController = storesController;
+    //         _storeLightningNodeApiController = storeLightningNodeApiController;
+    //         _userManager = userManager;
+    //         _httpContextAccessor = httpContextAccessor;
+    //     }
+    //     
+    //     public BTCPayServerClient Create(string userId = null, params string[] storeIds)
+    //     {
+    //         return new LocalBTCPayServerClient(
+    //             _storeRepository,
+    //             _identityOptions,
+    //             _chainPaymentMethodsController,
+    //             _storeOnChainWalletsController,
+    //             _healthController,
+    //             _paymentRequestController,
+    //             _apiKeysController, 
+    //             _notificationsController, 
+    //             _usersController, 
+    //             _storesController,
+    //             _storeLightningNodeApiController, 
+    //             _userManager, 
+    //             _httpContextAccessor, 
+    //             userId, 
+    //             storeIds);
+    //     }
+    //     
+    //     
+    public class  LocalBTCPayServerClient: BTCPayServerClient
     {
         private readonly StoreRepository _storeRepository;
         private readonly IOptionsMonitor<IdentityOptions> _identityOptions;
@@ -38,74 +104,8 @@ namespace BTCPayServer.Controllers.GreenField
         private readonly UserManager<ApplicationUser> _userManager;
         private readonly IHttpContextAccessor _httpContextAccessor;
 
-        public BTCPayServerClientFactory(StoreRepository storeRepository,
-            IOptionsMonitor<IdentityOptions> identityOptions,
-            StoreOnChainPaymentMethodsController chainPaymentMethodsController,
-            StoreOnChainWalletsController storeOnChainWalletsController,
-            HealthController healthController, 
-            GreenFieldPaymentRequestsController paymentRequestController,
-            ApiKeysController apiKeysController,
-            NotificationsController notificationsController, 
-            UsersController usersController,
-            GreenFieldStoresController storesController,
-            StoreLightningNodeApiController storeLightningNodeApiController,
-            UserManager<ApplicationUser> userManager,
-            IHttpContextAccessor httpContextAccessor )
-        {
-            _storeRepository = storeRepository;
-            _identityOptions = identityOptions;
-            _chainPaymentMethodsController = chainPaymentMethodsController;
-            _storeOnChainWalletsController = storeOnChainWalletsController;
-            _healthController = healthController;
-            _paymentRequestController = paymentRequestController;
-            _apiKeysController = apiKeysController;
-            _notificationsController = notificationsController;
-            _usersController = usersController;
-            _storesController = storesController;
-            _storeLightningNodeApiController = storeLightningNodeApiController;
-            _userManager = userManager;
-            _httpContextAccessor = httpContextAccessor;
-        }
+        private ControllerBase[] _controllers;
         
-        public BTCPayServerClient Create(string userId = null, params string[] storeIds)
-        {
-            return new LocalBTCPayServerClient(
-                _storeRepository,
-                _identityOptions,
-                _chainPaymentMethodsController,
-                _storeOnChainWalletsController,
-                _healthController,
-                _paymentRequestController,
-                _apiKeysController, 
-                _notificationsController, 
-                _usersController, 
-                _storesController,
-                _storeLightningNodeApiController, 
-                _userManager, 
-                _httpContextAccessor, 
-                userId, 
-                storeIds);
-        }
-        
-        
-    public class LocalBTCPayServerClient: BTCPayServerClient
-    {
-        private readonly StoreRepository _storeRepository;
-        private readonly IOptionsMonitor<IdentityOptions> _identityOptions;
-        private readonly StoreOnChainPaymentMethodsController _chainPaymentMethodsController;
-        private readonly StoreOnChainWalletsController _storeOnChainWalletsController;
-        private readonly HealthController _healthController;
-        private readonly GreenFieldPaymentRequestsController _paymentRequestController;
-        private readonly ApiKeysController _apiKeysController;
-        private readonly NotificationsController _notificationsController;
-        private readonly UsersController _usersController;
-        private readonly GreenFieldStoresController _storesController;
-        private readonly StoreLightningNodeApiController _storeLightningNodeApiController;
-        private readonly UserManager<ApplicationUser> _userManager;
-        private readonly IHttpContextAccessor _httpContextAccessor;
-        private readonly string _userId;
-        private readonly string[] _storeIds;
-
         public  LocalBTCPayServerClient(
             StoreRepository storeRepository,
             IOptionsMonitor<IdentityOptions> identityOptions,
@@ -119,11 +119,11 @@ namespace BTCPayServer.Controllers.GreenField
             GreenFieldStoresController storesController,
             StoreLightningNodeApiController storeLightningNodeApiController,
             UserManager<ApplicationUser> userManager,
-            IHttpContextAccessor httpContextAccessor,
-            string userId = null, params string[] storeIds) : base(new Uri(""), "", "")
+            IHttpContextAccessor httpContextAccessor) : base(new Uri("http://dummy.com"), "", "")
         {
             _storeRepository = storeRepository;
             _identityOptions = identityOptions;
+            _httpContextAccessor = httpContextAccessor;
             _chainPaymentMethodsController = chainPaymentMethodsController;
             _storeOnChainWalletsController = storeOnChainWalletsController;
             _healthController = healthController;
@@ -134,10 +134,25 @@ namespace BTCPayServer.Controllers.GreenField
             _storesController = storesController;
             _storeLightningNodeApiController = storeLightningNodeApiController;
             _userManager = userManager;
-            _httpContextAccessor = httpContextAccessor;
-            _userId = userId;
-            _storeIds = storeIds;
+
+            _controllers = new[]
+            {
+                chainPaymentMethodsController, 
+                storeOnChainWalletsController, 
+                healthController, 
+                paymentRequestController, 
+                apiKeysController, 
+                notificationsController, 
+                usersController, 
+                storesController, 
+                storeLightningNodeApiController as ControllerBase, 
+            };
+            foreach (var controller in _controllers)
+            {
+                controller.ControllerContext.HttpContext = httpContextAccessor.HttpContext;
+            }
         }
+        
 
         private T GetFromActionResult<T>(IActionResult result)
         {
@@ -170,35 +185,13 @@ namespace BTCPayServer.Controllers.GreenField
         }
         private T GetFromActionResult<T>(ActionResult<T> result)
         {
-            return GetFromActionResult<T>(result.Result);
+            return result.Value ?? GetFromActionResult<T>(result.Result);
         }
 
         private async Task SetStore(string storeId )
         {
             _httpContextAccessor.HttpContext ??= new DefaultHttpContext();
             _httpContextAccessor.HttpContext.SetStoreData(await _storeRepository.FindStore(storeId));
-        }
-
-        private async Task SetStores()
-        {
-            await SetUser(_userId);
-            _httpContextAccessor.HttpContext ??= new DefaultHttpContext();
-            _httpContextAccessor.HttpContext.SetStoresData(await _storeRepository.GetStoresByUserId(_userId));
-        }
-        private async Task SetUser(string userId)
-        {
-            _httpContextAccessor.HttpContext ??= new DefaultHttpContext();
-            var user = await _userManager.FindByIdAsync(userId);
-            List<Claim> claims = new List<Claim>
-            {
-                new Claim(_identityOptions.CurrentValue.ClaimsIdentity.UserIdClaimType, userId),
-                new Claim(GreenFieldConstants.ClaimTypes.Permission,
-                    Permission.Create(Policies.Unrestricted).ToString())
-            };
-            claims.AddRange((await _userManager.GetRolesAsync(user)).Select(s =>
-                new Claim(_identityOptions.CurrentValue.ClaimsIdentity.RoleClaimType, s)));
-            _httpContextAccessor.HttpContext.User =
-                new ClaimsPrincipal(new ClaimsIdentity(claims, GreenFieldConstants.AuthenticationType));
         }
         public override async Task<IEnumerable<OnChainPaymentMethodData>> GetStoreOnChainPaymentMethods(string storeId, CancellationToken token = default)
         {
@@ -272,7 +265,6 @@ namespace BTCPayServer.Controllers.GreenField
 
         public override async Task<ApiKeyData> CreateAPIKey(CreateApiKeyRequest request, CancellationToken token = default)
         {
-            await SetUser(_userId);
             return GetFromActionResult<ApiKeyData>(await _apiKeysController.CreateKey(request));
         }
 
@@ -283,25 +275,21 @@ namespace BTCPayServer.Controllers.GreenField
 
         public override async Task RevokeAPIKey(string apikey, CancellationToken token = default)
         {
-            await SetUser(_userId);
             HandleActionResult(await _apiKeysController.RevokeKey(apikey));
         }
 
         public override async Task<IEnumerable<NotificationData>> GetNotifications(bool? seen = null, CancellationToken token = default)
         {
-            await SetUser(_userId);
             return GetFromActionResult<IEnumerable<NotificationData>>(await _notificationsController.GetNotifications(seen));
         }
 
         public override async Task<NotificationData> GetNotification(string notificationId, CancellationToken token = default)
         {
-            await SetUser(_userId);
             return GetFromActionResult<NotificationData>(await _notificationsController.GetNotification(notificationId));
         }
 
         public override async Task<NotificationData> UpdateNotification(string notificationId, bool? seen, CancellationToken token = default)
         {
-            await SetUser(_userId);
             return GetFromActionResult<NotificationData>(await _notificationsController.UpdateNotification(notificationId, new UpdateNotification()
             {
                 Seen = seen
@@ -310,19 +298,16 @@ namespace BTCPayServer.Controllers.GreenField
 
         public override async Task RemoveNotification(string notificationId, CancellationToken token = default)
         {
-            await SetUser(_userId);
             HandleActionResult(await _notificationsController.DeleteNotification(notificationId));
         }
 
         public override async Task<ApplicationUserData> GetCurrentUser(CancellationToken token = default)
         {
-            await SetUser(_userId);
             return GetFromActionResult(await _usersController.GetCurrentUser());
         }
 
         public override async Task<ApplicationUserData> CreateUser(CreateApplicationUserRequest request, CancellationToken token = default)
         {
-            await SetUser(_userId);
             return GetFromActionResult<ApplicationUserData>(await _usersController.CreateUser(request, token));
         }
 
@@ -391,33 +376,28 @@ namespace BTCPayServer.Controllers.GreenField
 
         public override async Task<IEnumerable<StoreData>> GetStores(CancellationToken token = default)
         {
-            await SetStores();
             return GetFromActionResult(await _storesController.GetStores());
         }
 
         public override async Task<StoreData> GetStore(string storeId, CancellationToken token = default)
         {
-            await SetUser(_userId);
             await SetStore(storeId);
             return GetFromActionResult(await _storesController.GetStore(storeId));
         }
 
         public override async Task RemoveStore(string storeId, CancellationToken token = default)
         {
-            await SetUser(_userId);
             await SetStore(storeId);
             HandleActionResult(await _storesController.RemoveStore(storeId));
         }
 
         public override async Task<StoreData> CreateStore(CreateStoreRequest request, CancellationToken token = default)
         {
-            await SetUser(_userId);
             return GetFromActionResult<StoreData>(await _storesController.CreateStore(request));
         }
 
         public override async Task<StoreData> UpdateStore(string storeId, UpdateStoreRequest request, CancellationToken token = default)
         {
-            await SetUser(_userId);
             await SetStore(storeId);
             return GetFromActionResult<StoreData>(await _storesController.UpdateStore(storeId, request));
         }
@@ -495,5 +475,5 @@ namespace BTCPayServer.Controllers.GreenField
             throw new NotSupportedException();
         }
     }
-    }
+    
 }

--- a/BTCPayServer/Controllers/GreenField/LocalBTCPayServerClient.cs
+++ b/BTCPayServer/Controllers/GreenField/LocalBTCPayServerClient.cs
@@ -192,8 +192,8 @@ namespace BTCPayServer.Controllers.GreenField
                 chainPaymentMethodsController, storeOnChainWalletsController, healthController,
                 paymentRequestController, apiKeysController, notificationsController, usersController,
                 storeLightningNetworkPaymentMethodsController, greenFieldInvoiceController,
-                greenFieldServerInfoController, greenfieldPullPaymentController, storesController,lightningNodeApiController,
-                storeLightningNodeApiController as ControllerBase,
+                greenFieldServerInfoController, greenfieldPullPaymentController, storesController,
+                lightningNodeApiController, storeLightningNodeApiController as ControllerBase,
             };
             foreach (var controller in controllers)
             {
@@ -201,31 +201,36 @@ namespace BTCPayServer.Controllers.GreenField
             }
         }
 
-        protected override HttpRequestMessage CreateHttpRequest(string path, Dictionary<string, object> queryPayload = null, HttpMethod method = null)
+        protected override HttpRequestMessage CreateHttpRequest(string path,
+            Dictionary<string, object> queryPayload = null, HttpMethod method = null)
         {
             throw new NotSupportedException("This method is not supported by the LocalBTCPayServerClient.");
         }
 
-        public override async Task<StoreWebhookData> CreateWebhook(string storeId, CreateStoreWebhookRequest create, CancellationToken token = default)
+        public override async Task<StoreWebhookData> CreateWebhook(string storeId, CreateStoreWebhookRequest create,
+            CancellationToken token = default)
         {
             return GetFromActionResult<StoreWebhookData>(
                 await _storeWebhooksController.CreateWebhook(storeId, create));
         }
 
-        public override async Task<StoreWebhookData> GetWebhook(string storeId, string webhookId, CancellationToken token = default)
+        public override async Task<StoreWebhookData> GetWebhook(string storeId, string webhookId,
+            CancellationToken token = default)
         {
             return GetFromActionResult<StoreWebhookData>(
                 await _storeWebhooksController.ListWebhooks(storeId, webhookId));
         }
 
-        public override async Task<StoreWebhookData> UpdateWebhook(string storeId, string webhookId, UpdateStoreWebhookRequest update,
+        public override async Task<StoreWebhookData> UpdateWebhook(string storeId, string webhookId,
+            UpdateStoreWebhookRequest update,
             CancellationToken token = default)
         {
             return GetFromActionResult<StoreWebhookData>(
                 await _storeWebhooksController.UpdateWebhook(storeId, webhookId, update));
         }
 
-        public override async Task<bool> DeleteWebhook(string storeId, string webhookId, CancellationToken token = default)
+        public override async Task<bool> DeleteWebhook(string storeId, string webhookId,
+            CancellationToken token = default)
         {
             HandleActionResult(await _storeWebhooksController.DeleteWebhook(storeId, webhookId));
             return true;
@@ -237,54 +242,63 @@ namespace BTCPayServer.Controllers.GreenField
                 await _storeWebhooksController.ListWebhooks(storeId, null));
         }
 
-        public override async Task<WebhookDeliveryData[]> GetWebhookDeliveries(string storeId, string webhookId, CancellationToken token = default)
+        public override async Task<WebhookDeliveryData[]> GetWebhookDeliveries(string storeId, string webhookId,
+            CancellationToken token = default)
         {
             return GetFromActionResult<WebhookDeliveryData[]>(
                 await _storeWebhooksController.ListDeliveries(storeId, webhookId, null));
         }
 
-        public override async Task<WebhookDeliveryData> GetWebhookDelivery(string storeId, string webhookId, string deliveryId, CancellationToken token = default)
+        public override async Task<WebhookDeliveryData> GetWebhookDelivery(string storeId, string webhookId,
+            string deliveryId, CancellationToken token = default)
         {
             return GetFromActionResult<WebhookDeliveryData>(
                 await _storeWebhooksController.ListDeliveries(storeId, webhookId, deliveryId));
         }
 
-        public override async Task<string> RedeliverWebhook(string storeId, string webhookId, string deliveryId, CancellationToken token = default)
+        public override async Task<string> RedeliverWebhook(string storeId, string webhookId, string deliveryId,
+            CancellationToken token = default)
         {
             return GetFromActionResult<string>(
                 await _storeWebhooksController.RedeliverWebhook(storeId, webhookId, deliveryId));
         }
 
-        public override async Task<WebhookEvent> GetWebhookDeliveryRequest(string storeId, string webhookId, string deliveryId, CancellationToken token = default)
+        public override async Task<WebhookEvent> GetWebhookDeliveryRequest(string storeId, string webhookId,
+            string deliveryId, CancellationToken token = default)
         {
             return GetFromActionResult<WebhookEvent>(
                 await _storeWebhooksController.GetDeliveryRequest(storeId, webhookId, deliveryId));
         }
 
-        public override async Task<PullPaymentData> CreatePullPayment(string storeId, CreatePullPaymentRequest request, CancellationToken cancellationToken = default)
+        public override async Task<PullPaymentData> CreatePullPayment(string storeId, CreatePullPaymentRequest request,
+            CancellationToken cancellationToken = default)
         {
             return GetFromActionResult<PullPaymentData>(
                 await _greenfieldPullPaymentController.CreatePullPayment(storeId, request));
         }
 
-        public override async Task<PullPaymentData> GetPullPayment(string pullPaymentId, CancellationToken cancellationToken = default)
+        public override async Task<PullPaymentData> GetPullPayment(string pullPaymentId,
+            CancellationToken cancellationToken = default)
         {
             return GetFromActionResult<PullPaymentData>(
                 await _greenfieldPullPaymentController.GetPullPayment(pullPaymentId));
         }
 
-        public override async Task<PullPaymentData[]> GetPullPayments(string storeId, bool includeArchived = false, CancellationToken cancellationToken = default)
+        public override async Task<PullPaymentData[]> GetPullPayments(string storeId, bool includeArchived = false,
+            CancellationToken cancellationToken = default)
         {
             return GetFromActionResult<PullPaymentData[]>(
-                await _greenfieldPullPaymentController.GetPullPayments(storeId,includeArchived ));
+                await _greenfieldPullPaymentController.GetPullPayments(storeId, includeArchived));
         }
 
-        public override async Task ArchivePullPayment(string storeId, string pullPaymentId, CancellationToken cancellationToken = default)
+        public override async Task ArchivePullPayment(string storeId, string pullPaymentId,
+            CancellationToken cancellationToken = default)
         {
             HandleActionResult(await _greenfieldPullPaymentController.ArchivePullPayment(storeId, pullPaymentId));
         }
 
-        public override async Task<PayoutData[]> GetPayouts(string pullPaymentId, bool includeCancelled = false, CancellationToken cancellationToken = default)
+        public override async Task<PayoutData[]> GetPayouts(string pullPaymentId, bool includeCancelled = false,
+            CancellationToken cancellationToken = default)
         {
             return GetFromActionResult<PayoutData[]>(
                 await _greenfieldPullPaymentController.GetPayouts(pullPaymentId, includeCancelled));
@@ -297,107 +311,125 @@ namespace BTCPayServer.Controllers.GreenField
                 await _greenfieldPullPaymentController.CreatePayout(pullPaymentId, payoutRequest));
         }
 
-        public override async Task CancelPayout(string storeId, string payoutId, CancellationToken cancellationToken = default)
+        public override async Task CancelPayout(string storeId, string payoutId,
+            CancellationToken cancellationToken = default)
         {
             HandleActionResult(await _greenfieldPullPaymentController.CancelPayout(storeId, payoutId));
         }
 
-        public override async Task<PayoutData> ApprovePayout(string storeId, string payoutId, ApprovePayoutRequest request,
+        public override async Task<PayoutData> ApprovePayout(string storeId, string payoutId,
+            ApprovePayoutRequest request,
             CancellationToken cancellationToken = default)
         {
             return GetFromActionResult<PayoutData>(
                 await _greenfieldPullPaymentController.ApprovePayout(storeId, payoutId, request, cancellationToken));
         }
 
-        public override async Task<LightningNodeInformationData> GetLightningNodeInfo(string storeId, string cryptoCode, CancellationToken token = default)
+        public override async Task<LightningNodeInformationData> GetLightningNodeInfo(string storeId, string cryptoCode,
+            CancellationToken token = default)
         {
             return GetFromActionResult<LightningNodeInformationData>(
                 await _storeLightningNodeApiController.GetInfo(cryptoCode));
         }
 
-        public override async Task ConnectToLightningNode(string storeId, string cryptoCode, ConnectToNodeRequest request,
+        public override async Task ConnectToLightningNode(string storeId, string cryptoCode,
+            ConnectToNodeRequest request,
             CancellationToken token = default)
         {
             HandleActionResult(await _storeLightningNodeApiController.ConnectToNode(cryptoCode, request));
         }
 
-        public override async Task<IEnumerable<LightningChannelData>> GetLightningNodeChannels(string storeId, string cryptoCode, CancellationToken token = default)
+        public override async Task<IEnumerable<LightningChannelData>> GetLightningNodeChannels(string storeId,
+            string cryptoCode, CancellationToken token = default)
         {
             return GetFromActionResult<IEnumerable<LightningChannelData>>(
                 await _storeLightningNodeApiController.GetChannels(cryptoCode));
         }
 
-        public override async Task OpenLightningChannel(string storeId, string cryptoCode, OpenLightningChannelRequest request,
+        public override async Task OpenLightningChannel(string storeId, string cryptoCode,
+            OpenLightningChannelRequest request,
             CancellationToken token = default)
         {
             HandleActionResult(await _storeLightningNodeApiController.OpenChannel(cryptoCode, request));
         }
 
-        public override async Task<string> GetLightningDepositAddress(string storeId, string cryptoCode, CancellationToken token = default)
+        public override async Task<string> GetLightningDepositAddress(string storeId, string cryptoCode,
+            CancellationToken token = default)
         {
             return GetFromActionResult<string>(
                 await _storeLightningNodeApiController.GetDepositAddress(cryptoCode));
         }
 
-        public override async Task PayLightningInvoice(string storeId, string cryptoCode, PayLightningInvoiceRequest request,
+        public override async Task PayLightningInvoice(string storeId, string cryptoCode,
+            PayLightningInvoiceRequest request,
             CancellationToken token = default)
         {
             HandleActionResult(await _storeLightningNodeApiController.PayInvoice(cryptoCode, request));
         }
 
-        public override async Task<LightningInvoiceData> GetLightningInvoice(string storeId, string cryptoCode, string invoiceId, CancellationToken token = default)
+        public override async Task<LightningInvoiceData> GetLightningInvoice(string storeId, string cryptoCode,
+            string invoiceId, CancellationToken token = default)
         {
             return GetFromActionResult<LightningInvoiceData>(
                 await _storeLightningNodeApiController.GetInvoice(cryptoCode, invoiceId));
         }
 
-        public override async Task<LightningInvoiceData> CreateLightningInvoice(string storeId, string cryptoCode, CreateLightningInvoiceRequest request,
+        public override async Task<LightningInvoiceData> CreateLightningInvoice(string storeId, string cryptoCode,
+            CreateLightningInvoiceRequest request,
             CancellationToken token = default)
         {
             return GetFromActionResult<LightningInvoiceData>(
                 await _storeLightningNodeApiController.CreateInvoice(cryptoCode, request));
         }
 
-        public override async Task<LightningNodeInformationData> GetLightningNodeInfo(string cryptoCode, CancellationToken token = default)
+        public override async Task<LightningNodeInformationData> GetLightningNodeInfo(string cryptoCode,
+            CancellationToken token = default)
         {
             return GetFromActionResult<LightningNodeInformationData>(
                 await _lightningNodeApiController.GetInfo(cryptoCode));
         }
 
-        public override async Task ConnectToLightningNode(string cryptoCode, ConnectToNodeRequest request, CancellationToken token = default)
+        public override async Task ConnectToLightningNode(string cryptoCode, ConnectToNodeRequest request,
+            CancellationToken token = default)
         {
             HandleActionResult(await _lightningNodeApiController.ConnectToNode(cryptoCode, request));
         }
 
-        public override async Task<IEnumerable<LightningChannelData>> GetLightningNodeChannels(string cryptoCode, CancellationToken token = default)
+        public override async Task<IEnumerable<LightningChannelData>> GetLightningNodeChannels(string cryptoCode,
+            CancellationToken token = default)
         {
             return GetFromActionResult<IEnumerable<LightningChannelData>>(
                 await _lightningNodeApiController.GetChannels(cryptoCode));
         }
 
-        public override async Task OpenLightningChannel(string cryptoCode, OpenLightningChannelRequest request, CancellationToken token = default)
+        public override async Task OpenLightningChannel(string cryptoCode, OpenLightningChannelRequest request,
+            CancellationToken token = default)
         {
             HandleActionResult(await _lightningNodeApiController.OpenChannel(cryptoCode, request));
         }
 
-        public override async Task<string> GetLightningDepositAddress(string cryptoCode, CancellationToken token = default)
+        public override async Task<string> GetLightningDepositAddress(string cryptoCode,
+            CancellationToken token = default)
         {
             return GetFromActionResult<string>(
                 await _lightningNodeApiController.GetDepositAddress(cryptoCode));
         }
 
-        public override async Task PayLightningInvoice(string cryptoCode, PayLightningInvoiceRequest request, CancellationToken token = default)
+        public override async Task PayLightningInvoice(string cryptoCode, PayLightningInvoiceRequest request,
+            CancellationToken token = default)
         {
             HandleActionResult(await _lightningNodeApiController.PayInvoice(cryptoCode, request));
         }
 
-        public override async Task<LightningInvoiceData> GetLightningInvoice(string cryptoCode, string invoiceId, CancellationToken token = default)
+        public override async Task<LightningInvoiceData> GetLightningInvoice(string cryptoCode, string invoiceId,
+            CancellationToken token = default)
         {
             return GetFromActionResult<LightningInvoiceData>(
                 await _lightningNodeApiController.GetInvoice(cryptoCode, invoiceId));
         }
 
-        public override async Task<LightningInvoiceData> CreateLightningInvoice(string cryptoCode, CreateLightningInvoiceRequest request,
+        public override async Task<LightningInvoiceData> CreateLightningInvoice(string cryptoCode,
+            CreateLightningInvoiceRequest request,
             CancellationToken token = default)
         {
             return GetFromActionResult<LightningInvoiceData>(
@@ -441,6 +473,7 @@ namespace BTCPayServer.Controllers.GreenField
         {
             return result.Value ?? GetFromActionResult<T>(result.Result);
         }
+
         public override async Task<IEnumerable<OnChainPaymentMethodData>> GetStoreOnChainPaymentMethods(string storeId,
             CancellationToken token = default)
         {
@@ -686,7 +719,8 @@ namespace BTCPayServer.Controllers.GreenField
         }
 
         public override async Task<IEnumerable<LightningNetworkPaymentMethodData>>
-            GetStoreLightningNetworkPaymentMethods(string storeId, bool enabledOnly = false,CancellationToken token = default)
+            GetStoreLightningNetworkPaymentMethods(string storeId, bool enabledOnly = false,
+                CancellationToken token = default)
         {
             return GetFromActionResult(
                 _storeLightningNetworkPaymentMethodsController.GetLightningPaymentMethods(storeId, enabledOnly));
@@ -702,33 +736,41 @@ namespace BTCPayServer.Controllers.GreenField
         public override async Task RemoveStoreLightningNetworkPaymentMethod(string storeId, string cryptoCode,
             CancellationToken token = default)
         {
-            HandleActionResult(await _storeLightningNetworkPaymentMethodsController.RemoveLightningNetworkPaymentMethod(storeId, cryptoCode));
+            HandleActionResult(
+                await _storeLightningNetworkPaymentMethodsController.RemoveLightningNetworkPaymentMethod(storeId,
+                    cryptoCode));
         }
 
         public override async Task<LightningNetworkPaymentMethodData> UpdateStoreLightningNetworkPaymentMethod(
             string storeId, string cryptoCode,
             LightningNetworkPaymentMethodData paymentMethod, CancellationToken token = default)
         {
-            return GetFromActionResult<LightningNetworkPaymentMethodData>(await 
-                _storeLightningNetworkPaymentMethodsController.UpdateLightningNetworkPaymentMethod(storeId, cryptoCode, paymentMethod) );
+            return GetFromActionResult<LightningNetworkPaymentMethodData>(await
+                _storeLightningNetworkPaymentMethodsController.UpdateLightningNetworkPaymentMethod(storeId, cryptoCode,
+                    paymentMethod));
         }
 
-        public override async Task<IEnumerable<InvoiceData>> GetInvoices(string storeId, bool includeArchived = false,
-            CancellationToken token = default)
+        public override async Task<IEnumerable<InvoiceData>> GetInvoices(string storeId, string[] orderId = null,
+            InvoiceStatus[] status = null, DateTimeOffset? startDate = null,
+            DateTimeOffset? endDate = null, bool includeArchived = false, CancellationToken token = default)
         {
-            return GetFromActionResult<IEnumerable<InvoiceData>>(await  _greenFieldInvoiceController.GetInvoices(storeId, includeArchived) );
+            return GetFromActionResult<IEnumerable<InvoiceData>>(
+                await _greenFieldInvoiceController.GetInvoices(storeId, orderId,
+                    status?.Select(invoiceStatus => invoiceStatus.ToString())?.ToArray(), startDate,
+                    endDate, includeArchived));
         }
 
         public override async Task<InvoiceData> GetInvoice(string storeId, string invoiceId,
             CancellationToken token = default)
         {
-            return GetFromActionResult<InvoiceData>(await  _greenFieldInvoiceController.GetInvoice(storeId, invoiceId) );
+            return GetFromActionResult<InvoiceData>(await _greenFieldInvoiceController.GetInvoice(storeId, invoiceId));
         }
 
         public override async Task<InvoicePaymentMethodDataModel[]> GetInvoicePaymentMethods(string storeId,
             string invoiceId, CancellationToken token = default)
         {
-            return GetFromActionResult<InvoicePaymentMethodDataModel[]>(await  _greenFieldInvoiceController.GetInvoicePaymentMethods(storeId, invoiceId) );
+            return GetFromActionResult<InvoicePaymentMethodDataModel[]>(
+                await _greenFieldInvoiceController.GetInvoicePaymentMethods(storeId, invoiceId));
         }
 
         public override async Task ArchiveInvoice(string storeId, string invoiceId, CancellationToken token = default)
@@ -739,43 +781,48 @@ namespace BTCPayServer.Controllers.GreenField
         public override async Task<InvoiceData> CreateInvoice(string storeId, CreateInvoiceRequest request,
             CancellationToken token = default)
         {
-            return GetFromActionResult<InvoiceData>(await  _greenFieldInvoiceController.CreateInvoice(storeId, request) );
+            return GetFromActionResult<InvoiceData>(await _greenFieldInvoiceController.CreateInvoice(storeId, request));
         }
 
         public override async Task<InvoiceData> UpdateInvoice(string storeId, string invoiceId,
             UpdateInvoiceRequest request, CancellationToken token = default)
         {
-            return GetFromActionResult<InvoiceData>(await  _greenFieldInvoiceController.UpdateInvoice(storeId, invoiceId, request) );
+            return GetFromActionResult<InvoiceData>(
+                await _greenFieldInvoiceController.UpdateInvoice(storeId, invoiceId, request));
         }
 
         public override async Task<InvoiceData> MarkInvoiceStatus(string storeId, string invoiceId,
             MarkInvoiceStatusRequest request,
             CancellationToken token = default)
         {
-            return GetFromActionResult<InvoiceData>(await  _greenFieldInvoiceController.MarkInvoiceStatus(storeId, invoiceId, request) );
+            return GetFromActionResult<InvoiceData>(
+                await _greenFieldInvoiceController.MarkInvoiceStatus(storeId, invoiceId, request));
         }
 
         public override async Task<InvoiceData> UnarchiveInvoice(string storeId, string invoiceId,
             CancellationToken token = default)
         {
-            return GetFromActionResult<InvoiceData>(await  _greenFieldInvoiceController.UnarchiveInvoice(storeId, invoiceId) );
+            return GetFromActionResult<InvoiceData>(
+                await _greenFieldInvoiceController.UnarchiveInvoice(storeId, invoiceId));
         }
 
         public override async Task<ServerInfoData> GetServerInfo(CancellationToken token = default)
         {
-            return GetFromActionResult<ServerInfoData>(await  _greenFieldServerInfoController.ServerInfo() );
+            return GetFromActionResult<ServerInfoData>(await _greenFieldServerInfoController.ServerInfo());
         }
 
         public override async Task ActivateInvoicePaymentMethod(string storeId, string invoiceId, string paymentMethod,
             CancellationToken token = default)
         {
-            HandleActionResult(await _greenFieldInvoiceController.ActivateInvoicePaymentMethod(storeId, invoiceId, paymentMethod));
+            HandleActionResult(
+                await _greenFieldInvoiceController.ActivateInvoicePaymentMethod(storeId, invoiceId, paymentMethod));
         }
 
         public override async Task<OnChainWalletFeeRateData> GetOnChainFeeRate(string storeId, string cryptoCode,
             int? blockTarget = null, CancellationToken token = default)
         {
-            return GetFromActionResult<OnChainWalletFeeRateData>(await  _storeOnChainWalletsController.GetOnChainFeeRate(storeId,cryptoCode, blockTarget) );
+            return GetFromActionResult<OnChainWalletFeeRateData>(
+                await _storeOnChainWalletsController.GetOnChainFeeRate(storeId, cryptoCode, blockTarget));
         }
     }
 }

--- a/BTCPayServer/Controllers/GreenField/LocalBTCPayServerClient.cs
+++ b/BTCPayServer/Controllers/GreenField/LocalBTCPayServerClient.cs
@@ -107,6 +107,10 @@ namespace BTCPayServer.Controllers.GreenField
             if (storeIds?.Any() is true)
             {
                 context.SetStoreData(await _storeRepository.FindStore(storeIds.First()));
+                context.SetStoresData(await _storeRepository.GetStoresByUserId(userId, storeIds));
+            }
+            else
+            {
                 context.SetStoresData(await _storeRepository.GetStoresByUserId(userId));
             }
 

--- a/BTCPayServer/Controllers/GreenField/LocalBTCPayServerClient.cs
+++ b/BTCPayServer/Controllers/GreenField/LocalBTCPayServerClient.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Security.Claims;
 using System.Threading;
 using System.Threading.Tasks;
+using BTCPayServer.Abstractions.Contracts;
 using BTCPayServer.Client;
 using BTCPayServer.Client.Models;
 using BTCPayServer.Data;
@@ -17,81 +18,121 @@ using NBitcoin;
 using InvoiceData = BTCPayServer.Client.Models.InvoiceData;
 using NotificationData = BTCPayServer.Client.Models.NotificationData;
 using PaymentRequestData = BTCPayServer.Client.Models.PaymentRequestData;
+using PayoutData = BTCPayServer.Client.Models.PayoutData;
+using PullPaymentData = BTCPayServer.Client.Models.PullPaymentData;
 using StoreData = BTCPayServer.Client.Models.StoreData;
+using StoreWebhookData = BTCPayServer.Client.Models.StoreWebhookData;
+using WebhookDeliveryData = BTCPayServer.Client.Models.WebhookDeliveryData;
 
 namespace BTCPayServer.Controllers.GreenField
 {
-    //
-    // public class BTCPayServerClientFactory
-    // {
-    //     private readonly StoreRepository _storeRepository;
-    //     private readonly IOptionsMonitor<IdentityOptions> _identityOptions;
-    //     private readonly StoreOnChainPaymentMethodsController _chainPaymentMethodsController;
-    //     private readonly StoreOnChainWalletsController _storeOnChainWalletsController;
-    //     private readonly HealthController _healthController;
-    //     private readonly GreenFieldPaymentRequestsController _paymentRequestController;
-    //     private readonly ApiKeysController _apiKeysController;
-    //     private readonly NotificationsController _notificationsController;
-    //     private readonly UsersController _usersController;
-    //     private readonly GreenFieldStoresController _storesController;
-    //     private readonly StoreLightningNodeApiController _storeLightningNodeApiController;
-    //     private readonly UserManager<ApplicationUser> _userManager;
-    //     private readonly IHttpContextAccessor _httpContextAccessor;
-    //
-    //     public BTCPayServerClientFactory(StoreRepository storeRepository,
-    //         IOptionsMonitor<IdentityOptions> identityOptions,
-    //         StoreOnChainPaymentMethodsController chainPaymentMethodsController,
-    //         StoreOnChainWalletsController storeOnChainWalletsController,
-    //         HealthController healthController, 
-    //         GreenFieldPaymentRequestsController paymentRequestController,
-    //         ApiKeysController apiKeysController,
-    //         NotificationsController notificationsController, 
-    //         UsersController usersController,
-    //         GreenFieldStoresController storesController,
-    //         StoreLightningNodeApiController storeLightningNodeApiController,
-    //         UserManager<ApplicationUser> userManager,
-    //         IHttpContextAccessor httpContextAccessor )
-    //     {
-    //         _storeRepository = storeRepository;
-    //         _identityOptions = identityOptions;
-    //         _chainPaymentMethodsController = chainPaymentMethodsController;
-    //         _storeOnChainWalletsController = storeOnChainWalletsController;
-    //         _healthController = healthController;
-    //         _paymentRequestController = paymentRequestController;
-    //         _apiKeysController = apiKeysController;
-    //         _notificationsController = notificationsController;
-    //         _usersController = usersController;
-    //         _storesController = storesController;
-    //         _storeLightningNodeApiController = storeLightningNodeApiController;
-    //         _userManager = userManager;
-    //         _httpContextAccessor = httpContextAccessor;
-    //     }
-    //     
-    //     public BTCPayServerClient Create(string userId = null, params string[] storeIds)
-    //     {
-    //         return new LocalBTCPayServerClient(
-    //             _storeRepository,
-    //             _identityOptions,
-    //             _chainPaymentMethodsController,
-    //             _storeOnChainWalletsController,
-    //             _healthController,
-    //             _paymentRequestController,
-    //             _apiKeysController, 
-    //             _notificationsController, 
-    //             _usersController, 
-    //             _storesController,
-    //             _storeLightningNodeApiController, 
-    //             _userManager, 
-    //             _httpContextAccessor, 
-    //             userId, 
-    //             storeIds);
-    //     }
-    //     
-    //     
-    public class  LocalBTCPayServerClient: BTCPayServerClient
+    public class BTCPayServerClientFactory : IBTCPayServerClientFactory
     {
         private readonly StoreRepository _storeRepository;
         private readonly IOptionsMonitor<IdentityOptions> _identityOptions;
+        private readonly StoreOnChainPaymentMethodsController _chainPaymentMethodsController;
+        private readonly StoreOnChainWalletsController _storeOnChainWalletsController;
+        private readonly StoreLightningNetworkPaymentMethodsController _storeLightningNetworkPaymentMethodsController;
+        private readonly HealthController _healthController;
+        private readonly GreenFieldPaymentRequestsController _paymentRequestController;
+        private readonly ApiKeysController _apiKeysController;
+        private readonly NotificationsController _notificationsController;
+        private readonly UsersController _usersController;
+        private readonly GreenFieldStoresController _storesController;
+        private readonly InternalLightningNodeApiController _internalLightningNodeApiController;
+        private readonly StoreLightningNodeApiController _storeLightningNodeApiController;
+        private readonly GreenFieldInvoiceController _greenFieldInvoiceController;
+        private readonly UserManager<ApplicationUser> _userManager;
+        private readonly GreenFieldServerInfoController _greenFieldServerInfoController;
+        private readonly StoreWebhooksController _storeWebhooksController;
+        private readonly GreenfieldPullPaymentController _greenfieldPullPaymentController;
+
+        public BTCPayServerClientFactory(StoreRepository storeRepository,
+            IOptionsMonitor<IdentityOptions> identityOptions,
+            StoreOnChainPaymentMethodsController chainPaymentMethodsController,
+            StoreOnChainWalletsController storeOnChainWalletsController,
+            StoreLightningNetworkPaymentMethodsController storeLightningNetworkPaymentMethodsController,
+            HealthController healthController,
+            GreenFieldPaymentRequestsController paymentRequestController,
+            ApiKeysController apiKeysController,
+            NotificationsController notificationsController,
+            UsersController usersController,
+            GreenFieldStoresController storesController,
+            InternalLightningNodeApiController internalLightningNodeApiController,
+            StoreLightningNodeApiController storeLightningNodeApiController,
+            GreenFieldInvoiceController greenFieldInvoiceController,
+            UserManager<ApplicationUser> userManager,
+            GreenFieldServerInfoController greenFieldServerInfoController,
+            StoreWebhooksController storeWebhooksController,
+            GreenfieldPullPaymentController greenfieldPullPaymentController)
+        {
+            _storeRepository = storeRepository;
+            _identityOptions = identityOptions;
+            _chainPaymentMethodsController = chainPaymentMethodsController;
+            _storeOnChainWalletsController = storeOnChainWalletsController;
+            _storeLightningNetworkPaymentMethodsController = storeLightningNetworkPaymentMethodsController;
+            _healthController = healthController;
+            _paymentRequestController = paymentRequestController;
+            _apiKeysController = apiKeysController;
+            _notificationsController = notificationsController;
+            _usersController = usersController;
+            _storesController = storesController;
+            _internalLightningNodeApiController = internalLightningNodeApiController;
+            _storeLightningNodeApiController = storeLightningNodeApiController;
+            _greenFieldInvoiceController = greenFieldInvoiceController;
+            _userManager = userManager;
+            _greenFieldServerInfoController = greenFieldServerInfoController;
+            _storeWebhooksController = storeWebhooksController;
+            _greenfieldPullPaymentController = greenfieldPullPaymentController;
+        }
+
+        public async Task<BTCPayServerClient> Create(string userId, params string[] storeIds)
+        {
+            var context = new DefaultHttpContext();
+            if (!string.IsNullOrEmpty(userId))
+            {
+                var user = await _userManager.FindByIdAsync(userId);
+                List<Claim> claims = new List<Claim>
+                {
+                    new Claim(_identityOptions.CurrentValue.ClaimsIdentity.UserIdClaimType, userId),
+                    new Claim(GreenFieldConstants.ClaimTypes.Permission,
+                        Permission.Create(Policies.Unrestricted).ToString())
+                };
+                claims.AddRange((await _userManager.GetRolesAsync(user)).Select(s =>
+                    new Claim(_identityOptions.CurrentValue.ClaimsIdentity.RoleClaimType, s)));
+                context.User =
+                    new ClaimsPrincipal(new ClaimsIdentity(claims, GreenFieldConstants.AuthenticationType));
+            }
+
+            if (storeIds?.Any() is true)
+            {
+                context.SetStoreData(await _storeRepository.FindStore(storeIds.First()));
+                context.SetStoresData(await _storeRepository.GetStoresByUserId(userId));
+            }
+
+            return new LocalBTCPayServerClient(
+                _chainPaymentMethodsController,
+                _storeOnChainWalletsController,
+                _healthController,
+                _paymentRequestController,
+                _apiKeysController,
+                _notificationsController,
+                _usersController,
+                _storesController,
+                _storeLightningNodeApiController,
+                _internalLightningNodeApiController,
+                _storeLightningNetworkPaymentMethodsController,
+                _greenFieldInvoiceController,
+                _greenFieldServerInfoController,
+                _storeWebhooksController,
+                _greenfieldPullPaymentController,
+                new HttpContextAccessor() {HttpContext = context}
+            );
+        }
+    }
+
+    public class LocalBTCPayServerClient : BTCPayServerClient
+    {
         private readonly StoreOnChainPaymentMethodsController _chainPaymentMethodsController;
         private readonly StoreOnChainWalletsController _storeOnChainWalletsController;
         private readonly HealthController _healthController;
@@ -101,29 +142,30 @@ namespace BTCPayServer.Controllers.GreenField
         private readonly UsersController _usersController;
         private readonly GreenFieldStoresController _storesController;
         private readonly StoreLightningNodeApiController _storeLightningNodeApiController;
-        private readonly UserManager<ApplicationUser> _userManager;
-        private readonly IHttpContextAccessor _httpContextAccessor;
+        private readonly InternalLightningNodeApiController _lightningNodeApiController;
+        private readonly StoreLightningNetworkPaymentMethodsController _storeLightningNetworkPaymentMethodsController;
+        private readonly GreenFieldInvoiceController _greenFieldInvoiceController;
+        private readonly GreenFieldServerInfoController _greenFieldServerInfoController;
+        private readonly StoreWebhooksController _storeWebhooksController;
+        private readonly GreenfieldPullPaymentController _greenfieldPullPaymentController;
 
-        private ControllerBase[] _controllers;
-        
-        public  LocalBTCPayServerClient(
-            StoreRepository storeRepository,
-            IOptionsMonitor<IdentityOptions> identityOptions,
-            StoreOnChainPaymentMethodsController chainPaymentMethodsController,
+        public LocalBTCPayServerClient(StoreOnChainPaymentMethodsController chainPaymentMethodsController,
             StoreOnChainWalletsController storeOnChainWalletsController,
-            HealthController healthController, 
+            HealthController healthController,
             GreenFieldPaymentRequestsController paymentRequestController,
             ApiKeysController apiKeysController,
-            NotificationsController notificationsController, 
+            NotificationsController notificationsController,
             UsersController usersController,
             GreenFieldStoresController storesController,
             StoreLightningNodeApiController storeLightningNodeApiController,
-            UserManager<ApplicationUser> userManager,
+            InternalLightningNodeApiController lightningNodeApiController,
+            StoreLightningNetworkPaymentMethodsController storeLightningNetworkPaymentMethodsController,
+            GreenFieldInvoiceController greenFieldInvoiceController,
+            GreenFieldServerInfoController greenFieldServerInfoController,
+            StoreWebhooksController storeWebhooksController,
+            GreenfieldPullPaymentController greenfieldPullPaymentController,
             IHttpContextAccessor httpContextAccessor) : base(new Uri("http://dummy.com"), "", "")
         {
-            _storeRepository = storeRepository;
-            _identityOptions = identityOptions;
-            _httpContextAccessor = httpContextAccessor;
             _chainPaymentMethodsController = chainPaymentMethodsController;
             _storeOnChainWalletsController = storeOnChainWalletsController;
             _healthController = healthController;
@@ -133,26 +175,225 @@ namespace BTCPayServer.Controllers.GreenField
             _usersController = usersController;
             _storesController = storesController;
             _storeLightningNodeApiController = storeLightningNodeApiController;
-            _userManager = userManager;
+            _lightningNodeApiController = lightningNodeApiController;
+            _storeLightningNetworkPaymentMethodsController = storeLightningNetworkPaymentMethodsController;
+            _greenFieldInvoiceController = greenFieldInvoiceController;
+            _greenFieldServerInfoController = greenFieldServerInfoController;
+            _storeWebhooksController = storeWebhooksController;
+            _greenfieldPullPaymentController = greenfieldPullPaymentController;
 
-            _controllers = new[]
+            var controllers = new[]
             {
-                chainPaymentMethodsController, 
-                storeOnChainWalletsController, 
-                healthController, 
-                paymentRequestController, 
-                apiKeysController, 
-                notificationsController, 
-                usersController, 
-                storesController, 
-                storeLightningNodeApiController as ControllerBase, 
+                chainPaymentMethodsController, storeOnChainWalletsController, healthController,
+                paymentRequestController, apiKeysController, notificationsController, usersController,
+                storeLightningNetworkPaymentMethodsController, greenFieldInvoiceController,
+                greenFieldServerInfoController, greenfieldPullPaymentController, storesController,lightningNodeApiController,
+                storeLightningNodeApiController as ControllerBase,
             };
-            foreach (var controller in _controllers)
+            foreach (var controller in controllers)
             {
                 controller.ControllerContext.HttpContext = httpContextAccessor.HttpContext;
             }
         }
-        
+
+        public override async Task<StoreWebhookData> CreateWebhook(string storeId, CreateStoreWebhookRequest create, CancellationToken token = default)
+        {
+            return GetFromActionResult<StoreWebhookData>(
+                await _storeWebhooksController.CreateWebhook(storeId, create));
+        }
+
+        public override async Task<StoreWebhookData> GetWebhook(string storeId, string webhookId, CancellationToken token = default)
+        {
+            return GetFromActionResult<StoreWebhookData>(
+                await _storeWebhooksController.ListWebhooks(storeId, webhookId));
+        }
+
+        public override async Task<StoreWebhookData> UpdateWebhook(string storeId, string webhookId, UpdateStoreWebhookRequest update,
+            CancellationToken token = default)
+        {
+            return GetFromActionResult<StoreWebhookData>(
+                await _storeWebhooksController.UpdateWebhook(storeId, webhookId, update));
+        }
+
+        public override async Task<bool> DeleteWebhook(string storeId, string webhookId, CancellationToken token = default)
+        {
+            HandleActionResult(await _storeWebhooksController.DeleteWebhook(storeId, webhookId));
+            return true;
+        }
+
+        public override async Task<StoreWebhookData[]> GetWebhooks(string storeId, CancellationToken token = default)
+        {
+            return GetFromActionResult<StoreWebhookData[]>(
+                await _storeWebhooksController.ListWebhooks(storeId, null));
+        }
+
+        public override async Task<WebhookDeliveryData[]> GetWebhookDeliveries(string storeId, string webhookId, CancellationToken token = default)
+        {
+            return GetFromActionResult<WebhookDeliveryData[]>(
+                await _storeWebhooksController.ListDeliveries(storeId, webhookId, null));
+        }
+
+        public override async Task<WebhookDeliveryData> GetWebhookDelivery(string storeId, string webhookId, string deliveryId, CancellationToken token = default)
+        {
+            return GetFromActionResult<WebhookDeliveryData>(
+                await _storeWebhooksController.ListDeliveries(storeId, webhookId, deliveryId));
+        }
+
+        public override async Task<string> RedeliverWebhook(string storeId, string webhookId, string deliveryId, CancellationToken token = default)
+        {
+            return GetFromActionResult<string>(
+                await _storeWebhooksController.RedeliverWebhook(storeId, webhookId, deliveryId));
+        }
+
+        public override async Task<WebhookEvent> GetWebhookDeliveryRequest(string storeId, string webhookId, string deliveryId, CancellationToken token = default)
+        {
+            return GetFromActionResult<WebhookEvent>(
+                await _storeWebhooksController.GetDeliveryRequest(storeId, webhookId, deliveryId));
+        }
+
+        public override async Task<PullPaymentData> CreatePullPayment(string storeId, CreatePullPaymentRequest request, CancellationToken cancellationToken = default)
+        {
+            return GetFromActionResult<PullPaymentData>(
+                await _greenfieldPullPaymentController.CreatePullPayment(storeId, request));
+        }
+
+        public override async Task<PullPaymentData> GetPullPayment(string pullPaymentId, CancellationToken cancellationToken = default)
+        {
+            return GetFromActionResult<PullPaymentData>(
+                await _greenfieldPullPaymentController.GetPullPayment(pullPaymentId));
+        }
+
+        public override async Task<PullPaymentData[]> GetPullPayments(string storeId, bool includeArchived = false, CancellationToken cancellationToken = default)
+        {
+            return GetFromActionResult<PullPaymentData[]>(
+                await _greenfieldPullPaymentController.GetPullPayments(storeId,includeArchived ));
+        }
+
+        public override async Task ArchivePullPayment(string storeId, string pullPaymentId, CancellationToken cancellationToken = default)
+        {
+            HandleActionResult(await _greenfieldPullPaymentController.ArchivePullPayment(storeId, pullPaymentId));
+        }
+
+        public override async Task<PayoutData[]> GetPayouts(string pullPaymentId, bool includeCancelled = false, CancellationToken cancellationToken = default)
+        {
+            return GetFromActionResult<PayoutData[]>(
+                await _greenfieldPullPaymentController.GetPayouts(pullPaymentId, includeCancelled));
+        }
+
+        public override async Task<PayoutData> CreatePayout(string pullPaymentId, CreatePayoutRequest payoutRequest,
+            CancellationToken cancellationToken = default)
+        {
+            return GetFromActionResult<PayoutData>(
+                await _greenfieldPullPaymentController.CreatePayout(pullPaymentId, payoutRequest));
+        }
+
+        public override async Task CancelPayout(string storeId, string payoutId, CancellationToken cancellationToken = default)
+        {
+            HandleActionResult(await _greenfieldPullPaymentController.CancelPayout(storeId, payoutId));
+        }
+
+        public override async Task<PayoutData> ApprovePayout(string storeId, string payoutId, ApprovePayoutRequest request,
+            CancellationToken cancellationToken = default)
+        {
+            return GetFromActionResult<PayoutData>(
+                await _greenfieldPullPaymentController.ApprovePayout(storeId, payoutId, request, cancellationToken));
+        }
+
+        public override async Task<LightningNodeInformationData> GetLightningNodeInfo(string storeId, string cryptoCode, CancellationToken token = default)
+        {
+            return GetFromActionResult<LightningNodeInformationData>(
+                await _storeLightningNodeApiController.GetInfo(cryptoCode));
+        }
+
+        public override async Task ConnectToLightningNode(string storeId, string cryptoCode, ConnectToNodeRequest request,
+            CancellationToken token = default)
+        {
+            HandleActionResult(await _storeLightningNodeApiController.ConnectToNode(cryptoCode, request));
+        }
+
+        public override async Task<IEnumerable<LightningChannelData>> GetLightningNodeChannels(string storeId, string cryptoCode, CancellationToken token = default)
+        {
+            return GetFromActionResult<IEnumerable<LightningChannelData>>(
+                await _storeLightningNodeApiController.GetChannels(cryptoCode));
+        }
+
+        public override async Task OpenLightningChannel(string storeId, string cryptoCode, OpenLightningChannelRequest request,
+            CancellationToken token = default)
+        {
+            HandleActionResult(await _storeLightningNodeApiController.OpenChannel(cryptoCode, request));
+        }
+
+        public override async Task<string> GetLightningDepositAddress(string storeId, string cryptoCode, CancellationToken token = default)
+        {
+            return GetFromActionResult<string>(
+                await _storeLightningNodeApiController.GetDepositAddress(cryptoCode));
+        }
+
+        public override async Task PayLightningInvoice(string storeId, string cryptoCode, PayLightningInvoiceRequest request,
+            CancellationToken token = default)
+        {
+            HandleActionResult(await _storeLightningNodeApiController.PayInvoice(cryptoCode, request));
+        }
+
+        public override async Task<LightningInvoiceData> GetLightningInvoice(string storeId, string cryptoCode, string invoiceId, CancellationToken token = default)
+        {
+            return GetFromActionResult<LightningInvoiceData>(
+                await _storeLightningNodeApiController.GetInvoice(cryptoCode, invoiceId));
+        }
+
+        public override async Task<LightningInvoiceData> CreateLightningInvoice(string storeId, string cryptoCode, CreateLightningInvoiceRequest request,
+            CancellationToken token = default)
+        {
+            return GetFromActionResult<LightningInvoiceData>(
+                await _storeLightningNodeApiController.CreateInvoice(cryptoCode, request));
+        }
+
+        public override async Task<LightningNodeInformationData> GetLightningNodeInfo(string cryptoCode, CancellationToken token = default)
+        {
+            return GetFromActionResult<LightningNodeInformationData>(
+                await _lightningNodeApiController.GetInfo(cryptoCode));
+        }
+
+        public override async Task ConnectToLightningNode(string cryptoCode, ConnectToNodeRequest request, CancellationToken token = default)
+        {
+            HandleActionResult(await _lightningNodeApiController.ConnectToNode(cryptoCode, request));
+        }
+
+        public override async Task<IEnumerable<LightningChannelData>> GetLightningNodeChannels(string cryptoCode, CancellationToken token = default)
+        {
+            return GetFromActionResult<IEnumerable<LightningChannelData>>(
+                await _lightningNodeApiController.GetChannels(cryptoCode));
+        }
+
+        public override async Task OpenLightningChannel(string cryptoCode, OpenLightningChannelRequest request, CancellationToken token = default)
+        {
+            HandleActionResult(await _lightningNodeApiController.OpenChannel(cryptoCode, request));
+        }
+
+        public override async Task<string> GetLightningDepositAddress(string cryptoCode, CancellationToken token = default)
+        {
+            return GetFromActionResult<string>(
+                await _lightningNodeApiController.GetDepositAddress(cryptoCode));
+        }
+
+        public override async Task PayLightningInvoice(string cryptoCode, PayLightningInvoiceRequest request, CancellationToken token = default)
+        {
+            HandleActionResult(await _lightningNodeApiController.PayInvoice(cryptoCode, request));
+        }
+
+        public override async Task<LightningInvoiceData> GetLightningInvoice(string cryptoCode, string invoiceId, CancellationToken token = default)
+        {
+            return GetFromActionResult<LightningInvoiceData>(
+                await _lightningNodeApiController.GetInvoice(cryptoCode, invoiceId));
+        }
+
+        public override async Task<LightningInvoiceData> CreateLightningInvoice(string cryptoCode, CreateLightningInvoiceRequest request,
+            CancellationToken token = default)
+        {
+            return GetFromActionResult<LightningInvoiceData>(
+                await _lightningNodeApiController.CreateInvoice(cryptoCode, request));
+        }
+
 
         private T GetFromActionResult<T>(IActionResult result)
         {
@@ -165,6 +406,7 @@ namespace BTCPayServer.Controllers.GreenField
                     return default;
             }
         }
+
         private void HandleActionResult(IActionResult result)
         {
             switch (result)
@@ -179,52 +421,59 @@ namespace BTCPayServer.Controllers.GreenField
                     return;
             }
         }
+
         private T GetFromActionResult<T>(ActionResult result)
         {
             return GetFromActionResult<T>((IActionResult)result);
         }
+
         private T GetFromActionResult<T>(ActionResult<T> result)
         {
             return result.Value ?? GetFromActionResult<T>(result.Result);
         }
-
-        private async Task SetStore(string storeId )
+        public override async Task<IEnumerable<OnChainPaymentMethodData>> GetStoreOnChainPaymentMethods(string storeId,
+            CancellationToken token = default)
         {
-            _httpContextAccessor.HttpContext ??= new DefaultHttpContext();
-            _httpContextAccessor.HttpContext.SetStoreData(await _storeRepository.FindStore(storeId));
-        }
-        public override async Task<IEnumerable<OnChainPaymentMethodData>> GetStoreOnChainPaymentMethods(string storeId, CancellationToken token = default)
-        {
-            await SetStore(storeId);
             return GetFromActionResult(_chainPaymentMethodsController.GetOnChainPaymentMethods(storeId));
         }
 
-        public override async Task<OnChainPaymentMethodData> GetStoreOnChainPaymentMethod(string storeId, string cryptoCode, CancellationToken token = default)
+        public override async Task<OnChainPaymentMethodData> GetStoreOnChainPaymentMethod(string storeId,
+            string cryptoCode, CancellationToken token = default)
         {
-            return GetFromActionResult(await _chainPaymentMethodsController.GetOnChainPaymentMethod(storeId, cryptoCode));
+            return GetFromActionResult(
+                await _chainPaymentMethodsController.GetOnChainPaymentMethod(storeId, cryptoCode));
         }
 
-        public override async Task RemoveStoreOnChainPaymentMethod(string storeId, string cryptoCode, CancellationToken token = default)
-        {
-           HandleActionResult( await _chainPaymentMethodsController.RemoveOnChainPaymentMethod(storeId, cryptoCode));
-        }
-
-        public override async Task<OnChainPaymentMethodData> UpdateStoreOnChainPaymentMethod(string storeId, string cryptoCode, OnChainPaymentMethodData paymentMethod,
+        public override async Task RemoveStoreOnChainPaymentMethod(string storeId, string cryptoCode,
             CancellationToken token = default)
         {
-            return GetFromActionResult<OnChainPaymentMethodData>(await _chainPaymentMethodsController.UpdateOnChainPaymentMethod(storeId, cryptoCode, paymentMethod));
+            HandleActionResult(await _chainPaymentMethodsController.RemoveOnChainPaymentMethod(storeId, cryptoCode));
         }
 
-        public override Task<OnChainPaymentMethodPreviewResultData> PreviewProposedStoreOnChainPaymentMethodAddresses(string storeId, string cryptoCode,
+        public override async Task<OnChainPaymentMethodData> UpdateStoreOnChainPaymentMethod(string storeId,
+            string cryptoCode, OnChainPaymentMethodData paymentMethod,
+            CancellationToken token = default)
+        {
+            return GetFromActionResult<OnChainPaymentMethodData>(
+                await _chainPaymentMethodsController.UpdateOnChainPaymentMethod(storeId, cryptoCode, paymentMethod));
+        }
+
+        public override Task<OnChainPaymentMethodPreviewResultData> PreviewProposedStoreOnChainPaymentMethodAddresses(
+            string storeId, string cryptoCode,
             OnChainPaymentMethodData paymentMethod, int offset = 0, int amount = 10, CancellationToken token = default)
         {
-            return Task.FromResult(GetFromActionResult<OnChainPaymentMethodPreviewResultData>(_chainPaymentMethodsController.GetProposedOnChainPaymentMethodPreview(storeId, cryptoCode, paymentMethod, offset, amount)));
+            return Task.FromResult(GetFromActionResult<OnChainPaymentMethodPreviewResultData>(
+                _chainPaymentMethodsController.GetProposedOnChainPaymentMethodPreview(storeId, cryptoCode,
+                    paymentMethod, offset, amount)));
         }
 
-        public override async Task<OnChainPaymentMethodPreviewResultData> PreviewStoreOnChainPaymentMethodAddresses(string storeId, string cryptoCode, int offset = 0, int amount = 10,
+        public override async Task<OnChainPaymentMethodPreviewResultData> PreviewStoreOnChainPaymentMethodAddresses(
+            string storeId, string cryptoCode, int offset = 0, int amount = 10,
             CancellationToken token = default)
         {
-            return GetFromActionResult<OnChainPaymentMethodPreviewResultData>(await _chainPaymentMethodsController.GetOnChainPaymentMethodPreview(storeId, cryptoCode,  offset, amount));
+            return GetFromActionResult<OnChainPaymentMethodPreviewResultData>(
+                await _chainPaymentMethodsController.GetOnChainPaymentMethodPreview(storeId, cryptoCode, offset,
+                    amount));
         }
 
         public override Task<ApiHealthData> GetHealth(CancellationToken token = default)
@@ -232,45 +481,53 @@ namespace BTCPayServer.Controllers.GreenField
             return Task.FromResult(GetFromActionResult<ApiHealthData>(_healthController.GetHealth()));
         }
 
-        public override async Task<IEnumerable<PaymentRequestData>> GetPaymentRequests(string storeId, bool includeArchived = false, CancellationToken token = default)
+        public override async Task<IEnumerable<PaymentRequestData>> GetPaymentRequests(string storeId,
+            bool includeArchived = false, CancellationToken token = default)
         {
             return GetFromActionResult(await _paymentRequestController.GetPaymentRequests(storeId, includeArchived));
         }
 
-        public override async Task<PaymentRequestData> GetPaymentRequest(string storeId, string paymentRequestId, CancellationToken token = default)
+        public override async Task<PaymentRequestData> GetPaymentRequest(string storeId, string paymentRequestId,
+            CancellationToken token = default)
         {
             return GetFromActionResult(await _paymentRequestController.GetPaymentRequest(storeId, paymentRequestId));
         }
 
-        public override async Task ArchivePaymentRequest(string storeId, string paymentRequestId, CancellationToken token = default)
-        {
-            HandleActionResult( await _paymentRequestController.ArchivePaymentRequest(storeId, paymentRequestId));
-        }
-
-        public override async Task<PaymentRequestData> CreatePaymentRequest(string storeId, CreatePaymentRequestRequest request, CancellationToken token = default)
-        {
-            return GetFromActionResult<PaymentRequestData>(await _paymentRequestController.CreatePaymentRequest(storeId, request));
-        }
-
-        public override async Task<PaymentRequestData> UpdatePaymentRequest(string storeId, string paymentRequestId, UpdatePaymentRequestRequest request,
+        public override async Task ArchivePaymentRequest(string storeId, string paymentRequestId,
             CancellationToken token = default)
         {
-            return GetFromActionResult<PaymentRequestData>(await _paymentRequestController.UpdatePaymentRequest(storeId, paymentRequestId, request));
+            HandleActionResult(await _paymentRequestController.ArchivePaymentRequest(storeId, paymentRequestId));
+        }
+
+        public override async Task<PaymentRequestData> CreatePaymentRequest(string storeId,
+            CreatePaymentRequestRequest request, CancellationToken token = default)
+        {
+            return GetFromActionResult<PaymentRequestData>(
+                await _paymentRequestController.CreatePaymentRequest(storeId, request));
+        }
+
+        public override async Task<PaymentRequestData> UpdatePaymentRequest(string storeId, string paymentRequestId,
+            UpdatePaymentRequestRequest request,
+            CancellationToken token = default)
+        {
+            return GetFromActionResult<PaymentRequestData>(
+                await _paymentRequestController.UpdatePaymentRequest(storeId, paymentRequestId, request));
         }
 
         public override async Task<ApiKeyData> GetCurrentAPIKeyInfo(CancellationToken token = default)
         {
-            throw new NotSupportedException();
+            return GetFromActionResult(await _apiKeysController.GetKey());
         }
 
-        public override async Task<ApiKeyData> CreateAPIKey(CreateApiKeyRequest request, CancellationToken token = default)
+        public override async Task<ApiKeyData> CreateAPIKey(CreateApiKeyRequest request,
+            CancellationToken token = default)
         {
             return GetFromActionResult<ApiKeyData>(await _apiKeysController.CreateKey(request));
         }
 
         public override async Task RevokeCurrentAPIKeyInfo(CancellationToken token = default)
         {
-            throw new NotSupportedException();
+            HandleActionResult(await _apiKeysController.RevokeCurrentKey());
         }
 
         public override async Task RevokeAPIKey(string apikey, CancellationToken token = default)
@@ -278,22 +535,26 @@ namespace BTCPayServer.Controllers.GreenField
             HandleActionResult(await _apiKeysController.RevokeKey(apikey));
         }
 
-        public override async Task<IEnumerable<NotificationData>> GetNotifications(bool? seen = null, CancellationToken token = default)
+        public override async Task<IEnumerable<NotificationData>> GetNotifications(bool? seen = null,
+            CancellationToken token = default)
         {
-            return GetFromActionResult<IEnumerable<NotificationData>>(await _notificationsController.GetNotifications(seen));
+            return GetFromActionResult<IEnumerable<NotificationData>>(
+                await _notificationsController.GetNotifications(seen));
         }
 
-        public override async Task<NotificationData> GetNotification(string notificationId, CancellationToken token = default)
+        public override async Task<NotificationData> GetNotification(string notificationId,
+            CancellationToken token = default)
         {
-            return GetFromActionResult<NotificationData>(await _notificationsController.GetNotification(notificationId));
+            return GetFromActionResult<NotificationData>(
+                await _notificationsController.GetNotification(notificationId));
         }
 
-        public override async Task<NotificationData> UpdateNotification(string notificationId, bool? seen, CancellationToken token = default)
+        public override async Task<NotificationData> UpdateNotification(string notificationId, bool? seen,
+            CancellationToken token = default)
         {
-            return GetFromActionResult<NotificationData>(await _notificationsController.UpdateNotification(notificationId, new UpdateNotification()
-            {
-                Seen = seen
-            }));
+            return GetFromActionResult<NotificationData>(
+                await _notificationsController.UpdateNotification(notificationId,
+                    new UpdateNotification() {Seen = seen}));
         }
 
         public override async Task RemoveNotification(string notificationId, CancellationToken token = default)
@@ -306,72 +567,86 @@ namespace BTCPayServer.Controllers.GreenField
             return GetFromActionResult(await _usersController.GetCurrentUser());
         }
 
-        public override async Task<ApplicationUserData> CreateUser(CreateApplicationUserRequest request, CancellationToken token = default)
+        public override async Task<ApplicationUserData> CreateUser(CreateApplicationUserRequest request,
+            CancellationToken token = default)
         {
             return GetFromActionResult<ApplicationUserData>(await _usersController.CreateUser(request, token));
         }
 
-        public override async Task<OnChainWalletOverviewData> ShowOnChainWalletOverview(string storeId, string cryptoCode, CancellationToken token = default)
+        public override async Task<OnChainWalletOverviewData> ShowOnChainWalletOverview(string storeId,
+            string cryptoCode, CancellationToken token = default)
         {
-            await SetStore(storeId);
-            return GetFromActionResult<OnChainWalletOverviewData>(await _storeOnChainWalletsController.ShowOnChainWalletOverview(storeId, cryptoCode));
+            return GetFromActionResult<OnChainWalletOverviewData>(
+                await _storeOnChainWalletsController.ShowOnChainWalletOverview(storeId, cryptoCode));
         }
 
-        public override async Task<OnChainWalletAddressData> GetOnChainWalletReceiveAddress(string storeId, string cryptoCode, bool forceGenerate = false,
+        public override async Task<OnChainWalletAddressData> GetOnChainWalletReceiveAddress(string storeId,
+            string cryptoCode, bool forceGenerate = false,
             CancellationToken token = default)
         {
-            await SetStore(storeId);
-            return GetFromActionResult<OnChainWalletAddressData>(await _storeOnChainWalletsController.GetOnChainWalletReceiveAddress(storeId, cryptoCode, forceGenerate));
+            return GetFromActionResult<OnChainWalletAddressData>(
+                await _storeOnChainWalletsController.GetOnChainWalletReceiveAddress(storeId, cryptoCode,
+                    forceGenerate));
         }
 
-        public override async Task UnReserveOnChainWalletReceiveAddress(string storeId, string cryptoCode, CancellationToken token = default)
-        {
-            await SetStore(storeId);
-            HandleActionResult(await _storeOnChainWalletsController.UnReserveOnChainWalletReceiveAddress(storeId, cryptoCode));
-        }
-
-        public override async Task<IEnumerable<OnChainWalletTransactionData>> ShowOnChainWalletTransactions(string storeId, string cryptoCode, TransactionStatus[] statusFilter = null,
+        public override async Task UnReserveOnChainWalletReceiveAddress(string storeId, string cryptoCode,
             CancellationToken token = default)
         {
-            await SetStore(storeId);
-            return GetFromActionResult<IEnumerable<OnChainWalletTransactionData>>(await _storeOnChainWalletsController.ShowOnChainWalletTransactions(storeId, cryptoCode, statusFilter));
+            HandleActionResult(
+                await _storeOnChainWalletsController.UnReserveOnChainWalletReceiveAddress(storeId, cryptoCode));
         }
 
-        public override async Task<OnChainWalletTransactionData> GetOnChainWalletTransaction(string storeId, string cryptoCode, string transactionId,
+        public override async Task<IEnumerable<OnChainWalletTransactionData>> ShowOnChainWalletTransactions(
+            string storeId, string cryptoCode, TransactionStatus[] statusFilter = null,
             CancellationToken token = default)
         {
-            await SetStore(storeId);
-            return GetFromActionResult<OnChainWalletTransactionData>(await _storeOnChainWalletsController.GetOnChainWalletTransaction(storeId, cryptoCode, transactionId));
+            return GetFromActionResult<IEnumerable<OnChainWalletTransactionData>>(
+                await _storeOnChainWalletsController.ShowOnChainWalletTransactions(storeId, cryptoCode, statusFilter));
         }
 
-        public override async Task<IEnumerable<OnChainWalletUTXOData>> GetOnChainWalletUTXOs(string storeId, string cryptoCode, CancellationToken token = default)
-        {
-            await SetStore(storeId);
-            return GetFromActionResult<IEnumerable<OnChainWalletUTXOData>>(await _storeOnChainWalletsController.GetOnChainWalletUTXOs(storeId, cryptoCode));
-        }
-
-        public override async Task<OnChainWalletTransactionData> CreateOnChainTransaction(string storeId, string cryptoCode, CreateOnChainTransactionRequest request,
+        public override async Task<OnChainWalletTransactionData> GetOnChainWalletTransaction(string storeId,
+            string cryptoCode, string transactionId,
             CancellationToken token = default)
         {
-            await SetStore(storeId);
+            return GetFromActionResult<OnChainWalletTransactionData>(
+                await _storeOnChainWalletsController.GetOnChainWalletTransaction(storeId, cryptoCode, transactionId));
+        }
+
+        public override async Task<IEnumerable<OnChainWalletUTXOData>> GetOnChainWalletUTXOs(string storeId,
+            string cryptoCode, CancellationToken token = default)
+        {
+            return GetFromActionResult<IEnumerable<OnChainWalletUTXOData>>(
+                await _storeOnChainWalletsController.GetOnChainWalletUTXOs(storeId, cryptoCode));
+        }
+
+        public override async Task<OnChainWalletTransactionData> CreateOnChainTransaction(string storeId,
+            string cryptoCode, CreateOnChainTransactionRequest request,
+            CancellationToken token = default)
+        {
             if (!request.ProceedWithBroadcast)
             {
                 throw new ArgumentOutOfRangeException(nameof(request.ProceedWithBroadcast),
                     "Please use CreateOnChainTransactionButDoNotBroadcast when wanting to only create the transaction");
             }
-            return GetFromActionResult<OnChainWalletTransactionData>(await _storeOnChainWalletsController.CreateOnChainTransaction(storeId, cryptoCode, request));
+
+            return GetFromActionResult<OnChainWalletTransactionData>(
+                await _storeOnChainWalletsController.CreateOnChainTransaction(storeId, cryptoCode, request));
         }
 
-        public override async Task<Transaction> CreateOnChainTransactionButDoNotBroadcast(string storeId, string cryptoCode,
+        public override async Task<Transaction> CreateOnChainTransactionButDoNotBroadcast(string storeId,
+            string cryptoCode,
             CreateOnChainTransactionRequest request, Network network, CancellationToken token = default)
         {
-            await SetStore(storeId);
             if (request.ProceedWithBroadcast)
             {
                 throw new ArgumentOutOfRangeException(nameof(request.ProceedWithBroadcast),
                     "Please use CreateOnChainTransaction when wanting to also broadcast the transaction");
             }
-            return Transaction.Parse( GetFromActionResult<string>(await _storeOnChainWalletsController.CreateOnChainTransaction(storeId, cryptoCode, request)), network);
+
+            return Transaction.Parse(
+                GetFromActionResult<string>(
+                    await _storeOnChainWalletsController.CreateOnChainTransaction(storeId, cryptoCode, request)),
+                network);
         }
 
         public override async Task<IEnumerable<StoreData>> GetStores(CancellationToken token = default)
@@ -381,13 +656,11 @@ namespace BTCPayServer.Controllers.GreenField
 
         public override async Task<StoreData> GetStore(string storeId, CancellationToken token = default)
         {
-            await SetStore(storeId);
             return GetFromActionResult(await _storesController.GetStore(storeId));
         }
 
         public override async Task RemoveStore(string storeId, CancellationToken token = default)
         {
-            await SetStore(storeId);
             HandleActionResult(await _storesController.RemoveStore(storeId));
         }
 
@@ -396,84 +669,103 @@ namespace BTCPayServer.Controllers.GreenField
             return GetFromActionResult<StoreData>(await _storesController.CreateStore(request));
         }
 
-        public override async Task<StoreData> UpdateStore(string storeId, UpdateStoreRequest request, CancellationToken token = default)
+        public override async Task<StoreData> UpdateStore(string storeId, UpdateStoreRequest request,
+            CancellationToken token = default)
         {
-            await SetStore(storeId);
             return GetFromActionResult<StoreData>(await _storesController.UpdateStore(storeId, request));
         }
 
-        public override async Task<IEnumerable<LightningNetworkPaymentMethodData>> GetStoreLightningNetworkPaymentMethods(string storeId, CancellationToken token = default)
+        public override async Task<IEnumerable<LightningNetworkPaymentMethodData>>
+            GetStoreLightningNetworkPaymentMethods(string storeId, bool enabledOnly = false,CancellationToken token = default)
         {
-            throw new NotSupportedException();
+            return GetFromActionResult(
+                _storeLightningNetworkPaymentMethodsController.GetLightningPaymentMethods(storeId, enabledOnly));
         }
 
-        public override async Task<LightningNetworkPaymentMethodData> GetStoreLightningNetworkPaymentMethod(string storeId, string cryptoCode, CancellationToken token = default)
+        public override async Task<LightningNetworkPaymentMethodData> GetStoreLightningNetworkPaymentMethod(
+            string storeId, string cryptoCode, CancellationToken token = default)
         {
-            throw new NotSupportedException();
+            return GetFromActionResult(
+                _storeLightningNetworkPaymentMethodsController.GetLightningNetworkPaymentMethod(storeId, cryptoCode));
         }
 
-        public override async Task RemoveStoreLightningNetworkPaymentMethod(string storeId, string cryptoCode, CancellationToken token = default)
+        public override async Task RemoveStoreLightningNetworkPaymentMethod(string storeId, string cryptoCode,
+            CancellationToken token = default)
         {
-            throw new NotSupportedException();
+            HandleActionResult(await _storeLightningNetworkPaymentMethodsController.RemoveLightningNetworkPaymentMethod(storeId, cryptoCode));
         }
 
-        public override async Task<LightningNetworkPaymentMethodData> UpdateStoreLightningNetworkPaymentMethod(string storeId, string cryptoCode,
+        public override async Task<LightningNetworkPaymentMethodData> UpdateStoreLightningNetworkPaymentMethod(
+            string storeId, string cryptoCode,
             LightningNetworkPaymentMethodData paymentMethod, CancellationToken token = default)
         {
-            throw new NotSupportedException();
+            return GetFromActionResult<LightningNetworkPaymentMethodData>(await 
+                _storeLightningNetworkPaymentMethodsController.UpdateLightningNetworkPaymentMethod(storeId, cryptoCode, paymentMethod) );
         }
 
-        public override async Task<LightningNetworkPaymentMethodData> UpdateStoreLightningNetworkPaymentMethodToInternalNode(string storeId, string cryptoCode,
-            LightningNetworkPaymentMethodData paymentMethod, CancellationToken token = default)
+        public override async Task<IEnumerable<InvoiceData>> GetInvoices(string storeId, bool includeArchived = false,
+            CancellationToken token = default)
         {
-            throw new NotSupportedException();
+            return GetFromActionResult<IEnumerable<InvoiceData>>(await  _greenFieldInvoiceController.GetInvoices(storeId, includeArchived) );
         }
 
-        public override async Task<IEnumerable<InvoiceData>> GetInvoices(string storeId, bool includeArchived = false, CancellationToken token = default)
+        public override async Task<InvoiceData> GetInvoice(string storeId, string invoiceId,
+            CancellationToken token = default)
         {
-            throw new NotSupportedException();
+            return GetFromActionResult<InvoiceData>(await  _greenFieldInvoiceController.GetInvoice(storeId, invoiceId) );
         }
 
-        public override async Task<InvoiceData> GetInvoice(string storeId, string invoiceId, CancellationToken token = default)
+        public override async Task<InvoicePaymentMethodDataModel[]> GetInvoicePaymentMethods(string storeId,
+            string invoiceId, CancellationToken token = default)
         {
-            throw new NotSupportedException();
-        }
-
-        public override async Task<InvoicePaymentMethodDataModel[]> GetInvoicePaymentMethods(string storeId, string invoiceId, CancellationToken token = default)
-        {
-            throw new NotSupportedException();
+            return GetFromActionResult<InvoicePaymentMethodDataModel[]>(await  _greenFieldInvoiceController.GetInvoicePaymentMethods(storeId, invoiceId) );
         }
 
         public override async Task ArchiveInvoice(string storeId, string invoiceId, CancellationToken token = default)
         {
-            throw new NotSupportedException();
+            HandleActionResult(await _greenFieldInvoiceController.ArchiveInvoice(storeId, invoiceId));
         }
 
-        public override async Task<InvoiceData> CreateInvoice(string storeId, CreateInvoiceRequest request, CancellationToken token = default)
-        {
-            throw new NotSupportedException();
-        }
-
-        public override async Task<InvoiceData> UpdateInvoice(string storeId, string invoiceId, UpdateInvoiceRequest request, CancellationToken token = default)
-        {
-            throw new NotSupportedException();
-        }
-
-        public override async Task<InvoiceData> MarkInvoiceStatus(string storeId, string invoiceId, MarkInvoiceStatusRequest request,
+        public override async Task<InvoiceData> CreateInvoice(string storeId, CreateInvoiceRequest request,
             CancellationToken token = default)
         {
-            throw new NotSupportedException();
+            return GetFromActionResult<InvoiceData>(await  _greenFieldInvoiceController.CreateInvoice(storeId, request) );
         }
 
-        public override async Task<InvoiceData> UnarchiveInvoice(string storeId, string invoiceId, CancellationToken token = default)
+        public override async Task<InvoiceData> UpdateInvoice(string storeId, string invoiceId,
+            UpdateInvoiceRequest request, CancellationToken token = default)
         {
-            throw new NotSupportedException();
+            return GetFromActionResult<InvoiceData>(await  _greenFieldInvoiceController.UpdateInvoice(storeId, invoiceId, request) );
+        }
+
+        public override async Task<InvoiceData> MarkInvoiceStatus(string storeId, string invoiceId,
+            MarkInvoiceStatusRequest request,
+            CancellationToken token = default)
+        {
+            return GetFromActionResult<InvoiceData>(await  _greenFieldInvoiceController.MarkInvoiceStatus(storeId, invoiceId, request) );
+        }
+
+        public override async Task<InvoiceData> UnarchiveInvoice(string storeId, string invoiceId,
+            CancellationToken token = default)
+        {
+            return GetFromActionResult<InvoiceData>(await  _greenFieldInvoiceController.UnarchiveInvoice(storeId, invoiceId) );
         }
 
         public override async Task<ServerInfoData> GetServerInfo(CancellationToken token = default)
         {
-            throw new NotSupportedException();
+            return GetFromActionResult<ServerInfoData>(await  _greenFieldServerInfoController.ServerInfo() );
+        }
+
+        public override async Task ActivateInvoicePaymentMethod(string storeId, string invoiceId, string paymentMethod,
+            CancellationToken token = default)
+        {
+            HandleActionResult(await _greenFieldInvoiceController.ActivateInvoicePaymentMethod(storeId, invoiceId, paymentMethod));
+        }
+
+        public override async Task<OnChainWalletFeeRateData> GetOnChainFeeRate(string storeId, string cryptoCode,
+            int? blockTarget = null, CancellationToken token = default)
+        {
+            return GetFromActionResult<OnChainWalletFeeRateData>(await  _storeOnChainWalletsController.GetOnChainFeeRate(storeId,cryptoCode, blockTarget) );
         }
     }
-    
 }

--- a/BTCPayServer/Controllers/GreenField/LocalBTCPayServerClient.cs
+++ b/BTCPayServer/Controllers/GreenField/LocalBTCPayServerClient.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net.Http;
 using System.Security.Claims;
 using System.Threading;
 using System.Threading.Tasks;
@@ -198,6 +199,11 @@ namespace BTCPayServer.Controllers.GreenField
             {
                 controller.ControllerContext.HttpContext = httpContextAccessor.HttpContext;
             }
+        }
+
+        protected override HttpRequestMessage CreateHttpRequest(string path, Dictionary<string, object> queryPayload = null, HttpMethod method = null)
+        {
+            throw new NotSupportedException("This method is not supported by the LocalBTCPayServerClient.");
         }
 
         public override async Task<StoreWebhookData> CreateWebhook(string storeId, CreateStoreWebhookRequest create, CancellationToken token = default)

--- a/BTCPayServer/Controllers/GreenField/LocalBTCPayServerClient.cs
+++ b/BTCPayServer/Controllers/GreenField/LocalBTCPayServerClient.cs
@@ -1,0 +1,356 @@
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Security.Claims;
+using System.Threading;
+using System.Threading.Tasks;
+using BTCPayServer.Client;
+using BTCPayServer.Client.Models;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using NBitcoin;
+
+namespace BTCPayServer.Controllers.GreenField
+{
+    public class LocalBTCPayServerClient: BTCPayServerClient
+    {
+        private readonly StoreOnChainPaymentMethodsController _chainPaymentMethodsController;
+        private readonly StoreOnChainWalletsController _storeOnChainWalletsController;
+        private readonly HealthController _healthController;
+        private readonly GreenFieldPaymentRequestsController _paymentRequestController;
+        private readonly ApiKeysController _apiKeysController;
+        private readonly NotificationsController _notificationsController;
+        private readonly UsersController _usersController;
+        private readonly GreenFieldStoresController _storesController;
+        private readonly StoreLightningNodeApiController _storeLightningNodeApiController;
+        private readonly IHttpContextAccessor _httpContextAccessor;
+
+        public  LocalBTCPayServerClient(
+            StoreOnChainPaymentMethodsController chainPaymentMethodsController,
+            StoreOnChainWalletsController storeOnChainWalletsController,
+            HealthController healthController, 
+            GreenFieldPaymentRequestsController paymentRequestController,
+            ApiKeysController apiKeysController,
+            NotificationsController notificationsController, 
+            UsersController usersController,
+            GreenFieldStoresController storesController,
+            StoreLightningNodeApiController storeLightningNodeApiController,
+            IHttpContextAccessor httpContextAccessor) : base(new Uri(""), "", "")
+        {
+            _chainPaymentMethodsController = chainPaymentMethodsController;
+            _storeOnChainWalletsController = storeOnChainWalletsController;
+            _healthController = healthController;
+            _paymentRequestController = paymentRequestController;
+            _apiKeysController = apiKeysController;
+            _notificationsController = notificationsController;
+            _usersController = usersController;
+            _storesController = storesController;
+            _storeLightningNodeApiController = storeLightningNodeApiController;
+            _httpContextAccessor = httpContextAccessor;
+        }
+
+        private T GetFromActionResult<T>(IActionResult result)
+        {
+            HandleActionResult(result);
+            switch (result)
+            {
+                case OkObjectResult {Value: T res}:
+                    return res;
+                default:
+                    return default;
+            }
+        }
+        private void HandleActionResult(IActionResult result)
+        {
+            switch (result)
+            {
+                case UnprocessableEntityObjectResult {Value: List<GreenfieldValidationError> validationErrors}:
+                    throw new GreenFieldValidationException(validationErrors.ToArray());
+                case BadRequestObjectResult {Value: GreenfieldAPIError error}:
+                    throw new GreenFieldAPIException(error);
+                case NotFoundResult _:
+                    throw new GreenFieldAPIException(new GreenfieldAPIError("not-found", ""));
+                default:
+                    return;
+            }
+        }
+        private T GetFromActionResult<T>(ActionResult result)
+        {
+            return GetFromActionResult<T>((IActionResult)result);
+        }
+        private T GetFromActionResult<T>(ActionResult<T> result)
+        {
+            return GetFromActionResult<T>(result.Result);
+        }
+
+        public override async Task<IEnumerable<OnChainPaymentMethodData>> GetStoreOnChainPaymentMethods(string storeId, CancellationToken token = default)
+        {
+            return GetFromActionResult(await _chainPaymentMethodsController.GetOnChainPaymentMethods(storeId));
+        }
+
+        public override async Task<OnChainPaymentMethodData> GetStoreOnChainPaymentMethod(string storeId, string cryptoCode, CancellationToken token = default)
+        {
+            return GetFromActionResult(await _chainPaymentMethodsController.GetOnChainPaymentMethod(storeId, cryptoCode));
+        }
+
+        public override async Task RemoveStoreOnChainPaymentMethod(string storeId, string cryptoCode, CancellationToken token = default)
+        {
+           HandleActionResult( await _chainPaymentMethodsController.RemoveOnChainPaymentMethod(storeId, cryptoCode));
+        }
+
+        public override async Task<OnChainPaymentMethodData> UpdateStoreOnChainPaymentMethod(string storeId, string cryptoCode, OnChainPaymentMethodData paymentMethod,
+            CancellationToken token = default)
+        {
+            return GetFromActionResult<OnChainPaymentMethodData>(await _chainPaymentMethodsController.UpdateOnChainPaymentMethod(storeId, cryptoCode, paymentMethod));
+        }
+
+        public override Task<OnChainPaymentMethodPreviewResultData> PreviewProposedStoreOnChainPaymentMethodAddresses(string storeId, string cryptoCode,
+            OnChainPaymentMethodData paymentMethod, int offset = 0, int amount = 10, CancellationToken token = default)
+        {
+            return Task.FromResult(GetFromActionResult<OnChainPaymentMethodPreviewResultData>(_chainPaymentMethodsController.GetProposedOnChainPaymentMethodPreview(storeId, cryptoCode, paymentMethod, offset, amount)));
+        }
+
+        public override async Task<OnChainPaymentMethodPreviewResultData> PreviewStoreOnChainPaymentMethodAddresses(string storeId, string cryptoCode, int offset = 0, int amount = 10,
+            CancellationToken token = default)
+        {
+            return GetFromActionResult<OnChainPaymentMethodPreviewResultData>(await _chainPaymentMethodsController.GetOnChainPaymentMethodPreview(storeId, cryptoCode,  offset, amount));
+        }
+
+        public override Task<ApiHealthData> GetHealth(CancellationToken token = default)
+        {
+            return Task.FromResult(GetFromActionResult<ApiHealthData>(_healthController.GetHealth()));
+        }
+
+        public override async Task<IEnumerable<PaymentRequestData>> GetPaymentRequests(string storeId, bool includeArchived = false, CancellationToken token = default)
+        {
+            return GetFromActionResult(await _paymentRequestController.GetPaymentRequests(storeId, includeArchived));
+        }
+
+        public override async Task<PaymentRequestData> GetPaymentRequest(string storeId, string paymentRequestId, CancellationToken token = default)
+        {
+            return GetFromActionResult(await _paymentRequestController.GetPaymentRequest(storeId, paymentRequestId));
+        }
+
+        public override async Task ArchivePaymentRequest(string storeId, string paymentRequestId, CancellationToken token = default)
+        {
+            HandleActionResult( await _paymentRequestController.ArchivePaymentRequest(storeId, paymentRequestId));
+        }
+
+        public override async Task<PaymentRequestData> CreatePaymentRequest(string storeId, CreatePaymentRequestRequest request, CancellationToken token = default)
+        {
+            return GetFromActionResult<PaymentRequestData>(await _paymentRequestController.CreatePaymentRequest(storeId, request));
+        }
+
+        public override async Task<PaymentRequestData> UpdatePaymentRequest(string storeId, string paymentRequestId, UpdatePaymentRequestRequest request,
+            CancellationToken token = default)
+        {
+            return GetFromActionResult<PaymentRequestData>(await _paymentRequestController.UpdatePaymentRequest(storeId, paymentRequestId, request));
+        }
+
+        public override async Task<ApiKeyData> GetCurrentAPIKeyInfo(CancellationToken token = default)
+        {
+            return GetFromActionResult(await _apiKeysController.GetKey());
+        }
+
+        public override async Task<ApiKeyData> CreateAPIKey(CreateApiKeyRequest request, CancellationToken token = default)
+        {
+            return GetFromActionResult<ApiKeyData>(await _apiKeysController.CreateKey(request));
+        }
+
+        public override async Task RevokeCurrentAPIKeyInfo(CancellationToken token = default)
+        {
+            HandleActionResult(await _apiKeysController.RevokeCurrentKey());
+        }
+
+        public override async Task RevokeAPIKey(string apikey, CancellationToken token = default)
+        {
+            HandleActionResult(await _apiKeysController.RevokeKey(apikey));
+        }
+
+        public override async Task<IEnumerable<NotificationData>> GetNotifications(bool? seen = null, CancellationToken token = default)
+        {
+            return GetFromActionResult<IEnumerable<NotificationData>>(await _notificationsController.GetNotifications(seen));
+        }
+
+        public override async Task<NotificationData> GetNotification(string notificationId, CancellationToken token = default)
+        {
+            return GetFromActionResult<NotificationData>(await _notificationsController.GetNotification(notificationId));
+        }
+
+        public override async Task<NotificationData> UpdateNotification(string notificationId, bool? seen, CancellationToken token = default)
+        {
+            return GetFromActionResult<NotificationData>(await _notificationsController.UpdateNotification(notificationId, new UpdateNotification()
+            {
+                Seen = seen
+            }));
+        }
+
+        public override async Task RemoveNotification(string notificationId, CancellationToken token = default)
+        {
+            HandleActionResult(await _notificationsController.DeleteNotification(notificationId));
+        }
+
+        public override async Task<ApplicationUserData> GetCurrentUser(CancellationToken token = default)
+        {
+            return GetFromActionResult(await _usersController.GetCurrentUser());
+        }
+
+        public override async Task<ApplicationUserData> CreateUser(CreateApplicationUserRequest request, CancellationToken token = default)
+        {
+            return GetFromActionResult<ApplicationUserData>(await _usersController.CreateUser(request, token));
+        }
+
+        public override async Task<OnChainWalletOverviewData> ShowOnChainWalletOverview(string storeId, string cryptoCode, CancellationToken token = default)
+        {
+            return GetFromActionResult<OnChainWalletOverviewData>(await _storeOnChainWalletsController.ShowOnChainWalletOverview(storeId, cryptoCode));
+        }
+
+        public override async Task<OnChainWalletAddressData> GetOnChainWalletReceiveAddress(string storeId, string cryptoCode, bool forceGenerate = false,
+            CancellationToken token = default)
+        {
+            return GetFromActionResult<OnChainWalletAddressData>(await _storeOnChainWalletsController.GetOnChainWalletReceiveAddress(storeId, cryptoCode, forceGenerate));
+        }
+
+        public override async Task UnReserveOnChainWalletReceiveAddress(string storeId, string cryptoCode, CancellationToken token = default)
+        {
+            HandleActionResult(await _storeOnChainWalletsController.UnReserveOnChainWalletReceiveAddress(storeId, cryptoCode));
+        }
+
+        public override async Task<IEnumerable<OnChainWalletTransactionData>> ShowOnChainWalletTransactions(string storeId, string cryptoCode, TransactionStatus[] statusFilter = null,
+            CancellationToken token = default)
+        {
+            return GetFromActionResult<IEnumerable<OnChainWalletTransactionData>>(await _storeOnChainWalletsController.ShowOnChainWalletTransactions(storeId, cryptoCode, statusFilter));
+        }
+
+        public override async Task<OnChainWalletTransactionData> GetOnChainWalletTransaction(string storeId, string cryptoCode, string transactionId,
+            CancellationToken token = default)
+        {
+            return GetFromActionResult<OnChainWalletTransactionData>(await _storeOnChainWalletsController.GetOnChainWalletTransaction(storeId, cryptoCode, transactionId));
+        }
+
+        public override async Task<IEnumerable<OnChainWalletUTXOData>> GetOnChainWalletUTXOs(string storeId, string cryptoCode, CancellationToken token = default)
+        {
+            return GetFromActionResult<IEnumerable<OnChainWalletUTXOData>>(await _storeOnChainWalletsController.GetOnChainWalletUTXOs(storeId, cryptoCode));
+        }
+
+        public override async Task<OnChainWalletTransactionData> CreateOnChainTransaction(string storeId, string cryptoCode, CreateOnChainTransactionRequest request,
+            CancellationToken token = default)
+        {
+            if (!request.ProceedWithBroadcast)
+            {
+                throw new ArgumentOutOfRangeException(nameof(request.ProceedWithBroadcast),
+                    "Please use CreateOnChainTransactionButDoNotBroadcast when wanting to only create the transaction");
+            }
+            return GetFromActionResult<OnChainWalletTransactionData>(await _storeOnChainWalletsController.CreateOnChainTransaction(storeId, cryptoCode, request));
+        }
+
+        public override async Task<Transaction> CreateOnChainTransactionButDoNotBroadcast(string storeId, string cryptoCode,
+            CreateOnChainTransactionRequest request, Network network, CancellationToken token = default)
+        {
+            if (request.ProceedWithBroadcast)
+            {
+                throw new ArgumentOutOfRangeException(nameof(request.ProceedWithBroadcast),
+                    "Please use CreateOnChainTransaction when wanting to also broadcast the transaction");
+            }
+            return Transaction.Parse( GetFromActionResult<string>(await _storeOnChainWalletsController.CreateOnChainTransaction(storeId, cryptoCode, request)), network);
+        }
+
+        public override async Task<IEnumerable<StoreData>> GetStores(CancellationToken token = default)
+        {
+            return GetFromActionResult(await _storesController.GetStores());
+        }
+
+        public override async Task<StoreData> GetStore(string storeId, CancellationToken token = default)
+        {
+            return GetFromActionResult(await _storesController.GetStore(storeId));
+        }
+
+        public override async Task RemoveStore(string storeId, CancellationToken token = default)
+        {
+            HandleActionResult(await _storesController.RemoveStore(storeId));
+        }
+
+        public override async Task<StoreData> CreateStore(CreateStoreRequest request, CancellationToken token = default)
+        {
+            return GetFromActionResult<StoreData>(await _storesController.CreateStore(request));
+        }
+
+        public override async Task<StoreData> UpdateStore(string storeId, UpdateStoreRequest request, CancellationToken token = default)
+        {
+            return GetFromActionResult<StoreData>(await _storesController.UpdateStore(storeId, request));
+        }
+
+        public override async Task<IEnumerable<LightningNetworkPaymentMethodData>> GetStoreLightningNetworkPaymentMethods(string storeId, CancellationToken token = default)
+        {
+            throw new NotSupportedException();
+        }
+
+        public override async Task<LightningNetworkPaymentMethodData> GetStoreLightningNetworkPaymentMethod(string storeId, string cryptoCode, CancellationToken token = default)
+        {
+            throw new NotSupportedException();
+        }
+
+        public override async Task RemoveStoreLightningNetworkPaymentMethod(string storeId, string cryptoCode, CancellationToken token = default)
+        {
+            throw new NotSupportedException();
+        }
+
+        public override async Task<LightningNetworkPaymentMethodData> UpdateStoreLightningNetworkPaymentMethod(string storeId, string cryptoCode,
+            LightningNetworkPaymentMethodData paymentMethod, CancellationToken token = default)
+        {
+            throw new NotSupportedException();
+        }
+
+        public override async Task<LightningNetworkPaymentMethodData> UpdateStoreLightningNetworkPaymentMethodToInternalNode(string storeId, string cryptoCode,
+            LightningNetworkPaymentMethodData paymentMethod, CancellationToken token = default)
+        {
+            throw new NotSupportedException();
+        }
+
+        public override async Task<IEnumerable<InvoiceData>> GetInvoices(string storeId, bool includeArchived = false, CancellationToken token = default)
+        {
+            throw new NotSupportedException();
+        }
+
+        public override async Task<InvoiceData> GetInvoice(string storeId, string invoiceId, CancellationToken token = default)
+        {
+            throw new NotSupportedException();
+        }
+
+        public override async Task<InvoicePaymentMethodDataModel[]> GetInvoicePaymentMethods(string storeId, string invoiceId, CancellationToken token = default)
+        {
+            throw new NotSupportedException();
+        }
+
+        public override async Task ArchiveInvoice(string storeId, string invoiceId, CancellationToken token = default)
+        {
+            throw new NotSupportedException();
+        }
+
+        public override async Task<InvoiceData> CreateInvoice(string storeId, CreateInvoiceRequest request, CancellationToken token = default)
+        {
+            throw new NotSupportedException();
+        }
+
+        public override async Task<InvoiceData> UpdateInvoice(string storeId, string invoiceId, UpdateInvoiceRequest request, CancellationToken token = default)
+        {
+            throw new NotSupportedException();
+        }
+
+        public override async Task<InvoiceData> MarkInvoiceStatus(string storeId, string invoiceId, MarkInvoiceStatusRequest request,
+            CancellationToken token = default)
+        {
+            throw new NotSupportedException();
+        }
+
+        public override async Task<InvoiceData> UnarchiveInvoice(string storeId, string invoiceId, CancellationToken token = default)
+        {
+            throw new NotSupportedException();
+        }
+
+        public override async Task<ServerInfoData> GetServerInfo(CancellationToken token = default)
+        {
+            throw new NotSupportedException();
+        }
+    }
+}

--- a/BTCPayServer/Controllers/GreenField/LocalBTCPayServerClient.cs
+++ b/BTCPayServer/Controllers/GreenField/LocalBTCPayServerClient.cs
@@ -806,9 +806,9 @@ namespace BTCPayServer.Controllers.GreenField
                 await _greenFieldInvoiceController.UnarchiveInvoice(storeId, invoiceId));
         }
 
-        public override async Task<ServerInfoData> GetServerInfo(CancellationToken token = default)
+        public override Task<ServerInfoData> GetServerInfo(CancellationToken token = default)
         {
-            return GetFromActionResult<ServerInfoData>(await _greenFieldServerInfoController.ServerInfo());
+            return Task.FromResult(GetFromActionResult<ServerInfoData>(_greenFieldServerInfoController.ServerInfo()));
         }
 
         public override async Task ActivateInvoicePaymentMethod(string storeId, string invoiceId, string paymentMethod,
@@ -823,6 +823,16 @@ namespace BTCPayServer.Controllers.GreenField
         {
             return GetFromActionResult<OnChainWalletFeeRateData>(
                 await _storeOnChainWalletsController.GetOnChainFeeRate(storeId, cryptoCode, blockTarget));
+        }
+
+        public override async Task DeleteCurrentUser(CancellationToken token = default)
+        {
+            HandleActionResult(await _usersController.DeleteCurrentUser());
+        }
+
+        public override async Task DeleteUser(string userId, CancellationToken token = default)
+        {
+            HandleActionResult(await _usersController.DeleteUser(userId));
         }
     }
 }

--- a/BTCPayServer/Controllers/GreenField/LocalBTCPayServerClient.cs
+++ b/BTCPayServer/Controllers/GreenField/LocalBTCPayServerClient.cs
@@ -188,7 +188,7 @@ namespace BTCPayServer.Controllers.GreenField
             GreenfieldPullPaymentController greenfieldPullPaymentController,
             HomeController homeController,
             StorePaymentMethodsController storePaymentMethodsController,
-            IHttpContextAccessor httpContextAccessor) : base(new Uri("https://dummy.com"), "", "")
+            IHttpContextAccessor httpContextAccessor) : base(new Uri("https://dummy.local"), "", "")
         {
             _chainPaymentMethodsController = chainPaymentMethodsController;
             _storeOnChainWalletsController = storeOnChainWalletsController;

--- a/BTCPayServer/Controllers/GreenField/LocalBTCPayServerClient.cs
+++ b/BTCPayServer/Controllers/GreenField/LocalBTCPayServerClient.cs
@@ -169,7 +169,7 @@ namespace BTCPayServer.Controllers.GreenField
             GreenFieldServerInfoController greenFieldServerInfoController,
             StoreWebhooksController storeWebhooksController,
             GreenfieldPullPaymentController greenfieldPullPaymentController,
-            IHttpContextAccessor httpContextAccessor) : base(new Uri("http://dummy.com"), "", "")
+            IHttpContextAccessor httpContextAccessor) : base(new Uri("https://dummy.com"), "", "")
         {
             _chainPaymentMethodsController = chainPaymentMethodsController;
             _storeOnChainWalletsController = storeOnChainWalletsController;
@@ -474,10 +474,10 @@ namespace BTCPayServer.Controllers.GreenField
             return result.Value ?? GetFromActionResult<T>(result.Result);
         }
 
-        public override async Task<IEnumerable<OnChainPaymentMethodData>> GetStoreOnChainPaymentMethods(string storeId,
+        public override Task<IEnumerable<OnChainPaymentMethodData>> GetStoreOnChainPaymentMethods(string storeId,
             CancellationToken token = default)
         {
-            return GetFromActionResult(_chainPaymentMethodsController.GetOnChainPaymentMethods(storeId));
+            return Task.FromResult(GetFromActionResult(_chainPaymentMethodsController.GetOnChainPaymentMethods(storeId)));
         }
 
         public override async Task<OnChainPaymentMethodData> GetStoreOnChainPaymentMethod(string storeId,
@@ -718,19 +718,19 @@ namespace BTCPayServer.Controllers.GreenField
             return GetFromActionResult<StoreData>(await _storesController.UpdateStore(storeId, request));
         }
 
-        public override async Task<IEnumerable<LightningNetworkPaymentMethodData>>
+        public override Task<IEnumerable<LightningNetworkPaymentMethodData>>
             GetStoreLightningNetworkPaymentMethods(string storeId, bool enabledOnly = false,
                 CancellationToken token = default)
         {
-            return GetFromActionResult(
-                _storeLightningNetworkPaymentMethodsController.GetLightningPaymentMethods(storeId, enabledOnly));
+            return Task.FromResult(GetFromActionResult(
+                _storeLightningNetworkPaymentMethodsController.GetLightningPaymentMethods(storeId, enabledOnly)));
         }
 
-        public override async Task<LightningNetworkPaymentMethodData> GetStoreLightningNetworkPaymentMethod(
+        public override Task<LightningNetworkPaymentMethodData> GetStoreLightningNetworkPaymentMethod(
             string storeId, string cryptoCode, CancellationToken token = default)
         {
-            return GetFromActionResult(
-                _storeLightningNetworkPaymentMethodsController.GetLightningNetworkPaymentMethod(storeId, cryptoCode));
+            return Task.FromResult(GetFromActionResult(
+                _storeLightningNetworkPaymentMethodsController.GetLightningNetworkPaymentMethod(storeId, cryptoCode)));
         }
 
         public override async Task RemoveStoreLightningNetworkPaymentMethod(string storeId, string cryptoCode,

--- a/BTCPayServer/Controllers/GreenField/LocalBTCPayServerClient.cs
+++ b/BTCPayServer/Controllers/GreenField/LocalBTCPayServerClient.cs
@@ -104,6 +104,11 @@ namespace BTCPayServer.Controllers.GreenField
                 context.User =
                     new ClaimsPrincipal(new ClaimsIdentity(claims, GreenFieldConstants.AuthenticationType));
             }
+            else
+            {
+                context.User =
+                    new ClaimsPrincipal(new ClaimsIdentity(new List<Claim>(), $"Local{GreenFieldConstants.AuthenticationType}"));
+            }
 
             if (storeIds?.Any() is true)
             {

--- a/BTCPayServer/Controllers/GreenField/PaymentRequestsController.cs
+++ b/BTCPayServer/Controllers/GreenField/PaymentRequestsController.cs
@@ -33,7 +33,7 @@ namespace BTCPayServer.Controllers.GreenField
 
         [Authorize(Policy = Policies.CanViewPaymentRequests, AuthenticationSchemes = AuthenticationSchemes.Greenfield)]
         [HttpGet("~/api/v1/stores/{storeId}/payment-requests")]
-        public async Task<ActionResult<IEnumerable<PaymentRequestData>>> GetPaymentRequests(string storeId, bool includeArchived = false)
+        public async Task<ActionResult<IEnumerable<Client.Models.PaymentRequestData>>> GetPaymentRequests(string storeId, bool includeArchived = false)
         {
             var prs = await _paymentRequestRepository.FindPaymentRequests(
                 new PaymentRequestQuery() { StoreId = storeId, IncludeArchived = includeArchived });
@@ -42,7 +42,7 @@ namespace BTCPayServer.Controllers.GreenField
 
         [Authorize(Policy = Policies.CanViewPaymentRequests, AuthenticationSchemes = AuthenticationSchemes.Greenfield)]
         [HttpGet("~/api/v1/stores/{storeId}/payment-requests/{paymentRequestId}")]
-        public async Task<ActionResult<PaymentRequestData>> GetPaymentRequest(string storeId, string paymentRequestId)
+        public async Task<ActionResult<Client.Models.PaymentRequestData>> GetPaymentRequest(string storeId, string paymentRequestId)
         {
             var pr = await _paymentRequestRepository.FindPaymentRequests(
                 new PaymentRequestQuery() { StoreId = storeId, Ids = new[] { paymentRequestId } });

--- a/BTCPayServer/Controllers/GreenField/StoreLightningNetworkPaymentMethodsController.cs
+++ b/BTCPayServer/Controllers/GreenField/StoreLightningNetworkPaymentMethodsController.cs
@@ -73,7 +73,7 @@ namespace BTCPayServer.Controllers.GreenField
 
         [Authorize(Policy = Policies.CanModifyStoreSettings, AuthenticationSchemes = AuthenticationSchemes.Greenfield)]
         [HttpGet("~/api/v1/stores/{storeId}/payment-methods/LightningNetwork/{cryptoCode}")]
-        public ActionResult<LightningNetworkPaymentMethodData> GetLightningNetworkPaymentMethod(string cryptoCode)
+        public ActionResult<LightningNetworkPaymentMethodData> GetLightningNetworkPaymentMethod(string storeId, string cryptoCode)
         {
             if (!GetNetwork(cryptoCode, out BTCPayNetwork _))
             {
@@ -92,6 +92,7 @@ namespace BTCPayServer.Controllers.GreenField
         [Authorize(Policy = Policies.CanModifyStoreSettings, AuthenticationSchemes = AuthenticationSchemes.Greenfield)]
         [HttpDelete("~/api/v1/stores/{storeId}/payment-methods/LightningNetwork/{cryptoCode}")]
         public async Task<IActionResult> RemoveLightningNetworkPaymentMethod(
+            string storeId,
             string cryptoCode,
             int offset = 0, int amount = 10)
         {
@@ -109,7 +110,7 @@ namespace BTCPayServer.Controllers.GreenField
 
         [Authorize(Policy = Policies.CanModifyStoreSettings, AuthenticationSchemes = AuthenticationSchemes.Greenfield)]
         [HttpPut("~/api/v1/stores/{storeId}/payment-methods/LightningNetwork/{cryptoCode}")]
-        public async Task<IActionResult> UpdateLightningNetworkPaymentMethod(string cryptoCode,
+        public async Task<IActionResult> UpdateLightningNetworkPaymentMethod(string storeId, string cryptoCode,
             [FromBody] LightningNetworkPaymentMethodData paymentMethodData)
         {
             var paymentMethodId = new PaymentMethodId(cryptoCode, PaymentTypes.LightningLike);

--- a/BTCPayServer/Controllers/GreenField/StoreLightningNetworkPaymentMethodsController.cs
+++ b/BTCPayServer/Controllers/GreenField/StoreLightningNetworkPaymentMethodsController.cs
@@ -66,6 +66,7 @@ namespace BTCPayServer.Controllers.GreenField
         [Authorize(Policy = Policies.CanModifyStoreSettings, AuthenticationSchemes = AuthenticationSchemes.Greenfield)]
         [HttpGet("~/api/v1/stores/{storeId}/payment-methods/LightningNetwork")]
         public ActionResult<IEnumerable<LightningNetworkPaymentMethodData>> GetLightningPaymentMethods(
+            string storeId,
             [FromQuery] bool? enabled)
         {
             return Ok(GetLightningPaymentMethods(Store, _btcPayNetworkProvider, enabled));

--- a/BTCPayServer/Controllers/GreenField/StoreOnChainPaymentMethodsController.cs
+++ b/BTCPayServer/Controllers/GreenField/StoreOnChainPaymentMethodsController.cs
@@ -54,6 +54,7 @@ namespace BTCPayServer.Controllers.GreenField
         [Authorize(Policy = Policies.CanViewStoreSettings, AuthenticationSchemes = AuthenticationSchemes.Greenfield)]
         [HttpGet("~/api/v1/stores/{storeId}/payment-methods/onchain")]
         public ActionResult<IEnumerable<OnChainPaymentMethodData>> GetOnChainPaymentMethods(
+            string storeId,
             [FromQuery] bool? enabled)
         {
             return Ok(GetOnChainPaymentMethods(Store, _btcPayNetworkProvider, enabled));

--- a/BTCPayServer/Controllers/GreenField/StoreOnChainPaymentMethodsController.cs
+++ b/BTCPayServer/Controllers/GreenField/StoreOnChainPaymentMethodsController.cs
@@ -61,7 +61,9 @@ namespace BTCPayServer.Controllers.GreenField
 
         [Authorize(Policy = Policies.CanViewStoreSettings, AuthenticationSchemes = AuthenticationSchemes.Greenfield)]
         [HttpGet("~/api/v1/stores/{storeId}/payment-methods/onchain/{cryptoCode}")]
-        public ActionResult<OnChainPaymentMethodData> GetOnChainPaymentMethod(string cryptoCode)
+        public async Task<ActionResult<OnChainPaymentMethodData>> GetOnChainPaymentMethod(
+            string storeId,
+            string cryptoCode)
         {
             if (!GetCryptoCodeWallet(cryptoCode, out BTCPayNetwork _, out BTCPayWallet _))
             {
@@ -79,7 +81,8 @@ namespace BTCPayServer.Controllers.GreenField
 
         [Authorize(Policy = Policies.CanViewStoreSettings, AuthenticationSchemes = AuthenticationSchemes.Greenfield)]
         [HttpGet("~/api/v1/stores/{storeId}/payment-methods/onchain/{cryptoCode}/preview")]
-        public IActionResult GetOnChainPaymentMethodPreview(
+        public async Task<IActionResult> GetOnChainPaymentMethodPreview(
+            string storeId,
             string cryptoCode,
             int offset = 0, int amount = 10)
         {
@@ -126,7 +129,9 @@ namespace BTCPayServer.Controllers.GreenField
 
         [Authorize(Policy = Policies.CanViewStoreSettings, AuthenticationSchemes = AuthenticationSchemes.Greenfield)]
         [HttpPost("~/api/v1/stores/{storeId}/payment-methods/onchain/{cryptoCode}/preview")]
-        public IActionResult GetProposedOnChainPaymentMethodPreview(string cryptoCode,
+        public IActionResult GetProposedOnChainPaymentMethodPreview(
+            string storeId,
+            string cryptoCode,
             [FromBody] OnChainPaymentMethodData paymentMethodData,
             int offset = 0, int amount = 10)
         {
@@ -179,6 +184,7 @@ namespace BTCPayServer.Controllers.GreenField
         [Authorize(Policy = Policies.CanModifyStoreSettings, AuthenticationSchemes = AuthenticationSchemes.Greenfield)]
         [HttpDelete("~/api/v1/stores/{storeId}/payment-methods/onchain/{cryptoCode}")]
         public async Task<IActionResult> RemoveOnChainPaymentMethod(
+            string storeId,
             string cryptoCode,
             int offset = 0, int amount = 10)
         {
@@ -196,7 +202,9 @@ namespace BTCPayServer.Controllers.GreenField
 
         [Authorize(Policy = Policies.CanModifyStoreSettings, AuthenticationSchemes = AuthenticationSchemes.Greenfield)]
         [HttpPut("~/api/v1/stores/{storeId}/payment-methods/onchain/{cryptoCode}")]
-        public async Task<IActionResult> UpdateOnChainPaymentMethod(string cryptoCode,
+        public async Task<IActionResult> UpdateOnChainPaymentMethod(
+            string storeId,
+            string cryptoCode,
             [FromBody] OnChainPaymentMethodData paymentMethodData)
         {
             var id = new PaymentMethodId(cryptoCode, PaymentTypes.BTCLike);

--- a/BTCPayServer/Controllers/GreenField/StorePaymentMethodsController.cs
+++ b/BTCPayServer/Controllers/GreenField/StorePaymentMethodsController.cs
@@ -26,6 +26,7 @@ namespace BTCPayServer.Controllers.GreenField
         [Authorize(Policy = Policies.CanModifyStoreSettings, AuthenticationSchemes = AuthenticationSchemes.Greenfield)]
         [HttpGet("~/api/v1/stores/{storeId}/payment-methods")]
         public ActionResult<Dictionary<string, GenericPaymentMethodData>> GetStorePaymentMethods(
+            string storeId,
             [FromQuery] bool? enabled)
         {
             var storeBlob = Store.GetStoreBlob();

--- a/BTCPayServer/Controllers/GreenField/StoreWebhooksController.cs
+++ b/BTCPayServer/Controllers/GreenField/StoreWebhooksController.cs
@@ -36,7 +36,7 @@ namespace BTCPayServer.Controllers.GreenField
         public WebhookNotificationManager WebhookNotificationManager { get; }
 
         [HttpGet("~/api/v1/stores/{storeId}/webhooks/{webhookId?}")]
-        public async Task<IActionResult> ListWebhooks(string webhookId)
+        public async Task<IActionResult> ListWebhooks(string storeId, string webhookId)
         {
             if (webhookId is null)
             {
@@ -62,7 +62,7 @@ namespace BTCPayServer.Controllers.GreenField
         }
 
         [HttpPost("~/api/v1/stores/{storeId}/webhooks")]
-        public async Task<IActionResult> CreateWebhook(Client.Models.CreateStoreWebhookRequest create)
+        public async Task<IActionResult> CreateWebhook(string storeId, Client.Models.CreateStoreWebhookRequest create)
         {
             ValidateWebhookRequest(create);
             if (!ModelState.IsValid)
@@ -90,10 +90,10 @@ namespace BTCPayServer.Controllers.GreenField
             if (w is null)
                 return WebhookNotFound();
             await StoreRepository.UpdateWebhook(storeId, webhookId, ToModel(update));
-            return await ListWebhooks(webhookId);
+            return await ListWebhooks(storeId, webhookId);
         }
         [HttpDelete("~/api/v1/stores/{storeId}/webhooks/{webhookId}")]
-        public async Task<IActionResult> DeleteWebhook(string webhookId)
+        public async Task<IActionResult> DeleteWebhook(string storeId, string webhookId)
         {
             var w = await StoreRepository.GetWebhook(CurrentStoreId, webhookId);
             if (w is null)
@@ -130,7 +130,7 @@ namespace BTCPayServer.Controllers.GreenField
 
         
         [HttpGet("~/api/v1/stores/{storeId}/webhooks/{webhookId}/deliveries/{deliveryId?}")]
-        public async Task<IActionResult> ListDeliveries(string webhookId, string deliveryId, int? count = null)
+        public async Task<IActionResult> ListDeliveries(string storeId, string webhookId, string deliveryId, int? count = null)
         {
             if (deliveryId is null)
             {
@@ -147,7 +147,7 @@ namespace BTCPayServer.Controllers.GreenField
             }
         }
         [HttpPost("~/api/v1/stores/{storeId}/webhooks/{webhookId}/deliveries/{deliveryId}/redeliver")]
-        public async Task<IActionResult> RedeliverWebhook(string webhookId, string deliveryId)
+        public async Task<IActionResult> RedeliverWebhook(string storeId, string webhookId, string deliveryId)
         {
             var delivery = await StoreRepository.GetWebhookDelivery(CurrentStoreId, webhookId, deliveryId);
             if (delivery is null)
@@ -156,7 +156,7 @@ namespace BTCPayServer.Controllers.GreenField
         }
 
         [HttpGet("~/api/v1/stores/{storeId}/webhooks/{webhookId}/deliveries/{deliveryId}/request")]
-        public async Task<IActionResult> GetDeliveryRequest(string webhookId, string deliveryId)
+        public async Task<IActionResult> GetDeliveryRequest(string storeId, string webhookId, string deliveryId)
         {
             var delivery = await StoreRepository.GetWebhookDelivery(CurrentStoreId, webhookId, deliveryId);
             if (delivery is null)

--- a/BTCPayServer/Controllers/GreenField/StoresController.cs
+++ b/BTCPayServer/Controllers/GreenField/StoresController.cs
@@ -13,6 +13,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Cors;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
+using StoreData = BTCPayServer.Data.StoreData;
 
 namespace BTCPayServer.Controllers.GreenField
 {
@@ -33,7 +34,7 @@ namespace BTCPayServer.Controllers.GreenField
         }
         [Authorize(Policy = Policies.CanViewStoreSettings, AuthenticationSchemes = AuthenticationSchemes.Greenfield)]
         [HttpGet("~/api/v1/stores")]
-        public ActionResult<IEnumerable<Client.Models.StoreData>> GetStores()
+        public async Task<ActionResult<IEnumerable<Client.Models.StoreData>>> GetStores()
         {
             var stores = HttpContext.GetStoresData();
             return Ok(stores.Select(FromModel));
@@ -41,7 +42,7 @@ namespace BTCPayServer.Controllers.GreenField
 
         [Authorize(Policy = Policies.CanViewStoreSettings, AuthenticationSchemes = AuthenticationSchemes.Greenfield)]
         [HttpGet("~/api/v1/stores/{storeId}")]
-        public ActionResult<Client.Models.StoreData> GetStore(string storeId)
+        public async Task<ActionResult<Client.Models.StoreData>> GetStore(string storeId)
         {
             var store = HttpContext.GetStoreData();
             if (store == null)

--- a/BTCPayServer/Controllers/GreenField/StoresController.cs
+++ b/BTCPayServer/Controllers/GreenField/StoresController.cs
@@ -34,22 +34,22 @@ namespace BTCPayServer.Controllers.GreenField
         }
         [Authorize(Policy = Policies.CanViewStoreSettings, AuthenticationSchemes = AuthenticationSchemes.Greenfield)]
         [HttpGet("~/api/v1/stores")]
-        public async Task<ActionResult<IEnumerable<Client.Models.StoreData>>> GetStores()
+        public Task<ActionResult<IEnumerable<Client.Models.StoreData>>> GetStores()
         {
             var stores = HttpContext.GetStoresData();
-            return Ok(stores.Select(FromModel));
+            return Task.FromResult<ActionResult<IEnumerable<Client.Models.StoreData>>>(Ok(stores.Select(FromModel)));
         }
 
         [Authorize(Policy = Policies.CanViewStoreSettings, AuthenticationSchemes = AuthenticationSchemes.Greenfield)]
         [HttpGet("~/api/v1/stores/{storeId}")]
-        public async Task<ActionResult<Client.Models.StoreData>> GetStore(string storeId)
+        public Task<ActionResult<Client.Models.StoreData>> GetStore(string storeId)
         {
             var store = HttpContext.GetStoreData();
             if (store == null)
             {
-                return NotFound();
+                return Task.FromResult<ActionResult<Client.Models.StoreData>>(NotFound());
             }
-            return Ok(FromModel(store));
+            return Task.FromResult<ActionResult<Client.Models.StoreData>>(Ok(FromModel(store)));
         }
 
         [Authorize(Policy = Policies.CanModifyStoreSettings, AuthenticationSchemes = AuthenticationSchemes.Greenfield)]

--- a/BTCPayServer/Controllers/GreenField/TestApiKeyController.cs
+++ b/BTCPayServer/Controllers/GreenField/TestApiKeyController.cs
@@ -73,10 +73,17 @@ namespace BTCPayServer.Controllers.GreenField
             return true;
         }
 
-        [HttpGet("testlocal")]
+        [HttpGet("local/me")]
         public async Task<IActionResult> TestLocalClient()
         {
             return Ok(await _localBTCPayServerClient.GetCurrentUser());
+        }
+        [HttpGet("local/me/stores")]
+        [Authorize(Policy = Policies.CanModifyStoreSettings,
+            AuthenticationSchemes = AuthenticationSchemes.Greenfield)]
+        public async Task<IActionResult> TestLocalClient2()
+        {
+            return Ok(await _localBTCPayServerClient.GetStores());
         }
 
 

--- a/BTCPayServer/Controllers/GreenField/TestApiKeyController.cs
+++ b/BTCPayServer/Controllers/GreenField/TestApiKeyController.cs
@@ -20,11 +20,13 @@ namespace BTCPayServer.Controllers.GreenField
     {
         private readonly UserManager<ApplicationUser> _userManager;
         private readonly StoreRepository _storeRepository;
+        private readonly BTCPayServerClient _localBTCPayServerClient;
 
-        public TestApiKeyController(UserManager<ApplicationUser> userManager, StoreRepository storeRepository)
+        public TestApiKeyController(UserManager<ApplicationUser> userManager, StoreRepository storeRepository, BTCPayServerClient localBTCPayServerClient)
         {
             _userManager = userManager;
             _storeRepository = storeRepository;
+            _localBTCPayServerClient = localBTCPayServerClient;
         }
 
         [HttpGet("me/id")]
@@ -70,5 +72,13 @@ namespace BTCPayServer.Controllers.GreenField
         {
             return true;
         }
+
+        [HttpGet("testlocal")]
+        public async Task<IActionResult> TestLocalClient()
+        {
+            return Ok(await _localBTCPayServerClient.GetCurrentUser());
+        }
+
+
     }
 }

--- a/BTCPayServer/Controllers/GreenField/TestApiKeyController.cs
+++ b/BTCPayServer/Controllers/GreenField/TestApiKeyController.cs
@@ -72,20 +72,5 @@ namespace BTCPayServer.Controllers.GreenField
         {
             return true;
         }
-
-        [HttpGet("local/me")]
-        public async Task<IActionResult> TestLocalClient()
-        {
-            return Ok(await _localBTCPayServerClient.GetCurrentUser());
-        }
-        [HttpGet("local/me/stores")]
-        [Authorize(Policy = Policies.CanModifyStoreSettings,
-            AuthenticationSchemes = AuthenticationSchemes.Greenfield)]
-        public async Task<IActionResult> TestLocalClient2()
-        {
-            return Ok(await _localBTCPayServerClient.GetStores());
-        }
-
-
     }
 }

--- a/BTCPayServer/Hosting/BTCPayServerServices.cs
+++ b/BTCPayServer/Hosting/BTCPayServerServices.cs
@@ -385,7 +385,8 @@ namespace BTCPayServer.Hosting
             
             //create a simple client which hooks up to the http scope
             services.AddScoped<BTCPayServerClient, LocalBTCPayServerClient>();
-            
+            //also provide a factory that can impersonate user/store id
+            services.AddSingleton<IBTCPayServerClientFactory, BTCPayServerClientFactory>();
 
             services.AddAPIKeyAuthentication();
             services.AddBtcPayServerAuthenticationSchemes();

--- a/BTCPayServer/Hosting/BTCPayServerServices.cs
+++ b/BTCPayServer/Hosting/BTCPayServerServices.cs
@@ -6,8 +6,10 @@ using BTCPayServer.Abstractions.Contracts;
 using BTCPayServer.Abstractions.Extensions;
 using BTCPayServer.Abstractions.Models;
 using BTCPayServer.Common;
+using BTCPayServer.Client;
 using BTCPayServer.Configuration;
 using BTCPayServer.Controllers;
+using BTCPayServer.Controllers.GreenField;
 using BTCPayServer.Data;
 using BTCPayServer.HostedServices;
 using BTCPayServer.Lightning;
@@ -380,6 +382,10 @@ namespace BTCPayServer.Hosting
             services.AddTransient<PaymentRequestController>();
             // Add application services.
             services.AddSingleton<EmailSenderFactory>();
+            
+            //create a simple client which hooks up to the http scope
+            services.AddScoped<BTCPayServerClient, LocalBTCPayServerClient>();
+            
 
             services.AddAPIKeyAuthentication();
             services.AddBtcPayServerAuthenticationSchemes();

--- a/BTCPayServer/Security/GreenField/APIKeyExtensions.cs
+++ b/BTCPayServer/Security/GreenField/APIKeyExtensions.cs
@@ -37,6 +37,7 @@ namespace BTCPayServer.Security.GreenField
         {
             serviceCollection.AddSingleton<APIKeyRepository>();
             serviceCollection.AddScoped<IAuthorizationHandler, GreenFieldAuthorizationHandler>();
+            serviceCollection.AddScoped<IAuthorizationHandler, LocalGreenFieldAuthorizationHandler>();
             return serviceCollection;
         }
 

--- a/BTCPayServer/Security/GreenField/APIKeysAuthenticationHandler.cs
+++ b/BTCPayServer/Security/GreenField/APIKeysAuthenticationHandler.cs
@@ -16,7 +16,6 @@ namespace BTCPayServer.Security.GreenField
     {
         private readonly APIKeyRepository _apiKeyRepository;
         private readonly IOptionsMonitor<IdentityOptions> _identityOptions;
-        private readonly SignInManager<ApplicationUser> _signInManager;
         private readonly UserManager<ApplicationUser> _userManager;
 
         public APIKeysAuthenticationHandler(
@@ -26,12 +25,10 @@ namespace BTCPayServer.Security.GreenField
             ILoggerFactory logger,
             UrlEncoder encoder,
             ISystemClock clock,
-            SignInManager<ApplicationUser> signInManager,
             UserManager<ApplicationUser> userManager) : base(options, logger, encoder, clock)
         {
             _apiKeyRepository = apiKeyRepository;
             _identityOptions = identityOptions;
-            _signInManager = signInManager;
             _userManager = userManager;
         }
 

--- a/BTCPayServer/Security/GreenField/GreenFieldAuthorizationHandler.cs
+++ b/BTCPayServer/Security/GreenField/GreenFieldAuthorizationHandler.cs
@@ -9,6 +9,20 @@ using Microsoft.AspNetCore.Identity;
 
 namespace BTCPayServer.Security.GreenField
 {
+    public class LocalGreenFieldAuthorizationHandler : AuthorizationHandler<PolicyRequirement>
+    {
+        protected override Task HandleRequirementAsync(AuthorizationHandlerContext context, PolicyRequirement requirement)
+        {
+            var succeed = context.User.Identity.AuthenticationType == $"Local{GreenFieldConstants.AuthenticationType}";
+
+            if (succeed)
+            {
+                context.Succeed(requirement);
+            }
+            return Task.CompletedTask;
+        }
+    }
+    
     public class GreenFieldAuthorizationHandler : AuthorizationHandler<PolicyRequirement>
 
     {

--- a/BTCPayServer/Services/Notifications/NotificationManager.cs
+++ b/BTCPayServer/Services/Notifications/NotificationManager.cs
@@ -155,9 +155,7 @@ namespace BTCPayServer.Services.Notifications
         public INotificationHandler GetHandler(string notificationId)
         {
             _handlersByNotificationType.TryGetValue(notificationId, out var h);
-
             return h;
-            // throw new InvalidOperationException($"No INotificationHandler found for {notificationId}");
         }
     }
 


### PR DESCRIPTION
This introduces the GreenField client to the internal codebase, so that we can dogfood the API directly inside btcpay! This also allows plugins to have immediate access to many internal features that are needed.