### PR TITLE
Add setup links for LN URL integration

### DIFF
--- a/BTCPayServer.Tests/SeleniumTests.cs
+++ b/BTCPayServer.Tests/SeleniumTests.cs
@@ -1508,13 +1508,19 @@ namespace BTCPayServer.Tests
             //ln address tests
             var store = s.CreateNewStore();
             s.GoToStore(s.StoreId, StoreNavPages.Integrations);
-            //ensure ln address is not available as lnurl is not configured
+            //ensure ln address is not available as Lightning is not enable
             s.Driver.FindElement(By.Id("lightning-address-option"))
-                .FindElement(By.ClassName("btcpay-status--disabled"));
+                .FindElement(By.LinkText("You need to setup Lightning first"));
 
             s.GoToStore(s.StoreId, StoreNavPages.PaymentMethods);
             s.AddLightningNode("BTC", LightningConnectionType.LndREST, false);
 
+            s.GoToStore(s.StoreId, StoreNavPages.Integrations);
+            //ensure ln address is not available as lnurl is not configured
+            s.Driver.FindElement(By.Id("lightning-address-option"))
+                .FindElement(By.LinkText("You need LNURL configured first"));
+            
+            s.GoToStore(s.StoreId, StoreNavPages.PaymentMethods);
             s.Driver.FindElement(By.Id($"Modify-LightningBTC")).Click();
             s.Driver.SetCheckbox(By.Id("LNURLEnabled"), true);
             s.Driver.WaitForAndClick(By.Id("save"));

--- a/BTCPayServer/Views/Shared/LNURL/LightningAddressOption.cshtml
+++ b/BTCPayServer/Views/Shared/LNURL/LightningAddressOption.cshtml
@@ -1,6 +1,6 @@
 @using BTCPayServer.Payments.Lightning
 @using BTCPayServer.Payments
