### PR TITLE
Add View Style to Apps list

### DIFF
--- a/BTCPayServer/Controllers/AppsController.cs
+++ b/BTCPayServer/Controllers/AppsController.cs
@@ -73,8 +73,6 @@ namespace BTCPayServer.Controllers
                                 return app.StoreName;
                             case nameof(app.AppType):
                                 return app.AppType;
-                            case nameof(app.ViewStyle):
-                                return app.ViewStyle;
                             default:
                                 return app.Id;
                         }

--- a/BTCPayServer/Controllers/AppsController.cs
+++ b/BTCPayServer/Controllers/AppsController.cs
@@ -73,6 +73,8 @@ namespace BTCPayServer.Controllers
                                 return app.StoreName;
                             case nameof(app.AppType):
                                 return app.AppType;
+                            case nameof(app.ViewStyle):
+                                return app.ViewStyle;
                             default:
                                 return app.Id;
                         }

--- a/BTCPayServer/Models/AppViewModels/ListAppsViewModel.cs
+++ b/BTCPayServer/Models/AppViewModels/ListAppsViewModel.cs
@@ -9,6 +9,7 @@ namespace BTCPayServer.Models.AppViewModels
             public string StoreId { get; set; }
             public string AppName { get; set; }
             public string AppType { get; set; }
+            public string ViewStyle { get; set; }
             public bool IsOwner { get; set; }
 
             public string UpdateAction { get { return "Update" + AppType; } }

--- a/BTCPayServer/Services/Apps/AppService.cs
+++ b/BTCPayServer/Services/Apps/AppService.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using BTCPayServer.Client.Models;
+using BTCPayServer.Controllers;
 using BTCPayServer.Data;
 using BTCPayServer.Models.AppViewModels;
 using BTCPayServer.Payments;
@@ -227,7 +228,7 @@ namespace BTCPayServer.Services.Apps
         {
             using (var ctx = _ContextFactory.CreateContext())
             {
-                return await ctx.UserStore
+                var listApps = await ctx.UserStore
                     .Where(us =>
                         (allowNoUser && string.IsNullOrEmpty(userId) || us.ApplicationUserId == userId) &&
                         (storeId == null || us.StoreDataId == storeId))
@@ -243,7 +244,38 @@ namespace BTCPayServer.Services.Apps
                                 Id = app.Id
                             })
                     .ToArrayAsync();
+                
+                foreach (ListAppsViewModel.ListAppViewModel app in listApps)
+                {
+                    app.ViewStyle = await GetAppViewStyleAsync(app.Id, app.AppType);
+                }
+        
+                return listApps;
             }
+        }
+        
+        public async Task<string> GetAppViewStyleAsync(string appId, string appType)
+        {
+            AppType appTypeEnum = Enum.Parse<AppType>(appType);
+            AppData appData = await GetApp(appId, appTypeEnum, false);
+            var settings = appData.GetSettings<AppsController.PointOfSaleSettings>();
+
+            string style;
+            switch (appTypeEnum)
+            {
+                case AppType.PointOfSale:
+                    string posViewStyle = (settings.EnableShoppingCart ? PosViewType.Cart : settings.DefaultView).ToString();
+                    style = typeof(PosViewType).DisplayName(posViewStyle);
+                    break;
+                case AppType.Crowdfund:
+                    style = string.Empty;
+                    break;
+                default:
+                    style = string.Empty;
+                    break;
+            }
+
+            return style;
         }
 
         public async Task<List<AppData>> GetApps(string[] appIds, bool includeStore = false)

--- a/BTCPayServer/Views/Apps/ListApps.cshtml
+++ b/BTCPayServer/Views/Apps/ListApps.cshtml
@@ -5,6 +5,7 @@
     var storeNameSortOrder = (string)ViewData["StoreNameSortOrder"];
     var appNameSortOrder = (string)ViewData["AppNameSortOrder"];
     var appTypeSortOrder = (string)ViewData["AppTypeSortOrder"];
+    var viewStyleSortOrder = (string)ViewData["ViewStyleSortOrder"];
     var sortByDesc = "Sort by descending...";
     var sortByAsc = "Sort by ascending...";
 }
