### PR TITLE
Set lightning invoice fallback in QR code as uppercase

### DIFF
--- a/BTCPayServer.Tests/UnitTest1.cs
+++ b/BTCPayServer.Tests/UnitTest1.cs
@@ -2209,6 +2209,10 @@ namespace BTCPayServer.Tests
                 // Standard for all uppercase characters in QR codes is still not implemented in all wallets
                 // But we're proceeding with BECH32 being uppercase
                 Assert.True($"bitcoin:{paymentMethodSecond.BtcAddress.ToUpperInvariant()}" == split);
+
+                // Fallback lightning invoice should be uppercase inside the QR code.
+                var lightningFallback = paymentMethodSecond.InvoiceBitcoinUrlQR.Split(new string[] { "&lightning=" }, StringSplitOptions.None)[1];
+                Assert.True(lightningFallback.ToUpperInvariant() == lightningFallback);
             }
         }
 

--- a/BTCPayServer/Payments/Bitcoin/BitcoinLikePaymentHandler.cs
+++ b/BTCPayServer/Payments/Bitcoin/BitcoinLikePaymentHandler.cs
@@ -69,14 +69,16 @@ namespace BTCPayServer.Payments.Bitcoin
                 var lightningInfo = invoiceResponse.CryptoInfo.FirstOrDefault(a =>
                     a.GetpaymentMethodId() == new PaymentMethodId(model.CryptoCode, PaymentTypes.LightningLike));
                 if (!string.IsNullOrEmpty(lightningInfo?.PaymentUrls?.BOLT11))
-                    lightningFallback = "&" + lightningInfo.PaymentUrls.BOLT11.Replace("lightning:", "lightning=", StringComparison.OrdinalIgnoreCase);
+                    lightningFallback = "&" + lightningInfo.PaymentUrls.BOLT11
+                        .Replace("lightning:", "lightning=", StringComparison.OrdinalIgnoreCase)
+                        .ToUpperInvariant();
             }
 
             if (model.Activated)
             {
                 model.InvoiceBitcoinUrl = (cryptoInfo.PaymentUrls?.BIP21 ?? "") + lightningFallback;
-                model.InvoiceBitcoinUrlQR = (cryptoInfo.PaymentUrls?.BIP21 ?? "") + lightningFallback.ToUpperInvariant()
-                .Replace("LIGHTNING=", "lightning=", StringComparison.OrdinalIgnoreCase);
+                model.InvoiceBitcoinUrlQR = (cryptoInfo.PaymentUrls?.BIP21 ?? "") + lightningFallback
+                    .Replace("LIGHTNING=", "lightning=", StringComparison.OrdinalIgnoreCase);
             }
             else
             {
@@ -88,7 +90,6 @@ namespace BTCPayServer.Payments.Bitcoin
             // Ref: https://github.com/btcpayserver/btcpayserver/pull/2060#issuecomment-723828348
             //model.InvoiceBitcoinUrlQR = cryptoInfo.PaymentUrls.BIP21
             //    .Replace("bitcoin:", "BITCOIN:", StringComparison.OrdinalIgnoreCase)
-            //    + lightningFallback.ToUpperInvariant().Replace("LIGHTNING=", "lightning=", StringComparison.OrdinalIgnoreCase);
 
             // We're leading the way in Bitcoin community with adding UPPERCASE Bech32 addresses in QR Code
             if (network.CryptoCode.Equals("BTC", StringComparison.InvariantCultureIgnoreCase) && _bech32Prefix.TryGetValue(model.CryptoCode, out var prefix) && model.BtcAddress.StartsWith(prefix,  StringComparison.OrdinalIgnoreCase))

--- a/BTCPayServer/Payments/Bitcoin/BitcoinLikePaymentHandler.cs
+++ b/BTCPayServer/Payments/Bitcoin/BitcoinLikePaymentHandler.cs
@@ -75,7 +75,8 @@ namespace BTCPayServer.Payments.Bitcoin
             if (model.Activated)
             {
                 model.InvoiceBitcoinUrl = (cryptoInfo.PaymentUrls?.BIP21 ?? "") + lightningFallback;
-                model.InvoiceBitcoinUrlQR = model.InvoiceBitcoinUrl;
+                model.InvoiceBitcoinUrlQR = (cryptoInfo.PaymentUrls?.BIP21 ?? "") + lightningFallback.ToUpperInvariant()
+                .Replace("LIGHTNING=", "lightning=", StringComparison.OrdinalIgnoreCase);
             }
             else
             {


### PR DESCRIPTION
A lightning invoice is generally encoded as uppercase at checkout inside the QR code on the "Pay with Bitcoin (Lightning)" tab. However, this is not true if an invoice is added as a fallback option to the QR code on the "Pay with Bitcoin" tab.

I am not sure if adding the fallback invoice to the QR code is purposefully done in _lowercase_ for better compatibility. Otherwise, this PR fixes it by adding it in _uppercase_. 