### PR TITLE
Implement topup invoices

### DIFF
--- a/BTCPayServer.Client/Models/CreateInvoiceRequest.cs
+++ b/BTCPayServer.Client/Models/CreateInvoiceRequest.cs
@@ -10,7 +10,7 @@ namespace BTCPayServer.Client.Models
     public class CreateInvoiceRequest
     {
         [JsonConverter(typeof(NumericStringJsonConverter))]
-        public decimal Amount { get; set; }
+        public decimal? Amount { get; set; }
         public string Currency { get; set; }
         public JObject Metadata { get; set; }
         public CheckoutOptions Checkout { get; set; } = new CheckoutOptions();

--- a/BTCPayServer.Common/Altcoins/Liquid/ElementsLikeBtcPayNetwork.cs
+++ b/BTCPayServer.Common/Altcoins/Liquid/ElementsLikeBtcPayNetwork.cs
@@ -1,6 +1,7 @@
 #if ALTCOINS
 using System.Collections.Generic;
 using System.Linq;
+using BTCPayServer.Common;
 using NBitcoin;
 using NBXplorer;
 using NBXplorer.Models;
@@ -33,13 +34,15 @@ namespace BTCPayServer
                     output.Value is AssetMoney assetMoney && assetMoney.AssetId == AssetId));
         }
 
-        public override string GenerateBIP21(string cryptoInfoAddress, Money cryptoInfoDue)
+        public override PaymentUrlBuilder GenerateBIP21(string cryptoInfoAddress, Money cryptoInfoDue)
         {
             //precision 0: 10 = 0.00000010
             //precision 2: 10 = 0.00001000
             //precision 8: 10 = 10
             var money = cryptoInfoDue is null? null: new Money(cryptoInfoDue.ToDecimal(MoneyUnit.BTC) / decimal.Parse("1".PadRight(1 + 8 - Divisibility, '0')), MoneyUnit.BTC);
-            return $"{base.GenerateBIP21(cryptoInfoAddress, money)}{(money is null? "?": "&")}assetid={AssetId}";
+            var builder = base.GenerateBIP21(cryptoInfoAddress, money);
+            builder.QueryParams.Add("assetid", AssetId.ToString());
+            return builder;
         }
     }
 }

--- a/BTCPayServer.Common/BTCPayNetwork.cs
+++ b/BTCPayServer.Common/BTCPayNetwork.cs
@@ -2,7 +2,9 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using BTCPayServer.Common;
 using NBitcoin;
+using NBitcoin.Payment;
 using NBXplorer;
 using NBXplorer.Models;
 
@@ -121,9 +123,16 @@ namespace BTCPayServer
             });
         }
 
-        public virtual string GenerateBIP21(string cryptoInfoAddress, Money cryptoInfoDue)
+        public virtual PaymentUrlBuilder GenerateBIP21(string cryptoInfoAddress, Money cryptoInfoDue)
         {
-            return $"{UriScheme}:{cryptoInfoAddress}{(cryptoInfoDue is null? string.Empty: $"?amount={cryptoInfoDue.ToString(false, true)}")}";
+            var builder = new PaymentUrlBuilder();
+            builder.UriScheme = UriScheme;
+            builder.Host = cryptoInfoAddress;
+            if (cryptoInfoDue != null && cryptoInfoDue != Money.Zero)
+            {
+                builder.QueryParams.Add("amount", cryptoInfoDue.ToString(false, true));
+            }
+            return builder;
         }
 
         public virtual List<TransactionInformation> FilterValidTransactions(List<TransactionInformation> transactionInformationSet)

--- a/BTCPayServer.Common/PaymentUrlBuilder.cs
+++ b/BTCPayServer.Common/PaymentUrlBuilder.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace BTCPayServer.Common
+{
+    public class PaymentUrlBuilder
+    {
+        public string UriScheme { get; set; }
+        public Dictionary<string, string> QueryParams { get; set; } = new Dictionary<string, string>();
+        public string Host { get; set; }
+        public override string ToString()
+        {
+            StringBuilder builder = new StringBuilder($"{UriScheme}:{Host}");
+            if (QueryParams.Count != 0)
+            {
+                var parts = QueryParams.Select(q => Uri.EscapeDataString(q.Key) + "=" + System.Web.NBitcoin.HttpUtility.UrlEncode(q.Value))
+                    .ToArray();
+                builder.Append($"?{string.Join('&', parts)}");
+            }
+            return builder.ToString();
+        }
+    }
+}

