### PR TITLE
Decouple taproot activation from support in generate wallet

### DIFF
--- a/BTCPayServer/Controllers/StoresController.Onchain.cs
+++ b/BTCPayServer/Controllers/StoresController.Onchain.cs
@@ -55,7 +55,9 @@ namespace BTCPayServer.Controllers
             vm.RootKeyPath = network.GetRootKeyPath();
             vm.CanUseHotWallet = hotWallet;
             vm.CanUseRPCImport = rpcImport;
-            vm.CanUseTaproot = TaprootSupported(vm.CryptoCode);
+            vm.SupportTaproot = network.NBitcoinNetwork.Consensus.SupportTaproot;
+            vm.SupportSegwit = network.NBitcoinNetwork.Consensus.SupportSegwit;
+            vm.IsTaprootActivated = TaprootActivated(vm.CryptoCode);
 
             if (vm.Method == null)
             {
@@ -110,11 +112,6 @@ namespace BTCPayServer.Controllers
                 try
                 {
                     strategy = ParseDerivationStrategy(vm.DerivationScheme, network);
-                    if(strategy.AccountDerivation is TaprootDerivationStrategy && !TaprootSupported(vm.CryptoCode))
-                    {
-                        ModelState.AddModelError(nameof(vm.DerivationScheme), "Taproot is not supported");
-                        return View(vm.ViewName, vm);
-                    }
                     strategy.Source = "ManualDerivationScheme";
                     if (!string.IsNullOrEmpty(vm.AccountKey))
                     {
@@ -214,7 +211,9 @@ namespace BTCPayServer.Controllers
 
             vm.CanUseHotWallet = hotWallet;
             vm.CanUseRPCImport = rpcImport;
-            vm.CanUseTaproot = TaprootSupported(vm.CryptoCode);
+            vm.SupportTaproot = network.NBitcoinNetwork.Consensus.SupportTaproot;
+            vm.SupportSegwit = network.NBitcoinNetwork.Consensus.SupportSegwit;
+            vm.IsTaprootActivated = TaprootActivated(vm.CryptoCode);
             vm.RootKeyPath = network.GetRootKeyPath();
             vm.Network = network;
 
@@ -266,14 +265,11 @@ namespace BTCPayServer.Controllers
                 IsHotWallet = isImport ? request.SavePrivateKeys : method == WalletSetupMethod.HotWallet,
                 DerivationSchemeFormat = "BTCPay",
                 CanUseHotWallet = hotWallet,
-                CanUseRPCImport = rpcImport
+                CanUseRPCImport = rpcImport,
+                IsTaprootActivated = TaprootActivated(cryptoCode),
+                SupportTaproot = network.NBitcoinNetwork.Consensus.SupportTaproot,
+                SupportSegwit = network.NBitcoinNetwork.Consensus.SupportSegwit
             };
-
-            if (request.ScriptPubKeyType == ScriptPubKeyType.TaprootBIP86 && !TaprootSupported(cryptoCode) )
-            {
-                ModelState.AddModelError(nameof(request.ScriptPubKeyType), $"Taproot not supported");
-                return View(vm.ViewName, vm);
-            }
             
             if (isImport && string.IsNullOrEmpty(request.ExistingMnemonic))
             {

--- a/BTCPayServer/Controllers/StoresController.cs
+++ b/BTCPayServer/Controllers/StoresController.cs
@@ -146,11 +146,16 @@ namespace BTCPayServer.Controllers
             }
         }
 
-        public bool TaprootSupported(string crytoCode)
+        public bool TaprootActivated(string crytoCode)
         {
-            var networkSupport = ((BTCPayNetwork)_NetworkProvider.GetNetwork(crytoCode))?.NBitcoinNetwork?.Consensus?.SupportTaproot is true;
+            var network = (BTCPayNetwork)_NetworkProvider.GetNetwork(crytoCode);
+#pragma warning disable CS0618
+            if (!(network.IsBTC && network.NBitcoinNetwork.ChainName == ChainName.Mainnet))
+                // Consider it activated for everything that is not mainnet bitcoin
+                return true;
+#pragma warning restore CS0618
             var status = _Dashboard.Get(crytoCode).Status;
-            return networkSupport && !(status.NetworkType == ChainName.Mainnet && status.ChainHeight < 709632);
+            return  status.ChainHeight >= 709632;
         }
 
 

--- a/BTCPayServer/Models/StoreViewModels/DerivationSchemeViewModel.cs
+++ b/BTCPayServer/Models/StoreViewModels/DerivationSchemeViewModel.cs
@@ -39,8 +39,10 @@ namespace BTCPayServer.Models.StoreViewModels
         public bool CanUseHotWallet { get; set; }
         [Display(Name = "Can use RPC import")]
         public bool CanUseRPCImport { get; set; }
-        [Display(Name = "Can use Taproot")]
-        public bool CanUseTaproot { get; set; }
+        public bool SupportSegwit { get; set; }
+        public bool SupportTaproot { get; set; }
+        [Display(Name = "Is taproot activated")]
+        public bool IsTaprootActivated { get; set; }
         public RootedKeyPath GetAccountKeypath()
         {
             if (KeyPath != null && RootFingerprint != null &&

--- a/BTCPayServer/Views/Stores/GenerateWallet.cshtml
+++ b/BTCPayServer/Views/Stores/GenerateWallet.cshtml
@@ -7,7 +7,9 @@
     ViewData.SetActivePageAndTitle(StoreNavPages.Wallet, $"Create {Model.CryptoCode} {type} Wallet", Context.GetStoreData().StoreName);
     ViewData.Add(nameof(Model.CanUseHotWallet), Model.CanUseHotWallet);
     ViewData.Add(nameof(Model.CanUseRPCImport), Model.CanUseRPCImport);
-    ViewData.Add(nameof(Model.CanUseTaproot), Model.CanUseTaproot);
+    ViewData.Add(nameof(Model.IsTaprootActivated), Model.IsTaprootActivated);
+    ViewData.Add(nameof(Model.SupportSegwit), Model.SupportSegwit);
+    ViewData.Add(nameof(Model.SupportTaproot), Model.SupportTaproot);
     ViewData.Add(nameof(Model.Method), Model.Method);
 }
 

--- a/BTCPayServer/Views/Stores/ImportWallet/Seed.cshtml
+++ b/BTCPayServer/Views/Stores/ImportWallet/Seed.cshtml
@@ -21,7 +21,9 @@
     {
         ViewData.Add(nameof(Model.CanUseHotWallet), Model.CanUseHotWallet);
         ViewData.Add(nameof(Model.CanUseRPCImport), Model.CanUseRPCImport);
-        ViewData.Add(nameof(Model.CanUseTaproot), Model.CanUseTaproot);
+        ViewData.Add(nameof(Model.IsTaprootActivated), Model.IsTaprootActivated);
+        ViewData.Add(nameof(Model.SupportSegwit), Model.SupportSegwit);
+        ViewData.Add(nameof(Model.SupportTaproot), Model.SupportTaproot);
         ViewData.Add(nameof(Model.Method), Model.Method);
 
         <partial name="_GenerateWalletForm" model="Model.SetupRequest" />

--- a/BTCPayServer/Views/Stores/ImportWallet/Xpub.cshtml
+++ b/BTCPayServer/Views/Stores/ImportWallet/Xpub.cshtml
@@ -47,32 +47,35 @@
     </tr>
     </thead>
     <tbody>
-    <tr>
-        <td rowspan="4">P2WPKH</td>
-        <td class="font-monospace">xpub…</td>
-    </tr>
-    <tr>
-        <td class="font-monospace">zpub…</td>
-    </tr>
-    <tr>
-        <td class="font-monospace">wpkh(xpub…/0/*)</td>
-    </tr>
-    <tr>
-        <td class="font-monospace">wpkh([…/84'/0'/0']xpub…/0/*)</td>
-    </tr>
-    <tr>
-        <td rowspan="4">P2SH-P2WPKH</td>
-        <td class="font-monospace">xpub…-[p2sh]</td>
-    </tr>
-    <tr>
-        <td class="font-monospace">ypub…</td>
-    </tr>
-    <tr>
-        <td class="font-monospace">sh(wpkh(xpub…/0/*)</td>
-    </tr>
-    <tr>
-        <td class="font-monospace">sh(wpkh([…/49'/0'/0']xpub…/0/*)</td>
-    </tr>
+    @if (Model.SupportSegwit)
+    {
+        <tr>
+            <td rowspan="4">P2WPKH</td>
+            <td class="font-monospace">xpub…</td>
+        </tr>
+        <tr>
+            <td class="font-monospace">zpub…</td>
+        </tr>
+        <tr>
+            <td class="font-monospace">wpkh(xpub…/0/*)</td>
+        </tr>
+        <tr>
+            <td class="font-monospace">wpkh([…/84'/0'/0']xpub…/0/*)</td>
+        </tr>
+        <tr>
+            <td rowspan="4">P2SH-P2WPKH</td>
+            <td class="font-monospace">xpub…-[p2sh]</td>
+        </tr>
+        <tr>
+            <td class="font-monospace">ypub…</td>
+        </tr>
+        <tr>
+            <td class="font-monospace">sh(wpkh(xpub…/0/*)</td>
+        </tr>
+        <tr>
+            <td class="font-monospace">sh(wpkh([…/49'/0'/0']xpub…/0/*)</td>
+        </tr>
+    }
     <tr>
         <td rowspan="3">P2PKH</td>
         <td class="font-monospace">xpub…-[legacy]</td>
@@ -83,7 +86,7 @@
     <tr>
         <td class="font-monospace">pkh(xpub…/0/*)</td>
     </tr>
-    @if (Model.CanUseTaproot)
+    @if (Model.SupportTaproot && Model.IsTaprootActivated)
     {
         <tr>
             <td rowspan="1">P2TR</td>

--- a/BTCPayServer/Views/Stores/_GenerateWalletForm.cshtml
+++ b/BTCPayServer/Views/Stores/_GenerateWalletForm.cshtml
@@ -7,7 +7,7 @@
     var isHotWallet = method is WalletSetupMethod.HotWallet;
     var canUseHotWallet = ViewData["CanUseHotWallet"] is true;
     var canUseRpcImport = ViewData["CanUseRPCImport"] is true;
-    var canUseTaproot = ViewData["CanUseTaproot"] is true;
+    var isTaprootActivated = ViewData["IsTaprootActivated"] is true;
 }
 
 @if (!User.IsInRole(Roles.ServerAdmin))
@@ -34,12 +34,27 @@
     <div class="form-group">
         <label asp-for="ScriptPubKeyType" class="form-label">Address type</label>
         <select class="form-select w-auto" asp-for="ScriptPubKeyType">
-            <option value="@ScriptPubKeyType.Segwit">Segwit (Recommended, cheapest transaction fee)</option>
-            <option value="@ScriptPubKeyType.SegwitP2SH">Segwit wrapped (Compatible with old wallets)</option>
-            <option value="@ScriptPubKeyType.Legacy">Legacy (Not recommended)</option>
-            @if (canUseTaproot)
+            @if (ViewData["SupportSegwit"] is true)
             {
-                <option value="@ScriptPubKeyType.TaprootBIP86">Taproot (ONLY FOR DEVELOPMENT)</option>
+                <option value="@ScriptPubKeyType.Segwit">Segwit (Recommended)</option>
+                <option value="@ScriptPubKeyType.SegwitP2SH">Segwit wrapped (Compatible with old wallets)</option>
+                <option value="@ScriptPubKeyType.Legacy">Legacy (Not recommended)</option>
+            }
+            else
+            {
+                <option value="@ScriptPubKeyType.Legacy">Legacy</option>
+            }
+
+            @if (ViewData["SupportTaproot"] is true)
+            {
+                @if (isTaprootActivated)
+                {
+                    <option value="@ScriptPubKeyType.TaprootBIP86">Taproot (For advanced users)</option>
+                }
+                else
+                {
+                    <option value="@ScriptPubKeyType.TaprootBIP86" disabled>Taproot (Available from block 709632)</option>
+                }
             }
         </select>
         <span asp-validation-for="ScriptPubKeyType" class="text-danger"></span>


### PR DESCRIPTION
Built upon @sageprogrammer modifications. Rather than hiding taproot before the activation, we show it in the UI but disable the choice.

I also made sure that we don't show taproot and segwit options for shitcoin not supporting it.

![image](https://user-images.githubusercontent.com/3020646/131964482-10d051dd-b38e-41de-b585-2b12a4cac7c1.png)
