### PR TITLE
Cleanup some old code in wallet setup

### DIFF
--- a/BTCPayServer.Tests/AltcoinTests/AltcoinTests.cs
+++ b/BTCPayServer.Tests/AltcoinTests/AltcoinTests.cs
@@ -954,28 +954,6 @@ normal:
 
             result = testnetParser.Parse(tpub);
             Assert.Equal(tpub, result.ToString());
-            testnetParser.HintScriptPubKey = BitcoinAddress
-                .Create("tb1q4s33amqm8l7a07zdxcunqnn3gcsjcfz3xc573l", testnetParser.Network).ScriptPubKey;
-            result = testnetParser.Parse(tpub);
-            Assert.Equal(tpub, result.ToString());
-
-            testnetParser.HintScriptPubKey = BitcoinAddress
-                .Create("2N2humNio3YTApSfY6VztQ9hQwDnhDvaqFQ", testnetParser.Network).ScriptPubKey;
-            result = testnetParser.Parse(tpub);
-            Assert.Equal($"{tpub}-[p2sh]", result.ToString());
-
-            testnetParser.HintScriptPubKey = BitcoinAddress
-                .Create("mwD8bHS65cdgUf6rZUUSoVhi3wNQFu1Nfi", testnetParser.Network).ScriptPubKey;
-            result = testnetParser.Parse(tpub);
-            Assert.Equal($"{tpub}-[legacy]", result.ToString());
-
-            testnetParser.HintScriptPubKey = BitcoinAddress
-                .Create("2N2humNio3YTApSfY6VztQ9hQwDnhDvaqFQ", testnetParser.Network).ScriptPubKey;
-            result = testnetParser.Parse($"{tpub}-[legacy]");
-            Assert.Equal($"{tpub}-[p2sh]", result.ToString());
-
-            result = testnetParser.Parse(tpub);
-            Assert.Equal($"{tpub}-[p2sh]", result.ToString());
 
             var regtestParser = new DerivationSchemeParser(regtestNetworkProvider.GetNetwork<BTCPayNetwork>("BTC"));
             var parsed =

--- a/BTCPayServer.Tests/TestAccount.cs
+++ b/BTCPayServer.Tests/TestAccount.cs
@@ -189,8 +189,8 @@ namespace BTCPayServer.Tests
             };
 
             await store.GenerateWallet(StoreId, cryptoCode, WalletSetupMethod.HotWallet, generateRequest);
-            Assert.NotNull(store.GenerateWalletResponseV);
-            GenerateWalletResponseV = store.GenerateWalletResponseV;
+            Assert.NotNull(store.GenerateWalletResponse);
+            GenerateWalletResponseV = store.GenerateWalletResponse;
             return new WalletId(StoreId, cryptoCode);
         }
 

--- a/BTCPayServer.Tests/TestAccount.cs
+++ b/BTCPayServer.Tests/TestAccount.cs
@@ -191,7 +191,6 @@ namespace BTCPayServer.Tests
                 {
                     StoreId = StoreId,
                     Method = importKeysToNBX ? WalletSetupMethod.HotWallet : WalletSetupMethod.WatchOnly,
-                    Enabled = true,
                     CryptoCode = cryptoCode,
                     Network = SupportedNetwork,
                     RootFingerprint = GenerateWalletResponseV.AccountKeyPath.MasterFingerprint.ToString(),

--- a/BTCPayServer.Tests/TestAccount.cs
+++ b/BTCPayServer.Tests/TestAccount.cs
@@ -179,29 +179,18 @@ namespace BTCPayServer.Tests
             if (StoreId is null)
                 await CreateStoreAsync();
             SupportedNetwork = parent.NetworkProvider.GetNetwork<BTCPayNetwork>(cryptoCode);
-            var store = parent.PayTester.GetController<StoresController>(UserId, StoreId);
-            GenerateWalletResponseV = await parent.ExplorerClient.GenerateWalletAsync(new GenerateWalletRequest()
+            var store = parent.PayTester.GetController<StoresController>(UserId, StoreId, true);
+
+            var generateRequest = new GenerateWalletRequest()
             {
                 ScriptPubKeyType = segwit,
                 SavePrivateKeys = importKeysToNBX,
                 ImportKeysToRPC = importsKeysToBitcoinCore
-            });
-            await store.UpdateWallet(
-                new WalletSetupViewModel
-                {
-                    StoreId = StoreId,
-                    Method = importKeysToNBX ? WalletSetupMethod.HotWallet : WalletSetupMethod.WatchOnly,
-                    CryptoCode = cryptoCode,
-                    Network = SupportedNetwork,
-                    RootFingerprint = GenerateWalletResponseV.AccountKeyPath.MasterFingerprint.ToString(),
-                    RootKeyPath = SupportedNetwork.GetRootKeyPath(),
-                    Source = "NBXplorer",
-                    AccountKey = GenerateWalletResponseV.AccountHDKey.Neuter().ToWif(),
-                    DerivationSchemeFormat = "BTCPay",
-                    KeyPath = GenerateWalletResponseV.AccountKeyPath.KeyPath.ToString(),
-                    DerivationScheme = DerivationScheme.ToString(),
-                    Confirmation = true
-                });
+            };
+
+            await store.GenerateWallet(StoreId, cryptoCode, WalletSetupMethod.HotWallet, generateRequest);
+            Assert.NotNull(store.GenerateWalletResponseV);
+            GenerateWalletResponseV = store.GenerateWalletResponseV;
             return new WalletId(StoreId, cryptoCode);
         }
 

