### PR TITLE
Use offcanvas nav for mobile

### DIFF
--- a/BTCPayServer/Views/Shared/_Layout.cshtml
+++ b/BTCPayServer/Views/Shared/_Layout.cshtml
@@ -51,69 +51,71 @@
         <div class="container">
             @* Logo on Mobile *@
             @{ await Logo("d-lg-none"); }
-            <button class="navbar-toggler navbar-toggler-right border-0 shadow-none" type="button" data-bs-toggle="offcanvas" data-bs-target="#navbarResponsive" aria-controls="navbarResponsive" aria-expanded="false" aria-label="Toggle navigation">
+            <button class="navbar-toggler navbar-toggler-right border-0 shadow-none p-2" type="button" data-bs-toggle="offcanvas" data-bs-target="#navbarResponsive" aria-controls="navbarResponsive" aria-expanded="false" aria-label="Toggle navigation">
                 <svg class="navbar-toggler-icon" viewBox="0 0 30 30" xmlns="http://www.w3.org/2000/svg"><path stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-miterlimit="10" d="M4 7h22M4 15h22M4 23h22"/></svg>
             </button>
-            <div id="navbarResponsive" class="offcanvas offcanvas-start border-0">
-                <div class="offcanvas-header">
-                    <div class="offcanvas-title" id="offcanvasLabel">
-                        @* Logo in Offcanvas *@
-                        @{ await Logo(); }
+            <div id="navbarResponsive" class="offcanvas offcanvas-fade border-0" data-bs-scroll="true" tabindex="-1">
+                <div class="container">
+                    <div class="offcanvas-header">
+                        <div class="offcanvas-title" id="offcanvasLabel">
+                            @* Logo in Offcanvas *@
+                            @{ await Logo(); }
+                        </div>
+                        <button type="button" class="btn-close shadow-none m-0" data-bs-dismiss="offcanvas" aria-label="Close" style="padding:.8125rem;">
+                            <vc:icon symbol="close"/>
+                        </button>
                     </div>
