### PR TITLE
Add white background to Baillie Gifford logo

### DIFF
--- a/BTCPayServer/wwwroot/img/bailliegifford.svg
+++ b/BTCPayServer/wwwroot/img/bailliegifford.svg
@@ -2,7 +2,7 @@
 <!-- Generator: Adobe Illustrator 25.3.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
 <svg version="1.1" id="bdbb9e96-7dd2-4000-9304-0bf8a661aad9"
 	 xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 0 121.9 121.9"
-	 style="enable-background:new 0 0 121.9 121.9;" xml:space="preserve">
+	 style="enable-background:new 0 0 121.9 121.9;background:#FFF" xml:space="preserve">
 <style type="text/css">
 	.st0{fill:#222221;}
 	.st1{fill:#272425;}


### PR DESCRIPTION
Makes it work in dark mode, addresses btcpayserver/foundation.btcpayserver.org#19. This SVG is also used in the docs.

![supporters](https://user-images.githubusercontent.com/886/127691782-245fd023-8ee0-4a19-8bcd-de23044c15de.png)