--- a/BTCPayServer/Controllers/StoresController.Onchain.cs
+++ b/BTCPayServer/Controllers/StoresController.Onchain.cs
@@ -14,6 +14,7 @@ using BTCPayServer.Services;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ModelBinding.Metadata;
 using NBitcoin;
 using NBXplorer;
 using NBXplorer.DerivationStrategy;
@@ -257,7 +258,8 @@ namespace BTCPayServer.Controllers
                 Confirmation = string.IsNullOrEmpty(request.ExistingMnemonic),
                 Network = network,
                 RootKeyPath = network.GetRootKeyPath(),
-                Source = "NBXplorer",
+                Source = isImport ? "SeedImported" : "NBXplorerGenerated",
+                IsHotWallet = isImport ? request.SavePrivateKeys : method == WalletSetupMethod.HotWallet,
                 DerivationSchemeFormat = "BTCPay",
                 CanUseHotWallet = true,
                 CanUseRPCImport = rpcImport

--- a/BTCPayServer/Controllers/StoresController.Onchain.cs
+++ b/BTCPayServer/Controllers/StoresController.Onchain.cs
@@ -157,7 +157,6 @@ namespace BTCPayServer.Controllers
             var configChanged = oldConfig != vm.Config;
             PaymentMethodId paymentMethodId = new PaymentMethodId(network.CryptoCode, PaymentTypes.BTCLike);
             var storeBlob = store.GetStoreBlob();
-            var willBeExcluded = !vm.Enabled;
 
             var showAddress = // Show addresses if:
                 // - The user is clicking on continue after changing the config
@@ -171,7 +170,7 @@ namespace BTCPayServer.Controllers
                     if (strategy != null)
                         await wallet.TrackAsync(strategy.AccountDerivation);
                     store.SetSupportedPaymentMethod(paymentMethodId, strategy);
-                    storeBlob.SetExcluded(paymentMethodId, willBeExcluded);
+                    storeBlob.SetExcluded(paymentMethodId, false);
                     storeBlob.Hints.Wallet = false;
                     store.SetStoreBlob(storeBlob);
                 }
@@ -215,7 +214,6 @@ namespace BTCPayServer.Controllers
                 vm.Config = derivation.ToJson();
             }
 
-            vm.Enabled = !store.GetStoreBlob().IsExcluded(new PaymentMethodId(vm.CryptoCode, PaymentTypes.BTCLike));
             vm.CanUseHotWallet = hotWallet;
             vm.CanUseRPCImport = rpcImport;
             vm.RootKeyPath = network.GetRootKeyPath();
@@ -259,7 +257,6 @@ namespace BTCPayServer.Controllers
                 Confirmation = string.IsNullOrEmpty(request.ExistingMnemonic),
                 Network = network,
                 RootKeyPath = network.GetRootKeyPath(),
-                Enabled = !store.GetStoreBlob().IsExcluded(new PaymentMethodId(cryptoCode, PaymentTypes.BTCLike)),
                 Source = "NBXplorer",
                 DerivationSchemeFormat = "BTCPay",
                 CanUseHotWallet = true,
