### PR TITLE
Migrate existing U2F to Fido2

### DIFF
--- a/BTCPayServer.Data/Data/Fido2Credential.cs
+++ b/BTCPayServer.Data/Data/Fido2Credential.cs
@@ -16,8 +16,7 @@ namespace BTCPayServer.Data
         public CredentialType Type { get; set; }
         public enum CredentialType
         {
-            FIDO2,
-            U2F
+            FIDO2
         }
         public static void OnModelCreating(ModelBuilder builder)
         {

--- a/BTCPayServer.Tests/U2FTests.cs
+++ b/BTCPayServer.Tests/U2FTests.cs
@@ -9,6 +9,7 @@ using BTCPayServer.Tests.Logging;
 using BTCPayServer.U2F;
 using BTCPayServer.U2F.Models;
 using Microsoft.AspNetCore.Mvc;
+using NBitcoin;
 using U2F.Core.Models;
 using U2F.Core.Utils;
 using Xunit;
@@ -61,8 +62,8 @@ namespace BTCPayServer.Tests
                 Assert.Equal("testdevice", addDeviceVM.Name);
                 Assert.NotEmpty(addDeviceVM.Version);
                 Assert.Null(addDeviceVM.DeviceResponse);
-
-                var devReg = new DeviceRegistration(Guid.NewGuid().ToByteArray(), Guid.NewGuid().ToByteArray(),
+ 
+                var devReg = new DeviceRegistration(Guid.NewGuid().ToByteArray(), RandomUtils.GetBytes(65),
                     Guid.NewGuid().ToByteArray(), 1);
 
                 mock.GetDevReg = () => devReg;

--- a/BTCPayServer.Tests/UnitTest1.cs
+++ b/BTCPayServer.Tests/UnitTest1.cs
@@ -46,6 +46,7 @@ using BTCPayServer.Services.Rates;
 using BTCPayServer.Tests.Logging;
 using BTCPayServer.Validation;
 using ExchangeSharp;
+using Fido2NetLib;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
@@ -3339,14 +3340,11 @@ namespace BTCPayServer.Tests
                 Assert.Empty(Assert
                     .IsType<Fido2AuthenticationViewModel>(Assert
                         .IsType<ViewResult>(await manageController.List()).Model).Credentials);
-                var addRequest =
-                    Assert.IsType<AddFido2CredentialViewModel>(Assert
-                        .IsType<ViewResult>(manageController.Create(new AddFido2CredentialViewModel()
+                Assert.IsType<CredentialCreateOptions>(Assert
+                        .IsType<ViewResult>(await manageController.Create(new AddFido2CredentialViewModel()
                         {
                             Name = "label"
                         })).Model);
-                //name should match the one provided in beginning
-                Assert.Equal("label", addRequest.Name);
 
                 //sending an invalid response model back to server, should error out
                 Assert.IsType<RedirectToActionResult>(await manageController.CreateResponse("sdsdsa", "sds"));

--- a/BTCPayServer/BTCPayServer.csproj
+++ b/BTCPayServer/BTCPayServer.csproj
@@ -51,8 +51,8 @@
     <PackageReference Include="BundlerMinifier.Core" Version="3.2.435" />
     <PackageReference Include="BundlerMinifier.TagHelpers" Version="3.2.435" />
     <PackageReference Include="CsvHelper" Version="15.0.5" />
-    <PackageReference Include="Fido2" Version="2.0.0-preview2" />
-    <PackageReference Include="Fido2.AspNet" Version="2.0.0-preview2" />
+    <PackageReference Include="Fido2" Version="2.0.1" />
+    <PackageReference Include="Fido2.AspNet" Version="2.0.1" />
     <PackageReference Include="HtmlSanitizer" Version="5.0.372" />
     <PackageReference Include="McMaster.NETCore.Plugins.Mvc" Version="1.3.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Filter" Version="1.1.2" />

--- a/BTCPayServer/Fido2/Fido2Controller.cs
+++ b/BTCPayServer/Fido2/Fido2Controller.cs
@@ -78,8 +78,7 @@ namespace BTCPayServer.Fido2
         [HttpPost("register")]
         public async Task<IActionResult> CreateResponse([FromForm] string data, [FromForm] string name)
         {
-            var attestationResponse = JObject.Parse(data).ToObject<AuthenticatorAttestationRawResponse>();
-            if (await _fido2Service.CompleteCreation(_userManager.GetUserId(User), name, attestationResponse))
+            if (await _fido2Service.CompleteCreation(_userManager.GetUserId(User), name, data))
             {
 
                 TempData.SetStatusMessageModel(new StatusMessageModel

--- a/BTCPayServer/Fido2/Fido2Controller.cs
+++ b/BTCPayServer/Fido2/Fido2Controller.cs
@@ -2,7 +2,7 @@ using System.Threading.Tasks;
 using BTCPayServer.Abstractions.Extensions;
 using BTCPayServer.Abstractions.Models;
 using BTCPayServer.Data;
-using BTCPayServer.Fido2;
+using BTCPayServer.Fido2.Models;
 using BTCPayServer.Models;
 using Fido2NetLib;
 using Microsoft.AspNetCore.Authorization;
@@ -10,7 +10,7 @@ using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Newtonsoft.Json.Linq;
 
-namespace BTCPayServer.U2F.Models
+namespace BTCPayServer.Fido2
 {
 
     [Route("fido2")]

--- a/BTCPayServer/Fido2/Fido2Service.cs
+++ b/BTCPayServer/Fido2/Fido2Service.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using BTCPayServer.Data;
+using BTCPayServer.Fido2.Models;
 using ExchangeSharp;
 using Fido2NetLib;
 using Fido2NetLib.Objects;

--- a/BTCPayServer/Fido2/Fido2Service.cs
+++ b/BTCPayServer/Fido2/Fido2Service.cs
@@ -20,11 +20,13 @@ namespace BTCPayServer.Fido2
             new ConcurrentDictionary<string, AssertionOptions>();
         private readonly ApplicationDbContextFactory _contextFactory;
         private readonly IFido2 _fido2;
+        private readonly Fido2Configuration _fido2Configuration;
 
-        public Fido2Service(ApplicationDbContextFactory contextFactory, IFido2 fido2)
+        public Fido2Service(ApplicationDbContextFactory contextFactory, IFido2 fido2, Fido2Configuration fido2Configuration)
         {
             _contextFactory = contextFactory;
             _fido2 = fido2;
+            _fido2Configuration = fido2Configuration;
         }
 
         public async Task<CredentialCreateOptions> RequestCreation(string userId)
@@ -158,7 +160,9 @@ namespace BTCPayServer.Fido2
                 }, 
                 UserVerificationIndex = true, 
                 Location = true, 
-                UserVerificationMethod = true 
+                UserVerificationMethod = true ,
+                Extensions = true,
+                AppID = _fido2Configuration.Origin
             };
 
             // 3. Create options

--- a/BTCPayServer/Fido2/FidoExtensions.cs
+++ b/BTCPayServer/Fido2/FidoExtensions.cs
@@ -1,8 +1,9 @@
-using System;
+using BTCPayServer.Data;
+using BTCPayServer.Fido2.Models;
 using NBXplorer;
 using Newtonsoft.Json.Linq;
 
-namespace BTCPayServer.Data
+namespace BTCPayServer.Fido2
 {
     public static class Fido2Extensions
     { 

--- a/BTCPayServer/Fido2/Models/AddFido2CredentialViewModel.cs
+++ b/BTCPayServer/Fido2/Models/AddFido2CredentialViewModel.cs
@@ -1,6 +1,6 @@
 using Fido2NetLib.Objects;
 
-namespace BTCPayServer.U2F.Models
+namespace BTCPayServer.Fido2.Models
 {
     public class AddFido2CredentialViewModel
     {

--- a/BTCPayServer/Fido2/Models/Fido2AuthenticationViewModel.cs
+++ b/BTCPayServer/Fido2/Models/Fido2AuthenticationViewModel.cs
@@ -1,7 +1,7 @@
 using System.Collections.Generic;
 using BTCPayServer.Data;
 
-namespace BTCPayServer.U2F.Models
+namespace BTCPayServer.Fido2.Models
 {
     public class Fido2AuthenticationViewModel
     {

--- a/BTCPayServer/Fido2/Models/Fido2CredentialBlob.cs
+++ b/BTCPayServer/Fido2/Models/Fido2CredentialBlob.cs
@@ -2,7 +2,7 @@ using Fido2NetLib;
 using Fido2NetLib.Objects;
 using Newtonsoft.Json;
 
-namespace BTCPayServer.Data
+namespace BTCPayServer.Fido2.Models
 {
     public class Fido2CredentialBlob
     {

--- a/BTCPayServer/Hosting/MigrationStartupTask.cs
+++ b/BTCPayServer/Hosting/MigrationStartupTask.cs
@@ -10,6 +10,8 @@ using BTCPayServer.Abstractions.Contracts;
 using BTCPayServer.Client.Models;
 using BTCPayServer.Configuration;
 using BTCPayServer.Data;
+using BTCPayServer.Fido2;
+using BTCPayServer.Fido2.Models;
 using BTCPayServer.Logging;
 using BTCPayServer.Payments;
 using BTCPayServer.Payments.Lightning;
@@ -152,7 +154,7 @@ namespace BTCPayServer.Hosting
                 {
                     ApplicationUserId = u2FDevice.ApplicationUserId,
                     Name = u2FDevice.Name,
-                    Type = Fido2Credential.CredentialType.U2F
+                    Type = Fido2Credential.CredentialType.FIDO2
                 };
                 fido2.SetBlob(new Fido2CredentialBlob()
                 {

--- a/BTCPayServer/Hosting/MigrationStartupTask.cs
+++ b/BTCPayServer/Hosting/MigrationStartupTask.cs
@@ -173,6 +173,10 @@ namespace BTCPayServer.Hosting
         //from https://github.com/abergs/fido2-net-lib/blob/0fa7bb4b4a1f33f46c5f7ca4ee489b47680d579b/Test/ExistingU2fRegistrationDataTests.cs#L70
         private static CBORObject CreatePublicKeyFromU2fRegistrationData(byte[] publicKeyData)
         {
+            if (publicKeyData.Length != 65)
+            {
+                throw new ArgumentException("u2f public key must be 65 bytes", nameof(publicKeyData));
+            }
             var x = new byte[32];
             var y = new byte[32];
             Buffer.BlockCopy(publicKeyData, 1, x, 0, 32);

--- a/BTCPayServer/Hosting/MigrationStartupTask.cs
+++ b/BTCPayServer/Hosting/MigrationStartupTask.cs
@@ -127,7 +127,7 @@ namespace BTCPayServer.Hosting
                     await _Settings.UpdateSetting(settings);
                 }
 
-                if (!settings.MigrateU2FToFIDO2)
+                if (true || !settings.MigrateU2FToFIDO2)
                 {
                     await MigrateU2FToFIDO2();
                     settings.MigrateU2FToFIDO2 = true;

--- a/BTCPayServer/Security/GreenField/BasicAuthenticationHandler.cs
+++ b/BTCPayServer/Security/GreenField/BasicAuthenticationHandler.cs
@@ -9,6 +9,7 @@ using BTCPayServer.Client;
 using BTCPayServer.Data;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
@@ -61,7 +62,12 @@ namespace BTCPayServer.Security.GreenField
             if (!result.Succeeded)
                 return AuthenticateResult.Fail(result.ToString());
 
-            var user = await _userManager.FindByNameAsync(username);
+            var user = await _userManager.Users
+                .Include(applicationUser => applicationUser.U2FDevices)
+                .Include(applicationUser => applicationUser.Fido2Credentials)
+                .FirstOrDefaultAsync(applicationUser =>
+                    applicationUser.NormalizedUserName == _userManager.NormalizeName(username));
+            
             if (user.U2FDevices.Any() || user.Fido2Credentials.Any())
             {
                 return AuthenticateResult.Fail("Cannot use Basic authentication with multi-factor is enabled.");

--- a/BTCPayServer/Security/GreenField/BasicAuthenticationHandler.cs
+++ b/BTCPayServer/Security/GreenField/BasicAuthenticationHandler.cs
@@ -62,6 +62,10 @@ namespace BTCPayServer.Security.GreenField
                 return AuthenticateResult.Fail(result.ToString());
 
             var user = await _userManager.FindByNameAsync(username);
+            if (user.U2FDevices.Any() || user.Fido2Credentials.Any())
+            {
+                return AuthenticateResult.Fail("Cannot use Basic authentication with multi-factor is enabled.");
+            }
             var claims = new List<Claim>()
             {
                 new Claim(_identityOptions.CurrentValue.ClaimsIdentity.UserIdClaimType, user.Id),

--- a/BTCPayServer/Services/MigrationSettings.cs
+++ b/BTCPayServer/Services/MigrationSettings.cs
@@ -2,6 +2,7 @@ namespace BTCPayServer.Services
 {
     public class MigrationSettings
     {
+        public bool MigrateU2FToFIDO2{ get; set; }
         public bool UnreachableStoreCheck { get; set; }
         public bool DeprecatedLightningConnectionStringCheck { get; set; }
         public bool ConvertMultiplierToSpread { get; set; }

--- a/BTCPayServer/Views/Fido2/List.cshtml
+++ b/BTCPayServer/Views/Fido2/List.cshtml
@@ -1,4 +1,4 @@
-@model BTCPayServer.U2F.Models.Fido2AuthenticationViewModel
+@model BTCPayServer.Fido2.Models.Fido2AuthenticationViewModel
 @{
     ViewData.SetActivePageAndTitle(ManageNavPages.Fido2, "Registered FIDO2 Credentials");
 }

--- a/BTCPayServer/Views/Fido2/List.cshtml
+++ b/BTCPayServer/Views/Fido2/List.cshtml
@@ -3,8 +3,6 @@
     ViewData.SetActivePageAndTitle(ManageNavPages.Fido2, "Registered FIDO2 Credentials");
 }
 
-<partial name="_StatusMessage"/>
-
 <table class="table table-lg mb-4">
     <thead>
     <tr>


### PR DESCRIPTION
This seamlessly switches all u2f registrations over to the new FIDO2 support. Please note that I have not yet added a way to drop the u2f DB and its UI so that we can test the migration works properly for all.

THERE IS ADDITIONAL TEST CODE THAT WILL REMOVE ALL FIDO2 DEVICES ON EVERY START AND WILL ALSO MIGRATE ALL U2F DEVICES TO FIDO2. 

Please test this PR by:
* Creating u2f devices
* restarting Btcpay
* log in and verify it asks for fido2 and that it works 