--- a/BTCPayServer.Tests/GreenfieldAPITests.cs
+++ b/BTCPayServer.Tests/GreenfieldAPITests.cs
@@ -1023,7 +1023,7 @@ namespace BTCPayServer.Tests
                 //create
 
                 //validation errors
-                await AssertValidationError(new[] { nameof(CreateInvoiceRequest.Currency), nameof(CreateInvoiceRequest.Amount), $"{nameof(CreateInvoiceRequest.Checkout)}.{nameof(CreateInvoiceRequest.Checkout.PaymentTolerance)}", $"{nameof(CreateInvoiceRequest.Checkout)}.{nameof(CreateInvoiceRequest.Checkout.PaymentMethods)}[0]" }, async () =>
+                await AssertValidationError(new[] { nameof(CreateInvoiceRequest.Currency), $"{nameof(CreateInvoiceRequest.Checkout)}.{nameof(CreateInvoiceRequest.Checkout.PaymentTolerance)}", $"{nameof(CreateInvoiceRequest.Checkout)}.{nameof(CreateInvoiceRequest.Checkout.PaymentMethods)}[0]" }, async () =>
                {
                    await client.CreateInvoice(user.StoreId, new CreateInvoiceRequest() { Amount = -1, Checkout = new CreateInvoiceRequest.CheckoutOptions() { PaymentTolerance = -2, PaymentMethods = new[] { "jasaas_sdsad" } } });
                });

--- a/BTCPayServer/Controllers/GreenField/InvoiceController.cs
+++ b/BTCPayServer/Controllers/GreenField/InvoiceController.cs
@@ -155,11 +155,6 @@ namespace BTCPayServer.Controllers.GreenField
                 return StoreNotFound();
             }
 
-            if (request.Amount < 0.0m)
-            {
-                ModelState.AddModelError(nameof(request.Amount), "The amount should be 0 or more.");
-            }
-
             if (string.IsNullOrEmpty(request.Currency))
             {
                 ModelState.AddModelError(nameof(request.Currency), "Currency is required");

--- a/BTCPayServer/Controllers/GreenField/StoreOnChainWalletsController.cs
+++ b/BTCPayServer/Controllers/GreenField/StoreOnChainWalletsController.cs
@@ -129,13 +129,12 @@ namespace BTCPayServer.Controllers.GreenField
             var allowedPayjoin = derivationScheme.IsHotWallet && Store.GetStoreBlob().PayJoinEnabled;
             if (allowedPayjoin)
             {
-               bip21 +=
-                   $"?{PayjoinClient.BIP21EndpointKey}={Request.GetAbsoluteUri(Url.Action(nameof(PayJoinEndpointController.Submit), "PayJoinEndpoint", new {cryptoCode}))}";
+                bip21.QueryParams.Add(PayjoinClient.BIP21EndpointKey, Request.GetAbsoluteUri(Url.Action(nameof(PayJoinEndpointController.Submit), "PayJoinEndpoint", new { cryptoCode })));
             }
             return Ok(new OnChainWalletAddressData()
             {
                 Address = kpi.Address.ToString(),
-                PaymentLink =  bip21,
+                PaymentLink =  bip21.ToString(),
                 KeyPath = kpi.KeyPath
             });
         }

--- a/BTCPayServer/Controllers/InvoiceController.UI.cs
+++ b/BTCPayServer/Controllers/InvoiceController.UI.cs
@@ -547,6 +547,7 @@ namespace BTCPayServer.Controllers
                 BtcDue = accounting.Due.ShowMoney(divisibility),
                 InvoiceCurrency = invoice.Currency,
                 OrderAmount = (accounting.TotalDue - accounting.NetworkFee).ShowMoney(divisibility),
+                IsTopUp = invoice.Price == 0.0m,
                 OrderAmountFiat = OrderAmountFromInvoice(network.CryptoCode, invoice),
                 CustomerEmail = invoice.RefundMail,
                 RequiresRefundEmail = storeBlob.RequiresRefundEmail,

--- a/BTCPayServer/Controllers/WalletsController.PullPayments.cs
+++ b/BTCPayServer/Controllers/WalletsController.PullPayments.cs
@@ -283,8 +283,7 @@ namespace BTCPayServer.Controllers
                         var blob = payout.GetBlob(_jsonSerializerSettings);
                         if (payout.GetPaymentMethodId() != paymentMethodId)
                             continue;
