### PR TITLE
Allow accessing "misc/lang" endpoint with Greenfield auth schemes

### DIFF
--- a/BTCPayServer/Controllers/HomeController.cs
+++ b/BTCPayServer/Controllers/HomeController.cs
@@ -64,7 +64,7 @@ namespace BTCPayServer.Controllers
         }
 
         [Route("misc/lang")]
-        [Authorize(AuthenticationSchemes = AuthenticationSchemes.Cookie)]
+        [Authorize(AuthenticationSchemes = AuthenticationSchemes.Cookie + "," + AuthenticationSchemes.Greenfield)]
         public IActionResult Languages()
         {
             return Json(LanguageService.GetLanguages(), new JsonSerializerSettings() { Formatting = Formatting.Indented });


### PR DESCRIPTION
closes #2437