### PR TITLE
Enhance files actions to accept arrays of fileids

### DIFF
--- a/BTCPayServer.Tests/StorageTests.cs
+++ b/BTCPayServer.Tests/StorageTests.cs
@@ -196,7 +196,7 @@ namespace BTCPayServer.Tests
                 Assert.IsType<ViewFilesViewModel>(Assert.IsType<ViewResult>(await controller.Files(new string[] { fileId })).Model);
 
             Assert.NotEmpty(viewFilesViewModel.Files);
-            Assert.Equal(fileId, viewFilesViewModel.SelectedFileIds[0]);
+            Assert.True(viewFilesViewModel.DirectUrlByFiles.ContainsKey(fileId));
             Assert.NotEmpty(viewFilesViewModel.DirectUrlByFiles[fileId]);
 
 
@@ -236,7 +236,6 @@ namespace BTCPayServer.Tests
             viewFilesViewModel =
                 Assert.IsType<ViewFilesViewModel>(Assert.IsType<ViewResult>(await controller.Files(new string[] { fileId })).Model);
             Assert.Null(viewFilesViewModel.DirectUrlByFiles);
-            Assert.Null(viewFilesViewModel.SelectedFileIds);
         }
 
 

--- a/BTCPayServer.Tests/StorageTests.cs
+++ b/BTCPayServer.Tests/StorageTests.cs
@@ -13,6 +13,7 @@ using BTCPayServer.Tests.Logging;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Configuration;
+using Newtonsoft.Json;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -182,11 +183,12 @@ namespace BTCPayServer.Tests
         {
             var fileContent = "content";
             List<IFormFile> fileList = new List<IFormFile>();
-            fileList.Add(TestUtils.GetFormFile("uploadtestfile1.txt", fileContent));
+            fileList.Add(TestUtils.GetFormFile("uploadtestfile2.txt", fileContent));
 
             var uploadFormFileResult = Assert.IsType<RedirectToActionResult>(await controller.CreateFiles(fileList));
             Assert.True(uploadFormFileResult.RouteValues.ContainsKey("fileId"));
-            var fileId = uploadFormFileResult.RouteValues["fileId"].ToString();
+            var uploadFileList = JsonConvert.DeserializeObject<List<string>>(uploadFormFileResult.RouteValues["fileId"].ToString());
+            var fileId = uploadFileList[0];
             Assert.Equal("Files", uploadFormFileResult.ActionName);
 
             //check if file was uploaded and saved in db
@@ -194,13 +196,13 @@ namespace BTCPayServer.Tests
                 Assert.IsType<ViewFilesViewModel>(Assert.IsType<ViewResult>(await controller.Files(fileId)).Model);
 
             Assert.NotEmpty(viewFilesViewModel.Files);
-            Assert.Equal(fileId, viewFilesViewModel.SelectedFileId);
-            Assert.NotEmpty(viewFilesViewModel.DirectFileUrl);
+            Assert.Equal(fileId, viewFilesViewModel.SelectedFileIds[0]);
+            Assert.NotEmpty(viewFilesViewModel.DirectFileUrls[0]);
 
 
             //verify file is available and the same
             var net = new System.Net.WebClient();
-            var data = await net.DownloadStringTaskAsync(new Uri(viewFilesViewModel.DirectFileUrl));
+            var data = await net.DownloadStringTaskAsync(new Uri(viewFilesViewModel.DirectFileUrls[0]));
             Assert.Equal(fileContent, data);
 
             //create a temporary link to file
@@ -233,9 +235,8 @@ namespace BTCPayServer.Tests
             //attempt to fetch deleted file
             viewFilesViewModel =
                 Assert.IsType<ViewFilesViewModel>(Assert.IsType<ViewResult>(await controller.Files(fileId)).Model);
-
-            Assert.Null(viewFilesViewModel.DirectFileUrl);
-            Assert.Null(viewFilesViewModel.SelectedFileId);
+            Assert.Null(viewFilesViewModel.DirectFileUrls);
+            Assert.Null(viewFilesViewModel.SelectedFileIds);
         }
 
 

