### PR TITLE
Mark Payouts as Paid

### DIFF
--- a/BTCPayServer.Client/BTCPayServerClient.PullPayments.cs
+++ b/BTCPayServer.Client/BTCPayServerClient.PullPayments.cs
@@ -58,14 +58,14 @@ namespace BTCPayServer.Client
             return await HandleResponse<PayoutData>(response);
         }
 
-        public async Task<PayoutData> MarkPayoutPaid(string storeId, string payoutId,
+        public async Task MarkPayoutPaid(string storeId, string payoutId,
             CancellationToken cancellationToken = default)
         {
             var response = await _httpClient.SendAsync(
                 CreateHttpRequest(
                     $"api/v1/stores/{HttpUtility.UrlEncode(storeId)}/payouts/{HttpUtility.UrlEncode(payoutId)}/mark-paid",
                     method: HttpMethod.Post), cancellationToken);
-            return await HandleResponse<PayoutData>(response);
+            await HandleResponse(response);
         }
     }
 }

--- a/BTCPayServer.Client/BTCPayServerClient.PullPayments.cs
+++ b/BTCPayServer.Client/BTCPayServerClient.PullPayments.cs
@@ -57,5 +57,15 @@ namespace BTCPayServer.Client
             var response = await _httpClient.SendAsync(CreateHttpRequest($"api/v1/stores/{HttpUtility.UrlEncode(storeId)}/payouts/{HttpUtility.UrlEncode(payoutId)}", bodyPayload: request, method: HttpMethod.Post), cancellationToken);
             return await HandleResponse<PayoutData>(response);
         }
+
+        public async Task<PayoutData> MarkPayoutPaid(string storeId, string payoutId,
+            CancellationToken cancellationToken = default)
+        {
+            var response = await _httpClient.SendAsync(
+                CreateHttpRequest(
+                    $"api/v1/stores/{HttpUtility.UrlEncode(storeId)}/payouts/{HttpUtility.UrlEncode(payoutId)}/mark-paid",
+                    method: HttpMethod.Post), cancellationToken);
+            return await HandleResponse<PayoutData>(response);
+        }
     }
 }

--- a/BTCPayServer.Tests/GreenfieldAPITests.cs
+++ b/BTCPayServer.Tests/GreenfieldAPITests.cs
@@ -490,6 +490,10 @@ namespace BTCPayServer.Tests
                 // The payout should round the value of the payment down to the network of the payment method
                 Assert.Equal(12.30322814m, payout.PaymentMethodAmount);
                 Assert.Equal(12.303228134m, payout.Amount);
+
+                payout = await client.MarkPayoutPaid(storeId, payout.Id);
+                Assert.Equal(PayoutState.Completed,payout.State);
+                await AssertAPIError("invalid-state", async () => await client.MarkPayoutPaid(storeId, payout.Id));
             }
         }
 

--- a/BTCPayServer.Tests/GreenfieldAPITests.cs
+++ b/BTCPayServer.Tests/GreenfieldAPITests.cs
@@ -491,7 +491,8 @@ namespace BTCPayServer.Tests
                 Assert.Equal(12.30322814m, payout.PaymentMethodAmount);
                 Assert.Equal(12.303228134m, payout.Amount);
 
-                payout = await client.MarkPayoutPaid(storeId, payout.Id);
+                await client.MarkPayoutPaid(storeId, payout.Id);
+                payout = (await client.GetPayouts(payout.PullPaymentId)).First(data => data.Id == payout.Id);
                 Assert.Equal(PayoutState.Completed, payout.State);
                 await AssertAPIError("invalid-state", async () => await client.MarkPayoutPaid(storeId, payout.Id));
             }

--- a/BTCPayServer.Tests/GreenfieldAPITests.cs
+++ b/BTCPayServer.Tests/GreenfieldAPITests.cs
@@ -492,7 +492,7 @@ namespace BTCPayServer.Tests
                 Assert.Equal(12.303228134m, payout.Amount);
 
                 payout = await client.MarkPayoutPaid(storeId, payout.Id);
-                Assert.Equal(PayoutState.Completed,payout.State);
+                Assert.Equal(PayoutState.Completed, payout.State);
                 await AssertAPIError("invalid-state", async () => await client.MarkPayoutPaid(storeId, payout.Id));
             }
         }

