### PR TITLE
Make CanUseInternalLightningNode a sub policy of CanModifyServerSettings

### DIFF
--- a/BTCPayServer.Client/Permissions.cs
+++ b/BTCPayServer.Client/Permissions.cs
@@ -179,6 +179,7 @@ namespace BTCPayServer.Client
                 case Policies.CanCreateLightningInvoiceInternalNode when this.Policy == Policies.CanUseInternalLightningNode:
                 case Policies.CanCreateLightningInvoiceInStore when this.Policy == Policies.CanUseLightningNodeInStore:
                 case Policies.CanViewNotificationsForUser when this.Policy == Policies.CanManageNotificationsForUser:
+                case Policies.CanUseInternalLightningNode when this.Policy == Policies.CanModifyServerSettings:
                     return true;
                 default:
                     return false;


### PR DESCRIPTION
SInce CanModifyServerSettings can trivially modify any policy around lightning node sharing, it should automatically have access to the lightning node usage perm