### PR TITLE
Updates Pull Payment Payment Method

### DIFF
--- a/BTCPayServer.Tests/SeleniumTests.cs
+++ b/BTCPayServer.Tests/SeleniumTests.cs
@@ -1391,11 +1391,8 @@ namespace BTCPayServer.Tests
             await s.Server.CustomerLightningD.Pay(lnurlResponse.Pr);
             Assert.Equal(new LightMoney(0.0000001m, LightMoneyUnit.BTC),
                 lnurlResponse2.GetPaymentRequest(network).MinimumAmount);
-
-
-
-            s.GoToStore(s.StoreId);
-            s.Driver.FindElement(By.Id($"Modify-Lightning{cryptoCode}")).Click();
+            
+            s.GoToLightningSettings(s.StoreId, cryptoCode);
             // LNURL is enabled and settings are expanded
             Assert.True(s.Driver.FindElement(By.Id("LNURLEnabled")).Selected);
             Assert.Contains("show", s.Driver.FindElement(By.Id("LNURLSettings")).GetAttribute("class"));
@@ -1412,8 +1409,7 @@ namespace BTCPayServer.Tests
             s.GoToInvoiceCheckout(i);
             s.Driver.FindElement(By.ClassName("payment__currencies_noborder"));
 
-            s.GoToStore(s.StoreId);
-            s.Driver.FindElement(By.Id($"Modify-Lightning{cryptoCode}")).Click();
+            s.GoToLightningSettings(s.StoreId, cryptoCode);
             s.Driver.SetCheckbox(By.Id("LNURLBech32Mode"), false);
             s.Driver.SetCheckbox(By.Id("LNURLStandardInvoiceEnabled"), false);
             s.Driver.SetCheckbox(By.Id("DisableBolt11PaymentMethod"), true);
@@ -1421,7 +1417,7 @@ namespace BTCPayServer.Tests
             Assert.Contains($"{cryptoCode} Lightning settings successfully updated", s.FindAlertMessage().Text);
             
             // Ensure the toggles are set correctly
-            s.Driver.FindElement(By.Id($"Modify-Lightning{cryptoCode}")).Click();
+            s.GoToLightningSettings(s.StoreId, cryptoCode);
 
             //TODO: DisableBolt11PaymentMethod is actually disabled because LNURLStandardInvoiceEnabled is disabled
             // checkboxes is not good choice here, in next release we should have multi choice instead
@@ -1441,7 +1437,7 @@ namespace BTCPayServer.Tests
             s.GoToHome();
             var newStore = s.CreateNewStore(false);
             s.AddLightningNode(cryptoCode, LightningConnectionType.LndREST, false);
-            s.Driver.FindElement(By.Id($"Modify-Lightning{cryptoCode}")).Click();
+            s.GoToLightningSettings(newStore.storeId, cryptoCode);
             s.Driver.SetCheckbox(By.Id("LNURLEnabled"), true);
             s.Driver.SetCheckbox(By.Id("DisableBolt11PaymentMethod"), true);
             s.Driver.FindElement(By.Id("save")).Click();
@@ -1455,11 +1451,10 @@ namespace BTCPayServer.Tests
             // Check that pull payment has lightning option
             s.GoToStore(s.StoreId, StoreNavPages.PullPayments);
             s.Driver.FindElement(By.Id("NewPullPayment")).Click();
-            Assert.Equal(new PaymentMethodId(cryptoCode, PaymentTypes.LightningLike),PaymentMethodId.Parse(Assert.Single(s.Driver.FindElement(By.Id("PaymentMethods")).FindElements(By.TagName("option"))).GetAttribute("value")));
+            Assert.Equal(new PaymentMethodId(cryptoCode, PaymentTypes.LightningLike),PaymentMethodId.Parse(Assert.Single(s.Driver.FindElements(By.CssSelector("input[name='PaymentMethods']"))).GetAttribute("value")));
             s.Driver.FindElement(By.Id("Name")).SendKeys("PP1");
             s.Driver.FindElement(By.Id("Amount")).Clear();
             s.Driver.FindElement(By.Id("Amount")).SendKeys("0.0000001");
-            ;
             s.Driver.FindElement(By.Id("Create")).Click();
             s.Driver.FindElement(By.LinkText("View")).Click();
             s.Driver.FindElement(By.Id("Destination")).SendKeys(lnurl);

--- a/BTCPayServer.Tests/SeleniumTests.cs
+++ b/BTCPayServer.Tests/SeleniumTests.cs
@@ -1028,7 +1028,6 @@ namespace BTCPayServer.Tests
             s.Driver.FindElement(By.Id("Name")).SendKeys("PP1");
             s.Driver.FindElement(By.Id("Amount")).Clear();
             s.Driver.FindElement(By.Id("Amount")).SendKeys("99.0");
