### PR TITLE
Improves Create Store & Create App views

### DIFF
--- a/BTCPayServer/Views/Apps/CreateApp.cshtml
+++ b/BTCPayServer/Views/Apps/CreateApp.cshtml
@@ -14,7 +14,7 @@
         <h2 class="mb-4">@ViewData["Title"]</h2>
 
         <div class="row">
-            <div class="col-lg-12">
+            <div class="col-lg-6">
                 <form asp-action="CreateApp">
                     <div asp-validation-summary="ModelOnly" class="text-danger"></div>
                     <div class="form-group">
@@ -30,9 +30,9 @@
                         <label asp-for="SelectedStore" class="form-label" data-required></label>
                         <select asp-for="SelectedStore" asp-items="Model.Stores" class="form-select"></select>
                     </div>
-                    <div class="form-group">
+                    <div class="form-group mt-4">
                         <input type="submit" value="Create" class="btn btn-primary" id="Create"/>
-                        <a asp-action="ListApps" class="text-muted ms-3">Back to list</a>
+                        <a asp-action="ListApps" class="btn btn-link px-0 ms-3">Back to list</a>
                     </div>
                 </form>
             </div>

--- a/BTCPayServer/Views/Apps/CreateApp.cshtml
+++ b/BTCPayServer/Views/Apps/CreateApp.cshtml
@@ -18,20 +18,20 @@
                 <form asp-action="CreateApp">
                     <div asp-validation-summary="ModelOnly" class="text-danger"></div>
                     <div class="form-group">
-                        <label asp-for="Name" class="form-label" data-required></label>
-                        <input asp-for="Name" class="form-control" required />
-                        <span asp-validation-for="Name" class="text-danger"></span>
+                        <label asp-for="SelectedStore" class="form-label" data-required></label>
+                        <select asp-for="SelectedStore" asp-items="Model.Stores" class="form-select"></select>
                     </div>
                     <div class="form-group">
                         <label asp-for="SelectedAppType" class="form-label" data-required></label>
                         <select asp-for="SelectedAppType" asp-items="Model.AppTypes" class="form-select"></select>
                     </div>
                     <div class="form-group">
-                        <label asp-for="SelectedStore" class="form-label" data-required></label>
-                        <select asp-for="SelectedStore" asp-items="Model.Stores" class="form-select"></select>
+                        <label asp-for="Name" class="form-label" data-required></label>
+                        <input asp-for="Name" class="form-control" required />
+                        <span asp-validation-for="Name" class="text-danger"></span>
                     </div>
                     <div class="form-group mt-4">
-                        <input type="submit" value="Create" class="btn btn-primary" id="Create"/>
+                        <input type="submit" value="Create" class="btn btn-primary" id="Create" />
                         <a asp-action="ListApps" class="btn btn-link px-0 ms-3">Back to list</a>
                     </div>
                 </form>

--- a/BTCPayServer/Views/UserStores/CreateStore.cshtml
+++ b/BTCPayServer/Views/UserStores/CreateStore.cshtml
@@ -21,9 +21,9 @@
                         <input asp-for="Name" class="form-control" required />
                         <span asp-validation-for="Name" class="text-danger"></span>
                     </div>
-                    <div class="form-group">
+                    <div class="form-group mt-4">
                         <input type="submit" value="Create" class="btn btn-primary" id="Create" />
-                        <a asp-action="ListStores" class="text-muted ms-3">Back to list</a>
+                        <a asp-action="ListStores" class="btn btn-link px-0 ms-3">Back to list</a>
                     </div>
                 </form>
             </div>


### PR DESCRIPTION
I was planning to submit a larger PR that addressed many of the "create" views, and as a result, end up sitting on a larger PR, for the sake of making sure everything is done in one consistent edit ... but I was inspired by @woutersamaey's smaller PRs, and will likely submit a PR that addresses each individual view or a very small subset of views, depending on the complexity.

This PR improves the long row form for both the Create Store & App forms, makes the "back" link consistent with our other links (will make this consistent with the other create views), improves a bit of spacing, and re-orders the App form elements, placing the Store up top.

If smaller PRs aren't the move, LMK, and I will go back to doing a larger PR.

(not sure why tests failed)

<img width="1280" alt="Screen Shot 2021-06-21 at 2 47 10 PM" src="https://user-images.githubusercontent.com/6250771/122832493-42aa7600-d2a0-11eb-9785-0b804e06448a.png">

<img width="2091" alt="Screen Shot 2021-06-21 at 3 06 38 PM" src="https://user-images.githubusercontent.com/6250771/122833762-62429e00-d2a2-11eb-8c41-27645d2ee682.png">
