### PR TITLE
Improve error reporting in create invoice page

### DIFF
--- a/BTCPayServer/Controllers/InvoiceController.UI.cs
+++ b/BTCPayServer/Controllers/InvoiceController.UI.cs
@@ -894,8 +894,11 @@ namespace BTCPayServer.Controllers
             }
             catch (BitpayHttpException ex)
             {
-                Logs.PayServer.LogError(ex, $"Invoice creation failed due to invalid currency {model.Currency}");
-                ModelState.TryAddModelError(nameof(model.Currency), "Please make sure you entered a valid currency symbol, a rate provider is configured in store settings, and your configured rate provider is both online and providing rates for your selected currency.");
+                this.TempData.SetStatusMessageModel(new StatusMessageModel()
+                {
+                    Severity = StatusMessageModel.StatusSeverity.Error,
+                    Message = ex.Message
+                });
                 return View(model);
             }
         }

--- a/BTCPayServer/Controllers/InvoiceController.cs
+++ b/BTCPayServer/Controllers/InvoiceController.cs
@@ -409,6 +409,11 @@ namespace BTCPayServer.Controllers
                             return null;
                         }
                     }
+                    else
+                    {
+                        var suffix = currentRateToCrypto?.EvaluatedRule is string s ? $" ({s})" : string.Empty;
+                        logs.Write($"{logPrefix} This payment method should be created only if the amount of this invoice is in proper range. However, we are unable to fetch the rate of those limits. {suffix}", InvoiceEventData.EventSeverity.Warning);
+                    }
                 }
 
 #pragma warning disable CS0618

--- a/BTCPayServer/Views/Shared/_StatusMessage.cshtml
+++ b/BTCPayServer/Views/Shared/_StatusMessage.cshtml
@@ -1,4 +1,4 @@
-﻿@{
+@{
     var parsedModel = TempData.GetStatusMessageModel();
 }
 
@@ -13,7 +13,7 @@
         }
         @if (!string.IsNullOrEmpty(parsedModel.Message))
         {
-            @parsedModel.Message
+            <span style="white-space: pre-wrap;">@parsedModel.Message</span>
         }
         @if (!string.IsNullOrEmpty(parsedModel.Html))
         {


### PR DESCRIPTION
1. Report error messages properly in invoice create page, making it possible to find what is wrong in #3054 for example
2. Interpret new lines in status message as line break to make errors more readable
3. If a payment method shouldn't be available because it is below or above some limit, but that no conversion is available between the limit's currency and the invoice currency, properly log a warning in the logs.
4. Show the invoice creation error in status message rather than currency error. Error might come from several causes unrelated to the currency.


Fix #3059

![image](https://user-images.githubusercontent.com/3020646/140278692-9c4f8736-d1df-427d-b6e3-6978e04fa33f.png)