-                        bip21.Add(network.GenerateBIP21(payout.Destination, new Money(blob.CryptoAmount.Value, MoneyUnit.BTC)));
-                        
+                        bip21.Add(network.GenerateBIP21(payout.Destination, new Money(blob.CryptoAmount.Value, MoneyUnit.BTC)).ToString());
                     }
 
                     return RedirectToAction(nameof(WalletSend), new {walletId, bip21});

--- a/BTCPayServer/Controllers/WalletsController.cs
+++ b/BTCPayServer/Controllers/WalletsController.cs
@@ -368,18 +368,17 @@ namespace BTCPayServer.Controllers
                 return NotFound();
             var address = _walletReceiveService.Get(walletId)?.Address;
             var allowedPayjoin = paymentMethod.IsHotWallet && CurrentStore.GetStoreBlob().PayJoinEnabled;
-            var bip21 = address is null ? null : network.GenerateBIP21(address.ToString(), null);
+            var bip21 = network.GenerateBIP21(address?.ToString(), null);
             if (allowedPayjoin)
             {
-                bip21 +=
-                    $"?{PayjoinClient.BIP21EndpointKey}={Request.GetAbsoluteUri(Url.Action(nameof(PayJoinEndpointController.Submit), "PayJoinEndpoint", new {walletId.CryptoCode}))}";
+                bip21.QueryParams.Add(PayjoinClient.BIP21EndpointKey, Request.GetAbsoluteUri(Url.Action(nameof(PayJoinEndpointController.Submit), "PayJoinEndpoint", new { walletId.CryptoCode })));
             }
             return View(new WalletReceiveViewModel()
             {
                 CryptoCode = walletId.CryptoCode,
                 Address = address?.ToString(),
                 CryptoImage = GetImage(paymentMethod.PaymentId, network),
-                PaymentLink = bip21
+                PaymentLink = bip21?.ToString()
             });
         }
 

--- a/BTCPayServer/HostedServices/InvoiceWatcher.cs
+++ b/BTCPayServer/HostedServices/InvoiceWatcher.cs
@@ -43,6 +43,13 @@ namespace BTCPayServer.HostedServices
 
             public bool Dirty => _Dirty;
             public bool Unaffect => _Unaffect;
+
+            bool _IsBlobUpdated;
+            public bool IsBlobUpdated => _IsBlobUpdated;
+            public void BlobUpdated()
+            {
+                _IsBlobUpdated = true;
+            }
         }
 
         readonly InvoiceRepository _InvoiceRepository;
