### PR TITLE
Improve public LN node info 

### DIFF
--- a/BTCPayServer/Controllers/PublicLightningNodeInfoController.cs
+++ b/BTCPayServer/Controllers/PublicLightningNodeInfoController.cs
@@ -46,7 +46,7 @@ namespace BTCPayServer.Controllers
                 return View(new ShowLightningNodeInfoViewModel
                 {
                     Available = true,
-                    NodeInfo = nodeInfo,
+                    NodeInfo = nodeInfo.Select(n => new ShowLightningNodeInfoViewModel.NodeData(n)).ToArray(),
                     CryptoCode = cryptoCode,
                     CryptoImage = GetImage(paymentMethodDetails.PaymentId, network),
                     StoreName = store.StoreName
@@ -82,9 +82,26 @@ namespace BTCPayServer.Controllers
         }
     }
 
+
     public class ShowLightningNodeInfoViewModel
     {
-        public NodeInfo[] NodeInfo { get; set; }
+        public class NodeData
+        {
+            string _connection;
+            public NodeData(NodeInfo nodeInfo)
+            {
+                _connection = nodeInfo.ToString();
+                Id = $"{nodeInfo.Host}-{nodeInfo.Port}".Replace(".", "-", StringComparison.OrdinalIgnoreCase);
+                IsTor = nodeInfo.IsTor;
+            }
+            public string Id { get; }
+            public bool IsTor { get; }
+            public override string ToString()
+            {
+                return _connection;
+            }
+        }
+        public NodeData[] NodeInfo { get; set; }
         public bool Available { get; set; }
         public string CryptoCode { get; set; }
         public string CryptoImage { get; set; }

--- a/BTCPayServer/Controllers/PublicLightningNodeInfoController.cs
+++ b/BTCPayServer/Controllers/PublicLightningNodeInfoController.cs
@@ -55,7 +55,12 @@ namespace BTCPayServer.Controllers
             }
             catch (Exception)
             {
-                return View(new ShowLightningNodeInfoViewModel { Available = false, CryptoCode = cryptoCode });
+                return View(new ShowLightningNodeInfoViewModel
+                {
+                    Available = false, 
+                    CryptoCode = cryptoCode,
+                    StoreName = store.StoreName
+                });
             }
         }
 

--- a/BTCPayServer/Controllers/PublicLightningNodeInfoController.cs
+++ b/BTCPayServer/Controllers/PublicLightningNodeInfoController.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using BTCPayServer.Data;
 using BTCPayServer.Filters;
+using BTCPayServer.Lightning;
 using BTCPayServer.Payments;
 using BTCPayServer.Payments.Lightning;
 using BTCPayServer.Services.Stores;
