### PR TITLE
Simple Payment Request and Pull Payment Views Improvements

### DIFF
--- a/BTCPayServer/Views/PaymentRequest/ViewPaymentRequest.cshtml
+++ b/BTCPayServer/Views/PaymentRequest/ViewPaymentRequest.cshtml
@@ -219,18 +219,18 @@
                             <dl class="mb-0 mt-md-4">
                                 <div class="d-flex d-print-inline-block flex-column mb-4 me-5">
                                     <dt class="h4 fw-semibold text-nowrap text-primary text-print-default order-2 order-sm-1 mb-1" v-text="srvModel.amountDueFormatted">@Model.AmountDueFormatted</dt>
-                                    <dd class="text-muted order-1 order-sm-2 mb-1" data-test="amount-due-title">Amount due</dd>
+                                    <dd class="order-1 order-sm-2 mb-1" data-test="amount-due-title">Amount due</dd>
                                 </div>
                                 <div class="progress bg-light d-none d-sm-flex mb-sm-4 d-print-none" style="height:5px">
                                   <div class="progress-bar bg-primary" role="progressbar" style="width:@((Model.AmountCollected/Model.Amount)*100)%" v-bind:style="{ width: (srvModel.amountCollected/srvModel.amount*100) + '%' }"></div>
                                 </div>
                                 <div class="d-flex d-print-inline-block flex-column mb-4 me-5 d-sm-inline-flex mb-sm-0">
                                     <dt class="h4 fw-semibold text-nowrap order-2 order-sm-1 mb-1" v-text="srvModel.amountCollectedFormatted">@Model.AmountCollectedFormatted</dt>
-                                    <dd class="text-muted order-1 order-sm-2 mb-1">Amount paid</dd>
+                                    <dd class="order-1 order-sm-2 mb-1">Amount paid</dd>
                                 </div>
                                 <div class="d-flex d-print-inline-block flex-column mb-0 d-sm-inline-flex float-sm-end">
                                     <dt class="h4 text-sm-end fw-semibold text-nowrap order-2 order-sm-1 mb-1" v-text="srvModel.amountFormatted">@Model.AmountFormatted</dt>
-                                    <dd class="text-muted text-sm-end order-1 order-sm-2 mb-1">Total requested</dd>
+                                    <dd class="text-sm-end order-1 order-sm-2 mb-1">Total requested</dd>
                                 </div>
                             </dl>
                         </div>