@@ -371,7 +368,6 @@ namespace BTCPayServer.Controllers
             vm.DerivationScheme = derivation.AccountDerivation.ToString();
             vm.KeyPath = derivation.GetSigningAccountKeySettings().AccountKeyPath?.ToString();
             vm.Config = derivation.ToJson();
-            vm.Enabled = !store.GetStoreBlob().IsExcluded(new PaymentMethodId(vm.CryptoCode, PaymentTypes.BTCLike));
             vm.IsHotWallet = isHotWallet;
 
             return View(vm);

--- a/BTCPayServer/Controllers/StoresController.cs
+++ b/BTCPayServer/Controllers/StoresController.cs
@@ -689,10 +689,9 @@ namespace BTCPayServer.Controllers
 
         }
 
-        private DerivationSchemeSettings ParseDerivationStrategy(string derivationScheme, Script hint, BTCPayNetwork network)
+        private DerivationSchemeSettings ParseDerivationStrategy(string derivationScheme, BTCPayNetwork network)
         {
             var parser = new DerivationSchemeParser(network);
-            parser.HintScriptPubKey = hint;
             try
             {
                 var derivationSchemeSettings = new DerivationSchemeSettings();

--- a/BTCPayServer/Controllers/StoresController.cs
+++ b/BTCPayServer/Controllers/StoresController.cs
@@ -27,6 +27,7 @@ using BTCPayServer.Services.Stores;
 using BTCPayServer.Services.Wallets;
 using BundlerMinifier.TagHelpers;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.DataProtection;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
@@ -69,7 +70,8 @@ namespace BTCPayServer.Controllers
             AppService appService,
             IWebHostEnvironment webHostEnvironment,
             WebhookNotificationManager webhookNotificationManager,
-            IOptions<LightningNetworkOptions> lightningNetworkOptions)
+            IOptions<LightningNetworkOptions> lightningNetworkOptions,
+            IDataProtectionProvider dataProtector)
         {
             _RateFactory = rateFactory;
             _Repo = repo;
@@ -85,6 +87,7 @@ namespace BTCPayServer.Controllers
             _appService = appService;
             _webHostEnvironment = webHostEnvironment;
             _lightningNetworkOptions = lightningNetworkOptions;
+            DataProtector = dataProtector.CreateProtector("ConfigProtector");
             WebhookNotificationManager = webhookNotificationManager;
             _EventAggregator = eventAggregator;
             _NetworkProvider = networkProvider;
@@ -826,6 +829,7 @@ namespace BTCPayServer.Controllers
 
         public string GeneratedPairingCode { get; set; }
         public WebhookNotificationManager WebhookNotificationManager { get; }
+        public IDataProtector DataProtector { get; }
 
         [HttpGet]
         [Route("{storeId}/Tokens/Create")]

--- a/BTCPayServer/Controllers/WalletsController.cs
+++ b/BTCPayServer/Controllers/WalletsController.cs
@@ -1089,7 +1089,9 @@ namespace BTCPayServer.Controllers
                 DerivationScheme = derivationSchemeSettings.AccountDerivation.ToString(),
                 DerivationSchemeInput = derivationSchemeSettings.AccountOriginal,
                 SelectedSigningKey = derivationSchemeSettings.SigningKey.ToString(),
-                NBXSeedAvailable = await CanUseHotWallet() && !string.IsNullOrEmpty(await ExplorerClientProvider.GetExplorerClient(walletId.CryptoCode)
+                NBXSeedAvailable = derivationSchemeSettings.IsHotWallet && 
+                                   await CanUseHotWallet() &&
+                                   !string.IsNullOrEmpty(await ExplorerClientProvider.GetExplorerClient(walletId.CryptoCode)
                     .GetMetadataAsync<string>(GetDerivationSchemeSettings(walletId).AccountDerivation,
                         WellknownMetadataKeys.MasterHDKey))
             };

--- a/BTCPayServer/DerivationSchemeSettings.cs
+++ b/BTCPayServer/DerivationSchemeSettings.cs
@@ -276,8 +276,8 @@ namespace BTCPayServer
         [JsonIgnore]
         public BTCPayNetwork Network { get; set; }
         public string Source { get; set; }
-        [JsonIgnore]
-        public bool IsHotWallet => Source == "NBXplorer";
+
+        public bool IsHotWallet { get; set; }
 
         [Obsolete("Use GetSigningAccountKeySettings().AccountKeyPath instead")]
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]

