### PR TITLE
Properly clip taxIncluded and invoice's amount

### DIFF
--- a/BTCPayServer/Controllers/InvoiceController.cs
+++ b/BTCPayServer/Controllers/InvoiceController.cs
@@ -112,24 +112,14 @@ namespace BTCPayServer.Controllers
             FillBuyerInfo(invoice, entity);
 
             var taxIncluded = invoice.TaxIncluded.HasValue ? invoice.TaxIncluded.Value : 0m;
+            var price = invoice.Price;
 
-            var currencyInfo = _CurrencyNameTable.GetNumberFormatInfo(invoice.Currency, false);
-            if (currencyInfo != null)
-            {
-                int divisibility = currencyInfo.CurrencyDecimalDigits;
-                invoice.Price = invoice.Price.RoundToSignificant(ref divisibility);
-                divisibility = currencyInfo.CurrencyDecimalDigits;
-                invoice.TaxIncluded = taxIncluded.RoundToSignificant(ref divisibility);
-            }
-            invoice.Price = Math.Max(0.0m, invoice.Price);
-            invoice.TaxIncluded = Math.Max(0.0m, taxIncluded);
-            invoice.TaxIncluded = Math.Min(taxIncluded, invoice.Price);
             entity.Metadata.ItemCode = invoice.ItemCode;
             entity.Metadata.ItemDesc = invoice.ItemDesc;
             entity.Metadata.Physical = invoice.Physical;
             entity.Metadata.TaxIncluded = invoice.TaxIncluded;
             entity.Currency = invoice.Currency;
-            entity.Price = invoice.Price;
+            entity.Price = price;
 
             entity.RedirectURLTemplate = invoice.RedirectURL ?? store.StoreWebsite;
             entity.RedirectAutomatically =
@@ -194,6 +184,23 @@ namespace BTCPayServer.Controllers
         {
             InvoiceLogs logs = new InvoiceLogs();
             logs.Write("Creation of invoice starting", InvoiceEventData.EventSeverity.Info);
+
+            entity.Price = Math.Max(0.0m, entity.Price);
+            var currencyInfo = _CurrencyNameTable.GetNumberFormatInfo(entity.Currency, false);
+            if (currencyInfo != null)
+            {
+                entity.Price = entity.Price.RoundToSignificant(currencyInfo.CurrencyDecimalDigits);
+            }
+            if (entity.Metadata.TaxIncluded is decimal taxIncluded)
+            {
+                if (currencyInfo != null)
+                {
+                    taxIncluded = taxIncluded.RoundToSignificant(currencyInfo.CurrencyDecimalDigits);
+                }
+                taxIncluded = Math.Max(0.0m, taxIncluded);
+                taxIncluded = Math.Min(taxIncluded, entity.Price);
+                entity.Metadata.TaxIncluded = taxIncluded;
+            }
 
             var getAppsTaggingStore = _InvoiceRepository.GetAppsTaggingStore(store.Id);
             var storeBlob = store.GetStoreBlob();


### PR DESCRIPTION
Fix a bug where invoice's amount and taxIncluded may not be properly rounded to the right decimal.
This was previously only enforced for the bitpay API.

It was previously implemented in https://github.com/btcpayserver/btcpayserver/pull/2669