### PR TITLE
Update InvoiceConfirmed to InvoiceSettled in swagger

### DIFF
--- a/BTCPayServer/wwwroot/swagger/v1/swagger.template.webhooks.json
+++ b/BTCPayServer/wwwroot/swagger/v1/swagger.template.webhooks.json
@@ -615,7 +615,7 @@
                     "type": {
                         "type": "string",
                         "nullable": false,
-                        "description": "The type of this event, current available are `InvoiceCreated`, `InvoiceReceivedPayment`, `InvoicePaidInFull`, `InvoiceExpired`, `InvoiceConfirmed`, and `InvoiceInvalid`."
+                        "description": "The type of this event, current available are `InvoiceCreated`, `InvoiceReceivedPayment`, `InvoicePaidInFull`, `InvoiceExpired`, `InvoiceSettled`, and `InvoiceInvalid`."
                     },
                     "timestamp": {
                         "description": "The timestamp when this delivery has been created",


### PR DESCRIPTION
fix #2580

Looks like we were still specifying `InvoiceConfirmed` as an available webhook event type even though it doesn't exist.