### PR TITLE
Simple Invoice Detail View Cleanup

### DIFF
--- a/BTCPayServer.Tests/SeleniumTests.cs
+++ b/BTCPayServer.Tests/SeleniumTests.cs
@@ -412,7 +412,7 @@ namespace BTCPayServer.Tests
                 //let's test archiving an invoice
                 Assert.DoesNotContain("Archived", s.Driver.FindElement(By.Id("btn-archive-toggle")).Text);
                 s.Driver.FindElement(By.Id("btn-archive-toggle")).Click();
-                Assert.Contains("Archived", s.Driver.FindElement(By.Id("btn-archive-toggle")).Text);
+                Assert.Contains("Unarchive", s.Driver.FindElement(By.Id("btn-archive-toggle")).Text);
                 //check that it no longer appears in list
                 s.GoToInvoices();
 
@@ -421,7 +421,7 @@ namespace BTCPayServer.Tests
                 s.Driver.Navigate().GoToUrl(invoiceUrl);
                 s.Driver.FindElement(By.Id("btn-archive-toggle")).Click();
                 s.FindAlertMessage();
-                Assert.DoesNotContain("Archived", s.Driver.FindElement(By.Id("btn-archive-toggle")).Text);
+                Assert.DoesNotContain("Unarchive", s.Driver.FindElement(By.Id("btn-archive-toggle")).Text);
                 s.GoToInvoices();
                 Assert.Contains(invoiceId, s.Driver.PageSource);
 

--- a/BTCPayServer/Views/Invoice/Invoice.cshtml
+++ b/BTCPayServer/Views/Invoice/Invoice.cshtml
@@ -59,11 +59,11 @@
                     }
                     @if (Model.CanRefund)
                     {
-                        <a id="refundlink" class="btn btn-success text-nowrap" asp-action="Refund" asp-route-invoiceId="@Context.GetRouteValue("invoiceId")"><span class="fa fa-undo"></span> Issue refund</a>
+                        <a id="refundlink" class="btn btn-success text-nowrap" asp-action="Refund" asp-route-invoiceId="@Context.GetRouteValue("invoiceId")"><span class="fa fa-undo"></span> Issue Refund</a>
                     }
                     else
                     {
-                        <button href="#" class="btn btn-secondary text-nowrap" data-bs-toggle="tooltip" title="You can only issue refunds on invoices with confirmed payments" disabled><span class="fa fa-undo me-1"></span> Issue refund</button>
+                        <button href="#" class="btn btn-secondary text-nowrap" data-bs-toggle="tooltip" title="You can only issue refunds on invoices with confirmed payments" disabled><span class="fa fa-undo me-1"></span> Issue Refund</button>
                     }
                     <form class="p-0 ms-3" asp-action="ToggleArchive" asp-route-invoiceId="@Model.Id" method="post">
                         <button type="submit" class="btn @(Model.Archived ? "btn-warning" : "btn btn-danger")" id="btn-archive-toggle">
@@ -173,7 +173,7 @@
                     @if (!string.IsNullOrEmpty(Model.RefundEmail))
                     {
                         <tr>
-                            <th class="semibold">Refund email</th>
+                            <th class="semibold">Refund Email</th>
                             <td><a href="mailto:@Model.RefundEmail">@Model.RefundEmail</a></td>
                         </tr>
                     }

--- a/BTCPayServer/Views/Invoice/Invoice.cshtml
+++ b/BTCPayServer/Views/Invoice/Invoice.cshtml
@@ -47,7 +47,7 @@
     <div class="container">
     <partial name="_StatusMessage" />
 
-        <div class="row mb-4">
+        <div class="row mb-5">
             <h2 class="col-xs-12 col-lg-6 mb-4 mb-lg-0">@ViewData["Title"]</h2>
             <div class="col-xs-12 col-lg-6 mb-2 mb-lg-0 text-lg-end">
                 <div class="d-inline-flex">
@@ -83,20 +83,20 @@
             </div>
         </div>
 
-        <div class="row">
-            <div class="col-md-6 mb-4">
+        <div class="row justify-content-between">
+            <div class="col-md-5 mb-4">
                 <h3 class="mb-3">Invoice Information</h3>
                 <table class="table table-responsive-md">
                     <tr>
