### PR TITLE
Add ability to send test webhook call

### DIFF
--- a/BTCPayServer/Controllers/StoresController.Integrations.cs
+++ b/BTCPayServer/Controllers/StoresController.Integrations.cs
@@ -126,7 +126,7 @@ namespace BTCPayServer.Controllers
             var result = await WebhookNotificationManager.TestWebhook(CurrentStore.Id, webhookId, viewModel.Type);
 
             if (result.Success) {
-                TempData[WellKnownTempData.SuccessMessage] = $"{viewModel.Type.ToString()} event delivered successfully!";
+                TempData[WellKnownTempData.SuccessMessage] = $"{viewModel.Type.ToString()} event delivered successfully! Delivery ID is {result.DeliveryId}";
             } else {
                 TempData[WellKnownTempData.ErrorMessage] = $"{viewModel.Type.ToString()} event could not be delivered. Error message received: {(result.ErrorMessage ?? "unknown")}";
             }

--- a/BTCPayServer/Controllers/StoresController.Integrations.cs
+++ b/BTCPayServer/Controllers/StoresController.Integrations.cs
@@ -121,9 +121,11 @@ namespace BTCPayServer.Controllers
         }
 
         [HttpPost("{storeId}/webhooks/{webhookId}/test")]
-        public async void TestWebhook(string webhookId, TestWebhookViewModel viewModel)
+        public async Task<IActionResult> TestWebhook(string webhookId, TestWebhookViewModel viewModel)
         {
             await WebhookNotificationManager.TestWebhook(CurrentStore.Id, webhookId, viewModel.Type);
+
+            return View(nameof(TestWebhook));
         }
 
         [HttpPost("{storeId}/webhooks/{webhookId}/deliveries/{deliveryId}/redeliver")]

--- a/BTCPayServer/Controllers/StoresController.Integrations.cs
+++ b/BTCPayServer/Controllers/StoresController.Integrations.cs
@@ -128,7 +128,7 @@ namespace BTCPayServer.Controllers
             if (result.Success) {
                 TempData[WellKnownTempData.SuccessMessage] = $"{viewModel.Type.ToString()} event delivered successfully!";
             } else {
-                TempData[WellKnownTempData.ErrorMessage] = $"{viewModel.Type.ToString()} event could not be delivered";
+                TempData[WellKnownTempData.ErrorMessage] = $"{viewModel.Type.ToString()} event could not be delivered. Error message received: {(result.ErrorMessage ?? "unknown")}";
             }
 
             return View(nameof(TestWebhook));

--- a/BTCPayServer/Controllers/StoresController.Integrations.cs
+++ b/BTCPayServer/Controllers/StoresController.Integrations.cs
@@ -123,7 +123,13 @@ namespace BTCPayServer.Controllers
         [HttpPost("{storeId}/webhooks/{webhookId}/test")]
         public async Task<IActionResult> TestWebhook(string webhookId, TestWebhookViewModel viewModel)
         {
-            await WebhookNotificationManager.TestWebhook(CurrentStore.Id, webhookId, viewModel.Type);
+            var result = await WebhookNotificationManager.TestWebhook(CurrentStore.Id, webhookId, viewModel.Type);
+
+            if (result.Success) {
+                TempData[WellKnownTempData.SuccessMessage] = $"{viewModel.Type.ToString()} event delivered successfully!";
+            } else {
+                TempData[WellKnownTempData.ErrorMessage] = $"{viewModel.Type.ToString()} event could not be delivered";
+            }
 
             return View(nameof(TestWebhook));
         }

--- a/BTCPayServer/Controllers/StoresController.Integrations.cs
+++ b/BTCPayServer/Controllers/StoresController.Integrations.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System.Linq;
 using System.Threading.Tasks;
 using BTCPayServer.Data;
@@ -14,7 +15,7 @@ namespace BTCPayServer.Controllers
         [HttpGet("{storeId}/integrations")]
         public IActionResult Integrations()
         {            
-            return View("Integrations",new IntegrationsViewModel());
+            return View("Integrations", new IntegrationsViewModel());
         }
 
         [HttpGet("{storeId}/webhooks")]