--- a/BTCPayServer/Controllers/PullPaymentController.cs
+++ b/BTCPayServer/Controllers/PullPaymentController.cs
@@ -42,6 +42,7 @@ namespace BTCPayServer.Controllers
             _serializerSettings = serializerSettings;
             _payoutHandlers = payoutHandlers;
         }
+        
         [Route("pull-payments/{pullPaymentId}")]
         public async Task<IActionResult> ViewPullPayment(string pullPaymentId)
         {

--- a/BTCPayServer/Data/Payouts/BitcoinLike/BitcoinLikePayoutHandler.cs
+++ b/BTCPayServer/Data/Payouts/BitcoinLike/BitcoinLikePayoutHandler.cs
@@ -18,6 +18,7 @@ using NBitcoin.Payment;
 using NBitcoin.RPC;
 using NBXplorer.Models;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using NewBlockEvent = BTCPayServer.Events.NewBlockEvent;
 using PayoutData = BTCPayServer.Data.PayoutData;
 
@@ -70,10 +71,19 @@ public class BitcoinLikePayoutHandler : IPayoutHandler
         if (payout?.Proof is null)
             return null;
         var paymentMethodId = payout.GetPaymentMethodId();
-        var res =  JsonConvert.DeserializeObject<PayoutTransactionOnChainBlob>(Encoding.UTF8.GetString(payout.Proof), _jsonSerializerSettings.GetSerializer(paymentMethodId.CryptoCode));
+        var raw =  JObject.Parse(Encoding.UTF8.GetString(payout.Proof));
+        if (raw.TryGetValue("proofType", StringComparison.InvariantCultureIgnoreCase, out var proofType) &&
+            proofType.Value<string>() == ManualPayoutProof.Type)
+        {
+            return raw.ToObject<ManualPayoutProof>();
+        }
+        var res = raw.ToObject<PayoutTransactionOnChainBlob>(
+            JsonSerializer.Create(_jsonSerializerSettings.GetSerializer(paymentMethodId.CryptoCode)));
         var network = _btcPayNetworkProvider.GetNetwork<BTCPayNetwork>(paymentMethodId.CryptoCode);
+        if (res == null) return null;
         res.LinkTemplate = network.BlockExplorerLink;
         return res;
+
     }
 
     public void StartBackgroundCheck(Action<Type[]> subscribe)

--- a/BTCPayServer/Data/Payouts/BitcoinLike/BitcoinLikePayoutHandler.cs
+++ b/BTCPayServer/Data/Payouts/BitcoinLike/BitcoinLikePayoutHandler.cs
@@ -83,7 +83,6 @@ public class BitcoinLikePayoutHandler : IPayoutHandler
         if (res == null) return null;
         res.LinkTemplate = network.BlockExplorerLink;
         return res;
-
     }
 
     public void StartBackgroundCheck(Action<Type[]> subscribe)

--- a/BTCPayServer/Data/Payouts/BitcoinLike/PayoutTransactionOnChainBlob.cs
+++ b/BTCPayServer/Data/Payouts/BitcoinLike/PayoutTransactionOnChainBlob.cs
@@ -13,6 +13,8 @@ namespace BTCPayServer.Data
         public HashSet<uint256> Candidates { get; set; } = new HashSet<uint256>();
 
         [JsonIgnore] public string LinkTemplate { get; set; }
