### PR TITLE
Bumpo Clightning to 0.10.1

### DIFF
--- a/BTCPayServer.Tests/docker-compose.altcoins.yml
+++ b/BTCPayServer.Tests/docker-compose.altcoins.yml
@@ -146,7 +146,7 @@ services:
       - "bitcoin_datadir:/data"
 
   customer_lightningd:
-    image: btcpayserver/lightning:v0.10.0-dev
+    image: btcpayserver/lightning:v0.10.1-dev
     stop_signal: SIGKILL
     restart: unless-stopped
     environment: 
@@ -195,7 +195,7 @@ services:
       - merchant_lightningd
 
   merchant_lightningd:
-    image: btcpayserver/lightning:v0.10.0-dev
+    image: btcpayserver/lightning:v0.10.1-dev
     stop_signal: SIGKILL
     environment: 
       EXPOSE_TCP: "true"

--- a/BTCPayServer.Tests/docker-compose.yml
+++ b/BTCPayServer.Tests/docker-compose.yml
@@ -133,7 +133,7 @@ services:
       - "bitcoin_datadir:/data"
 
   customer_lightningd:
-    image: btcpayserver/lightning:v0.10.0-dev
+    image: btcpayserver/lightning:v0.10.1-dev
     stop_signal: SIGKILL
     restart: unless-stopped
     environment: 
@@ -182,7 +182,7 @@ services:
       - merchant_lightningd
 
   merchant_lightningd:
-    image: btcpayserver/lightning:v0.10.0-dev
+    image: btcpayserver/lightning:v0.10.1-dev
     stop_signal: SIGKILL
     environment: 
       EXPOSE_TCP: "true"

--- a/BTCPayServer/BTCPayServer.csproj
+++ b/BTCPayServer/BTCPayServer.csproj
@@ -46,7 +46,7 @@
   <ItemGroup>
     <PackageReference Include="BIP78.Sender" Version="0.2.0" />
     <PackageReference Include="BTCPayServer.Hwi" Version="2.0.1" />
-    <PackageReference Include="BTCPayServer.Lightning.All" Version="1.2.9" />
+    <PackageReference Include="BTCPayServer.Lightning.All" Version="1.2.10" />
     <PackageReference Include="BuildBundlerMinifier" Version="3.2.449" />
     <PackageReference Include="BundlerMinifier.Core" Version="3.2.435" />
     <PackageReference Include="BundlerMinifier.TagHelpers" Version="3.2.435" />

--- a/Changelog.md
+++ b/Changelog.md
@@ -61,6 +61,7 @@
 * Properly clip taxIncluded and invoice's amount (#2724) @nicolasdorier
 * Fix PoS bug on dark mode (#2743) @dennisreimann 
 * Remove support for payout to a Bitcoin Url (#2766) @NicolasDorier 
+* Fix: Support Clightning 0.10.1 @kukks
 
 ## 1.1.2
 

--- a/btcpayserver.sln
+++ b/btcpayserver.sln
@@ -18,6 +18,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Misc", "Misc", "{29290EC7-0
 		docker-entrypoint.sh = docker-entrypoint.sh
 		.circleci\run-tests.sh = .circleci\run-tests.sh
 		Build\Version.csproj = Build\Version.csproj
+		Changelog.md = Changelog.md
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BTCPayServer.Rating", "BTCPayServer.Rating\BTCPayServer.Rating.csproj", "{6DC77459-D52F-45EE-B3F3-315043D33A1B}"


### PR DESCRIPTION
Requires a new version of BTCPayServer.Lightning to be published and used here