@@ -68,6 +75,7 @@ namespace BTCPayServer.HostedServices
         private void UpdateInvoice(UpdateInvoiceContext context)
         {
             var invoice = context.Invoice;
+            var isTopup = invoice.Price == 0.0m;
             if (invoice.Status == InvoiceStatusLegacy.New && invoice.ExpirationTime <= DateTimeOffset.UtcNow)
             {
                 context.MarkDirty();
@@ -83,13 +91,26 @@ namespace BTCPayServer.HostedServices
                 return;
             if (invoice.Status == InvoiceStatusLegacy.New || invoice.Status == InvoiceStatusLegacy.Expired)
             {
-                if (accounting.Paid >= accounting.MinimumTotalDue)
+                var isPaid = isTopup ?
+                    accounting.Paid > Money.Zero :
+                    accounting.Paid >= accounting.MinimumTotalDue;
+                if (isPaid)
                 {
                     if (invoice.Status == InvoiceStatusLegacy.New)
                     {
                         context.Events.Add(new InvoiceEvent(invoice, InvoiceEvent.PaidInFull));
                         invoice.Status = InvoiceStatusLegacy.Paid;
-                        invoice.ExceptionStatus = accounting.Paid > accounting.TotalDue ? InvoiceExceptionStatus.PaidOver : InvoiceExceptionStatus.None;
+                        if (isTopup)
+                        {
+                            invoice.ExceptionStatus = InvoiceExceptionStatus.None;
+                            invoice.Price = (accounting.Paid - accounting.NetworkFeeAlreadyPaid).ToDecimal(MoneyUnit.BTC) * paymentMethod.Rate;
+                            accounting = paymentMethod.Calculate();
+                            context.BlobUpdated();
+                        }
+                        else
+                        {
+                            invoice.ExceptionStatus = accounting.Paid > accounting.TotalDue ? InvoiceExceptionStatus.PaidOver : InvoiceExceptionStatus.None;
+                        }
                         context.UnaffectAddresses();
                         context.MarkDirty();
                     }
@@ -292,6 +313,10 @@ namespace BTCPayServer.HostedServices
                         {
                             await _InvoiceRepository.UpdateInvoiceStatus(invoice.Id, invoice.GetInvoiceState());
                             updateContext.Events.Insert(0, new InvoiceDataChangedEvent(invoice));
+                        }
+                        if (updateContext.IsBlobUpdated)
+                        {
+                            await _InvoiceRepository.UpdateInvoicePrice(invoice.Id, invoice);
                         }
 
                         foreach (var evt in updateContext.Events)

--- a/BTCPayServer/Models/BitpayCreateInvoiceRequest.cs
+++ b/BTCPayServer/Models/BitpayCreateInvoiceRequest.cs
@@ -51,7 +51,7 @@ namespace BTCPayServer.Models
         [JsonProperty(PropertyName = "currency", DefaultValueHandling = DefaultValueHandling.Ignore)]
         public string Currency { get; set; }
         [JsonProperty(PropertyName = "price", DefaultValueHandling = DefaultValueHandling.Ignore)]
-        public decimal Price { get; set; }
+        public decimal? Price { get; set; }
         [JsonProperty(PropertyName = "notificationEmail", DefaultValueHandling = DefaultValueHandling.Ignore)]
         public string NotificationEmail { get; set; }
         [JsonConverter(typeof(DateTimeJsonConverter))]

--- a/BTCPayServer/Models/InvoicingModels/PaymentModel.cs
+++ b/BTCPayServer/Models/InvoicingModels/PaymentModel.cs
@@ -27,6 +27,7 @@ namespace BTCPayServer.Models.InvoicingModels
         public string DefaultLang { get; set; }
         public List<AvailableCrypto> AvailableCryptos { get; set; } = new List<AvailableCrypto>();
         public bool IsModal { get; set; }
+        public bool IsTopUp { get; set; }
         public string CryptoCode { get; set; }
         public string InvoiceId { get; set; }
         public string BtcAddress { get; set; }

--- a/BTCPayServer/Payments/PayJoin/PayJoinEndpointController.cs
+++ b/BTCPayServer/Payments/PayJoin/PayJoinEndpointController.cs
@@ -370,6 +370,7 @@ namespace BTCPayServer.Payments.PayJoin
                 return CreatePayjoinErrorAndLog(503, PayjoinReceiverWellknownErrors.Unavailable, "The HD Key of the store changed");
             }
 
+            bool isTopUp = invoice?.Price is 0.0m;
             Money contributedAmount = Money.Zero;
             var newTx = ctx.OriginalTransaction.Clone();
             var ourNewOutput = newTx.Outputs[originalPaymentOutput.Index];
@@ -413,7 +414,7 @@ namespace BTCPayServer.Payments.PayJoin
             if (additionalFee > Money.Zero)
             {
                 // If the user overpaid, taking fee on our output (useful if sender dump a full UTXO for privacy)
-                for (int i = 0; i < newTx.Outputs.Count && additionalFee > Money.Zero && due < Money.Zero; i++)
+                for (int i = 0; i < newTx.Outputs.Count && additionalFee > Money.Zero && due < Money.Zero && !isTopUp; i++)
                 {
                     if (disableoutputsubstitution)
                         break;

--- a/BTCPayServer/Payments/PaymentTypes.Bitcoin.cs
+++ b/BTCPayServer/Payments/PaymentTypes.Bitcoin.cs
@@ -78,9 +78,9 @@ namespace BTCPayServer.Payments
 
             if ((paymentMethodDetails as BitcoinLikeOnChainPaymentMethod)?.PayjoinEnabled is true && serverUri != null)
             {
-                bip21 += $"&{PayjoinClient.BIP21EndpointKey}={serverUri.WithTrailingSlash()}{network.CryptoCode}/{PayjoinClient.BIP21EndpointKey}";
+                bip21.QueryParams.Add(PayjoinClient.BIP21EndpointKey, $"{serverUri.WithTrailingSlash()}{network.CryptoCode}/{PayjoinClient.BIP21EndpointKey}");
             }
-            return bip21;
+            return bip21.ToString();
         }
 
         public override string InvoiceViewPaymentPartialName { get; } = "Bitcoin/ViewBitcoinLikePaymentData";

--- a/BTCPayServer/Services/Invoices/InvoiceRepository.cs
+++ b/BTCPayServer/Services/Invoices/InvoiceRepository.cs
@@ -420,6 +420,19 @@ namespace BTCPayServer.Services.Invoices
                 await context.SaveChangesAsync().ConfigureAwait(false);
             }
         }
+        internal async Task UpdateInvoicePrice(string invoiceId, InvoiceEntity invoice)
+        {
+            using (var context = _ContextFactory.CreateContext())
+            {
+                var invoiceData = await context.FindAsync<Data.InvoiceData>(invoiceId).ConfigureAwait(false);
+                if (invoiceData == null)
+                    return;
+                var blob = invoiceData.GetBlob(_Networks);
+                blob.Price = invoice.Price;
+                invoiceData.Blob = ToBytes(blob, null);
+                await context.SaveChangesAsync().ConfigureAwait(false);
+            }
+        }
 
         public async Task MassArchive(string[] invoiceIds)
         {

--- a/BTCPayServer/Views/Invoice/Checkout-Body.cshtml
+++ b/BTCPayServer/Views/Invoice/Checkout-Body.cshtml
@@ -95,10 +95,10 @@
             </div>
         </div>
         <div class="single-item-order__right">
-            <div class="single-item-order__right__btc-price" v-if="srvModel.status === 'paid'">
+            <div class="single-item-order__right__btc-price" v-if="srvModel.status === 'paid' && !srvModel.isTopUp">
                 <span>{{ srvModel.btcPaid }} {{ srvModel.cryptoCode }}</span>
             </div>
-            <div class="single-item-order__right__btc-price" v-else>
+            <div class="single-item-order__right__btc-price" v-if="srvModel.status !== 'paid' && !srvModel.isTopUp">
                 <span>{{ srvModel.btcDue }} {{ srvModel.cryptoCode }}</span>
             </div>
             <div class="single-item-order__right__ex-rate" v-if="srvModel.orderAmountFiat && srvModel.cryptoCode">
@@ -106,10 +106,10 @@
                 <span v-else>1 {{ srvModel.cryptoCodeSrv }} = {{ srvModel.rate }}</span>
             </div>
         </div>
-        <span class="fa fa-angle-double-down"></span>
-        <span class="fa fa-angle-double-up"></span>
+        <span class="fa fa-angle-double-down" v-if="!srvModel.isTopUp"></span>
+        <span class="fa fa-angle-double-up" v-if="!srvModel.isTopUp"></span>
     </div>
-    <line-items>
+    <line-items v-if="!srvModel.isTopUp">
         <div class="extraPayment" v-if="srvModel.status === 'new' && srvModel.txCount > 1">
             {{$t("NotPaid_ExtraTransaction")}}
         </div>

--- a/BTCPayServer/Views/Shared/Bitcoin/BitcoinLikeMethodCheckout.cshtml
+++ b/BTCPayServer/Views/Shared/Bitcoin/BitcoinLikeMethodCheckout.cshtml
@@ -19,14 +19,14 @@
                 </div>
             </div>
             <div class="bp-view payment manual-flow" id="copy" v-bind:class="{ 'active': currentTab == 'copy'}">
-                <div class="manual__step-two__instructions">
+                <div class="manual__step-two__instructions" v-if="!srvModel.isTopUp">
                     <span v-html="$t('CompletePay_Body', srvModel)"></span>
                 </div>
                 <div class="copyLabelPopup">
                     <span>{{$t("Copied")}}</span>
                 </div>
                 <nav class="copyBox">
-                    <div class="copySectionBox bottomBorder">
+                    <div class="copySectionBox bottomBorder" v-if="!srvModel.isTopUp">
                         <label>{{$t("Amount")}}</label>
                         <div class="copyAmountText copy-cursor _copySpan">
                             <span>{{srvModel.btcDue}}</span> {{ srvModel.cryptoCode }}

--- a/BTCPayServer/wwwroot/swagger/v1/swagger.template.invoices.json
+++ b/BTCPayServer/wwwroot/swagger/v1/swagger.template.invoices.json
@@ -935,7 +935,8 @@
                     "amount": {
                         "type": "string",
                         "format": "decimal",
-                        "description": "The amount of the invoice"
+                        "nullable": true,
+                        "description": "The amount of the invoice. If null or unspecified, the invoice will be a top-up invoice. (ie. The invoice will consider any payment as a full payment)"
                     },
                     "currency": {
                         "type": "string",


### PR DESCRIPTION
Implement idea on https://github.com/btcpayserver/btcpayserver/discussions/2659

There is still a bug on top-up invoices with payjoin that I need to solve. I also need to add a test for this.

An invoice with an amount of 0 now has a special meaning: The first payment to it will change its amount to the amount of the payment.