+        public string ProofType { get; } = "PayoutTransactionOnChainBlob";
+
         [JsonIgnore]
         public string Link
         {

--- a/BTCPayServer/Data/Payouts/IClaimDestination.cs
+++ b/BTCPayServer/Data/Payouts/IClaimDestination.cs
@@ -1,12 +1,8 @@
+using System;
+
 namespace BTCPayServer.Data
 {
     public interface IClaimDestination
     {
-    }
-
-    public interface IPayoutProof
-    {
-        string Link { get; }
-        string Id { get; }
     }
 }

--- a/BTCPayServer/Data/Payouts/IPayoutProof.cs
+++ b/BTCPayServer/Data/Payouts/IPayoutProof.cs
@@ -1,0 +1,9 @@
+namespace BTCPayServer.Data
+{
+    public interface IPayoutProof
+    {
+        string ProofType { get; }
+        string Link { get; }
+        string Id { get; }
+    }
+}

--- a/BTCPayServer/Data/Payouts/ManualPayoutProof.cs
+++ b/BTCPayServer/Data/Payouts/ManualPayoutProof.cs
@@ -1,0 +1,10 @@
+namespace BTCPayServer.Data
+{
+    public class ManualPayoutProof : IPayoutProof
+    {
+        public static string Type = "ManualPayoutProof";
+        public string ProofType { get; } = Type;
+        public string Link { get; set; }
+        public string Id { get; set; }
+    }
+}

--- a/BTCPayServer/Data/Payouts/PayoutExtensions.cs
+++ b/BTCPayServer/Data/Payouts/PayoutExtensions.cs
@@ -38,5 +38,17 @@ namespace BTCPayServer.Data
         {
             data.Blob = Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(blob, serializers.GetSerializer(data.GetPaymentMethodId().CryptoCode)));
         }
+
+        public static void SetProofBlob(this PayoutData data, ManualPayoutProof blob)
+        {
+            if(blob is null)
+                return;
+            var bytes = Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(blob));
+            // We only update the property if the bytes actually changed, this prevent from hammering the DB too much
+            if (data.Proof is null || bytes.Length != data.Proof.Length || !bytes.SequenceEqual(data.Proof))
+            {
+                data.Proof = bytes;
+            }
+        }
     }
 }

--- a/BTCPayServer/HostedServices/PullPaymentHostedService.cs
+++ b/BTCPayServer/HostedServices/PullPaymentHostedService.cs
@@ -206,6 +206,10 @@ namespace BTCPayServer.HostedServices
                 {
                     await HandleCancel(cancel);
                 } 
+                if (o is InternalPayoutPaidRequest paid)
+                {
+                    await HandleMarkPaid(paid);
+                } 
                 foreach (IPayoutHandler payoutHandler in _payoutHandlers)
                 {
                    await payoutHandler.BackgroundCheck(o);
@@ -285,6 +289,35 @@ namespace BTCPayServer.HostedServices
                 payout.SetBlob(payoutBlob, _jsonSerializerSettings);
                 await ctx.SaveChangesAsync();
                 req.Completion.SetResult(PayoutApproval.Result.Ok);
+            }
+            catch (Exception ex)
+            {
+                req.Completion.TrySetException(ex);
+            }
+        }
+        private async Task HandleMarkPaid(InternalPayoutPaidRequest req)
+        {
+            try
+            {
+                await using var ctx = _dbContextFactory.CreateContext();
+                var payout = await ctx.Payouts.Include(p => p.PullPaymentData).Where(p => p.Id == req.Request.PayoutId).FirstOrDefaultAsync();
+                if (payout is null)
+                {
+                    req.Completion.SetResult(PayoutPaidRequest.PayoutPaidResult.NotFound);
+                    return;
+                }
+                if (payout.State != PayoutState.AwaitingPayment)
+                {
+                    req.Completion.SetResult(PayoutPaidRequest.PayoutPaidResult.InvalidState);
+                    return;
+                }
+                if (req.Request.Proof != null)
+                {
+                    payout.SetProofBlob(req.Request.Proof);
+                }
+                payout.State = PayoutState.Completed;
+                await ctx.SaveChangesAsync();
+                req.Completion.SetResult(PayoutPaidRequest.PayoutPaidResult.Ok);
             }
             catch (Exception ex)
             {
@@ -444,6 +477,60 @@ namespace BTCPayServer.HostedServices
             _subscriptions.Dispose();
             return base.StopAsync(cancellationToken);
         }
+
+        public Task<PayoutPaidRequest.PayoutPaidResult> MarkPaid(PayoutPaidRequest request)
+        {
+            CancellationToken.ThrowIfCancellationRequested();
+            var cts = new TaskCompletionSource<PayoutPaidRequest.PayoutPaidResult>(TaskCreationOptions.RunContinuationsAsynchronously);
+            if (!_Channel.Writer.TryWrite(new InternalPayoutPaidRequest(cts, request)))
+                throw new ObjectDisposedException(nameof(PullPaymentHostedService));
+            return cts.Task;
+        }
+
+
+        class InternalPayoutPaidRequest
+        {
+            public InternalPayoutPaidRequest(TaskCompletionSource<PayoutPaidRequest.PayoutPaidResult> completionSource, PayoutPaidRequest request)
+            {
+                if (request == null)
+                    throw new ArgumentNullException(nameof(request));
+                if (completionSource == null)
+                    throw new ArgumentNullException(nameof(completionSource));
+                Completion = completionSource;
+                Request = request;
+            }
+            public TaskCompletionSource<PayoutPaidRequest.PayoutPaidResult> Completion { get; set; }
+            public PayoutPaidRequest Request { get; }
+        }
+        
+    }
+
+    public class PayoutPaidRequest
+    {
+        public enum PayoutPaidResult
+        {
+            Ok,
+            NotFound,
+            InvalidState
+        }
+        public string PayoutId { get; set; }
+        public ManualPayoutProof Proof { get; set; }
+        
+        public static string GetErrorMessage(PayoutPaidResult result)
+        {
+            switch (result)
+            {
+                case PayoutPaidResult.NotFound:
+                    return "The payout is not found";
+                case PayoutPaidResult.Ok:
+                    return "Ok";
+                case PayoutPaidResult.InvalidState:
+                    return "The payout is not in a state that can be marked as paid";
+                default:
+                    throw new NotSupportedException();
+            }
+        }
+        
     }
 
     public class ClaimRequest

