### PR TITLE
PR for Issue #3038 adds params for getInvoices pagination

### DIFF
--- a/BTCPayServer.Client/BTCPayServerClient.Invoices.cs
+++ b/BTCPayServer.Client/BTCPayServerClient.Invoices.cs
@@ -17,6 +17,8 @@ namespace BTCPayServer.Client
             DateTimeOffset? endDate = null,
             string textSearch = null,
             bool includeArchived = false,
+            int? skip = null,
+            int? take = null,
             CancellationToken token = default)
         {
             Dictionary<string, object> queryPayload = new Dictionary<string, object>();
@@ -34,6 +36,14 @@ namespace BTCPayServer.Client
                 queryPayload.Add(nameof(textSearch), textSearch);
             if (status != null)
                 queryPayload.Add(nameof(status), status.Select(s=> s.ToString().ToLower()).ToArray());
+
+            if(skip != null) {
+                queryPayload.Add(nameof(skip), skip);
+            }
+
+             if(take != null) {
+                queryPayload.Add(nameof(take), take);
+            }
             
             var response =
                 await _httpClient.SendAsync(

--- a/BTCPayServer/Controllers/GreenField/InvoiceController.cs
+++ b/BTCPayServer/Controllers/GreenField/InvoiceController.cs
@@ -56,6 +56,8 @@ namespace BTCPayServer.Controllers.GreenField
             [FromQuery] 
             [ModelBinder(typeof(ModelBinders.DateTimeOffsetModelBinder))]
             DateTimeOffset? endDate = null,
+            [FromQuery] int? skip = null,
+            [FromQuery] int? take = null,
             [FromQuery] string textSearch = null,
             [FromQuery] bool includeArchived = false)
         {
@@ -77,6 +79,8 @@ namespace BTCPayServer.Controllers.GreenField
             var invoices =
                 await _invoiceRepository.GetInvoices(new InvoiceQuery()
                 {
+                    Skip = skip,
+                    Take = take,
                     StoreId = new[] {store.Id},
                     IncludeArchived = includeArchived,
                     StartDate = startDate,

--- a/BTCPayServer/Controllers/GreenField/InvoiceController.cs
+++ b/BTCPayServer/Controllers/GreenField/InvoiceController.cs
@@ -56,10 +56,11 @@ namespace BTCPayServer.Controllers.GreenField
             [FromQuery] 
             [ModelBinder(typeof(ModelBinders.DateTimeOffsetModelBinder))]
             DateTimeOffset? endDate = null,
-            [FromQuery] int? skip = null,
-            [FromQuery] int? take = null,
             [FromQuery] string textSearch = null,
-            [FromQuery] bool includeArchived = false)
+            [FromQuery] bool includeArchived = false,
+            [FromQuery] int? skip = null,
+            [FromQuery] int? take = null
+            )
         {
             var store = HttpContext.GetStoreData();
             if (store == null)

--- a/BTCPayServer/Controllers/GreenField/LocalBTCPayServerClient.cs
+++ b/BTCPayServer/Controllers/GreenField/LocalBTCPayServerClient.cs
@@ -823,12 +823,16 @@ namespace BTCPayServer.Controllers.GreenField
             DateTimeOffset? endDate = null,
             string textSearch = null,
             bool includeArchived = false,
-            CancellationToken token = default)
+            int? skip = null,
+            int? take = null,
+            CancellationToken token = default
+            
+            )
         {
             return GetFromActionResult<IEnumerable<InvoiceData>>(
                 await _greenFieldInvoiceController.GetInvoices(storeId, orderId,
                     status?.Select(invoiceStatus => invoiceStatus.ToString())?.ToArray(), startDate,
-                    endDate, textSearch, includeArchived));
+                    endDate, textSearch, includeArchived,skip,take));
         }
 
         public override async Task<InvoiceData> GetInvoice(string storeId, string invoiceId,

--- a/BTCPayServer/wwwroot/swagger/v1/swagger.template.invoices.json
+++ b/BTCPayServer/wwwroot/swagger/v1/swagger.template.invoices.json
@@ -75,7 +75,7 @@
                         "required": false,
                         "description": "Number of records returned in response",
                         "schema": {
-                            "nullable": false,
+                            "nullable": true,
                             "type": "number"
                         }
                     }

--- a/BTCPayServer/wwwroot/swagger/v1/swagger.template.invoices.json
+++ b/BTCPayServer/wwwroot/swagger/v1/swagger.template.invoices.json
@@ -58,6 +58,26 @@
                         "required": false,
                         "description": "End date of the period to retrieve invoices",
                         "$ref": "#/components/schemas/UnixTimestamp"
+                    },
+                    {
+                        "name": "skip",
+                        "in": "query",
+                        "required": false,
+                        "description": "Number of records to skip",
+                        "schema": {
+                            "nullable": true,
+                            "type": "number"
+                        }
+                    },
+                    {
+                        "name": "take",
+                        "in": "query",
+                        "required": false,
+                        "description": "Number of records returned in response",
+                        "schema": {
+                            "nullable": false,
+                            "type": "number"
+                        }
                     }
                 ],
                 "description": "View information about the existing invoices",


### PR DESCRIPTION
This pull request is related to [Issue 3038](https://github.com/btcpayserver/btcpayserver/issues/3038) 
It adds take and skip query parameters to the getInvoices endpoint of the Greenfield API to allow pagination when fetching invoices