### PR TITLE
Hide referrer URL to hide our BTCPay Server URL

### DIFF
--- a/BTCPayServer/Views/PaymentRequest/ViewPaymentRequest.cshtml
+++ b/BTCPayServer/Views/PaymentRequest/ViewPaymentRequest.cshtml
@@ -275,7 +275,7 @@
                                                                 <td class="ps-3 text-break">
                                                                     @if (!string.IsNullOrEmpty(payment.Link))
                                                                     {
-                                                                        <a href="@payment.Link" class="text-print-default" target="_blank">@payment.Id</a>
+                                                                        <a href="@payment.Link" class="text-print-default" rel="noreferrer noopener" target="_blank">@payment.Id</a>
                                                                     }
                                                                     else
                                                                     {


### PR DESCRIPTION
PRIVACY!
Hide our referer URL when linking to blockstream.info for transcation details (or other sites).
This is 1 case I found where clicking the link would tell the external site where our BTCPay Server is.

I need your help:
1) Are there more cases like this?
2) Should I use JavaScript to auto-add "noreferrer noopener" to all `<a href>` with external domains? I vote yes, but open to comments.
3) Are there cases where we use the referrer in a meaningful way?