### PR TITLE
Add payjoin option to hot wallet setup

### DIFF
--- a/BTCPayServer.Tests/AltcoinTests/AltcoinTests.cs
+++ b/BTCPayServer.Tests/AltcoinTests/AltcoinTests.cs
@@ -77,7 +77,7 @@ namespace BTCPayServer.Tests
 
                 // Get enabled state from overview action
                 StoreViewModel storeModel;
-                response = controller.UpdateStore();
+                response = await controller.UpdateStore();
                 storeModel = (StoreViewModel)Assert.IsType<ViewResult>(response).Model;
                 var lnNode = storeModel.LightningNodes.Find(node => node.CryptoCode == cryptoCode);
                 Assert.NotNull(lnNode);
@@ -89,7 +89,7 @@ namespace BTCPayServer.Tests
                 Assert.IsType<ViewResult>(response);
 
                 // Get enabled state from overview action
-                response = controller.UpdateStore();
+                response = await controller.UpdateStore();
                 storeModel = (StoreViewModel)Assert.IsType<ViewResult>(response).Model;
                 var derivationScheme = storeModel.DerivationSchemes.Find(scheme => scheme.Crypto == cryptoCode);
                 Assert.NotNull(derivationScheme);
@@ -98,7 +98,7 @@ namespace BTCPayServer.Tests
                 // Disable wallet
                 response = controller.SetWalletEnabled(storeId, cryptoCode, false).GetAwaiter().GetResult();
                 Assert.IsType<RedirectToActionResult>(response);
-                response = controller.UpdateStore();
+                response = await controller.UpdateStore();
                 storeModel = (StoreViewModel)Assert.IsType<ViewResult>(response).Model;
                 derivationScheme = storeModel.DerivationSchemes.Find(scheme => scheme.Crypto == cryptoCode);
                 Assert.NotNull(derivationScheme);

--- a/BTCPayServer.Tests/AltcoinTests/AltcoinTests.cs
+++ b/BTCPayServer.Tests/AltcoinTests/AltcoinTests.cs
@@ -85,7 +85,7 @@ namespace BTCPayServer.Tests
 
                 WalletSetupViewModel setupVm;
                 var storeId = user.StoreId;
-                response = await controller.GenerateWallet(storeId, cryptoCode, WalletSetupMethod.GenerateOptions, new GenerateWalletRequest());
+                response = await controller.GenerateWallet(storeId, cryptoCode, WalletSetupMethod.GenerateOptions, new WalletSetupRequest());
                 Assert.IsType<ViewResult>(response);
 
                 // Get enabled state from overview action

--- a/BTCPayServer.Tests/CrowdfundTests.cs
+++ b/BTCPayServer.Tests/CrowdfundTests.cs
@@ -165,7 +165,7 @@ namespace BTCPayServer.Tests
                 var user = tester.NewAccount();
                 user.GrantAccess();
                 user.RegisterDerivationScheme("BTC");
-                user.ModifyStore(s => s.NetworkFeeMode = NetworkFeeMode.Never);
+                await user.ModifyStore(s => s.NetworkFeeMode = NetworkFeeMode.Never);
                 var apps = user.GetController<AppsController>();
                 var vm = Assert.IsType<CreateAppViewModel>(Assert.IsType<ViewResult>(apps.CreateApp().Result).Model);
                 vm.Name = "test";

--- a/BTCPayServer.Tests/PayJoinTests.cs
+++ b/BTCPayServer.Tests/PayJoinTests.cs
@@ -515,7 +515,7 @@ namespace BTCPayServer.Tests
                 address = (await nbx.GetUnusedAsync(bob.DerivationScheme, DerivationFeature.Deposit)).Address;
                 tester.ExplorerNode.SendToAddress(address, Money.Coins(1.1m));
                 await notifications.NextEventAsync();
