### PR TITLE
Improves notification view

### DIFF
--- a/BTCPayServer/Views/Notifications/Index.cshtml
+++ b/BTCPayServer/Views/Notifications/Index.cshtml
@@ -9,7 +9,7 @@
 
         <div class="d-flex flex-wrap align-items-center justify-content-between mb-2">
             <h2>@ViewData["Title"]</h2>
-            <a id="NotificationSettings" asp-action="NotificationSettings" class="btn btn-secondary">
+            <a id="NotificationSettings" asp-controller="Manage" asp-action="NotificationSettings" class="btn btn-secondary">
                 <span class="fa fa-cog"></span>
                 Settings                
             </a>

--- a/BTCPayServer/Views/Notifications/Index.cshtml
+++ b/BTCPayServer/Views/Notifications/Index.cshtml
@@ -13,100 +13,110 @@
                 <span class="btn btn-secondary" title="Notification Settings">Settings</span>
             </a>
         </div>
-
-
-        <form method="post" asp-action="MassAction">
-            <div class="row button-row">
-                <div class="col-lg-6">
-                    <span class="dropdown" style="display:none;" id="MassAction">
-                        <button class="btn btn-primary dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                            Actions
-                        </button>
-                        <div class="dropdown-menu">
-                            <button type="submit" class="dropdown-item" name="command" value="mark-seen"><i class="fa fa-eye"></i> Mark seen</button>
-                            <button type="submit" class="dropdown-item" name="command" value="mark-unseen"><i class="fa fa-eye-slash"></i> Mark unseen</button>
-                            <button type="submit" class="dropdown-item" name="command" value="delete"><i class="fa fa-trash-o"></i> Delete</button>
-                        </div>
-                    </span>
+        @if (Model.Total > 0)
+        {
+            <form method="post" asp-action="MassAction">
+                <div class="row button-row">
+                    <div class="col-lg-6">
+                        <span class="dropdown" style="display:none;" id="MassAction">
+                            <button class="btn btn-primary dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                                Actions
+                            </button>
+                            <div class="dropdown-menu">
+                                <button type="submit" class="dropdown-item" name="command" value="mark-seen"><i class="fa fa-eye"></i> Mark seen</button>
+                                <button type="submit" class="dropdown-item" name="command" value="mark-unseen"><i class="fa fa-eye-slash"></i> Mark unseen</button>
+                                <button type="submit" class="dropdown-item" name="command" value="delete"><i class="fa fa-trash-o"></i> Delete</button>
+                            </div>
+                        </span>
+                    </div>
                 </div>
-            </div>
-            <div class="row">
-                <div class="col-lg-12">
-                    <table class="table table-sm table-responsive-md">
-                        <thead>
-                            <tr>
-                                <th width="30px" class="only-for-js">
-                                    @if (Model.Total > 0)
-                                    {
-                                        <input name="selectedItems" type="checkbox" class="form-check-input" onClick="selectAll(this);" />
-                                    }
-                                </th>
-                                <th width="190px">
-                                    Date
-                                    <a href="javascript:switchTimeFormat()">
-                                        <span class="fa fa-clock-o" title="Switch date format"></span>
-                                    </a>
-                                </th>
-                                <th>Message</th>
-                                <th class="text-end">Actions</th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                            @foreach (var item in Model.Items)
-                            {
-                                <tr data-guid="@item.Id" class="notification-row @(item.Seen ? "seen" : "")">
-                                    <td class="only-for-js">
-                                        <input name="selectedItems" type="checkbox" class="selector form-check-input" value="@item.Id" />
-                                    </td>
-                                    <td onclick="toggleRowCheckbox(this)">
-                                        <span class="switchTimeFormat" data-switch="@item.Created.ToTimeAgo()">
-                                            @item.Created.ToBrowserDate()
-                                        </span>
-                                    </td>
-                                    <td onclick="toggleRowCheckbox(this)">
-                                        @item.Body
-                                    </td>
-                                    <td class="text-end fw-normal">
-                                        @if (!String.IsNullOrEmpty(item.ActionLink))
+                <div class="row">
+                    <div class="col-lg-12">
+                        <table class="table table-sm table-responsive-md">
+                            <thead>
+                                <tr>
+                                    <th width="30px" class="only-for-js">
+                                        @if (Model.Total > 0)
                                         {
-                                            <a href="@item.ActionLink" class="btn btn-link p-0">Details</a>
-                                            <span class="d-none d-md-inline-block"> - </span>
+                                            <input name="selectedItems" type="checkbox" class="form-check-input" onClick="selectAll(this);" />
                                         }
-                                        <button onclick="return rowseen(this)" class="btn btn-link p-0 btn-toggle-seen" type="submit" name="command" value="flip-individual:@(item.Id)">
-                                            <span>Mark&nbsp;</span><span class="seen-text"></span>
-                                        </button>
-                                    </td>
+                                    </th>
+                                    <th width="190px">
+                                        Date
+                                        <a href="javascript:switchTimeFormat()">
+                                            <span class="fa fa-clock-o" title="Switch date format"></span>
+                                        </a>
+                                    </th>
+                                    <th>Message</th>
+                                    <th class="text-end">Actions</th>
                                 </tr>
-                            }
-                        </tbody>
-                    </table>
+                            </thead>
+                            <tbody>
+                                @foreach (var item in Model.Items)
+                                {
+                                    <tr data-guid="@item.Id" class="notification-row @(item.Seen ? "seen" : "")">
+                                        <td class="only-for-js">
+                                            <input name="selectedItems" type="checkbox" class="selector form-check-input" value="@item.Id" />
+                                        </td>
+                                        <td onclick="toggleRowCheckbox(this)">
+                                            <span class="switchTimeFormat" data-switch="@item.Created.ToTimeAgo()">
+                                                @item.Created.ToBrowserDate()
+                                            </span>
+                                        </td>
+                                        <td onclick="toggleRowCheckbox(this)">
+                                            @item.Body
+                                        </td>
+                                        <td class="text-end fw-normal">
+                                            @if (!String.IsNullOrEmpty(item.ActionLink))
+                                            {
+                                                <a href="@item.ActionLink" class="btn btn-link p-0">Details</a>
+                                                <span class="d-none d-md-inline-block"> - </span>
+                                            }
+                                            <button onclick="return rowseen(this)" class="btn btn-link p-0 btn-toggle-seen" type="submit" name="command" value="flip-individual:@(item.Id)">
+                                                <span>Mark&nbsp;</span><span class="seen-text"></span>
+                                            </button>
+                                        </td>
+                                    </tr>
+                                }
+                            </tbody>
+                        </table>
 
-                    <vc:pager view-model="Model" />
+                        <vc:pager view-model="Model" />
+
+                    </div>
                 </div>
-            </div>
-
-        </form>
-
+            </form>
+        }
+        else
+        {
+            <p class="text-secondary mt-3">
+                There are no notifications.
+            </p>
+        }
     </div>
 </section>
 
 <style>
