### PR TITLE
Showing NetworkFee if needed and fixing counting of NetworkFee transactions

### DIFF
--- a/BTCPayServer/Controllers/InvoiceController.UI.cs
+++ b/BTCPayServer/Controllers/InvoiceController.UI.cs
@@ -557,6 +557,13 @@ namespace BTCPayServer.Controllers
                 RedirectAutomatically = invoice.RedirectAutomatically,
                 StoreName = store.StoreName,
                 TxCount = accounting.TxRequired,
+                TxCountForFee = storeBlob.NetworkFeeMode switch
+                {
+                    NetworkFeeMode.Always => accounting.TxRequired,
+                    NetworkFeeMode.MultiplePaymentsOnly => accounting.TxRequired - 1,
+                    NetworkFeeMode.Never => 0,
+                    _ => throw new NotImplementedException()
+                },
                 BtcPaid = accounting.Paid.ShowMoney(divisibility),
 #pragma warning disable CS0618 // Type or member is obsolete
                 Status = invoice.StatusString,

--- a/BTCPayServer/Models/InvoicingModels/InvoiceDetailsModel.cs
+++ b/BTCPayServer/Models/InvoicingModels/InvoiceDetailsModel.cs
@@ -22,6 +22,8 @@ namespace BTCPayServer.Models.InvoicingModels
         public bool Replaced { get; set; }
         public BitcoinLikePaymentData CryptoPaymentData { get; set; }
         public string AdditionalInformation { get; set; }
+
+        public decimal NetworkFee { get; set; }
     }
 
     public class OffChainPaymentViewModel

--- a/BTCPayServer/Models/InvoicingModels/PaymentModel.cs
+++ b/BTCPayServer/Models/InvoicingModels/PaymentModel.cs
@@ -49,6 +49,7 @@ namespace BTCPayServer.Models.InvoicingModels
         public string InvoiceBitcoinUrl { get; set; }
         public string InvoiceBitcoinUrlQR { get; set; }
         public int TxCount { get; set; }
+        public int TxCountForFee { get; set; }
         public string BtcPaid { get; set; }
         public string StoreEmail { get; set; }
 

--- a/BTCPayServer/Views/Invoice/Checkout-Body.cshtml
+++ b/BTCPayServer/Views/Invoice/Checkout-Body.cshtml
@@ -1,4 +1,4 @@
-﻿@model PaymentModel
+@model PaymentModel
 
 <div class="top-header">
     <div class="header">
@@ -133,7 +133,7 @@
                         {{ srvModel.networkFee }} {{ srvModel.cryptoCode }}
                     </span>
                     <span v-else>
-                        {{$t("txCount", {count: srvModel.txCount})}} x {{ srvModel.networkFee }} {{ srvModel.cryptoCode }}
+                        {{$t("txCount", {count: srvModel.txCountForFee})}} x {{ srvModel.networkFee }} {{ srvModel.cryptoCode }}
                     </span>
                 </div>
             </div>

--- a/BTCPayServer/Views/Invoice/Checkout-Body.cshtml
+++ b/BTCPayServer/Views/Invoice/Checkout-Body.cshtml
@@ -124,7 +124,7 @@
                     {{srvModel.orderAmountFiat}}
                 </div>
             </div>
-            <div class="line-items__item" v-show="srvModel.networkFee > 0">
+            <div class="line-items__item" v-show="srvModel.isMultiCurrency || srvModel.txCountForFee > 0">
                 <div class="line-items__item__label">
                     <span>{{$t("Network Cost")}}</span>
                 </div>
@@ -132,8 +132,8 @@
                     <span v-if="srvModel.isMultiCurrency">
                         {{ srvModel.networkFee }} {{ srvModel.cryptoCode }}
                     </span>
