### PR TITLE
Bugfix #3049: Price type of edit item in PoS shows only "fixed"

### DIFF
--- a/BTCPayServer/Views/Apps/TemplateEditor.cshtml
+++ b/BTCPayServer/Views/Apps/TemplateEditor.cshtml
@@ -210,8 +210,6 @@ document.addEventListener("DOMContentLoaded", function () {
                         }
                         if (productProperty.indexOf('price_type:') !== -1) {
                             custom = productProperty.replace('price_type:', '').trim();
-                        }else{
-                            custom = "fixed";
                         }
                         if (productProperty.indexOf('buyButtonText:') !== -1) {
                             buyButtonText = productProperty.replace('buyButtonText:', '').trim();
@@ -235,7 +233,7 @@ document.addEventListener("DOMContentLoaded", function () {
                             price: price,
                             image: image || null,
                             description:  description || '',
-                            custom: custom,
+                            custom: custom || "fixed",
                             buyButtonText: buyButtonText,
                             inventory: isNaN(inventory)? null: inventory,
                             paymentMethods: paymentMethods,


### PR DESCRIPTION
The loop through all properties caused the problem. The "else" case was alway the last and so was the variable "custom" always "fixed". 
Removed the else case and added a default value.
Fixes #3049