### PR TITLE
Adjust invoice details header layout

### DIFF
--- a/BTCPayServer/Views/Invoice/Invoice.cshtml
+++ b/BTCPayServer/Views/Invoice/Invoice.cshtml
@@ -16,8 +16,8 @@
     <partial name="_StatusMessage" />
 
         <div class="row mb-4">
-            <h2 class="col-xs-12 col-lg-9 mb-4 mb-lg-0">@ViewData["Title"]</h2>
-            <div class="col-xs-12 col-lg-3 mb-2 mb-lg-0 text-lg-end">
+            <h2 class="col-xs-12 col-lg-6 mb-4 mb-lg-0">@ViewData["Title"]</h2>
+            <div class="col-xs-12 col-lg-6 mb-2 mb-lg-0 text-lg-end">
                 <div class="d-inline-flex">
                     
                     @if (Model.ShowCheckout)


### PR DESCRIPTION
Invoice details page header layout looks weird if you create a new invoice because the buttons on the right go past the page content boundary. This PR adjusts the header layout slightly to avoid this issue.

Before:

![Screen Shot 2021-09-29 at 9 21 28 PM](https://user-images.githubusercontent.com/1934678/135554264-11b2be1a-3379-4985-ad45-7f53183980ec.png)

After:

![Screen Shot 2021-09-30 at 7 01 05 PM](https://user-images.githubusercontent.com/1934678/135554278-5f261b0c-b264-4523-91a5-667f1ee263e5.png)