@@ -107,6 +108,22 @@ namespace BTCPayServer.Controllers
             await _Repo.UpdateWebhook(CurrentStore.Id, webhookId, viewModel.CreateBlob());
             TempData[WellKnownTempData.SuccessMessage] = "The webhook has been updated";
             return RedirectToAction(nameof(Webhooks), new { storeId = CurrentStore.Id });
+        }
+
+        [HttpGet("{storeId}/webhooks/{webhookId}/test")]
+        public async Task<IActionResult> TestWebhook(string webhookId)
+        {
+            var webhook = await _Repo.GetWebhook(CurrentStore.Id, webhookId);
+            if (webhook is null)
+                return NotFound();
+
+            return View(nameof(TestWebhook));
+        }
+
+        [HttpPost("{storeId}/webhooks/{webhookId}/test")]
+        public async void TestWebhook(string webhookId, TestWebhookViewModel viewModel)
+        {
+            await WebhookNotificationManager.TestWebhook(CurrentStore.Id, webhookId, viewModel.Type);
         }
 
         [HttpPost("{storeId}/webhooks/{webhookId}/deliveries/{deliveryId}/redeliver")]

--- a/BTCPayServer/HostedServices/WebhookNotificationManager.cs
+++ b/BTCPayServer/HostedServices/WebhookNotificationManager.cs
@@ -263,15 +263,15 @@ namespace BTCPayServer.HostedServices
                         var originalDeliveryId = result.DeliveryId;
                         foreach (var wait in new[]
                         {
-                        TimeSpan.FromSeconds(10),
-                        TimeSpan.FromMinutes(1),
-                        TimeSpan.FromMinutes(10),
-                        TimeSpan.FromMinutes(10),
-                        TimeSpan.FromMinutes(10),
-                        TimeSpan.FromMinutes(10),
-                        TimeSpan.FromMinutes(10),
-                        TimeSpan.FromMinutes(10),
-                    })
+                            TimeSpan.FromSeconds(10),
+                            TimeSpan.FromMinutes(1),
+                            TimeSpan.FromMinutes(10),
+                            TimeSpan.FromMinutes(10),
+                            TimeSpan.FromMinutes(10),
+                            TimeSpan.FromMinutes(10),
+                            TimeSpan.FromMinutes(10),
+                            TimeSpan.FromMinutes(10),
+                        })
                         {
                             await Task.Delay(wait, CancellationToken);
                             ctx = await CreateRedeliveryRequest(originalDeliveryId);

--- a/BTCPayServer/HostedServices/WebhookNotificationManager.cs
+++ b/BTCPayServer/HostedServices/WebhookNotificationManager.cs
@@ -126,16 +126,14 @@ namespace BTCPayServer.HostedServices
         {
             var delivery = NewDelivery(webhookId);
             var webhook = (await StoreRepository.GetWebhooks(storeId)).Where(w => w.Id == webhookId).FirstOrDefault();
-
-            var channel = Channel.CreateUnbounded<WebhookDeliveryRequest>();
             var deliveryRequest = new WebhookDeliveryRequest(
                 webhookId, 
                 GetTestWebHook(storeId, webhookId, webhookEventType, delivery), 
                 delivery, 
                 webhook.GetBlob()
             );
-            channel.Writer.TryWrite(deliveryRequest);
-            _ = Process(webhookId, channel);
+            
+            var result = await SendDelivery(deliveryRequest);
         }
 
         protected override async Task ProcessEvent(object evt, CancellationToken cancellationToken)

--- a/BTCPayServer/HostedServices/WebhookNotificationManager.cs
+++ b/BTCPayServer/HostedServices/WebhookNotificationManager.cs
@@ -125,7 +125,7 @@ namespace BTCPayServer.HostedServices
         public async Task<DeliveryResult> TestWebhook(string storeId, string webhookId, WebhookEventType webhookEventType)
         {
             var delivery = NewDelivery(webhookId);
-            var webhook = (await StoreRepository.GetWebhooks(storeId)).Where(w => w.Id == webhookId).FirstOrDefault();
+            var webhook = (await StoreRepository.GetWebhooks(storeId)).FirstOrDefault(w => w.Id == webhookId);
             var deliveryRequest = new WebhookDeliveryRequest(
                 webhookId, 
                 GetTestWebHook(storeId, webhookId, webhookEventType, delivery), 

--- a/BTCPayServer/HostedServices/WebhookNotificationManager.cs
+++ b/BTCPayServer/HostedServices/WebhookNotificationManager.cs
@@ -299,6 +299,7 @@ namespace BTCPayServer.HostedServices
         {
             public string? DeliveryId { get; set; }
             public bool Success { get; set; }
+            public string? ErrorMessage { get; set; }
         }
 
         private async Task<DeliveryResult> SendDelivery(WebhookDeliveryRequest ctx)
@@ -338,7 +339,12 @@ namespace BTCPayServer.HostedServices
             }
             ctx.Delivery.SetBlob(deliveryBlob);
 
-            return new DeliveryResult() { Success = deliveryBlob.ErrorMessage is null, DeliveryId = ctx.Delivery.Id };
+            return new DeliveryResult() 
+            { 
+                Success = deliveryBlob.ErrorMessage is null, 
+                DeliveryId = ctx.Delivery.Id, 
+                ErrorMessage = deliveryBlob.ErrorMessage
+            };
         }
 
 

--- a/BTCPayServer/HostedServices/WebhookNotificationManager.cs
+++ b/BTCPayServer/HostedServices/WebhookNotificationManager.cs
@@ -133,7 +133,7 @@ namespace BTCPayServer.HostedServices
                 webhook.GetBlob()
             );
             