--- a/BTCPayServer/Views/PaymentRequest/ViewPaymentRequest.cshtml
+++ b/BTCPayServer/Views/PaymentRequest/ViewPaymentRequest.cshtml
@@ -244,7 +244,7 @@
                                 <noscript>
                                     @if (Model.Invoices == null || !Model.Invoices.Any())
                                     {
-                                        <p class="text-muted">No payments made yet.</p>
+                                        <p class="text-muted mt-3">No payments made yet.</p>
                                     }
                                     else
                                     {

--- a/BTCPayServer/Views/PaymentRequest/ViewPaymentRequest.cshtml
+++ b/BTCPayServer/Views/PaymentRequest/ViewPaymentRequest.cshtml
@@ -239,7 +239,7 @@
                 <div class="row">
                     <div class="col">
                         <div class="bg-tile h-100 m-0 p-3 p-sm-5 rounded">
-                            <h2 class="h4 mb-3">Payment History</h2>
+                            <h2 class="h4 mb-0">Payment History</h2>
                             <div class="table-responsive">
                                 <noscript>
                                     @if (Model.Invoices == null || !Model.Invoices.Any())

--- a/BTCPayServer/Views/PaymentRequest/ViewPaymentRequest.cshtml
+++ b/BTCPayServer/Views/PaymentRequest/ViewPaymentRequest.cshtml
@@ -244,7 +244,7 @@
                                 <noscript>
                                     @if (Model.Invoices == null || !Model.Invoices.Any())
                                     {
-                                        <p class="text-muted mt-3">No payments made yet.</p>
+                                        <p class="text-muted mt-3 mb-0">No payments made yet.</p>
                                     }
                                     else
                                     {

--- a/BTCPayServer/Views/PaymentRequest/ViewPaymentRequest.cshtml
+++ b/BTCPayServer/Views/PaymentRequest/ViewPaymentRequest.cshtml
@@ -205,12 +205,16 @@
                     <div class="col col-12 col-lg-6 mb-4">
                         <div class="bg-tile h-100 m-0 p-3 p-sm-5 rounded">
                             <h2 class="h4 mb-3">Invoice Summary</h2>
-                            <div v-html="srvModel.description">
-                                @if (!string.IsNullOrEmpty(Model.Description) && Model.Description != "<br>")
-                                {
+                            @if (!string.IsNullOrEmpty(Model.Description) && Model.Description != "<br>")
+                            {
+                                <div v-html="srvModel.description">
                                     @Safe.Raw(Model.Description)
-                                }
-                            </div>
+                                </div>
+                            }
+                            else
+                            {
+                                <p class="text-muted mt-3 mb-0">No details provided.</p>
+                            }
                         </div>
                     </div>
                     <div class="col col-12 col-lg-6 mb-4">

--- a/BTCPayServer/Views/PaymentRequest/ViewPaymentRequest.cshtml
+++ b/BTCPayServer/Views/PaymentRequest/ViewPaymentRequest.cshtml
@@ -83,10 +83,10 @@
                                 &nbsp;
                                 <span class="text-nowrap d-print-none" v-text="lastUpdated" v-cloak>@Model.LastUpdated.ToString("g")</span>
                                 <span class="text-nowrap d-none d-print-block" v-text="lastUpdatedDate">@Model.LastUpdated.ToString("g")</span>
-                                <button type="button" class="btn btn-link d-none d-lg-inline-block d-print-none border-0 p-0 ms-4 only-for-js" v-on:click="window.print" v-cloak>
+                                <button type="button" class="btn btn-link fw-semibold d-none d-lg-inline-block d-print-none border-0 p-0 ms-4 only-for-js" v-on:click="window.print" v-cloak>
                                     Print
                                 </button>
-                                <button type="button" class="btn btn-link d-none d-lg-inline-block d-print-none border-0 p-0 ms-4 only-for-js" v-on:click="window.copyUrlToClipboard" v-cloak>
+                                <button type="button" class="btn btn-link fw-semibold d-none d-lg-inline-block d-print-none border-0 p-0 ms-4 only-for-js" v-on:click="window.copyUrlToClipboard" v-cloak>
                                     Copy Link
                                 </button>
                             </div>
@@ -218,18 +218,18 @@
                             <h2 class="h4 mb-3">Payment Details</h2>
                             <dl class="mb-0 mt-md-4">
                                 <div class="d-flex d-print-inline-block flex-column mb-4 me-5">
-                                    <dt class="h4 fw-normal text-nowrap text-primary text-print-default order-2 order-sm-1 mb-0" v-text="srvModel.amountDueFormatted">@Model.AmountDueFormatted</dt>
+                                    <dt class="h4 fw-semibold text-nowrap text-primary text-print-default order-2 order-sm-1 mb-1" v-text="srvModel.amountDueFormatted">@Model.AmountDueFormatted</dt>
                                     <dd class="text-muted order-1 order-sm-2 mb-1" data-test="amount-due-title">Amount due</dd>
                                 </div>
                                 <div class="progress bg-light d-none d-sm-flex mb-sm-4 d-print-none" style="height:5px">
                                   <div class="progress-bar bg-primary" role="progressbar" style="width:@((Model.AmountCollected/Model.Amount)*100)%" v-bind:style="{ width: (srvModel.amountCollected/srvModel.amount*100) + '%' }"></div>
                                 </div>
                                 <div class="d-flex d-print-inline-block flex-column mb-4 me-5 d-sm-inline-flex mb-sm-0">
-                                    <dt class="h4 fw-normal text-nowrap order-2 order-sm-1 mb-0" v-text="srvModel.amountCollectedFormatted">@Model.AmountCollectedFormatted</dt>
+                                    <dt class="h4 fw-semibold text-nowrap order-2 order-sm-1 mb-1" v-text="srvModel.amountCollectedFormatted">@Model.AmountCollectedFormatted</dt>
                                     <dd class="text-muted order-1 order-sm-2 mb-1">Amount paid</dd>
                                 </div>
                                 <div class="d-flex d-print-inline-block flex-column mb-0 d-sm-inline-flex float-sm-end">
-                                    <dt class="h4 text-sm-end fw-normal text-nowrap order-2 order-sm-1 mb-0" v-text="srvModel.amountFormatted">@Model.AmountFormatted</dt>
+                                    <dt class="h4 text-sm-end fw-semibold text-nowrap order-2 order-sm-1 mb-1" v-text="srvModel.amountFormatted">@Model.AmountFormatted</dt>
                                     <dd class="text-muted text-sm-end order-1 order-sm-2 mb-1">Total requested</dd>
                                 </div>
                             </dl>

--- a/BTCPayServer/Views/PaymentRequest/ViewPaymentRequest.cshtml
+++ b/BTCPayServer/Views/PaymentRequest/ViewPaymentRequest.cshtml
@@ -1,4 +1,4 @@
-@using BTCPayServer.Services.Invoices
+﻿@using BTCPayServer.Services.Invoices
 @using BTCPayServer.Client.Models
 @using BTCPayServer.Abstractions.Contracts
 @model BTCPayServer.Models.PaymentRequestViewModels.ViewPaymentRequestViewModel
@@ -203,7 +203,7 @@
                 <partial name="_StatusMessage" model="@(new ViewDataDictionary(ViewData){ { "Margin", "mb-4" } })" />
                 <div class="row">
                     <div class="col col-12 col-lg-6 mb-4">
-                        <div class="bg-tile h-100 m-0 p-3 p-sm-5">
+                        <div class="bg-tile h-100 m-0 p-3 p-sm-5 rounded">
                             <h2 class="h4 mb-3">Invoice Summary</h2>
                             <div v-html="srvModel.description">
                                 @if (!string.IsNullOrEmpty(Model.Description) && Model.Description != "<br>")
@@ -214,7 +214,7 @@
                         </div>
                     </div>
                     <div class="col col-12 col-lg-6 mb-4">
-                        <div class="bg-tile h-100 m-0 p-3 p-sm-5">
+                        <div class="bg-tile h-100 m-0 p-3 p-sm-5 rounded">
                             <h2 class="h4 mb-3">Payment Details</h2>
                             <dl class="mb-0 mt-md-4">
                                 <div class="d-flex d-print-inline-block flex-column mb-4 me-5">
@@ -238,7 +238,7 @@
                 </div>
                 <div class="row">
                     <div class="col">
-                        <div class="bg-tile h-100 m-0 p-3 p-sm-5">
+                        <div class="bg-tile h-100 m-0 p-3 p-sm-5 rounded">
                             <h2 class="h4 mb-3">Payment History</h2>
                             <div class="table-responsive">
                                 <noscript>

--- a/BTCPayServer/Views/PaymentRequest/ViewPaymentRequest.cshtml
+++ b/BTCPayServer/Views/PaymentRequest/ViewPaymentRequest.cshtml
@@ -310,7 +310,7 @@
                                 </noscript>
 
                                 <template v-if="!srvModel.invoices || srvModel.invoices.length == 0">
-                                    <p class="text-muted">No payments made yet.</p>
+                                    <p class="text-muted mt-3 mb-0">No payments made yet.</p>
                                 </template>
                                 <template v-else>
                                     <table v-for="invoice of srvModel.invoices" :key="invoice.id" class="invoice table">

--- a/BTCPayServer/Views/PullPayment/ViewPullPayment.cshtml
+++ b/BTCPayServer/Views/PullPayment/ViewPullPayment.cshtml
@@ -190,7 +190,7 @@
                                 }
                                 else
                                 {
-                                    <p class="text-muted mt-3">No claim made yet.</p>
+                                    <p class="text-muted mt-3 mb-0">No claim made yet.</p>
                                 }
                             </div>
                         </div>

--- a/BTCPayServer/Views/PullPayment/ViewPullPayment.cshtml
+++ b/BTCPayServer/Views/PullPayment/ViewPullPayment.cshtml
@@ -190,7 +190,7 @@
                                 }
                                 else
                                 {
-                                    <p class="text-muted">No claim made yet.</p>
+                                    <p class="text-muted mt-3">No claim made yet.</p>
                                 }
                             </div>
                         </div>

