### PR TITLE
Fix fallback logic for default payment method

### DIFF
--- a/BTCPayServer/Controllers/GreenField/StoresController.cs
+++ b/BTCPayServer/Controllers/GreenField/StoresController.cs
@@ -119,7 +119,7 @@ namespace BTCPayServer.Controllers.GreenField
                 Name = data.StoreName,
                 Website = data.StoreWebsite,
                 SpeedPolicy = data.SpeedPolicy,
-                DefaultPaymentMethod = data.GetDefaultPaymentId(_btcPayNetworkProvider)?.ToStringNormalized(),
+                DefaultPaymentMethod = data.GetDefaultPaymentId()?.ToStringNormalized(),
                 //blob
                 //we do not include DefaultCurrencyPairs,Spread, PreferredExchange, RateScripting, RateScript  in this model and instead opt to set it in stores/storeid/rates endpoints
                 //we do not include ExcludedPaymentMethods in this model and instead opt to set it in stores/storeid/payment-methods endpoints

--- a/BTCPayServer/Controllers/InvoiceController.Testing.cs
+++ b/BTCPayServer/Controllers/InvoiceController.Testing.cs
@@ -59,7 +59,7 @@ namespace BTCPayServer.Controllers
             //var network = invoice.Networks.GetNetwork(invoice.Currency);
             var cryptoCode = "BTC";
             var network = _NetworkProvider.GetNetwork<BTCPayNetwork>(cryptoCode);
-            var paymentMethodId = store.GetDefaultPaymentId(_NetworkProvider);
+            var paymentMethodId = store.GetDefaultPaymentId();
 
             //var network = NetworkProvider.GetNetwork<BTCPayNetwork>("BTC");
             var bitcoinAddressString = invoice.GetPaymentMethod(paymentMethodId).GetPaymentMethodDetails().GetPaymentDestination();

