### PR TITLE
Show Immature Balance in walletsend page

### DIFF
--- a/BTCPayServer.Common/BTCPayServer.Common.csproj
+++ b/BTCPayServer.Common/BTCPayServer.Common.csproj
@@ -4,7 +4,7 @@
 
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="NBXplorer.Client" Version="4.0.0" />
+    <PackageReference Include="NBXplorer.Client" Version="4.0.1" />
   </ItemGroup>
   <ItemGroup Condition="'$(Altcoins)' != 'true'">
     <Compile Remove="Altcoins\**\*.cs"></Compile>

--- a/BTCPayServer/Controllers/WalletsController.cs
+++ b/BTCPayServer/Controllers/WalletsController.cs
@@ -489,8 +489,13 @@ namespace BTCPayServer.Controllers
                     .ToArray();
             var balance = _walletProvider.GetWallet(network).GetBalance(paymentMethod.AccountDerivation);
             model.NBXSeedAvailable = await GetSeed(walletId, network) != null;
-            model.CurrentBalance = (await balance).Total.GetValue(network);
-
+            var Balance= await balance;
+            model.CurrentBalance = (Balance.Available ?? Balance.Total).GetValue(network);
+            if (Balance.Immature is null)
+                model.ImmatureBalance = 0;
+            else
+                model.ImmatureBalance = Balance.Immature.GetValue(network);
+                
             await Task.WhenAll(recommendedFees);
             model.RecommendedSatoshiPerByte =
                 recommendedFees.Select(tuple => tuple.Result).Where(option => option != null).ToList();

--- a/BTCPayServer/Models/WalletViewModels/WalletSendModel.cs
+++ b/BTCPayServer/Models/WalletViewModels/WalletSendModel.cs
@@ -35,6 +35,7 @@ namespace BTCPayServer.Models.WalletViewModels
             public bool SubtractFeesFromOutput { get; set; }
         }
         public decimal CurrentBalance { get; set; }
+        public decimal ImmatureBalance { get; set; }
 
         public string CryptoCode { get; set; }
 

--- a/BTCPayServer/Views/Wallets/WalletSend.cshtml
+++ b/BTCPayServer/Views/Wallets/WalletSend.cshtml
@@ -84,7 +84,7 @@
                         <button type="button" class="crypto-balance-link btn btn-link p-0 align-baseline">@Model.CurrentBalance</button> <span>@Model.CryptoCode</span>.
                         @if (Model.ImmatureBalance>0)
                         {
-                            <span>@Model.ImmatureBalance @Model.CryptoCode are still immature and require additional confirmations.</span>
+                            <span><br>Note: @Model.ImmatureBalance @Model.CryptoCode are still immature and require additional confirmations.</span>
                         }
                     </p>
                 </div>
@@ -116,7 +116,7 @@
                                             <button type="button" class="crypto-balance-link btn btn-link p-0 align-baseline">@Model.CurrentBalance</button> <span>@Model.CryptoCode</span>.
                                             @if (Model.ImmatureBalance > 0)
                                             {
-                                                <span>@Model.ImmatureBalance @Model.CryptoCode are still immature and require additional confirmations.</span>
+                                                <span><br>Note: @Model.ImmatureBalance @Model.CryptoCode are still immature and require additional confirmations.</span>
                                             }
                                         </p>
                                         <span asp-validation-for="Outputs[index].Amount" class="text-danger"></span>

--- a/BTCPayServer/Views/Wallets/WalletSend.cshtml
+++ b/BTCPayServer/Views/Wallets/WalletSend.cshtml
@@ -84,7 +84,7 @@
                         <button type="button" class="crypto-balance-link btn btn-link p-0 align-baseline">@Model.CurrentBalance</button> <span>@Model.CryptoCode</span>.
                         @if (Model.ImmatureBalance>0)
                         {
-                            <span title="@Model.ImmatureBalance @Model.CryptoCode are still immature and require additional confirmations." class="fa fa-exclamation-circle text-secondary"></span>
+                            <span>@Model.ImmatureBalance @Model.CryptoCode are still immature and require additional confirmations.</span>
                         }
                     </p>
                 </div>