--- a/BTCPayServer/Views/PullPayment/ViewPullPayment.cshtml
+++ b/BTCPayServer/Views/PullPayment/ViewPullPayment.cshtml
@@ -107,7 +107,7 @@
                                 <span class="text-muted text-nowrap">Last Updated</span>
                                 &nbsp;
                                 <span class="text-nowrap">@Model.LastRefreshed.ToString("g")</span>
-                                <button type="button" class="btn btn-link d-none d-lg-inline-block d-print-none border-0 p-0 ms-4 only-for-js" id="copyLink">
+                                <button type="button" class="btn btn-link fw-semibold d-none d-lg-inline-block d-print-none border-0 p-0 ms-4 only-for-js" id="copyLink">
                                     Copy Link
                                 </button>
                             </div>
@@ -130,18 +130,18 @@
                             <h2 class="h4 mb-3">Payment Details</h2>
                             <dl class="mb-0 mt-md-4">
                                 <div class="d-flex d-print-inline-block flex-column mb-4 me-5">
-                                    <dt class="h4 fw-normal text-nowrap text-primary text-print-default order-2 order-sm-1 mb-0">@Model.AmountDueFormatted</dt>
+                                    <dt class="h4 fw-semibold text-nowrap text-primary text-print-default order-2 order-sm-1 mb-1">@Model.AmountDueFormatted</dt>
                                     <dd class="text-muted order-1 order-sm-2 mb-1">Available claim</dd>
                                 </div>
                                 <div class="progress bg-light d-none d-sm-flex mb-sm-4 d-print-none" style="height:5px">
                                     <div class="progress-bar bg-primary" role="progressbar" style="width:@((Model.AmountCollected / Model.Amount) * 100)%"></div>
                                 </div>
                                 <div class="d-flex d-print-inline-block flex-column mb-4 me-5 d-sm-inline-flex mb-sm-0">
