### PR TITLE
Greenfield doc error. Should be singular. Rewording to focus on a single result.

### DIFF
--- a/BTCPayServer/wwwroot/swagger/v1/swagger.template.stores-wallet.on-chain.json
+++ b/BTCPayServer/wwwroot/swagger/v1/swagger.template.stores-wallet.on-chain.json
@@ -412,7 +412,7 @@
                         }
                     }
                 ],
-                "description": "Get a store on-chain wallet transaction",
+                "description": "Get store on-chain wallet transaction",
                 "operationId": "StoreOnChainWallets_GetOnChainWalletTransaction",
                 "responses": {
                     "200": {

--- a/BTCPayServer/wwwroot/swagger/v1/swagger.template.stores-wallet.on-chain.json
+++ b/BTCPayServer/wwwroot/swagger/v1/swagger.template.stores-wallet.on-chain.json
@@ -382,7 +382,7 @@
                 "tags": [
                     "Store Wallet (On Chain)"
                 ],
-                "summary": "Get store on-chain wallet transactions",
+                "summary": "Get a store on-chain wallet transaction",
                 "parameters": [
                     {
                         "name": "storeId",
@@ -412,7 +412,7 @@
                         }
                     }
                 ],
-                "description": "Get store on-chain wallet transaction",
+                "description": "Get a store on-chain wallet transaction",
                 "operationId": "StoreOnChainWallets_GetOnChainWalletTransaction",
                 "responses": {
                     "200": {

--- a/BTCPayServer/wwwroot/swagger/v1/swagger.template.stores-wallet.on-chain.json
+++ b/BTCPayServer/wwwroot/swagger/v1/swagger.template.stores-wallet.on-chain.json
@@ -382,7 +382,7 @@
                 "tags": [
                     "Store Wallet (On Chain)"
                 ],
-                "summary": "Get a store on-chain wallet transaction",
+                "summary": "Get store on-chain wallet transaction",
                 "parameters": [
                     {
                         "name": "storeId",


### PR DESCRIPTION
The docs have 2 API calls that "Get store on-chain wallet transactions" (plural), but this is wrong. One if for multiple transactions and one is for a single transaction. Fixed the typo + added focus on single result.