### PR TITLE
Add number formatting in crowdfund app

### DIFF
--- a/BTCPayServer/Views/AppsPublic/ViewCrowdfund.cshtml
+++ b/BTCPayServer/Views/AppsPublic/ViewCrowdfund.cshtml
@@ -65,7 +65,7 @@
                     {
                         <span v-if="srvModel.targetAmount" class="mt-3" id="crowdfund-header-target">
                             <h3 class="d-inline-block">
-                                <span class="badge bg-info px-3" v-text="`${srvModel.targetAmount} ${targetCurrency}`">@Math.Round(Model.TargetAmount.GetValueOrDefault(0)) @Model.TargetCurrency</span>
+                                <span class="badge bg-info px-3" v-text="`${new Intl.NumberFormat().format(srvModel.targetAmount)} ${targetCurrency}`">@Math.Round(Model.TargetAmount.GetValueOrDefault(0)) @Model.TargetCurrency</span>
                             </h3>
                             @if (Model.ResetEveryAmount > 0 && !Model.NeverReset)
                             {
@@ -123,7 +123,7 @@
                 <div class="card-body">
                     <div class="row py-2 text-center crowdfund-stats">
                         <div class="col-sm border-end p-3 text-center" id="crowdfund-body-raised-amount">
-                            <h3 v-text="`${raisedAmount} ${targetCurrency}`">@Math.Round(Model.Info.CurrentAmount + Model.Info.CurrentPendingAmount) @Model.TargetCurrency</h3>
+                            <h3 v-text="`${new Intl.NumberFormat().format(raisedAmount)} ${targetCurrency}`">@Math.Round(Model.Info.CurrentAmount + Model.Info.CurrentPendingAmount) @Model.TargetCurrency</h3>
                             <h5 class="text-muted fst-italic mb-0">Raised</h5>
                             <b-tooltip target="crowdfund-body-raised-amount" v-if="paymentStats && paymentStats.length > 0" class="only-for-js">
                                 <ul class="p-0 text-uppercase">
@@ -143,7 +143,7 @@
                         </div>
                         
                         <div class="col-sm border-end p-3 text-center" id="crowdfund-body-total-contributors">
-                            <h3 v-text="srvModel.info.totalContributors">@Model.Info.TotalContributors</h3>
+                            <h3 v-text="new Intl.NumberFormat().format(srvModel.info.totalContributors)">@Model.Info.TotalContributors</h3>
                             <h5 class="text-muted fst-italic mb-0">Contributors</h5>
                         </div>
                         @if (Model.StartDate.HasValue || Model.EndDate.HasValue)
@@ -327,7 +327,7 @@
                         <span class="h5">{{perk.title? perk.title : perk.id}}</span>
                         <span class="text-muted"> 
                             <template v-if="perk.price && perk.price.value">
-                                {{perk.price.value.noExponents()}}
+                                {{new Intl.NumberFormat().format(perk.price.value.noExponents())}}
                                 {{targetCurrency}}
                                 <template v-if="perk.price.type == 1">or more</template>
                             </template>
@@ -366,10 +366,10 @@
                     </div>
                 </div>
                 <div class="card-footer d-flex justify-content-between" v-if="perk.sold || perk.inventory != null">
-                    <span v-if="perk.inventory != null && perk.inventory > 0" class="text-center text-muted">{{perk.inventory}} left</span>
+                    <span v-if="perk.inventory != null && perk.inventory > 0" class="text-center text-muted">{{new Intl.NumberFormat().format(perk.inventory)}} left</span>
                     <span v-if="perk.inventory != null && perk.inventory <= 0" class="text-center text-muted">Sold out</span>
-                    <span v-if="perk.sold">{{perk.sold}} Contributor{{perk.sold === 1 ? "": "s"}}</span>
-                    <span v-if="perk.value">{{perk.value}} {{targetCurrency}} total</span>
+                    <span v-if="perk.sold">{{new Intl.NumberFormat().format(perk.sold)}} Contributor{{perk.sold === 1 ? "": "s"}}</span>
+                    <span v-if="perk.value">{{new Intl.NumberFormat().format(perk.value)}} {{targetCurrency}} total</span>
                 </div>
             </form>
         </div> 


### PR DESCRIPTION
Added number formatting in crowdfund app. See discussion here: https://github.com/btcpayserver/btcpayserver/discussions/2967.

|Before|After|
|---|---|
|![before](https://user-images.githubusercontent.com/1934678/138613879-7f68dd53-6825-4d08-be9e-d9a382aed60f.PNG)|![after](https://user-images.githubusercontent.com/1934678/138613891-3678f4f0-6103-478f-a525-6b3fffe82741.PNG)|