### PR TITLE
Auto-select store when creating a new invoice

### DIFF
--- a/BTCPayServer/Controllers/InvoiceController.UI.cs
+++ b/BTCPayServer/Controllers/InvoiceController.UI.cs
@@ -434,8 +434,8 @@ namespace BTCPayServer.Controllers
         [AcceptMediaTypeConstraint("application/bitcoin-paymentrequest", false)]
         [XFrameOptionsAttribute(null)]
         [ReferrerPolicyAttribute("origin")]
-        public async Task<IActionResult> Checkout(string invoiceId, string id = null, string paymentMethodId = null,
-            [FromQuery] string view = null, [FromQuery] string lang = null)
+        public async Task<IActionResult> Checkout(string? invoiceId, string? id = null, string? paymentMethodId = null,
+            [FromQuery] string? view = null, [FromQuery] string? lang = null)
         {
             //Keep compatibility with Bitpay
             invoiceId = invoiceId ?? id;
@@ -467,7 +467,7 @@ namespace BTCPayServer.Controllers
 
         [HttpGet]
         [Route("invoice-noscript")]
-        public async Task<IActionResult> CheckoutNoScript(string invoiceId, string id = null, string paymentMethodId = null, [FromQuery] string lang = null)
+        public async Task<IActionResult> CheckoutNoScript(string? invoiceId, string? id = null, string? paymentMethodId = null, [FromQuery] string? lang = null)
         {
             //Keep compatibility with Bitpay
             invoiceId = invoiceId ?? id;
@@ -481,7 +481,7 @@ namespace BTCPayServer.Controllers
             return View(model);
         }
 
-        private async Task<PaymentModel> GetInvoiceModel(string invoiceId, PaymentMethodId paymentMethodId, string lang)
+        private async Task<PaymentModel?> GetInvoiceModel(string invoiceId, PaymentMethodId paymentMethodId, string lang)
         {
             var invoice = await _InvoiceRepository.GetInvoice(invoiceId);
             if (invoice == null)
@@ -605,7 +605,7 @@ namespace BTCPayServer.Controllers
             return model;
         }
 
-        private string OrderAmountFromInvoice(string cryptoCode, InvoiceEntity invoiceEntity)
+        private string? OrderAmountFromInvoice(string cryptoCode, InvoiceEntity invoiceEntity)
         {
             // if invoice source currency is the same as currently display currency, no need for "order amount from invoice"
             if (cryptoCode == invoiceEntity.Currency)
@@ -625,7 +625,7 @@ namespace BTCPayServer.Controllers
         [Route("invoice/{invoiceId}/status")]
         [Route("invoice/{invoiceId}/{paymentMethodId}/status")]
         [Route("invoice/status")]
-        public async Task<IActionResult> GetStatus(string invoiceId, string paymentMethodId = null, [FromQuery] string lang = null)
+        public async Task<IActionResult> GetStatus(string invoiceId, string? paymentMethodId = null, [FromQuery] string? lang = null)
         {
             var model = await GetInvoiceModel(invoiceId, paymentMethodId == null ? null : PaymentMethodId.Parse(paymentMethodId), lang);
             if (model == null)
@@ -700,7 +700,7 @@ namespace BTCPayServer.Controllers
         [Route("invoices")]
         [Authorize(AuthenticationSchemes = AuthenticationSchemes.Cookie)]
         [BitpayAPIConstraint(false)]
-        public async Task<IActionResult> ListInvoices(InvoicesModel model = null)
+        public async Task<IActionResult> ListInvoices(InvoicesModel? model = null)
         {
             model = this.ParseListQuery(model ?? new InvoicesModel());
 
@@ -736,7 +736,7 @@ namespace BTCPayServer.Controllers
             return View(model);
         }
 
-        private InvoiceQuery GetInvoiceQuery(string searchTerm = null, int timezoneOffset = 0)
+        private InvoiceQuery GetInvoiceQuery(string? searchTerm = null, int timezoneOffset = 0)
         {
             var fs = new SearchString(searchTerm);
             var invoiceQuery = new InvoiceQuery()
@@ -759,7 +759,7 @@ namespace BTCPayServer.Controllers
         [HttpGet]
         [Authorize(AuthenticationSchemes = AuthenticationSchemes.Cookie)]
         [BitpayAPIConstraint(false)]
-        public async Task<IActionResult> Export(string format, string searchTerm = null, int timezoneOffset = 0)
+        public async Task<IActionResult> Export(string format, string? searchTerm = null, int timezoneOffset = 0)
         {
             var model = new InvoiceExport(_CurrencyNameTable);
 

--- a/BTCPayServer/Controllers/InvoiceController.UI.cs
+++ b/BTCPayServer/Controllers/InvoiceController.UI.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Collections.Generic;
 using System.Globalization;
@@ -792,9 +793,14 @@ namespace BTCPayServer.Controllers
         [Route("invoices/create")]
         [Authorize(AuthenticationSchemes = AuthenticationSchemes.Cookie)]
         [BitpayAPIConstraint(false)]
-        public async Task<IActionResult> CreateInvoice()
+        public async Task<IActionResult> CreateInvoice(InvoicesModel? model = null)
         {
-            var stores = new SelectList(await _StoreRepository.GetStoresByUserId(GetUserId()), nameof(StoreData.Id), nameof(StoreData.StoreName), null);
+            var stores = new SelectList(
+                await _StoreRepository.GetStoresByUserId(GetUserId()),
+                nameof(StoreData.Id),
+                nameof(StoreData.StoreName),
+                new SearchString(model?.SearchTerm).GetFilterArray("storeid")?.ToArray().FirstOrDefault()
+            );
             if (!stores.Any())
             {
                 TempData[WellKnownTempData.ErrorMessage] = "You need to create at least one store before creating a transaction";

--- a/BTCPayServer/Views/Invoice/ListInvoices.cshtml
+++ b/BTCPayServer/Views/Invoice/ListInvoices.cshtml
@@ -184,7 +184,7 @@
                     </a>
                 </small>
             </h2>
-            <a id="CreateNewInvoice" asp-action="CreateInvoice" class="btn btn-primary mt-3 mt-sm-0">
+            <a id="CreateNewInvoice" asp-action="CreateInvoice" asp-route-searchTerm="@Model.SearchTerm" class="btn btn-primary mt-3 mt-sm-0">
                 <span class="fa fa-plus"></span>
                 Create an invoice
             </a>


### PR DESCRIPTION
It was annoying to me that when I go to "Stores", then click on "Invoices" for a store I get the invoices for that store but then if I proceed on clicking on "Create an invoice" button on the invoices page, my store is not pre-selected so I can end up creating an invoice for a store that I didn't intend to create an invoice for.

This PR will use the existing store id from the search term to pre-select the right store when user is on the "Create an invoice" page. If store id is not present in the search term, it will work as it did previously (i.e., the first item in the list will be selected).