-            var result = await SendDelivery(deliveryRequest);
+            var result = await SendAndSaveDelivery(deliveryRequest);
         }
 
         protected override async Task ProcessEvent(object evt, CancellationToken cancellationToken)
@@ -249,7 +249,7 @@ namespace BTCPayServer.HostedServices
                     var wh = (await StoreRepository.GetWebhook(ctx.WebhookId))?.GetBlob();
                     if (wh is null || !ShouldDeliver(ctx.WebhookEvent.Type, wh))
                         continue;
-                    var result = await SendDelivery(ctx);
+                    var result = await SendAndSaveDelivery(ctx);
                     if (ctx.WebhookBlob.AutomaticRedelivery &&
                         !result.Success &&
                         result.DeliveryId is string)
@@ -273,7 +273,7 @@ namespace BTCPayServer.HostedServices
                             if (!ctx.WebhookBlob.AutomaticRedelivery ||
                                 !ShouldDeliver(ctx.WebhookEvent.Type, ctx.WebhookBlob))
                                 break;
-                            result = await SendDelivery(ctx);
+                            result = await SendAndSaveDelivery(ctx);
                             if (result.Success)
                                 break;
                         }
@@ -300,7 +300,7 @@ namespace BTCPayServer.HostedServices
             public string DeliveryId { get; set; }
             public bool Success { get; set; }
         }
