### PR TITLE
Improve create payment request view

### DIFF
--- a/BTCPayServer/Views/PaymentRequest/EditPaymentRequest.cshtml
+++ b/BTCPayServer/Views/PaymentRequest/EditPaymentRequest.cshtml
@@ -42,7 +42,7 @@
                         <input type="email" asp-for="Email" class="form-control" />
                         <span asp-validation-for="Email" class="text-danger"></span>
                         <p id="PaymentRequestEmailHelpBlock" class="form-text text-muted">
-                            Recieve updates for this payment request.
+                            Receive updates for this payment request.
                         </p>
                     </div>
                     <h4 class="mt-5 mb-4">Request Details</h4>

--- a/BTCPayServer/Views/PaymentRequest/EditPaymentRequest.cshtml
+++ b/BTCPayServer/Views/PaymentRequest/EditPaymentRequest.cshtml
@@ -87,7 +87,7 @@
                         <textarea asp-for="Description" class="form-control richtext"></textarea>
                         <span asp-validation-for="Description" class="text-danger"></span>
                     </div>
-                    <h4 class="mt-5 mb-4">Custom Styling</h4>
+                    <h4 class="mt-5 mb-4">Custom Appearance</h4>
                     <div class="form-group">
                         <label asp-for="CustomCSSLink" class="form-label"></label>
                         <a href="https://docs.btcpayserver.org/Theme/#2-bootstrap-themes" target="_blank">

--- a/BTCPayServer/Views/PaymentRequest/EditPaymentRequest.cshtml
+++ b/BTCPayServer/Views/PaymentRequest/EditPaymentRequest.cshtml
@@ -18,36 +18,12 @@
 <section>
     <div class="container">
         <partial name="_StatusMessage" />
-
         <h2 class="mb-4">@ViewData["Title"]</h2>
-
         <form method="post" action="@Url.Action("EditPaymentRequest", "PaymentRequest", new { id = Model.Id}, Context.Request.Scheme)">
-
             <div class="row">
                 <div class="col-lg-6">
-
                     <input type="hidden" name="Id" value="@Model.Id" />
                     <div asp-validation-summary="ModelOnly" class="text-danger"></div>
-                    <div class="form-group">
-                        <label asp-for="Title" class="form-label" data-required></label>
-                        <input asp-for="Title" class="form-control" required />
-                        <span asp-validation-for="Title" class="text-danger"></span>
-                    </div>
-                    <div class="form-group">
-                        <label asp-for="Amount" class="form-label" data-required></label>
-                        <input type="number" step="any" asp-for="Amount" class="form-control" required />
-                        <span asp-validation-for="Amount" class="text-danger"></span>
-                    </div>
-                    <div class="form-group">
-                        <label asp-for="Currency" class="form-label" data-required></label>
-                        <input asp-for="Currency" class="form-control" required />
-                        <span asp-validation-for="Currency" class="text-danger"></span>
-                    </div>
-                    <div class="form-group form-check">
-                        <input asp-for="AllowCustomPaymentAmounts" type="checkbox" class="form-check-input" />
-                        <label asp-for="AllowCustomPaymentAmounts" class="form-check-label"></label>
-                        <span asp-validation-for="AllowCustomPaymentAmounts" class="text-danger"></span>
-                    </div>
                     <div class="form-group">
                         <label asp-for="StoreId" class="form-label"></label>
                         @if (string.IsNullOrEmpty(Model.Id))
@@ -67,6 +43,28 @@
                         <span asp-validation-for="Email" class="text-danger"></span>
                     </div>
                     <div class="form-group">
+                        <label asp-for="Title" class="form-label" data-required></label>
+                        <input asp-for="Title" class="form-control" required />
+                        <span asp-validation-for="Title" class="text-danger"></span>
+                    </div>
+
+                    <div class="form-group">
+                        <label asp-for="Amount" class="form-label" data-required></label>
+                        <input type="number" step="any" asp-for="Amount" class="form-control" required />
+                        <span asp-validation-for="Amount" class="text-danger"></span>
+                    </div>
+                    <div class="form-group">
+                        <label asp-for="Currency" class="form-label" data-required></label>
+                        <input asp-for="Currency" class="form-control" required />
+                        <span asp-validation-for="Currency" class="text-danger"></span>
+                    </div>
+
+                    <div class="form-group form-check">
+                        <input asp-for="AllowCustomPaymentAmounts" type="checkbox" class="form-check-input" />
+                        <label asp-for="AllowCustomPaymentAmounts" class="form-check-label"></label>
+                        <span asp-validation-for="AllowCustomPaymentAmounts" class="text-danger"></span>
+                    </div>
+                    <div class="form-group">
                         <label asp-for="ExpiryDate" class="form-label"></label>
                         <div class="input-group ">
                             <input asp-for="ExpiryDate"
@@ -78,6 +76,8 @@
                         </div>
                         <span asp-validation-for="ExpiryDate" class="text-danger"></span>
                     </div>
