### PR TITLE
Fix code display

### DIFF
--- a/BTCPayServer/Views/Wallets/WalletPSBTDecoded.cshtml
+++ b/BTCPayServer/Views/Wallets/WalletPSBTDecoded.cshtml
@@ -121,10 +121,10 @@ else
                         </ul>
                         <div class="tab-content" id="export-tabContent">
                             <div class="tab-pane fade show active" id="export-base64" role="tabpanel" aria-labelledby="export-base64-tab">
-                                <pre class="mb-4"><code class="text text-wrap">@Model.PSBT</code></pre>
+                                <pre class="mb-4 text-wrap"><code class="text">@Model.PSBT</code></pre>
                             </div>
                             <div class="tab-pane fade" id="export-hex" role="tabpanel" aria-labelledby="export-hex-tab">
-                                <pre class="mb-4"><code class="text text-wrap">@Model.PSBTHex</code></pre>
+                                <pre class="mb-4 text-wrap"><code class="text">@Model.PSBTHex</code></pre>
                             </div>
                             <div class="tab-pane fade" id="export-json" role="tabpanel" aria-labelledby="export-json-tab">
                                 <pre class="mb-0"><code class="json">@Model.Decoded</code></pre>


### PR DESCRIPTION
Fixes a visual bug that is cause by the text-wrap class being applied to the code element instead of the parent pre element.

## Before

![image](https://user-images.githubusercontent.com/886/144617075-4a379784-2f78-4547-9f45-51a0eed6b2c9.png)


## After

![image](https://user-images.githubusercontent.com/886/144616934-f12c1c1e-d11a-4fff-9db4-375410bb975e.png)
