### PR TITLE
Update HWI library, warn users to run newer version

### DIFF
--- a/BTCPayServer.Client/BTCPayServer.Client.csproj
+++ b/BTCPayServer.Client/BTCPayServer.Client.csproj
@@ -27,7 +27,7 @@
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
   </ItemGroup>
     <ItemGroup>
-      <PackageReference Include="NBitcoin" Version="5.0.77" />
+      <PackageReference Include="NBitcoin" Version="5.0.81" />
       <PackageReference Include="BTCPayServer.Lightning.Common" Version="1.2.0" />
       <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     </ItemGroup>

--- a/BTCPayServer.Rating/BTCPayServer.Rating.csproj
+++ b/BTCPayServer.Rating/BTCPayServer.Rating.csproj
@@ -6,7 +6,7 @@
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.6.0" />
     <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.7" />
-    <PackageReference Include="NBitcoin" Version="5.0.77" />
+    <PackageReference Include="NBitcoin" Version="5.0.81" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="DigitalRuby.ExchangeSharp" Version="0.6.3" />
   </ItemGroup>

--- a/BTCPayServer/BTCPayServer.csproj
+++ b/BTCPayServer/BTCPayServer.csproj
@@ -45,7 +45,7 @@
 
   <ItemGroup>
     <PackageReference Include="BIP78.Sender" Version="0.2.0" />
-    <PackageReference Include="BTCPayServer.Hwi" Version="1.1.3" />
+    <PackageReference Include="BTCPayServer.Hwi" Version="2.0.1" />
     <PackageReference Include="BTCPayServer.Lightning.All" Version="1.2.7" />
     <PackageReference Include="BuildBundlerMinifier" Version="3.2.449" />
     <PackageReference Include="BundlerMinifier.Core" Version="3.2.435" />

--- a/BTCPayServer/Controllers/GreenField/ServerInfoController.cs
+++ b/BTCPayServer/Controllers/GreenField/ServerInfoController.cs
@@ -32,7 +32,7 @@ namespace BTCPayServer.Controllers.GreenField
 
         [Authorize(AuthenticationSchemes = AuthenticationSchemes.Greenfield)]
         [HttpGet("~/api/v1/server/info")]
-        public async Task<ActionResult> ServerInfo()
+        public ActionResult ServerInfo()
         {
             var supportedPaymentMethods = _paymentMethodHandlerDictionary
                 .SelectMany(handler => handler.GetSupportedPaymentMethods().Select(id => id.ToString()))

--- a/BTCPayServer/Payments/Lightning/LightningListener.cs
+++ b/BTCPayServer/Payments/Lightning/LightningListener.cs
@@ -167,7 +167,7 @@ namespace BTCPayServer.Payments.Lightning
                 }
                 
             }));
