### PR TITLE
Print view improvements

### DIFF
--- a/BTCPayServer/Views/AppsPublic/PointOfSale/Print.cshtml
+++ b/BTCPayServer/Views/AppsPublic/PointOfSale/Print.cshtml
@@ -15,22 +15,32 @@
         supported = null;
     }
     
-    
 }
 @if (supported is null)
 {
     <div class="alert alert-warning text-center sticky-top mb-0 rounded-0" role="alert">
         LNURL is not enabled on your store, which this print feature relies on.
+        <a asp-action="PaymentMethods" asp-controller="Stores" asp-route-storeId="@Model.Store.Id" class="btn btn-link p-0">
+            Enable LNURL
+        </a>
     </div>
 }
+
+@if (supported != null)
+{
+    <button type="button" class="btn btn-primary d-print-none" onclick="window.print()">
+        <i class="fa fa-print"></i>&nbsp;Print
+    </button>
+}
+
 <div class="container d-flex h-100">
     <div class="justify-content-center align-self-center text-center mx-auto px-2 py-3 w-100 m-auto">
         <partial name="_StatusMessage" />
 
-        <h1 class="mb-4">@Model.Title</h1>
+        <h1 class="mb-4 d-print-none">@Model.Title</h1>
         @if (!string.IsNullOrEmpty(Model.Description))
         {
-            <div class="row">
+            <div class="row d-print-none">
                 <div class="overflow-hidden col-12">@Safe.Raw(Model.Description)</div>
             </div>
         }
@@ -77,7 +87,7 @@
                                 }, Context.Request.Scheme, Context.Request.Host.ToString()));
                                 var lnUrl = LNURL.EncodeUri(lnurlEndpoint, "payRequest", supported.UseBech32Scheme);
                                 <vc:qr-code data="@lnUrl.ToString().ToUpperInvariant()"></vc:qr-code>
-
+                                
                                 <a href="@lnUrl" class="btn btn-secondary d-print-none w-100 mt-2 lnurl" data-choice="@item.Id" rel="noreferrer noopener">
                                     Open in wallet
                                 </a>