-                    <button type="button" class="btn-close shadow-none me-1" data-bs-dismiss="offcanvas" aria-label="Close">
-                        <vc:icon symbol="close" />
-                    </button>
-                </div>
-                <div class="offcanvas-body d-lg-flex w-100 align-items-center justify-content-between">
-                    @* Logo on Desktop *@
-                    @{ await Logo("d-none d-lg-inline-block"); }
-                    @if (SignInManager.IsSignedIn(User))
-                    {
-                        <ul class="navbar-nav">
-                            @if (User.IsInRole(Roles.ServerAdmin))
-                            {
-                                <li class="nav-item"><a asp-area="" asp-controller="Server" asp-action="ListUsers" class="nav-link js-scroll-trigger @ViewData.IsActiveCategory(typeof(ServerNavPages))" id="ServerSettings">Server settings</a></li>
-                            }
-                            <li class="nav-item"><a asp-area="" asp-controller="UserStores" asp-action="ListStores" class="nav-link js-scroll-trigger @ViewData.IsActiveCategory(typeof(StoreNavPages))" id="Stores">Stores</a></li>
-                            <li class="nav-item"><a asp-area="" asp-controller="Apps" asp-action="ListApps" class="nav-link js-scroll-trigger @ViewData.IsActiveCategory(typeof(AppsNavPages))" id="Apps">Apps</a></li>
-                            <li class="nav-item"><a asp-area="" asp-controller="Wallets" asp-action="ListWallets" class="nav-link js-scroll-trigger @ViewData.IsActiveCategory(typeof(WalletsNavPages))" id="Wallets">Wallets</a></li>
-                            <li class="nav-item"><a asp-area="" asp-controller="Invoice" asp-action="ListInvoices" class="nav-link js-scroll-trigger @ViewData.IsActiveCategory(typeof(InvoiceNavPages))" id="Invoices">Invoices</a></li>
-                            <li class="nav-item"><a asp-area="" asp-controller="PaymentRequest" asp-action="GetPaymentRequests" class="nav-link js-scroll-trigger @ViewData.IsActiveCategory(typeof(PaymentRequestsNavPages))" id="PaymentRequests">Payment Requests</a></li>
-                            <vc:ui-extension-point location="header-nav"/>
-                        </ul>
-                        <ul class="navbar-nav">
-                            <li class="nav-item">
-                                <a asp-area="" asp-controller="Manage" asp-action="Index" title="My settings" class="nav-link js-scroll-trigger @ViewData.IsActiveCategory(typeof(ManageNavPages))" id="MySettings"><span class="d-lg-none d-sm-block">Account</span><i class="fa fa-user d-lg-inline-block d-none"></i></a>
-                            </li>
-                            <vc:notifications-dropdown/>
-                            @if (!theme.CustomTheme)
-                            {
+                    <div class="offcanvas-body d-lg-flex w-100 align-items-center justify-content-between">
+                        @* Logo on Desktop *@
+                        @{ await Logo("d-none d-lg-inline-block"); }
+                        @if (SignInManager.IsSignedIn(User))
+                        {
+                            <ul class="navbar-nav">
+                                @if (User.IsInRole(Roles.ServerAdmin))
+                                {
+                                    <li class="nav-item"><a asp-area="" asp-controller="Server" asp-action="ListUsers" class="nav-link js-scroll-trigger @ViewData.IsActiveCategory(typeof(ServerNavPages))" id="ServerSettings">Server settings</a></li>
+                                }
+                                <li class="nav-item"><a asp-area="" asp-controller="UserStores" asp-action="ListStores" class="nav-link js-scroll-trigger @ViewData.IsActiveCategory(typeof(StoreNavPages))" id="Stores">Stores</a></li>
+                                <li class="nav-item"><a asp-area="" asp-controller="Apps" asp-action="ListApps" class="nav-link js-scroll-trigger @ViewData.IsActiveCategory(typeof(AppsNavPages))" id="Apps">Apps</a></li>
+                                <li class="nav-item"><a asp-area="" asp-controller="Wallets" asp-action="ListWallets" class="nav-link js-scroll-trigger @ViewData.IsActiveCategory(typeof(WalletsNavPages))" id="Wallets">Wallets</a></li>
+                                <li class="nav-item"><a asp-area="" asp-controller="Invoice" asp-action="ListInvoices" class="nav-link js-scroll-trigger @ViewData.IsActiveCategory(typeof(InvoiceNavPages))" id="Invoices">Invoices</a></li>
+                                <li class="nav-item"><a asp-area="" asp-controller="PaymentRequest" asp-action="GetPaymentRequests" class="nav-link js-scroll-trigger @ViewData.IsActiveCategory(typeof(PaymentRequestsNavPages))" id="PaymentRequests">Payment Requests</a></li>
+                                <vc:ui-extension-point location="header-nav"/>
+                            </ul>
+                            <ul class="navbar-nav">
                                 <li class="nav-item">
-                                    <button class="btcpay-theme-switch nav-link">
-                                        <span class="d-lg-none d-sm-block"><span class="btcpay-theme-switch-dark">Dark theme</span><span class="btcpay-theme-switch-light">Light theme</span></span>
-                                        <svg class="d-lg-inline-block d-none" xmlns="http://www.w3.org/2000/svg" width="10" height="10" viewBox="0 0 10 10">
-                                            <path class="btcpay-theme-switch-dark" transform="translate(1 1)" d="M2.72 0A3.988 3.988 0 000 3.78c0 2.21 1.79 4 4 4 1.76 0 3.25-1.14 3.78-2.72-.4.13-.83.22-1.28.22-2.21 0-4-1.79-4-4 0-.45.08-.88.22-1.28z"/>
-                                            <path class="btcpay-theme-switch-light" transform="translate(1 1)" d="M4 0c-.28 0-.5.22-.5.5s.22.5.5.5.5-.22.5-.5S4.28 0 4 0zM1.5 1c-.28 0-.5.22-.5.5s.22.5.5.5.5-.22.5-.5-.22-.5-.5-.5zm5 0c-.28 0-.5.22-.5.5s.22.5.5.5.5-.22.5-.5-.22-.5-.5-.5zM4 2c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zM.5 3.5c-.28 0-.5.22-.5.5s.22.5.5.5.5-.22.5-.5-.22-.5-.5-.5zm7 0c-.28 0-.5.22-.5.5s.22.5.5.5.5-.22.5-.5-.22-.5-.5-.5zM1.5 6c-.28 0-.5.22-.5.5s.22.5.5.5.5-.22.5-.5-.22-.5-.5-.5zm5 0c-.28 0-.5.22-.5.5s.22.5.5.5.5-.22.5-.5-.22-.5-.5-.5zM4 7c-.28 0-.5.22-.5.5s.22.5.5.5.5-.22.5-.5S4.28 7 4 7z"/>
-                                        </svg>
-                                    </button>
+                                    <a asp-area="" asp-controller="Manage" asp-action="Index" title="My settings" class="nav-link js-scroll-trigger @ViewData.IsActiveCategory(typeof(ManageNavPages))" id="MySettings"><span class="d-lg-none d-sm-block">Account</span><i class="fa fa-user d-lg-inline-block d-none"></i></a>
                                 </li>
-                            }
-                            <li class="nav-item">
-                                <a asp-area="" asp-controller="Account" asp- asp-action="Logout" title="Logout" class="nav-link js-scroll-trigger" id="Logout"><span class="d-lg-none d-sm-block">Logout</span><i class="fa fa-sign-out d-lg-inline-block d-none"></i></a>
-                            </li>
-                        </ul>
-                    }
-                    else if (Env.IsSecure)
-                    {
-                        <ul class="navbar-nav">
-                            @if (!(await SettingsRepository.GetPolicies()).LockSubscription)
-                            {
-                                <li class="nav-item"><a asp-area="" asp-controller="Account" asp-action="Register" class="nav-link js-scroll-trigger" id="Register">Register</a></li>
-                            }
-                            <li class="nav-item"><a asp-area="" asp-controller="Account" asp-action="Login" class="nav-link js-scroll-trigger" id="Login">Log in</a></li>
-                            <vc:ui-extension-point location="header-nav"/>
-                        </ul>
-                    }
+                                <vc:notifications-dropdown/>
+                                @if (!theme.CustomTheme)
+                                {
+                                    <li class="nav-item">
+                                        <button class="btcpay-theme-switch nav-link">
+                                            <span class="d-lg-none d-sm-block"><span class="btcpay-theme-switch-dark">Dark theme</span><span class="btcpay-theme-switch-light">Light theme</span></span>
+                                            <svg class="d-lg-inline-block d-none" xmlns="http://www.w3.org/2000/svg" width="10" height="10" viewBox="0 0 10 10">
+                                                <path class="btcpay-theme-switch-dark" transform="translate(1 1)" d="M2.72 0A3.988 3.988 0 000 3.78c0 2.21 1.79 4 4 4 1.76 0 3.25-1.14 3.78-2.72-.4.13-.83.22-1.28.22-2.21 0-4-1.79-4-4 0-.45.08-.88.22-1.28z"/>
+                                                <path class="btcpay-theme-switch-light" transform="translate(1 1)" d="M4 0c-.28 0-.5.22-.5.5s.22.5.5.5.5-.22.5-.5S4.28 0 4 0zM1.5 1c-.28 0-.5.22-.5.5s.22.5.5.5.5-.22.5-.5-.22-.5-.5-.5zm5 0c-.28 0-.5.22-.5.5s.22.5.5.5.5-.22.5-.5-.22-.5-.5-.5zM4 2c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zM.5 3.5c-.28 0-.5.22-.5.5s.22.5.5.5.5-.22.5-.5-.22-.5-.5-.5zm7 0c-.28 0-.5.22-.5.5s.22.5.5.5.5-.22.5-.5-.22-.5-.5-.5zM1.5 6c-.28 0-.5.22-.5.5s.22.5.5.5.5-.22.5-.5-.22-.5-.5-.5zm5 0c-.28 0-.5.22-.5.5s.22.5.5.5.5-.22.5-.5-.22-.5-.5-.5zM4 7c-.28 0-.5.22-.5.5s.22.5.5.5.5-.22.5-.5S4.28 7 4 7z"/>
+                                            </svg>
+                                        </button>
+                                    </li>
+                                }
+                                <li class="nav-item">
+                                    <a asp-area="" asp-controller="Account" asp- asp-action="Logout" title="Logout" class="nav-link js-scroll-trigger" id="Logout"><span class="d-lg-none d-sm-block">Logout</span><i class="fa fa-sign-out d-lg-inline-block d-none"></i></a>
+                                </li>
+                            </ul>
+                        }
+                        else if (Env.IsSecure)
+                        {
+                            <ul class="navbar-nav">
+                                @if (!(await SettingsRepository.GetPolicies()).LockSubscription)
+                                {
+                                    <li class="nav-item"><a asp-area="" asp-controller="Account" asp-action="Register" class="nav-link js-scroll-trigger" id="Register">Register</a></li>
+                                }
+                                <li class="nav-item"><a asp-area="" asp-controller="Account" asp-action="Login" class="nav-link js-scroll-trigger" id="Login">Log in</a></li>
+                                <vc:ui-extension-point location="header-nav"/>
+                            </ul>
+                        }
+                    </div>
                 </div>
             </div>
             <div id="badUrl" class="alert alert-danger alert-dismissible" style="display:none; position:absolute; top:75px;" role="alert">