-                                    <dt class="h4 fw-normal text-nowrap order-2 order-sm-1 mb-0">@Model.AmountCollectedFormatted</dt>
+                                    <dt class="h4 fw-normal text-nowrap order-2 order-sm-1 mb-1">@Model.AmountCollectedFormatted</dt>
                                     <dd class="text-muted order-1 order-sm-2 mb-1">Already claimed</dd>
                                 </div>
                                 <div class="d-flex d-print-inline-block flex-column mb-0 d-sm-inline-flex float-sm-end">
-                                    <dt class="h4 text-sm-end fw-normal text-nowrap order-2 order-sm-1 mb-0">@Model.AmountFormatted</dt>
+                                    <dt class="h4 text-sm-end fw-normal text-nowrap order-2 order-sm-1 mb-1">@Model.AmountFormatted</dt>
                                     <dd class="text-muted text-sm-end order-1 order-sm-2 mb-1">Claim limit</dd>
                                 </div>
                             </dl>

--- a/BTCPayServer/Views/PullPayment/ViewPullPayment.cshtml
+++ b/BTCPayServer/Views/PullPayment/ViewPullPayment.cshtml
@@ -151,7 +151,7 @@
                 <div class="row">
                     <div class="col">
                         <div class="bg-tile h-100 m-0 p-3 p-sm-5 rounded">
-                            <h2 class="h4 mb-3">Claims</h2>
+                            <h2 class="h4 mb-0">Claims</h2>
                             <div class="table-responsive">
                                 @if (Model.Payouts.Any())
                                 {

--- a/BTCPayServer/Views/PullPayment/ViewPullPayment.cshtml
+++ b/BTCPayServer/Views/PullPayment/ViewPullPayment.cshtml
@@ -93,7 +93,7 @@
                 }
                 <div class="row">
                     <div class="col col-12 col-lg-6 mb-4">
