### PR TITLE
Refactoring: Move payment config

### DIFF
--- a/BTCPayServer.Tests/CheckoutUITests.cs
+++ b/BTCPayServer.Tests/CheckoutUITests.cs
@@ -137,15 +137,14 @@ namespace BTCPayServer.Tests
                 s.RegisterNewUser(true);
                 var store = s.CreateNewStore();
                 s.AddLightningNode();
-                s.GoToStore(store.storeId, StoreNavPages.Checkout);
+                s.GoToStore(store.storeId);
                 s.Driver.SetCheckbox(By.Id("LightningAmountInSatoshi"), true);
-                var command = s.Driver.FindElement(By.Name("command"));
-
-                command.Click();
+                s.Driver.FindElement(By.Id("Save")).Click();
+                Assert.Contains("Store successfully updated", s.FindAlertMessage().Text);
+                
                 var invoiceId = s.CreateInvoice(store.storeName, 10, "USD", "a@g.com");
                 s.GoToInvoiceCheckout(invoiceId);
                 Assert.Contains("Sats", s.Driver.FindElement(By.ClassName("payment__currencies_noborder")).Text);
-
             }
         }
 

--- a/BTCPayServer.Tests/UnitTest1.cs
+++ b/BTCPayServer.Tests/UnitTest1.cs
@@ -2365,12 +2365,12 @@ namespace BTCPayServer.Tests
                 Assert.DoesNotContain("&lightning=", paymentMethodFirst.InvoiceBitcoinUrlQR);
 
                 // enable unified QR code in settings
-                var vm = Assert.IsType<CheckoutExperienceViewModel>(Assert
-                    .IsType<ViewResult>(user.GetController<StoresController>().CheckoutExperience()).Model
+                var vm = Assert.IsType<StoreViewModel>(Assert
+                    .IsType<ViewResult>(await user.GetController<StoresController>().UpdateStore()).Model
                 );
                 vm.OnChainWithLnInvoiceFallback = true;
                 Assert.IsType<RedirectToActionResult>(
-                    user.GetController<StoresController>().CheckoutExperience(vm).Result
+                    user.GetController<StoresController>().UpdateStore(vm).Result
                 );
 
                 // validate that QR code now has both onchain and offchain payment urls

--- a/BTCPayServer/Controllers/StoresController.cs
+++ b/BTCPayServer/Controllers/StoresController.cs
@@ -366,8 +366,7 @@ namespace BTCPayServer.Controllers
             return RedirectToAction(nameof(Rates), new { storeId = CurrentStore.Id });
         }
 
-        [HttpGet]
-        [Route("{storeId}/checkout")]
+        [HttpGet("{storeId}/checkout")]
         public IActionResult CheckoutExperience()
         {
             var storeBlob = CurrentStore.GetStoreBlob();
@@ -398,20 +397,16 @@ namespace BTCPayServer.Controllers
                     };
                 }
             }).ToList();
+            
             vm.RequiresRefundEmail = storeBlob.RequiresRefundEmail;
-            vm.LightningAmountInSatoshi = storeBlob.LightningAmountInSatoshi;
-            vm.LightningPrivateRouteHints = storeBlob.LightningPrivateRouteHints;
-            vm.OnChainWithLnInvoiceFallback = storeBlob.OnChainWithLnInvoiceFallback;
             vm.LazyPaymentMethods = storeBlob.LazyPaymentMethods;
             vm.RedirectAutomatically = storeBlob.RedirectAutomatically;
-            vm.ShowRecommendedFee = storeBlob.ShowRecommendedFee;
-            vm.RecommendedFeeBlockTarget = storeBlob.RecommendedFeeBlockTarget;
-
             vm.CustomCSS = storeBlob.CustomCSS;
             vm.CustomLogo = storeBlob.CustomLogo;
             vm.HtmlTitle = storeBlob.HtmlTitle;
             vm.AutoDetectLanguage = storeBlob.AutoDetectLanguage;
             vm.SetLanguages(_LangService, storeBlob.DefaultLang);
+            
             return View(vm);
         }
 
@@ -431,8 +426,7 @@ namespace BTCPayServer.Controllers
             vm.PaymentMethods = new SelectList(choices, nameof(chosen.Value), nameof(chosen.Name), chosen?.Value);
             vm.DefaultPaymentMethod = chosen?.Value;
         }