-                    <span v-else>
-                        {{$t("txCount", {count: srvModel.txCountForFee})}} x {{ srvModel.networkFee }} {{ srvModel.cryptoCode }}
+                    <span v-else-if="srvModel.txCountForFee > 0">
+                        {{$t("txCount", {count: srvModel.txCount})}} x {{ srvModel.networkFee }} {{ srvModel.cryptoCode }}
                     </span>
                 </div>
             </div>

--- a/BTCPayServer/Views/Shared/Bitcoin/ViewBitcoinLikePaymentData.cshtml
+++ b/BTCPayServer/Views/Shared/Bitcoin/ViewBitcoinLikePaymentData.cshtml
@@ -63,7 +63,7 @@
                     {
                     <th>
                         Network Fee
-                        <a href="https://docs.btcpayserver.org/FAQ/FAQ-Stores/#allow-anyone-to-create-invoice" target="_blank">
+                        <a href="https://docs.btcpayserver.org/FAQ/FAQ-Stores/#allow-anyone-to-create-invoice" target="_blank"  rel="noreferrer noopener">
                             <span class="fa fa-question-circle-o text-secondary" title="More information..."></span>
                         </a>
                     </th>

--- a/BTCPayServer/Views/Shared/Bitcoin/ViewBitcoinLikePaymentData.cshtml
+++ b/BTCPayServer/Views/Shared/Bitcoin/ViewBitcoinLikePaymentData.cshtml
@@ -41,12 +41,14 @@
         m.TransactionLink = string.Format(CultureInfo.InvariantCulture, payment.Network.BlockExplorerLink, m.TransactionId);
         m.Replaced = !payment.Accounted;
         m.CryptoPaymentData = onChainPaymentData;
+        m.NetworkFee = payment.NetworkFee;
         return m;
     }).Where(model => model != null);
 }
 
 @if (onchainPayments.Any())
 {
+    var hasNetworkFee = onchainPayments.Sum(a => a.NetworkFee) > 0;
     <div class="row">
         <div class="col-md-12 invoice-payments">
             <h3>On-Chain payments</h3>
@@ -57,6 +59,15 @@
                     <th>Index</th>
                     <th>Deposit address</th>
                     <th>Amount</th>
+                    @if (hasNetworkFee)
+                    {
+                    <th>
+                        Network Fee
+                        <a href="https://docs.btcpayserver.org/FAQ/FAQ-Stores/#allow-anyone-to-create-invoice" target="_blank">
+                            <span class="fa fa-question-circle-o text-secondary" title="More information..."></span>
+                        </a>
+                    </th>
+                    }
                     <th>Transaction Id</th>
                     <th class="text-end">Confirmations</th>
                 </tr>
@@ -69,7 +80,11 @@
                         <td>@(payment.CryptoPaymentData.KeyPath?.ToString()?? "Unknown")</td>
                         <td style="max-width:300px;" data-bs-toggle="tooltip" class="text-truncate" title="@payment.DepositAddress">@payment.DepositAddress</td>
                         <td class="payment-value">@payment.CryptoPaymentData.GetValue() @Safe.Raw(payment.AdditionalInformation is string i ? $"<br/>({i})" : string.Empty)</td>
-                        <td style="max-width:300px;" data-bs-toggle="tooltip" class="text-truncate"  title="@payment.TransactionId">
+                        @if (hasNetworkFee)
+                        {
+                            <td>@payment.NetworkFee</td>
+                        }
+                        <td style="max-width:200px;" data-bs-toggle="tooltip" class="text-truncate" title="@payment.TransactionId">
                             <div class="wraptextAuto">
                                 <a href="@payment.TransactionLink" target="_blank">
                                     @payment.TransactionId


### PR DESCRIPTION
Resolves: #2637

I am only showing `NetworkFee` column in Invoice details if it's needed.

Also, I needed to introduce new `TxCountForFee` property on `PaymentModel` because number of NetworkFee transactions differs depending on mode chosen for the store.

Here is PR in action: 

https://user-images.githubusercontent.com/5191402/124522453-987c3380-ddf3-11eb-92e9-410be5d2fef0.mp4

