### PR TITLE
Add admin badge to user list

### DIFF
--- a/BTCPayServer/Controllers/ServerController.Users.cs
+++ b/BTCPayServer/Controllers/ServerController.Users.cs
@@ -63,6 +63,12 @@ namespace BTCPayServer.Controllers
                 })
                 .ToListAsync();
             model.Total = await usersQuery.CountAsync();
+
+            foreach (UsersViewModel.UserViewModel uvm in model.Users)
+            {
+                var userId = await _UserManager.FindByIdAsync(uvm.Id);
+                uvm.IsAdmin = await _userService.IsAdminUser(userId);;
+            }
              
             return View(model);
         }

--- a/BTCPayServer/Views/Server/ListUsers.cshtml
+++ b/BTCPayServer/Views/Server/ListUsers.cshtml
@@ -66,7 +66,7 @@
                 @user.Email
                 @if (user.IsAdmin)
                 {
-                    <span class="badge">ADMIN</span>
+                    <span class="badge bg-info">Admin</span>
                 }
             </td>
             <td>@user.Created?.ToBrowserDate()</td>

--- a/BTCPayServer/Views/Server/ListUsers.cshtml
+++ b/BTCPayServer/Views/Server/ListUsers.cshtml
@@ -62,8 +62,8 @@
     @foreach (var user in Model.Users)
     {
         <tr>
-            <td>
-                @user.Email
+            <td class="d-flex align-items-center">
+                <span class="me-2">@user.Email</span>
                 @if (user.IsAdmin)
                 {
                     <span class="badge bg-info">Admin</span>

--- a/BTCPayServer/Views/Server/ListUsers.cshtml
+++ b/BTCPayServer/Views/Server/ListUsers.cshtml
@@ -62,7 +62,13 @@
     @foreach (var user in Model.Users)
     {
         <tr>
-            <td>@user.Email</td>
+            <td>
+                @user.Email
+                @if (user.IsAdmin)
+                {
+                    <span class="badge">ADMIN</span>
+                }
+            </td>
             <td>@user.Created?.ToBrowserDate()</td>
             <td class="text-center">
                 @if (user.Verified)


### PR DESCRIPTION
Currently, one must click "Edit" on each individual user to see whether that user has admin privs.

This PR provides list-view visibility of admin privs by adding an `ADMIN` badge beside an admin user's email.

![image](https://user-images.githubusercontent.com/4956763/139509672-30607e71-d668-4d9d-ab33-2a0532e183ae.png)