### PR TITLE
Remove sync modal from "Forgot password" page

### DIFF
--- a/BTCPayServer/Views/Account/ForgotPassword.cshtml
+++ b/BTCPayServer/Views/Account/ForgotPassword.cshtml
@@ -1,6 +1,7 @@
 ﻿@model ForgotPasswordViewModel
 @{
     ViewData["Title"] = "Forgot your password?";
+    Layout = "_LayoutSimple";
 }
 
 <section>

--- a/BTCPayServer/Views/Shared/LayoutPartials/SyncModal.cshtml
+++ b/BTCPayServer/Views/Shared/LayoutPartials/SyncModal.cshtml
@@ -63,7 +63,13 @@
                 localStorage.removeItem("sync-collapsed");
             });
             function handleFooterBottom() {
-                if (document.getElementsByTagName("footer")[0].getBoundingClientRect().top < window.innerHeight){
+                var footer = document.getElementsByTagName("footer")[0];
+                // Not all pages have a footer
+                if (!footer) {
+                    return;
+                }
+
+                if (footer.getBoundingClientRect().top < window.innerHeight){
                     syncModal.stop().animate({"bottom":"40px"}, 200);
                 } else {      
                     syncModal.stop().animate({"bottom":"10px"}, 200);


### PR DESCRIPTION
Close #2996

Updated layout on "Forgot password" page so that it never shows the sync progress modal.

|Before|After|
|---|---|
|![Capture](https://user-images.githubusercontent.com/1934678/143503540-5c1dc080-2fc0-416d-8670-f0c14db27531.PNG)|![after](https://user-images.githubusercontent.com/1934678/143503551-e08ddb6f-f817-40fd-be94-d3d2ed6a4947.PNG)|

Also fixed a null reference error that can happen:

![Capture2](https://user-images.githubusercontent.com/1934678/143503577-d521557c-fb78-4538-b60a-75733fade434.PNG)
