### PR TITLE
Fix LN Node availability check

### DIFF
--- a/BTCPayServer/Controllers/PublicLightningNodeInfoController.cs
+++ b/BTCPayServer/Controllers/PublicLightningNodeInfoController.cs
@@ -47,7 +47,7 @@ namespace BTCPayServer.Controllers
 
                 return View(new ShowLightningNodeInfoViewModel
                 {
-                    Available = true,
+                    Available = nodeInfo.Any(),
                     NodeInfo = nodeInfo.Select(n => new ShowLightningNodeInfoViewModel.NodeData(n)).ToArray(),
                     CryptoCode = cryptoCode,
                     CryptoImage = GetImage(paymentMethodDetails.PaymentId, network),


### PR DESCRIPTION
With c921b2ca7b89021a638813b5af6ecebf4f961e6b the simple way of checking the availability broke, because some cases do not throw an exception anymore. This corrects the checks and validates that there is at least one possible connection available.