### PR TITLE
Update toggle styling to have pointer cursor

### DIFF
--- a/BTCPayServer/wwwroot/main/bootstrap/bootstrap.css
+++ b/BTCPayServer/wwwroot/main/bootstrap/bootstrap.css
@@ -10231,6 +10231,7 @@ input[type=number].hide-number-spin {
   border-radius: calc(var(--toggle-height) / 2);
   background: var(--btcpay-neutral-500);
   font-size: 0;
+  cursor: pointer;
 }
 
 input.btcpay-toggle {


### PR DESCRIPTION
For some reason our toggle doesn't switch the cursor to pointer like what you normally get for buttons and checkboxes/radio buttons on hover. This PR adds the cursor styling.

**Before:**

https://user-images.githubusercontent.com/1934678/136498395-be0c2630-64c1-4f3d-b7df-158b1199c779.mov

**After:**

https://user-images.githubusercontent.com/1934678/136498423-b0321cb1-573f-4265-ab2d-2ef37430dd2d.mov

