### PR TITLE
Make sure to only select accounted payments where we should

### DIFF
--- a/BTCPayServer.Tests/PayJoinTests.cs
+++ b/BTCPayServer.Tests/PayJoinTests.cs
@@ -320,7 +320,7 @@ namespace BTCPayServer.Tests
                     await TestUtils.EventuallyAsync(async () =>
                     {
                         var invoice = await invoiceRepository.GetInvoice(invoiceId);
-                        var payments = invoice.GetPayments();
+                        var payments = invoice.GetPayments(false);
                         Assert.Equal(2, payments.Count);
                         var originalPayment = payments[0];
                         var coinjoinPayment = payments[1];
@@ -1088,7 +1088,7 @@ retry:
                 {
                     var invoiceEntity = await tester.PayTester.GetService<InvoiceRepository>().GetInvoice(invoice7.Id);
                     Assert.Equal(InvoiceStatusLegacy.Paid, invoiceEntity.Status);
-                    Assert.Contains(invoiceEntity.GetPayments(), p => p.Accounted &&
+                    Assert.Contains(invoiceEntity.GetPayments(false), p => p.Accounted &&
                                                                       ((BitcoinLikePaymentData)p.GetCryptoPaymentData()).PayjoinInformation is null);
                 });
                 ////Assert.Contains(receiverWalletPayJoinState.GetRecords(), item => item.InvoiceId == invoice7.Id && item.TxSeen);
@@ -1117,8 +1117,8 @@ retry:
                 {
                     var invoiceEntity = await tester.PayTester.GetService<InvoiceRepository>().GetInvoice(invoice7.Id);
                     Assert.Equal(InvoiceStatusLegacy.New, invoiceEntity.Status);
-                    Assert.True(invoiceEntity.GetPayments().All(p => !p.Accounted));
-                    ourOutpoint = invoiceEntity.GetAllBitcoinPaymentData().First().PayjoinInformation.ContributedOutPoints[0];
+                    Assert.True(invoiceEntity.GetPayments(false).All(p => !p.Accounted));
+                    ourOutpoint = invoiceEntity.GetAllBitcoinPaymentData(false).First().PayjoinInformation.ContributedOutPoints[0];
                 });
                 var payjoinRepository = tester.PayTester.GetService<PayJoinRepository>();
                 // The outpoint should now be available for next pj selection

--- a/BTCPayServer.Tests/UnitTest1.cs
+++ b/BTCPayServer.Tests/UnitTest1.cs
@@ -1639,8 +1639,8 @@ namespace BTCPayServer.Tests
                 {
                     var i = await tester.PayTester.InvoiceRepository.GetInvoice(invoice2.Id);
                     Assert.Equal(InvoiceStatusLegacy.New, i.Status);
-                    Assert.Single(i.GetPayments());
-                    Assert.False(i.GetPayments().First().Accounted);
+                    Assert.Single(i.GetPayments(false));
+                    Assert.False(i.GetPayments(false).First().Accounted);
                 });
 
                 Logs.Tester.LogInformation(
@@ -1672,8 +1672,8 @@ namespace BTCPayServer.Tests
                 await TestUtils.EventuallyAsync(async () =>
                     {
                         var invoiceEntity = await tester.PayTester.InvoiceRepository.GetInvoice(invoice.Id);
-                        var btcPayments = invoiceEntity.GetAllBitcoinPaymentData().ToArray();
-                        var payments = invoiceEntity.GetPayments().ToArray();
+                        var btcPayments = invoiceEntity.GetAllBitcoinPaymentData(false).ToArray();
+                        var payments = invoiceEntity.GetPayments(false).ToArray();
                         Assert.Equal(tx1, btcPayments[0].Outpoint.Hash);
                         Assert.False(payments[0].Accounted);
                         Assert.Equal(tx1Bump, payments[1].Outpoint.Hash);

--- a/BTCPayServer/Controllers/InvoiceController.UI.cs
+++ b/BTCPayServer/Controllers/InvoiceController.UI.cs
@@ -359,7 +359,7 @@ namespace BTCPayServer.Controllers
             return new InvoiceDetailsModel
             {
                 Archived = invoice.Archived,
-                Payments = invoice.GetPayments(),
+                Payments = invoice.GetPayments(false),
                 CryptoPayments = invoice.GetPaymentMethods().Select(
                     data =>
                     {
@@ -561,7 +561,7 @@ namespace BTCPayServer.Controllers
                 Status = invoice.StatusString,
 #pragma warning restore CS0618 // Type or member is obsolete
                 NetworkFee = paymentMethodDetails.GetNextNetworkFee(),
-                IsMultiCurrency = invoice.GetPayments().Select(p => p.GetPaymentMethodId()).Concat(new[] { paymentMethod.GetId() }).Distinct().Count() > 1,
+                IsMultiCurrency = invoice.GetPayments(false).Select(p => p.GetPaymentMethodId()).Concat(new[] { paymentMethod.GetId() }).Distinct().Count() > 1,
                 StoreId = store.Id,
                 AvailableCryptos = invoice.GetPaymentMethods()
                                           .Where(i => i.Network != null)

--- a/BTCPayServer/Extensions.cs
+++ b/BTCPayServer/Extensions.cs
@@ -133,9 +133,9 @@ namespace BTCPayServer
             finally { try { webSocket.Dispose(); } catch { } }
         }
 
-        public static IEnumerable<BitcoinLikePaymentData> GetAllBitcoinPaymentData(this InvoiceEntity invoice)
+        public static IEnumerable<BitcoinLikePaymentData> GetAllBitcoinPaymentData(this InvoiceEntity invoice, bool accountedOnly)
         {
-            return invoice.GetPayments()
+            return invoice.GetPayments(accountedOnly)
                 .Where(p => p.GetPaymentMethodId()?.PaymentType == PaymentTypes.BTCLike)
                 .Select(p => (BitcoinLikePaymentData)p.GetCryptoPaymentData())
                 .Where(data => data != null);

--- a/BTCPayServer/HostedServices/InvoiceWatcher.cs
+++ b/BTCPayServer/HostedServices/InvoiceWatcher.cs
@@ -101,7 +101,7 @@ namespace BTCPayServer.HostedServices
                     }
                 }
 
-                if (accounting.Paid < accounting.MinimumTotalDue && invoice.GetPayments().Count != 0 && invoice.ExceptionStatus != InvoiceExceptionStatus.PaidPartial)
+                if (accounting.Paid < accounting.MinimumTotalDue && invoice.GetPayments(true).Count != 0 && invoice.ExceptionStatus != InvoiceExceptionStatus.PaidPartial)
                 {
                     invoice.ExceptionStatus = InvoiceExceptionStatus.PaidPartial;
                     context.MarkDirty();
@@ -335,7 +335,7 @@ namespace BTCPayServer.HostedServices
         {
             bool extendInvoiceMonitoring = false;
             var updateConfirmationCountIfNeeded = invoice
-                .GetPayments()
+                .GetPayments(false)
                 .Select<PaymentEntity, Task<PaymentEntity>>(async payment =>
                 {
                     var paymentData = payment.GetCryptoPaymentData();

--- a/BTCPayServer/HostedServices/TransactionLabelMarkerHostedService.cs
+++ b/BTCPayServer/HostedServices/TransactionLabelMarkerHostedService.cs
@@ -46,7 +46,7 @@ namespace BTCPayServer.HostedServices
                     UpdateTransactionLabel.InvoiceLabelTemplate(invoiceEvent.Invoice.Id)
                 };
 
-                if (invoiceEvent.Invoice.GetPayments(invoiceEvent.Payment.GetCryptoCode()).Any(entity =>
+                if (invoiceEvent.Invoice.GetPayments(invoiceEvent.Payment.GetCryptoCode(), false).Any(entity =>
                     entity.GetCryptoPaymentData() is BitcoinLikePaymentData pData &&
                     pData.PayjoinInformation?.CoinjoinTransactionHash == transactionId))
                 {

--- a/BTCPayServer/PaymentRequest/PaymentRequestService.cs
+++ b/BTCPayServer/PaymentRequest/PaymentRequestService.cs
@@ -111,8 +111,7 @@ namespace BTCPayServer.PaymentRequest
                         State = state,
                         StateFormatted = state.ToString(),
                         Payments = entity
-                            .GetPayments()
-                            .Where(p => p.Accounted)
+                            .GetPayments(true)
                             .Select(paymentEntity =>
                             {
                                 var paymentData = paymentEntity.GetCryptoPaymentData();

--- a/BTCPayServer/Payments/Bitcoin/NBXplorerListener.cs
+++ b/BTCPayServer/Payments/Bitcoin/NBXplorerListener.cs
@@ -157,7 +157,7 @@ namespace BTCPayServer.Payments.Bitcoin
                                             output.matchedOutput.Value, output.outPoint,
                                             evt.TransactionData.Transaction.RBF, output.Item1.KeyPath);
 
-                                        var alreadyExist = invoice.GetAllBitcoinPaymentData().Where(c => c.GetPaymentId() == paymentData.GetPaymentId()).Any();
+                                        var alreadyExist = invoice.GetAllBitcoinPaymentData(false).Where(c => c.GetPaymentId() == paymentData.GetPaymentId()).Any();
                                         if (!alreadyExist)
                                         {
                                             var payment = await _InvoiceRepository.AddPayment(invoice.Id, DateTimeOffset.UtcNow, paymentData, network);
@@ -220,7 +220,7 @@ namespace BTCPayServer.Payments.Bitcoin
         {
 
             List<PaymentEntity> updatedPaymentEntities = new List<PaymentEntity>();
-            var transactions = await wallet.GetTransactions(invoice.GetAllBitcoinPaymentData()
+            var transactions = await wallet.GetTransactions(invoice.GetAllBitcoinPaymentData(false)
                     .Select(p => p.Outpoint.Hash)
                     .ToArray(), true);
             bool? originalPJBroadcasted = null;
@@ -228,7 +228,7 @@ namespace BTCPayServer.Payments.Bitcoin
             bool cjPJBroadcasted = false;
             PayjoinInformation payjoinInformation = null;
             var paymentEntitiesByPrevOut = new Dictionary<OutPoint, PaymentEntity>();
-            foreach (var payment in invoice.GetPayments(wallet.Network))
+            foreach (var payment in invoice.GetPayments(wallet.Network, false))
             {
                 if (payment.GetPaymentMethodId()?.PaymentType != PaymentTypes.BTCLike)
                     continue;
@@ -347,7 +347,7 @@ namespace BTCPayServer.Payments.Bitcoin
                 var invoice = await _InvoiceRepository.GetInvoice(invoiceId, true);
                 if (invoice == null)
                     continue;
-                var alreadyAccounted = invoice.GetAllBitcoinPaymentData().Select(p => p.Outpoint).ToHashSet();
+                var alreadyAccounted = invoice.GetAllBitcoinPaymentData(false).Select(p => p.Outpoint).ToHashSet();
                 var strategy = GetDerivationStrategy(invoice, network);
                 if (strategy == null)
                     continue;

--- a/BTCPayServer/Payments/PayJoin/PayJoinEndpointController.cs
+++ b/BTCPayServer/Payments/PayJoin/PayJoinEndpointController.cs
@@ -300,7 +300,7 @@ namespace BTCPayServer.Payments.PayJoin
                     paymentAddress = paymentDetails.GetDepositAddress(network.NBitcoinNetwork);
                     paymentAddressIndex = paymentDetails.KeyPath;
 
-                    if (invoice.GetAllBitcoinPaymentData().Any())
+                    if (invoice.GetAllBitcoinPaymentData(false).Any())
                     {
                         ctx.DoNotBroadcast();
                         return UnprocessableEntity(CreatePayjoinError("already-paid",

--- a/BTCPayServer/Services/Altcoins/Ethereum/Services/EthereumWatcher.cs
+++ b/BTCPayServer/Services/Altcoins/Ethereum/Services/EthereumWatcher.cs
@@ -242,7 +242,7 @@ namespace BTCPayServer.Services.Altcoins.Ethereum.Services
                     .Select(entity => (
                         Invoice: entity,
                         PaymentMethodDetails: entity.GetPaymentMethods().TryGet(paymentMethodId),
-                        ExistingPayments: entity.GetPayments(network).Select(paymentEntity => (Payment: paymentEntity,
+                        ExistingPayments: entity.GetPayments(network, true).Select(paymentEntity => (Payment: paymentEntity,
                             PaymentData: (EthereumLikePaymentData)paymentEntity.GetCryptoPaymentData(),
                             Invoice: entity))
                     )).Where(tuple => tuple.PaymentMethodDetails?.GetPaymentMethodDetails()?.Activated is true).ToList();

--- a/BTCPayServer/Services/Altcoins/Monero/Services/MoneroListener.cs
+++ b/BTCPayServer/Services/Altcoins/Monero/Services/MoneroListener.cs
@@ -372,7 +372,7 @@ namespace BTCPayServer.Services.Altcoins.Monero.Services
 
         private IEnumerable<PaymentEntity> GetAllMoneroLikePayments(InvoiceEntity invoice, string cryptoCode)
         {
-            return invoice.GetPayments()
+            return invoice.GetPayments(false)
                 .Where(p => p.GetPaymentMethodId() == new PaymentMethodId(cryptoCode, MoneroPaymentType.Instance));
         }
     }

--- a/BTCPayServer/Services/Apps/AppService.cs
+++ b/BTCPayServer/Services/Apps/AppService.cs
@@ -359,7 +359,7 @@ namespace BTCPayServer.Services.Apps
 
                     // If the user get a donation via other mean, he can register an invoice manually for such amount
                     // then mark the invoice as complete
-                    var payments = p.GetPayments();
+                    var payments = p.GetPayments(true);
                     if (payments.Count == 0 &&
                         p.ExceptionStatus == InvoiceExceptionStatus.Marked &&
                         p.Status == InvoiceStatusLegacy.Complete)

--- a/BTCPayServer/Services/Invoices/Export/InvoiceExport.cs
+++ b/BTCPayServer/Services/Invoices/Export/InvoiceExport.cs
@@ -59,11 +59,8 @@ namespace BTCPayServer.Services.Invoices.Export
             var currency = Currencies.GetNumberFormatInfo(invoice.Currency, true);
             var invoiceDue = invoice.Price;
             // in this first version we are only exporting invoices that were paid
-            foreach (var payment in invoice.GetPayments())
+            foreach (var payment in invoice.GetPayments(true))
             {
-                // not accounted payments are payments which got double spent like RBfed
-                if (!payment.Accounted)
-                    continue;
                 var cryptoCode = payment.GetPaymentMethodId().CryptoCode;
                 var pdata = payment.GetCryptoPaymentData();
 

--- a/BTCPayServer/wwwroot/swagger/v1/swagger.template.invoices.json
+++ b/BTCPayServer/wwwroot/swagger/v1/swagger.template.invoices.json
@@ -347,6 +347,16 @@
                         "schema": {
                             "type": "string"
                         }
+                    },
+                    {
+                        "name": "onlyAccountedPayments",
+                        "in": "query",
+                        "required": false,
+                        "description": "If default or true, only returns payments which are accounted (in Bitcoin, this mean not returning RBF'd or double spent payments)",
+                        "schema": {
+                            "type": "boolean",
+                            "default": true
+                        }
                     }
                 ],
                 "description": "View information about the specified invoice's payment methods",


### PR DESCRIPTION
I noticed that in crowdfunding and payment requests, we were not properly filtering payment that should not be accounted. (for example, if those have been double spent)

Since it is easy to forget it, I added a boolean `onlyAccounted` we need to specify on `invoice.GetPayment`.
This revealed several places where we were not properly checking it.

This does not impact invoice accounting though.

Since this is something easy to forget, I changed the greenfield API so that the user must specify `onlyAccountedPayments=false` in `/api/v1/stores/{storeId}/invoices/{invoiceId}/payment-methods`. This prevent foot shooting.