### PR TITLE
Removed the tagline character limit in the crowdfunding app

### DIFF
--- a/BTCPayServer/Models/AppViewModels/UpdateCrowdfundViewModel.cs
+++ b/BTCPayServer/Models/AppViewModels/UpdateCrowdfundViewModel.cs
@@ -15,7 +15,6 @@ namespace BTCPayServer.Models.AppViewModels
         [MaxLength(30)]
         public string Title { get; set; }
 
-        [MaxLength(50)]
         public string Tagline { get; set; }
 
         [Required]


### PR DESCRIPTION
Fixes #2781