--- a/BTCPayServer/Views/Shared/_Layout.cshtml
+++ b/BTCPayServer/Views/Shared/_Layout.cshtml
@@ -18,6 +18,20 @@
     var theme = await SettingsRepository.GetTheme();
 }
 
+@functions {
+    // The .NET function for inserting classes requires this to be async
+    private async Task Logo(string classes = "")
+    {
+        <a href="~/" class="navbar-brand py-2 js-scroll-trigger @classes">
+            <svg class="logo" viewBox="0 0 192 84" xmlns="http://www.w3.org/2000/svg"><g><path d="M5.206 83.433a4.86 4.86 0 01-4.859-4.861V5.431a4.86 4.86 0 119.719 0v73.141a4.861 4.861 0 01-4.86 4.861" fill="#CEDC21" class="logo-brand-light"/><path d="M5.209 83.433a4.862 4.862 0 01-2.086-9.253L32.43 60.274 2.323 38.093a4.861 4.861 0 015.766-7.826l36.647 26.999a4.864 4.864 0 01-.799 8.306L7.289 82.964a4.866 4.866 0 01-2.08.469" fill="#51B13E" class="logo-brand-medium"/><path d="M5.211 54.684a4.86 4.86 0 01-2.887-8.774L32.43 23.73 3.123 9.821a4.861 4.861 0 014.166-8.784l36.648 17.394a4.86 4.86 0 01.799 8.305l-36.647 27a4.844 4.844 0 01-2.878.948" fill="#CEDC21" class="logo-brand-light"/><path d="M10.066 31.725v20.553L24.01 42.006z" fill="#1E7A44" class="logo-brand-dark"/><path d="M10.066 5.431A4.861 4.861 0 005.206.57 4.86 4.86 0 00.347 5.431v61.165h9.72V5.431h-.001z" fill="#CEDC21" class="logo-brand-light"/><path d="M74.355 41.412c3.114.884 4.84 3.704 4.84 7.238 0 5.513-3.368 8.082-7.955 8.082H60.761V27.271h9.259c4.504 0 7.997 2.146 7.997 7.743 0 2.821-1.179 5.43-3.662 6.398m-4.293-.716c3.324 0 6.018-1.179 6.018-5.724 0-4.586-2.776-5.808-6.145-5.808h-7.197v11.531h7.324v.001zm1.052 14.099c3.366 0 6.06-1.768 6.06-6.145 0-4.713-3.072-6.144-6.901-6.144h-7.534v12.288h8.375v.001zM98.893 27.271v1.81h-8.122v27.651h-1.979V29.081h-8.123v-1.81zM112.738 26.85c5.01 0 9.554 2.524 10.987 8.543h-1.895c-1.348-4.923-5.303-6.732-9.134-6.732-6.944 0-10.605 5.681-10.605 13.341 0 8.08 3.661 13.256 10.646 13.256 4.125 0 7.828-1.85 9.26-7.279h1.895c-1.264 6.271-6.229 9.174-11.154 9.174-7.87 0-12.583-5.808-12.583-15.15 0-8.966 4.969-15.153 12.583-15.153M138.709 27.271c5.091 0 8.795 3.326 8.795 9.764 0 6.06-3.704 9.722-8.795 9.722h-7.746v9.976h-1.935V27.271h9.681zm0 17.549c3.745 0 6.816-2.397 6.816-7.827 0-5.429-2.947-7.869-6.816-7.869h-7.746V44.82h7.746zM147.841 56.732v-.255l11.741-29.29h.885l11.615 29.29v.255h-2.062l-3.322-8.501H153.27l-3.324 8.501h-2.105zm12.164-26.052l-6.059 15.697h12.078l-6.019-15.697zM189.551 27.271h2.104v.293l-9.176 16.92v12.248h-2.02V44.484l-9.216-16.961v-.252h2.147l3.997 7.492 4.043 7.786h.04l4.081-7.786z" class="logo-brand-text"/></g></svg>
+            @if (Env.NetworkType != NBitcoin.ChainName.Mainnet)
+            {
+                <span class="badge bg-warning" style="font-size:10px;">@Env.NetworkType.ToString()</span>
+            }
+        </a>
+    }
+}
+
 <!DOCTYPE html>
 <html lang="en"@(Env.IsDeveloping ? " data-devenv" : "")>
 <head>