@@ -68,6 +69,18 @@
                                     <span class="fa @(appTypeSortOrder == "asc" ? "fa-sort-alpha-desc" : appTypeSortOrder == "desc" ? "fa-sort-alpha-asc" : "fa-sort")" />
                                 </a>
                             </th>
+                            <th>
+                                <a
+                                    asp-action="ListApps"
+                                    asp-route-sortOrder="@(viewStyleSortOrder ?? "asc")"
+                                    asp-route-sortOrderColumn="ViewStyle"
+                                    class="text-nowrap"
+                                    title="@(viewStyleSortOrder == "desc" ? sortByDesc : sortByAsc)"
+                                >
+                                    View Style
+                                    <span class="fa @(viewStyleSortOrder == "asc" ? "fa-sort-alpha-desc" : viewStyleSortOrder == "desc" ? "fa-sort-alpha-asc" : "fa-sort")" />
+                                </a>
+                            </th>
                             <th style="text-align:right">Actions</th>
                         </tr>
                         </thead>
@@ -87,6 +100,7 @@
                                 </td>
                                 <td>@app.AppName</td>
                                 <td>@typeof(AppType).DisplayName(app.AppType)</td>
+                                <td>@app.ViewStyle</td>
                                 <td style="text-align:right">
                                     @if (app.IsOwner)
                                     {

--- a/BTCPayServer/Views/Apps/ListApps.cshtml
+++ b/BTCPayServer/Views/Apps/ListApps.cshtml
@@ -5,7 +5,6 @@
     var storeNameSortOrder = (string)ViewData["StoreNameSortOrder"];
     var appNameSortOrder = (string)ViewData["AppNameSortOrder"];
     var appTypeSortOrder = (string)ViewData["AppTypeSortOrder"];
-    var viewStyleSortOrder = (string)ViewData["ViewStyleSortOrder"];
     var sortByDesc = "Sort by descending...";
     var sortByAsc = "Sort by ascending...";
 }
@@ -69,18 +68,6 @@
                                     <span class="fa @(appTypeSortOrder == "asc" ? "fa-sort-alpha-desc" : appTypeSortOrder == "desc" ? "fa-sort-alpha-asc" : "fa-sort")" />
                                 </a>
                             </th>
-                            <th>
-                                <a
-                                    asp-action="ListApps"
-                                    asp-route-sortOrder="@(viewStyleSortOrder ?? "asc")"
-                                    asp-route-sortOrderColumn="ViewStyle"
-                                    class="text-nowrap"
-                                    title="@(viewStyleSortOrder == "desc" ? sortByDesc : sortByAsc)"
-                                >
-                                    View Style
-                                    <span class="fa @(viewStyleSortOrder == "asc" ? "fa-sort-alpha-desc" : viewStyleSortOrder == "desc" ? "fa-sort-alpha-asc" : "fa-sort")" />
-                                </a>
-                            </th>
                             <th style="text-align:right">Actions</th>
                         </tr>
                         </thead>
@@ -99,8 +86,15 @@
                                     }
                                 </td>
                                 <td>@app.AppName</td>
-                                <td>@typeof(AppType).DisplayName(app.AppType)</td>
-                                <td>@app.ViewStyle</td>
+                                <td>
+                                    @typeof(AppType).DisplayName(app.AppType) 
+                                    @if (app.AppType != AppType.Crowdfund.ToString())
+                                    {
+                                        <span>-</span> 
+                                    }
+                                    
+                                    @app.ViewStyle
+                                </td>
                                 <td style="text-align:right">
                                     @if (app.IsOwner)
                                     {


### PR DESCRIPTION
When using/debugging PoS apps and needing to test a particular view style, I can never remember which app is set to which view style. 

This gives sortable, ListApps-level visibility to the view style of PoS apps. If Crowdfund (or a future app type) eventually has multiple view styles, this can be extended to incorporate those, too.

![image](https://user-images.githubusercontent.com/4956763/139999914-2925cc92-bac6-400a-a961-2199737cb006.png)