-                bob.ModifyStore(s => s.PayJoinEnabled = true);
+                await bob.ModifyStore(s => s.PayJoinEnabled = true);
                 var invoice = bob.BitPay.CreateInvoice(
                     new Invoice() { Price = 0.1m, Currency = "BTC", FullNotifications = true });
                 var invoiceBIP21 = new BitcoinUrlBuilder(invoice.CryptoInfo.First().PaymentUrls.BIP21,

--- a/BTCPayServer.Tests/PayJoinTests.cs
+++ b/BTCPayServer.Tests/PayJoinTests.cs
@@ -238,19 +238,15 @@ namespace BTCPayServer.Tests
                     var receiverSeed = s.GenerateWallet("BTC", "", true, true, format);
                     var receiverWalletId = new WalletId(receiver.storeId, "BTC");
 
-                    //payjoin is not enabled by default.
+                    //payjoin is enabled by default.
                     var invoiceId = s.CreateInvoice(receiver.storeName);
                     s.GoToInvoiceCheckout(invoiceId);
                     var bip21 = s.Driver.FindElement(By.ClassName("payment__details__instruction__open-wallet__btn"))
                         .GetAttribute("href");
-                    Assert.DoesNotContain($"{PayjoinClient.BIP21EndpointKey}=", bip21);
+                    Assert.Contains($"{PayjoinClient.BIP21EndpointKey}=", bip21);
 
                     s.GoToHome();
                     s.GoToStore(receiver.storeId);
-                    //payjoin is not enabled by default.
-                    Assert.False(s.Driver.FindElement(By.Id("PayJoinEnabled")).Selected);
-                    s.Driver.SetCheckbox(By.Id("PayJoinEnabled"), true);
-                    s.Driver.FindElement(By.Id("Save")).Click();
                     Assert.True(s.Driver.FindElement(By.Id("PayJoinEnabled")).Selected);
 
                     var sender = s.CreateNewStore();

--- a/BTCPayServer.Tests/TestAccount.cs
+++ b/BTCPayServer.Tests/TestAccount.cs
@@ -125,25 +125,27 @@ namespace BTCPayServer.Tests
             CreateStoreAsync().GetAwaiter().GetResult();
         }
 