--- a/BTCPayServer.Tests/StorageTests.cs
+++ b/BTCPayServer.Tests/StorageTests.cs
@@ -183,26 +183,26 @@ namespace BTCPayServer.Tests
         {
             var fileContent = "content";
             List<IFormFile> fileList = new List<IFormFile>();
-            fileList.Add(TestUtils.GetFormFile("uploadtestfile2.txt", fileContent));
+            fileList.Add(TestUtils.GetFormFile("uploadtestfile1.txt", fileContent));
 
             var uploadFormFileResult = Assert.IsType<RedirectToActionResult>(await controller.CreateFiles(fileList));
-            Assert.True(uploadFormFileResult.RouteValues.ContainsKey("fileId"));
-            var uploadFileList = JsonConvert.DeserializeObject<List<string>>(uploadFormFileResult.RouteValues["fileId"].ToString());
+            Assert.True(uploadFormFileResult.RouteValues.ContainsKey("fileIds"));
+            string[] uploadFileList = (string[])uploadFormFileResult.RouteValues["fileIds"];
             var fileId = uploadFileList[0];
             Assert.Equal("Files", uploadFormFileResult.ActionName);
 
             //check if file was uploaded and saved in db
             var viewFilesViewModel =
-                Assert.IsType<ViewFilesViewModel>(Assert.IsType<ViewResult>(await controller.Files(fileId)).Model);
+                Assert.IsType<ViewFilesViewModel>(Assert.IsType<ViewResult>(await controller.Files(new string[] { fileId })).Model);
 
             Assert.NotEmpty(viewFilesViewModel.Files);
             Assert.Equal(fileId, viewFilesViewModel.SelectedFileIds[0]);
-            Assert.NotEmpty(viewFilesViewModel.DirectFileUrls[0]);
+            Assert.NotEmpty(viewFilesViewModel.DirectUrlByFiles[fileId]);
 
 
             //verify file is available and the same
             var net = new System.Net.WebClient();
-            var data = await net.DownloadStringTaskAsync(new Uri(viewFilesViewModel.DirectFileUrls[0]));
+            var data = await net.DownloadStringTaskAsync(new Uri(viewFilesViewModel.DirectUrlByFiles[fileId]));
             Assert.Equal(fileContent, data);
 
             //create a temporary link to file
@@ -234,8 +234,8 @@ namespace BTCPayServer.Tests
 
             //attempt to fetch deleted file
             viewFilesViewModel =
-                Assert.IsType<ViewFilesViewModel>(Assert.IsType<ViewResult>(await controller.Files(fileId)).Model);
-            Assert.Null(viewFilesViewModel.DirectFileUrls);
+                Assert.IsType<ViewFilesViewModel>(Assert.IsType<ViewResult>(await controller.Files(new string[] { fileId })).Model);
+            Assert.Null(viewFilesViewModel.DirectUrlByFiles);
             Assert.Null(viewFilesViewModel.SelectedFileIds);
         }
 

--- a/BTCPayServer/Controllers/ServerController.Storage.cs
+++ b/BTCPayServer/Controllers/ServerController.Storage.cs
@@ -57,10 +57,29 @@ namespace BTCPayServer.Controllers
                 }
 
                 List<string> fileUrlList = (fileIds == null || fileIds.Count == 0) ? null : new List<string>();
+                bool allFilesExist = true;
                 foreach (string filename in fileIds)
                 {
                     string fileUrl = await _FileService.GetFileUrl(Request.GetAbsoluteRootUri(), filename);
+                    if (fileUrl == null)
+                    {
+                        allFilesExist = false;
+                        break;
+                    }
                     fileUrlList.Add(fileUrl);
+                }
+
+                if (!allFilesExist)
+                {
+                    return View(
+                        new ViewFilesViewModel()
+                        {
+                            Files = await _StoredFileRepository.GetFiles(),
+                            SelectedFileIds = null,
+                            DirectFileUrls = null,
+                            StorageConfigured = (await _SettingsRepository.GetSettingAsync<StorageSettings>()) != null
+                        }
+                    );
                 }
 
                 var model = new ViewFilesViewModel()