-@using NBitcoin;
+@using NBitcoin
 @inject BTCPayNetworkProvider BTCPayNetworkProvider
 @{
     var store = Context.GetStoreData();

--- a/BTCPayServer/Views/Shared/LNURL/LightningAddressOption.cshtml
+++ b/BTCPayServer/Views/Shared/LNURL/LightningAddressOption.cshtml
@@ -1,35 +1,9 @@
 @using BTCPayServer.Payments.Lightning
-@using BTCPayServer.Payments
-@using NBitcoin
 @inject BTCPayNetworkProvider BTCPayNetworkProvider
 @{
     var store = Context.GetStoreData();
-    var lightningByCryptoCode = store
-            .GetSupportedPaymentMethods(BTCPayNetworkProvider)
-            .OfType<LightningSupportedPaymentMethod>()
-            .Where(method => method.PaymentId.PaymentType == LightningPaymentType.Instance)
-            .ToDictionary(c => c.CryptoCode.ToUpperInvariant());
-    var excludeFilters = store.GetStoreBlob().GetExcludedPaymentMethods();
-
-    var isLightningEnabled = false;
-    var isLNUrlEnabled = false;
-    
-    var paymentMethods = store.GetSupportedPaymentMethods(BTCPayNetworkProvider);
-    foreach (var paymentMethod in paymentMethods)
-    {
-        var paymentMethodId = paymentMethod.PaymentId;
-        switch (paymentMethodId.PaymentType)
-        {
-            case LNURLPayPaymentType lnurlPayPaymentType:
-                isLNUrlEnabled = !excludeFilters.Match(paymentMethodId);
-                break;
-            case LightningPaymentType _:
-                var lightning = lightningByCryptoCode.TryGet(paymentMethodId.CryptoCode);
-                isLightningEnabled = !excludeFilters.Match(paymentMethodId) && lightning != null;
-                break;
-        }
-    }
-
+    var isLightningEnabled = store.IsLightningEnabled(BTCPayNetworkProvider);
+    var isLNUrlEnabled = store.IsLNUrlEnabled(BTCPayNetworkProvider);
     var possible =
         isLightningEnabled &&
         isLNUrlEnabled &&

--- a/BTCPayServer/Views/Shared/LNURL/LightningAddressOption.cshtml
+++ b/BTCPayServer/Views/Shared/LNURL/LightningAddressOption.cshtml
@@ -1,8 +1,39 @@
 @using BTCPayServer.Payments.Lightning
+@using BTCPayServer.Payments
+@using NBitcoin;
 @inject BTCPayNetworkProvider BTCPayNetworkProvider
 @{
     var store = Context.GetStoreData();
-    var possible = store.GetSupportedPaymentMethods(BTCPayNetworkProvider).OfType<LNURLPaySupportedPaymentMethod>().Any(type => type.CryptoCode == "BTC");
+    var lightningByCryptoCode = store
+            .GetSupportedPaymentMethods(BTCPayNetworkProvider)
+            .OfType<LightningSupportedPaymentMethod>()
+            .Where(method => method.PaymentId.PaymentType == LightningPaymentType.Instance)
+            .ToDictionary(c => c.CryptoCode.ToUpperInvariant());
+    var excludeFilters = store.GetStoreBlob().GetExcludedPaymentMethods();
+
+    var isLightningEnabled = false;
+    var isLNUrlEnabled = false;
+    
+    var paymentMethods = store.GetSupportedPaymentMethods(BTCPayNetworkProvider);
+    foreach (var paymentMethod in paymentMethods)
+    {
+        var paymentMethodId = paymentMethod.PaymentId;
+        switch (paymentMethodId.PaymentType)
+        {
+            case LNURLPayPaymentType lnurlPayPaymentType:
+                isLNUrlEnabled = !excludeFilters.Match(paymentMethodId);
+                break;
+            case LightningPaymentType _:
+                var lightning = lightningByCryptoCode.TryGet(paymentMethodId.CryptoCode);
+                isLightningEnabled = !excludeFilters.Match(paymentMethodId) && lightning != null;
+                break;
+        }
+    }
+
+    var possible =
+        isLightningEnabled &&
+        isLNUrlEnabled &&
+        store.GetSupportedPaymentMethods(BTCPayNetworkProvider).OfType<LNURLPaySupportedPaymentMethod>().Any(type => type.CryptoCode == "BTC");
 }
 <li class="list-group-item bg-tile" id="lightning-address-option">
     <div class="d-flex align-items-center">
@@ -23,10 +54,21 @@
             }
             else
             {
-                <span class="d-flex align-items-center text-danger">
-                    <span class="me-2 btcpay-status btcpay-status--disabled"></span>
-                    You need LNURL configured first.
-                </span>
+                if (!isLightningEnabled)
+                {
+                    <a asp-action="PaymentMethods" asp-controller="Stores" asp-route-storeId="@store.Id" class="btn btn-link p-0">
+                        You need to setup Lightning first
+                    </a>
+                }
+                else
+                {
+                    <span class="d-flex align-items-center text-danger">
+                        <span class="me-2 btcpay-status btcpay-status--disabled"></span>
+                        <a asp-action="LightningSettings" asp-route-cryptoCode="BTC" asp-route-storeId="@store.Id" asp-fragment="ln-url">
+                            You need LNURL configured first
+                        </a>
+                    </span>
+                }
             }
         </span>
     </div>

--- a/BTCPayServer/Views/Stores/LightningSettings.cshtml
+++ b/BTCPayServer/Views/Stores/LightningSettings.cshtml
@@ -54,7 +54,7 @@
                         </p>
                     </div>
                     
-                    <h4 class="mt-5 mb-3">LNURL</h4>
+                    <h4 class="mt-5 mb-3" id="ln-url">LNURL</h4>
                     <div class="d-flex align-items-center">
                         <input asp-for="LNURLEnabled" type="checkbox" class="btcpay-toggle me-2" data-bs-toggle="collapse" data-bs-target="#LNURLSettings" aria-expanded="@Model.LNURLEnabled" aria-controls="LNURLSettings"/>
                         <label asp-for="LNURLEnabled" class="form-label mb-0 me-1"></label>

--- a/BTCPayServer/wwwroot/main/bootstrap/bootstrap.css
+++ b/BTCPayServer/wwwroot/main/bootstrap/bootstrap.css
@@ -10191,6 +10191,7 @@ input[type=number].hide-number-spin {
 }
 .btcpay-status {
   display: inline-flex;
+  flex-shrink: 0;
   align-items: center;
   justify-content: center;
   border: .25em solid transparent;


### PR DESCRIPTION
Currently if user doesn't have LN set up or if they do but don't have the LN URL option enabled they have to manually navigate to payment methods and enable LN if it's disabled or go to LN settings and enable LN URL.

This PR adds two setup links:

- If LN is not set up at all user will get a link to set up LN first (see screenshot below)
- If LN is set up but LN URL option is not turned on yet user will get a link that takes them exactly to the LN settings page and even to the exact heading (in case use is on a mobile phone so they don't have to swipe up)

![Capture](https://user-images.githubusercontent.com/1934678/139616751-4c313bf7-8fd0-48d7-aedb-f9ce4635d01a.PNG)
