### PR TITLE
Improves maintenance domain name form element

### DIFF
--- a/BTCPayServer/Views/Server/Maintenance.cshtml
+++ b/BTCPayServer/Views/Server/Maintenance.cshtml
@@ -11,12 +11,16 @@
             <h4 class="mb-2">Domain name</h4>
             <p class="text-secondary">You can change the domain name of your server by following <a href="https://docs.btcpayserver.org/Deployment/ChangeDomain/" target="_blank" rel="noreferrer noopener">this guide</a>.</pclass="text-secondary">
 
-            <div class="d-flex">
-                <input asp-for="DNSDomain" class="form-control flex-fill" disabled="@(Model.CanUseSSH ? null : "disabled")" />
-                <span asp-validation-for="DNSDomain" class="text-danger"></span>
-                <button name="command" type="submit" class="btn btn-primary ms-3" value="changedomain" title="Change domain" disabled="@(Model.CanUseSSH ? null : "disabled")">
-                    Confirm
-                </button>
+            <div class="row g-2">
+                <div class="col-sm">
+                    <input asp-for="DNSDomain" class="form-control flex-fill" disabled="@(Model.CanUseSSH ? null : "disabled")" />
+                    <span asp-validation-for="DNSDomain" class="text-danger"></span>
+                </div>
+                <div class="col-sm">
+                    <button name="command" type="submit" class="btn btn-primary ms-3" value="changedomain" title="Change domain" disabled="@(Model.CanUseSSH ? null : "disabled")">
+                        Confirm
+                    </button>
+                </div>
             </div>
 
             <h4 class="mt-5 mb-2">Update</h4>

--- a/BTCPayServer/Views/Server/Maintenance.cshtml
+++ b/BTCPayServer/Views/Server/Maintenance.cshtml
@@ -12,11 +12,11 @@
             <p class="text-secondary">You can change the domain name of your server by following <a href="https://docs.btcpayserver.org/Deployment/ChangeDomain/" target="_blank" rel="noreferrer noopener">this guide</a>.</pclass="text-secondary">
 
             <div class="d-flex">
-                <div class="">
+                <div class="mb-2">
                     <input asp-for="DNSDomain" class="form-control flex-fill" disabled="@(Model.CanUseSSH ? null : "disabled")" />
                     <span asp-validation-for="DNSDomain" class="text-danger"></span>
                 </div>
-                <button name="command" type="submit" class="btn btn-primary mb-3 ms-3" value="changedomain" title="Change domain" disabled="@(Model.CanUseSSH ? null : "disabled")">
+                <button name="command" type="submit" class="btn btn-primary mb-2 ms-3" value="changedomain" title="Change domain" disabled="@(Model.CanUseSSH ? null : "disabled")">
                     Confirm
                 </button>
             </div>

--- a/BTCPayServer/Views/Server/Maintenance.cshtml
+++ b/BTCPayServer/Views/Server/Maintenance.cshtml
@@ -8,8 +8,8 @@
 <form method="post">
     <div class="row mb-5">
         <div class="col-lg-6">
-            <h4 class="mb-3">Domain name</h4>
-            <p>You can change the domain name of your server by following <a href="https://docs.btcpayserver.org/Deployment/ChangeDomain/" target="_blank" rel="noreferrer noopener">this guide</a>.</p>
+            <h4 class="mb-2">Domain name</h4>
+            <p class="text-secondary">You can change the domain name of your server by following <a href="https://docs.btcpayserver.org/Deployment/ChangeDomain/" target="_blank" rel="noreferrer noopener">this guide</a>.</pclass="text-secondary">
 
             <div class="d-flex">
                 <div class="">
@@ -21,7 +21,7 @@
                 </button>
             </div>
 
-            <h4 class="mt-5 mb-3">Update</h4>
+            <h4 class="mt-5 mb-2">Update</h4>
             <p class="text-secondary">Update to the latest version of BTCPay Server.</p>
             <div class="form-group">
                 <div class="input-group">
@@ -29,7 +29,7 @@
                 </div>
             </div>
 
-            <h4 class="mt-5 mb-3">Restart</h4>
+            <h4 class="mt-5 mb-2">Restart</h4>
             <p class="text-secondary">Restart BTCPay Server and related services.</p>
             <div class="form-group">
                 <div class="input-group">