--- a/BTCPayServer/Controllers/ServerController.Storage.cs
+++ b/BTCPayServer/Controllers/ServerController.Storage.cs
@@ -34,8 +34,7 @@ namespace BTCPayServer.Controllers
         {
             var model = new ViewFilesViewModel()
             {
-                Files = await _StoredFileRepository.GetFiles(),
-                SelectedFileIds = null,
+                Files = await _StoredFileRepository.GetFiles(),          
                 DirectUrlByFiles = null,
                 StorageConfigured = (await _SettingsRepository.GetSettingAsync<StorageSettings>()) != null
             };
@@ -64,8 +63,7 @@ namespace BTCPayServer.Controllers
                     });
                 }
                 else
-                {
-                    model.SelectedFileIds = fileIds;
+                {                
                     model.DirectUrlByFiles = directUrlByFiles;
                 }
             }

--- a/BTCPayServer/Models/ServerViewModels/ViewFilesViewModel.cs
+++ b/BTCPayServer/Models/ServerViewModels/ViewFilesViewModel.cs
@@ -6,8 +6,8 @@ namespace BTCPayServer.Models.ServerViewModels
     public class ViewFilesViewModel
     {
         public List<StoredFile> Files { get; set; }
-        public string DirectFileUrl { get; set; }
-        public string SelectedFileId { get; set; }
+        public List<string> DirectFileUrls { get; set; }
+        public List<string> SelectedFileIds { get; set; }
         public bool StorageConfigured { get; set; }
     }
 }

--- a/BTCPayServer/Models/ServerViewModels/ViewFilesViewModel.cs
+++ b/BTCPayServer/Models/ServerViewModels/ViewFilesViewModel.cs
@@ -6,8 +6,8 @@ namespace BTCPayServer.Models.ServerViewModels
     public class ViewFilesViewModel
     {
         public List<StoredFile> Files { get; set; }
-        public List<string> DirectFileUrls { get; set; }
-        public List<string> SelectedFileIds { get; set; }
+        public Dictionary<string, string> DirectUrlByFiles { get; set; }
+        public string[] SelectedFileIds { get; set; }
         public bool StorageConfigured { get; set; }
     }
 }

--- a/BTCPayServer/Models/ServerViewModels/ViewFilesViewModel.cs
+++ b/BTCPayServer/Models/ServerViewModels/ViewFilesViewModel.cs
@@ -7,7 +7,6 @@ namespace BTCPayServer.Models.ServerViewModels
     {
         public List<StoredFile> Files { get; set; }
         public Dictionary<string, string> DirectUrlByFiles { get; set; }
-        public string[] SelectedFileIds { get; set; }
         public bool StorageConfigured { get; set; }
     }
 }

--- a/BTCPayServer/Views/Server/Files.cshtml
+++ b/BTCPayServer/Views/Server/Files.cshtml
@@ -45,7 +45,7 @@ else
                         <td>@file.Timestamp.ToBrowserDate()</td>
                         <td>@file.ApplicationUser.UserName</td>
                         <td class="text-end">
-                            <a asp-action="Files" asp-route-fileId="@file.Id">Get Link</a>
+                            <a href="@Url.Action("Files", "Server", new { fileIds = new string[] { file.Id} })">Get Link</a>
                             - <a asp-action="CreateTemporaryFileUrl" asp-route-fileId="@file.Id">Get Temp Link</a>
                             - <a asp-action="DeleteFile" asp-route-fileId="@file.Id">Remove</a>
                         </td>
@@ -63,13 +63,13 @@ else
 }
 
 
