### PR TITLE
Add crypto code for invoice and pull payment payout API response

### DIFF
--- a/BTCPayServer.Client/Models/InvoicePaymentMethodDataModel.cs
+++ b/BTCPayServer.Client/Models/InvoicePaymentMethodDataModel.cs
@@ -33,6 +33,8 @@ namespace BTCPayServer.Client.Models
         public List<Payment> Payments { get; set; }
         public string PaymentMethod { get; set; }
 
+        public string CryptoCode { get; set; }
+
         public class Payment
         {
             public string Id { get; set; }

--- a/BTCPayServer.Client/Models/PayoutData.cs
+++ b/BTCPayServer.Client/Models/PayoutData.cs
@@ -21,6 +21,7 @@ namespace BTCPayServer.Client.Models
         public string PullPaymentId { get; set; }
         public string Destination { get; set; }
         public string PaymentMethod { get; set; }
+        public string CryptoCode { get; set; }
         [JsonConverter(typeof(NumericStringJsonConverter))]
         public decimal Amount { get; set; }
         [JsonConverter(typeof(NumericStringJsonConverter))]

--- a/BTCPayServer.Tests/GreenfieldAPITests.cs
+++ b/BTCPayServer.Tests/GreenfieldAPITests.cs
@@ -1186,6 +1186,7 @@ namespace BTCPayServer.Tests
                 Assert.Single(paymentMethods);
                 var paymentMethod = paymentMethods.First();
                 Assert.Equal("BTC", paymentMethod.PaymentMethod);
+                Assert.Equal("BTC", paymentMethod.CryptoCode);
                 Assert.Empty(paymentMethod.Payments);
 
 

--- a/BTCPayServer.Tests/GreenfieldAPITests.cs
+++ b/BTCPayServer.Tests/GreenfieldAPITests.cs
@@ -437,6 +437,8 @@ namespace BTCPayServer.Tests
                 Assert.Equal(payout.Id, payout2.Id);
                 Assert.Equal(destination, payout2.Destination);
                 Assert.Equal(PayoutState.AwaitingApproval, payout.State);
+                Assert.Equal("BTC", payout2.PaymentMethod);
+                Assert.Equal("BTC", payout2.CryptoCode);
                 Assert.Null(payout.PaymentMethodAmount);
 
                 Logs.Tester.LogInformation("Can't overdraft");

--- a/BTCPayServer/Controllers/GreenField/InvoiceController.cs
+++ b/BTCPayServer/Controllers/GreenField/InvoiceController.cs
@@ -354,6 +354,7 @@ namespace BTCPayServer.Controllers.GreenField
                     {
                         Activated = details.Activated,
                         PaymentMethod = method.GetId().ToStringNormalized(),
+                        CryptoCode = method.GetId().CryptoCode,
                         Destination = details.GetPaymentDestination(),
                         Rate = method.Rate,
                         Due = accounting.DueUncapped.ToDecimal(MoneyUnit.BTC),

--- a/BTCPayServer/Controllers/GreenField/InvoiceController.cs
+++ b/BTCPayServer/Controllers/GreenField/InvoiceController.cs
@@ -1,8 +1,8 @@
+#nullable enable
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using System.Globalization;
 using BTCPayServer.Abstractions.Constants;
 using BTCPayServer.Client;
 using BTCPayServer.Client.Models;
@@ -49,14 +49,14 @@ namespace BTCPayServer.Controllers.GreenField
         [Authorize(Policy = Policies.CanViewInvoices,
             AuthenticationSchemes = AuthenticationSchemes.Greenfield)]
         [HttpGet("~/api/v1/stores/{storeId}/invoices")]
-        public async Task<IActionResult> GetInvoices(string storeId, [FromQuery] string[] orderId = null, [FromQuery] string[] status = null,
+        public async Task<IActionResult> GetInvoices(string storeId, [FromQuery] string[]? orderId = null, [FromQuery] string[]? status = null,
             [FromQuery]
             [ModelBinder(typeof(ModelBinders.DateTimeOffsetModelBinder))]
             DateTimeOffset? startDate = null,
             [FromQuery] 
             [ModelBinder(typeof(ModelBinders.DateTimeOffsetModelBinder))]
             DateTimeOffset? endDate = null,
-            [FromQuery] string textSearch = null,
+            [FromQuery] string? textSearch = null,
             [FromQuery] bool includeArchived = false,
             [FromQuery] int? skip = null,
             [FromQuery] int? take = null

--- a/BTCPayServer/Controllers/GreenField/PullPaymentController.cs
+++ b/BTCPayServer/Controllers/GreenField/PullPaymentController.cs
@@ -218,6 +218,7 @@ namespace BTCPayServer.Controllers.GreenField
             };
             model.Destination = blob.Destination;
             model.PaymentMethod = p.PaymentMethodId;
+            model.CryptoCode = p.GetPaymentMethodId().CryptoCode;
             return model;
         }
 

--- a/BTCPayServer/Controllers/GreenField/PullPaymentController.cs
+++ b/BTCPayServer/Controllers/GreenField/PullPaymentController.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -98,7 +99,7 @@ namespace BTCPayServer.Controllers.GreenField
             {
                 ModelState.AddModelError(nameof(request.Period), $"The period should be positive");
             }
-            PaymentMethodId[] paymentMethods = null;
+            PaymentMethodId?[]? paymentMethods = null;
             if (request.PaymentMethods is { } paymentMethodsStr)
             {
                 paymentMethods = paymentMethodsStr.Select(s =>
@@ -246,7 +247,7 @@ namespace BTCPayServer.Controllers.GreenField
             if (pp is null)
                 return PullPaymentNotFound();
             var ppBlob = pp.GetBlob();
-            var destination = await payoutHandler.ParseClaimDestination(paymentMethodId,request.Destination, true);
+            var destination = await payoutHandler.ParseClaimDestination(paymentMethodId, request!.Destination, true);
             if (destination.destination is null)
             {
                 ModelState.AddModelError(nameof(request.Destination), destination.error??"The destination is invalid for the payment specified");
@@ -339,7 +340,7 @@ namespace BTCPayServer.Controllers.GreenField
             var payout = await ctx.Payouts.GetPayout(payoutId, storeId, true, true);
             if (payout is null)
                 return PayoutNotFound();
-            RateResult rateResult = null;
+            RateResult? rateResult = null;
             try
             {
                 rateResult = await _pullPaymentService.GetRate(payout, approvePayoutRequest?.RateRule, cancellationToken);
@@ -358,7 +359,7 @@ namespace BTCPayServer.Controllers.GreenField
             var result = await _pullPaymentService.Approve(new PullPaymentHostedService.PayoutApproval()
             {
                 PayoutId = payoutId,
-                Revision = revision.Value,
+                Revision = revision!.Value,
                 Rate = rateResult.BidAsk.Ask
             });
             var errorMessage = PullPaymentHostedService.PayoutApproval.GetErrorMessage(result);

--- a/BTCPayServer/wwwroot/swagger/v1/swagger.template.invoices.json
+++ b/BTCPayServer/wwwroot/swagger/v1/swagger.template.invoices.json
@@ -1152,7 +1152,11 @@
                 "properties": {
                     "paymentMethod": {
                         "type": "string",
-                        "description": "The payment method"
+                        "description": "Payment method available for the invoice (e.g., \"BTC\" or \"BTC-LightningNetwork\" or \"BTC-LNURLPAY\")"
+                    },
+                    "cryptoCode": {
+                        "type": "string",
+                        "description": "Crypto code of the payment method (e.g., \"BTC\" or \"LTC\")"
                     },
                     "destination": {
                         "type": "string",

--- a/BTCPayServer/wwwroot/swagger/v1/swagger.template.pull-payments.json
+++ b/BTCPayServer/wwwroot/swagger/v1/swagger.template.pull-payments.json
@@ -313,6 +313,46 @@
                 "security": []
             }
         },
+        "/api/v1/pull-payments/{pullPaymentId}/payouts/{payoutId}": {
+            "parameters": [
+                {
+                    "name": "pullPaymentId",
+                    "in": "path",
+                    "required": true,
+                    "description": "The ID of the pull payment",
+                    "schema": { "type": "string" }
+                },
+                {
+                    "name": "payoutId",
+                    "in": "path",
+                    "required": true,
+                    "description": "The ID of the pull payment payout",
+                    "schema": { "type": "string" }
+                }
+            ],
+            "get": {
+                "summary": "Get Payout",
+                "operationId": "PullPayments_GetPayout",
+                "description": "Get payout",
+                "responses": {
+                    "200": {
+                        "description": "A specific payout of a pull payment",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/PayoutData"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Pull payment payout not found"
+                    }
+                },
+                "tags": [ "Pull payments (Public)", "Pull payments payout (Public)" ],
+                "security": []
+            }
+        },
         "/api/v1/stores/{storeId}/payouts/{payoutId}": {
             "parameters": [
                 {
@@ -554,7 +594,12 @@
                     "paymentMethod": {
                         "type": "string",
                         "example": "BTC",
-                        "description": "The payment method of the payout"
+                        "description": "The payment method of the payout (e.g., \"BTC\" or \"BTC_LightningLike\""
+                    },
+                    "cryptoCode": {
+                        "type": "string",
+                        "example": "BTC",
+                        "description": "Crypto code of the payment method of the payout (e.g., \"BTC\" or \"LTC\")"
                     },
                     "paymentMethodAmount": {
                         "type": "string",


### PR DESCRIPTION
See discussion here: https://github.com/btcpayserver/btcpayserver/issues/3087

This PR adds `cryptoCode` property to the response of `"~/api/v1/stores/{storeId}/invoices/{invoiceId}/payment-methods"` and `"~/api/v1/pull-payments/{pullPaymentId}/payouts/{payoutId}"` Greenfield API endpoints so that user doesn't have to parse the `paymentMethod` field to get to the underlying crypto code.

Additionally it adds Swagger docs for previously undocumented `"~/api/v1/pull-payments/{pullPaymentId}/payouts/{payoutId}"` endpoint.

Also added `#nullable enable` for controllers for these two endpoints.

![Capture](https://user-images.githubusercontent.com/1934678/141667051-b903f22a-67b0-4005-9780-d058be7f5a09.PNG)
![Capture2](https://user-images.githubusercontent.com/1934678/141667053-7a0680b6-13e1-4f7b-8ffe-6026c3beb49a.PNG)