+                </div>
+                <div class="col-lg-9">
                     <div class="form-group">
                         <label asp-for="Description" class="form-label"></label>
                         <textarea asp-for="Description" class="form-control richtext"></textarea>

--- a/BTCPayServer/Views/PaymentRequest/EditPaymentRequest.cshtml
+++ b/BTCPayServer/Views/PaymentRequest/EditPaymentRequest.cshtml
@@ -41,7 +41,11 @@
                         <label asp-for="Email" class="form-label"></label>
                         <input type="email" asp-for="Email" class="form-control" />
                         <span asp-validation-for="Email" class="text-danger"></span>
+                        <p id="PaymentRequestEmailHelpBlock" class="form-text text-muted">
+                            Recieve updates for this payment request.
+                        </p>
                     </div>
+                    <h4 class="mt-5 mb-4">Request Details</h4>
                     <div class="form-group">
                         <label asp-for="Title" class="form-label" data-required></label>
                         <input asp-for="Title" class="form-control" required />
@@ -83,6 +87,7 @@
                         <textarea asp-for="Description" class="form-control richtext"></textarea>
                         <span asp-validation-for="Description" class="text-danger"></span>
                     </div>
+                    <h4 class="mt-5 mb-4">Custom Styling</h4>
                     <div class="form-group">
                         <label asp-for="CustomCSSLink" class="form-label"></label>
                         <a href="https://docs.btcpayserver.org/Theme/#2-bootstrap-themes" target="_blank">

--- a/BTCPayServer/Views/PaymentRequest/EditPaymentRequest.cshtml
+++ b/BTCPayServer/Views/PaymentRequest/EditPaymentRequest.cshtml
@@ -21,9 +21,11 @@
 
         <h2 class="mb-4">@ViewData["Title"]</h2>
 
-        <div class="row">
-            <div class="col-lg-12">
-                <form method="post" action="@Url.Action("EditPaymentRequest", "PaymentRequest", new { id = Model.Id}, Context.Request.Scheme)">
+        <form method="post" action="@Url.Action("EditPaymentRequest", "PaymentRequest", new { id = Model.Id}, Context.Request.Scheme)">
+
+            <div class="row">
+                <div class="col-lg-6">
+
                     <input type="hidden" name="Id" value="@Model.Id" />
                     <div asp-validation-summary="ModelOnly" class="text-danger"></div>
                     <div class="form-group">
@@ -94,7 +96,7 @@
                         <textarea asp-for="EmbeddedCSS" rows="10" cols="40" class="form-control"></textarea>
                         <span asp-validation-for="EmbeddedCSS" class="text-danger"></span>
                     </div>
-                    <div class="form-group">
+                    <div class="form-group mt-4">
                         <button type="submit" class="btn btn-primary" id="SaveButton">Save</button>
                         @if (!string.IsNullOrEmpty(Model.Id))
                         {
@@ -114,10 +116,10 @@
                                 <a class="btn btn-secondary" data-bs-toggle="tooltip" title="Unarchive this payment request" asp-route-id="@Context.GetRouteValue("id")" asp-controller="PaymentRequest" asp-action="TogglePaymentRequestArchival">Unarchive</a>
                             }
                         }
-                        <a asp-action="GetPaymentRequests" class="text-muted ms-3">Back to list</a>
+                        <a asp-action="GetPaymentRequests" class="btn btn-link px-0 ms-3">Back to list</a>
                     </div>
-                </form>
+                </div>
             </div>
-        </div>
+        </form>
     </div>
 </section>


### PR DESCRIPTION
In my attempt to improve some of the create views, I've moved on Payment Requests.

Few things to note:
- Added helper text under the Email
- Added section headers
- For the future, want to improve the currency / amount based on the dropdown selector we've discussed (@dennisreimann @woutersamaey)
- For the future, want to improve and clean up the calendar / time selector (need to mock up the component), as the input field color (should be white), currently looks disabled.
- Made the back to list, a link element, consistent with the others .. for now, til deprecated.
- Left the "create" heading, until we can move to the header bar.
- For the future, want to make sure the correct store is selected, would be based on the work @woutersamaey is doing on Invoices currently.
- Added the store selector to the top, as it should be the first thing the user considers where the money is going.
- Need to improve the default spacing for the entire app to be 8px, so the spacing between form elements is 24px (3x), not the 21px .. more on the design system / CSS side of things though.

There will be a subsequent PR for this view when more changes and improvements facilitate an improved view, but for now...

Current:
<img width="2047" alt="Screen Shot 2021-06-27 at 10 23 41 AM" src="https://user-images.githubusercontent.com/6250771/123553744-f2b13080-d731-11eb-9452-ca9620441c16.png">

Based on my mock, minus the obvious differences:
<img width="1197" alt="Screen Shot 2021-06-27 at 10 29 12 AM" src="https://user-images.githubusercontent.com/6250771/123553940-a74b5200-d732-11eb-826d-97985c565a2b.png">

@dennisreimann On my fork -- feel free to make any additional changes you think might be helpful, or potentially easy based on the notes above.

As always, any feedback, suggestions welcome.