### PR TITLE
Support multi currency contributions

### DIFF
--- a/BTCPayServer/Services/Apps/AppHubStreamer.cs
+++ b/BTCPayServer/Services/Apps/AppHubStreamer.cs
@@ -32,16 +32,24 @@ namespace BTCPayServer.Services.Apps
             {
                 foreach (var appId in AppService.GetAppInternalTags(invoiceEvent.Invoice))
                 {
-                    if (invoiceEvent.Name == InvoiceEvent.ReceivedPayment)
+                    if (invoiceEvent.Name == InvoiceEvent.ReceivedPayment ||
+                        invoiceEvent.Name == InvoiceEvent.MarkedCompleted ||
+                        invoiceEvent.Name == InvoiceEvent.MarkedInvalid)
                     {
-                        var data = invoiceEvent.Payment.GetCryptoPaymentData();
-                        await _HubContext.Clients.Group(appId).SendCoreAsync(AppHub.PaymentReceived, new object[]
-                            {
-                        data.GetValue(),
-                        invoiceEvent.Payment.GetCryptoCode(),
-                        invoiceEvent.Payment.GetPaymentMethodId()?.PaymentType?.ToString()
-                            }, cancellationToken);
+                        var data = invoiceEvent.Payment?.GetCryptoPaymentData();
+                        if (data != null)
+                        {
+
+
+                            await _HubContext.Clients.Group(appId).SendCoreAsync(AppHub.PaymentReceived,
+                                new object[]
+                                {
+                                    data.GetValue(), invoiceEvent.Payment.GetCryptoCode(),
+                                    invoiceEvent.Payment.GetPaymentMethodId()?.PaymentType?.ToString()
+                                }, cancellationToken);
+                        }
                     }
+
                     await InfoUpdated(appId);
                 }
             }

--- a/BTCPayServer/Views/AppsPublic/Crowdfund/MinimalCrowdfund.cshtml
+++ b/BTCPayServer/Views/AppsPublic/Crowdfund/MinimalCrowdfund.cshtml
@@ -77,10 +77,13 @@
                         <h5>@(Model.Info.CurrentAmount + Model.Info.CurrentPendingAmount) @Model.TargetCurrency </h5>
                         <h5 class="text-muted">Raised</h5>
                     </div>
-                    <div class="col-sm border-right">
-                        <h5>@(Model.Info.PendingProgressPercentage.GetValueOrDefault(0) + Model.Info.ProgressPercentage.GetValueOrDefault(0))%</h5>
-                        <h5 class="text-muted">Of Goal</h5>
-                    </div>
+                     @if (Model.TargetAmount.HasValue)
+                     {
+                         <div class="col-sm border-right">
+                             <h5>@(Model.Info.PendingProgressPercentage.GetValueOrDefault(0) + Model.Info.ProgressPercentage.GetValueOrDefault(0))%</h5>
+                             <h5 class="text-muted">Of Goal</h5>
+                         </div>
+                     }
                     <div class="col-sm text-end">
                         <h5>
                             @Model.Info.TotalContributors

--- a/BTCPayServer/Views/AppsPublic/Crowdfund/VueCrowdfund.cshtml
+++ b/BTCPayServer/Views/AppsPublic/Crowdfund/VueCrowdfund.cshtml
@@ -63,7 +63,7 @@
                         <h5>{{ raisedAmount }} {{targetCurrency}} </h5>
                         <h5 class="text-muted">Raised</h5>
                     </div>
-                    <div  class="col-sm  border-right" id="crowdfund-body-goal-raised">
+                    <div  class="col-sm  border-right" id="crowdfund-body-goal-raised" v-if="srvModel.targetAmount">
                         <h5>{{ percentageRaisedAmount }}%</h5>
                         <h5 class="text-muted">Of Goal</h5>
                     </div>


### PR DESCRIPTION
Previously, if crowdfund was set to count all invoices on the store towards the goal, and invoices were in different currencies, they would not be counted unless the invoice currency matched the crowdfund currency. This fixes that UNLESS the store rate source cannot find an exchange rate for between the invoice current and the crowdfund currency