@@ -37,7 +37,7 @@
                 </div>
             </div>
 
-            <h4 class="mt-5 mb-3">Clean</h4>
+            <h4 class="mt-5 mb-2">Clean</h4>
             <p class="text-secondary">Delete unused Docker images present on your system.</p>
             <div class="form-group">
                 <div class="input-group">

--- a/BTCPayServer/Views/Server/Maintenance.cshtml
+++ b/BTCPayServer/Views/Server/Maintenance.cshtml
@@ -11,17 +11,20 @@
             <h4 class="mb-3">Domain name</h4>
             <p>You can change the domain name of your server by following <a href="https://docs.btcpayserver.org/Deployment/ChangeDomain/" target="_blank" rel="noreferrer noopener">this guide</a>.</p>
 
-            <div class="row g-1">
-                <div class="col">
+    
+
+
+
+            <div class="d-flex">
+                <div class="">
                     <input asp-for="DNSDomain" class="form-control flex-fill" disabled="@(Model.CanUseSSH ? null : "disabled")" />
                     <span asp-validation-for="DNSDomain" class="text-danger"></span>
                 </div>
-                <div class="col">
-                    <button name="command" type="submit" class="btn btn-primary mt-2 mt-sm-0 ms-sm-2" value="changedomain" title="Change domain" disabled="@(Model.CanUseSSH ? null : "disabled")">
-                        <span class="fa fa-check"></span> Confirm
-                    </button>
-                </div>
+                <button name="command" type="submit" class="btn btn-primary mb-3 ms-3" value="changedomain" title="Change domain" disabled="@(Model.CanUseSSH ? null : "disabled")">
+                    Confirm
+                </button>
             </div>
+
 
             <h4 class="mt-5 mb-3">Update</h4>
             <p class="text-secondary">Update to the latest version of BTCPay Server.</p>

--- a/BTCPayServer/Views/Server/Maintenance.cshtml
+++ b/BTCPayServer/Views/Server/Maintenance.cshtml
@@ -11,10 +11,6 @@
             <h4 class="mb-3">Domain name</h4>
             <p>You can change the domain name of your server by following <a href="https://docs.btcpayserver.org/Deployment/ChangeDomain/" target="_blank" rel="noreferrer noopener">this guide</a>.</p>
 
-    
-
-
-
             <div class="d-flex">
                 <div class="">
                     <input asp-for="DNSDomain" class="form-control flex-fill" disabled="@(Model.CanUseSSH ? null : "disabled")" />
@@ -24,7 +20,6 @@
                     Confirm
                 </button>
             </div>
-
 
             <h4 class="mt-5 mb-3">Update</h4>
             <p class="text-secondary">Update to the latest version of BTCPay Server.</p>

--- a/BTCPayServer/Views/Server/Maintenance.cshtml
+++ b/BTCPayServer/Views/Server/Maintenance.cshtml
@@ -12,11 +12,9 @@
             <p class="text-secondary">You can change the domain name of your server by following <a href="https://docs.btcpayserver.org/Deployment/ChangeDomain/" target="_blank" rel="noreferrer noopener">this guide</a>.</pclass="text-secondary">
 
             <div class="d-flex">
-                <div class="mb-2">
-                    <input asp-for="DNSDomain" class="form-control flex-fill" disabled="@(Model.CanUseSSH ? null : "disabled")" />
-                    <span asp-validation-for="DNSDomain" class="text-danger"></span>
-                </div>
-                <button name="command" type="submit" class="btn btn-primary mb-2 ms-3" value="changedomain" title="Change domain" disabled="@(Model.CanUseSSH ? null : "disabled")">
+                <input asp-for="DNSDomain" class="form-control flex-fill" disabled="@(Model.CanUseSSH ? null : "disabled")" />
+                <span asp-validation-for="DNSDomain" class="text-danger"></span>
+                <button name="command" type="submit" class="btn btn-primary ms-3" value="changedomain" title="Change domain" disabled="@(Model.CanUseSSH ? null : "disabled")">
                     Confirm
                 </button>
             </div>

