### PR TITLE
Remove support for payout to a Bitcoin Url

### DIFF
--- a/BTCPayServer/Controllers/WalletsController.PullPayments.cs
+++ b/BTCPayServer/Controllers/WalletsController.PullPayments.cs
@@ -297,7 +297,10 @@ namespace BTCPayServer.Controllers
                         
                     }
                     if(bip21.Any())
+                    {
+                        TempData.SetStatusMessageModel(null);
                         return RedirectToAction(nameof(WalletSend), new {walletId, bip21});
+                    }
                     TempData.SetStatusMessageModel(new StatusMessageModel()
                     {
                         Severity = StatusMessageModel.StatusSeverity.Error,

--- a/BTCPayServer/Data/Payouts/BitcoinLike/BitcoinLikePayoutHandler.cs
+++ b/BTCPayServer/Data/Payouts/BitcoinLike/BitcoinLikePayoutHandler.cs
@@ -70,10 +70,11 @@ public class BitcoinLikePayoutHandler : IPayoutHandler
         destination = destination.Trim();
         try
         {
-            if (destination.StartsWith($"{network.UriScheme}:", StringComparison.OrdinalIgnoreCase))
-            {
-                return Task.FromResult<IClaimDestination>(new UriClaimDestination(new BitcoinUrlBuilder(destination, network.NBitcoinNetwork)));
-            }
+            // This doesn't work properly, (payouts are not detected), we can reactivate later when we fix the bug https://github.com/btcpayserver/btcpayserver/issues/2765
+            //if (destination.StartsWith($"{network.UriScheme}:", StringComparison.OrdinalIgnoreCase))
+            //{
+            //    return Task.FromResult<IClaimDestination>(new UriClaimDestination(new BitcoinUrlBuilder(destination, network.NBitcoinNetwork)));
+            //}
 
             return Task.FromResult<IClaimDestination>(new AddressClaimDestination(BitcoinAddress.Create(destination, network.NBitcoinNetwork)));
         }


### PR DESCRIPTION
Since this doesn't work properly and we are preparing a release, I remove the support https://github.com/btcpayserver/btcpayserver/issues/2765

Also this fix a bug, where paying the claim would show an error `Unknown action` in the Wallet Send.