### PR TITLE
Support preview/codegen for custom currencies in pay button

### DIFF
--- a/BTCPayServer/wwwroot/paybutton/paybutton.js
+++ b/BTCPayServer/wwwroot/paybutton/paybutton.js
@@ -224,8 +224,17 @@ function addInputPrice(name, price, widthInput, customFn, type, min, max, step) 
 }
 
 function addSelectCurrency(currency) {
+    // Remove all non-alphabet characters from input string and uppercase it for display
+    var safeCurrency = currency.replace(/[^a-z]/gi, '').toUpperCase();
+    var defaultCurrencies = ['USD', 'GBP', 'EUR', 'BTC'];
+    var options = defaultCurrencies.map(c => '      <option value="' + c + '"' + (c === safeCurrency ? ' selected' : '') + '>' + c + '</option>');
+    // If user provided a currency not in our default currencies list, add it to the top of the options as a selected option
+    if (defaultCurrencies.indexOf(safeCurrency) === -1) {
+        options.unshift('      <option value="' + safeCurrency + '" selected>' + safeCurrency + '</option>')
+    }
+
     return '    <select name="currency">\n' +
-        ['USD', 'GBP', 'EUR', 'BTC'].map(c => '      <option value="' + c + '"' + (c === currency ? ' selected' : '') + '>' + c + '</option>').join('\n') + '\n' +
+        options.join('\n') + '\n' +
     '    </select>\n'
 }
 


### PR DESCRIPTION
Previously only one of the default currencies could be specified for the pay button so that you get a preview and codegen. With this PR user can now input any currency (e.g., `SATS` or `JPY`) and get preview in place and appropriate codegen.

If you use a nonsense currency you will get an appropriate error when you generate an invoice:

![Capture](https://user-images.githubusercontent.com/1934678/133950726-67e324c6-12a6-43c0-b0b2-174a1aa39a6a.PNG)

|Before|After|
|---|---|
|![before](https://user-images.githubusercontent.com/1934678/133950588-0b063a36-a41c-4cfe-ac77-9c4677802e62.PNG)|![after](https://user-images.githubusercontent.com/1934678/133950595-751cc8df-1cbe-436b-aa51-8fac813c6887.PNG)|
|![before2](https://user-images.githubusercontent.com/1934678/133950495-272cb791-6437-4963-bed7-54e7fc25a01c.PNG)|![after2](https://user-images.githubusercontent.com/1934678/133950489-6ef7e0f9-9c2a-4732-a86a-ea338b65351a.PNG)|

See discussion here: https://github.com/btcpayserver/btcpayserver/discussions/2885