@@ -34,28 +48,25 @@
     }
     <!-- Navigation -->
     <nav class="navbar navbar-expand-lg fixed-top py-2 @additionalStyle" id="mainNav">
-        <div class="container px-sm-3">
+        <div class="container">
             @* Logo on Mobile *@
-            <a class="navbar-brand py-2 js-scroll-trigger d-lg-none" href="~/">
-                <svg class="logo" viewBox="0 0 192 84" xmlns="http://www.w3.org/2000/svg"><g><path d="M5.206 83.433a4.86 4.86 0 01-4.859-4.861V5.431a4.86 4.86 0 119.719 0v73.141a4.861 4.861 0 01-4.86 4.861" fill="#CEDC21" class="logo-brand-light"/><path d="M5.209 83.433a4.862 4.862 0 01-2.086-9.253L32.43 60.274 2.323 38.093a4.861 4.861 0 015.766-7.826l36.647 26.999a4.864 4.864 0 01-.799 8.306L7.289 82.964a4.866 4.866 0 01-2.08.469" fill="#51B13E" class="logo-brand-medium"/><path d="M5.211 54.684a4.86 4.86 0 01-2.887-8.774L32.43 23.73 3.123 9.821a4.861 4.861 0 014.166-8.784l36.648 17.394a4.86 4.86 0 01.799 8.305l-36.647 27a4.844 4.844 0 01-2.878.948" fill="#CEDC21" class="logo-brand-light"/><path d="M10.066 31.725v20.553L24.01 42.006z" fill="#1E7A44" class="logo-brand-dark"/><path d="M10.066 5.431A4.861 4.861 0 005.206.57 4.86 4.86 0 00.347 5.431v61.165h9.72V5.431h-.001z" fill="#CEDC21" class="logo-brand-light"/><path d="M74.355 41.412c3.114.884 4.84 3.704 4.84 7.238 0 5.513-3.368 8.082-7.955 8.082H60.761V27.271h9.259c4.504 0 7.997 2.146 7.997 7.743 0 2.821-1.179 5.43-3.662 6.398m-4.293-.716c3.324 0 6.018-1.179 6.018-5.724 0-4.586-2.776-5.808-6.145-5.808h-7.197v11.531h7.324v.001zm1.052 14.099c3.366 0 6.06-1.768 6.06-6.145 0-4.713-3.072-6.144-6.901-6.144h-7.534v12.288h8.375v.001zM98.893 27.271v1.81h-8.122v27.651h-1.979V29.081h-8.123v-1.81zM112.738 26.85c5.01 0 9.554 2.524 10.987 8.543h-1.895c-1.348-4.923-5.303-6.732-9.134-6.732-6.944 0-10.605 5.681-10.605 13.341 0 8.08 3.661 13.256 10.646 13.256 4.125 0 7.828-1.85 9.26-7.279h1.895c-1.264 6.271-6.229 9.174-11.154 9.174-7.87 0-12.583-5.808-12.583-15.15 0-8.966 4.969-15.153 12.583-15.153M138.709 27.271c5.091 0 8.795 3.326 8.795 9.764 0 6.06-3.704 9.722-8.795 9.722h-7.746v9.976h-1.935V27.271h9.681zm0 17.549c3.745 0 6.816-2.397 6.816-7.827 0-5.429-2.947-7.869-6.816-7.869h-7.746V44.82h7.746zM147.841 56.732v-.255l11.741-29.29h.885l11.615 29.29v.255h-2.062l-3.322-8.501H153.27l-3.324 8.501h-2.105zm12.164-26.052l-6.059 15.697h12.078l-6.019-15.697zM189.551 27.271h2.104v.293l-9.176 16.92v12.248h-2.02V44.484l-9.216-16.961v-.252h2.147l3.997 7.492 4.043 7.786h.04l4.081-7.786z" class="logo-brand-text"/></g></svg>
-                @if (Env.NetworkType != NBitcoin.ChainName.Mainnet)
-                {
-                    <span class="badge bg-warning" style="font-size:10px;">@Env.NetworkType.ToString()</span>
-                }
-            </a>
-            <button class="navbar-toggler navbar-toggler-right" type="button" data-bs-toggle="collapse" data-bs-target="#navbarResponsive" aria-controls="navbarResponsive" aria-expanded="false" aria-label="Toggle navigation">
+            @{ await Logo("d-lg-none"); }
+            <button class="navbar-toggler navbar-toggler-right border-0 shadow-none" type="button" data-bs-toggle="offcanvas" data-bs-target="#navbarResponsive" aria-controls="navbarResponsive" aria-expanded="false" aria-label="Toggle navigation">
                 <svg class="navbar-toggler-icon" viewBox="0 0 30 30" xmlns="http://www.w3.org/2000/svg"><path stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-miterlimit="10" d="M4 7h22M4 15h22M4 23h22"/></svg>
             </button>