-                        <th>Store</th>
+                        <th class="semibold">Store</th>
                         <td><a href="@Model.StoreLink" rel="noreferrer noopener">@Model.StoreName</a></td>
                     </tr>
                     <tr>
-                        <th>Invoice Id</th>
+                        <th class="semibold">Invoice Id</th>
                         <td>@Model.Id</td>
                     </tr>
                     <tr>
-                        <th>Order Id</th>
+                        <th class="semibold">Order Id</th>
                         <td>
                             @if (string.IsNullOrEmpty(Model.TypedMetadata.OrderUrl))
                             {
@@ -118,11 +118,11 @@
                         </td>
                     </tr>
                     <tr>
-                        <th>Payment Request Id</th>
+                        <th class="semibold">Payment Request Id</th>
                         <td><a href="@Model.PaymentRequestLink" rel="noreferrer noopener">@Model.TypedMetadata.PaymentRequestId</a></td>
                     </tr>
                     <tr>
-                        <th>State</th>
+                        <th class="semibold">State</th>
                         <td>
                             @if (Model.CanMarkStatus)
                             {
@@ -152,85 +152,85 @@
                         </td>
                     </tr>
                     <tr>
-                        <th>Created date</th>
+                        <th class="semibold">Created Date</th>
                         <td>@Model.CreatedDate.ToBrowserDate()</td>
                     </tr>
                     <tr>
-                        <th>Expiration date</th>
+                        <th class="semibold">Expiration Date</th>
                         <td>@Model.ExpirationDate.ToBrowserDate()</td>
                     </tr>
                     <tr>
-                        <th>Monitoring date</th>
+                        <th class="semibold">Monitoring Date</th>
                         <td>@Model.MonitoringDate.ToBrowserDate()</td>
                     </tr>
                     <tr>
-                        <th>Transaction speed</th>
+                        <th class="semibold">Transaction Speed</th>
                         <td>@Model.TransactionSpeed</td>
                     </tr>
                     <tr>
-                        <th>Total fiat due</th>
+                        <th class="semibold">Total Fiat Due</th>
                         <td>@Model.Fiat</td>
                     </tr>
                     @if (!string.IsNullOrEmpty(Model.RefundEmail))
                     {
                         <tr>
-                            <th>Refund email</th>
+                            <th class="semibold">Refund email</th>
                             <td><a href="mailto:@Model.RefundEmail">@Model.RefundEmail</a></td>
                         </tr>
                     }
                     @if (!string.IsNullOrEmpty(Model.NotificationUrl))
                     {
                         <tr>
-                            <th>Notification Url</th>
+                            <th class="semibold">Notification Url</th>
                             <td>@Model.NotificationUrl</td>
                         </tr>
                     }
                     @if (!string.IsNullOrEmpty(Model.RedirectUrl))
                     {
                         <tr>
-                            <th>Redirect Url</th>
+                            <th class="semibold">Redirect Url</th>
                             <td><a href="@Model.RedirectUrl" rel="noreferrer noopener">@Model.RedirectUrl</a></td>
                         </tr>
                     }
                 </table>
             </div>
-            <div class="col-md-6 mb-4">
+            <div class="col-md-5 mb-4">
                 <h3 class="mb-3">Buyer Information</h3>
                 <table class="table table-responsive-md">
                     <tr>
-                        <th>Name</th>
+                        <th class="semibold">Name</th>
                         <td>@Model.TypedMetadata.BuyerName</td>
                     </tr>
                     <tr>
-                        <th>Email</th>
+                        <th class="semibold">Email</th>
                         <td><a href="mailto:@Model.TypedMetadata.BuyerEmail">@Model.TypedMetadata.BuyerEmail</a></td>
                     </tr>
                     <tr>
-                        <th>Phone</th>
+                        <th class="semibold">Phone</th>
                         <td>@Model.TypedMetadata.BuyerPhone</td>
                     </tr>
                     <tr>
-                        <th>Address 1</th>
+                        <th class="semibold">Address 1</th>
                         <td>@Model.TypedMetadata.BuyerAddress1</td>
                     </tr>
                     <tr>
-                        <th>Address 2</th>
+                        <th class="semibold">Address 2</th>
                         <td>@Model.TypedMetadata.BuyerAddress2</td>
                     </tr>
                     <tr>
-                        <th>City</th>
+                        <th class="semibold">City</th>
                         <td>@Model.TypedMetadata.BuyerCity</td>
                     </tr>
                     <tr>
-                        <th>State</th>
+                        <th class="semibold">State</th>
                         <td>@Model.TypedMetadata.BuyerState</td>
                     </tr>
                     <tr>
-                        <th>Country</th>
+                        <th class="semibold">Country</th>
                         <td>@Model.TypedMetadata.BuyerCountry</td>
                     </tr>
                     <tr>
-                        <th>Zip</th>
+                        <th class="semibold">Zip</th>
                         <td>@Model.TypedMetadata.BuyerZip</td>
                     </tr>
                 </table>
@@ -241,23 +241,23 @@
                         @if (!string.IsNullOrEmpty(Model.TypedMetadata.ItemCode))
                         {
                             <tr>
-                                <th>Item code</th>
+                                <th class="semibold">Item code</th>
                                 <td>@Model.TypedMetadata.ItemCode</td>
                             </tr>
                         }
                         @if (!string.IsNullOrEmpty(Model.TypedMetadata.ItemDesc))
                         {
                             <tr>
-                                <th>Item Description</th>
+                                <th class="semibold">Item Description</th>
                                 <td>@Model.TypedMetadata.ItemDesc</td>
                             </tr>
                         }
                         <tr>
-                            <th>Price</th>
+                            <th class="semibold">Price</th>
                             <td>@Model.Fiat</td>
                         </tr>
                         <tr>
-                            <th>Tax included</th>
+                            <th class="semibold">Tax Included</th>
                             <td>@Model.TaxIncluded</td>
                         </tr>
                     </table>

--- a/BTCPayServer/Views/Invoice/Invoice.cshtml
+++ b/BTCPayServer/Views/Invoice/Invoice.cshtml
@@ -86,15 +86,15 @@
                 <h3 class="mb-3">Invoice Information</h3>
                 <table class="table table-responsive-md mb-5">
                     <tr>
-                        <th class="semibold">Store</th>
+                        <th class="fw-semibold">Store</th>
                         <td><a href="@Model.StoreLink" rel="noreferrer noopener">@Model.StoreName</a></td>
                     </tr>
                     <tr>
-                        <th class="semibold">Invoice Id</th>
+                        <th class="fw-semibold">Invoice Id</th>
                         <td>@Model.Id</td>
                     </tr>
                     <tr>
-                        <th class="semibold">Order Id</th>
+                        <th class="fw-semibold">Order Id</th>
                         <td>
                             @if (string.IsNullOrEmpty(Model.TypedMetadata.OrderUrl))
                             {
@@ -116,11 +116,11 @@
                         </td>
                     </tr>
                     <tr>
-                        <th class="semibold">Payment Request Id</th>
+                        <th class="fw-semibold">Payment Request Id</th>
                         <td><a href="@Model.PaymentRequestLink" rel="noreferrer noopener">@Model.TypedMetadata.PaymentRequestId</a></td>
                     </tr>
                     <tr>
-                        <th class="semibold">State</th>
+                        <th class="fw-semibold">State</th>
                         <td>
                             @if (Model.CanMarkStatus)
                             {
@@ -151,43 +151,43 @@
                         </td>
                     </tr>
                     <tr>
-                        <th class="semibold">Created Date</th>
+                        <th class="fw-semibold">Created Date</th>
                         <td>@Model.CreatedDate.ToBrowserDate()</td>
                     </tr>
                     <tr>
-                        <th class="semibold">Expiration Date</th>
+                        <th class="fw-semibold">Expiration Date</th>
                         <td>@Model.ExpirationDate.ToBrowserDate()</td>
                     </tr>
                     <tr>
-                        <th class="semibold">Monitoring Date</th>
+                        <th class="fw-semibold">Monitoring Date</th>
                         <td>@Model.MonitoringDate.ToBrowserDate()</td>
                     </tr>
                     <tr>
-                        <th class="semibold">Transaction Speed</th>
+                        <th class="fw-semibold">Transaction Speed</th>
                         <td>@Model.TransactionSpeed</td>
                     </tr>
                     <tr>
-                        <th class="semibold">Total Fiat Due</th>
+                        <th class="fw-semibold">Total Fiat Due</th>
                         <td>@Model.Fiat</td>
                     </tr>
                     @if (!string.IsNullOrEmpty(Model.RefundEmail))
                     {
                         <tr>
-                            <th class="semibold">Refund Email</th>
+                            <th class="fw-semibold">Refund Email</th>
                             <td><a href="mailto:@Model.RefundEmail">@Model.RefundEmail</a></td>
                         </tr>
                     }
                     @if (!string.IsNullOrEmpty(Model.NotificationUrl))
                     {
                         <tr>
-                            <th class="semibold">Notification Url</th>
+                            <th class="fw-semibold">Notification Url</th>
                             <td>@Model.NotificationUrl</td>
                         </tr>
                     }
                     @if (!string.IsNullOrEmpty(Model.RedirectUrl))
                     {
                         <tr>
-                            <th class="semibold">Redirect Url</th>
+                            <th class="fw-semibold">Redirect Url</th>
                             <td><a href="@Model.RedirectUrl" rel="noreferrer noopener">@Model.RedirectUrl</a></td>
                         </tr>
                     }
@@ -199,23 +199,23 @@
                         @if (!string.IsNullOrEmpty(Model.TypedMetadata.ItemCode))
                         {
                             <tr>
-                                <th class="semibold">Item code</th>
+                                <th class="fw-semibold">Item code</th>
                                 <td>@Model.TypedMetadata.ItemCode</td>
                             </tr>
                         }
                         @if (!string.IsNullOrEmpty(Model.TypedMetadata.ItemDesc))
                         {
                             <tr>
-                                <th class="semibold">Item Description</th>
+                                <th class="fw-semibold">Item Description</th>
                                 <td>@Model.TypedMetadata.ItemDesc</td>
                             </tr>
                         }
                         <tr>
-                            <th class="semibold">Price</th>
+                            <th class="fw-semibold">Price</th>
                             <td>@Model.Fiat</td>
                         </tr>
                         <tr>
-                            <th class="semibold">Tax Included</th>
+                            <th class="fw-semibold">Tax Included</th>
                             <td>@Model.TaxIncluded</td>
                         </tr>
                     </table>
@@ -225,39 +225,39 @@
                 <h3 class="mb-3">Buyer Information</h3>
                 <table class="table table-responsive-md mb-5">
                     <tr>
-                        <th class="semibold">Name</th>
+                        <th class="fw-semibold">Name</th>
                         <td>@Model.TypedMetadata.BuyerName</td>
                     </tr>
                     <tr>
-                        <th class="semibold">Email</th>
+                        <th class="fw-semibold">Email</th>
                         <td><a href="mailto:@Model.TypedMetadata.BuyerEmail">@Model.TypedMetadata.BuyerEmail</a></td>
                     </tr>
                     <tr>
-                        <th class="semibold">Phone</th>
+                        <th class="fw-semibold">Phone</th>
                         <td>@Model.TypedMetadata.BuyerPhone</td>
                     </tr>
                     <tr>
-                        <th class="semibold">Address 1</th>
+                        <th class="fw-semibold">Address 1</th>
                         <td>@Model.TypedMetadata.BuyerAddress1</td>
                     </tr>
                     <tr>
-                        <th class="semibold">Address 2</th>
+                        <th class="fw-semibold">Address 2</th>
                         <td>@Model.TypedMetadata.BuyerAddress2</td>
                     </tr>
                     <tr>
-                        <th class="semibold">City</th>
+                        <th class="fw-semibold">City</th>
                         <td>@Model.TypedMetadata.BuyerCity</td>
                     </tr>
                     <tr>
-                        <th class="semibold">State</th>
+                        <th class="fw-semibold">State</th>
                         <td>@Model.TypedMetadata.BuyerState</td>
                     </tr>
                     <tr>
-                        <th class="semibold">Country</th>
+                        <th class="fw-semibold">Country</th>
                         <td>@Model.TypedMetadata.BuyerCountry</td>
                     </tr>
                     <tr>
-                        <th class="semibold">Zip</th>
+                        <th class="fw-semibold">Zip</th>
                         <td>@Model.TypedMetadata.BuyerZip</td>
                     </tr>
                 </table>

--- a/BTCPayServer/Views/Invoice/Invoice.cshtml
+++ b/BTCPayServer/Views/Invoice/Invoice.cshtml
@@ -71,7 +71,7 @@
                         <button type="submit" class="btn @(Model.Archived ? "btn-warning" : "btn btn-danger")" id="btn-archive-toggle">
                             @if (Model.Archived)
                             {
-                                <span class="text-nowrap" data-bs-toggle="tooltip" title="Unarchive this invoice"><i class="ms-1 fa fa-close"></i> Archived</span>
+                                <span class="text-nowrap" data-bs-toggle="tooltip" title="Unarchive this invoice">Unarchive</span>
                             }
                             else
                             {

--- a/BTCPayServer/Views/Invoice/Invoice.cshtml
+++ b/BTCPayServer/Views/Invoice/Invoice.cshtml
@@ -46,7 +46,6 @@
 <section class="invoice-details">
     <div class="container">
     <partial name="_StatusMessage" />
-
         <div class="row mb-5">
             <h2 class="col-xs-12 col-lg-6 mb-4 mb-lg-0">@ViewData["Title"]</h2>
             <div class="col-xs-12 col-lg-6 mb-2 mb-lg-0 text-lg-end">
@@ -58,16 +57,15 @@
                             Checkout
                         </a>
                     }
-                    
                     @if (Model.CanRefund)
                     {
-                        <a id="refundlink" class="btn btn-success text-nowrap ms-2" asp-action="Refund" asp-route-invoiceId="@Context.GetRouteValue("invoiceId")"><span class="fa fa-undo"></span> Issue refund</a>
+                        <a id="refundlink" class="btn btn-success text-nowrap" asp-action="Refund" asp-route-invoiceId="@Context.GetRouteValue("invoiceId")"><span class="fa fa-undo"></span> Issue refund</a>
                     }
                     else
                     {
-                        <button href="#" class="btn btn-secondary text-nowrap ms-2" data-bs-toggle="tooltip" title="You can only issue refunds on invoices with confirmed payments" disabled><span class="fa fa-undo"></span> Issue refund</button>
+                        <button href="#" class="btn btn-secondary text-nowrap" data-bs-toggle="tooltip" title="You can only issue refunds on invoices with confirmed payments" disabled><span class="fa fa-undo me-1"></span> Issue refund</button>
                     }
-                    <form class="p-0 ms-2" asp-action="ToggleArchive" asp-route-invoiceId="@Model.Id" method="post">
+                    <form class="p-0 ms-3" asp-action="ToggleArchive" asp-route-invoiceId="@Model.Id" method="post">
                         <button type="submit" class="btn @(Model.Archived ? "btn-warning" : "btn btn-danger")" id="btn-archive-toggle">
                             @if (Model.Archived)
                             {
@@ -75,7 +73,7 @@
                             }
                             else
                             {
-                                <span class="text-nowrap" data-bs-toggle="tooltip" title="Archive this invoice so that it does not appear in the invoice list by default"><i class="ms-1 fa fa-archive"></i> Archive</span>
+                                <span class="text-nowrap" data-bs-toggle="tooltip" title="Archive this invoice so that it does not appear in the invoice list by default"><i class="fa fa-archive me-1"></i> Archive</span>
                             }
                         </button>
                     </form>
@@ -84,9 +82,9 @@
         </div>
 
         <div class="row justify-content-between">
-            <div class="col-md-5 mb-4">
+            <div class="col-md-5">
                 <h3 class="mb-3">Invoice Information</h3>
-                <table class="table table-responsive-md">
+                <table class="table table-responsive-md mb-5">
                     <tr>
                         <th class="semibold">Store</th>
                         <td><a href="@Model.StoreLink" rel="noreferrer noopener">@Model.StoreName</a></td>
@@ -145,8 +143,9 @@
                                         }
                                     </div>
                                 </div>
-                            } 
-                            else {
+                            }
+                            else
+                            {
                                 @Model.State
                             }
                         </td>
@@ -193,10 +192,38 @@
                         </tr>
                     }
                 </table>
+                @if (Model.PosData.Count == 0)
+                {
+                    <h3 class="mb-3">Product Information</h3>
+                    <table class="table table-responsive-md mb-5">
+                        @if (!string.IsNullOrEmpty(Model.TypedMetadata.ItemCode))
+                        {
+                            <tr>
+                                <th class="semibold">Item code</th>
+                                <td>@Model.TypedMetadata.ItemCode</td>
+                            </tr>
+                        }
+                        @if (!string.IsNullOrEmpty(Model.TypedMetadata.ItemDesc))
+                        {
+                            <tr>
+                                <th class="semibold">Item Description</th>
+                                <td>@Model.TypedMetadata.ItemDesc</td>
+                            </tr>
+                        }
+                        <tr>
+                            <th class="semibold">Price</th>
+                            <td>@Model.Fiat</td>
+                        </tr>
+                        <tr>
+                            <th class="semibold">Tax Included</th>
+                            <td>@Model.TaxIncluded</td>
+                        </tr>
+                    </table>
+                }
             </div>
-            <div class="col-md-5 mb-4">
+            <div class="col-md-5">
                 <h3 class="mb-3">Buyer Information</h3>
-                <table class="table table-responsive-md">
+                <table class="table table-responsive-md mb-5">
                     <tr>
                         <th class="semibold">Name</th>
                         <td>@Model.TypedMetadata.BuyerName</td>
@@ -234,43 +261,15 @@
                         <td>@Model.TypedMetadata.BuyerZip</td>
                     </tr>
                 </table>
-                @if (Model.PosData.Count == 0)
-                {
-                    <h3 class="mb-3">Product Information</h3>
-                    <table class="table table-responsive-md">
-                        @if (!string.IsNullOrEmpty(Model.TypedMetadata.ItemCode))
-                        {
-                            <tr>
-                                <th class="semibold">Item code</th>
-                                <td>@Model.TypedMetadata.ItemCode</td>
-                            </tr>
-                        }
-                        @if (!string.IsNullOrEmpty(Model.TypedMetadata.ItemDesc))
-                        {
-                            <tr>
-                                <th class="semibold">Item Description</th>
-                                <td>@Model.TypedMetadata.ItemDesc</td>
-                            </tr>
-                        }
-                        <tr>
-                            <th class="semibold">Price</th>
-                            <td>@Model.Fiat</td>
-                        </tr>
-                        <tr>
-                            <th class="semibold">Tax Included</th>
-                            <td>@Model.TaxIncluded</td>
-                        </tr>
-                    </table>
-                }
             </div>
         </div>
 
         @if (Model.PosData.Count != 0)
         {
             <div class="row">
-                <div class="col-md-6 mb-4">
+                <div class="col-md-6">
                     <h3 class="mb-3">Product information</h3>
-                    <table class="table table-responsive-md">
+                    <table class="table table-responsive-md mb-5">
                         @if (!string.IsNullOrEmpty(Model.TypedMetadata.ItemCode))
                         {
                             <tr>
@@ -362,7 +361,6 @@
                 }
             </ul>
         }
-
         <div class="row">
             <div class="col-md-12">
                 <h3 class="mb-0">Events</h3>

--- a/BTCPayServer/wwwroot/main/site.css
+++ b/BTCPayServer/wwwroot/main/site.css
@@ -49,10 +49,6 @@ hr.light {
     white-space: nowrap;
 }
 
-.semibold {
-    font-weight: var(--btcpay-font-weight-semibold);
-}
-
 @media (min-width: 768px) {
     .text-md-nowrap {
         white-space: nowrap;

--- a/BTCPayServer/wwwroot/main/site.css
+++ b/BTCPayServer/wwwroot/main/site.css
@@ -49,6 +49,10 @@ hr.light {
     white-space: nowrap;
 }
 
+.semibold {
+    font-weight: var(--btcpay-font-weight-semibold);
+}
+
 @media (min-width: 768px) {
     .text-md-nowrap {
         white-space: nowrap;


### PR DESCRIPTION
Just more minor changes in my audit of this view ... as minor as consistent paddings, moving the Product Information to the left column, icons, etc..

I opted to add a class to site.css to leverage in the table headers, and I figure @dennisreimann might have an opinion on this .. wasn't sure this was the smartest way to do this, happy to redo as needed.

Before:
<img width="1558" alt="Screen Shot 2021-11-13 at 10 27 22 PM" src="https://user-images.githubusercontent.com/6250771/141670276-1c90ca25-4d6a-4052-8acc-9c0a9a350cfd.png">

After:
<img width="1557" alt="Screen Shot 2021-11-13 at 10 27 01 PM" src="https://user-images.githubusercontent.com/6250771/141670284-f7ef27f6-23d6-43f9-862d-60d110aa8d6e.png">

I'd like to do more to this view in the future, but for now, just a few patches.

Open to any additional things I might be missing here.