-                        <div class="bg-tile h-100 m-0 p-3 p-sm-5">
+                        <div class="bg-tile h-100 m-0 p-3 p-sm-5 rounded">
                             @if (!Model.Title.IsNullOrWhiteSpace())
                             {
                                 <h2 class="h4 mb-3">@Model.Title</h2>
@@ -126,7 +126,7 @@
                         </div>
                     </div>
                     <div class="col col-12 col-lg-6 mb-4">
-                        <div class="bg-tile h-100 m-0 p-3 p-sm-5">
+                        <div class="bg-tile h-100 m-0 p-3 p-sm-5 rounded">
                             <h2 class="h4 mb-3">Payment Details</h2>
                             <dl class="mb-0 mt-md-4">
                                 <div class="d-flex d-print-inline-block flex-column mb-4 me-5">
@@ -150,7 +150,7 @@
                 </div>
                 <div class="row">
                     <div class="col">
-                        <div class="bg-tile h-100 m-0 p-3 p-sm-5">
+                        <div class="bg-tile h-100 m-0 p-3 p-sm-5 rounded">
                             <h2 class="h4 mb-3">Claims</h2>
                             <div class="table-responsive">
                                 @if (Model.Payouts.Any())

--- a/BTCPayServer/Views/PullPayment/ViewPullPayment.cshtml
+++ b/BTCPayServer/Views/PullPayment/ViewPullPayment.cshtml
@@ -131,18 +131,18 @@
                             <dl class="mb-0 mt-md-4">
                                 <div class="d-flex d-print-inline-block flex-column mb-4 me-5">
                                     <dt class="h4 fw-semibold text-nowrap text-primary text-print-default order-2 order-sm-1 mb-1">@Model.AmountDueFormatted</dt>
-                                    <dd class="text-muted order-1 order-sm-2 mb-1">Available claim</dd>
+                                    <dd class="order-1 order-sm-2 mb-1">Available claim</dd>
                                 </div>
                                 <div class="progress bg-light d-none d-sm-flex mb-sm-4 d-print-none" style="height:5px">
                                     <div class="progress-bar bg-primary" role="progressbar" style="width:@((Model.AmountCollected / Model.Amount) * 100)%"></div>
                                 </div>
                                 <div class="d-flex d-print-inline-block flex-column mb-4 me-5 d-sm-inline-flex mb-sm-0">
-                                    <dt class="h4 fw-normal text-nowrap order-2 order-sm-1 mb-1">@Model.AmountCollectedFormatted</dt>
-                                    <dd class="text-muted order-1 order-sm-2 mb-1">Already claimed</dd>
+                                    <dt class="h4 fw-semibold text-nowrap order-2 order-sm-1 mb-1">@Model.AmountCollectedFormatted</dt>
+                                    <dd class="order-1 order-sm-2 mb-1">Already claimed</dd>
                                 </div>
                                 <div class="d-flex d-print-inline-block flex-column mb-0 d-sm-inline-flex float-sm-end">
-                                    <dt class="h4 text-sm-end fw-normal text-nowrap order-2 order-sm-1 mb-1">@Model.AmountFormatted</dt>
-                                    <dd class="text-muted text-sm-end order-1 order-sm-2 mb-1">Claim limit</dd>
+                                    <dt class="h4 text-sm-end fw-semibold text-nowrap order-2 order-sm-1 mb-1">@Model.AmountFormatted</dt>
+                                    <dd class="text-sm-end order-1 order-sm-2 mb-1">Claim limit</dd>
                                 </div>
                             </dl>
                         </div>


### PR DESCRIPTION
Entirely aesthetic changes, from padding to font weights, border-radius, etc..

I have a few more changes I want to make to these views, but I'll follow up on that in another PR to keep this one simple.

Updates:
<img width="1231" alt="Screen Shot 2021-11-18 at 12 04 13 PM" src="https://user-images.githubusercontent.com/6250771/142489140-d609ca40-46e2-4b3f-952e-22d9016803df.png">
<img width="1244" alt="Screen Shot 2021-11-18 at 12 04 19 PM" src="https://user-images.githubusercontent.com/6250771/142489142-be2bf27b-b7bc-446c-a013-e353a0076cb2.png">

-------

The only issue I had was trying to resolve but couldn't was the conditional switch for adding this to the "Invoice Summary" on the Payment Request as shown:

<img width="1023" alt="Screen Shot 2021-11-18 at 12 08 06 PM" src="https://user-images.githubusercontent.com/6250771/142490254-2e2bae79-cce9-4155-952f-957d3d7874ca.png">

Really simple conditional, but for whatever reason, I wasn't able to get the empty state } else { condition to display "No details provided." as shown in the first screenshot.

Snippet of the existing conditional sans my attempts:
`@if (!string.IsNullOrEmpty(Model.Description) && Model.Description != "<br>")
{
@Safe.Raw(Model.Description)
}`

cc @satwo @dennisreimann 