### PR TITLE
Remove padding from "Show QR" button

### DIFF
--- a/BTCPayServer/Views/Manage/APIKeys.cshtml
+++ b/BTCPayServer/Views/Manage/APIKeys.cshtml
@@ -59,7 +59,7 @@
             <td class="text-end">
                 <a asp-action="DeleteAPIKey" asp-route-id="@keyData.Id" asp-controller="Manage" data-bs-toggle="modal" data-bs-target="#ConfirmModal" data-description="Any application using the API key <strong>@(keyData.Label ?? keyData.Id)<strong> will immediately lose access." data-confirm-input="DELETE">Delete</a>
                 <span>-</span>
-                <button type="button" class="btn btn-link only-for-js" data-qr="@index">Show QR</button>
+                <button type="button" class="btn btn-link only-for-js p-0" data-qr="@index">Show QR</button>
             </td>
         </tr>
         index++;


### PR DESCRIPTION
Fix for a tiny visual issue on "Manage your API Keys" page that's been bothering me for a long time.

|Before|After|
|---|---|
|![Capture](https://user-images.githubusercontent.com/1934678/133915581-ca87baf1-5112-441e-a755-5f5bc23d19d5.PNG)|![after](https://user-images.githubusercontent.com/1934678/133915586-5b5cdf85-6c8a-43a1-9262-e2600ae2900e.PNG)|