### PR TITLE
Make sure BTCPayServer does not take the culture of the server

### DIFF
--- a/BTCPayServer/Hosting/BTCpayMiddleware.cs
+++ b/BTCPayServer/Hosting/BTCpayMiddleware.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Globalization;
 using System.Linq;
 using System.Net.WebSockets;
 using System.Threading.Tasks;
@@ -32,6 +33,8 @@ namespace BTCPayServer.Hosting
 
         public async Task Invoke(HttpContext httpContext)
         {
+            CultureInfo.CurrentCulture = CultureInfo.InvariantCulture;
+            CultureInfo.CurrentUICulture = CultureInfo.InvariantCulture;
             try
             {
                 var bitpayAuth = GetBitpayAuth(httpContext, out bool isBitpayAuth);

--- a/BTCPayServer/Hosting/Startup.cs
+++ b/BTCPayServer/Hosting/Startup.cs
@@ -32,6 +32,7 @@ using Microsoft.Net.Http.Headers;
 using NBitcoin;
 using Microsoft.AspNetCore.Mvc;
 using BTCPayServer.Controllers.GreenField;
+using System.Globalization;
 
 namespace BTCPayServer.Hosting
 {
@@ -113,6 +114,7 @@ namespace BTCPayServer.Hosting
                 o.Filters.Add(new XContentTypeOptionsAttribute("nosniff"));
                 o.Filters.Add(new XXSSProtectionAttribute());
                 o.Filters.Add(new ReferrerPolicyAttribute("same-origin"));
+                o.ModelBinderProviders.Insert(0, new ModelBinders.DefaultModelBinderProvider());
                 //o.Filters.Add(new ContentSecurityPolicyAttribute()
                 //{
                 //    FontSrc = "'self' https://fonts.gstatic.com/",
@@ -121,7 +123,7 @@ namespace BTCPayServer.Hosting
                 //    StyleSrc = "'self' 'unsafe-inline'",
                 //    ScriptSrc = "'self' 'unsafe-inline'"
                 //});
-            })
+        })
             .ConfigureApiBehaviorOptions(options =>
             {
                 options.InvalidModelStateResponseFactory = context =>
@@ -141,8 +143,6 @@ namespace BTCPayServer.Hosting
 #endif
             .AddPlugins(services, Configuration, LoggerFactory)
             .AddControllersAsServices();
-
-            
 
             services.TryAddScoped<ContentSecurityPolicies>();
             services.Configure<IdentityOptions>(options =>

--- a/BTCPayServer/ModelBinders/DefaultModelBinderProvider.cs
+++ b/BTCPayServer/ModelBinders/DefaultModelBinderProvider.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
+using BTCPayServer.Payments;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+
+namespace BTCPayServer.ModelBinders
+{
+    public class DefaultModelBinderProvider : IModelBinderProvider
+    {
+        public IModelBinder GetBinder(ModelBinderProviderContext context)
+        {
+            if (context.Metadata.ModelType == typeof(decimal) || context.Metadata.ModelType == typeof(decimal?))
+                return new InvariantDecimalModelBinder();
+            if (context.Metadata.ModelType == typeof(PaymentMethodId))
+                return new PaymentMethodIdModelBinder();
+            if (context.Metadata.ModelType == typeof(WalletIdModelBinder))
+                return new ModelBinders.WalletIdModelBinder();
+            if (typeof(DateTimeOffset).GetTypeInfo().IsAssignableFrom(context.Metadata.ModelType) ||
+                typeof(DateTimeOffset?).GetTypeInfo().IsAssignableFrom(context.Metadata.ModelType))
+            {
+                return new DateTimeOffsetModelBinder();
+            }
+                return null;
+        }
+    }
+}

--- a/BTCPayServer/PaymentRequest/PaymentRequestService.cs
+++ b/BTCPayServer/PaymentRequest/PaymentRequestService.cs
@@ -112,6 +112,7 @@ namespace BTCPayServer.PaymentRequest
                         StateFormatted = state.ToString(),
                         Payments = entity
                             .GetPayments()
+                            .Where(p => p.Accounted)
                             .Select(paymentEntity =>
                             {
                                 var paymentData = paymentEntity.GetCryptoPaymentData();


### PR DESCRIPTION
@dennisreimann reported a bug, where, running btcpayserver on a linux with some local culture would make it impossible to send money from the wallet.

This PR not only make sure that the request is always CultureInvariant, so things are predictably formatted, but on top of this, I added our model binders as default, which would allow us to remove some of of the attribute spread around the code later on.