-        private async Task<DeliveryResult> SendDelivery(WebhookDeliveryRequest ctx)
+        private async Task<DeliveryResult> SendAndSaveDelivery(WebhookDeliveryRequest ctx)
         {
             var uri = new Uri(ctx.WebhookBlob.Url, UriKind.Absolute);
             var httpClient = GetClient(uri);

--- a/BTCPayServer/Models/StoreViewModels/TestWebhookViewModel.cs
+++ b/BTCPayServer/Models/StoreViewModels/TestWebhookViewModel.cs
@@ -1,0 +1,9 @@
+using BTCPayServer.Client.Models;
+
+namespace BTCPayServer.Models.StoreViewModels
+{
+    public class TestWebhookViewModel
+    {
+        public WebhookEventType Type { get; set; }
+    }
+}

--- a/BTCPayServer/Views/Stores/TestWebhook.cshtml
+++ b/BTCPayServer/Views/Stores/TestWebhook.cshtml
@@ -11,23 +11,13 @@
             <h4 class="mb-3">@ViewData["PageTitle"]</h4>
 
             <div class="form-group">
-                <label for="Type">Event type</label>
-                <select name="Type" id="Type" class="form-control w-auto">
-                    @foreach (var evt in new[]
-                    {
-                        WebhookEventType.InvoiceCreated,
-                        WebhookEventType.InvoiceReceivedPayment,
-                        WebhookEventType.InvoiceProcessing,
-                        WebhookEventType.InvoiceExpired,
-                        WebhookEventType.InvoiceSettled,
-                        WebhookEventType.InvoiceInvalid
-                    })
-                    {
-                        <option value="@evt">
-                            @evt
-                        </option>
-                    }
-                </select>
+                <label for="Type" class="form-label">Event type</label>
+                <select 
+                    asp-items="Html.GetEnumSelectList<WebhookEventType>()" 
+                    name="Type" 
+                    id="Type"
+                    class="form-select w-auto"
+                ></select>
             </div>
 
             <button type="submit" class="btn btn-primary">Send test webhook</button>

--- a/BTCPayServer/Views/Stores/TestWebhook.cshtml
+++ b/BTCPayServer/Views/Stores/TestWebhook.cshtml
@@ -2,7 +2,7 @@
 @using  BTCPayServer.Client.Models;
 @{
     Layout = "../Shared/_NavLayout.cshtml";
-    ViewData.SetActivePageAndTitle(StoreNavPages.Webhooks, "Test Webhook", Context.GetStoreData().StoreName);
+    ViewData.SetActivePageAndTitle(StoreNavPages.Webhooks, "Send a test event to a webhook endpoint", Context.GetStoreData().StoreName);
 }
 
 <div class="row">
@@ -10,22 +10,27 @@
         <form method="post">
             <h4 class="mb-3">@ViewData["PageTitle"]</h4>
 
-            <ul class="list-group">
-                @foreach (var evt in new[]
-                {
-                    ("Test InvoiceCreated event", WebhookEventType.InvoiceCreated),
-                    ("Test InvoiceReceivedPayment event", WebhookEventType.InvoiceReceivedPayment),
-                    ("Test InvoiceProcessing event", WebhookEventType.InvoiceProcessing),
-                    ("Test InvoiceExpired event", WebhookEventType.InvoiceExpired),
-                    ("Test InvoiceSettled event", WebhookEventType.InvoiceSettled),
-                    ("Test InvoiceInvalid event", WebhookEventType.InvoiceInvalid)
-                })
-                {
-                    <li class="list-group-item">
-                        <button type="submit" name="Type" class="btn btn-primary" value="@evt.Item2">@evt.Item1</button>
-                    </li>
-                }
-            </ul>
+            <div class="form-group">
+                <label for="Type">Event type</label>
+                <select name="Type" id="Type" class="form-control w-auto">
+                    @foreach (var evt in new[]
+                    {
+                        WebhookEventType.InvoiceCreated,
+                        WebhookEventType.InvoiceReceivedPayment,
+                        WebhookEventType.InvoiceProcessing,
+                        WebhookEventType.InvoiceExpired,
+                        WebhookEventType.InvoiceSettled,
+                        WebhookEventType.InvoiceInvalid
+                    })
+                    {
+                        <option value="@evt">
+                            @evt
+                        </option>
+                    }
+                </select>
+            </div>
+
+            <button type="submit" class="btn btn-primary">Send test webhook</button>
         </form>
     </div>
 </div>

--- a/BTCPayServer/Views/Stores/TestWebhook.cshtml
+++ b/BTCPayServer/Views/Stores/TestWebhook.cshtml
@@ -1,0 +1,31 @@
+@model EditWebhookViewModel
+@using  BTCPayServer.Client.Models;
+@{
+    Layout = "../Shared/_NavLayout.cshtml";
+    ViewData.SetActivePageAndTitle(StoreNavPages.Webhooks, "Test Webhook", Context.GetStoreData().StoreName);
+}
+
+<div class="row">
+    <div class="col-lg-8">
+        <form method="post">
+            <h4 class="mb-3">@ViewData["PageTitle"]</h4>
+
+            <ul class="list-group">
+                @foreach (var evt in new[]
+                {
+                    ("Test InvoiceCreated event", WebhookEventType.InvoiceCreated),
+                    ("Test InvoiceReceivedPayment event", WebhookEventType.InvoiceReceivedPayment),
+                    ("Test InvoiceProcessing event", WebhookEventType.InvoiceProcessing),
+                    ("Test InvoiceExpired event", WebhookEventType.InvoiceExpired),
+                    ("Test InvoiceSettled event", WebhookEventType.InvoiceSettled),
+                    ("Test InvoiceInvalid event", WebhookEventType.InvoiceInvalid)
+                })
+                {
+                    <li class="list-group-item">
+                        <button type="submit" name="Type" class="btn btn-primary" value="@evt.Item2">@evt.Item1</button>
+                    </li>
+                }
+            </ul>
+        </form>
+    </div>
+</div>

--- a/BTCPayServer/Views/Stores/Webhooks.cshtml
+++ b/BTCPayServer/Views/Stores/Webhooks.cshtml
@@ -30,7 +30,9 @@
                     <tr>
                         <td class="text-truncate d-block" style="max-width:300px;">@wh.Url</td>
                         <td class="text-end">
-                            <a asp-action="ModifyWebhook" asp-route-storeId="@this.Context.GetRouteValue("storeId")" asp-route-webhookId="@wh.Id">Modify</a> - <a asp-action="DeleteWebhook" asp-route-storeId="@this.Context.GetRouteValue("storeId")" asp-route-webhookId="@wh.Id">Delete</a>
+                            <a asp-action="TestWebhook" asp-route-storeId="@this.Context.GetRouteValue("storeId")" asp-route-webhookId="@wh.Id">Test</a> -
+                            <a asp-action="ModifyWebhook" asp-route-storeId="@this.Context.GetRouteValue("storeId")" asp-route-webhookId="@wh.Id">Modify</a> - 
+                            <a asp-action="DeleteWebhook" asp-route-storeId="@this.Context.GetRouteValue("storeId")" asp-route-webhookId="@wh.Id">Delete</a>
                         </td>
                     </tr>
                 }


