### PR TITLE
New API endpoint: Send email using store SMTP

### DIFF
--- a/BTCPayServer.Client/BTCPayServerClient.StoreEmail.cs
+++ b/BTCPayServer.Client/BTCPayServerClient.StoreEmail.cs
@@ -1,0 +1,19 @@
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using BTCPayServer.Client.Models;
+
+namespace BTCPayServer.Client
+{
+    public partial class BTCPayServerClient
+    {
+        public virtual async Task SendEmail(string storeId, SendEmailRequest request,
+            CancellationToken token = default)
+        {
+            using var response = await _httpClient.SendAsync(
+                CreateHttpRequest($"api/v1/stores/{storeId}/email/send", bodyPayload: request, method: HttpMethod.Post),
+                token);
+            await HandleResponse(response);
+        }
+    }
+}

--- a/BTCPayServer.Client/Models/SendEmailRequest.cs
+++ b/BTCPayServer.Client/Models/SendEmailRequest.cs
@@ -1,0 +1,17 @@
+using System.Net.Mail;
+
+namespace BTCPayServer.Client.Models
+{
+    public class SendEmailRequest
+    {
+        public string toName;
+        public string toEmail;
+        public string subject;
+        public string body;
+
+        public MailAddress toMailAddress()
+        {
+            return new MailAddress(toEmail, toName);
+        }
+    }
+}

--- a/BTCPayServer.Client/Models/SendEmailRequest.cs
+++ b/BTCPayServer.Client/Models/SendEmailRequest.cs
@@ -1,18 +1,10 @@
-using System.Net.Mail;
-using MimeKit;
 
 namespace BTCPayServer.Client.Models
 {
     public class SendEmailRequest
     {
-        public string toName;
-        public string toEmail;
-        public string subject;
-        public string body;
-
-        public MailboxAddress toMailAddress()
-        {
-            return new MailboxAddress(toEmail, toName);
-        }
+        public string Email;
+        public string Subject;
+        public string Body;
     }
 }

--- a/BTCPayServer.Client/Models/SendEmailRequest.cs
+++ b/BTCPayServer.Client/Models/SendEmailRequest.cs
@@ -1,4 +1,5 @@
 using System.Net.Mail;
+using MimeKit;
 
 namespace BTCPayServer.Client.Models
 {
@@ -9,9 +10,9 @@ namespace BTCPayServer.Client.Models
         public string subject;
         public string body;
 
-        public MailAddress toMailAddress()
+        public MailboxAddress toMailAddress()
         {
-            return new MailAddress(toEmail, toName);
+            return new MailboxAddress(toEmail, toName);
         }
     }
 }

--- a/BTCPayServer.Tests/GreenfieldAPITests.cs
+++ b/BTCPayServer.Tests/GreenfieldAPITests.cs
@@ -2265,6 +2265,24 @@ namespace BTCPayServer.Tests
             await AssertAPIError("store-user-role-orphaned", async () => await user2Client.RemoveStoreUser(user.StoreId, user2.UserId));
 
         }
-        
+
+
+        [Fact(Timeout = 60 * 2 * 1000)]
+        [Trait("Integration", "Integration")]
+        public async Task StoreEmailTests()
+        {
+            using var tester = CreateServerTester();
+            await tester.StartAsync();
+            var admin = tester.NewAccount();
+            await admin.GrantAccessAsync(true);
+            var adminClient = await admin.CreateClient(Policies.Unrestricted);
+
+            await adminClient.SendEmail(admin.StoreId, new SendEmailRequest()
+            {
+                Body = "lol",
+                Subject = "subj",
+                Email = "sdasdas"
+            });
+        }
     }
 }

--- a/BTCPayServer/Controllers/GreenField/GreenfieldStoreEmailController.cs
+++ b/BTCPayServer/Controllers/GreenField/GreenfieldStoreEmailController.cs
@@ -2,9 +2,9 @@
 using System;
 using System.Threading.Tasks;
 using BTCPayServer.Abstractions.Constants;
+using BTCPayServer.Abstractions.Extensions;
 using BTCPayServer.Client;
 using BTCPayServer.Client.Models;
-using BTCPayServer.Data;
 using BTCPayServer.Services.Mails;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Cors;
@@ -15,10 +15,17 @@ namespace BTCPayServer.Controllers.GreenField
     [ApiController]
     [Authorize(AuthenticationSchemes = AuthenticationSchemes.Greenfield)]
     [EnableCors(CorsPolicies.All)]
