### PR TITLE
Fix documentation links

### DIFF
--- a/BTCPayServer/Views/Apps/UpdateCrowdfund.cshtml
+++ b/BTCPayServer/Views/Apps/UpdateCrowdfund.cshtml
@@ -199,7 +199,7 @@
                                     <div class="accordion-body">
                                         <div class="form-group">
                                             <label asp-for="CustomCSSLink" class="form-label"></label>
-                                            <a href="https://docs.btcpayserver.org/Theme/#2-bootstrap-themes" target="_blank" rel="noreferrer noopener">
+                                            <a href="https://docs.btcpayserver.org/Development/Theme/#2-bootstrap-themes" target="_blank" rel="noreferrer noopener">
                                                 <span class="fa fa-question-circle-o text-secondary" title="More information..."></span>
                                             </a>
                                             <input asp-for="CustomCSSLink" class="form-control" />

--- a/BTCPayServer/Views/Apps/UpdatePointOfSale.cshtml
+++ b/BTCPayServer/Views/Apps/UpdatePointOfSale.cshtml
@@ -202,7 +202,7 @@
                                     <div class="accordion-body">
                                         <div class="form-group">
                                             <label asp-for="CustomCSSLink" class="form-label"></label>
-                                            <a href="https://docs.btcpayserver.org/Theme/#2-bootstrap-themes" target="_blank" rel="noreferrer noopener">
+                                            <a href="https://docs.btcpayserver.org/Development/Theme/#2-bootstrap-themes" target="_blank" rel="noreferrer noopener">
                                                 <span class="fa fa-question-circle-o text-secondary" title="More information..."></span>
                                             </a>
                                             <input asp-for="CustomCSSLink" class="form-control" />

--- a/BTCPayServer/Views/Manage/APIKeys.cshtml
+++ b/BTCPayServer/Views/Manage/APIKeys.cshtml
@@ -6,7 +6,7 @@
 
 <p>
     The <a asp-controller="Home" asp-action="SwaggerDocs" target="_blank">BTCPay Server Greenfield API</a> offers programmatic access to your instance. You can manage your BTCPay
-    Server (e.g. stores, invoices, users) as well as automate workflows and integrations (see <a href="https://docs.btcpayserver.org/GreenFieldExample/" rel="noreferrer noopener">use case examples</a>).
+    Server (e.g. stores, invoices, users) as well as automate workflows and integrations (see <a href="https://docs.btcpayserver.org/Development/GreenFieldExample/" rel="noreferrer noopener">use case examples</a>).
     For that you need the API keys, which can be generated here. Find more information in the <a href="@Url.Action("SwaggerDocs", "Home")#section/Authentication" target="_blank" rel="noreferrer noopener">API authentication docs</a>.
 </p>
 <table class="table table-lg">

--- a/BTCPayServer/Views/PaymentRequest/EditPaymentRequest.cshtml
+++ b/BTCPayServer/Views/PaymentRequest/EditPaymentRequest.cshtml
@@ -90,7 +90,7 @@
                     <h4 class="mt-5 mb-4">Custom Appearance</h4>
                     <div class="form-group">
                         <label asp-for="CustomCSSLink" class="form-label"></label>
-                        <a href="https://docs.btcpayserver.org/Theme/#2-bootstrap-themes" target="_blank" rel="noreferrer noopener">
+                        <a href="https://docs.btcpayserver.org/Development/Theme/#2-bootstrap-themes" target="_blank" rel="noreferrer noopener">
                             <span class="fa fa-question-circle-o text-secondary" title="More information..."></span>
                         </a>
                         <input asp-for="CustomCSSLink" class="form-control" />

--- a/BTCPayServer/Views/Server/DynamicDnsServices.cshtml
+++ b/BTCPayServer/Views/Server/DynamicDnsServices.cshtml
@@ -26,7 +26,7 @@
             </p>
             <p>
                 Note that you need to properly configure your NAT and BTCPay Server installation to get the HTTPS certificate. 
-                See the documentation for <a href="https://docs.btcpayserver.org/DynamicDNS/" target="_blank" rel="noreferrer noopener">more information</a>.
+                See the documentation for <a href="https://docs.btcpayserver.org/Deployment/DynamicDNS/" target="_blank" rel="noreferrer noopener">more information</a>.
             </p>
         </div>
         

--- a/BTCPayServer/Views/Server/Maintenance.cshtml
+++ b/BTCPayServer/Views/Server/Maintenance.cshtml
@@ -9,7 +9,7 @@
     <div class="row mb-5">
         <div class="col-lg-6">
             <h4 class="mb-3">Domain name</h4>