--- a/BTCPayServer/HostedServices/PullPaymentHostedService.cs
+++ b/BTCPayServer/HostedServices/PullPaymentHostedService.cs
@@ -123,8 +123,8 @@ namespace BTCPayServer.HostedServices
 
         public async Task<Data.PullPaymentData> GetPullPayment(string pullPaymentId)
         {
-            using var ctx = _dbContextFactory.CreateContext();
-            return await ctx.PullPayments.FindAsync(pullPaymentId);
+            await using var ctx = _dbContextFactory.CreateContext();
+            return await ctx.PullPayments.Include(data => data.Payouts).FirstOrDefaultAsync(data => data.Id == pullPaymentId);
         }
 
         class PayoutRequest

--- a/BTCPayServer/Models/WalletViewModels/PayoutsModel.cs
+++ b/BTCPayServer/Models/WalletViewModels/PayoutsModel.cs
@@ -23,7 +23,7 @@ namespace BTCPayServer.Models.WalletViewModels
             public string PullPaymentName { get; set; }
             public string Destination { get; set; }
             public string Amount { get; set; }
-            public string TransactionLink { get; set; }
+            public string ProofLink { get; set; }
         }
 
         public class PayoutStateSet

--- a/BTCPayServer/Views/PullPayment/ViewPullPayment.cshtml
+++ b/BTCPayServer/Views/PullPayment/ViewPullPayment.cshtml
@@ -139,7 +139,7 @@
                 <div class="row">
                     <div class="col">
                         <div class="bg-tile h-100 m-0 p-3 p-sm-5">
-                            <h2 class="h4 mb-3">Awaiting Claims</h2>
+                            <h2 class="h4 mb-3">Claims</h2>
                             <div class="table-responsive">
                                 @if (Model.Payouts.Any())
                                 {

--- a/BTCPayServer/Views/Wallets/Payouts.cshtml
+++ b/BTCPayServer/Views/Wallets/Payouts.cshtml
@@ -4,7 +4,7 @@
 @inject IEnumerable<IPayoutHandler> PayoutHandlers;
 @{
     Layout = "../Shared/_NavLayout.cshtml";
-    ViewData.SetActivePageAndTitle(WalletsNavPages.Payouts, "Manage payouts", Context.GetStoreData().StoreName);
+    ViewData.SetActivePageAndTitle(WalletsNavPages.Payouts, $"Manage {Model.PaymentMethodId.ToPrettyString()} payouts", Context.GetStoreData().StoreName);
 }
 
 @section PageFootContent {
@@ -55,6 +55,7 @@
                     case PayoutState.AwaitingPayment:
                         stateActions.Add(("pay", "Send selected payouts"));
                         stateActions.Add(("cancel", "Cancel selected payouts"));
+                        stateActions.Add(("mark-paid", "Mark selected payouts as already paid"));
                         break;
                 }
                 <div class="tab-pane @(index == 0 ? "active" : "") " id="@state.State" role="tabpanel">
@@ -122,9 +123,9 @@
                                         @if (state.State != PayoutState.AwaitingApproval)
                                         {
                                             <td class="text-end">
-                                                @if (!(pp.TransactionLink is null))
+                                                @if (!(pp.ProofLink is null))
                                                 {
-                                                    <a class="transaction-link" href="@pp.TransactionLink">Link</a>
+                                                    <a class="transaction-link" href="@pp.ProofLink">Link</a>
                                                 }
                                             </td>
                                         }

--- a/BTCPayServer/wwwroot/swagger/v1/swagger.template.pull-payments.json
+++ b/BTCPayServer/wwwroot/swagger/v1/swagger.template.pull-payments.json
@@ -490,28 +490,6 @@
                         "Basic": []
                     }
                 ]
