### PR TITLE
Fix LockSubscription bug

### DIFF
--- a/BTCPayServer.Tests/TestAccount.cs
+++ b/BTCPayServer.Tests/TestAccount.cs
@@ -215,6 +215,17 @@ namespace BTCPayServer.Tests
                 IsAdmin = isAdmin
             };
             await account.Register(RegisterDetails);
+
+            //this addresses an obscure issue where LockSubscription is unintentionally set to "true",
+            //resulting in a large number of tests failing.  
+            if (account.RegisteredUserId == null) 
+            {
+                var settings = parent.PayTester.GetService<SettingsRepository>();
+                var policies = await settings.GetSettingAsync<PoliciesSettings>() ?? new PoliciesSettings();
+                policies.LockSubscription = false;
+                await account.Register(RegisterDetails);
+            }
+
             UserId = account.RegisteredUserId;
             IsAdmin = account.RegisteredAdmin;
         }


### PR DESCRIPTION
This addresses an issue in which `LockSubscription` is unintentionally set to `true`,
resulting in a large number of tests failing in a slightly obscure manner. For example:

![image](https://user-images.githubusercontent.com/4956763/140934824-7cdf874e-f838-4b87-84ae-c4cafd9c2f8a.png)


 h/t to @NicolasDorier for the assist.