-            <p>You can change the domain name of your server by following <a href="https://docs.btcpayserver.org/ChangeDomain" target="_blank" rel="noreferrer noopener">this guide</a>.</p>
+            <p>You can change the domain name of your server by following <a href="https://docs.btcpayserver.org/Deployment/ChangeDomain/" target="_blank" rel="noreferrer noopener">this guide</a>.</p>
 
             <div class="row g-1">
                 <div class="col">

--- a/BTCPayServer/Views/Server/Theme.cshtml
+++ b/BTCPayServer/Views/Server/Theme.cshtml
@@ -26,7 +26,7 @@
             <div class="collapse @(Model.CustomTheme ? "show" : "")" id="CustomThemeSettings">
                 <div class="form-group">
                     <label asp-for="CustomThemeCssUri" class="form-label"></label>
-                    <a href="https://docs.btcpayserver.org/Theme/#1-custom-themes" target="_blank" rel="noreferrer noopener">
+                    <a href="https://docs.btcpayserver.org/Development/Theme/#1-custom-themes" target="_blank" rel="noreferrer noopener">
                         <span class="fa fa-question-circle-o text-secondary" title="More information..."></span>
                     </a>
                     <input asp-for="CustomThemeCssUri" class="form-control" />

--- a/BTCPayServer/Views/Stores/CheckoutExperience.cshtml
+++ b/BTCPayServer/Views/Stores/CheckoutExperience.cshtml
@@ -100,7 +100,7 @@
             </div>
             <div class="form-group">
                 <label asp-for="CustomLogo" class="form-label"></label>
-                <a href="https://docs.btcpayserver.org/Theme/#checkout-page-themes" target="_blank" rel="noreferrer noopener">
+                <a href="https://docs.btcpayserver.org/Development/Theme/#checkout-page-themes" target="_blank" rel="noreferrer noopener">
                     <span class="fa fa-question-circle-o text-secondary" title="More information..."></span>
                 </a>
                 <input asp-for="CustomLogo" class="form-control"/>
@@ -108,7 +108,7 @@
             </div>
             <div class="form-group">
                 <label asp-for="CustomCSS" class="form-label"></label>
-                <a href="https://docs.btcpayserver.org/Theme/#checkout-page-themes" target="_blank" rel="noreferrer noopener">
+                <a href="https://docs.btcpayserver.org/Development/Theme/#checkout-page-themes" target="_blank" rel="noreferrer noopener">
                     <span class="fa fa-question-circle-o text-secondary" title="More information..."></span>
                 </a>
                 <input asp-for="CustomCSS" class="form-control"/>

--- a/BTCPayServer/Views/Stores/_GenerateWalletForm.cshtml
+++ b/BTCPayServer/Views/Stores/_GenerateWalletForm.cshtml
@@ -15,8 +15,8 @@
     <div class="alert alert-warning">
         You are not an admin on this server. While you are able to import or generate a wallet via seed with
         your account, please understand that you are trusting the server admins not just with your
-        <a href="https://docs.btcpayserver.org/ThirdPartyHosting/#privacy-concerns" target="_blank" class="alert-link" rel="noreferrer noopener">privacy</a>
-        but also with <a href="https://docs.btcpayserver.org/ThirdPartyHosting/#trust-concerns" target="_blank" class="alert-link" rel="noreferrer noopener">trivial access to your funds.</a>
+        <a href="https://docs.btcpayserver.org/Deployment/ThirdPartyHosting/#privacy-concerns" target="_blank" class="alert-link" rel="noreferrer noopener">privacy</a>
+        but also with <a href="https://docs.btcpayserver.org/Deployment/ThirdPartyHosting/#trust-concerns" target="_blank" class="alert-link" rel="noreferrer noopener">trivial access to your funds.</a>
         If you NEED to use this feature, please reconsider hosting your own BTCPay Server instance.
     </div>
 }

--- a/BTCPayServer/Views/Wallets/NewPullPayment.cshtml
+++ b/BTCPayServer/Views/Wallets/NewPullPayment.cshtml
@@ -74,7 +74,7 @@
             </div>
             <div class="form-group">
                 <label asp-for="CustomCSSLink" class="form-label"></label>
-                <a href="https://docs.btcpayserver.org/Theme/#2-bootstrap-themes" target="_blank" rel="noreferrer noopener">
+                <a href="https://docs.btcpayserver.org/Development/Theme/#2-bootstrap-themes" target="_blank" rel="noreferrer noopener">
                     <span class="fa fa-question-circle-o text-secondary" title="More information..."></span>
                 </a>
                 <input asp-for="CustomCSSLink" class="form-control" />


### PR DESCRIPTION
Some links changed with the [recent docs restructuring](https://github.com/btcpayserver/btcpayserver-doc/pull/962). I've also [added redirects](https://github.com/btcpayserver/btcpayserver-doc/commit/b4f700c7f25251df626b00195d8c393136b1bd8a) for these on the docs side now.