### PR DESCRIPTION
# Description

This PR adds the ability to test webhooks by allowing a user to send a fake webhook event for any webhooks they have. Stripe allows you do this as well: https://stripe.com/docs/webhooks/test

See discussion here: https://github.com/btcpayserver/btcpayserver/discussions/2442

## Video

https://user-images.githubusercontent.com/1934678/116029039-48237100-a60d-11eb-9f9a-7fda1b6df3a5.mov

## Screenshots

### Success state

![Screen Shot 2021-04-25 at 9 17 37 PM](https://user-images.githubusercontent.com/1934678/116029110-6d17e400-a60d-11eb-9d6c-f073611f1124.png)

Design inspired by Stripe's UI:

![Screen Shot 2021-04-25 at 9 12 38 PM](https://user-images.githubusercontent.com/1934678/116029142-7d2fc380-a60d-11eb-9e6b-ad52c25069e8.png)


### Error states

![Screen Shot 2021-04-25 at 8 25 47 PM](https://user-images.githubusercontent.com/1934678/116029167-87ea5880-a60d-11eb-9854-52b7d7dc8a3b.png)
![Screen Shot 2021-04-25 at 8 26 54 PM](https://user-images.githubusercontent.com/1934678/116029168-8882ef00-a60d-11eb-8915-846a8db8b084.png)
![Screen Shot 2021-04-25 at 8 28 15 PM](https://user-images.githubusercontent.com/1934678/116029170-891b8580-a60d-11eb-8770-9a3f6c777726.png)
![Screen Shot 2021-04-25 at 8 28 41 PM](https://user-images.githubusercontent.com/1934678/116029171-89b41c00-a60d-11eb-9b83-74dabed0682d.png)