-
-
+        
         [HttpPost]
         [Route("{storeId}/checkout")]
         public async Task<IActionResult> CheckoutExperience(CheckoutExperienceViewModel model)
@@ -475,13 +469,7 @@ namespace BTCPayServer.Controllers
 
             blob.RequiresRefundEmail = model.RequiresRefundEmail;
             blob.LazyPaymentMethods = model.LazyPaymentMethods;
-            blob.LightningAmountInSatoshi = model.LightningAmountInSatoshi;
-            blob.LightningPrivateRouteHints = model.LightningPrivateRouteHints;
-            blob.OnChainWithLnInvoiceFallback = model.OnChainWithLnInvoiceFallback;
             blob.RedirectAutomatically = model.RedirectAutomatically;
-            blob.ShowRecommendedFee = model.ShowRecommendedFee;
-            blob.RecommendedFeeBlockTarget = model.RecommendedFeeBlockTarget;
-
             blob.CustomLogo = model.CustomLogo;
             blob.CustomCSS = model.CustomCSS;
             blob.HtmlTitle = string.IsNullOrWhiteSpace(model.HtmlTitle) ? null : model.HtmlTitle;
@@ -578,9 +566,14 @@ namespace BTCPayServer.Controllers
             vm.PayJoinEnabled = storeBlob.PayJoinEnabled;
             vm.HintWallet = storeBlob.Hints.Wallet;
             vm.HintLightning = storeBlob.Hints.Lightning;
+            vm.LightningAmountInSatoshi = storeBlob.LightningAmountInSatoshi;
+            vm.LightningPrivateRouteHints = storeBlob.LightningPrivateRouteHints;
+            vm.OnChainWithLnInvoiceFallback = storeBlob.OnChainWithLnInvoiceFallback;
+            vm.ShowRecommendedFee = storeBlob.ShowRecommendedFee;
+            vm.RecommendedFeeBlockTarget = storeBlob.RecommendedFeeBlockTarget;
             vm.IsOnchainSetup = vm.DerivationSchemes.Any(scheme => !string.IsNullOrWhiteSpace(scheme.Value));
             vm.IsLightningSetup = vm.LightningNodes.Any(scheme => !string.IsNullOrWhiteSpace(scheme.Address));
-
+            
             (bool canUseHotWallet, _) = await CanUseHotWallet();
             vm.CanUsePayJoin = canUseHotWallet && store
                 .GetSupportedPaymentMethods(_NetworkProvider)
@@ -617,6 +610,12 @@ namespace BTCPayServer.Controllers
             blob.InvoiceExpiration = TimeSpan.FromMinutes(model.InvoiceExpiration);
             blob.LightningDescriptionTemplate = model.LightningDescriptionTemplate ?? string.Empty;
             blob.PaymentTolerance = model.PaymentTolerance;
+            blob.LightningAmountInSatoshi = model.LightningAmountInSatoshi;
+            blob.LightningPrivateRouteHints = model.LightningPrivateRouteHints;
+            blob.OnChainWithLnInvoiceFallback = model.OnChainWithLnInvoiceFallback;
+            blob.ShowRecommendedFee = model.ShowRecommendedFee;
+            blob.RecommendedFeeBlockTarget = model.RecommendedFeeBlockTarget;
+            
             var payjoinChanged = blob.PayJoinEnabled != model.PayJoinEnabled;
             blob.PayJoinEnabled = model.PayJoinEnabled;
             if (CurrentStore.SetStoreBlob(blob))

--- a/BTCPayServer/Controllers/StoresController.cs
+++ b/BTCPayServer/Controllers/StoresController.cs
@@ -578,6 +578,8 @@ namespace BTCPayServer.Controllers
             vm.PayJoinEnabled = storeBlob.PayJoinEnabled;
             vm.HintWallet = storeBlob.Hints.Wallet;
             vm.HintLightning = storeBlob.Hints.Lightning;
+            vm.IsOnchainSetup = vm.DerivationSchemes.Any(scheme => !string.IsNullOrWhiteSpace(scheme.Value));
+            vm.IsLightningSetup = vm.LightningNodes.Any(scheme => !string.IsNullOrWhiteSpace(scheme.Address));
 
             (bool canUseHotWallet, _) = await CanUseHotWallet();
             vm.CanUsePayJoin = canUseHotWallet && store

