### PR TITLE
Adds spacer fix to invoice view

### DIFF
--- a/BTCPayServer/Views/Invoice/ListInvoices.cshtml
+++ b/BTCPayServer/Views/Invoice/ListInvoices.cshtml
@@ -332,7 +332,7 @@
                     <span class="fa fa-question-circle-o text-secondary" title="More information..."></span>
                 </a>
 
-                <table id="invoices" class="table table-hover table-responsive-md">
+                <table id="invoices" class="table table-hover table-responsive-md mt-4">
                     <thead>
                     <tr>
                         <th style="width:2rem;" class="only-for-js">


### PR DESCRIPTION
Small fix.

Before:
<img width="1309" alt="Screen Shot 2021-10-30 at 3 29 08 PM" src="https://user-images.githubusercontent.com/6250771/139560308-afbfeaaa-32f5-421f-9d34-2e02e64871b7.png">
After:
<img width="1281" alt="Screen Shot 2021-10-30 at 3 29 13 PM" src="https://user-images.githubusercontent.com/6250771/139560313-74558190-47dd-4cdf-8e8e-c9f4464132cc.png">