-            leases.Add(_Aggregator.Subscribe<Events.InvoicePaymentMethodActivated>(async inv =>
+            leases.Add(_Aggregator.Subscribe<Events.InvoicePaymentMethodActivated>(inv =>
             {
                 if (inv.PaymentMethodId.PaymentType == LightningPaymentType.Instance)
                 {

--- a/BTCPayServer/wwwroot/js/vaultbridge.js
+++ b/BTCPayServer/wwwroot/js/vaultbridge.js
@@ -1,4 +1,4 @@
-﻿var vault = (function () {
+var vault = (function () {
     /** @param {WebSocket} websocket
     */
     function VaultBridge(websocket) {
@@ -97,7 +97,7 @@
             notRunning: "NotRunning",
             denied: "Denied",
             socketNotSupported: "SocketNotSupported",
-            socketError: "SocketError",
+            socketError: "SocketError"
         },
         askVaultPermission: askVaultPermission,
         connectToBackendSocket: connectToBackendSocket,

--- a/BTCPayServer/wwwroot/js/vaultbridge.ui.js
+++ b/BTCPayServer/wwwroot/js/vaultbridge.ui.js
@@ -32,7 +32,7 @@ var vaultui = (function () {
         noWebsockets: new VaultFeedback("failed", "Web sockets are not supported by the browser.", "vault-feedback1", "no-websocket"),
         errorWebsockets: new VaultFeedback("failed", "Error of the websocket while connecting to the backend.", "vault-feedback1", "error-websocket"),
         bridgeConnected: new VaultFeedback("ok", "BTCPayServer successfully connected to the vault.", "vault-feedback1", "bridge-connected"),
-        vaultNeedUpdate: new VaultFeedback("failed", "BTCPayServer Vault is running, but you need to update. Download the latest version on <a target=\"_blank\" href=\"https://github.com/btcpayserver/BTCPayServer.Vault/releases/latest\">Github</a>.", "vault-feedback2", "vault-outdated"),
+        vaultNeedUpdate: new VaultFeedback("failed", "Your BTCPay Server Vault version is obsolete. Please <a target=\"_blank\" href=\"https://github.com/btcpayserver/BTCPayServer.Vault/releases/latest\">download</a> the latest version.", "vault-feedback2", "vault-outdated"),
         noDevice: new VaultFeedback("failed", "No device connected.", "vault-feedback2", "no-device"),
         needInitialized: new VaultFeedback("failed", "The device has not been initialized.", "vault-feedback2", "need-initialized"),
         fetchingDevice: new VaultFeedback("?", "Fetching device...", "vault-feedback2", "fetching-device"),

--- a/BTCPayServer/wwwroot/js/vaultbridge.ui.js
+++ b/BTCPayServer/wwwroot/js/vaultbridge.ui.js
@@ -32,6 +32,7 @@ var vaultui = (function () {
         noWebsockets: new VaultFeedback("failed", "Web sockets are not supported by the browser.", "vault-feedback1", "no-websocket"),
         errorWebsockets: new VaultFeedback("failed", "Error of the websocket while connecting to the backend.", "vault-feedback1", "error-websocket"),
         bridgeConnected: new VaultFeedback("ok", "BTCPayServer successfully connected to the vault.", "vault-feedback1", "bridge-connected"),
+        vaultNeedUpdate: new VaultFeedback("failed", "BTCPayServer Vault is running, but you need to update. Download the latest version on <a target=\"_blank\" href=\"https://github.com/btcpayserver/BTCPayServer.Vault/releases/latest\">Github</a>.", "vault-feedback2", "vault-outdated"),
         noDevice: new VaultFeedback("failed", "No device connected.", "vault-feedback2", "no-device"),
         needInitialized: new VaultFeedback("failed", "The device has not been initialized.", "vault-feedback2", "need-initialized"),
         fetchingDevice: new VaultFeedback("?", "Fetching device...", "vault-feedback2", "fetching-device"),

--- a/BTCPayServer/wwwroot/js/vaultbridge.ui.js
+++ b/BTCPayServer/wwwroot/js/vaultbridge.ui.js
@@ -32,7 +32,7 @@ var vaultui = (function () {
         noWebsockets: new VaultFeedback("failed", "Web sockets are not supported by the browser.", "vault-feedback1", "no-websocket"),
         errorWebsockets: new VaultFeedback("failed", "Error of the websocket while connecting to the backend.", "vault-feedback1", "error-websocket"),
         bridgeConnected: new VaultFeedback("ok", "BTCPayServer successfully connected to the vault.", "vault-feedback1", "bridge-connected"),
-        vaultNeedUpdate: new VaultFeedback("failed", "Your BTCPay Server Vault version is obsolete. Please <a target=\"_blank\" href=\"https://github.com/btcpayserver/BTCPayServer.Vault/releases/latest\">download</a> the latest version.", "vault-feedback2", "vault-outdated"),
+        vaultNeedUpdate: new VaultFeedback("failed", "Your BTCPay Server Vault version is outdated. Please <a target=\"_blank\" href=\"https://github.com/btcpayserver/BTCPayServer.Vault/releases/latest\">download</a> the latest version.", "vault-feedback2", "vault-outdated"),
         noDevice: new VaultFeedback("failed", "No device connected.", "vault-feedback2", "no-device"),
         needInitialized: new VaultFeedback("failed", "The device has not been initialized.", "vault-feedback2", "need-initialized"),
         fetchingDevice: new VaultFeedback("?", "Fetching device...", "vault-feedback2", "fetching-device"),


### PR DESCRIPTION
hwi made some breaking change in version 2.0.1.
The next release of BTCPayServer assume hwi on version 2.0.1, if not the following message will appear.

Note that the 2.0.1 version of the vault is in pre-release at this stage. I plan to release it when we release next btcpayserver version.

New version of the vault should work on old version of btcpayserver. (except one edge case for the address verification steps when adding a wallet)
Because of this edge case, I wait for next release to put the new vault out of pre release.

![image](https://user-images.githubusercontent.com/3020646/119788364-0851f100-bf0d-11eb-9ecc-207d15553908.png)