-            },
-            "delete": {
-                "summary": "Cancel Payout",
-                "description": "Cancel the payout",
-                "operationId": "PullPayments_CancelPayout",
-                "responses": {
-                    "200": {
-                        "description": "The payout has been cancelled"
-                    },
-                    "404": {
-                        "description": "The payout is not found"
-                    }
-                },
-                "tags": [ "Pull payments (Management)" ],
-                "security": [
-                    {
-                        "API Key": [
-                            "btcpay.store.canmanagepullpayments"
-                        ],
-                        "Basic": []
-                    }
-                ]
             }
         }
     },

--- a/BTCPayServer/wwwroot/swagger/v1/swagger.template.pull-payments.json
+++ b/BTCPayServer/wwwroot/swagger/v1/swagger.template.pull-payments.json
@@ -423,6 +423,96 @@
                     }
                 ]
             }
+        },
+        "/api/v1/stores/{storeId}/payouts/{payoutId}/mark-paid": {
+            "parameters": [
+                {
+                    "name": "storeId",
+                    "in": "path",
+                    "required": true,
+                    "description": "The ID of the store",
+                    "schema": { "type": "string" }
+                },
+                {
+                    "name": "payoutId",
+                    "in": "path",
+                    "required": true,
+                    "description": "The ID of the payout",
+                    "schema": { "type": "string" }
+                }
+            ],
+            "post": {
+
+                "summary": "Mark Payout as Paid",
+                "operationId": "PullPayments_MarkPayoutPaid",
+                "description": "Mark a payout as paid",
+                "responses": {
+                    "200": {
+                        "description": "The payout has been marked paid, transitioning to `Completed` state.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/PayoutData"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Unable to validate the request",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ValidationProblemDetails"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Wellknown error codes are: `invalid-state`",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProblemDetails"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "The payout is not found"
+                    }
+                },
+                "tags": [ "Pull payments (Management)" ],
+                "security": [
+                    {
+                        "API Key": [
+                            "btcpay.store.canmanagepullpayments"
+                        ],
+                        "Basic": []
+                    }
+                ]
+            },
+            "delete": {
+                "summary": "Cancel Payout",
+                "description": "Cancel the payout",
+                "operationId": "PullPayments_CancelPayout",
+                "responses": {
+                    "200": {
+                        "description": "The payout has been cancelled"
+                    },
+                    "404": {
+                        "description": "The payout is not found"
+                    }
+                },
+                "tags": [ "Pull payments (Management)" ],
+                "security": [
+                    {
+                        "API Key": [
+                            "btcpay.store.canmanagepullpayments"
+                        ],
+                        "Basic": []
+                    }
+                ]
+            }
         }
     },
     "components": {

--- a/BTCPayServer/wwwroot/swagger/v1/swagger.template.pull-payments.json
+++ b/BTCPayServer/wwwroot/swagger/v1/swagger.template.pull-payments.json
@@ -448,14 +448,7 @@
                 "description": "Mark a payout as paid",
                 "responses": {
                     "200": {
-                        "description": "The payout has been marked paid, transitioning to `Completed` state.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/PayoutData"
-                                }
-                            }
-                        }
+                        "description": "The payout has been marked paid, transitioning to `Completed` state."                        
                     },
                     "422": {
                         "description": "Unable to validate the request",


### PR DESCRIPTION
This PR allows users to mark payouts as paid manually through the UI  and through the API. It also sets up the payout proof system to be able store a manual proof that will in a later PR allow you to specify a proof of payment (link or text)