### PR TITLE
Allow email notifications when creating invoices from Web UI

### DIFF
--- a/BTCPayServer/Controllers/InvoiceController.UI.cs
+++ b/BTCPayServer/Controllers/InvoiceController.UI.cs
@@ -868,6 +868,8 @@ namespace BTCPayServer.Controllers
                         Enabled = true
                     }),
                     DefaultPaymentMethod = model.DefaultPaymentMethod,
+                    NotificationEmail = model.NotificationEmail,
+                    ExtendedNotifications = model.NotificationEmail != null
                 }, store, HttpContext.Request.GetAbsoluteRoot(), cancellationToken: cancellationToken);
 
                 TempData[WellKnownTempData.SuccessMessage] = $"Invoice {result.Data.Id} just created!";

--- a/BTCPayServer/HostedServices/InvoiceNotificationManager.cs
+++ b/BTCPayServer/HostedServices/InvoiceNotificationManager.cs
@@ -121,7 +121,7 @@ namespace BTCPayServer.HostedServices
 #pragma warning restore CS0618
             }
 
-            if (invoiceEvent.Name != InvoiceEvent.Expired && !String.IsNullOrEmpty(invoice.NotificationEmail))
+            if ((invoice.ExtendedNotifications || invoiceEvent.Name != InvoiceEvent.Expired) && !String.IsNullOrEmpty(invoice.NotificationEmail))
             {
                 var json = NBitcoin.JsonConverters.Serializer.ToString(notification);
                 var store = await _StoreRepository.FindStore(invoice.StoreId);

--- a/BTCPayServer/Models/InvoicingModels/CreateInvoiceModel.cs
+++ b/BTCPayServer/Models/InvoicingModels/CreateInvoiceModel.cs
@@ -86,5 +86,12 @@ namespace BTCPayServer.Models.InvoicingModels
         {
             get; set;
         }
+
+        [EmailAddress]
+        [DisplayName("Notification Email")]
+        public string NotificationEmail
+        {
+            get; set;
+        }
     }
 }

--- a/BTCPayServer/Views/Invoice/CreateInvoice.cshtml
+++ b/BTCPayServer/Views/Invoice/CreateInvoice.cshtml
@@ -85,6 +85,11 @@
                         <span asp-validation-for="DefaultPaymentMethod" class="text-danger"></span>
                     </div>
                     <div class="form-group">
+                        <label asp-for="NotificationEmail" class="form-label"></label>
+                        <input asp-for="NotificationEmail" class="form-control" />
+                        <span asp-validation-for="NotificationEmail" class="text-danger"></span>
+                    </div>
+                    <div class="form-group">
                         <input type="submit" value="Create" class="btn btn-primary" id="Create" />
                         <a asp-action="ListInvoices" class="text-muted ms-3">Back to list</a>
                     </div>


### PR DESCRIPTION
Currently invoice email notifications are only sent when the invoice is created via the API. This commit adds an option to set an email address for notifications when an invoice is created from the Web UI.

As noted in #2891 the invoice notification mechanism changed slightly recently. In the midst of troubleshooting that on my BTCPayServer instance I encountered difficulties determinign why inovice email notifications weren't being sent. The change in this PR does two things:

 - Adds a new `NotificationEmail` filed to the create inoice. If this field is set then both email and extended invoice notificaitons will be enabled for that invoice.
  
 - If extended invoice notifcations are enabled then a notification will be sent for invoice expired events. The expired event can be useful in certain cirumstances and this PR adds back the ability for it to trigger a notification.