-    public class StoreSendEmail : Controller
+    public class GreenfieldStoreEmailController : Controller
     {
+        private readonly EmailSenderFactory _emailSenderFactory;
+
+        public GreenfieldStoreEmailController(EmailSenderFactory  emailSenderFactory)
+        {
+            _emailSenderFactory = emailSenderFactory;
+        }
+        
         [Authorize(Policy = Policies.CanModifyStoreSettings, AuthenticationSchemes = AuthenticationSchemes.Greenfield)]
-        [HttpPost("~/api/v1/stores/{storeId}/email")]
+        [HttpPost("~/api/v1/stores/{storeId}/email/send")]
         public async Task<IActionResult> SendEmailFromStore(string storeId,
             [FromBody] SendEmailRequest request)
         {
@@ -27,26 +34,14 @@ namespace BTCPayServer.Controllers.GreenField
             {
                 return this.CreateAPIError(404, "store-not-found", "The store was not found");
             }
-
-            var emailSettings = store.GetStoreBlob().EmailSettings ?? null;
-            if (emailSettings != null || !emailSettings.IsComplete())
+            var emailSender = await _emailSenderFactory.GetEmailSender(storeId);
+            if (emailSender is null )
             {
                 return this.CreateAPIError(404,"smtp-not-configured", "Store does not have an SMTP server configured.");
             }
-
-            var client = await emailSettings.CreateSmtpClient();
-            var message = emailSettings.CreateMailMessage(request.toMailAddress(), request.subject, request.body, false);
-
-            try
-            {
-                await client.SendAsync(message);
-                await client.DisconnectAsync(true);
-                return Ok();
-            }
-            catch (Exception e)
-            {
-                return this.CreateAPIError(500,"smtp-error", e.Message);
-            }
+            
+            emailSender.SendEmail(request.Email, request.Subject, request.Body);
+            return Ok();
         }
     }
 }

--- a/BTCPayServer/Controllers/GreenField/LocalBTCPayServerClient.cs
+++ b/BTCPayServer/Controllers/GreenField/LocalBTCPayServerClient.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 using BTCPayServer.Abstractions.Contracts;
 using BTCPayServer.Client;
 using BTCPayServer.Client.Models;
+using BTCPayServer.Controllers.GreenField;
 using BTCPayServer.Data;
 using BTCPayServer.Security.Greenfield;
 using BTCPayServer.Services.Stores;
@@ -56,6 +57,7 @@ namespace BTCPayServer.Controllers.Greenfield
         private readonly GreenfieldPullPaymentController _greenfieldPullPaymentController;
         private readonly UIHomeController _homeController;
         private readonly GreenfieldStorePaymentMethodsController _storePaymentMethodsController;
+        private readonly GreenfieldStoreEmailController _greenfieldStoreEmailController;
         private readonly IServiceProvider _serviceProvider;
 
         public BTCPayServerClientFactory(StoreRepository storeRepository,
@@ -79,6 +81,7 @@ namespace BTCPayServer.Controllers.Greenfield
             GreenfieldPullPaymentController greenfieldPullPaymentController,
             UIHomeController homeController,
             GreenfieldStorePaymentMethodsController storePaymentMethodsController,
+            GreenfieldStoreEmailController greenfieldStoreEmailController,
             IServiceProvider serviceProvider)
         {
             _storeRepository = storeRepository;
@@ -102,6 +105,7 @@ namespace BTCPayServer.Controllers.Greenfield
             _greenfieldPullPaymentController = greenfieldPullPaymentController;
             _homeController = homeController;
             _storePaymentMethodsController = storePaymentMethodsController;
+            _greenfieldStoreEmailController = greenfieldStoreEmailController;
             _serviceProvider = serviceProvider;
         }
 
@@ -158,6 +162,7 @@ namespace BTCPayServer.Controllers.Greenfield
                 _greenfieldPullPaymentController,
                 _homeController,
                 _storePaymentMethodsController,
+                _greenfieldStoreEmailController,
                 new LocalHttpContextAccessor() { HttpContext = context }
             );
         }
@@ -188,6 +193,7 @@ namespace BTCPayServer.Controllers.Greenfield
         private readonly GreenfieldPullPaymentController _greenfieldPullPaymentController;
         private readonly UIHomeController _homeController;
         private readonly GreenfieldStorePaymentMethodsController _storePaymentMethodsController;
