### PR TITLE
Fix possible null reference exception when creating a pull payment

### DIFF
--- a/BTCPayServer/Controllers/StorePullPaymentsController.PullPayments.cs
+++ b/BTCPayServer/Controllers/StorePullPaymentsController.PullPayments.cs
@@ -95,9 +95,13 @@ namespace BTCPayServer.Controllers
             model.PaymentMethodItems =
                 paymentMethodOptions.Select(id => new SelectListItem(id.ToPrettyString(), id.ToString(), true));
             model.Name ??= string.Empty;
-            model.Currency = model.Currency.ToUpperInvariant().Trim();
+            model.Currency = model.Currency != null ? model.Currency.ToUpperInvariant().Trim() : String.Empty;
+            model.PaymentMethods ??= new List<string>();
             if (!model.PaymentMethods.Any())
             {
+                // Since we assign all payment methods to be selected by default above we need to update 
+                // them here to reflect user's selection so that they can correct their mistake
+                model.PaymentMethodItems = paymentMethodOptions.Select(id => new SelectListItem(id.ToPrettyString(), id.ToString(), false));
                 ModelState.AddModelError(nameof(model.PaymentMethods), "You need at least one payment method");
             }
             if (_currencyNameTable.GetCurrencyData(model.Currency, false) is null)

--- a/BTCPayServer/Controllers/StorePullPaymentsController.PullPayments.cs
+++ b/BTCPayServer/Controllers/StorePullPaymentsController.PullPayments.cs
@@ -95,7 +95,7 @@ namespace BTCPayServer.Controllers
             model.PaymentMethodItems =
                 paymentMethodOptions.Select(id => new SelectListItem(id.ToPrettyString(), id.ToString(), true));
             model.Name ??= string.Empty;
-            model.Currency = model.Currency != null ? model.Currency.ToUpperInvariant().Trim() : String.Empty;
+            model.Currency = model.Currency?.ToUpperInvariant()?.Trim() ?? String.Empty;
             model.PaymentMethods ??= new List<string>();
             if (!model.PaymentMethods.Any())
             {

--- a/BTCPayServer/Views/StorePullPayments/NewPullPayment.cshtml
+++ b/BTCPayServer/Views/StorePullPayments/NewPullPayment.cshtml
@@ -42,6 +42,7 @@
                         </label>
                     </div>
                 }
+                <span asp-validation-for="PaymentMethods" class="text-danger mt-0"></span>
             </div>
 
             <h5 class="mt-4 mb-2">Additional Options</h5>


### PR DESCRIPTION
I noticed we can run into null reference exception when creating a pull payment. This PR fixes these issues.

![error](https://user-images.githubusercontent.com/1934678/143665850-c52122be-45b8-4849-ba91-ff3547e54268.PNG)
![error2](https://user-images.githubusercontent.com/1934678/143665851-382d1934-7f57-4328-a4a9-55b13d789f9b.PNG)
