### PR TITLE
Refactoring: Allow ViewsRazor extension to be used by plugins

### DIFF
--- a/BTCPayServer.Abstractions/Extensions/ViewsRazor.cs
+++ b/BTCPayServer.Abstractions/Extensions/ViewsRazor.cs
@@ -3,7 +3,7 @@ using System.Globalization;
 using Microsoft.AspNetCore.Html;
 using Microsoft.AspNetCore.Mvc.ViewFeatures;
 
-namespace BTCPayServer.Views
+namespace BTCPayServer.Abstractions.Extensions
 {
     public static class ViewsRazor
     {

--- a/BTCPayServer/Components/NotificationsDropdown/Default.cshtml
+++ b/BTCPayServer/Components/NotificationsDropdown/Default.cshtml
@@ -3,6 +3,7 @@
 @inject ISettingsRepository SettingsRepository
 @using BTCPayServer.HostedServices
 @using BTCPayServer.Views.Notifications
+@using BTCPayServer.Abstractions.Extensions
 @using BTCPayServer.Abstractions.Contracts
 @using BTCPayServer.Client
 @using BTCPayServer.Services

--- a/BTCPayServer/Models/ServerViewModels/DynamicDnsViewModel.cs
+++ b/BTCPayServer/Models/ServerViewModels/DynamicDnsViewModel.cs
@@ -1,4 +1,5 @@
 using System;
+using BTCPayServer.Abstractions.Extensions;
 using BTCPayServer.Services;
 
 namespace BTCPayServer.Models.ServerViewModels
@@ -23,7 +24,7 @@ namespace BTCPayServer.Models.ServerViewModels
             {
                 if (Settings?.LastUpdated is DateTimeOffset date)
                 {
-                    return Views.ViewsRazor.ToTimeAgo(date);
+                    return ViewsRazor.ToTimeAgo(date);
                 }
                 return null;
             }

--- a/BTCPayServer/Models/ViewPullPaymentModel.cs
+++ b/BTCPayServer/Models/ViewPullPaymentModel.cs
@@ -1,9 +1,9 @@
 using System;
 using System.Collections.Generic;
+using BTCPayServer.Abstractions.Extensions;
 using BTCPayServer.Client.Models;
 using BTCPayServer.Data;
 using BTCPayServer.Services.Rates;
-using BTCPayServer.Views;
 using PullPaymentData = BTCPayServer.Data.PullPaymentData;
 
 namespace BTCPayServer.Models

--- a/BTCPayServer/Views/Apps/_ViewImports.cshtml
+++ b/BTCPayServer/Views/Apps/_ViewImports.cshtml
@@ -1,2 +1,3 @@
-﻿@using BTCPayServer.Views.Apps
+﻿@using BTCPayServer.Abstractions.Extensions
+@using BTCPayServer.Views.Apps
 @using BTCPayServer.Models.AppViewModels

--- a/BTCPayServer/Views/Apps/_ViewStart.cshtml
+++ b/BTCPayServer/Views/Apps/_ViewStart.cshtml
@@ -1,4 +1,5 @@
-﻿@using BTCPayServer.Views
+﻿@using BTCPayServer.Abstractions.Extensions
+@using BTCPayServer.Views
 @using BTCPayServer.Views.Apps
 @{
     ViewBag.CategoryTitle = "Apps";

--- a/BTCPayServer/Views/CoinSwitch/UpdateCoinSwitchSettings.cshtml
+++ b/BTCPayServer/Views/CoinSwitch/UpdateCoinSwitchSettings.cshtml
@@ -1,5 +1,5 @@
-﻿@using Microsoft.AspNetCore.Mvc.Rendering
-@using BTCPayServer.Views.Stores
+﻿@using BTCPayServer.Views.Stores
+@using BTCPayServer.Abstractions.Extensions
 @model UpdateCoinSwitchSettingsViewModel
 @{
     Layout = "../Shared/_NavLayout.cshtml";

--- a/BTCPayServer/Views/EthereumLikeStore/GetStoreEthereumLikePaymentMethod.cshtml
+++ b/BTCPayServer/Views/EthereumLikeStore/GetStoreEthereumLikePaymentMethod.cshtml
@@ -1,4 +1,5 @@
 @using BTCPayServer.Views.Stores
+@using BTCPayServer.Abstractions.Extensions
 @model BTCPayServer.Services.Altcoins.Ethereum.UI.EditEthereumPaymentMethodViewModel
 
 @{

--- a/BTCPayServer/Views/EthereumLikeStore/GetStoreEthereumLikePaymentMethods.cshtml
+++ b/BTCPayServer/Views/EthereumLikeStore/GetStoreEthereumLikePaymentMethods.cshtml
@@ -1,5 +1,6 @@
 
 @using BTCPayServer.Views.Stores
+@using BTCPayServer.Abstractions.Extensions
 @model BTCPayServer.Services.Altcoins.Ethereum.UI.ViewEthereumStoreOptionsViewModel
 @inject SignInManager<ApplicationUser> SignInManager;
 @inject BTCPayNetworkProvider BTCPayNetworkProvider;

--- a/BTCPayServer/Views/Fido2/_ViewImports.cshtml
+++ b/BTCPayServer/Views/Fido2/_ViewImports.cshtml
@@ -1,1 +1,2 @@
-﻿@using BTCPayServer.Views.Manage
+﻿@using BTCPayServer.Abstractions.Extensions
+@using BTCPayServer.Views.Manage

--- a/BTCPayServer/Views/Invoice/_ViewImports.cshtml
+++ b/BTCPayServer/Views/Invoice/_ViewImports.cshtml
@@ -1,2 +1,3 @@
-﻿@using BTCPayServer.Services.Invoices
+﻿@using BTCPayServer.Abstractions.Extensions
+@using BTCPayServer.Services.Invoices
 @using BTCPayServer.Views.Invoice

--- a/BTCPayServer/Views/Invoice/_ViewStart.cshtml
+++ b/BTCPayServer/Views/Invoice/_ViewStart.cshtml
@@ -1,3 +1,4 @@
+@using BTCPayServer.Abstractions.Extensions
 @using BTCPayServer.Views
 @using BTCPayServer.Views.Invoice
 @{

--- a/BTCPayServer/Views/Manage/_ViewImports.cshtml
+++ b/BTCPayServer/Views/Manage/_ViewImports.cshtml
@@ -1,1 +1,2 @@
-﻿@using BTCPayServer.Views.Manage
+﻿@using BTCPayServer.Abstractions.Extensions
+@using BTCPayServer.Views.Manage

--- a/BTCPayServer/Views/Manage/_ViewStart.cshtml
+++ b/BTCPayServer/Views/Manage/_ViewStart.cshtml
@@ -1,4 +1,5 @@
-﻿@using BTCPayServer.Views
+﻿@using BTCPayServer.Abstractions.Extensions
+@using BTCPayServer.Views
 @using BTCPayServer.Views.Manage
 @{
     Layout = "../Shared/_NavLayout.cshtml";

--- a/BTCPayServer/Views/MoneroLikeStore/GetStoreMoneroLikePaymentMethod.cshtml
+++ b/BTCPayServer/Views/MoneroLikeStore/GetStoreMoneroLikePaymentMethod.cshtml
@@ -1,5 +1,5 @@
-@using BTCPayServer.Controllers
 @using BTCPayServer.Views.Stores
+@using BTCPayServer.Abstractions.Extensions
 @model BTCPayServer.Services.Altcoins.Monero.UI.MoneroLikeStoreController.MoneroLikePaymentMethodViewModel
 
 @{

--- a/BTCPayServer/Views/MoneroLikeStore/GetStoreMoneroLikePaymentMethods.cshtml
+++ b/BTCPayServer/Views/MoneroLikeStore/GetStoreMoneroLikePaymentMethods.cshtml
@@ -1,4 +1,5 @@
 @using BTCPayServer.Views.Stores
+@using BTCPayServer.Abstractions.Extensions
 @model BTCPayServer.Services.Altcoins.Monero.UI.MoneroLikeStoreController.MoneroLikePaymentMethodListViewModel
 
 @{

--- a/BTCPayServer/Views/Notifications/_ViewImports.cshtml
+++ b/BTCPayServer/Views/Notifications/_ViewImports.cshtml
@@ -1,1 +1,1 @@
-﻿
+﻿@using BTCPayServer.Abstractions.Extensions

--- a/BTCPayServer/Views/Notifications/_ViewStart.cshtml
+++ b/BTCPayServer/Views/Notifications/_ViewStart.cshtml
@@ -1,4 +1,5 @@
-﻿@using BTCPayServer.Views
+﻿@using BTCPayServer.Abstractions.Extensions
+@using BTCPayServer.Views
 @using BTCPayServer.Views.Notifications
 
 @{

--- a/BTCPayServer/Views/PaymentRequest/_ViewImports.cshtml
+++ b/BTCPayServer/Views/PaymentRequest/_ViewImports.cshtml
@@ -1,1 +1,2 @@
-﻿@using BTCPayServer.Views.PaymentRequest
+﻿@using BTCPayServer.Abstractions.Extensions
+@using BTCPayServer.Views.PaymentRequest

--- a/BTCPayServer/Views/PaymentRequest/_ViewStart.cshtml
+++ b/BTCPayServer/Views/PaymentRequest/_ViewStart.cshtml
@@ -1,3 +1,4 @@
+@using BTCPayServer.Abstractions.Extensions
 @using BTCPayServer.Views
 @using BTCPayServer.Views.PaymentRequest
 @{

--- a/BTCPayServer/Views/Server/_ViewImports.cshtml
+++ b/BTCPayServer/Views/Server/_ViewImports.cshtml
@@ -1,2 +1,3 @@
-﻿@using BTCPayServer.Views.Server
+﻿@using BTCPayServer.Abstractions.Extensions
+@using BTCPayServer.Views.Server
 @using BTCPayServer.Models.ServerViewModels

--- a/BTCPayServer/Views/Server/_ViewStart.cshtml
+++ b/BTCPayServer/Views/Server/_ViewStart.cshtml
@@ -1,4 +1,5 @@
-﻿@using BTCPayServer.Views
+﻿@using BTCPayServer.Abstractions.Extensions
+@using BTCPayServer.Views
 @using BTCPayServer.Views.Server
 @{
     Layout = "../Shared/_NavLayout.cshtml";

--- a/BTCPayServer/Views/Shared/Ethereum/UpdateChainConfig.cshtml
+++ b/BTCPayServer/Views/Shared/Ethereum/UpdateChainConfig.cshtml
@@ -1,6 +1,6 @@
-@using BTCPayServer.Services.Altcoins.Ethereum.UI
 @using BTCPayServer.Views.Server
 @using System.Net.Http
+@using BTCPayServer.Abstractions.Extensions
 @model BTCPayServer.Services.Altcoins.Ethereum.Configuration.EthereumLikeConfiguration
 @inject BTCPayNetworkProvider BTCPayNetworkProvider;
 @inject IHttpClientFactory HttpClientFactory;

--- a/BTCPayServer/Views/Shared/_Layout.cshtml
+++ b/BTCPayServer/Views/Shared/_Layout.cshtml
@@ -6,6 +6,7 @@
 @using BTCPayServer.Views.PaymentRequest
 @using BTCPayServer.Views.Wallets
 @using BTCPayServer.Abstractions.Contracts
+@using BTCPayServer.Abstractions.Extensions
 @inject SignInManager<ApplicationUser> SignInManager
 @inject UserManager<ApplicationUser> UserManager
 @inject RoleManager<IdentityRole> RoleManager

--- a/BTCPayServer/Views/Shopify/EditShopifyIntegration.cshtml
+++ b/BTCPayServer/Views/Shopify/EditShopifyIntegration.cshtml
@@ -1,12 +1,11 @@
 @using BTCPayServer.Views.Stores
+@using BTCPayServer.Abstractions.Extensions
 @model BTCPayServer.Plugins.Shopify.Models.ShopifySettings
 @{
-    
     Layout = "../Shared/_NavLayout.cshtml";
     
     ViewData["NavPartialName"] = "../Stores/_Nav";
     ViewData.SetActivePageAndTitle(StoreNavPages.Integrations, "Integrations");
-    
     
     var shopifyCredsSet = Model?.IntegratedAt.HasValue is true;
     var shopifyUrl = Model?.ShopifyUrl;

--- a/BTCPayServer/Views/Stores/_ViewImports.cshtml
+++ b/BTCPayServer/Views/Stores/_ViewImports.cshtml
@@ -1,2 +1,3 @@
-﻿@using BTCPayServer.Views.Stores
+﻿@using BTCPayServer.Abstractions.Extensions
+@using BTCPayServer.Views.Stores
 @using BTCPayServer.Models.StoreViewModels

--- a/BTCPayServer/Views/Stores/_ViewStart.cshtml
+++ b/BTCPayServer/Views/Stores/_ViewStart.cshtml
@@ -1,4 +1,5 @@
-﻿@using BTCPayServer.Views
+﻿@using BTCPayServer.Abstractions.Extensions
+@using BTCPayServer.Views
 @using BTCPayServer.Views.Stores
 
 @{

--- a/BTCPayServer/Views/UserStores/_ViewImports.cshtml
+++ b/BTCPayServer/Views/UserStores/_ViewImports.cshtml
@@ -1,2 +1,3 @@
-﻿@using BTCPayServer.Views.Stores
+﻿@using BTCPayServer.Abstractions.Extensions
+@using BTCPayServer.Views.Stores
 @using BTCPayServer.Models.StoreViewModels

--- a/BTCPayServer/Views/UserStores/_ViewStart.cshtml
+++ b/BTCPayServer/Views/UserStores/_ViewStart.cshtml
@@ -1,3 +1,4 @@
+@using BTCPayServer.Abstractions.Extensions
 @using BTCPayServer.Views
 @using BTCPayServer.Views.Stores
 

--- a/BTCPayServer/Views/Wallets/_ViewImports.cshtml
+++ b/BTCPayServer/Views/Wallets/_ViewImports.cshtml
@@ -1,3 +1,4 @@
-﻿@using BTCPayServer.Views.Wallets
+﻿@using BTCPayServer.Abstractions.Extensions
+@using BTCPayServer.Views.Wallets
 @using BTCPayServer.Models.WalletViewModels
 @addTagHelper *, BundlerMinifier.TagHelpers

--- a/BTCPayServer/Views/Wallets/_ViewStart.cshtml
+++ b/BTCPayServer/Views/Wallets/_ViewStart.cshtml
@@ -1,4 +1,5 @@
-﻿@using BTCPayServer.Views
+﻿@using BTCPayServer.Abstractions.Extensions
+@using BTCPayServer.Views
 @using BTCPayServer.Views.Wallets
 @{
     ViewBag.CategoryTitle = "Wallets";


### PR DESCRIPTION
Moves the `ViewsRazor` extension into Abstractions, so that it can be used by plugins.

Separated out of #2701, prerequisite for the LNbank plugin integration.