-@if(Model.SelectedFileIds!=null && Model.SelectedFileIds.Count > 0)
+@if(Model.SelectedFileIds!=null && Model.SelectedFileIds.Length > 0)
 {
-    for (int i = 0; i < Model.SelectedFileIds.Count; ++i)
+    for (int i = 0; i < Model.SelectedFileIds.Length; ++i)
     {
         var file = Model.Files.Single(storedFile => storedFile.Id.Equals(Model.SelectedFileIds[i], StringComparison.InvariantCultureIgnoreCase));
         var fileId = Model.SelectedFileIds[i];
-        var fileUrl = Model.DirectFileUrls[i];
+        var fileUrl = Model.DirectUrlByFiles[fileId];
 
         <div class="card mb-2">
             <div class="card-text">

--- a/BTCPayServer/Views/Server/Files.cshtml
+++ b/BTCPayServer/Views/Server/Files.cshtml
@@ -63,31 +63,37 @@ else
 }
 
 
-@if (!string.IsNullOrEmpty(Model.SelectedFileId))
+@if(Model.SelectedFileIds!=null && Model.SelectedFileIds.Count > 0)
 {
-    var file = Model.Files.Single(storedFile => storedFile.Id.Equals(Model.SelectedFileId, StringComparison.InvariantCultureIgnoreCase));
-    <div class="card mb-2">
-        <div class="card-text">
-            <ul class="list-group list-group-flush">
-                <li class="list-group-item">
-                    @file.FileName
-                </li>
-                <li class="list-group-item">
-                    <strong>URL:</strong>
-                    <a asp-action="GetFile" asp-controller="Storage" asp-route-fileId="@Model.SelectedFileId" target="_blank">
-                        @Url.Action("GetFile", "Storage", new
-                        {
-                            fileId = Model.SelectedFileId
-                        }, Context.Request.Scheme, Context.Request.Host.ToString())
-                    </a>
-                </li>
-                <li class="list-group-item">
-                    <strong>Direct URL:</strong>
-                    <a href="@Model.DirectFileUrl" target="_blank" rel="noreferrer noopener">@Model.DirectFileUrl</a>
-                </li>
-            </ul>
+    for (int i = 0; i < Model.SelectedFileIds.Count; ++i)
+    {
+        var file = Model.Files.Single(storedFile => storedFile.Id.Equals(Model.SelectedFileIds[i], StringComparison.InvariantCultureIgnoreCase));
+        var fileId = Model.SelectedFileIds[i];
+        var fileUrl = Model.DirectFileUrls[i];
+
+        <div class="card mb-2">
+            <div class="card-text">
+                <ul class="list-group list-group-flush">
+                    <li class="list-group-item">
+                        @file.FileName
+                    </li>
+                    <li class="list-group-item">
+                        <strong>URL:</strong>
+                        <a asp-action="GetFile" asp-controller="Storage" asp-route-fileId="@fileId" target="_blank">
+                            @Url.Action("GetFile", "Storage", new
+                       {
+                           fileId = fileId
+                       }, Context.Request.Scheme, Context.Request.Host.ToString())
+                        </a>
+                    </li>
+                    <li class="list-group-item">
+                        <strong>Direct URL:</strong>
+                        <a href="@fileUrl" target="_blank" rel="noreferrer noopener">@fileUrl</a>
+                    </li>
+                </ul>
+            </div>
         </div>
-    </div>
+    }
 }
 
 @if (Model.StorageConfigured)

--- a/BTCPayServer/Views/Server/Files.cshtml
+++ b/BTCPayServer/Views/Server/Files.cshtml
@@ -63,13 +63,14 @@ else
 }
 
 
-@if(Model.SelectedFileIds!=null && Model.SelectedFileIds.Length > 0)
+@if(Model.DirectUrlByFiles!=null && Model.DirectUrlByFiles.Count > 0)
 {
-    for (int i = 0; i < Model.SelectedFileIds.Length; ++i)
+    foreach (KeyValuePair<string, string> fileUrlPair in Model.DirectUrlByFiles)
     {
-        var file = Model.Files.Single(storedFile => storedFile.Id.Equals(Model.SelectedFileIds[i], StringComparison.InvariantCultureIgnoreCase));
-        var fileId = Model.SelectedFileIds[i];
-        var fileUrl = Model.DirectUrlByFiles[fileId];
+        var fileId = fileUrlPair.Key;
+        var fileUrl = fileUrlPair.Value;
+        var file = Model.Files.Single(storedFile => storedFile.Id.Equals(fileId, StringComparison.InvariantCultureIgnoreCase));
+
 
         <div class="card mb-2">
             <div class="card-text">


### PR DESCRIPTION
Closes #2707 
Following the conversation in #2705 and #2707, I've updated the Files action model.
- Changed the SelectedFileId and DirectFileUrl properties in the ViewFilesViewModel from string to a list of strings
- Updated the UI to show a list of cards corresponding to the list of SelectedFileIds
- The changes made are backward compatible, if one passes a string containing a single file Id, it won't break. All methods which calls the Files view like Delete, CreateTempUrl are still working.
- Updated the tests
- Checks whether all files passed exist or not