@@ -116,7 +116,7 @@
                                             <button type="button" class="crypto-balance-link btn btn-link p-0 align-baseline">@Model.CurrentBalance</button> <span>@Model.CryptoCode</span>.
                                             @if (Model.ImmatureBalance > 0)
                                             {
-                                                <span title="@Model.ImmatureBalance @Model.CryptoCode are still immature and require additional confirmations." class="fa fa-exclamation-circle text-secondary"></span>
+                                                <span>@Model.ImmatureBalance @Model.CryptoCode are still immature and require additional confirmations.</span>
                                             }
                                         </p>
                                         <span asp-validation-for="Outputs[index].Amount" class="text-danger"></span>

--- a/BTCPayServer/Views/Wallets/WalletSend.cshtml
+++ b/BTCPayServer/Views/Wallets/WalletSend.cshtml
@@ -84,7 +84,7 @@
                         <button type="button" class="crypto-balance-link btn btn-link p-0 align-baseline">@Model.CurrentBalance</button> <span>@Model.CryptoCode</span>.
                         @if (Model.ImmatureBalance>0)
                         {
-                            <span title="@Model.ImmatureBalance @Model.CryptoCode are still immature ans require additional confirmations." class="fa fa-exclamation-circle text-secondary"></span>
+                            <span title="@Model.ImmatureBalance @Model.CryptoCode are still immature and require additional confirmations." class="fa fa-exclamation-circle text-secondary"></span>
                         }
                     </p>
                 </div>
@@ -116,7 +116,7 @@
                                             <button type="button" class="crypto-balance-link btn btn-link p-0 align-baseline">@Model.CurrentBalance</button> <span>@Model.CryptoCode</span>.
                                             @if (Model.ImmatureBalance > 0)
                                             {
-                                                <span title="@Model.ImmatureBalance @Model.CryptoCode are still immature ans require additional confirmations." class="fa fa-exclamation-circle text-secondary"></span>
+                                                <span title="@Model.ImmatureBalance @Model.CryptoCode are still immature and require additional confirmations." class="fa fa-exclamation-circle text-secondary"></span>
                                             }
                                         </p>
                                         <span asp-validation-for="Outputs[index].Amount" class="text-danger"></span>

--- a/BTCPayServer/Views/Wallets/WalletSend.cshtml
+++ b/BTCPayServer/Views/Wallets/WalletSend.cshtml
@@ -33,6 +33,7 @@
             <input type="hidden" asp-for="Fiat" />
             <input type="hidden" asp-for="Rate" />
             <input type="hidden" asp-for="CurrentBalance" />
+            <input type="hidden" asp-for="ImmatureBalance" />
             <input type="hidden" asp-for="CryptoCode" />
             <input type="hidden" name="BIP21" id="BIP21" />
         
@@ -79,8 +80,12 @@
                     </div>
                     <span asp-validation-for="Outputs[0].Amount" class="text-danger"></span>
                     <p class="form-text text-secondary crypto-info">
-                        Your current balance is
+                        Your available balance is
                         <button type="button" class="crypto-balance-link btn btn-link p-0 align-baseline">@Model.CurrentBalance</button> <span>@Model.CryptoCode</span>.
+                        @if (Model.ImmatureBalance>0)
+                        {
+                            <span title="@Model.ImmatureBalance @Model.CryptoCode are still immature ans require additional confirmations." class="fa fa-exclamation-circle text-secondary"></span>
+                        }
                     </p>
                 </div>
             }
@@ -109,6 +114,10 @@
                                         <p class="form-text text-secondary crypto-info mb-2">
                                             Your current balance is
                                             <button type="button" class="crypto-balance-link btn btn-link p-0 align-baseline">@Model.CurrentBalance</button> <span>@Model.CryptoCode</span>.
+                                            @if (Model.ImmatureBalance > 0)
+                                            {
+                                                <span title="@Model.ImmatureBalance @Model.CryptoCode are still immature ans require additional confirmations." class="fa fa-exclamation-circle text-secondary"></span>
+                                            }
                                         </p>
                                         <span asp-validation-for="Outputs[index].Amount" class="text-danger"></span>
                                     </div>


### PR DESCRIPTION
**A wallet with Immature txn shows as**
![20210801_15h54m16s_grim](https://user-images.githubusercontent.com/16453468/127767575-1aaf1d2c-9023-4737-9fcd-f45dcd48dd2a.png)

**A wallet without any immature txn shows as**
![20210801_15h54m35s_grim](https://user-images.githubusercontent.com/16453468/127767586-7b1aeaf5-7395-428c-ac61-dced765336d5.png)

I also thought of putting the msg into the tooltip, but decided against that.

Closes: #2656 
