### PR TITLE
POS Light: Add Bootstrap bundle

### DIFF
--- a/BTCPayServer/Views/Shared/_LayoutPos.cshtml
+++ b/BTCPayServer/Views/Shared/_LayoutPos.cshtml
@@ -43,6 +43,7 @@
         <script type="text/javascript">
             var srvModel = @Safe.Json(Model);
         </script>
+        <bundle name="wwwroot/bundles/bootstrap-bundle.min.js" asp-append-version="true" />
         <bundle name="wwwroot/bundles/light-pos-bundle.min.js" asp-append-version="true" />
     }
     <style>


### PR DESCRIPTION
So that the alert can be closed. Brought up by @satwo in this [Mattermost discussion](https://chat.btcpayserver.org/btcpayserver/pl/3f46i9yociydmkk4apncxp7shw).