### PR TITLE
Fix for crowdfund perk editor

### DIFF
--- a/BTCPayServer/Views/Apps/TemplateEditor.cshtml
+++ b/BTCPayServer/Views/Apps/TemplateEditor.cshtml
@@ -340,8 +340,9 @@ document.addEventListener("DOMContentLoaded", function () {
                 return this.errors.length === 0;
             },
             saveEditingItem: function(){
-                if(!this.editingItem.id){
-                    this.editingItem.id = this.editingItem.title.toLowerCase().trim();
+                const fallbackId = this.editingItem.title.toLowerCase().trim();
+                if(!this.editingItem.id && fallbackId){
+                    this.editingItem.id = fallbackId;
                     this.$nextTick(this.saveEditingItem.bind(this));
                     return;
                 }


### PR DESCRIPTION
With no title entered, the editor got stuck in an endless loop, because it recursively invoked the save function without checking for the ID fallback being present.

Fixes #2862.