@@ -40,14 +41,12 @@ namespace BTCPayServer.Controllers
             {
                 var paymentMethodDetails = GetExistingLightningSupportedPaymentMethod(cryptoCode, store);
                 var network = _BtcPayNetworkProvider.GetNetwork<BTCPayNetwork>(cryptoCode);
-                var nodeInfo =
-                    await _LightningLikePaymentHandler.GetNodeInfo(Request.IsOnion(), paymentMethodDetails,
-                        network);
+                var nodeInfo = await _LightningLikePaymentHandler.GetNodeInfo(paymentMethodDetails, network);
 
                 return View(new ShowLightningNodeInfoViewModel
                 {
                     Available = true,
-                    NodeInfo = nodeInfo.ToString(),
+                    NodeInfo = nodeInfo,
                     CryptoCode = cryptoCode,
                     CryptoImage = GetImage(paymentMethodDetails.PaymentId, network),
                     StoreName = store.StoreName
@@ -85,7 +84,7 @@ namespace BTCPayServer.Controllers
 
     public class ShowLightningNodeInfoViewModel
     {
-        public string NodeInfo { get; set; }
+        public NodeInfo[] NodeInfo { get; set; }
         public bool Available { get; set; }
         public string CryptoCode { get; set; }
         public string CryptoImage { get; set; }

--- a/BTCPayServer/Controllers/StoresController.LightningLike.cs
+++ b/BTCPayServer/Controllers/StoresController.LightningLike.cs
@@ -109,7 +109,7 @@ namespace BTCPayServer.Controllers
                     var handler = _ServiceProvider.GetRequiredService<LightningLikePaymentHandler>();
                     try
                     {
-                        var info = await handler.GetNodeInfo(paymentMethod, network);
+                        var info = await handler.GetNodeInfo(paymentMethod, network, Request.IsOnion());
                         if (!vm.SkipPortTest)
                         {
                             using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(20));

--- a/BTCPayServer/Controllers/StoresController.LightningLike.cs
+++ b/BTCPayServer/Controllers/StoresController.LightningLike.cs
@@ -109,13 +109,13 @@ namespace BTCPayServer.Controllers
                     var handler = _ServiceProvider.GetRequiredService<LightningLikePaymentHandler>();
                     try
                     {
-                        var info = await handler.GetNodeInfo(Request.IsOnion(), paymentMethod, network);
+                        var info = await handler.GetNodeInfo(paymentMethod, network);
                         if (!vm.SkipPortTest)
                         {
                             using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(20));
-                            await handler.TestConnection(info, cts.Token);
+                            await handler.TestConnection(info.First(), cts.Token);
                         }
-                        TempData[WellKnownTempData.SuccessMessage] = $"Connection to the Lightning node successful. Your node address: {info}";
+                        TempData[WellKnownTempData.SuccessMessage] = $"Connection to the Lightning node successful. Your node address: {info.First()}";
                     }
                     catch (Exception ex)
                     {

--- a/BTCPayServer/Payments/Lightning/LightningLikePaymentHandler.cs
+++ b/BTCPayServer/Payments/Lightning/LightningLikePaymentHandler.cs
@@ -135,7 +135,8 @@ namespace BTCPayServer.Payments.Lightning
                 }
                 catch (Exception ex)
                 {
-                    throw new PaymentMethodUnavailableException($"Error while connecting to the API ({ex.Message})");
+                    throw new PaymentMethodUnavailableException($"Error while connecting to the API: {ex.Message}" + 
+                                                                (!string.IsNullOrEmpty(ex.InnerException?.Message) ? $" ({ex.InnerException.Message})" : "")));
                 }
 
                 var nodeInfo = preferOnion != null && info.NodeInfoList.Any(i => i.IsTor == preferOnion)

--- a/BTCPayServer/Payments/Lightning/LightningLikePaymentHandler.cs
+++ b/BTCPayServer/Payments/Lightning/LightningLikePaymentHandler.cs
@@ -68,6 +68,8 @@ namespace BTCPayServer.Payments.Lightning
             }
             //direct casting to (BTCPayNetwork) is fixed in other pull requests with better generic interfacing for handlers
             var storeBlob = store.GetStoreBlob();
+            var test = GetNodeInfo(supportedPaymentMethod, network, paymentMethod.PreferOnion);
+            
             var invoice = paymentMethod.ParentEntity;
             decimal due = Extensions.RoundUp(invoice.Price / paymentMethod.Rate, network.Divisibility);
             try
@@ -106,7 +108,8 @@ namespace BTCPayServer.Payments.Lightning
                     throw new PaymentMethodUnavailableException($"Impossible to create lightning invoice ({ex.Message})", ex);
                 }
             }
-            var nodeInfo = await GetNodeInfo(supportedPaymentMethod, network, paymentMethod.PreferOnion);
+
+            var nodeInfo = await test;
             return new LightningLikePaymentMethodDetails
             {
                 Activated = true,

--- a/BTCPayServer/Payments/Lightning/LightningLikePaymentHandler.cs
+++ b/BTCPayServer/Payments/Lightning/LightningLikePaymentHandler.cs
@@ -112,7 +112,7 @@ namespace BTCPayServer.Payments.Lightning
                 Activated = true,
                 BOLT11 = lightningInvoice.BOLT11,
                 InvoiceId = lightningInvoice.Id,
-                NodeInfo = nodeInfo.FirstOrDefault()?.ToString()
+                NodeInfo = nodeInfo.First().ToString()
             };
         }
 

--- a/BTCPayServer/Payments/Lightning/LightningLikePaymentHandler.cs
+++ b/BTCPayServer/Payments/Lightning/LightningLikePaymentHandler.cs
@@ -140,7 +140,7 @@ namespace BTCPayServer.Payments.Lightning
                 }
 
                 var nodeInfo = preferOnion != null && info.NodeInfoList.Any(i => i.IsTor == preferOnion)
-                    ? info.NodeInfoList.Where(i => i.IsTor == preferOnion).ToArray()
+                    ? info.NodeInfoList.Where(i => i.IsTor == preferOnion.Value).ToArray()
                     : info.NodeInfoList.Select(i => i).ToArray();
                 
                 if (!nodeInfo.Any())