-            ;
             s.Driver.FindElement(By.Id("Create")).Click();
             s.Driver.FindElement(By.LinkText("View")).Click();
 
@@ -1178,7 +1177,7 @@ namespace BTCPayServer.Tests
 
             s.Driver.FindElement(By.Id("NewPullPayment")).Click();
 
-            var paymentMethodOptions = s.Driver.FindElements(By.CssSelector("#PaymentMethods option"));
+            var paymentMethodOptions = s.Driver.FindElements(By.CssSelector("input[name='PaymentMethods']"));
             Assert.Equal(2, paymentMethodOptions.Count);
             
             s.Driver.FindElement(By.Id("Name")).SendKeys("Lightning Test");

--- a/BTCPayServer/Models/WalletViewModels/PullPaymentsModel.cs
+++ b/BTCPayServer/Models/WalletViewModels/PullPaymentsModel.cs
@@ -49,6 +49,7 @@ namespace BTCPayServer.Models.WalletViewModels
         [Display(Name = "Custom CSS Code")]
         public string EmbeddedCSS { get; set; }
 
+        [Display(Name = "Payment Methods")]
         public IEnumerable<string> PaymentMethods { get; set; }
         public IEnumerable<SelectListItem> PaymentMethodItems { get; set; }
     }

--- a/BTCPayServer/Views/PullPayment/ViewPullPayment.cshtml
+++ b/BTCPayServer/Views/PullPayment/ViewPullPayment.cshtml
@@ -57,7 +57,15 @@
                             <div class="col-12 mb-3 col-lg-6 mb-lg-0">
                                 <div class="input-group">
                                     <input class="form-control form-control-lg font-monospace" asp-for="Destination" placeholder="Enter destination to claim funds" required style="font-size:.9rem;height:42px;">
-                                    <select class="form-select w-auto" asp-for="SelectedPaymentMethod" asp-items="Model.PaymentMethods.Select(id => new SelectListItem(id.ToPrettyString(), id.ToString()))"></select>
+                                    @if (Model.PaymentMethods.Length == 1)
+                                    {
+                                        <input type="hidden" asp-for="SelectedPaymentMethod">
+                                        <span class="input-group-text">@Model.PaymentMethods.First().ToPrettyString()</span>
+                                    }
+                                    else
+                                    {
+                                        <select class="form-select w-auto" asp-for="SelectedPaymentMethod" asp-items="Model.PaymentMethods.Select(id => new SelectListItem(id.ToPrettyString(), id.ToString()))"></select>
+                                    }
                                 </div>
                             </div>
 

--- a/BTCPayServer/Views/StorePullPayments/NewPullPayment.cshtml
+++ b/BTCPayServer/Views/StorePullPayments/NewPullPayment.cshtml
@@ -37,7 +37,7 @@
                 {
                     <div class="form-check mb-2">
                         <label class="form-label">
-                            <input name="PaymentMethodItems" class="form-check-input" type="checkbox" value="@item.Value" @(item.Selected ? "checked" : "")>
+                            <input name="PaymentMethods" class="form-check-input" type="checkbox" value="@item.Value" @(item.Selected ? "checked" : "")>
                             @item.Text
                         </label>
                     </div>

--- a/BTCPayServer/Views/StorePullPayments/NewPullPayment.cshtml
+++ b/BTCPayServer/Views/StorePullPayments/NewPullPayment.cshtml
@@ -7,50 +7,6 @@
     ViewData.SetActivePageAndTitle(StoreNavPages.PullPayments, "New pull payment", Context.GetStoreData().StoreName);
 }
 
-<style type="text/css">
-    .smMaxWidth {
-        max-width: 200px;
-    }
-
-    @@media (min-width: 768px) {
-        .smMaxWidth {
-            max-width: 400px;
-        }
-    }
-
-    .unconf > * {
-        opacity: 0.5;
-    }
-
-    .switchTimeFormat {
-        display: block;
-        max-width: 150px;
-        width: 150px;
-        overflow: hidden;
-        white-space: nowrap;
-        text-overflow: ellipsis;
-    }
-
-    .transactionLabel:not(:last-child) {
-        margin-bottom: 4px;
-    }
-
-    .removeTransactionLabelForm {
-        display: inline;
-        position: absolute;
-        right: 4px;
-    }
-
-        .removeTransactionLabelForm button {
-            color: #212529;
-            cursor: pointer;
-            display: inline;
-            padding: 0;
-            background-color: transparent;
-            border: 0;
-        }
-</style>
-
 <div class="row">
     <div class="col-md-6">
         <h4 class="mb-3">@ViewData["Title"]</h4>