--- a/BTCPayServer/Models/StoreViewModels/CheckoutExperienceViewModel.cs
+++ b/BTCPayServer/Models/StoreViewModels/CheckoutExperienceViewModel.cs
@@ -34,27 +34,11 @@ namespace BTCPayServer.Models.StoreViewModels
         [Display(Name = "Requires a refund email")]
         public bool RequiresRefundEmail { get; set; }
 
-        [Display(Name = "Display Lightning payment amounts in Satoshis")]
-        public bool LightningAmountInSatoshi { get; set; }
-
-        [Display(Name = "Add hop hints for private channels to the Lightning invoice")]
-        public bool LightningPrivateRouteHints { get; set; }
-
-        [Display(Name = "Include Lightning invoice fallback to on-chain BIP21 payment URL")]
-        public bool OnChainWithLnInvoiceFallback { get; set; }
-
         [Display(Name = "Only enable the payment method after user explicitly chooses it")]
         public bool LazyPaymentMethods { get; set; }
 
         [Display(Name = "Redirect invoice to redirect url automatically after paid")]
         public bool RedirectAutomatically { get; set; }
-
-        [Display(Name = "Show recommended fee")]
-        public bool ShowRecommendedFee { get; set; }
-
-        [Display(Name = "Recommended fee confirmation target blocks")]
-        [Range(1, double.PositiveInfinity)]
-        public int RecommendedFeeBlockTarget { get; set; }
         
         [Display(Name = "Auto-detect language on checkout")]
         public bool AutoDetectLanguage { get; set; }

--- a/BTCPayServer/Models/StoreViewModels/StoreViewModel.cs
+++ b/BTCPayServer/Models/StoreViewModels/StoreViewModel.cs
@@ -89,6 +89,8 @@ namespace BTCPayServer.Models.StoreViewModels
         [Display(Name = "Enable Payjoin/P2EP")]
         public bool PayJoinEnabled { get; set; }
         public bool CanUsePayJoin { get; set; }
+        public bool IsOnchainSetup { get; set; }
+        public bool IsLightningSetup { get; set; }
 
         public bool HintWallet { get; set; }
         public bool HintLightning { get; set; }

--- a/BTCPayServer/Models/StoreViewModels/StoreViewModel.cs
+++ b/BTCPayServer/Models/StoreViewModels/StoreViewModel.cs
@@ -95,6 +95,22 @@ namespace BTCPayServer.Models.StoreViewModels
         public bool HintWallet { get; set; }
         public bool HintLightning { get; set; }
 