+        private readonly GreenfieldStoreEmailController _greenfieldStoreEmailController;
 
         public LocalBTCPayServerClient(
             IServiceProvider serviceProvider,
@@ -209,6 +215,7 @@ namespace BTCPayServer.Controllers.Greenfield
             GreenfieldPullPaymentController greenfieldPullPaymentController,
             UIHomeController homeController,
             GreenfieldStorePaymentMethodsController storePaymentMethodsController,
+            GreenfieldStoreEmailController greenfieldStoreEmailController,
             IHttpContextAccessor httpContextAccessor) : base(new Uri("https://dummy.local"), "", "")
         {
             _chainPaymentMethodsController = chainPaymentMethodsController;
@@ -229,6 +236,7 @@ namespace BTCPayServer.Controllers.Greenfield
             _greenfieldPullPaymentController = greenfieldPullPaymentController;
             _homeController = homeController;
             _storePaymentMethodsController = storePaymentMethodsController;
+            _greenfieldStoreEmailController = greenfieldStoreEmailController;
 
             var controllers = new[]
             {
@@ -236,7 +244,8 @@ namespace BTCPayServer.Controllers.Greenfield
                 paymentRequestController, apiKeysController, notificationsController, usersController,
                 storeLightningNetworkPaymentMethodsController, greenFieldInvoiceController, storeWebhooksController,
                 greenFieldServerInfoController, greenfieldPullPaymentController, storesController, homeController,
-                lightningNodeApiController, storeLightningNodeApiController as ControllerBase, storePaymentMethodsController
+                lightningNodeApiController, storeLightningNodeApiController as ControllerBase, storePaymentMethodsController, 
+                greenfieldStoreEmailController
             };
 
             var authoverride = new DefaultAuthorizationService(
@@ -998,6 +1007,11 @@ namespace BTCPayServer.Controllers.Greenfield
                 ScriptPubKeyType = request.ScriptPubKeyType,
                 ImportKeysToRPC = request.ImportKeysToRPC
             }));
+        }
+
+        public override async Task SendEmail(string storeId, SendEmailRequest request, CancellationToken token = default)
+        {
+            HandleActionResult(await _greenfieldStoreEmailController.SendEmailFromStore(storeId, request));
         }
     }
 }

--- a/BTCPayServer/Controllers/GreenField/StoreSendEmail.cs
+++ b/BTCPayServer/Controllers/GreenField/StoreSendEmail.cs
@@ -31,19 +31,21 @@ namespace BTCPayServer.Controllers.GreenField
             var emailSettings = store.GetStoreBlob().EmailSettings ?? null;
             if (emailSettings != null || !emailSettings.IsComplete())
             {
-                return this.CreateAPIError("smtp-not-configured", "Store does not have an SMTP server configured.");
+                return this.CreateAPIError(404,"smtp-not-configured", "Store does not have an SMTP server configured.");
             }
 
-            var client = emailSettings.CreateSmtpClient();
-            var message = emailSettings.CreateMailMessage(request.toMailAddress(), request.subject, request.body);
+            var client = await emailSettings.CreateSmtpClient();
+            var message = emailSettings.CreateMailMessage(request.toMailAddress(), request.subject, request.body, false);
+
             try
             {
-                await client.SendMailAsync(message);
+                await client.SendAsync(message);
+                await client.DisconnectAsync(true);
                 return Ok();
             }
             catch (Exception e)
             {
-                return this.CreateAPIError("not-available", e.Message);
+                return this.CreateAPIError(500,"smtp-error", e.Message);
             }
         }
     }

--- a/BTCPayServer/Controllers/GreenField/StoreSendEmail.cs
+++ b/BTCPayServer/Controllers/GreenField/StoreSendEmail.cs
@@ -1,0 +1,50 @@
+#nullable enable
+using System;
+using System.Threading.Tasks;
+using BTCPayServer.Abstractions.Constants;
+using BTCPayServer.Client;
+using BTCPayServer.Client.Models;
+using BTCPayServer.Data;
+using BTCPayServer.Services.Mails;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Cors;
+using Microsoft.AspNetCore.Mvc;
+
+namespace BTCPayServer.Controllers.GreenField
+{
+    [ApiController]
+    [Authorize(AuthenticationSchemes = AuthenticationSchemes.Greenfield)]
+    [EnableCors(CorsPolicies.All)]
+    public class StoreSendEmail : Controller
+    {
+        [Authorize(Policy = Policies.CanModifyStoreSettings, AuthenticationSchemes = AuthenticationSchemes.Greenfield)]
+        [HttpPost("~/api/v1/stores/{storeId}/email")]
+        public async Task<IActionResult> SendEmailFromStore(string storeId,
+            [FromBody] SendEmailRequest request)
+        {
+            var store = HttpContext.GetStoreData();
+            if (store == null)
+            {
+                return this.CreateAPIError(404, "store-not-found", "The store was not found");
+            }
+
+            var emailSettings = store.GetStoreBlob().EmailSettings ?? null;
+            if (emailSettings != null || !emailSettings.IsComplete())
+            {
+                return this.CreateAPIError("smtp-not-configured", "Store does not have an SMTP server configured.");
+            }
+
+            var client = emailSettings.CreateSmtpClient();
+            var message = emailSettings.CreateMailMessage(request.toMailAddress(), request.subject, request.body);
+            try
+            {
+                await client.SendMailAsync(message);
+                return Ok();
+            }
+            catch (Exception e)
+            {
+                return this.CreateAPIError("not-available", e.Message);
+            }
+        }
+    }
+}