--- a/BTCPayServer/Views/Server/Maintenance.cshtml
+++ b/BTCPayServer/Views/Server/Maintenance.cshtml
@@ -9,22 +9,18 @@
     <div class="row mb-5">
         <div class="col-lg-6">
             <h4 class="mb-2">Domain name</h4>
-            <p class="text-secondary">You can change the domain name of your server by following <a href="https://docs.btcpayserver.org/Deployment/ChangeDomain/" target="_blank" rel="noreferrer noopener">this guide</a>.</pclass="text-secondary">
+            <p>You can change the domain name of your server by following <a href="https://docs.btcpayserver.org/Deployment/ChangeDomain/" target="_blank" rel="noreferrer noopener">this guide</a>.</pclass="text-secondary">
 
-            <div class="row g-2">
-                <div class="col-sm">
-                    <input asp-for="DNSDomain" class="form-control flex-fill" disabled="@(Model.CanUseSSH ? null : "disabled")" />
-                    <span asp-validation-for="DNSDomain" class="text-danger"></span>
-                </div>
-                <div class="col-sm">
-                    <button name="command" type="submit" class="btn btn-primary ms-3" value="changedomain" title="Change domain" disabled="@(Model.CanUseSSH ? null : "disabled")">
-                        Confirm
-                    </button>
-                </div>
+            <div class="d-flex">
+                <input asp-for="DNSDomain" class="form-control flex-fill" disabled="@(Model.CanUseSSH ? null : "disabled")" />
+                <span asp-validation-for="DNSDomain" class="text-danger"></span>
+                <button name="command" type="submit" class="btn btn-primary ms-3" value="changedomain" title="Change domain" disabled="@(Model.CanUseSSH ? null : "disabled")">
+                    Confirm
+                </button>
             </div>
 
             <h4 class="mt-5 mb-2">Update</h4>
-            <p class="text-secondary">Update to the latest version of BTCPay Server.</p>
+            <p>Update to the latest version of BTCPay Server.</p>
             <div class="form-group">
                 <div class="input-group">
                     <button name="command" type="submit" class="btn btn-primary" value="update" disabled="@(Model.CanUseSSH ? null : "disabled")">Update</button>
@@ -32,7 +28,7 @@
             </div>
 
             <h4 class="mt-5 mb-2">Restart</h4>
-            <p class="text-secondary">Restart BTCPay Server and related services.</p>
+            <p>Restart BTCPay Server and related services.</p>
             <div class="form-group">
                 <div class="input-group">
                     <button name="command" type="submit" class="btn btn-primary" value="restart" disabled="@(Model.CanUseSSH ? null : "disabled")">Restart</button>
@@ -40,7 +36,7 @@
             </div>
 
             <h4 class="mt-5 mb-2">Clean</h4>
-            <p class="text-secondary">Delete unused Docker images present on your system.</p>
+            <p>Delete unused Docker images present on your system.</p>
             <div class="form-group">
                 <div class="input-group">
                     <button name="command" type="submit" class="btn btn-secondary" value="clean" disabled="@(Model.CanUseSSH ? null : "disabled")">Clean</button>


### PR DESCRIPTION
More small fixes.

Updated domain form section to flex-box (as opposed to the "row/g-2" & "col-sm" pattern cc @dennisreimann curious to hear your thoughts on this, as we might have some consistencies throughout the app regardless).

The display error below was caused by a stray "mb-2" class, and we could simply adjust and remove that class, if flex-box isn't the path forward.

<img width="517" alt="Screen Shot 2021-10-31 at 5 09 05 PM" src="https://user-images.githubusercontent.com/6250771/139606496-543884eb-bdf4-484b-8e9a-f605f46fa77e.png">

Otherwise, just some spacing and consistency edits.

After:
<img width="1319" alt="Screen Shot 2021-10-31 at 5 50 01 PM" src="https://user-images.githubusercontent.com/6250771/139607721-4d63d267-04ac-4bdc-8e41-1fb2a2055a02.png">
<img width="394" alt="Screen Shot 2021-10-31 at 5 51 40 PM" src="https://user-images.githubusercontent.com/6250771/139607741-0374df26-b3a8-4a00-afe7-c6ec3c43e33d.png">