--- a/BTCPayServer/Views/StorePullPayments/NewPullPayment.cshtml
+++ b/BTCPayServer/Views/StorePullPayments/NewPullPayment.cshtml
@@ -102,7 +102,6 @@
             </div>
             <div class="form-group">
                 <input type="submit" value="Create" class="btn btn-primary" id="Create" />
-                <a asp-action="PullPayments" asp-route-walletId="@Context.GetRouteValue("walletId")" class="text-muted ms-3">Back to list</a>
             </div>
         </form>
     </div>

--- a/BTCPayServer/Views/StorePullPayments/NewPullPayment.cshtml
+++ b/BTCPayServer/Views/StorePullPayments/NewPullPayment.cshtml
@@ -43,19 +43,38 @@
                     </div>
                 }
             </div>
+
+            <h5 class="mt-4 mb-2">Additional Options</h5>
             <div class="form-group">
-                <label asp-for="CustomCSSLink" class="form-label"></label>
-                <a href="https://docs.btcpayserver.org/Development/Theme/#2-bootstrap-themes" target="_blank" rel="noreferrer noopener">
-                    <span class="fa fa-question-circle-o text-secondary" title="More information..."></span>
-                </a>
-                <input asp-for="CustomCSSLink" class="form-control" />
-                <span asp-validation-for="CustomCSSLink" class="text-danger"></span>
+                <div class="accordion" id="additional">
+                    <div class="accordion-item">
+                        <h2 class="accordion-header" id="additional-custom-css-header">
+                            <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#additional-custom-css" aria-expanded="false" aria-controls="additional-custom-css">
+                                Custom CSS
+                                <vc:icon symbol="caret-down" />
+                            </button>
+                        </h2>
+                        <div id="additional-custom-css" class="accordion-collapse collapse" aria-labelledby="additional-custom-css-header">
+                            <div class="accordion-body">
+                                <div class="form-group">
+                                    <label asp-for="CustomCSSLink" class="form-label"></label>
+                                    <a href="https://docs.btcpayserver.org/Development/Theme/#2-bootstrap-themes" target="_blank" rel="noreferrer noopener">
+                                        <span class="fa fa-question-circle-o text-secondary" title="More information..."></span>
+                                    </a>
+                                    <input asp-for="CustomCSSLink" class="form-control" />
+                                    <span asp-validation-for="CustomCSSLink" class="text-danger"></span>
+                                </div>
+                                <div class="form-group">
+                                    <label asp-for="EmbeddedCSS" class="form-label"></label>
+                                    <textarea asp-for="EmbeddedCSS" rows="10" cols="40" class="form-control"></textarea>
+                                    <span asp-validation-for="EmbeddedCSS" class="text-danger"></span>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
             </div>
-            <div class="form-group">
-                <label asp-for="EmbeddedCSS" class="form-label"></label>
-                <textarea asp-for="EmbeddedCSS" rows="10" cols="40" class="form-control"></textarea>
-                <span asp-validation-for="EmbeddedCSS" class="text-danger"></span>
-            </div>
+            
             <div class="form-group">
                 <input type="submit" value="Create" class="btn btn-primary" id="Create" />
             </div>

--- a/BTCPayServer/Views/StorePullPayments/NewPullPayment.cshtml
+++ b/BTCPayServer/Views/StorePullPayments/NewPullPayment.cshtml
@@ -75,9 +75,17 @@
                     <span asp-validation-for="Currency" class="text-danger"></span>
                 </div>
             </div>
-            <div class="form-group">
-                <label asp-for="PaymentMethods"></label>
-                <select asp-for="PaymentMethods" asp-items="Model.PaymentMethodItems" class="form-select" multiple></select>
+            <div class="form-group mb-4">
+                <label asp-for="PaymentMethods" class="form-label"></label>
+                @foreach (var item in Model.PaymentMethodItems)
+                {
+                    <div class="form-check mb-2">
+                        <label class="form-label">
+                            <input name="PaymentMethodItems" class="form-check-input" type="checkbox" value="@item.Value" @(item.Selected ? "checked" : "")>
+                            @item.Text
+                        </label>
+                    </div>
+                }
             </div>
             <div class="form-group">
                 <label asp-for="CustomCSSLink" class="form-label"></label>


### PR DESCRIPTION
Similar to the recent invoice PR, updates the terrible multi-selector to a checkbox. There might be an even better component for this, but for the time being, a quick fix until we have something better.

Removes "back to list" and updates the label.

Before:
<img width="538" alt="Screen Shot 2021-11-15 at 1 48 38 AM" src="https://user-images.githubusercontent.com/6250771/141760323-30e0bed8-7453-4ce2-8a98-33caafaa3d43.png">

After:
<img width="535" alt="Screen Shot 2021-11-15 at 1 48 20 AM" src="https://user-images.githubusercontent.com/6250771/141760347-aa5fe481-3375-43d7-b734-2feacf59f626.png">

cc @dennisreimann 
