### PR TITLE
Taproot support for wallets

### DIFF
--- a/BTCPayServer.Tests/docker-compose.altcoins.yml
+++ b/BTCPayServer.Tests/docker-compose.altcoins.yml
@@ -84,7 +84,7 @@ services:
       - customer_lnd
       - merchant_lnd
   nbxplorer:
-    image: nicolasdorier/nbxplorer:2.2.0
+    image: nicolasdorier/nbxplorer:2.2.1
     restart: unless-stopped
     ports:
       - "32838:32838"

--- a/BTCPayServer.Tests/docker-compose.yml
+++ b/BTCPayServer.Tests/docker-compose.yml
@@ -81,7 +81,7 @@ services:
       - customer_lnd
       - merchant_lnd
   nbxplorer:
-    image: nicolasdorier/nbxplorer:2.2.0
+    image: nicolasdorier/nbxplorer:2.2.1
     restart: unless-stopped
     ports:
       - "32838:32838"

--- a/BTCPayServer/Controllers/StoresController.Onchain.cs
+++ b/BTCPayServer/Controllers/StoresController.Onchain.cs
@@ -110,6 +110,11 @@ namespace BTCPayServer.Controllers
                 try
                 {
                     strategy = ParseDerivationStrategy(vm.DerivationScheme, network);
+                    if(strategy.AccountDerivation is TaprootDerivationStrategy && !TaprootSupported(vm.CryptoCode))
+                    {
+                        ModelState.AddModelError(nameof(vm.DerivationScheme), "Taproot is not supported");
+                        return View(vm.ViewName, vm);
+                    }
                     strategy.Source = "ManualDerivationScheme";
                     if (!string.IsNullOrEmpty(vm.AccountKey))
                     {

--- a/BTCPayServer/Controllers/StoresController.Onchain.cs
+++ b/BTCPayServer/Controllers/StoresController.Onchain.cs
@@ -55,6 +55,7 @@ namespace BTCPayServer.Controllers
             vm.RootKeyPath = network.GetRootKeyPath();
             vm.CanUseHotWallet = hotWallet;
             vm.CanUseRPCImport = rpcImport;
+            vm.CanUseTaproot = TaprootSupported(vm.CryptoCode);
 
             if (vm.Method == null)
             {
@@ -208,6 +209,7 @@ namespace BTCPayServer.Controllers
 
             vm.CanUseHotWallet = hotWallet;
             vm.CanUseRPCImport = rpcImport;
+            vm.CanUseTaproot = TaprootSupported(vm.CryptoCode);
             vm.RootKeyPath = network.GetRootKeyPath();
             vm.Network = network;
 
@@ -262,6 +264,12 @@ namespace BTCPayServer.Controllers
                 CanUseRPCImport = rpcImport
             };
 
+            if (request.ScriptPubKeyType == ScriptPubKeyType.TaprootBIP86 && !TaprootSupported(cryptoCode) )
+            {
+                ModelState.AddModelError(nameof(request.ScriptPubKeyType), $"Taproot not supported");
+                return View(vm.ViewName, vm);
+            }
+            
             if (isImport && string.IsNullOrEmpty(request.ExistingMnemonic))
             {
                 ModelState.AddModelError(nameof(request.ExistingMnemonic), "Please provide your existing seed");

--- a/BTCPayServer/Controllers/VaultController.cs
+++ b/BTCPayServer/Controllers/VaultController.cs
@@ -222,7 +222,21 @@ namespace BTCPayServer.Controllers
                                     continue;
                                 }
 
-                                if (addressType == "segwit")
+                                if (!network.NBitcoinNetwork.Consensus.SupportTaproot && addressType == "taproot")
+                                {
+                                    await websocketHelper.Send("{ \"error\": \"taproot-notsupported\"}", cancellationToken);
+                                    continue;
+                                }
+                                if (addressType == "taproot")
+                                {
+                                    keyPath = new KeyPath("86'").Derive(network.CoinType).Derive(accountNumber, true);
+                                    xpub = await device.GetXPubAsync(keyPath);
+                                    strategy = factory.CreateDirectDerivationStrategy(xpub, new DerivationStrategyOptions()
+                                    {
+                                        ScriptPubKeyType = ScriptPubKeyType.TaprootBIP86
+                                    });
+                                }
+                                else if (addressType == "segwit")
                                 {
                                     keyPath = new KeyPath("84'").Derive(network.CoinType).Derive(accountNumber, true);
                                     xpub = await device.GetXPubAsync(keyPath);

--- a/BTCPayServer/Controllers/VaultController.cs
+++ b/BTCPayServer/Controllers/VaultController.cs
@@ -351,6 +351,8 @@ askdevice:
         private ScriptPubKeyType GetScriptPubKeyType(RootedKeyPath keyPath)
         {
             var path = keyPath.KeyPath.ToString();
+            if (path.StartsWith("86'", StringComparison.OrdinalIgnoreCase))
+                return ScriptPubKeyType.TaprootBIP86;
             if (path.StartsWith("84'", StringComparison.OrdinalIgnoreCase))
                 return ScriptPubKeyType.Segwit;
             if (path.StartsWith("49'", StringComparison.OrdinalIgnoreCase))

--- a/BTCPayServer/Models/StoreViewModels/DerivationSchemeViewModel.cs
+++ b/BTCPayServer/Models/StoreViewModels/DerivationSchemeViewModel.cs
@@ -39,7 +39,8 @@ namespace BTCPayServer.Models.StoreViewModels
         public bool CanUseHotWallet { get; set; }
         [Display(Name = "Can use RPC import")]
         public bool CanUseRPCImport { get; set; }
-
+        [Display(Name = "Can use Taproot")]
+        public bool CanUseTaproot { get; set; }
         public RootedKeyPath GetAccountKeypath()
         {
             if (KeyPath != null && RootFingerprint != null &&

--- a/BTCPayServer/Views/Stores/GenerateWallet.cshtml
+++ b/BTCPayServer/Views/Stores/GenerateWallet.cshtml
@@ -7,6 +7,7 @@
     ViewData.SetActivePageAndTitle(StoreNavPages.Wallet, $"Create {Model.CryptoCode} {type} Wallet", Context.GetStoreData().StoreName);
     ViewData.Add(nameof(Model.CanUseHotWallet), Model.CanUseHotWallet);
     ViewData.Add(nameof(Model.CanUseRPCImport), Model.CanUseRPCImport);
+    ViewData.Add(nameof(Model.CanUseTaproot), Model.CanUseTaproot);
     ViewData.Add(nameof(Model.Method), Model.Method);
 }
 

--- a/BTCPayServer/Views/Stores/ImportWallet/Hardware.cshtml
+++ b/BTCPayServer/Views/Stores/ImportWallet/Hardware.cshtml
@@ -31,7 +31,10 @@
                     <option value="segwit">Segwit (Recommended, cheapest fee)</option>
                     <option value="segwitWrapped">Segwit wrapped (Compatible with old wallets)</option>
                     <option value="legacy">Legacy (Not recommended)</option>
-                    <option value="taproot">Taproot (ONLY FOR DEVELOPMENT)</option>
+                    @if (ViewData["CanUseTaproot"] is true)
+                    {
+                        <option value="taproot">Taproot (ONLY FOR DEVELOPMENT)</option>
+                    }
                 </select>
             </div>
             <div class="form-group">

--- a/BTCPayServer/Views/Stores/ImportWallet/Hardware.cshtml
+++ b/BTCPayServer/Views/Stores/ImportWallet/Hardware.cshtml
@@ -6,14 +6,16 @@
 }
 
 @section Navbar {
-    <a asp-controller="Stores" asp-action="ImportWallet" asp-route-storeId="@Model.StoreId" asp-route-cryptoCode="@Model.CryptoCode" asp-route-method="">
-        <vc:icon symbol="back" />
-    </a>
+<a asp-controller="Stores" asp-action="ImportWallet" asp-route-storeId="@Model.StoreId"
+    asp-route-cryptoCode="@Model.CryptoCode" asp-route-method="">
+    <vc:icon symbol="back" />
+</a>
 }
 
 <header class="text-center">
     <h1>@ViewData["Title"]</h1>
-    <p class="lead text-secondary mt-3">In order to securely connect to your hardware wallet you must first download, install, and run the BTCPay Server Vault.</p>
+    <p class="lead text-secondary mt-3">In order to securely connect to your hardware wallet you must first download,
+        install, and run the BTCPay Server Vault.</p>
 </header>
 
 @if (!ViewContext.ModelState.IsValid)
@@ -31,6 +33,7 @@
                     <option value="segwit">Segwit (Recommended, cheapest fee)</option>
                     <option value="segwitWrapped">Segwit wrapped (Compatible with old wallets)</option>
                     <option value="legacy">Legacy (Not recommended)</option>
+                    <option value="taproot">Taproot (ONLY FOR DEVELOPMENT)</option>
                 </select>
             </div>
             <div class="form-group">
@@ -54,7 +57,7 @@
     <input asp-for="Config" type="hidden" />
     <input asp-for="CryptoCode" type="hidden" />
     <input asp-for="AccountKey" type="hidden" />
-    <input asp-for="Source" type="hidden" value="Vault"/>
+    <input asp-for="Source" type="hidden" value="Vault" />
     <input asp-for="DerivationSchemeFormat" type="hidden" value="BTCPay" />
 
     <div class="row mb-5">
@@ -63,7 +66,8 @@
 
             <div class="form-group">
                 <label asp-for="DerivationScheme" class="form-label"></label>
-                <textarea asp-for="DerivationScheme" class="form-control store-derivation-scheme font-monospace py-2" rows="3" readonly></textarea>
+                <textarea asp-for="DerivationScheme" class="form-control store-derivation-scheme font-monospace py-2"
+                    rows="3" readonly></textarea>
             </div>
             <div class="form-group">
                 <label asp-for="RootFingerprint" class="form-label"></label>
@@ -79,35 +83,34 @@
 </form>
 
 @section PageFootContent {
-    <partial name="_ValidationScriptsPartial" />
-    <partial name="VaultElements" />
+<partial name="_ValidationScriptsPartial" />
+<partial name="VaultElements" />
 
-    <script src="~/js/vaultbridge.js" defer asp-append-version="true"></script>
-    <script src="~/js/vaultbridge.ui.js" defer asp-append-version="true"></script>
+<script src="~/js/vaultbridge.js" defer asp-append-version="true"></script>
+<script src="~/js/vaultbridge.ui.js" defer asp-append-version="true"></script>
 
-    <script>
-        window.addEventListener("load", async () => {
-            const wsPath = "@Url.Action("VaultBridgeConnection", "Vault", new {cryptoCode = Model.CryptoCode})";
-            const wsProto = location.protocol.replace(/^http/, "ws");
-            const vaultUI = new vaultui.VaultBridgeUI(`${wsProto}//${location.host}${wsPath}`);
+<script>
+    window.addEventListener("load", async () => {
+        const wsPath = "@Url.Action("VaultBridgeConnection", "Vault", new {cryptoCode = Model.CryptoCode})";
+        const wsProto = location.protocol.replace(/^http/, "ws");
+        const vaultUI = new vaultui.VaultBridgeUI(`${wsProto}//${location.host}${wsPath}`);
 
-            document.getElementById("vault-status").innerHTML = document.getElementById("VaultConnection").innerHTML;
+        document.getElementById("vault-status").innerHTML = document.getElementById("VaultConnection").innerHTML;
 
-            window.addEventListener("beforeunload", () => {
-                vaultUI.closeBridge();
-            });
-
-            while (!await vaultUI.askForDevice() || !await vaultUI.askForXPubs()) {};
-
-            const { xpub: { strategy, fingerprint, accountKey, keyPath } } = vaultUI;
-
-            document.getElementById("DerivationScheme").value = strategy;
-            document.getElementById("RootFingerprint").value = fingerprint;
-            document.getElementById("AccountKey").value = accountKey;
-            document.getElementById("KeyPath").value = keyPath;
-
-            document.getElementById("walletInfo").style = null;
+        window.addEventListener("beforeunload", () => {
+            vaultUI.closeBridge();
         });
-    </script>
-}
 
+        while (!await vaultUI.askForDevice() || !await vaultUI.askForXPubs()) { };
+
+        const { xpub: { strategy, fingerprint, accountKey, keyPath } } = vaultUI;
+
+        document.getElementById("DerivationScheme").value = strategy;
+        document.getElementById("RootFingerprint").value = fingerprint;
+        document.getElementById("AccountKey").value = accountKey;
+        document.getElementById("KeyPath").value = keyPath;
+
+        document.getElementById("walletInfo").style = null;
+    });
+</script>
+}

--- a/BTCPayServer/Views/Stores/ImportWallet/Hardware.cshtml
+++ b/BTCPayServer/Views/Stores/ImportWallet/Hardware.cshtml
@@ -6,16 +6,14 @@
 }
 
 @section Navbar {
-<a asp-controller="Stores" asp-action="ImportWallet" asp-route-storeId="@Model.StoreId"
-    asp-route-cryptoCode="@Model.CryptoCode" asp-route-method="">
-    <vc:icon symbol="back" />
-</a>
+    <a asp-controller="Stores" asp-action="ImportWallet" asp-route-storeId="@Model.StoreId" asp-route-cryptoCode="@Model.CryptoCode" asp-route-method="">
+        <vc:icon symbol="back" />
+    </a>
 }
 
 <header class="text-center">
     <h1>@ViewData["Title"]</h1>
-    <p class="lead text-secondary mt-3">In order to securely connect to your hardware wallet you must first download,
-        install, and run the BTCPay Server Vault.</p>
+    <p class="lead text-secondary mt-3">In order to securely connect to your hardware wallet you must first download, install, and run the BTCPay Server Vault.</p>
 </header>
 
 @if (!ViewContext.ModelState.IsValid)
@@ -57,7 +55,7 @@
     <input asp-for="Config" type="hidden" />
     <input asp-for="CryptoCode" type="hidden" />
     <input asp-for="AccountKey" type="hidden" />
-    <input asp-for="Source" type="hidden" value="Vault" />
+    <input asp-for="Source" type="hidden" value="Vault"/>
     <input asp-for="DerivationSchemeFormat" type="hidden" value="BTCPay" />
 
     <div class="row mb-5">
@@ -66,8 +64,7 @@
 
             <div class="form-group">
                 <label asp-for="DerivationScheme" class="form-label"></label>
-                <textarea asp-for="DerivationScheme" class="form-control store-derivation-scheme font-monospace py-2"
-                    rows="3" readonly></textarea>
+                <textarea asp-for="DerivationScheme" class="form-control store-derivation-scheme font-monospace py-2" rows="3" readonly></textarea>
             </div>
             <div class="form-group">
                 <label asp-for="RootFingerprint" class="form-label"></label>
@@ -83,34 +80,35 @@
 </form>
 
 @section PageFootContent {
-<partial name="_ValidationScriptsPartial" />
-<partial name="VaultElements" />
+    <partial name="_ValidationScriptsPartial" />
+    <partial name="VaultElements" />
 
-<script src="~/js/vaultbridge.js" defer asp-append-version="true"></script>
-<script src="~/js/vaultbridge.ui.js" defer asp-append-version="true"></script>
+    <script src="~/js/vaultbridge.js" defer asp-append-version="true"></script>
+    <script src="~/js/vaultbridge.ui.js" defer asp-append-version="true"></script>
 
-<script>
-    window.addEventListener("load", async () => {
-        const wsPath = "@Url.Action("VaultBridgeConnection", "Vault", new {cryptoCode = Model.CryptoCode})";
-        const wsProto = location.protocol.replace(/^http/, "ws");
-        const vaultUI = new vaultui.VaultBridgeUI(`${wsProto}//${location.host}${wsPath}`);
+    <script>
+        window.addEventListener("load", async () => {
+            const wsPath = "@Url.Action("VaultBridgeConnection", "Vault", new {cryptoCode = Model.CryptoCode})";
+            const wsProto = location.protocol.replace(/^http/, "ws");
+            const vaultUI = new vaultui.VaultBridgeUI(`${wsProto}//${location.host}${wsPath}`);
 
-        document.getElementById("vault-status").innerHTML = document.getElementById("VaultConnection").innerHTML;
+            document.getElementById("vault-status").innerHTML = document.getElementById("VaultConnection").innerHTML;
 
-        window.addEventListener("beforeunload", () => {
-            vaultUI.closeBridge();
+            window.addEventListener("beforeunload", () => {
+                vaultUI.closeBridge();
+            });
+
+            while (!await vaultUI.askForDevice() || !await vaultUI.askForXPubs()) {};
+
+            const { xpub: { strategy, fingerprint, accountKey, keyPath } } = vaultUI;
+
+            document.getElementById("DerivationScheme").value = strategy;
+            document.getElementById("RootFingerprint").value = fingerprint;
+            document.getElementById("AccountKey").value = accountKey;
+            document.getElementById("KeyPath").value = keyPath;
+
+            document.getElementById("walletInfo").style = null;
         });
-
-        while (!await vaultUI.askForDevice() || !await vaultUI.askForXPubs()) { };
-
-        const { xpub: { strategy, fingerprint, accountKey, keyPath } } = vaultUI;
-
-        document.getElementById("DerivationScheme").value = strategy;
-        document.getElementById("RootFingerprint").value = fingerprint;
-        document.getElementById("AccountKey").value = accountKey;
-        document.getElementById("KeyPath").value = keyPath;
-
-        document.getElementById("walletInfo").style = null;
-    });
-</script>
+    </script>
 }
+

--- a/BTCPayServer/Views/Stores/ImportWallet/Seed.cshtml
+++ b/BTCPayServer/Views/Stores/ImportWallet/Seed.cshtml
@@ -21,6 +21,7 @@
     {
         ViewData.Add(nameof(Model.CanUseHotWallet), Model.CanUseHotWallet);
         ViewData.Add(nameof(Model.CanUseRPCImport), Model.CanUseRPCImport);
+        ViewData.Add(nameof(Model.CanUseTaproot), Model.CanUseTaproot);
         ViewData.Add(nameof(Model.Method), Model.Method);
 
         <partial name="_GenerateWalletForm" model="Model.SetupRequest" />

--- a/BTCPayServer/Views/Stores/ImportWallet/Xpub.cshtml
+++ b/BTCPayServer/Views/Stores/ImportWallet/Xpub.cshtml
@@ -83,6 +83,13 @@
     <tr>
         <td class="font-monospace">pkh(xpub…/0/*)</td>
     </tr>
+    @if (Model.CanUseTaproot)
+    {
+        <tr>
+            <td rowspan="1">P2TR</td>
+            <td class="font-monospace">xpub…-[taproot]</td>
+        </tr>
+    }
     <tr class="additional">
         <td class="text-nowrap" rowspan="2">Multi-sig P2WSH</td>
         <td class="font-monospace">2-of-xpub1…-xpub2…</td>

--- a/BTCPayServer/Views/Stores/_GenerateWalletForm.cshtml
+++ b/BTCPayServer/Views/Stores/_GenerateWalletForm.cshtml
@@ -12,20 +12,25 @@
 @if (!User.IsInRole(Roles.ServerAdmin))
 {
     <div class="alert alert-warning">
-        You are not an admin on this server. While you are able to import or generate a wallet via seed with
-        your account, please understand that you are trusting the server admins not just with your
-        <a href="https://docs.btcpayserver.org/ThirdPartyHosting/#privacy-concerns" target="_blank" class="alert-link" rel="noreferrer noopener">privacy</a>
-        but also with <a href="https://docs.btcpayserver.org/ThirdPartyHosting/#trust-concerns" target="_blank" class="alert-link" rel="noreferrer noopener">trivial access to your funds.</a>
-        If you NEED to use this feature, please reconsider hosting your own BTCPay Server instance.
-    </div>
+    You are not an admin on this server. While you are able to import or generate a wallet via seed with
+    your account, please understand that you are trusting the server admins not just with your
+    <a href="https://docs.btcpayserver.org/ThirdPartyHosting/#privacy-concerns" target="_blank" class="alert-link"
+        rel="noreferrer noopener">privacy</a>
+    but also with <a href="https://docs.btcpayserver.org/ThirdPartyHosting/#trust-concerns" target="_blank"
+        class="alert-link" rel="noreferrer noopener">trivial access to your funds.</a>
+    If you NEED to use this feature, please reconsider hosting your own BTCPay Server instance.
+</div>
 }
 
-<form id="generate-wallet-form" method="post" asp-action="GenerateWallet" asp-route-storeId="@Context.GetRouteValue("storeId")" asp-route-cryptoCode="@Context.GetRouteValue("cryptoCode")" asp-route-method="@method">
+<form id="generate-wallet-form" method="post" asp-action="GenerateWallet"
+    asp-route-storeId="@Context.GetRouteValue("storeId")" asp-route-cryptoCode="@Context.GetRouteValue("cryptoCode")"
+    asp-route-method="@method">
     @if (isImport)
     {
         <div class="form-group">
             <label asp-for="ExistingMnemonic" class="form-label">Wallet Recovery Seed</label>
-            <textarea asp-for="ExistingMnemonic" class="form-control font-monospace py-2" rows="2" autocomplete="off" autocorrect="off" autocapitalize="off"></textarea>
+            <textarea asp-for="ExistingMnemonic" class="form-control font-monospace py-2" rows="2" autocomplete="off"
+            autocorrect="off" autocapitalize="off"></textarea>
             <span asp-validation-for="ExistingMnemonic" class="text-danger"></span>
         </div>
     }
@@ -36,7 +41,7 @@
             <option value="@ScriptPubKeyType.Segwit">Segwit (Recommended, cheapest transaction fee)</option>
             <option value="@ScriptPubKeyType.SegwitP2SH">Segwit wrapped (Compatible with old wallets)</option>
             <option value="@ScriptPubKeyType.Legacy">Legacy (Not recommended)</option>
-            <option value="@ScriptPubKeyType.TaprootBIP86">Taproot (Purely Experimental, ONLY FOR DEVELOPMENT)</option>
+            <option value="@ScriptPubKeyType.TaprootBIP86">Taproot (ONLY FOR DEVELOPMENT)</option>
         </select>
         <span asp-validation-for="ScriptPubKeyType" class="text-danger"></span>
     </div>
@@ -75,10 +80,12 @@
     }
 
     <div class="mb-4">
-        <button class="btn btn-link px-0" type="button" id="AdvancedSettingsButton" data-bs-toggle="collapse" data-bs-target="#AdvancedSettings" aria-expanded="false" aria-controls="advanced-settings">
+        <button class="btn btn-link px-0" type="button" id="AdvancedSettingsButton" data-bs-toggle="collapse"
+            data-bs-target="#AdvancedSettings" aria-expanded="false" aria-controls="advanced-settings">
             Advanced settings
         </button>
-        <div id="AdvancedSettings" class="collapse @(string.IsNullOrEmpty(Model.Passphrase) && !Model.ImportKeysToRPC ? "" : "show")">
+        <div id="AdvancedSettings"
+            class="collapse @(string.IsNullOrEmpty(Model.Passphrase) && !Model.ImportKeysToRPC ? "" : "show")">
             <div class="pt-3 pb-1">
                 @if (isImport) // hide account option when creating a wallet
                 {
@@ -95,12 +102,12 @@
                 }
                 <div class="form-group">
                     <label asp-for="Passphrase" class="form-label">Optional passphrase (BIP39)</label>
-                    <input type="text" asp-for="Passphrase" class="form-control" autocomplete="off"/>
+                    <input type="text" asp-for="Passphrase" class="form-control" autocomplete="off" />
                     <span asp-validation-for="Passphrase" class="text-danger"></span>
                 </div>
                 <div class="form-group">
                     <label for="passphrase_conf" class="form-label">Confirm passphrase</label>
-                    <input type="text" name="passphrase_conf" id="passphrase_conf" class="form-control"/>
+                    <input type="text" name="passphrase_conf" id="passphrase_conf" class="form-control" />
                     <span class="text-danger field-validation-valid" id="passphrase_conf_validation"></span>
                 </div>
 
@@ -111,10 +118,12 @@
                         <input type="checkbox" asp-for="ImportKeysToRPC" class="btcpay-toggle ms-2" />
                         <span asp-validation-for="ImportKeysToRPC" class="text-danger"></span>
                         <p class="text-muted pt-2">
-                            Each address generated will be imported into the node wallet and you can view your balance through the node.
+                            Each address generated will be imported into the node wallet and you can view your balance
+                            through the node.
                             @if (isImport || isHotWallet)
                             {
-                                <span>When this is enabled for a hot wallet, you are also able to use the node wallet to spend.</span>
+                                <span>When this is enabled for a hot wallet, you are also able to use the node wallet to
+                                    spend.</span>
                             }
                         </p>
                     </div>

--- a/BTCPayServer/Views/Stores/_GenerateWalletForm.cshtml
+++ b/BTCPayServer/Views/Stores/_GenerateWalletForm.cshtml
@@ -36,6 +36,7 @@
             <option value="@ScriptPubKeyType.Segwit">Segwit (Recommended, cheapest transaction fee)</option>
             <option value="@ScriptPubKeyType.SegwitP2SH">Segwit wrapped (Compatible with old wallets)</option>
             <option value="@ScriptPubKeyType.Legacy">Legacy (Not recommended)</option>
+            <option value="@ScriptPubKeyType.TaprootBIP86">Taproot (Purely Experimental, ONLY FOR DEVELOPMENT)</option>
         </select>
         <span asp-validation-for="ScriptPubKeyType" class="text-danger"></span>
     </div>

--- a/BTCPayServer/Views/Stores/_GenerateWalletForm.cshtml
+++ b/BTCPayServer/Views/Stores/_GenerateWalletForm.cshtml
@@ -12,25 +12,20 @@
 @if (!User.IsInRole(Roles.ServerAdmin))
 {
     <div class="alert alert-warning">
-    You are not an admin on this server. While you are able to import or generate a wallet via seed with
-    your account, please understand that you are trusting the server admins not just with your
-    <a href="https://docs.btcpayserver.org/ThirdPartyHosting/#privacy-concerns" target="_blank" class="alert-link"
-        rel="noreferrer noopener">privacy</a>
-    but also with <a href="https://docs.btcpayserver.org/ThirdPartyHosting/#trust-concerns" target="_blank"
-        class="alert-link" rel="noreferrer noopener">trivial access to your funds.</a>
-    If you NEED to use this feature, please reconsider hosting your own BTCPay Server instance.
-</div>
+        You are not an admin on this server. While you are able to import or generate a wallet via seed with
+        your account, please understand that you are trusting the server admins not just with your
+        <a href="https://docs.btcpayserver.org/ThirdPartyHosting/#privacy-concerns" target="_blank" class="alert-link" rel="noreferrer noopener">privacy</a>
+        but also with <a href="https://docs.btcpayserver.org/ThirdPartyHosting/#trust-concerns" target="_blank" class="alert-link" rel="noreferrer noopener">trivial access to your funds.</a>
+        If you NEED to use this feature, please reconsider hosting your own BTCPay Server instance.
+    </div>
 }
 
-<form id="generate-wallet-form" method="post" asp-action="GenerateWallet"
-    asp-route-storeId="@Context.GetRouteValue("storeId")" asp-route-cryptoCode="@Context.GetRouteValue("cryptoCode")"
-    asp-route-method="@method">
+<form id="generate-wallet-form" method="post" asp-action="GenerateWallet" asp-route-storeId="@Context.GetRouteValue("storeId")" asp-route-cryptoCode="@Context.GetRouteValue("cryptoCode")" asp-route-method="@method">
     @if (isImport)
     {
         <div class="form-group">
             <label asp-for="ExistingMnemonic" class="form-label">Wallet Recovery Seed</label>
-            <textarea asp-for="ExistingMnemonic" class="form-control font-monospace py-2" rows="2" autocomplete="off"
-            autocorrect="off" autocapitalize="off"></textarea>
+            <textarea asp-for="ExistingMnemonic" class="form-control font-monospace py-2" rows="2" autocomplete="off" autocorrect="off" autocapitalize="off"></textarea>
             <span asp-validation-for="ExistingMnemonic" class="text-danger"></span>
         </div>
     }
@@ -80,12 +75,10 @@
     }
 
     <div class="mb-4">
-        <button class="btn btn-link px-0" type="button" id="AdvancedSettingsButton" data-bs-toggle="collapse"
-            data-bs-target="#AdvancedSettings" aria-expanded="false" aria-controls="advanced-settings">
+        <button class="btn btn-link px-0" type="button" id="AdvancedSettingsButton" data-bs-toggle="collapse" data-bs-target="#AdvancedSettings" aria-expanded="false" aria-controls="advanced-settings">
             Advanced settings
         </button>
-        <div id="AdvancedSettings"
-            class="collapse @(string.IsNullOrEmpty(Model.Passphrase) && !Model.ImportKeysToRPC ? "" : "show")">
+        <div id="AdvancedSettings" class="collapse @(string.IsNullOrEmpty(Model.Passphrase) && !Model.ImportKeysToRPC ? "" : "show")">
             <div class="pt-3 pb-1">
                 @if (isImport) // hide account option when creating a wallet
                 {
@@ -102,12 +95,12 @@
                 }
                 <div class="form-group">
                     <label asp-for="Passphrase" class="form-label">Optional passphrase (BIP39)</label>
-                    <input type="text" asp-for="Passphrase" class="form-control" autocomplete="off" />
+                    <input type="text" asp-for="Passphrase" class="form-control" autocomplete="off"/>
                     <span asp-validation-for="Passphrase" class="text-danger"></span>
                 </div>
                 <div class="form-group">
                     <label for="passphrase_conf" class="form-label">Confirm passphrase</label>
-                    <input type="text" name="passphrase_conf" id="passphrase_conf" class="form-control" />
+                    <input type="text" name="passphrase_conf" id="passphrase_conf" class="form-control"/>
                     <span class="text-danger field-validation-valid" id="passphrase_conf_validation"></span>
                 </div>
 
@@ -118,12 +111,10 @@
                         <input type="checkbox" asp-for="ImportKeysToRPC" class="btcpay-toggle ms-2" />
                         <span asp-validation-for="ImportKeysToRPC" class="text-danger"></span>
                         <p class="text-muted pt-2">
-                            Each address generated will be imported into the node wallet and you can view your balance
-                            through the node.
+                            Each address generated will be imported into the node wallet and you can view your balance through the node.
                             @if (isImport || isHotWallet)
                             {
-                                <span>When this is enabled for a hot wallet, you are also able to use the node wallet to
-                                    spend.</span>
+                                <span>When this is enabled for a hot wallet, you are also able to use the node wallet to spend.</span>
                             }
                         </p>
                     </div>

--- a/BTCPayServer/Views/Stores/_GenerateWalletForm.cshtml
+++ b/BTCPayServer/Views/Stores/_GenerateWalletForm.cshtml
@@ -7,6 +7,7 @@
     var isHotWallet = method is WalletSetupMethod.HotWallet;
     var canUseHotWallet = ViewData["CanUseHotWallet"] is true;
     var canUseRpcImport = ViewData["CanUseRPCImport"] is true;
+    var canUseTaproot = ViewData["CanUseTaproot"] is true;
 }
 
 @if (!User.IsInRole(Roles.ServerAdmin))
@@ -36,7 +37,10 @@
             <option value="@ScriptPubKeyType.Segwit">Segwit (Recommended, cheapest transaction fee)</option>
             <option value="@ScriptPubKeyType.SegwitP2SH">Segwit wrapped (Compatible with old wallets)</option>
             <option value="@ScriptPubKeyType.Legacy">Legacy (Not recommended)</option>
-            <option value="@ScriptPubKeyType.TaprootBIP86">Taproot (ONLY FOR DEVELOPMENT)</option>
+            @if (canUseTaproot)
+            {
+                <option value="@ScriptPubKeyType.TaprootBIP86">Taproot (ONLY FOR DEVELOPMENT)</option>
+            }
         </select>
         <span asp-validation-for="ScriptPubKeyType" class="text-danger"></span>
     </div>


### PR DESCRIPTION
This PR adds experimantal support for taproot in btcpayserver.
It enables creating a wallet with Taproot support.