### PR TITLE
UI: Fix duplicate status messages

### DIFF
--- a/BTCPayServer/Views/Manage/APIKeys.cshtml
+++ b/BTCPayServer/Views/Manage/APIKeys.cshtml
@@ -4,8 +4,6 @@
     ViewData.SetActivePageAndTitle(ManageNavPages.APIKeys, "Manage your API Keys");
 }
 
-<partial name="_StatusMessage" />
-
 <p>
     The <a asp-controller="Home" asp-action="SwaggerDocs" target="_blank">BTCPay Server Greenfield API</a> offers programmatic access to your instance. You can manage your BTCPay
     Server (e.g. stores, invoices, users) as well as automate workflows and integrations (see <a href="https://docs.btcpayserver.org/GreenFieldExample/">use case examples</a>).

--- a/BTCPayServer/Views/Manage/AddApiKey.cshtml
+++ b/BTCPayServer/Views/Manage/AddApiKey.cshtml
@@ -7,8 +7,6 @@
     ViewData.SetActivePageAndTitle(ManageNavPages.APIKeys, "Add API Key");
 }
 
-<partial name="_StatusMessage" />
-
 <h2 class="mb-4">@ViewData["PageTitle"]</h2>
 
 <p>Generate a new api key to use BTCPay through its API.</p>

--- a/BTCPayServer/Views/Manage/ChangePassword.cshtml
+++ b/BTCPayServer/Views/Manage/ChangePassword.cshtml
@@ -3,8 +3,6 @@
     ViewData.SetActivePageAndTitle(ManageNavPages.ChangePassword, "Change password");
 }
 
-<partial name="_StatusMessage" />
-
 <div class="row">
     <div class="col-md-6">
         @if (!ViewContext.ModelState.IsValid)

--- a/BTCPayServer/Views/Manage/Index.cshtml
+++ b/BTCPayServer/Views/Manage/Index.cshtml
@@ -3,8 +3,6 @@
     ViewData.SetActivePageAndTitle(ManageNavPages.Index, "Profile");
 }
 
-<partial name="_StatusMessage" />
-
 <form method="post">
     @if (!ViewContext.ModelState.IsValid)
     {

--- a/BTCPayServer/Views/Manage/NotificationSettings.cshtml
+++ b/BTCPayServer/Views/Manage/NotificationSettings.cshtml
@@ -5,8 +5,6 @@
     ViewData.SetActivePageAndTitle(ManageNavPages.Notifications, "Notification preferences");
 }
 
-<partial name="_StatusMessage" />
-
 <form method="post" asp-action="NotificationSettings">
     @if (Model.All)
     {

--- a/BTCPayServer/Views/Manage/SetPassword.cshtml
+++ b/BTCPayServer/Views/Manage/SetPassword.cshtml
@@ -3,8 +3,6 @@
     ViewData.SetActivePageAndTitle(ManageNavPages.ChangePassword, "Set password");
 }
 
-<partial name="_StatusMessage" />
-
 <h4>Set your password</h4>
 
 <p class="text-info">

--- a/BTCPayServer/Views/Manage/U2FAuthentication.cshtml
+++ b/BTCPayServer/Views/Manage/U2FAuthentication.cshtml
@@ -3,8 +3,6 @@
     ViewData.SetActivePageAndTitle(ManageNavPages.U2F, "Registered U2F devices");
 }
 
-<partial name="_StatusMessage" />
-
 <form asp-action="AddU2FDevice" method="get">
     <table class="table table-lg mb-4">
         <thead>

--- a/BTCPayServer/Views/Shared/Ethereum/UpdateChainConfig.cshtml
+++ b/BTCPayServer/Views/Shared/Ethereum/UpdateChainConfig.cshtml
@@ -11,8 +11,7 @@
     ViewData.SetActivePageAndTitle(ServerNavPages.Policies, $"ETH Chain {Model.ChainId} Configuration");
 }
 
-<partial name="_StatusMessage"/>
-@if (!this.ViewContext.ModelState.IsValid)
+@if (!ViewContext.ModelState.IsValid)
 {
     <div asp-validation-summary="All" class="text-danger"></div>
 }

--- a/BTCPayServer/Views/Wallets/NewPullPayment.cshtml
+++ b/BTCPayServer/Views/Wallets/NewPullPayment.cshtml
@@ -48,8 +48,6 @@
         }
 </style>
 
-<partial name="_StatusMessage" />
-
 <div class="row">
     <div class="col-md-6">
         <h4 class="mb-3">@ViewData["Title"]</h4>


### PR DESCRIPTION
The status message is included in the NavLayout, hence the pages that use this layout should not include the status message.

Fixes #2478.