-            <div class="collapse navbar-collapse" id="navbarResponsive">
-                <div class="py-3 py-lg-0 d-lg-flex w-100 align-items-center justify-content-between">
+            <div id="navbarResponsive" class="offcanvas offcanvas-start border-0">
+                <div class="offcanvas-header">
+                    <div class="offcanvas-title" id="offcanvasLabel">
+                        @* Logo in Offcanvas *@
+                        @{ await Logo(); }
+                    </div>
+                    <button type="button" class="btn-close shadow-none me-1" data-bs-dismiss="offcanvas" aria-label="Close">
+                        <vc:icon symbol="close" />
+                    </button>
+                </div>
+                <div class="offcanvas-body d-lg-flex w-100 align-items-center justify-content-between">
                     @* Logo on Desktop *@
-                    <a class="navbar-brand py-2 js-scroll-trigger d-none d-lg-inline-block" href="~/">
-                        <svg class="logo" viewBox="0 0 192 84" xmlns="http://www.w3.org/2000/svg"><g><path d="M5.206 83.433a4.86 4.86 0 01-4.859-4.861V5.431a4.86 4.86 0 119.719 0v73.141a4.861 4.861 0 01-4.86 4.861" fill="#CEDC21" class="logo-brand-light"/><path d="M5.209 83.433a4.862 4.862 0 01-2.086-9.253L32.43 60.274 2.323 38.093a4.861 4.861 0 015.766-7.826l36.647 26.999a4.864 4.864 0 01-.799 8.306L7.289 82.964a4.866 4.866 0 01-2.08.469" fill="#51B13E" class="logo-brand-medium"/><path d="M5.211 54.684a4.86 4.86 0 01-2.887-8.774L32.43 23.73 3.123 9.821a4.861 4.861 0 014.166-8.784l36.648 17.394a4.86 4.86 0 01.799 8.305l-36.647 27a4.844 4.844 0 01-2.878.948" fill="#CEDC21" class="logo-brand-light"/><path d="M10.066 31.725v20.553L24.01 42.006z" fill="#1E7A44" class="logo-brand-dark"/><path d="M10.066 5.431A4.861 4.861 0 005.206.57 4.86 4.86 0 00.347 5.431v61.165h9.72V5.431h-.001z" fill="#CEDC21" class="logo-brand-light"/><path d="M74.355 41.412c3.114.884 4.84 3.704 4.84 7.238 0 5.513-3.368 8.082-7.955 8.082H60.761V27.271h9.259c4.504 0 7.997 2.146 7.997 7.743 0 2.821-1.179 5.43-3.662 6.398m-4.293-.716c3.324 0 6.018-1.179 6.018-5.724 0-4.586-2.776-5.808-6.145-5.808h-7.197v11.531h7.324v.001zm1.052 14.099c3.366 0 6.06-1.768 6.06-6.145 0-4.713-3.072-6.144-6.901-6.144h-7.534v12.288h8.375v.001zM98.893 27.271v1.81h-8.122v27.651h-1.979V29.081h-8.123v-1.81zM112.738 26.85c5.01 0 9.554 2.524 10.987 8.543h-1.895c-1.348-4.923-5.303-6.732-9.134-6.732-6.944 0-10.605 5.681-10.605 13.341 0 8.08 3.661 13.256 10.646 13.256 4.125 0 7.828-1.85 9.26-7.279h1.895c-1.264 6.271-6.229 9.174-11.154 9.174-7.87 0-12.583-5.808-12.583-15.15 0-8.966 4.969-15.153 12.583-15.153M138.709 27.271c5.091 0 8.795 3.326 8.795 9.764 0 6.06-3.704 9.722-8.795 9.722h-7.746v9.976h-1.935V27.271h9.681zm0 17.549c3.745 0 6.816-2.397 6.816-7.827 0-5.429-2.947-7.869-6.816-7.869h-7.746V44.82h7.746zM147.841 56.732v-.255l11.741-29.29h.885l11.615 29.29v.255h-2.062l-3.322-8.501H153.27l-3.324 8.501h-2.105zm12.164-26.052l-6.059 15.697h12.078l-6.019-15.697zM189.551 27.271h2.104v.293l-9.176 16.92v12.248h-2.02V44.484l-9.216-16.961v-.252h2.147l3.997 7.492 4.043 7.786h.04l4.081-7.786z" class="logo-brand-text"/></g></svg>
-                        @if (Env.NetworkType != NBitcoin.ChainName.Mainnet)
-                        {
-                            <span class="badge bg-warning" style="font-size:10px;">@Env.NetworkType.ToString()</span>
-                        }
-                    </a>
+                    @{ await Logo("d-none d-lg-inline-block"); }
                     @if (SignInManager.IsSignedIn(User))
                     {
                         <ul class="navbar-nav">

--- a/BTCPayServer/wwwroot/main/bootstrap/bootstrap.css
+++ b/BTCPayServer/wwwroot/main/bootstrap/bootstrap.css
@@ -6073,7 +6073,7 @@ fieldset:disabled .btn {
   z-index: 1040;
   width: 100vw;
   height: 100vh;
-  background-color: var(--btcpay-black);
+  background-color: var(--btcpay-bg-tile);
 }
 
 .offcanvas-backdrop.fade {
@@ -6081,21 +6081,21 @@ fieldset:disabled .btn {
 }
 
 .offcanvas-backdrop.show {
-  opacity: 0.8;
+  opacity: 1;
 }
 
 .offcanvas-header {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 1rem 1rem;
+  padding: 0.5rem 0;
 }
 
 .offcanvas-header .btn-close {
-  padding: 0.5rem 0.5rem;
-  margin-top: -0.5rem;
-  margin-right: -0.5rem;
-  margin-bottom: -0.5rem;
+  padding: 0.25rem 0;
+  margin-top: -0.25rem;
+  margin-right: 0;
+  margin-bottom: -0.25rem;
 }
 
 .offcanvas-title {
@@ -6105,23 +6105,23 @@ fieldset:disabled .btn {
 
 .offcanvas-body {
   flex-grow: 1;
-  padding: 1rem 1rem;
+  padding: 0.5rem 0;
   overflow-y: auto;
 }
 
 .offcanvas-start {
   top: 0;
   left: 0;
-  width: 400px;
-  border-right: 1px solid var(--btcpay-body-border-medium);
+  width: 100vw;
+  border-right: 0 solid rgba(0, 0, 0, 0.2);
   transform: translateX(-100%);
 }
 
 .offcanvas-end {
   top: 0;
   right: 0;
-  width: 400px;
-  border-left: 1px solid var(--btcpay-body-border-medium);
+  width: 100vw;
+  border-left: 0 solid rgba(0, 0, 0, 0.2);
   transform: translateX(100%);
 }
 
@@ -6129,18 +6129,18 @@ fieldset:disabled .btn {
   top: 0;
   right: 0;
   left: 0;
-  height: 30vh;
+  height: auto;
   max-height: 100%;
-  border-bottom: 1px solid var(--btcpay-body-border-medium);
+  border-bottom: 0 solid rgba(0, 0, 0, 0.2);
   transform: translateY(-100%);
 }
 
 .offcanvas-bottom {
   right: 0;
   left: 0;
-  height: 30vh;
+  height: auto;
   max-height: 100%;
-  border-top: 1px solid var(--btcpay-body-border-medium);
+  border-top: 0 solid rgba(0, 0, 0, 0.2);
   transform: translateY(100%);
 }
 
@@ -9831,12 +9831,16 @@ code {
 
 pre {
   border-radius: var(--btcpay-border-radius);
+}
+
+pre,
+pre code {
   background: var(--btcpay-pre-bg);
 }
 
-pre code {
+pre.text-wrap,
+pre:not(.text-wrap) code {
   padding: var(--btcpay-space-m) !important;
-  background: var(--btcpay-pre-bg);
 }
 
 ol {

--- a/BTCPayServer/wwwroot/main/site.css
+++ b/BTCPayServer/wwwroot/main/site.css
@@ -72,13 +72,6 @@ hr.light {
 }
 
 /* Navigation bar */
-@media (max-width: 991px) {
-    .offcanvas-body {
-        color: var(--btcpay-body-text);
-        background: var(--btcpay-body-bg);
-    }
-}
-
 @media (max-width: 575px) {
     .offcanvas-header,
     .offcanvas-body {
@@ -87,7 +80,35 @@ hr.light {
     }
 }
 
-.offcanvas-header,
+@media (max-width: 991px) {
+    .offcanvas-header {
+        padding-top: 0.75rem;
+        padding-bottom: 0.75rem;
+    }
+}
+
+.offcanvas-fade {
+    top: 0;
+    right: 0;
+    left: 0;
+    bottom: 0;
+    background: none;
+}
+
+.offcanvas-fade .offcanvas-header {
+    background-color: var(--btcpay-header-bg);
+}
+
+.offcanvas-fade .offcanvas-body {
+    opacity: 0;
+    transition: opacity 0.15s linear, transform 0.15s linear;
+}
+
+.offcanvas-fade.show .offcanvas-body {
+    opacity: 1;
+    transform: translate(0, .5rem);
+}
+
 #mainNav {
     color: var(--btcpay-header-text);
     background: var(--btcpay-header-bg);

--- a/BTCPayServer/wwwroot/main/site.css
+++ b/BTCPayServer/wwwroot/main/site.css
@@ -72,10 +72,22 @@ hr.light {
 }
 
 /* Navigation bar */
-#mainNav {
-    background: var(--btcpay-header-bg);
+@media (max-width: 991px) {
+    .offcanvas-body {
+        color: var(--btcpay-body-text);
+        background: var(--btcpay-body-bg);
+    }
 }
 
+@media (max-width: 575px) {
+    .offcanvas-header,
+    .offcanvas-body {
+        padding-left: var(--btcpay-gutter-x, 0.75rem);
+        padding-right: var(--btcpay-gutter-x, 0.75rem);
+    }
+}
+
+.offcanvas-header,
 #mainNav {
     color: var(--btcpay-header-text);
     background: var(--btcpay-header-bg);

--- a/BTCPayServer/wwwroot/main/site.css
+++ b/BTCPayServer/wwwroot/main/site.css
@@ -85,28 +85,28 @@ hr.light {
         padding-top: 0.75rem;
         padding-bottom: 0.75rem;
     }
-}
+    
+    .offcanvas-fade {
+        top: 0;
+        right: 0;
+        left: 0;
+        bottom: 0;
+        background: none;
+    }
 
-.offcanvas-fade {
-    top: 0;
-    right: 0;
-    left: 0;
-    bottom: 0;
-    background: none;
-}
+    .offcanvas-fade .offcanvas-header {
+        background-color: var(--btcpay-header-bg);
+    }
 
-.offcanvas-fade .offcanvas-header {
-    background-color: var(--btcpay-header-bg);
-}
+    .offcanvas-fade .offcanvas-body {
+        opacity: 0;
+        transition: opacity 0.15s linear, transform 0.15s linear;
+    }
 
-.offcanvas-fade .offcanvas-body {
-    opacity: 0;
-    transition: opacity 0.15s linear, transform 0.15s linear;
-}
-
-.offcanvas-fade.show .offcanvas-body {
-    opacity: 1;
-    transform: translate(0, .5rem);
+    .offcanvas-fade.show .offcanvas-body {
+        opacity: 1;
+        transform: translate(0, .5rem);
+    }
 }
 
 #mainNav {


### PR DESCRIPTION
Bootstrap v5 introduced the offcanvas navigation component, which makes for a nicer UX than our current collapsing approach.

![offcanvas](https://user-images.githubusercontent.com/886/133224744-fbe8e565-4b6f-4eea-b4e8-c624460c7626.gif)

I also tried having the topbar present all the time, so that just the navigation menu slides in (underneath the header/topbar), but this doesn't work without duplicating markup and it also behaves weird visually when scaling. So I ended up with this version and I think it works quite nice. 

Feedback welcome!