### PR TITLE
Bumping LND to 0.13.1-beta

### DIFF
--- a/BTCPayServer.Tests/docker-compose.altcoins.yml
+++ b/BTCPayServer.Tests/docker-compose.altcoins.yml
@@ -227,7 +227,7 @@ services:
       - "5432"
 
   merchant_lnd:
-    image: btcpayserver/lnd:v0.12.1-beta
+    image: btcpayserver/lnd:v0.13.1-beta-withloop
     restart: unless-stopped
     environment:
       LND_CHAIN: "btc"
@@ -261,7 +261,7 @@ services:
       - bitcoind
 
   customer_lnd:
-    image: btcpayserver/lnd:v0.12.1-beta
+    image: btcpayserver/lnd:v0.13.1-beta-withloop
     restart: unless-stopped
     environment:
       LND_CHAIN: "btc"

--- a/BTCPayServer.Tests/docker-compose.yml
+++ b/BTCPayServer.Tests/docker-compose.yml
@@ -215,7 +215,7 @@ services:
       - "5432"
 
   merchant_lnd:
-    image: btcpayserver/lnd:v0.12.1-beta
+    image: btcpayserver/lnd:v0.13.1-beta-withloop
     restart: unless-stopped
     environment:
       LND_CHAIN: "btc"
@@ -249,7 +249,7 @@ services:
       - bitcoind
 
   customer_lnd:
-    image: btcpayserver/lnd:v0.12.1-beta
+    image: btcpayserver/lnd:v0.13.1-beta-withloop
     restart: unless-stopped
     environment:
       LND_CHAIN: "btc"


### PR DESCRIPTION
There is PR in BTCPayServer.Lightning as well: https://github.com/btcpayserver/BTCPayServer.Lightning/pull/48

Check if it works locally for you and if it does, we start testing with local IDEs before I open PR in `btcpayserver-docker` repository.