-.notification-row.loading {
-    cursor: wait;
-    pointer-events: none;
-}
-.seen-text::after {
-    content: "seen";
-}
-tr.seen td .seen-text::after {
-    content: "unseen";
-}
-tr td {
-    font-weight: bold;
-}
-tr.seen td {
-    font-weight: normal;
-}
+    .notification-row.loading {
+        cursor: wait;
+        pointer-events: none;
+    }
+
+    .seen-text::after {
+        content: "seen";
+    }
+
+    tr.seen td .seen-text::after {
+        content: "unseen";
+    }
+
+    tr td {
+        font-weight: bold;
+    }
+
+    tr.seen td {
+        font-weight: normal;
+    }
 </style>
 <script type="text/javascript">
     function rowseen(sender) {
@@ -118,7 +128,7 @@ tr.seen td {
         });
         return false;
     }
-    
+
     function toggleRowCheckbox(sender){
         var input  = $(sender).parents(".notification-row").find(".selector");
         input.prop('checked', !input.prop("checked"));

--- a/BTCPayServer/Views/Notifications/Index.cshtml
+++ b/BTCPayServer/Views/Notifications/Index.cshtml
@@ -9,8 +9,9 @@
 
         <div class="d-flex flex-wrap align-items-center justify-content-between mb-2">
             <h2>@ViewData["Title"]</h2>
-            <a asp-action="NotificationSettings">
-                <span class="btn btn-secondary" title="Notification Settings">Settings</span>
+            <a id="NotificationSettings" asp-action="NotificationSettings" class="btn btn-secondary">
+                <span class="fa fa-cog"></span>
+                Settings                
             </a>
         </div>
         @if (Model.Total > 0)

--- a/BTCPayServer/Views/Notifications/Index.cshtml
+++ b/BTCPayServer/Views/Notifications/Index.cshtml
@@ -7,12 +7,13 @@
     <div class="container">
         <partial name="_StatusMessage" />
 
-        <div class="row">
-            <div class="col-lg-12 section-heading">
-                <h2>@ViewData["Title"]</h2>
-                <hr class="primary">
-            </div>
+        <div class="d-flex flex-wrap align-items-center justify-content-between mb-2">
+            <h2>@ViewData["Title"]</h2>
+            <a asp-action="NotificationSettings">
+                <span class="btn btn-secondary" title="Notification Settings">Settings</span>
+            </a>
         </div>
+
 
         <form method="post" asp-action="MassAction">
             <div class="row button-row">
@@ -33,50 +34,50 @@
                 <div class="col-lg-12">
                     <table class="table table-sm table-responsive-md">
                         <thead>
-                        <tr>
-                            <th width="30px" class="only-for-js">
-                                @if (Model.Total > 0) 
-                                {
-                                    <input name="selectedItems" type="checkbox" class="form-check-input" onClick="selectAll(this);" />
-                                }
-                            </th>
-                            <th width="190px">
-                                Date
-                                <a href="javascript:switchTimeFormat()">
-                                    <span class="fa fa-clock-o" title="Switch date format"></span>
-                                </a>
-                            </th>
-                            <th>Message</th>
-                            <th class="text-end">Actions</th>
-                        </tr>
+                            <tr>
+                                <th width="30px" class="only-for-js">
+                                    @if (Model.Total > 0)
+                                    {
+                                        <input name="selectedItems" type="checkbox" class="form-check-input" onClick="selectAll(this);" />
+                                    }
+                                </th>
+                                <th width="190px">
+                                    Date
+                                    <a href="javascript:switchTimeFormat()">
+                                        <span class="fa fa-clock-o" title="Switch date format"></span>
+                                    </a>
+                                </th>
+                                <th>Message</th>
+                                <th class="text-end">Actions</th>
+                            </tr>
                         </thead>
                         <tbody>
-                        @foreach (var item in Model.Items)
-                        {
-                            <tr data-guid="@item.Id" class="notification-row @(item.Seen ? "seen" : "")">
-                                <td class="only-for-js">
-                                    <input name="selectedItems" type="checkbox" class="selector form-check-input" value="@item.Id"/>
-                                </td>
-                                <td onclick="toggleRowCheckbox(this)">
-                                    <span class="switchTimeFormat" data-switch="@item.Created.ToTimeAgo()">
-                                        @item.Created.ToBrowserDate()
-                                    </span>
-                                </td>
-                                <td onclick="toggleRowCheckbox(this)">
-                                    @item.Body
-                                </td>
-                                <td class="text-end fw-normal">
-                                    @if (!String.IsNullOrEmpty(item.ActionLink))
-                                    {
-                                        <a href="@item.ActionLink" class="btn btn-link p-0">Details</a>
-                                        <span class="d-none d-md-inline-block"> - </span>
-                                    }
-                                    <button onclick="return rowseen(this)" class="btn btn-link p-0 btn-toggle-seen" type="submit" name="command" value="flip-individual:@(item.Id)">
-                                        <span>Mark&nbsp;</span><span class="seen-text"></span>
-                                    </button>
-                                </td>
-                            </tr>
-                        }
+                            @foreach (var item in Model.Items)
+                            {
+                                <tr data-guid="@item.Id" class="notification-row @(item.Seen ? "seen" : "")">
+                                    <td class="only-for-js">
+                                        <input name="selectedItems" type="checkbox" class="selector form-check-input" value="@item.Id" />
+                                    </td>
+                                    <td onclick="toggleRowCheckbox(this)">
+                                        <span class="switchTimeFormat" data-switch="@item.Created.ToTimeAgo()">
+                                            @item.Created.ToBrowserDate()
+                                        </span>
+                                    </td>
+                                    <td onclick="toggleRowCheckbox(this)">
+                                        @item.Body
+                                    </td>
+                                    <td class="text-end fw-normal">
+                                        @if (!String.IsNullOrEmpty(item.ActionLink))
+                                        {
+                                            <a href="@item.ActionLink" class="btn btn-link p-0">Details</a>
+                                            <span class="d-none d-md-inline-block"> - </span>
+                                        }
+                                        <button onclick="return rowseen(this)" class="btn btn-link p-0 btn-toggle-seen" type="submit" name="command" value="flip-individual:@(item.Id)">
+                                            <span>Mark&nbsp;</span><span class="seen-text"></span>
+                                        </button>
+                                    </td>
+                                </tr>
+                            }
                         </tbody>
                     </table>
 


### PR DESCRIPTION
Cleans up the view, and adds a more refined "no notifications" state until there is > 1 notification, then the table appears + adds button to link to notification settings.

TODO before merge:
- Link the settings button to "NotificationSettings" @dennisreimann or @woutersamaey I need some help with that.
- Decide that the "no notification" view is ideal until we implement the updated view for all screens, discussing mocks and implementation of this in tomorrow's design meeting (https://github.com/btcpayserver/btcpayserver/issues/2619). Sill exploring some design elements, but even these small improvements are helpful.

Before:
<img width="1438" alt="Screen Shot 2021-06-30 at 11 54 20 AM" src="https://user-images.githubusercontent.com/6250771/124053170-9cafe780-d9d4-11eb-8900-80ca0093425f.png">

After:
<img width="1438" alt="Screen Shot 2021-06-30 at 1 14 35 PM" src="https://user-images.githubusercontent.com/6250771/124053172-9faad800-d9d4-11eb-9eac-99cc7258faf8.png">

Potential Future Example & More Context (https://github.com/btcpayserver/btcpayserver/issues/2619):
<img width="1961" alt="Screen Shot 2021-06-30 at 7 01 49 PM" src="https://user-images.githubusercontent.com/6250771/124053812-bef63500-d9d5-11eb-8025-dad6211429b9.png">