--- a/BTCPayServer/Models/StoreViewModels/DerivationSchemeViewModel.cs
+++ b/BTCPayServer/Models/StoreViewModels/DerivationSchemeViewModel.cs
@@ -21,7 +21,6 @@ namespace BTCPayServer.Models.StoreViewModels
         [Display(Name = "Root fingerprint")]
         public string RootFingerprint { get; set; }
         public bool Confirmation { get; set; }
-        public bool Enabled { get; set; } = true;
 
         public KeyPath RootKeyPath { get; set; }
 

--- a/BTCPayServer/Models/StoreViewModels/DerivationSchemeViewModel.cs
+++ b/BTCPayServer/Models/StoreViewModels/DerivationSchemeViewModel.cs
@@ -20,8 +20,6 @@ namespace BTCPayServer.Models.StoreViewModels
         public string KeyPath { get; set; }
         [Display(Name = "Root fingerprint")]
         public string RootFingerprint { get; set; }
-        [Display(Name = "Hint address")]
-        public string HintAddress { get; set; }
         public bool Confirmation { get; set; }
         public bool Enabled { get; set; } = true;
 

--- a/BTCPayServer/Services/MigrationSettings.cs
+++ b/BTCPayServer/Services/MigrationSettings.cs
@@ -2,6 +2,7 @@ namespace BTCPayServer.Services
 {
     public class MigrationSettings
     {
+        public bool MigrateHotwalletProperty { get; set; }
         public bool MigrateU2FToFIDO2{ get; set; }
         public bool UnreachableStoreCheck { get; set; }
         public bool DeprecatedLightningConnectionStringCheck { get; set; }

--- a/BTCPayServer/Views/Stores/ImportWallet/ConfirmAddresses.cshtml
+++ b/BTCPayServer/Views/Stores/ImportWallet/ConfirmAddresses.cshtml
@@ -83,21 +83,6 @@
         </table>
     </div>
 
-    <div class="text-center mb-4">
-        <button class="btn btn-link" type="button" data-bs-toggle="collapse" data-bs-target="#wrong-addresses" aria-expanded="false" aria-controls="wrong-addresses">
-            Wrong addresses?
-        </button>
-        <div id="wrong-addresses" class="collapse @(ViewContext.ModelState.IsValid ? "" : "show")">
-            <div class="pb-1">
-                <div class="form-group">
-                    <label asp-for="HintAddress" class="form-label">Help us to find the correct settings by telling us the first address of your wallet.</label>
-                    <input asp-for="HintAddress" class="form-control"/>
-                    <span asp-validation-for="HintAddress" class="text-danger"></span>
-                </div>
-            </div>
-        </div>
-    </div>
-
     <div class="text-center">
         <button name="command" type="submit" class="btn btn-primary" value="save" id="Confirm">Confirm</button>
     </div>

--- a/BTCPayServer/Views/Stores/ImportWallet/ConfirmAddresses.cshtml
+++ b/BTCPayServer/Views/Stores/ImportWallet/ConfirmAddresses.cshtml
@@ -50,7 +50,6 @@
     <input asp-for="Config" type="hidden"/>
     <input asp-for="Confirmation" type="hidden"/>
     <input asp-for="DerivationScheme" type="hidden"/>
-    <input asp-for="Enabled" type="hidden"/>
 
     <div class="form-group">
         <table class="table table-sm table-responsive-md">


### PR DESCRIPTION
**Remove the possibility to enter a hint address in the address confirmation screen.** 

This is because this made only sense when the xpub is manually entered. 
Nowadays, there is almost no reason to enter a xpub manually, and we do not recommend doing this.

**Remove the DerivationSchemeViewmodel.Enabled property**

This property existed because originally the enable/disable checkbox of a payment method was inside the setup wallet flow.
This is not the case anymore, so this property is useless.

**Encrypt WalletSetupViewModel.Config**

This is to make sure a client can't inject arbitrary config, bypassing the checks we have.