--- a/BTCPayServer/Data/StoreDataExtensions.cs
+++ b/BTCPayServer/Data/StoreDataExtensions.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -12,14 +13,10 @@ namespace BTCPayServer.Data
     public static class StoreDataExtensions
     {
 #pragma warning disable CS0618
-        public static PaymentMethodId GetDefaultPaymentId(this StoreData storeData, BTCPayNetworkProvider networks)
+        public static PaymentMethodId? GetDefaultPaymentId(this StoreData storeData)
         {
-            PaymentMethodId[] paymentMethodIds = storeData.GetEnabledPaymentIds(networks);
             PaymentMethodId.TryParse(storeData.DefaultCrypto, out var defaultPaymentId);
-            var chosen = paymentMethodIds.FirstOrDefault(f => f == defaultPaymentId) ??
-                         paymentMethodIds.FirstOrDefault(f => f.CryptoCode == defaultPaymentId?.CryptoCode) ??
-                         paymentMethodIds.FirstOrDefault();
-            return chosen;
+            return defaultPaymentId;
         }
 
         public static PaymentMethodId[] GetEnabledPaymentIds(this StoreData storeData, BTCPayNetworkProvider networks)
@@ -104,7 +101,7 @@ namespace BTCPayServer.Data
         /// </summary>
         /// <param name="paymentMethodId">The paymentMethodId</param>
         /// <param name="supportedPaymentMethod">The payment method, or null to remove</param>
-        public static void SetSupportedPaymentMethod(this StoreData storeData, PaymentMethodId paymentMethodId, ISupportedPaymentMethod supportedPaymentMethod)
+        public static void SetSupportedPaymentMethod(this StoreData storeData, PaymentMethodId? paymentMethodId, ISupportedPaymentMethod? supportedPaymentMethod)
         {
             if (supportedPaymentMethod != null && paymentMethodId != null && paymentMethodId != supportedPaymentMethod.PaymentId)
             {

--- a/BTCPayServer/Payments/PaymentMethodId.cs
+++ b/BTCPayServer/Payments/PaymentMethodId.cs
@@ -1,4 +1,7 @@
+#nullable enable
 using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 
 namespace BTCPayServer.Payments
 {
@@ -8,6 +11,13 @@ namespace BTCPayServer.Payments
     /// </summary>
     public class PaymentMethodId
     {
+        public PaymentMethodId? FindNearest(PaymentMethodId[] others)
+        {
+            if (others is null)
+                throw new ArgumentNullException(nameof(others));
+            return others.FirstOrDefault(f => f == this) ??
+                   others.FirstOrDefault(f => f.CryptoCode == CryptoCode);
+        }
         public PaymentMethodId(string cryptoCode, PaymentType paymentType)
         {
             if (cryptoCode == null)
@@ -31,23 +41,22 @@ namespace BTCPayServer.Payments
         public PaymentType PaymentType { get; private set; }
 
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
-            PaymentMethodId item = obj as PaymentMethodId;
-            if (item == null)
-                return false;
-            return ToString().Equals(item.ToString(), StringComparison.InvariantCulture);
+            if (obj is PaymentMethodId id)
+                return ToString().Equals(id.ToString(), StringComparison.OrdinalIgnoreCase);
+            return false;
         }
-        public static bool operator ==(PaymentMethodId a, PaymentMethodId b)
+        public static bool operator ==(PaymentMethodId? a, PaymentMethodId? b)
         {
-            if (System.Object.ReferenceEquals(a, b))
+            if (a is null && b is null)
                 return true;
-            if (((object)a == null) || ((object)b == null))
-                return false;
-            return a.ToString() == b.ToString();
+            if (a is PaymentMethodId ai && b is PaymentMethodId bi)
+                return ai.Equals(bi);
+            return false;
         }
 
-        public static bool operator !=(PaymentMethodId a, PaymentMethodId b)
+        public static bool operator !=(PaymentMethodId? a, PaymentMethodId? b)
         {
             return !(a == b);
         }
@@ -84,12 +93,12 @@ namespace BTCPayServer.Payments
             return $"{CryptoCode} ({PaymentType.ToPrettyString()})";
         }
         static char[] Separators = new[] { '_', '-' };
-        public static PaymentMethodId TryParse(string str)
+        public static PaymentMethodId? TryParse(string? str)
         {
             TryParse(str, out var r);
             return r;
         }
-        public static bool TryParse(string str, out PaymentMethodId paymentMethodId)
+        public static bool TryParse(string? str, [MaybeNullWhen(false)] out PaymentMethodId paymentMethodId)
         {
             str ??= "";
             paymentMethodId = null;

--- a/BTCPayServer/Services/Invoices/InvoiceEntity.cs
+++ b/BTCPayServer/Services/Invoices/InvoiceEntity.cs
@@ -258,7 +258,13 @@ namespace BTCPayServer.Services.Invoices
         public decimal Price { get; set; }
         public string Currency { get; set; }
         public string DefaultPaymentMethod { get; set; }
-
+#nullable enable
+        public PaymentMethodId? GetDefaultPaymentMethod()
+        {
+            PaymentMethodId.TryParse(DefaultPaymentMethod, out var id);
+            return id;
+        }
+#nullable restore
         [JsonExtensionData]
         public IDictionary<string, JToken> AdditionalData { get; set; }
 


### PR DESCRIPTION
The logic before was broken.
What is expected: If invoice's `DefaultPaymentMethod` isn't set, then it should default to store's `DefaultPaymentMethod`.

What happened was: If invoice's `DefaultPaymentMehtod` isn't set, just pick the first in the list.

I also fixed corner cases, if the requested default payment method isn't found, so in summary, in order of priority:

* Exact match on invoice's default
* Exact match on store's default
* Partial match on invoice's default (ie, if the invoice's default is lightning BTC and lightning is not enabled, it should try to pick BTC)
* Partial match on store's default
* Take first of the list

It partially fix #2963 but also need #2975 for fix in the UI.