-        public void SetNetworkFeeMode(NetworkFeeMode mode)
+        public async Task SetNetworkFeeMode(NetworkFeeMode mode)
         {
-            ModifyStore((store) =>
+            await ModifyStore(store =>
             {
                 store.NetworkFeeMode = mode;
             });
         }
 
-        public void ModifyStore(Action<StoreViewModel> modify)
+        public async Task ModifyStore(Action<StoreViewModel> modify)
         {
             var storeController = GetController<StoresController>();
-            StoreViewModel store = (StoreViewModel)((ViewResult)storeController.UpdateStore()).Model;
+            var response = await storeController.UpdateStore();
+            StoreViewModel store = (StoreViewModel)Assert.IsType<ViewResult>(response).Model;
             modify(store);
             storeController.UpdateStore(store).GetAwaiter().GetResult();
         }
         public Task ModifyStoreAsync(Action<StoreViewModel> modify)
         {
             var storeController = GetController<StoresController>();
-            StoreViewModel store = (StoreViewModel)((ViewResult)storeController.UpdateStore()).Model;
+            var response = storeController.UpdateStore();
+            StoreViewModel store = (StoreViewModel)Assert.IsType<ViewResult>(response).Model;
             modify(store);
             return storeController.UpdateStore(store);
         }

--- a/BTCPayServer.Tests/TestAccount.cs
+++ b/BTCPayServer.Tests/TestAccount.cs
@@ -175,7 +175,7 @@ namespace BTCPayServer.Tests
             SupportedNetwork = parent.NetworkProvider.GetNetwork<BTCPayNetwork>(cryptoCode);
             var store = parent.PayTester.GetController<StoresController>(UserId, StoreId, true);
 
-            var generateRequest = new GenerateWalletRequest()
+            var generateRequest = new WalletSetupRequest
             {
                 ScriptPubKeyType = segwit,
                 SavePrivateKeys = importKeysToNBX,

--- a/BTCPayServer.Tests/TestAccount.cs
+++ b/BTCPayServer.Tests/TestAccount.cs
@@ -137,17 +137,9 @@ namespace BTCPayServer.Tests
         {
             var storeController = GetController<StoresController>();
             var response = await storeController.UpdateStore();
-            StoreViewModel store = (StoreViewModel)Assert.IsType<ViewResult>(response).Model;
+            StoreViewModel store = (StoreViewModel)((ViewResult)response).Model;
             modify(store);
             storeController.UpdateStore(store).GetAwaiter().GetResult();
-        }
-        public Task ModifyStoreAsync(Action<StoreViewModel> modify)
-        {
-            var storeController = GetController<StoresController>();
-            var response = storeController.UpdateStore();
-            StoreViewModel store = (StoreViewModel)Assert.IsType<ViewResult>(response).Model;
-            modify(store);
-            return storeController.UpdateStore(store);
         }
 
         public T GetController<T>(bool setImplicitStore = true) where T : Controller
@@ -198,7 +190,7 @@ namespace BTCPayServer.Tests
 
         public Task EnablePayJoin()
         {
-            return ModifyStoreAsync(s => s.PayJoinEnabled = true);
+            return ModifyStore(s => s.PayJoinEnabled = true);
         }
 
         public GenerateWalletResponse GenerateWalletResponseV { get; set; }

--- a/BTCPayServer.Tests/UnitTest1.cs
+++ b/BTCPayServer.Tests/UnitTest1.cs
@@ -941,7 +941,7 @@ namespace BTCPayServer.Tests
             await user.GrantAccessAsync(true);
             await user.RegisterDerivationSchemeAsync("BTC");
             await user.RegisterLightningNodeAsync("BTC", LightningConnectionType.CLightning);
-            user.SetNetworkFeeMode(NetworkFeeMode.Never);
+            await user.SetNetworkFeeMode(NetworkFeeMode.Never);
             await user.ModifyStoreAsync(model => model.SpeedPolicy = SpeedPolicy.HighSpeed);
             var invoice = await user.BitPay.CreateInvoiceAsync(new Invoice(0.0001m, "BTC"));
             await tester.WaitForEvent<InvoiceNewPaymentDetailsEvent>(async () =>
@@ -1545,7 +1545,7 @@ namespace BTCPayServer.Tests
                 var user = tester.NewAccount();
                 user.GrantAccess();
                 user.RegisterDerivationScheme("BTC");
-                user.SetNetworkFeeMode(NetworkFeeMode.Always);
+                await user.SetNetworkFeeMode(NetworkFeeMode.Always);
                 var invoice =
                     user.BitPay.CreateInvoice(new Invoice() { Price = 5000.0m, Currency = "USD" }, Facade.Merchant);
                 var payment1 = invoice.BtcDue + Money.Coins(0.0001m);
@@ -1646,7 +1646,7 @@ namespace BTCPayServer.Tests
 
                 Logs.Tester.LogInformation(
                     $"Let's test if we can RBF a normal payment without adding fees to the invoice");
-                user.SetNetworkFeeMode(NetworkFeeMode.MultiplePaymentsOnly);
+                await user.SetNetworkFeeMode(NetworkFeeMode.MultiplePaymentsOnly);
                 invoice = user.BitPay.CreateInvoice(new Invoice() { Price = 5000.0m, Currency = "USD" }, Facade.Merchant);
                 payment1 = invoice.BtcDue;
                 tx1 = new uint256(tester.ExplorerNode.SendCommand("sendtoaddress", new object[]
@@ -2449,7 +2449,7 @@ namespace BTCPayServer.Tests
                 var user = tester.NewAccount();
                 user.GrantAccess();
                 user.RegisterDerivationScheme("BTC");
-                user.SetNetworkFeeMode(NetworkFeeMode.Always);
+                await user.SetNetworkFeeMode(NetworkFeeMode.Always);
                 var invoice = user.BitPay.CreateInvoice(
                     new Invoice()
                     {
@@ -2525,7 +2525,7 @@ namespace BTCPayServer.Tests
                 foreach (var networkFeeMode in Enum.GetValues(typeof(NetworkFeeMode)).Cast<NetworkFeeMode>())
                 {
                     Logs.Tester.LogInformation($"Trying with {nameof(networkFeeMode)}={networkFeeMode}");
-                    user.SetNetworkFeeMode(networkFeeMode);
+                    await user.SetNetworkFeeMode(networkFeeMode);
                     var invoice = user.BitPay.CreateInvoice(
                         new Invoice()
                         {
@@ -2612,7 +2612,7 @@ namespace BTCPayServer.Tests
                 var user = tester.NewAccount();
                 user.GrantAccess();
                 user.RegisterDerivationScheme("BTC");
-                user.SetNetworkFeeMode(NetworkFeeMode.Always);
+                await user.SetNetworkFeeMode(NetworkFeeMode.Always);
                 var invoice = user.BitPay.CreateInvoice(
                     new Invoice()
                     {

--- a/BTCPayServer.Tests/UnitTest1.cs
+++ b/BTCPayServer.Tests/UnitTest1.cs
@@ -1131,8 +1131,8 @@ namespace BTCPayServer.Tests
                     var acc = tester.NewAccount();
                     acc.GrantAccess();
                     acc.RegisterDerivationScheme("BTC");
-                    acc.ModifyStore(s => s.SpeedPolicy = SpeedPolicy.LowSpeed);
-                    var invoice = acc.BitPay.CreateInvoice(new Invoice()
+                    await acc.ModifyStore(s => s.SpeedPolicy = SpeedPolicy.LowSpeed);
+                    var invoice = acc.BitPay.CreateInvoice(new Invoice
                     {
                         Price = 5.0m,
                         Currency = "USD",

--- a/BTCPayServer/Controllers/StoresController.Onchain.cs
+++ b/BTCPayServer/Controllers/StoresController.Onchain.cs
@@ -217,10 +217,12 @@ namespace BTCPayServer.Controllers
             }
             else
             {
+                var canUsePayJoin = hotWallet && isHotWallet && network.SupportPayJoin;
                 vm.SetupRequest = new WalletSetupRequest
                 {
                     SavePrivateKeys = isHotWallet,
-                    PayJoinEnabled = isHotWallet
+                    CanUsePayJoin = canUsePayJoin,
+                    PayJoinEnabled = canUsePayJoin
                 };
             }
 

--- a/BTCPayServer/Controllers/StoresController.cs
+++ b/BTCPayServer/Controllers/StoresController.cs
@@ -466,7 +466,6 @@ namespace BTCPayServer.Controllers
                 }
             }
             
-
             if (!ModelState.IsValid)
             {
                 return View(model);
@@ -558,12 +557,9 @@ namespace BTCPayServer.Controllers
                 }
             }
         }
-
-
-
-        [HttpGet]
-        [Route("{storeId}")]
-        public IActionResult UpdateStore()
+        
+        [HttpGet("{storeId}")]
+        public async Task<IActionResult> UpdateStore()
         {
             var store = HttpContext.GetStoreData();
             if (store == null)
@@ -586,12 +582,19 @@ namespace BTCPayServer.Controllers
             vm.PayJoinEnabled = storeBlob.PayJoinEnabled;
             vm.HintWallet = storeBlob.Hints.Wallet;
             vm.HintLightning = storeBlob.Hints.Lightning;
+            
+            (bool canUseHotWallet, _) = await CanUseHotWallet();
+            vm.CanUsePayJoin = canUseHotWallet && store
+                .GetSupportedPaymentMethods(_NetworkProvider)
+                .OfType<DerivationSchemeSettings>()
+                .Any(settings => settings.Network.SupportPayJoin &&
+                                 !string.IsNullOrEmpty(_ExplorerProvider.GetExplorerClient(settings.Network)
+                                     .GetMetadata<string>(settings.AccountDerivation, WellknownMetadataKeys.Mnemonic)));
+            
             return View(vm);
         }
-
-
-        [HttpPost]
-        [Route("{storeId}")]
+        
+        [HttpPost("{storeId}")]
         public async Task<IActionResult> UpdateStore(StoreViewModel model, string command = null)
         {
             bool needUpdate = false;

--- a/BTCPayServer/Controllers/StoresController.cs
+++ b/BTCPayServer/Controllers/StoresController.cs
@@ -587,9 +587,7 @@ namespace BTCPayServer.Controllers
             vm.CanUsePayJoin = canUseHotWallet && store
                 .GetSupportedPaymentMethods(_NetworkProvider)
                 .OfType<DerivationSchemeSettings>()
-                .Any(settings => settings.Network.SupportPayJoin &&
-                                 !string.IsNullOrEmpty(_ExplorerProvider.GetExplorerClient(settings.Network)
-                                     .GetMetadata<string>(settings.AccountDerivation, WellknownMetadataKeys.Mnemonic)));
+                .Any(settings => settings.Network.SupportPayJoin && settings.IsHotWallet);
             
             return View(vm);
         }
@@ -638,11 +636,7 @@ namespace BTCPayServer.Controllers
                 {
                     var problematicPayjoinEnabledMethods = CurrentStore.GetSupportedPaymentMethods(_NetworkProvider)
                         .OfType<DerivationSchemeSettings>()
-                        .Where(settings =>
-                            settings.Network.SupportPayJoin &&
-                            string.IsNullOrEmpty(_ExplorerProvider.GetExplorerClient(settings.Network)
-                                .GetMetadata<string>(settings.AccountDerivation,
-                                    WellknownMetadataKeys.Mnemonic)))
+                        .Where(settings => settings.Network.SupportPayJoin && !settings.IsHotWallet)
                         .Select(settings => settings.PaymentId.CryptoCode)
                         .ToArray();
 

--- a/BTCPayServer/Models/StoreViewModels/StoreViewModel.cs
+++ b/BTCPayServer/Models/StoreViewModels/StoreViewModel.cs
@@ -88,6 +88,7 @@ namespace BTCPayServer.Models.StoreViewModels
 
         [Display(Name = "Enable Payjoin/P2EP")]
         public bool PayJoinEnabled { get; set; }
+        public bool CanUsePayJoin { get; set; }
 
         public bool HintWallet { get; set; }
         public bool HintLightning { get; set; }

--- a/BTCPayServer/Models/StoreViewModels/WalletSetupRequest.cs
+++ b/BTCPayServer/Models/StoreViewModels/WalletSetupRequest.cs
@@ -1,0 +1,9 @@
+using NBXplorer.Models;
+
+namespace BTCPayServer.Models.StoreViewModels
+{
+    public class WalletSetupRequest : GenerateWalletRequest
+    {
+        public bool PayJoinEnabled { get; set; }
+    }
+}

--- a/BTCPayServer/Models/StoreViewModels/WalletSetupRequest.cs
+++ b/BTCPayServer/Models/StoreViewModels/WalletSetupRequest.cs
@@ -5,5 +5,6 @@ namespace BTCPayServer.Models.StoreViewModels
     public class WalletSetupRequest : GenerateWalletRequest
     {
         public bool PayJoinEnabled { get; set; }
+        public bool CanUsePayJoin { get; set; }
     }
 }

--- a/BTCPayServer/Models/StoreViewModels/WalletSetupViewModel.cs
+++ b/BTCPayServer/Models/StoreViewModels/WalletSetupViewModel.cs
@@ -1,5 +1,3 @@
-using NBXplorer.Models;
-
 namespace BTCPayServer.Models.StoreViewModels
 {
     public enum WalletSetupMethod
@@ -18,7 +16,7 @@ namespace BTCPayServer.Models.StoreViewModels
     public class WalletSetupViewModel : DerivationSchemeViewModel
     {
         public WalletSetupMethod? Method { get; set; }
-        public GenerateWalletRequest SetupRequest { get; set; }
+        public WalletSetupRequest SetupRequest { get; set; }
         public string StoreId { get; set; }
         public bool IsHotWallet { get; set; }
 

--- a/BTCPayServer/Views/Stores/UpdateStore.cshtml
+++ b/BTCPayServer/Views/Stores/UpdateStore.cshtml
@@ -175,25 +175,27 @@
             </div>
 
             <h4 class="mt-5 mb-3">Payment</h4>
-            <div class="form-group form-check">
-                <input asp-for="AnyoneCanCreateInvoice" type="checkbox" class="form-check-input" />
-                <label asp-for="AnyoneCanCreateInvoice" class="form-check-label"></label>
+            <div class="form-group d-flex align-items-center">
+                <input asp-for="AnyoneCanCreateInvoice" type="checkbox" class="btcpay-toggle me-2" />
+                <label asp-for="AnyoneCanCreateInvoice" class="form-label mb-0 me-1"></label>
                 <a href="https://docs.btcpayserver.org/FAQ/FAQ-Stores/#allow-anyone-to-create-invoice" target="_blank">
                     <span class="fa fa-question-circle-o text-secondary" title="More information..."></span>
                 </a>
             </div>
             @if (Model.CanUsePayJoin)
             {
-                <div class="form-group form-check">
-                    <input asp-for="PayJoinEnabled" type="checkbox" class="form-check-input" />
-                    <label asp-for="PayJoinEnabled" class="form-check-label"></label>
-                    <a href="https://docs.btcpayserver.org/Payjoin/" target="_blank">
-                        <span class="fa fa-question-circle-o text-secondary" title="More information..."></span>
-                    </a>
+                <div class="form-group">
+                    <div class="d-flex align-items-center">
+                        <input asp-for="PayJoinEnabled" type="checkbox" class="btcpay-toggle me-2"/>
+                        <label asp-for="PayJoinEnabled" class="form-label mb-0 me-1"></label>
+                        <a href="https://docs.btcpayserver.org/Payjoin/" target="_blank">
+                            <span class="fa fa-question-circle-o text-secondary" title="More information..."></span>
+                        </a>
+                    </div>
                     <span asp-validation-for="PayJoinEnabled" class="text-danger"></span>
                 </div>
             }
-            <div class="form-group">
+            <div class="form-group mt-4">
                 <label asp-for="NetworkFeeMode" class="form-label"></label>
                 <a href="https://docs.btcpayserver.org/FAQ/FAQ-Stores/#add-network-fee-to-invoice-vary-with-mining-fees" target="_blank">
                     <span class="fa fa-question-circle-o text-secondary" title="More information..."></span>

--- a/BTCPayServer/Views/Stores/UpdateStore.cshtml
+++ b/BTCPayServer/Views/Stores/UpdateStore.cshtml
@@ -182,14 +182,17 @@
                     <span class="fa fa-question-circle-o text-secondary" title="More information..."></span>
                 </a>
             </div>
-            <div class="form-group form-check">
-                <input asp-for="PayJoinEnabled" type="checkbox" class="form-check-input" />
-                <label asp-for="PayJoinEnabled" class="form-check-label"></label>
-                <a href="https://docs.btcpayserver.org/Payjoin/" target="_blank">
-                    <span class="fa fa-question-circle-o text-secondary" title="More information..."></span>
-                </a>
-                <span asp-validation-for="PayJoinEnabled" class="text-danger"></span>
-            </div>
+            @if (Model.CanUsePayJoin)
+            {
+                <div class="form-group form-check">
+                    <input asp-for="PayJoinEnabled" type="checkbox" class="form-check-input" />
+                    <label asp-for="PayJoinEnabled" class="form-check-label"></label>
+                    <a href="https://docs.btcpayserver.org/Payjoin/" target="_blank">
+                        <span class="fa fa-question-circle-o text-secondary" title="More information..."></span>
+                    </a>
+                    <span asp-validation-for="PayJoinEnabled" class="text-danger"></span>
+                </div>
+            }
             <div class="form-group">
                 <label asp-for="NetworkFeeMode" class="form-label"></label>
                 <a href="https://docs.btcpayserver.org/FAQ/FAQ-Stores/#add-network-fee-to-invoice-vary-with-mining-fees" target="_blank">

--- a/BTCPayServer/Views/Stores/_GenerateWalletForm.cshtml
+++ b/BTCPayServer/Views/Stores/_GenerateWalletForm.cshtml
@@ -1,5 +1,5 @@
 @using NBitcoin
-@model NBXplorer.Models.GenerateWalletRequest
+@model WalletSetupRequest
 
 @{
     var method = ViewData["Method"];
@@ -55,6 +55,22 @@
     else
     {
         <input asp-for="SavePrivateKeys" type="hidden" value="@isHotWallet" />
+
+        @if (isHotWallet)
+        {
+            <div class="form-group mt-4">
+                <label asp-for="PayJoinEnabled">Enable PayJoin</label>
+                <input type="checkbox" asp-for="PayJoinEnabled" class="btcpay-toggle ml-2" />
+                <span asp-validation-for="PayJoinEnabled" class="text-danger"></span>
+                <p class="text-muted pt-2">
+                    PayJoin enhances the privacy for you and your customers.
+                    Enabling it gives your customers the option to use PayJoin during checkout.
+                    <a href="https://docs.btcpayserver.org/Payjoin/" target="_blank">
+                        <span class="fa fa-question-circle-o text-secondary" title="More information..."></span>
+                    </a>
+                </p>
+            </div>
+        }
     }
 
     <div class="mb-4">

--- a/BTCPayServer/Views/Stores/_GenerateWalletForm.cshtml
+++ b/BTCPayServer/Views/Stores/_GenerateWalletForm.cshtml
@@ -56,7 +56,7 @@
     {
         <input asp-for="SavePrivateKeys" type="hidden" value="@isHotWallet" />
 
-        @if (isHotWallet)
+        @if (Model.CanUsePayJoin)
         {
             <div class="form-group mt-4">
                 <label asp-for="PayJoinEnabled">Enable PayJoin</label>


### PR DESCRIPTION
Follow-up to the discussion in #2406.

Enables payjoin by default when creating a hot wallet and offers the user an opt-out.

If we enable it by default I'd recommend to show it immediately and not hide it in the advanced settings, though it feels like it would naturaly belong there.

Wording for the accompanying text tbd, the help icon links to the [PayJoin docs](https://docs.btcpayserver.org/Payjoin/).

This is currently only available when generating a new hot wallet. It could potentially also be offered on the seed import page, but there we have a toggle for first choosing it to be a hot wallet. I think it might be confusing to have the separate PayJoin toggle there as well, because having the hot wallet enabled is a prerequisite for offering the PayJoin toggle. 

![hotwallet-payjoin](https://user-images.githubusercontent.com/886/114053793-8db31080-988f-11eb-8388-abcee03a4fec.png)

Let's continue the discussion around that here.