@@ -86,7 +96,7 @@
                         @if (item.Inventory.HasValue)
                         {
 
-                            <div class="w-100 pt-2 text-center text-muted">
+                            <div class="w-100 pt-2 text-center text-muted d-print-none">
                                 @if (item.Inventory > 0)
                                 {
                                     <span>@item.Inventory left</span>

--- a/BTCPayServer/Views/AppsPublic/PointOfSale/Print.cshtml
+++ b/BTCPayServer/Views/AppsPublic/PointOfSale/Print.cshtml
@@ -5,15 +5,20 @@
 @model BTCPayServer.Models.AppViewModels.ViewPointOfSaleViewModel
 
 <style>
-    .card-deck { display: unset; }
-    .card { page-break-inside: avoid; width: 300px; margin: 0 1em 1em 0; float: left; }
+    /* This hides unwanted metadata such as url, date, etc from appearing on a printed page. */
+    @@media print {
+        @@page {
+            margin-top: 0;
+            margin-bottom: 0;
+        }
+    }
+    .card { display: inline-block; width: 300px; page-break-inside: avoid; margin: 2em 1em 0 1em; }
 </style>
 
 @{
+    Layout = "_LayoutPos";
     Context.Request.Query.TryGetValue("cryptocode", out var cryptoCodeValues);
     var cryptoCode = cryptoCodeValues.FirstOrDefault() ?? "BTC";
-    Layout = "_LayoutPos";
-    var anyInventoryItems = Model.Items.Any(item => item.Inventory.HasValue);
     var supported = Model.Store.GetSupportedPaymentMethods(BTCPayNetworkProvider).OfType<LNURLPaySupportedPaymentMethod>().OrderBy(method => method.CryptoCode == cryptoCode).FirstOrDefault();
     if (supported != null && !Model.Store.GetEnabledPaymentIds(BTCPayNetworkProvider).Contains(supported.PaymentId))
     {
@@ -21,117 +26,65 @@
     }
     
 }
+
 @if (supported is null)
 {
     <div class="alert alert-warning text-center sticky-top mb-0 rounded-0" role="alert">
         LNURL is not enabled on your store, which this print feature relies on.
-        <a asp-action="PaymentMethods" asp-controller="Stores" asp-route-storeId="@Model.Store.Id" class="btn btn-link p-0">
+        <a asp-action="PaymentMethods" asp-controller="Stores" asp-route-storeId="@Model.Store.Id" class="alert-link p-0">
             Enable LNURL
         </a>
     </div>
 }
-
-@if (supported != null)
+else
 {
-    <button type="button" class="btn btn-primary d-print-none" onclick="window.print()">
-        <i class="fa fa-print"></i>&nbsp;Print
-    </button>
+    <div class="alert alert-info d-flex align-items-center justify-content-center sticky-top mb-0 rounded-0 d-print-none" role="alert">
+        <button type="button" class="btn btn-info me-4 border border-light" onclick="window.print()">
+            <i class="fa fa-print"></i>&nbsp;Print
+        </button>
+        This view is intended for printing only —
+        <a asp-route-viewType="static" class="alert-link">Regular version</a>
+    </div>
 }
 
-<div class="container d-flex h-100">
-    <div class="justify-content-center align-self-center text-center mx-auto px-2 py-3 w-100 m-auto">
-        <partial name="_StatusMessage" />
-
-        <h1 class="mb-4 d-print-none">@Model.Title</h1>
-        @if (!string.IsNullOrEmpty(Model.Description))
-        {
-            <div class="row d-print-none">
-                <div class="overflow-hidden col-12">@Safe.Raw(Model.Description)</div>
-            </div>
-        }
-        <div class="card-deck my-3 mx-auto">
-            @for (int x = 0; x < Model.Items.Length; x++)
-            {
-                var item = Model.Items[x];
-                var buttonText = string.IsNullOrEmpty(item.BuyButtonText) ? item.Price.Type != ViewPointOfSaleViewModel.Item.ItemPrice.ItemPriceType.Fixed ? Model.CustomButtonText : Model.ButtonText : item.BuyButtonText;
-                buttonText = buttonText.Replace("{0}",item.Price.Formatted)
-                    ?.Replace("{Price}",item.Price.Formatted);
-                
-                <div class="card px-0" data-id="@x">
-                    @if (!String.IsNullOrWhiteSpace(item.Image))
-                    {
-                        <img class="card-img-top d-print-none" src="@item.Image" asp-append-version="true">
-                    }
-                    @{CardBody(item.Title, item.Description);}
-                    <div class="card-footer bg-transparent border-0 pb-3">
-                        <div class="w-100 pt-2 text-center text-muted">
-                            @switch (item.Price.Type)
-                            {
-                                case ViewPointOfSaleViewModel.Item.ItemPrice.ItemPriceType.Topup:
-                                    <span>Any amount</span>
-                                    break;
-                                case ViewPointOfSaleViewModel.Item.ItemPrice.ItemPriceType.Minimum:
-                                    <span>@item.Price.Formatted minimum</span>
-                                    break;
-                                case ViewPointOfSaleViewModel.Item.ItemPrice.ItemPriceType.Fixed:
-                                    @item.Price.Formatted
-                                    break;
-                                default:
-                                    throw new ArgumentOutOfRangeException();
-                            }
-                        </div>
-                        @if (!item.Inventory.HasValue || item.Inventory.Value > 0)
-                        {
-                            if (supported != null)
-                            {
-                                var lnurlEndpoint = new Uri(Url.Action("GetLNURLForApp", "LNURL", new
-                                {
-                                    cryptoCode = supported.CryptoCode,
-                                    appid = Model.AppId,
-                                    ItemCode = item.Id
-                                }, Context.Request.Scheme, Context.Request.Host.ToString()));
-                                var lnUrl = LNURL.EncodeUri(lnurlEndpoint, "payRequest", supported.UseBech32Scheme);
-                                <vc:qr-code data="@lnUrl.ToString().ToUpperInvariant()"></vc:qr-code>
-                                
-                                <a href="@lnUrl" class="btn btn-secondary d-print-none w-100 mt-2 lnurl" data-choice="@item.Id" rel="noreferrer noopener">
-                                    Open in wallet
-                                </a>
-                            }
-                        }
-                        @if (item.Inventory.HasValue)
-                        {
-
-                            <div class="w-100 pt-2 text-center text-muted d-print-none">
-                                @if (item.Inventory > 0)
-                                {
-                                    <span>@item.Inventory left</span>
-                                }
-                                else
-                                {
-                                    <span>Sold out</span>
-                                }
-                            </div>
-                        }
-                        else if (anyInventoryItems)
-                        {
-                            <div class="w-100 pt-2">&nbsp;</div>
-                        }
-                    </div>
-                </div>
-            }
-        </div>
-    </div>
-</div>
-
-@functions {
-    private void CardBody(string title, string description)
+<div class="container text-center">
+    @for (int x = 0; x < Model.Items.Length; x++)
     {
-        <div class="card-body my-auto pb-0">
-            <h5 class="card-title">@title</h5>
-            @if (!String.IsNullOrWhiteSpace(description))
-            {
-                <p class="card-text d-print-none">@Safe.Raw(description)</p>
-            }
+        var item = Model.Items[x];
+        <div class="card" data-id="@x">
+            <div class="card-body my-auto">
+                <h4 class="card-title text-center">@item.Title</h4>
+                <div class="w-100 mb-3 fs-5 text-center">
+                    @switch (item.Price.Type)
+                    {
+                        case ViewPointOfSaleViewModel.Item.ItemPrice.ItemPriceType.Topup:
+                            <span>Any amount</span>
+                            break;
+                        case ViewPointOfSaleViewModel.Item.ItemPrice.ItemPriceType.Minimum:
+                            <span>@item.Price.Formatted minimum</span>
+                            break;
+                        case ViewPointOfSaleViewModel.Item.ItemPrice.ItemPriceType.Fixed:
+                            @item.Price.Formatted
+                            break;
+                        default:
+                            throw new ArgumentOutOfRangeException();
+                    }
+                </div>
+                @if (!item.Inventory.HasValue || item.Inventory.Value > 0)
+                {
+                    if (supported != null)
+                    {
+                        var lnurlEndpoint = new Uri(Url.Action("GetLNURLForApp", "LNURL", new
+                        {
+                            cryptoCode = supported.CryptoCode,
+                            appid = Model.AppId,
+                            ItemCode = item.Id
+                        }, Context.Request.Scheme, Context.Request.Host.ToString()));
+                        var lnUrl = LNURL.EncodeUri(lnurlEndpoint, "payRequest", supported.UseBech32Scheme);
+                        <vc:qr-code data="@lnUrl.ToString().ToUpperInvariant()" />
+                    }
+                }
+            </div>
         </div>
     }
-}
+</div>

--- a/BTCPayServer/Views/AppsPublic/PointOfSale/Print.cshtml
+++ b/BTCPayServer/Views/AppsPublic/PointOfSale/Print.cshtml
@@ -4,6 +4,11 @@
 @inject BTCPayNetworkProvider BTCPayNetworkProvider
 @model BTCPayServer.Models.AppViewModels.ViewPointOfSaleViewModel
 
+<style>
+    .card-deck { display: unset; }
+    .card { page-break-inside: avoid; width: 300px; margin: 0 1em 1em 0; float: left; }
+</style>
+
 @{
     Context.Request.Query.TryGetValue("cryptocode", out var cryptoCodeValues);
     var cryptoCode = cryptoCodeValues.FirstOrDefault() ?? "BTC";
@@ -55,7 +60,7 @@
                 <div class="card px-0" data-id="@x">
                     @if (!String.IsNullOrWhiteSpace(item.Image))
                     {
-                        <img class="card-img-top" src="@item.Image" asp-append-version="true">
+                        <img class="card-img-top d-print-none" src="@item.Image" asp-append-version="true">
                     }
                     @{CardBody(item.Title, item.Description);}
                     <div class="card-footer bg-transparent border-0 pb-3">
@@ -125,7 +130,7 @@
             <h5 class="card-title">@title</h5>
             @if (!String.IsNullOrWhiteSpace(description))
             {
-                <p class="card-text">@Safe.Raw(description)</p>
+                <p class="card-text d-print-none">@Safe.Raw(description)</p>
             }
         </div>
     }

--- a/BTCPayServer/wwwroot/main/site.css
+++ b/BTCPayServer/wwwroot/main/site.css
@@ -536,3 +536,15 @@ header.masthead .header-content .header-content-inner p {
     height: 1rem;
     padding: 0 0.5rem 0 1rem;
 }
+
+
+@media print {
+    @page {
+        margin-top: 0;
+        margin-bottom: 0;
+    }
+    body {
+        padding-top: 72px;
+        padding-bottom: 72px ;
+    }
+}

--- a/BTCPayServer/wwwroot/main/site.css
+++ b/BTCPayServer/wwwroot/main/site.css
@@ -537,7 +537,9 @@ header.masthead .header-content .header-content-inner p {
     padding: 0 0.5rem 0 1rem;
 }
 
-
+/* This hides unwanted metadata such as url, date, etc from appearing on a printed page. 
+The purpose is to clean the Print view of a PoS app, but it may cut off the headers and footers
+if someone tries to print a different page in BTCPay Server. */
 @media print {
     @page {
         margin-top: 0;

--- a/BTCPayServer/wwwroot/main/site.css
+++ b/BTCPayServer/wwwroot/main/site.css
@@ -536,17 +536,3 @@ header.masthead .header-content .header-content-inner p {
     height: 1rem;
     padding: 0 0.5rem 0 1rem;
 }
-
-/* This hides unwanted metadata such as url, date, etc from appearing on a printed page. 
-The purpose is to clean the Print view of a PoS app, but it may cut off the headers and footers
-if someone tries to print a different page in BTCPay Server. */
-@media print {
-    @page {
-        margin-top: 0;
-        margin-bottom: 0;
-    }
-    body {
-        padding-top: 72px;
-        padding-bottom: 72px ;
-    }
-}


### PR DESCRIPTION
WIP. EDIT: Ready for review.
 
- Adds a print button
- Modifies the warning message on the `Print` PoS view to include a link to the proper settings page (h/t @bolatovumar)
- Adds the css class `d-print-none` to hide some potentially undesired elements for the printed page (Store title, store description, and item inventory probably aren't appropriate for a printed page displayed in a storefront*). This also simplifies the formatting of the printed page.

Despite the last bullet point, I'm still running into trouble with the formatting of the bootstrap `card` elements on the page-to-print:

![image](https://user-images.githubusercontent.com/4956763/139785386-c2b38d11-04bb-4b1f-a80c-9eddd7ba6e1f.png)

I also haven't figured out a way to prevent the items from going over the page break. I'm using the default 8.5x11 inch ANSI letter, but I assume we'd have similar issues with A4.

Paging @dstrukt @dennisreimann, any ideas?


*It would be nice to hear some feedback on this from users who plan to use the `print` PoS view, i.e.: what item elements do they need on the printed page? Presumably for formatting purposes, the fewer, the better (but again I'll defer to the CSS experts on this one).