--- a/BTCPayServer/wwwroot/swagger/v1/swagger.template.stores-email.json
+++ b/BTCPayServer/wwwroot/swagger/v1/swagger.template.stores-email.json
@@ -1,6 +1,6 @@
 {
     "paths": {
-        "/api/v1/stores/{storeId}/email": {
+        "/api/v1/stores/{storeId}/email/send": {
             "post": {
                 "tags": [
                     "Stores"
@@ -21,7 +21,7 @@
                 },
                 "responses": {
                     "201": {
-                        "description": "The email was sent successfully"
+                        "description": "The email was sent (scheduled) successfully"
                     },
                     "400": {
                         "description": "The store's SMTP is not configured"
@@ -31,9 +31,6 @@
                     },
                     "404": {
                         "description": "The store was not found"
-                    },
-                    "500": {
-                        "description": "There was a problem while trying to send the email using the store's SMTP server."
                     }
                 },
                 "security": [
@@ -53,11 +50,7 @@
                 "type": "object",
                 "additionalProperties": false,
                 "properties": {
-                    "toName": {
-                        "type": "string",
-                        "description": "Name of the recipient"
-                    },
-                    "toEmail": {
+                    "email": {
                         "type": "string",
                         "description": "Email of the recipient"
                     },
@@ -67,7 +60,7 @@
                     },
                     "body": {
                         "type": "string",
-                        "description": "Body of the email to send as plain text. HTML is not supported."
+                        "description": "Body of the email to send as plain text."
                     }
                 }
             }

--- a/BTCPayServer/wwwroot/swagger/v1/swagger.template.stores-email.json
+++ b/BTCPayServer/wwwroot/swagger/v1/swagger.template.stores-email.json
@@ -1,0 +1,81 @@
+{
+    "paths": {
+        "/api/v1/stores/{storeId}/email": {
+            "post": {
+                "tags": [
+                    "Stores"
+                ],
+                "summary": "Send an email for a store",
+                "description": "Send an email using the store's SMTP server",
+                "requestBody": {
+                    "x-name": "request",
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/EmailData"
+                            }
+                        }
+                    },
+                    "required": true,
+                    "x-position": 1
+                },
+                "responses": {
+                    "201": {
+                        "description": "The email was sent successfully"
+                    },
+                    "400": {
+                        "description": "The store's SMTP is not configured"
+                    },
+                    "403": {
+                        "description": "If you are authenticated but forbidden to add new stores"
+                    },
+                    "404": {
+                        "description": "The store was not found"
+                    },
+                    "500": {
+                        "description": "There was a problem while trying to send the email using the store's SMTP server."
+                    }
+                },
+                "security": [
+                    {
+                        "API Key": [
+                            "btcpay.store.canmodifystoresettings"
+                        ],
+                        "Basic": []
+                    }
+                ]
+            }
+        }
+    },
+    "components": {
+        "schemas": {
+            "EmailData": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "toName": {
+                        "type": "string",
+                        "description": "Name of the recipient"
+                    },
+                    "toEmail": {
+                        "type": "string",
+                        "description": "Email of the recipient"
+                    },
+                    "subject": {
+                        "type": "string",
+                        "description": "Subject of the email"
+                    },
+                    "body": {
+                        "type": "string",
+                        "description": "Body of the email to send as plain text. HTML is not supported."
+                    }
+                }
+            }
+        }
+    },
+    "tags": [
+        {
+            "name": "Store Email"
+        }
+    ]
+}


### PR DESCRIPTION
- Send a plain text email using the Store's SMTP
- No HTML mail support yet as we may want to develop our own email letterhead etc at a later time
- No attachment support yet, this could be an incremental improvement later on
- I'm using the `CanModifyStoreSettings` permission, but think we can make a new permission `CanSendStoreEmail` or similar as we are adding a new feature. Changing this later would mean breaking changes at that time, so would be best to consider this now.

**Usage**
```
POST /api/v1/stores/xxxxx/email
{"toName": "Wouter Samaey", "toEmail": "wouter.samaey@storefront.be", "subject": "Hey hey!", "body": "Testing testing"}
```

**Responses**
200 OK
404 if store not found
400 SMTP not configured yet
400 some other email problem