### PR TITLE
Send block reward to a random address instead of the invoice address. Default mine 1 block.

### DIFF
--- a/BTCPayServer/Controllers/InvoiceController.Testing.cs
+++ b/BTCPayServer/Controllers/InvoiceController.Testing.cs
@@ -20,7 +20,7 @@ namespace BTCPayServer.Controllers
 
         public class MineBlocksRequest
         {
-            public int BlockCount { get; set; }
+            public int BlockCount { get; set; } = 1;
             public string CryptoCode { get; set; } = "BTC";
         }
         
@@ -69,13 +69,11 @@ namespace BTCPayServer.Controllers
         [CheatModeRoute]
         public async Task<IActionResult> MineBlock(string invoiceId, MineBlocksRequest request, [FromServices] Cheater cheater)
         {
-            var invoice = await _InvoiceRepository.GetInvoice(invoiceId);
-            var store = await _StoreRepository.FindStore(invoice.StoreId);
-
             // TODO support altcoins, not just bitcoin
             var network = _NetworkProvider.GetNetwork<BTCPayNetwork>(request.CryptoCode);
-            var paymentMethodId = store.GetDefaultPaymentId() ?? store.GetEnabledPaymentIds(_NetworkProvider).FirstOrDefault(p => p.CryptoCode == request.CryptoCode && p.PaymentType == PaymentTypes.BTCLike);
-            var bitcoinAddressString = invoice.GetPaymentMethod(paymentMethodId).GetPaymentMethodDetails().GetPaymentDestination();
+            
+            // A random address where the block reward should be sent to
+            var bitcoinAddressString = "bcrt1pl63qqarewgeze8m34ysg0eadqvtrtqcnvf9u2y67xag9a9rlzz8qgka32t";
             var bitcoinAddressObj = BitcoinAddress.Create(bitcoinAddressString, network.NBitcoinNetwork);
             
             // Mine the blocks

--- a/BTCPayServer/Controllers/InvoiceController.Testing.cs
+++ b/BTCPayServer/Controllers/InvoiceController.Testing.cs
@@ -70,21 +70,15 @@ namespace BTCPayServer.Controllers
         public async Task<IActionResult> MineBlock(string invoiceId, MineBlocksRequest request, [FromServices] Cheater cheater)
         {
             // TODO support altcoins, not just bitcoin
-            var network = _NetworkProvider.GetNetwork<BTCPayNetwork>(request.CryptoCode);
-            
-            // A random address where the block reward should be sent to
-            var bitcoinAddressString = "bcrt1pl63qqarewgeze8m34ysg0eadqvtrtqcnvf9u2y67xag9a9rlzz8qgka32t";
-            var bitcoinAddressObj = BitcoinAddress.Create(bitcoinAddressString, network.NBitcoinNetwork);
-            
-            // Mine the blocks
+            var blockRewardBitcoinAddress = cheater.CashCow.GetNewAddress();
             try
             {
                 if (request.BlockCount > 0) 
                 {
-                    cheater.CashCow.GenerateToAddress(request.BlockCount, bitcoinAddressObj);
+                    cheater.CashCow.GenerateToAddress(request.BlockCount, blockRewardBitcoinAddress);
                     return Ok(new
                     {
-                        SuccessMessage = "Mined "+request.BlockCount+" blocks for " + bitcoinAddressObj
+                        SuccessMessage = "Mined "+request.BlockCount+" blocks"
                     });                    
                 }
                 return BadRequest(new


### PR DESCRIPTION
In previous PR (#3163) I made a dumb mistake of sending the block reward to the invoice address. This is fixed in this PR.