--- a/BTCPayServer/Payments/Lightning/LightningLikePaymentHandler.cs
+++ b/BTCPayServer/Payments/Lightning/LightningLikePaymentHandler.cs
@@ -136,7 +136,7 @@ namespace BTCPayServer.Payments.Lightning
                 catch (Exception ex)
                 {
                     throw new PaymentMethodUnavailableException($"Error while connecting to the API: {ex.Message}" + 
-                                                                (!string.IsNullOrEmpty(ex.InnerException?.Message) ? $" ({ex.InnerException.Message})" : "")));
+                                                                (!string.IsNullOrEmpty(ex.InnerException?.Message) ? $" ({ex.InnerException.Message})" : ""));
                 }
 
                 var nodeInfo = preferOnion != null && info.NodeInfoList.Any(i => i.IsTor == preferOnion)

--- a/BTCPayServer/Views/PublicLightningNodeInfo/ShowLightningNodeInfo.cshtml
+++ b/BTCPayServer/Views/PublicLightningNodeInfo/ShowLightningNodeInfo.cshtml
@@ -2,10 +2,16 @@
 @inject ISettingsRepository _settingsRepository
 
 @using BTCPayServer.Abstractions.Contracts
+@using BTCPayServer.Lightning
 @model BTCPayServer.Controllers.ShowLightningNodeInfoViewModel
 @{
     Layout = null;
     var theme = await _settingsRepository.GetTheme();
+    var nodeInfoList = Model.NodeInfo.Select((value, i) => (value, i)).ToArray();
+    string NodeInfoId(NodeInfo nodeInfo)
+    {
+        return $"{nodeInfo.Host}-{nodeInfo.Port}";
+    }
 }
 <!DOCTYPE html>
 <html>
@@ -28,7 +34,7 @@
                 <div class="card border-0">
                     <div class="card-body p-4">
                         <h1 class="card-title text-center">@Model.StoreName</h1>
-                        <h2 class="card-subtitle text-center text-secondary mb-2">
+                        <h2 class="card-subtitle text-center text-secondary my-3">
                             <span>@Model.CryptoCode</span>
                             Lightning Node
                         </h2>
@@ -42,13 +48,31 @@
                         </h3>
                         @if (Model.Available)
                         {
-                            <div class="qr-container my-3">
-                                <img  alt="@Model.CryptoCode" class="qr-icon" src="@Model.CryptoImage" />
-                                <vc:qr-code data="@Model.NodeInfo"> </vc:qr-code>
-                            </div>
-                            <div class="input-group  d-flex" data-clipboard="@Model.NodeInfo">
-                                <input type="text" class="form-control" style="cursor: copy" readonly="readonly" value="@Model.NodeInfo" id="peer-info"/>
-                                <button type="button" class="btn btn-outline-secondary" data-clipboard-confirm>Copy node info</button>
+                            @if (Model.NodeInfo.Length > 1)
+                            {
+                                <ul class="nav nav-pills justify-content-center mt-4" id="nodeInfo-tab" role="tablist">
+                                    @foreach (var (nodeInfo, index) in nodeInfoList)
+                                    {
+                                        <li class="nav-item" role="presentation">
+                                            <button class="nav-link w-100px @(index == 0 ? "active" : "")" id="nodeInfo-tab-@NodeInfoId(nodeInfo)" data-bs-toggle="pill" data-bs-target="#nodeInfo-@NodeInfoId(nodeInfo)" type="button" role="tab" aria-controls="nodeInfo-@NodeInfoId(nodeInfo)" aria-selected="true">@(nodeInfo.IsTor ? "Tor" : "Clearnet")</button>
+                                        </li>
+                                    }
+                                </ul>
+                            }
+                            <div class="tab-content" id="nodeInfo-tabContent">
+                                @foreach (var (nodeInfo, index) in nodeInfoList)
+                                {
+                                    <div class="tab-pane fade @(index == 0 ? "show active" : "")" id="nodeInfo-@NodeInfoId(nodeInfo)" role="tabpanel" aria-labelledby="nodeInfo-tab-@NodeInfoId(nodeInfo)">
+                                        <div class="qr-container my-3">
+                                            <img alt="@Model.CryptoCode" class="qr-icon" src="@Model.CryptoImage"/>
+                                            <vc:qr-code data="@nodeInfo.ToString()"/>
+                                        </div>
+                                        <div class="input-group" data-clipboard="@nodeInfo.ToString()">
+                                            <input type="text" class="form-control" style="cursor:copy" readonly="readonly" value="@nodeInfo.ToString()" id="nodeInfo-addr-@NodeInfoId(nodeInfo)"/>
+                                            <button type="button" class="btn btn-outline-secondary" data-clipboard-confirm>Copy</button>
+                                        </div>
+                                    </div>
+                                }
                             </div>
                         }
                     </div>