+        [Display(Name = "Show recommended fee")]
+        public bool ShowRecommendedFee { get; set; }
+
+        [Display(Name = "Recommended fee confirmation target blocks")]
+        [Range(1, double.PositiveInfinity)]
+        public int RecommendedFeeBlockTarget { get; set; }
+
+        [Display(Name = "Display Lightning payment amounts in Satoshis")]
+        public bool LightningAmountInSatoshi { get; set; }
+
+        [Display(Name = "Add hop hints for private channels to the Lightning invoice")]
+        public bool LightningPrivateRouteHints { get; set; }
+
+        [Display(Name = "Include Lightning invoice fallback to on-chain BIP21 payment URL")]
+        public bool OnChainWithLnInvoiceFallback { get; set; }
+
         public class LightningNode
         {
             public string CryptoCode { get; set; }

--- a/BTCPayServer/Views/Stores/CheckoutExperience.cshtml
+++ b/BTCPayServer/Views/Stores/CheckoutExperience.cshtml
@@ -21,7 +21,7 @@
                 </div>
                 <div class="form-group mb-4">
                     <div class="form-label mb-1">Enable payment methods only when amount is …</div>
-                    <table class="table">
+                    <table class="table table-sm mt-0 mx-0">
                         @for (var index = 0; index < Model.PaymentMethodCriteria.Count; index++)
                         {
                             var criteria = Model.PaymentMethodCriteria[index];
@@ -43,7 +43,6 @@
                     </table>
                 </div>
             }
-            <h5 class="mb-3">General</h5>
             <div class="form-check my-1">
                 <input asp-for="RequiresRefundEmail" type="checkbox" class="form-check-input"/>
                 <label asp-for="RequiresRefundEmail" class="form-check-label"></label>
@@ -55,30 +54,6 @@
             <div class="form-check my-1">
                 <input asp-for="RedirectAutomatically" type="checkbox" class="form-check-input" />
                 <label asp-for="RedirectAutomatically" class="form-check-label"></label>
-            </div>
-            <div class="form-check my-1">
-                <input asp-for="ShowRecommendedFee" type="checkbox" class="form-check-input"/>
-                <label asp-for="ShowRecommendedFee" class="form-check-label"></label>
-                <p class="form-text text-muted mb-0">Fee will be shown for BTC and LTC onchain payments only.</p>
-            </div>
-            <div class="form-group mt-2 mb-4">
-                <label asp-for="RecommendedFeeBlockTarget" class="form-label"></label>
-                <input asp-for="RecommendedFeeBlockTarget" class="form-control" style="width:8ch" min="1" />
-                <span asp-validation-for="RecommendedFeeBlockTarget" class="text-danger"></span>
-            </div>
-            
-            <h5 class="mt-4 mb-3">Lightning</h5>
-            <div class="form-check my-1">
-                <input asp-for="LightningAmountInSatoshi" type="checkbox" class="form-check-input"/>
-                <label asp-for="LightningAmountInSatoshi" class="form-check-label"></label>
-            </div>
-            <div class="form-check my-1">
-                <input asp-for="LightningPrivateRouteHints" type="checkbox" class="form-check-input"/>
-                <label asp-for="LightningPrivateRouteHints" class="form-check-label"></label>
-            </div>
-            <div class="form-check my-1">
-                <input asp-for="OnChainWithLnInvoiceFallback" type="checkbox" class="form-check-input"/>
-                <label asp-for="OnChainWithLnInvoiceFallback" class="form-check-label"></label>
             </div>
 
             <h4 class="mt-5 mb-3">Appearance</h4>

--- a/BTCPayServer/Views/Stores/UpdateStore.cshtml
+++ b/BTCPayServer/Views/Stores/UpdateStore.cshtml
@@ -182,98 +182,108 @@
                 <input asp-for="StoreWebsite" class="form-control" />
                 <span asp-validation-for="StoreWebsite" class="text-danger"></span>
             </div>
-
-            <h4 class="mt-5 mb-3">Payment</h4>
-            <div class="form-group d-flex align-items-center">
-                <input asp-for="AnyoneCanCreateInvoice" type="checkbox" class="btcpay-toggle me-2" />
-                <label asp-for="AnyoneCanCreateInvoice" class="form-label mb-0 me-1"></label>
-                <a href="https://docs.btcpayserver.org/FAQ/FAQ-Stores/#allow-anyone-to-create-invoice" target="_blank" rel="noreferrer noopener">
-                    <span class="fa fa-question-circle-o text-secondary" title="More information..."></span>
-                </a>
-            </div>
-            @if (Model.CanUsePayJoin)
+            
+            @if (Model.IsOnchainSetup || Model.IsLightningSetup)
             {
+                <h4 class="mt-5 mb-3">Payment</h4>
+                <div class="form-group d-flex align-items-center">
+                    <input asp-for="AnyoneCanCreateInvoice" type="checkbox" class="btcpay-toggle me-2"/>
+                    <label asp-for="AnyoneCanCreateInvoice" class="form-label mb-0 me-1"></label>
+                    <a href="https://docs.btcpayserver.org/FAQ/FAQ-Stores/#allow-anyone-to-create-invoice" target="_blank" rel="noreferrer noopener">
+                        <span class="fa fa-question-circle-o text-secondary" title="More information..."></span>
+                    </a>
+                </div>
+                <div class="form-group mt-4">
+                    <label asp-for="NetworkFeeMode" class="form-label"></label>
+                    <a href="https://docs.btcpayserver.org/FAQ/FAQ-Stores/#add-network-fee-to-invoice-vary-with-mining-fees" target="_blank" rel="noreferrer noopener">
+                        <span class="fa fa-question-circle-o text-secondary" title="More information..."></span>
+                    </a>
+                    <select asp-for="NetworkFeeMode" class="form-select">
+                        <option value="MultiplePaymentsOnly">... only if the customer makes more than one payment for the invoice</option>
+                        <option value="Always">... on every payment</option>
+                        <option value="Never">Never add network fee</option>
+                    </select>
+                </div>
                 <div class="form-group">
-                    <div class="d-flex align-items-center">
-                        <input asp-for="PayJoinEnabled" type="checkbox" class="btcpay-toggle me-2"/>
-                        <label asp-for="PayJoinEnabled" class="form-label mb-0 me-1"></label>
-                        <a href="https://docs.btcpayserver.org/Payjoin/" target="_blank" rel="noreferrer noopener">
+                    <label asp-for="InvoiceExpiration" class="form-label"></label>
+                    <a href="https://docs.btcpayserver.org/FAQ/FAQ-Stores/#invoice-expires-if-the-full-amount-has-not-been-paid-after-minutes" target="_blank" rel="noreferrer noopener">
+                        <span class="fa fa-question-circle-o text-secondary" title="More information..."></span>
+                    </a>
+                    <div class="input-group">
+                        <input asp-for="InvoiceExpiration" class="form-control" style="max-width:10ch;"/>
+                        <span class="input-group-text">minutes</span>
+                    </div>
+                    <span asp-validation-for="InvoiceExpiration" class="text-danger"></span>
+                </div>
+                <div class="form-group">
+                    <label asp-for="PaymentTolerance" class="form-label"></label>
+                    <a href="https://docs.btcpayserver.org/FAQ/FAQ-Stores/#consider-the-invoice-paid-even-if-the-paid-amount-is-less-than-expected" target="_blank" rel="noreferrer noopener">
+                        <span class="fa fa-question-circle-o text-secondary" title="More information..."></span>
+                    </a>
+                    <div class="input-group">
+                        <input asp-for="PaymentTolerance" class="form-control" style="max-width:10ch;"/>
+                        <span class="input-group-text">percent</span>
+                    </div>
+                    <span asp-validation-for="PaymentTolerance" class="text-danger"></span>
+                </div>
+                @if (Model.IsOnchainSetup)
+                {
+                    <h5 class="mt-4 mb-3">Onchain</h5>
+                    @if (Model.CanUsePayJoin)
+                    {
+                        <div class="form-group">
+                            <div class="d-flex align-items-center">
+                                <input asp-for="PayJoinEnabled" type="checkbox" class="btcpay-toggle me-2"/>
+                                <label asp-for="PayJoinEnabled" class="form-label mb-0 me-1"></label>
+                                <a href="https://docs.btcpayserver.org/Payjoin/" target="_blank" rel="noreferrer noopener">
+                                    <span class="fa fa-question-circle-o text-secondary" title="More information..."></span>
+                                </a>
+                            </div>
+                            <span asp-validation-for="PayJoinEnabled" class="text-danger"></span>
+                        </div>
+                    }
+                    <div class="form-group">
+                        <label asp-for="MonitoringExpiration" class="form-label"></label>
+                        <a href="https://docs.btcpayserver.org/FAQ/FAQ-Stores/#payment-invalid-if-transactions-fails-to-confirm-minutes-after-invoice-expiration" target="_blank" rel="noreferrer noopener">
                             <span class="fa fa-question-circle-o text-secondary" title="More information..."></span>
                         </a>
+                        <div class="input-group">
+                            <input asp-for="MonitoringExpiration" class="form-control" style="max-width:10ch;"/>
+                            <span class="input-group-text">minutes</span>
+                        </div>
+                        <span asp-validation-for="MonitoringExpiration" class="text-danger"></span>
                     </div>
-                    <span asp-validation-for="PayJoinEnabled" class="text-danger"></span>
-                </div>
+                    <div class="form-group">
+                        <label asp-for="SpeedPolicy" class="form-label"></label>
+                        <a href="https://docs.btcpayserver.org/FAQ/FAQ-Stores/#consider-the-invoice-confirmed-when-the-payment-transaction" target="_blank" rel="noreferrer noopener">
+                            <span class="fa fa-question-circle-o text-secondary" title="More information..."></span>
+                        </a>
+                        <select asp-for="SpeedPolicy" class="form-select w-auto" onchange="document.getElementById('unconfirmed-warning').hidden = this.value !== '0';">
+                            <option value="0">Is unconfirmed</option>
+                            <option value="1">Has at least 1 confirmation</option>
+                            <option value="3">Has at least 2 confirmations</option>
+                            <option value="2">Has at least 6 confirmations</option>
+                        </select>
+                        <div class="alert alert-warning my-2" hidden="@(Model.SpeedPolicy != 0)" id="unconfirmed-warning" role="alert">
+                            Choosing to accept an unconfirmed invoice can lead to double-spending and is strongly discouraged.
+                        </div>
+                        <span asp-validation-for="SpeedPolicy" class="text-danger"></span>
+                    </div>
+                }
+                @if (Model.IsLightningSetup)
+                {
+                    <h5 class="mt-4 mb-3">Lightning</h5>
+                    <div class="form-group">
+                        <label asp-for="LightningDescriptionTemplate" class="form-label"></label>
+                        <input asp-for="LightningDescriptionTemplate" class="form-control"/>
+                        <span asp-validation-for="LightningDescriptionTemplate" class="text-danger"></span>
+                        <p class="form-text text-muted">
+                            Available placeholders:
+                            <code>{StoreName} {ItemDescription} {OrderId}</code>
+                        </p>
+                    </div>
+                }
             }
-            <div class="form-group mt-4">
-                <label asp-for="NetworkFeeMode" class="form-label"></label>
-                <a href="https://docs.btcpayserver.org/FAQ/FAQ-Stores/#add-network-fee-to-invoice-vary-with-mining-fees" target="_blank" rel="noreferrer noopener">
-                    <span class="fa fa-question-circle-o text-secondary" title="More information..."></span>
-                </a>
-                <select asp-for="NetworkFeeMode" class="form-select">
-                    <option value="MultiplePaymentsOnly">... only if the customer makes more than one payment for the invoice</option>
-                    <option value="Always">... on every payment</option>
-                    <option value="Never">Never add network fee</option>
-                </select>
-            </div>
-            <div class="form-group">
-                <label asp-for="InvoiceExpiration" class="form-label"></label>
-                <a href="https://docs.btcpayserver.org/FAQ/FAQ-Stores/#invoice-expires-if-the-full-amount-has-not-been-paid-after-minutes" target="_blank" rel="noreferrer noopener">
-                    <span class="fa fa-question-circle-o text-secondary" title="More information..."></span>
-                </a>
-                <div class="input-group">
-                    <input asp-for="InvoiceExpiration" class="form-control" style="max-width:10ch;" />
-                    <span class="input-group-text">minutes</span>
-                </div>
-                <span asp-validation-for="InvoiceExpiration" class="text-danger"></span>
-            </div>
-            <div class="form-group">
-                <label asp-for="MonitoringExpiration" class="form-label"></label>
-                <a href="https://docs.btcpayserver.org/FAQ/FAQ-Stores/#payment-invalid-if-transactions-fails-to-confirm-minutes-after-invoice-expiration" target="_blank" rel="noreferrer noopener">
-                    <span class="fa fa-question-circle-o text-secondary" title="More information..."></span>
-                </a>
-                <div class="input-group">
-                    <input asp-for="MonitoringExpiration" class="form-control" style="max-width:10ch;" />
-                    <span class="input-group-text">minutes</span>
-                </div>
-                <span asp-validation-for="MonitoringExpiration" class="text-danger"></span>
-            </div>
-            <div class="form-group">
-                <label asp-for="PaymentTolerance" class="form-label"></label>
-                <a href="https://docs.btcpayserver.org/FAQ/FAQ-Stores/#consider-the-invoice-paid-even-if-the-paid-amount-is-less-than-expected" target="_blank" rel="noreferrer noopener">
-                    <span class="fa fa-question-circle-o text-secondary" title="More information..."></span>
-                </a>
-                <div class="input-group">
-                    <input asp-for="PaymentTolerance" class="form-control" style="max-width:10ch;" />
-                    <span class="input-group-text">percent</span>
-                </div>
-                <span asp-validation-for="PaymentTolerance" class="text-danger"></span>
-            </div>
-            <div class="form-group">
-                <label asp-for="SpeedPolicy" class="form-label"></label>
-                <a href="https://docs.btcpayserver.org/FAQ/FAQ-Stores/#consider-the-invoice-confirmed-when-the-payment-transaction" target="_blank" rel="noreferrer noopener">
-                    <span class="fa fa-question-circle-o text-secondary" title="More information..."></span>
-                </a>
-                <select asp-for="SpeedPolicy" class="form-select w-auto" onchange="document.getElementById('unconfirmed-warning').hidden = this.value !== '0';">
-                    <option value="0">Is unconfirmed</option>
-                    <option value="1">Has at least 1 confirmation</option>
-                    <option value="3">Has at least 2 confirmations</option>
-                    <option value="2">Has at least 6 confirmations</option>
-                </select>
-                <div class="alert alert-warning my-2" hidden="@(Model.SpeedPolicy != 0)" id="unconfirmed-warning" role="alert">
-                    Choosing to accept an unconfirmed invoice can lead to double-spending and is strongly discouraged.
-                </div>
-                <span asp-validation-for="SpeedPolicy" class="text-danger"></span>
-            </div>
-            <div class="form-group">
-                <label asp-for="LightningDescriptionTemplate" class="form-label"></label>
-                <input asp-for="LightningDescriptionTemplate" class="form-control" />
-                <span asp-validation-for="LightningDescriptionTemplate" class="text-danger"></span>
-                <p class="form-text text-muted">
-                    Available placeholders:
-                    <code>{StoreName} {ItemDescription} {OrderId}</code>
-                </p>
-            </div>
-
             <button name="command" type="submit" class="btn btn-primary" value="Save" id="Save">Save Store Settings</button>
         </form>
 

--- a/BTCPayServer/Views/Stores/UpdateStore.cshtml
+++ b/BTCPayServer/Views/Stores/UpdateStore.cshtml
@@ -228,7 +228,7 @@
                 </div>
                 @if (Model.IsOnchainSetup)
                 {
-                    <h5 class="mt-4 mb-3">Onchain</h5>
+                    <h5 class="mt-5 mb-3">On-Chain</h5>
                     @if (Model.CanUsePayJoin)
                     {
                         <div class="form-group">
@@ -269,11 +269,34 @@
                         </div>
                         <span asp-validation-for="SpeedPolicy" class="text-danger"></span>
                     </div>
+                    <div class="form-check my-1">
+                        <input asp-for="ShowRecommendedFee" type="checkbox" class="form-check-input"/>
+                        <label asp-for="ShowRecommendedFee" class="form-check-label"></label>
+                        <p class="form-text text-muted mb-0">Fee will be shown for BTC and LTC onchain payments only.</p>
+                    </div>
+                    <div class="form-group mt-2 mb-4">
+                        <label asp-for="RecommendedFeeBlockTarget" class="form-label"></label>
+                        <input asp-for="RecommendedFeeBlockTarget" class="form-control" style="width:8ch" min="1" />
+                        <span asp-validation-for="RecommendedFeeBlockTarget" class="text-danger"></span>
+                    </div>
                 }
+            
                 @if (Model.IsLightningSetup)
                 {
-                    <h5 class="mt-4 mb-3">Lightning</h5>
-                    <div class="form-group">
+                    <h5 class="mt-5 mb-3">Lightning</h5>
+                    <div class="form-check my-1">
+                        <input asp-for="LightningAmountInSatoshi" type="checkbox" class="form-check-input"/>
+                        <label asp-for="LightningAmountInSatoshi" class="form-check-label"></label>
+                    </div>
+                    <div class="form-check my-1">
+                        <input asp-for="LightningPrivateRouteHints" type="checkbox" class="form-check-input"/>
+                        <label asp-for="LightningPrivateRouteHints" class="form-check-label"></label>
+                    </div>
+                    <div class="form-check my-1">
+                        <input asp-for="OnChainWithLnInvoiceFallback" type="checkbox" class="form-check-input"/>
+                        <label asp-for="OnChainWithLnInvoiceFallback" class="form-check-label"></label>
+                    </div>
+                    <div class="form-group mt-3">
                         <label asp-for="LightningDescriptionTemplate" class="form-label"></label>
                         <input asp-for="LightningDescriptionTemplate" class="form-control"/>
                         <span asp-validation-for="LightningDescriptionTemplate" class="text-danger"></span>


### PR DESCRIPTION
This is a preliminary step for changes in #2897: Move some of the payment config options out of the checkout experience into the payments section of the store.

![payment](https://user-images.githubusercontent.com/886/135809600-4c5e3b31-0cfd-43b5-a4a6-a84603e112fe.png)

![ce](https://user-images.githubusercontent.com/886/135809598-e6939bee-74cf-4d9f-b611-e16826b6e624.png)

Also displays only those options that are available in the context of how the store is configured: If there is no on-chain wallet set up, those options won't be displayed -- same goes for Lightning.

As this will tend to become crowded over time, we will need to figure out where to move the payment method options.