### PR TITLE
Signing context cleanup

### DIFF
--- a/BTCPayServer/Controllers/WalletsController.PSBT.cs
+++ b/BTCPayServer/Controllers/WalletsController.PSBT.cs
@@ -119,7 +119,6 @@ namespace BTCPayServer.Controllers
             }
 
             vm.PSBTHex = psbt.ToHex();
-            vm.SigningContext.NBXSeedAvailable = vm.NBXSeedAvailable;
             var routeBack = new Dictionary<string, string>
             {
                 {"action", nameof(WalletPSBT)}, {"walletId", walletId.ToString()}

--- a/BTCPayServer/Controllers/WalletsController.cs
+++ b/BTCPayServer/Controllers/WalletsController.cs
@@ -708,8 +708,7 @@ namespace BTCPayServer.Controllers
             {
                 PayJoinBIP21 = vm.PayJoinBIP21,
                 EnforceLowR = psbtResponse.Suggestions?.ShouldEnforceLowR,
-                ChangeAddress = psbtResponse.ChangeAddress?.ToString(),
-                NBXSeedAvailable = vm.NBXSeedAvailable
+                ChangeAddress = psbtResponse.ChangeAddress?.ToString()
             };
                 
             var routeBack = new Dictionary<string, string>

--- a/BTCPayServer/Models/WalletViewModels/SigningContextModel.cs
+++ b/BTCPayServer/Models/WalletViewModels/SigningContextModel.cs
@@ -17,6 +17,5 @@ namespace BTCPayServer.Models.WalletViewModels
         public string PayJoinBIP21 { get; set; }
         public bool? EnforceLowR { get; set; }
         public string ChangeAddress { get; set; }
-        public bool NBXSeedAvailable { get; set; }
     }
 }

--- a/BTCPayServer/Views/Wallets/WalletPSBT.cshtml
+++ b/BTCPayServer/Views/Wallets/WalletPSBT.cshtml
@@ -52,7 +52,7 @@
                     <input type="hidden" asp-for="PSBT"/>
                     <input type="hidden" asp-for="FileName"/>
                     <div class="d-flex">
-                        <button type="submit" id="SignTransaction" name="command" value="@(Model.SigningContext.NBXSeedAvailable ? "nbx-seed" : "sign")" class="btn btn-primary">Sign transaction</button>
+                        <button type="submit" id="SignTransaction" name="command" value="@(Model.NBXSeedAvailable ? "nbx-seed" : "sign")" class="btn btn-primary">Sign transaction</button>
                         <div class="ms-2 dropdown">
                             <button class="btn btn-secondary dropdown-toggle" type="button" id="OtherActionsDropdownToggle" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                                 Other actions...

--- a/BTCPayServer/Views/Wallets/WalletSigningOptions.cshtml
+++ b/BTCPayServer/Views/Wallets/WalletSigningOptions.cshtml
@@ -65,7 +65,7 @@
                     Partially Signed Bitcoin Transaction
                     <small>
                         <a href="https://docs.btcpayserver.org/Wallet/#signing-with-a-wallet-supporting-psbt" target="_blank">
-                            <span class="fa fa-question-circle-o text-secondary" title="More information..."></span>
+                            <span class="fa fa-question-circle-o text-secondary pe-none" title="More information..."></span>
                         </a>
                     </small>
                 </h4>


### PR DESCRIPTION
- Code cleanup: Removes extra `NBXSeedAvailable` property in `SigningContext`, which got introduced in #2559. It is not needed since each view model involved already has it.
- Fix for the doc link inside the button. 