### PR TITLE
Update Display Names on Create App View

### DIFF
--- a/BTCPayServer/Models/AppViewModels/CreateAppViewModel.cs
+++ b/BTCPayServer/Models/AppViewModels/CreateAppViewModel.cs
@@ -21,6 +21,8 @@ namespace BTCPayServer.Models.AppViewModels
         [Required]
         [MaxLength(50)]
         [MinLength(1)]
+
+        [Display(Name = "App Name")]
         public string AppName { get; set; }
 
         [Display(Name = "Store")]
@@ -37,7 +39,7 @@ namespace BTCPayServer.Models.AppViewModels
 
         public SelectList Stores { get; set; }
 
-        [Display(Name = "App type")]
+        [Display(Name = "App Type")]
         public string SelectedAppType { get; set; }
 
         public SelectList AppTypes { get; set; }


### PR DESCRIPTION
More small fixes.

Adds display name for App Name, and adjusts the display name for App Type.

Before:
<img width="645" alt="Screen Shot 2021-10-30 at 4 40 14 PM" src="https://user-images.githubusercontent.com/6250771/139561353-8d80eb93-3ac2-455a-a009-a5899b50bf3c.png">

After:
<img width="678" alt="Screen Shot 2021-10-30 at 4 44 31 PM" src="https://user-images.githubusercontent.com/6250771/139561357-9c029dd7-489f-4336-871f-f7a5351e9aab.png">

