### PR TITLE
Fix missing master fingerprint/account key path on wallet import

### DIFF
--- a/BTCPayServer.Tests/SeleniumTests.cs
+++ b/BTCPayServer.Tests/SeleniumTests.cs
@@ -831,6 +831,11 @@ namespace BTCPayServer.Tests
                 s.Driver.FindElement(By.LinkText("Manage")).Click();
 
                 s.ClickOnAllSideMenus();
+                
+                // Make sure wallet info is correct
+                s.Driver.FindElement(By.Id("WalletSettings")).Click();
+                Assert.Contains(mnemonic.DeriveExtKey().GetPublicKey().GetHDFingerPrint().ToString(), s.Driver.FindElement(By.Id("AccountKeys_0__MasterFingerprint")).GetAttribute("value"));
+                Assert.Contains("m/84'/1'/0'", s.Driver.FindElement(By.Id("AccountKeys_0__AccountKeyPath")).GetAttribute("value"));
 
                 // Make sure we can rescan, because we are admin!
                 s.Driver.FindElement(By.Id("WalletRescan")).Click();
@@ -905,6 +910,23 @@ namespace BTCPayServer.Tests
                 Assert.Empty(s.Driver.FindElements(By.Id("confirm")));
                 s.Driver.FindElement(By.Id("proceed")).Click();
                 Assert.Equal(walletUrl, s.Driver.Url);
+            }
+        }
+
+        [Fact(Timeout = TestTimeout)]
+        public async Task CanImportWallet()
+        {
+            using (var s = SeleniumTester.Create())
+            {
+                await s.StartAsync();
+                s.RegisterNewUser(true);
+                var (_, storeId) = s.CreateNewStore();
+                var mnemonic = s.GenerateWallet("BTC", "click chunk owner kingdom faint steak safe evidence bicycle repeat bulb wheel");
+                
+                // Make sure wallet info is correct
+                s.GoToWallet(new WalletId(storeId, "BTC"), WalletsNavPages.Settings);
+                Assert.Contains(mnemonic.DeriveExtKey().GetPublicKey().GetHDFingerPrint().ToString(), s.Driver.FindElement(By.Id("AccountKeys_0__MasterFingerprint")).GetAttribute("value"));
+                Assert.Contains( "m/84'/1'/0'", s.Driver.FindElement(By.Id("AccountKeys_0__AccountKeyPath")).GetAttribute("value"));
             }
         }
 

--- a/BTCPayServer/Controllers/StoresController.Onchain.cs
+++ b/BTCPayServer/Controllers/StoresController.Onchain.cs
@@ -305,8 +305,10 @@ namespace BTCPayServer.Controllers
             derivationSchemeSettings.AccountOriginal = response.DerivationScheme.ToString();
 
             // Set wallet properties from generate response
+            vm.RootFingerprint = response.AccountKeyPath.MasterFingerprint.ToString();
+            vm.AccountKey = response.AccountHDKey.Neuter().ToWif();
+            vm.KeyPath = response.AccountKeyPath.KeyPath.ToString();
             vm.Config = ProtectString(derivationSchemeSettings.ToJson());
-
 
             var result = await UpdateWallet(vm);
 

--- a/BTCPayServer/Views/Stores/ImportWallet/ConfirmAddresses.cshtml
+++ b/BTCPayServer/Views/Stores/ImportWallet/ConfirmAddresses.cshtml
@@ -50,6 +50,9 @@
     <input asp-for="Config" type="hidden"/>
     <input asp-for="Confirmation" type="hidden"/>
     <input asp-for="DerivationScheme" type="hidden"/>
+    <input asp-for="AccountKey" type="hidden" />
+    <input asp-for="RootFingerprint" type="hidden" />
+    <input asp-for="KeyPath" type="hidden" />
 
     <div class="form-group">
         <table class="table table-sm table-responsive-md">


### PR DESCRIPTION
Re-adds the view model properties that got removed in 8a1d5bbc57176377a3e76fe3f55f6942bc3fe457 and passes them through the confirm addresses form.

I noticed that the master fingerprint and account key path were missing for watch-only wallets that were imported using a seed.
The accountSettings are correct were left on the `Config`property on the `vm`, but the following `UpdateWallet(vm)` method assumes that the `RootFingerprint`, `AccountKey`  and `KeyPath` properties are set directly on the `vm`. That's why they also have to be passed through the confirm addresses form.

