### PR TITLE
Fix Selenium flakyness on Circle CI

### DIFF
--- a/BTCPayServer.Tests/ApiKeysTests.cs
+++ b/BTCPayServer.Tests/ApiKeysTests.cs
@@ -124,8 +124,8 @@ namespace BTCPayServer.Tests
                 //redirect
                 //appidentifier
                 var appidentifier = "testapp";
-                var callbackUrl = tester.PayTester.ServerUri + "postredirect-callback-test";
-                var authUrl = BTCPayServerClient.GenerateAuthorizeUri(tester.PayTester.ServerUri,
+                var callbackUrl = s.ServerUri + "postredirect-callback-test";
+                var authUrl = BTCPayServerClient.GenerateAuthorizeUri(s.ServerUri,
                     new[] { Policies.CanModifyStoreSettings, Policies.CanModifyServerSettings }, applicationDetails: (appidentifier, new Uri(callbackUrl))).ToString();
                 s.Driver.Navigate().GoToUrl(authUrl);
                 Assert.Contains(appidentifier, s.Driver.PageSource);
@@ -143,7 +143,7 @@ namespace BTCPayServer.Tests
                 await TestApiAgainstAccessToken(accessToken, tester, user,
                     (await apiKeyRepo.GetKey(accessToken)).GetBlob().Permissions);
 
-                authUrl = BTCPayServerClient.GenerateAuthorizeUri(tester.PayTester.ServerUri,
+                authUrl = BTCPayServerClient.GenerateAuthorizeUri(s.ServerUri,
                     new[] { Policies.CanModifyStoreSettings, Policies.CanModifyServerSettings }, false, true,  applicationDetails: (null, new Uri(callbackUrl))).ToString();
 
                 s.Driver.Navigate().GoToUrl(authUrl);
@@ -164,7 +164,7 @@ namespace BTCPayServer.Tests
                     (await apiKeyRepo.GetKey(accessToken)).GetBlob().Permissions);
 
                 //let's test the app identifier system
-                authUrl = BTCPayServerClient.GenerateAuthorizeUri(tester.PayTester.ServerUri,
+                authUrl = BTCPayServerClient.GenerateAuthorizeUri(s.ServerUri,
                     new[] { Policies.CanModifyStoreSettings, Policies.CanModifyServerSettings }, false, true, (appidentifier, new Uri(callbackUrl))).ToString();
 
                 //if it's the same, go to the confirm page
@@ -173,7 +173,7 @@ namespace BTCPayServer.Tests
                 Assert.Equal(callbackUrl, s.Driver.Url);
                 
                 //same app but different redirect = nono
-                authUrl = BTCPayServerClient.GenerateAuthorizeUri(tester.PayTester.ServerUri,
+                authUrl = BTCPayServerClient.GenerateAuthorizeUri(s.ServerUri,
                     new[] { Policies.CanModifyStoreSettings, Policies.CanModifyServerSettings }, false, true, (appidentifier, new Uri("https://international.local/callback"))).ToString();
                 
                 s.Driver.Navigate().GoToUrl(authUrl);

--- a/BTCPayServer.Tests/CheckoutUITests.cs
+++ b/BTCPayServer.Tests/CheckoutUITests.cs
@@ -163,7 +163,7 @@ namespace BTCPayServer.Tests
                 var invoiceId = s.CreateInvoice(store.storeId, 0.001m, "BTC", "a@x.com");
                 var invoice = await s.Server.PayTester.InvoiceRepository.GetInvoice(invoiceId);
                 s.Driver.Navigate()
-                    .GoToUrl(new Uri(s.Server.PayTester.ServerUri, $"tests/index.html?invoice={invoiceId}"));
+                    .GoToUrl(new Uri(s.ServerUri, $"tests/index.html?invoice={invoiceId}"));
                 TestUtils.Eventually(() =>
                 {
                     Assert.True(s.Driver.FindElement(By.Name("btcpay")).Displayed);
@@ -184,7 +184,7 @@ namespace BTCPayServer.Tests
                 closebutton.Click();
                 s.Driver.AssertElementNotFound(By.Name("btcpay"));
                 Assert.Equal(s.Driver.Url,
-                    new Uri(s.Server.PayTester.ServerUri, $"tests/index.html?invoice={invoiceId}").ToString());
+                    new Uri(s.ServerUri, $"tests/index.html?invoice={invoiceId}").ToString());
             }
         }
     }

--- a/BTCPayServer.Tests/SeleniumTests.cs
+++ b/BTCPayServer.Tests/SeleniumTests.cs
@@ -461,7 +461,7 @@ namespace BTCPayServer.Tests
                 s.FindAlertMessage();
                 Assert.Contains(pairingCode, s.Driver.PageSource);
 
-                var client = new NBitpayClient.Bitpay(new Key(), s.Server.PayTester.ServerUri);
+                var client = new NBitpayClient.Bitpay(new Key(), s.ServerUri);
                 await client.AuthorizeClient(new NBitpayClient.PairingCode(pairingCode));
                 await client.CreateInvoiceAsync(new NBitpayClient.Invoice()
                 {
@@ -470,10 +470,10 @@ namespace BTCPayServer.Tests
                     FullNotifications = true
                 }, NBitpayClient.Facade.Merchant);
 
-                client = new NBitpayClient.Bitpay(new Key(), s.Server.PayTester.ServerUri);
+                client = new NBitpayClient.Bitpay(new Key(), s.ServerUri);
 
                 var code = await client.RequestClientAuthorizationAsync("hehe", NBitpayClient.Facade.Merchant);
-                s.Driver.Navigate().GoToUrl(code.CreateLink(s.Server.PayTester.ServerUri));
+                s.Driver.Navigate().GoToUrl(code.CreateLink(s.ServerUri));
                 s.Driver.FindElement(By.Id("ApprovePairing")).Click();
 
                 await client.CreateInvoiceAsync(new NBitpayClient.Invoice()

--- a/BTCPayServer.Tests/docker-compose.altcoins.yml
+++ b/BTCPayServer.Tests/docker-compose.altcoins.yml
@@ -34,6 +34,7 @@ services:
       - "80"
     links:
       - dev
+      - selenium
     extra_hosts: 
       - "tests:127.0.0.1"
     volumes:
@@ -83,6 +84,10 @@ services:
       - postgres
       - customer_lnd
       - merchant_lnd
+  selenium:
+    image: selenium/standalone-chrome:3
+    expose:
+      - "4444"
   nbxplorer:
     image: nicolasdorier/nbxplorer:2.2.7
     restart: unless-stopped

--- a/BTCPayServer.Tests/docker-compose.yml
+++ b/BTCPayServer.Tests/docker-compose.yml
@@ -32,6 +32,7 @@ services:
       - "80"
     links:
       - dev
+      - selenium
     extra_hosts: 
       - "tests:127.0.0.1"
     volumes:
@@ -80,6 +81,10 @@ services:
       - postgres
       - customer_lnd
       - merchant_lnd
+  selenium:
+    image: selenium/standalone-chrome:3
+    expose:
+      - "4444"
   nbxplorer:
     image: nicolasdorier/nbxplorer:2.2.7
     restart: unless-stopped


### PR DESCRIPTION
Fixing once for all issues of flaky tests on in Circle CI.

The problem comes from the `ChromeDriver` Selenium class which create a new `ChromeDriverService` for each tests (see it as a server receiving requests which pilot the chrome instance)
Problem is that for obscure reasons, those sometimes fail to start properly and time out, making the tests fail.

This PR detects if we are running in CI, and if we are, we are instead relying on a standalone server that is reused across tests so each tests don't need to create their own selenium server.

---
WARNING:

When the tests run on CI, the btcpay test server  access the selenium server. But for some reason, the selenium server can't resolve the domain name of the btcpay test server when making the browser queries.
It means I needed to do a ugly hack, where YOU MUST use `SeleniumTester.ServerUri` in any call to Selenium rather than the `SeleniumTester.PayServer.ServerUri` like before.

Failure to do so will result in a test working on your dev machine but failing on CI with typically an error `ERR_NAME_NOT_RESOLVED`