### PR TITLE
Removes lightning setup & wallet setup back button

### DIFF
--- a/BTCPayServer/Views/Stores/ModifyWallet.cshtml
+++ b/BTCPayServer/Views/Stores/ModifyWallet.cshtml
@@ -4,12 +4,6 @@
     ViewData.SetActivePageAndTitle(StoreNavPages.Wallet, $"Modify {Model.CryptoCode} Wallet");
 }
 
-@section Navbar {
-    <a asp-controller="Stores" asp-action="UpdateStore" asp-route-storeId="@Model.StoreId">
-        <vc:icon symbol="back" />
-    </a>
-}
-
 <header class="text-center">
     <h1>@ViewData["Title"]</h1>
     <p class="lead text-secondary mt-3">Change your current wallet settings</p>

--- a/BTCPayServer/Views/Stores/SetupLightningNode.cshtml
+++ b/BTCPayServer/Views/Stores/SetupLightningNode.cshtml
@@ -4,9 +4,6 @@
     ViewData.SetActivePageAndTitle(StoreNavPages.Index, "Connect to a Lightning node", Context.GetStoreData().StoreName);
 }
 
-@section Navbar {
-}
-
 <header class="text-center">
     <h1>@ViewData["Title"]</h1>
     <div class="d-flex mt-4 mb-5">

--- a/BTCPayServer/Views/Stores/SetupLightningNode.cshtml
+++ b/BTCPayServer/Views/Stores/SetupLightningNode.cshtml
@@ -5,9 +5,6 @@
 }
 
 @section Navbar {
-    <a asp-controller="Stores" asp-action="UpdateStore" asp-route-storeId="@Model.StoreId">
-        <vc:icon symbol="back" />
-    </a>
 }
 
 <header class="text-center">

--- a/BTCPayServer/Views/Stores/SetupWallet.cshtml
+++ b/BTCPayServer/Views/Stores/SetupWallet.cshtml
@@ -4,18 +4,6 @@
     ViewData.SetActivePageAndTitle(StoreNavPages.Wallet, $"Setup {Model.CryptoCode} Wallet", Context.GetStoreData().StoreName);
 }
 
-@section Navbar {
-    @if (string.IsNullOrWhiteSpace(Model.DerivationScheme)) {
-        <a asp-controller="Stores" asp-action="UpdateStore" asp-route-storeId="@Model.StoreId">
-            <vc:icon symbol="back"/>
-        </a>
-    } else {
-        <a asp-controller="Stores" asp-action="ModifyWallet" asp-route-storeId="@Model.StoreId" asp-route-cryptoCode="@Model.CryptoCode">
-            <vc:icon symbol="back"/>
-        </a>
-    }
-}
-
 <h1 class="text-center">Let's get started</h1>
 <br>
 <div class="mt-5">


### PR DESCRIPTION
I've noticed we have redundant back buttons on both the wallet (on the first page, not subsequent steps) and lightning setup (singular setup page) pages, and also "X" close buttons.

I've made this PR to remove both of those buttons.

If there's a better way to handle this in the code, feel free to make adjustments!

Lightning Network

Before:
<img width="1433" alt="Screen Shot 2021-06-27 at 11 36 26 AM" src="https://user-images.githubusercontent.com/6250771/123558310-7414bd00-d74a-11eb-8ffb-b9ac73a97fdd.png">

After:
<img width="1770" alt="Screen Shot 2021-06-27 at 12 31 56 PM" src="https://user-images.githubusercontent.com/6250771/123558312-7545ea00-d74a-11eb-9c97-210a252f1740.png">

Wallet

Before:
<img width="1769" alt="Screen Shot 2021-06-27 at 12 39 36 PM" src="https://user-images.githubusercontent.com/6250771/123558337-842c9c80-d74a-11eb-8b82-7ef7d4fd4321.png">
After:
<img width="1770" alt="Screen Shot 2021-06-27 at 1 18 10 PM" src="https://user-images.githubusercontent.com/6250771/123558347-91498b80-d74a-11eb-9a43-d177f025294d.png">
