### PR TITLE
Greenfield: Add pagination for API GetNotifications

### DIFF
--- a/BTCPayServer.Client/BTCPayServerClient.Notifications.cs
+++ b/BTCPayServer.Client/BTCPayServerClient.Notifications.cs
@@ -9,13 +9,22 @@ namespace BTCPayServer.Client
 {
     public partial class BTCPayServerClient
     {
-        public virtual async Task<IEnumerable<NotificationData>> GetNotifications(bool? seen = null,
-            CancellationToken token = default)
+        public virtual async Task<IEnumerable<NotificationData>> GetNotifications(bool? seen = null, int? skip = null, 
+            int? take = null, CancellationToken token = default)
         {
-            var response =
-                await _httpClient.SendAsync(
-                    CreateHttpRequest($"api/v1/users/me/notifications",
-                        seen != null ? new Dictionary<string, object>() {{nameof(seen), seen}} : null), token);
+            Dictionary<string, object> queryPayload = new Dictionary<string, object>();
+            
+            if (seen != null)
+                queryPayload.Add(nameof(seen), seen);
+            if (skip != null)
+                queryPayload.Add(nameof(skip), skip);
+            if (take != null)
+                queryPayload.Add(nameof(take), take);
+
+            var response = await _httpClient.SendAsync(
+                CreateHttpRequest($"api/v1/users/me/notifications",
+                    queryPayload), token);
+
             return await HandleResponse<IEnumerable<NotificationData>>(response);
         }
 

--- a/BTCPayServer/Controllers/GreenField/LocalBTCPayServerClient.cs
+++ b/BTCPayServer/Controllers/GreenField/LocalBTCPayServerClient.cs
@@ -612,12 +612,12 @@ namespace BTCPayServer.Controllers.GreenField
         {
             HandleActionResult(await _apiKeysController.RevokeKey(apikey));
         }
-
-        public override async Task<IEnumerable<NotificationData>> GetNotifications(bool? seen = null,
-            CancellationToken token = default)
+        
+        public override async Task<IEnumerable<NotificationData>> GetNotifications(bool? seen = null, 
+            int? skip = null, int? take = null, CancellationToken token = default)
         {
             return GetFromActionResult<IEnumerable<NotificationData>>(
-                await _notificationsController.GetNotifications(seen));
+                await _notificationsController.GetNotifications(seen, skip, take));
         }
 
         public override async Task<NotificationData> GetNotification(string notificationId,

--- a/BTCPayServer/Controllers/GreenField/NotificationsController.cs
+++ b/BTCPayServer/Controllers/GreenField/NotificationsController.cs
@@ -33,11 +33,11 @@ namespace BTCPayServer.Controllers.GreenField
         [Authorize(Policy = Policies.CanViewNotificationsForUser,
             AuthenticationSchemes = AuthenticationSchemes.Greenfield)]
         [HttpGet("~/api/v1/users/me/notifications")]
-        public async Task<IActionResult> GetNotifications(bool? seen = null)
+        public async Task<IActionResult> GetNotifications(bool? seen = null, [FromQuery] int? skip = null, [FromQuery] int? take = null)
         {
             var items = await _notificationManager.GetNotifications(new NotificationsQuery()
             {
-                Seen = seen, UserId = _userManager.GetUserId(User)
+                Seen = seen, UserId = _userManager.GetUserId(User), Skip = skip, Take = take
             });
 
             return Ok(items.Items.Select(ToModel));

--- a/BTCPayServer/wwwroot/swagger/v1/swagger.template.notifications.json
+++ b/BTCPayServer/wwwroot/swagger/v1/swagger.template.notifications.json
@@ -16,6 +16,26 @@
                             "type": "string",
                             "nullable": true
                         }
+                    },
+                    {
+                        "name": "skip",
+                        "in": "query",
+                        "required": false,
+                        "description": "Number of records to skip",
+                        "schema": {
+                            "nullable": true,
+                            "type": "number"
+                        }
+                    },
+                    {
+                        "name": "take",
+                        "in": "query",
+                        "required": false,
+                        "description": "Number of records returned in response",
+                        "schema": {
+                            "nullable": true,
+                            "type": "number"
+                        }
                     }
                 ],
                 "description": "View current user's notifications",


### PR DESCRIPTION
This adds `skip` and `take` pagination for the GetNotifications API, in keeping with the legacy BitPay api. Similar to #3039.
