### PR TITLE
Add webhook delivery status indicator

### DIFF
--- a/BTCPayServer/Models/StoreViewModels/WebhooksViewModel.cs
+++ b/BTCPayServer/Models/StoreViewModels/WebhooksViewModel.cs
@@ -1,7 +1,5 @@
+#nullable enable
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 
 namespace BTCPayServer.Models.StoreViewModels
 {
@@ -11,6 +9,9 @@ namespace BTCPayServer.Models.StoreViewModels
         {
             public string Id { get; set; }
             public string Url { get; set; }
+            public bool LastDeliverySuccessful { get; set; } = true;
+            public DateTimeOffset? LastDeliveryTimeStamp { get; set; } = null;
+            public string? LastDeliveryErrorMessage { get; set; } = null;
         }
         public WebhookViewModel[] Webhooks { get; set; }
     }

--- a/BTCPayServer/Views/Stores/Webhooks.cshtml
+++ b/BTCPayServer/Views/Stores/Webhooks.cshtml
@@ -30,17 +30,26 @@
                 <td class="align-baseline">
                     @if (wh.LastDeliverySuccessful)
                     {
-                        <span class="d-flex align-items-center fa fa-check text-success" title="@(wh.LastDeliveryTimeStamp == null ? "No deliveries for this webhook yet" : "Last delivery on: " + @wh.LastDeliveryTimeStamp)"></span>
+                        <span
+                            class="fa fa-check text-success"
+                            id="delivery-status-icon"
+                            data-bs-toggle="tooltip"
+                            title="@(wh.LastDeliveryTimeStamp == null ? "No deliveries for this webhook yet" : "Last delivery " + @wh.LastDeliveryTimeStamp?.ToTimeAgo())"></span>
                     }
                     else
                     {
-                        <span class="d-flex align-items-center fa fa-times text-danger" title="Error: @wh.LastDeliveryErrorMessage. Delivery last attempted on: @wh.LastDeliveryTimeStamp"></span>
+                        <span
+                            class="fa fa-times text-danger"
+                            id="delivery-status-icon"
+                            data-bs-toggle="tooltip"
+                            data-bs-html="true"
+                            title="Error: @wh.LastDeliveryErrorMessage. <br/> Delivery last attempted <span id='last-delivery-time'>@wh.LastDeliveryTimeStamp?.ToTimeAgo()</span>"></span>
                     }
                 </td>
                 <td class="d-block text-break">@wh.Url</td>
                 <td class="text-end text-md-nowrap">
                     <a asp-action="TestWebhook" asp-route-storeId="@this.Context.GetRouteValue("storeId")" asp-route-webhookId="@wh.Id">Test</a> -
-                    <a asp-action="ModifyWebhook" asp-route-storeId="@this.Context.GetRouteValue("storeId")" asp-route-webhookId="@wh.Id">Modify</a> - 
+                    <a asp-action="ModifyWebhook" asp-route-storeId="@this.Context.GetRouteValue("storeId")" asp-route-webhookId="@wh.Id">Modify</a> -
                     <a asp-action="DeleteWebhook" asp-route-storeId="@this.Context.GetRouteValue("storeId")" asp-route-webhookId="@wh.Id">Delete</a>
                 </td>
             </tr>

--- a/BTCPayServer/Views/Stores/Webhooks.cshtml
+++ b/BTCPayServer/Views/Stores/Webhooks.cshtml
@@ -17,15 +17,26 @@
 {
     <table class="table table-sm table-responsive-md">
         <thead>
-        <tr>
-            <th>Url</th>
-            <th class="text-end">Actions</th>
-        </tr>
+            <tr>
+                <th>Status</th>
+                <th>Url</th>
+                <th class="text-end">Actions</th>
+            </tr>
         </thead>
         <tbody>
         @foreach (var wh in Model.Webhooks)
         {
             <tr>
+                <td class="align-baseline">
+                    @if (wh.LastDeliverySuccessful)
+                    {
+                        <span class="d-flex align-items-center fa fa-check text-success" title="@(wh.LastDeliveryTimeStamp == null ? "No deliveries for this webhook yet" : "Last delivery on: " + @wh.LastDeliveryTimeStamp)"></span>
+                    }
+                    else
+                    {
+                        <span class="d-flex align-items-center fa fa-times text-danger" title="Error: @wh.LastDeliveryErrorMessage. Delivery last attempted on: @wh.LastDeliveryTimeStamp"></span>
+                    }
+                </td>
                 <td class="d-block text-break">@wh.Url</td>
                 <td class="text-end text-md-nowrap">
                     <a asp-action="TestWebhook" asp-route-storeId="@this.Context.GetRouteValue("storeId")" asp-route-webhookId="@wh.Id">Test</a> -
@@ -45,5 +56,5 @@ else
 }
 
 @section PageFootContent {
-<partial name="_ValidationScriptsPartial" />
+    <partial name="_ValidationScriptsPartial" />
 }


### PR DESCRIPTION
As discussed in: https://github.com/btcpayserver/btcpayserver/discussions/2616

Added status indicator for each webhook for a store. Besides just the visual indicator you also get a tooltip on hover with some additional info like when the last delivery occurred and what error message we have if any.

![Screen Shot 2021-07-07 at 1 19 30 PM](https://user-images.githubusercontent.com/1934678/124823475-1d676a00-df26-11eb-9d12-ca454d129943.png)
