### PR TITLE
Removes Slack link on Dashboard

### DIFF
--- a/BTCPayServer/Views/Home/Home.cshtml
+++ b/BTCPayServer/Views/Home/Home.cshtml
@@ -115,25 +115,19 @@
     </div>
 
     <div class="row social-row">
-        <div class="col-6 col-md-3 ms-auto text-center">
+        <div class="col-4 col-md-4 ms-auto text-center">
             <a href="https://chat.btcpayserver.org/" target="_blank" rel="noreferrer noopener">
                 <img src="~/img/mattermost.svg" alt="Mattermost" class="social-logo" asp-append-version="true" />
                 <span>On Mattermost</span>
             </a>
         </div>
-        <div class="col-6 col-md-3 ms-auto text-center">
-            <a href="https://slack.btcpayserver.org/" target="_blank" rel="noreferrer noopener">
-                <img src="~/img/slack.svg" alt="Slack" class="social-logo" asp-append-version="true" />
-                <span>On Slack</span>
-            </a>
-        </div>
-        <div class="col-6 col-md-3 me-auto text-center">
+        <div class="col-4 col-md-4 me-auto text-center">
             <a href="https://twitter.com/BtcpayServer" target="_blank" rel="noreferrer noopener">
                 <img src="~/img/twitter.svg" alt="Twitter" class="social-logo" asp-append-version="true" />
                 <span>On Twitter</span>
             </a>
         </div>
-        <div class="col-6 col-md-3 me-auto text-center">
+        <div class="col-4 col-md-4 me-auto text-center">
             <a href="https://github.com/btcpayserver/btcpayserver" target="_blank" rel="noreferrer noopener">
                 <img src="~/img/github.svg" alt="Github" class="social-logo" asp-append-version="true" />
                 <span>On Github</span>


### PR DESCRIPTION
Addresses https://github.com/btcpayserver/btcpayserver/issues/2883.

Considering we're eventually going to overhaul this section completely in the coming weeks, kept it simple with a 4/4/4 column on both desktop and mobile.

Screenshots below.

<img width="493" alt="Screen Shot 2021-09-15 at 2 27 15 PM" src="https://user-images.githubusercontent.com/6250771/133512270-3efc263e-f2a2-4eb9-afa5-145f30588fb2.png">

<img width="1059" alt="Screen Shot 2021-09-15 at 2 26 41 PM" src="https://user-images.githubusercontent.com/6250771/133512262-92e0cf6d-a8e0-4e26-ab67-6b8ff9cb42a4.png">