@@ -56,6 +80,6 @@
             </div>
         </div>
     </div>
-    <script src="~/js/copy-to-clipboard.js" asp-append-version="true"></script>
+    <partial name="LayoutFoot" />
 </body>
 </html>

--- a/BTCPayServer/Views/PublicLightningNodeInfo/ShowLightningNodeInfo.cshtml
+++ b/BTCPayServer/Views/PublicLightningNodeInfo/ShowLightningNodeInfo.cshtml
@@ -10,7 +10,7 @@
     var nodeInfoList = Model.NodeInfo.Select((value, i) => (value, i)).ToArray();
     string NodeInfoId(NodeInfo nodeInfo)
     {
-        return $"{nodeInfo.Host}-{nodeInfo.Port}";
+        return $"{nodeInfo.Host}-{nodeInfo.Port}".Replace(".", "-");
     }
 }
 <!DOCTYPE html>

--- a/BTCPayServer/Views/PublicLightningNodeInfo/ShowLightningNodeInfo.cshtml
+++ b/BTCPayServer/Views/PublicLightningNodeInfo/ShowLightningNodeInfo.cshtml
@@ -7,7 +7,6 @@
 @{
     Layout = null;
     var theme = await _settingsRepository.GetTheme();
-    var nodeInfoList = Model.NodeInfo.Select((value, i) => (value, i)).ToArray();
     string NodeInfoId(NodeInfo nodeInfo)
     {
         return $"{nodeInfo.Host}-{nodeInfo.Port}".Replace(".", "-");
@@ -51,18 +50,18 @@
                             @if (Model.NodeInfo.Length > 1)
                             {
                                 <ul class="nav nav-pills justify-content-center mt-4" id="nodeInfo-tab" role="tablist">
-                                    @foreach (var (nodeInfo, index) in nodeInfoList)
+                                    @foreach (var nodeInfo in Model.NodeInfo)
                                     {
                                         <li class="nav-item" role="presentation">
-                                            <button class="nav-link w-100px @(index == 0 ? "active" : "")" id="nodeInfo-tab-@NodeInfoId(nodeInfo)" data-bs-toggle="pill" data-bs-target="#nodeInfo-@NodeInfoId(nodeInfo)" type="button" role="tab" aria-controls="nodeInfo-@NodeInfoId(nodeInfo)" aria-selected="true">@(nodeInfo.IsTor ? "Tor" : "Clearnet")</button>
+                                            <button class="nav-link w-100px @(nodeInfo == Model.NodeInfo.First() ? "active" : "")" id="nodeInfo-tab-@NodeInfoId(nodeInfo)" data-bs-toggle="pill" data-bs-target="#nodeInfo-@NodeInfoId(nodeInfo)" type="button" role="tab" aria-controls="nodeInfo-@NodeInfoId(nodeInfo)" aria-selected="true">@(nodeInfo.IsTor ? "Tor" : "Clearnet")</button>
                                         </li>
                                     }
                                 </ul>
                             }
                             <div class="tab-content" id="nodeInfo-tabContent">
-                                @foreach (var (nodeInfo, index) in nodeInfoList)
+                                @foreach (var nodeInfo in Model.NodeInfo)
                                 {
-                                    <div class="tab-pane fade @(index == 0 ? "show active" : "")" id="nodeInfo-@NodeInfoId(nodeInfo)" role="tabpanel" aria-labelledby="nodeInfo-tab-@NodeInfoId(nodeInfo)">
+                                    <div class="tab-pane fade @(nodeInfo == Model.NodeInfo.First() ? "show active" : "")" id="nodeInfo-@NodeInfoId(nodeInfo)" role="tabpanel" aria-labelledby="nodeInfo-tab-@NodeInfoId(nodeInfo)">
                                         <div class="qr-container my-3">
                                             <img alt="@Model.CryptoCode" class="qr-icon" src="@Model.CryptoImage"/>
                                             <vc:qr-code data="@nodeInfo.ToString()"/>

--- a/BTCPayServer/Views/PublicLightningNodeInfo/ShowLightningNodeInfo.cshtml
+++ b/BTCPayServer/Views/PublicLightningNodeInfo/ShowLightningNodeInfo.cshtml
@@ -1,4 +1,4 @@
-﻿@addTagHelper *, BundlerMinifier.TagHelpers
+@addTagHelper *, BundlerMinifier.TagHelpers
 @inject ISettingsRepository _settingsRepository
 
 @using BTCPayServer.Abstractions.Contracts
@@ -7,10 +7,6 @@
 @{
     Layout = null;
     var theme = await _settingsRepository.GetTheme();
-    string NodeInfoId(NodeInfo nodeInfo)
-    {
-        return $"{nodeInfo.Host}-{nodeInfo.Port}".Replace(".", "-");
-    }
 }
 <!DOCTYPE html>
 <html>
@@ -50,24 +46,26 @@
                             @if (Model.NodeInfo.Length > 1)
                             {
                                 <ul class="nav nav-pills justify-content-center mt-4" id="nodeInfo-tab" role="tablist">
-                                    @foreach (var nodeInfo in Model.NodeInfo)
+                                    @for (int i = 0; i < Model.NodeInfo.Length; i++)
                                     {
+                                        var nodeInfo = Model.NodeInfo[i];
                                         <li class="nav-item" role="presentation">
-                                            <button class="nav-link w-100px @(nodeInfo == Model.NodeInfo.First() ? "active" : "")" id="nodeInfo-tab-@NodeInfoId(nodeInfo)" data-bs-toggle="pill" data-bs-target="#nodeInfo-@NodeInfoId(nodeInfo)" type="button" role="tab" aria-controls="nodeInfo-@NodeInfoId(nodeInfo)" aria-selected="true">@(nodeInfo.IsTor ? "Tor" : "Clearnet")</button>
+                                            <button class="nav-link w-100px @(i == 0 ? "active" : "")" id="nodeInfo-tab-@nodeInfo.Id" data-bs-toggle="pill" data-bs-target="#nodeInfo-@nodeInfo.Id" type="button" role="tab" aria-controls="nodeInfo-@nodeInfo.Id" aria-selected="true">@(Model.NodeInfo[i].IsTor ? "Tor" : "Clearnet")</button>
                                         </li>
                                     }
                                 </ul>
                             }
                             <div class="tab-content" id="nodeInfo-tabContent">
-                                @foreach (var nodeInfo in Model.NodeInfo)
+                                @for (int i = 0; i < Model.NodeInfo.Length; i++)
                                 {
-                                    <div class="tab-pane fade @(nodeInfo == Model.NodeInfo.First() ? "show active" : "")" id="nodeInfo-@NodeInfoId(nodeInfo)" role="tabpanel" aria-labelledby="nodeInfo-tab-@NodeInfoId(nodeInfo)">
+                                    var nodeInfo = Model.NodeInfo[i];
+                                    <div class="tab-pane fade @(i == 0 ? "show active" : "")" id="nodeInfo-@nodeInfo.Id" role="tabpanel" aria-labelledby="nodeInfo-tab-@nodeInfo.Id">
                                         <div class="qr-container my-3">
                                             <img alt="@Model.CryptoCode" class="qr-icon" src="@Model.CryptoImage"/>
                                             <vc:qr-code data="@nodeInfo.ToString()"/>
                                         </div>
                                         <div class="input-group" data-clipboard="@nodeInfo.ToString()">
-                                            <input type="text" class="form-control" style="cursor:copy" readonly="readonly" value="@nodeInfo.ToString()" id="nodeInfo-addr-@NodeInfoId(nodeInfo)"/>
+                                            <input type="text" class="form-control" style="cursor:copy" readonly="readonly" value="@nodeInfo.ToString()" id="nodeInfo-addr-@nodeInfo.Id"/>
                                             <button type="button" class="btn btn-outline-secondary" data-clipboard-confirm>Copy</button>
                                         </div>
                                     </div>


### PR DESCRIPTION
Allows to view clearnet and Tor connection info side by side.

![lninfo](https://user-images.githubusercontent.com/886/133116126-7ca8481b-fa85-4e78-85db-7d25a86e6ee0.png)

Also displays the store name in case the LN node is unavailable.