### PR TITLE
Add example for orderId query string param in /api/v1/stores/{storeId}/invoices

### DIFF
--- a/BTCPayServer/wwwroot/swagger/v1/swagger.template.invoices.json
+++ b/BTCPayServer/wwwroot/swagger/v1/swagger.template.invoices.json
@@ -26,7 +26,8 @@
                             "items": {
                                 "type": "string"
                             }
-                        }
+                        },
+                        "example": "1000&orderId=1001&orderId=1002"
                     },
                     {
                         "name": "status",
@@ -983,7 +984,7 @@
                         "allOf": [ {"$ref": "#/components/schemas/TimeSpanMinutes"}]
                     },
                     "monitoringMinutes": {
-                        "type": "integer",
+                        "type": "number",
                         "nullable": true,
                         "description": "The number of minutes after an invoice expired after which we are still monitoring for incoming payments. Defaults to the store's settings. (The default store settings is 1440, 1 day)",
                         "allOf": [ {"$ref": "#/components/schemas/TimeSpanMinutes"}]


### PR DESCRIPTION
close #2736 

Adds an example for `orderId` query string param in ` /api/v1/stores/{storeId}/invoices` to make it clear how it's supposed to be used. There are different conventions for using arrays in query string parameter values so those not familiar with .NET conventions may get confused without an example provided.

![Screen Shot 2021-08-08 at 8 23 19 PM](https://user-images.githubusercontent.com/1934678/128657430-c89fb67a-3897-444b-bdc3-d4acada94fd6.png)
