### PR TITLE
Mention the missing API permission in the response of a Greenfield request

### DIFF
--- a/BTCPayServer.Client/Models/GreenfieldPermissionAPIError.cs
+++ b/BTCPayServer.Client/Models/GreenfieldPermissionAPIError.cs
@@ -1,15 +1,13 @@
+using System;
+
 namespace BTCPayServer.Client.Models
 {
     public class GreenfieldPermissionAPIError : GreenfieldAPIError
     {
-        public GreenfieldPermissionAPIError(string missingPermission) : base()
+        public GreenfieldPermissionAPIError(string missingPermission, string missingPermissionDescription) : base()
         {
             MissingPermission = missingPermission;
-            
-            // TODO for some reason this line does not work??
-            // MissingPermissionDescription = BTCPayServer.Controllers.ManageController.AddApiKeyViewModel.PermissionValueItem.PermissionDescriptions[missingPermission].Description;
-            MissingPermissionDescription = "TODO";
-
+            MissingPermissionDescription = missingPermissionDescription;
             Code = "insufficient-api-permissions";
             Message = $"Insufficient API Permissions. Please use an API key with permission \"{MissingPermissionDescription}\" ({missingPermission}).";
         }

--- a/BTCPayServer.Client/Models/GreenfieldPermissionAPIError.cs
+++ b/BTCPayServer.Client/Models/GreenfieldPermissionAPIError.cs
@@ -1,0 +1,21 @@
+namespace BTCPayServer.Client.Models
+{
+    public class GreenfieldPermissionAPIError : GreenfieldAPIError
+    {
+        public GreenfieldPermissionAPIError(string missingPermission) : base()
+        {
+            MissingPermission = missingPermission;
+            
+            // TODO for some reason this line does not work??
+            // MissingPermissionDescription = BTCPayServer.Controllers.ManageController.AddApiKeyViewModel.PermissionValueItem.PermissionDescriptions[missingPermission].Description;
+            MissingPermissionDescription = "TODO";
+
+            Code = "insufficient-api-permissions";
+            Message = $"Insufficient API Permissions. Please use an API key with permission \"{MissingPermissionDescription}\" ({missingPermission}).";
+        }
+
+        public string MissingPermission { get; }
+        public string MissingPermissionDescription { get; }
+        
+    }
+}

--- a/BTCPayServer.Client/Models/GreenfieldPermissionAPIError.cs
+++ b/BTCPayServer.Client/Models/GreenfieldPermissionAPIError.cs
@@ -4,16 +4,14 @@ namespace BTCPayServer.Client.Models
 {
     public class GreenfieldPermissionAPIError : GreenfieldAPIError
     {
-        public GreenfieldPermissionAPIError(string missingPermission, string missingPermissionDescription) : base()
+        public GreenfieldPermissionAPIError(string missingPermission, string message = null) : base()
         {
             MissingPermission = missingPermission;
-            MissingPermissionDescription = missingPermissionDescription;
-            Code = "insufficient-api-permissions";
-            Message = $"Insufficient API Permissions. Please use an API key with permission \"{MissingPermissionDescription}\" ({missingPermission}).";
+            Code = "missing-permission";
+            Message = message ?? $"Insufficient API Permissions. Please use an API key with permission \"{MissingPermission}\". You can create an API key in your account's settings / Api Keys.";
         }
 
         public string MissingPermission { get; }
-        public string MissingPermissionDescription { get; }
         
     }
 }

--- a/BTCPayServer.Tests/GreenfieldAPITests.cs
+++ b/BTCPayServer.Tests/GreenfieldAPITests.cs
@@ -77,9 +77,7 @@ namespace BTCPayServer.Tests
                 {
                     Assert.Equal("insufficient-api-permissions", e.APIError.Code);
                     Assert.NotNull(e.APIError.Message);
-                    Assert.IsType<GreenfieldPermissionAPIError>(e.APIError);
-
-                    GreenfieldPermissionAPIError permissionError = (GreenfieldPermissionAPIError)e.APIError;
+                    GreenfieldPermissionAPIError permissionError = Assert.IsType<GreenfieldPermissionAPIError>(e.APIError);
                     Assert.Equal(permissionError.MissingPermission, Policies.CanModifyStoreSettings);
                     Assert.NotNull(permissionError.MissingPermissionDescription);
                 }

--- a/BTCPayServer.Tests/GreenfieldAPITests.cs
+++ b/BTCPayServer.Tests/GreenfieldAPITests.cs
@@ -66,12 +66,11 @@ namespace BTCPayServer.Tests
                 var user = tester.NewAccount();
                 user.GrantAccess();
                 var clientWithWrongPermissions = await user.CreateClient(Policies.CanViewProfile);
-                var e = await AssertAPIError("insufficient-api-permissions", () => clientWithWrongPermissions.CreateStore(new CreateStoreRequest() { Name = "mystore" }));
-                Assert.Equal("insufficient-api-permissions", e.APIError.Code);
+                var e = await AssertAPIError("missing-permission", () => clientWithWrongPermissions.CreateStore(new CreateStoreRequest() { Name = "mystore" }));
+                Assert.Equal("missing-permission", e.APIError.Code);
                 Assert.NotNull(e.APIError.Message);
                 GreenfieldPermissionAPIError permissionError = Assert.IsType<GreenfieldPermissionAPIError>(e.APIError);
                 Assert.Equal(permissionError.MissingPermission, Policies.CanModifyStoreSettings);
-                Assert.NotNull(permissionError.MissingPermissionDescription);
             }
         }
 
@@ -179,7 +178,7 @@ namespace BTCPayServer.Tests
                     }));
 
                 await unrestricted.RevokeAPIKey(apiKey.ApiKey);
-                await AssertHttpError(404, async () => await unrestricted.RevokeAPIKey(apiKey.ApiKey));
+                await AssertAPIError("apikey-not-found", () => unrestricted.RevokeAPIKey(apiKey.ApiKey));
             }
         }
 
@@ -269,10 +268,10 @@ namespace BTCPayServer.Tests
 
                 // Creating a new user without proper creds is now impossible (unauthorized) 
                 // Because if registration are locked and that an admin exists, we don't accept unauthenticated connection
-                await AssertHttpError(401,
+                var ex = await AssertAPIError("unauthenticated",
                     async () => await unauthClient.CreateUser(
                         new CreateApplicationUserRequest() { Email = "test3@gmail.com", Password = "afewfoiewiou" }));
-
+                Assert.Equal("New user creation isn't authorized to users who are not admin", ex.APIError.Message);
 
                 // But should be ok with subscriptions unlocked
                 var settings = tester.PayTester.GetService<SettingsRepository>();
@@ -281,7 +280,7 @@ namespace BTCPayServer.Tests
                     new CreateApplicationUserRequest() { Email = "test3@gmail.com", Password = "afewfoiewiou" });
 
                 // But it should be forbidden to create an admin without being authenticated
-                await AssertHttpError(403,
+                await AssertHttpError(401,
                     async () => await unauthClient.CreateUser(new CreateApplicationUserRequest()
                     {
                         Email = "admin2@gmail.com",
@@ -299,7 +298,7 @@ namespace BTCPayServer.Tests
                 await AssertHttpError(403,
                     async () => await adminClient.CreateUser(
                         new CreateApplicationUserRequest() { Email = "test4@gmail.com", Password = "afewfoiewiou" }));
-                await AssertHttpError(403,
+                await AssertAPIError("missing-permission",
                     async () => await adminClient.CreateUser(new CreateApplicationUserRequest()
                     {
                         Email = "test4@gmail.com",
@@ -412,9 +411,10 @@ namespace BTCPayServer.Tests
                 });
 
                 TestLogs.LogInformation("Can't archive without knowing the walletId");
-                await Assert.ThrowsAsync<HttpRequestException>(async () => await client.ArchivePullPayment("lol", result.Id));
+                var ex = await AssertAPIError("missing-permission", async () => await client.ArchivePullPayment("lol", result.Id));
+                Assert.Equal("btcpay.store.canmanagepullpayments", ((GreenfieldPermissionAPIError)ex.APIError).MissingPermission);
                 TestLogs.LogInformation("Can't archive without permission");
-                await Assert.ThrowsAsync<HttpRequestException>(async () => await unauthenticated.ArchivePullPayment(storeId, result.Id));
+                await AssertAPIError("unauthenticated", async () => await unauthenticated.ArchivePullPayment(storeId, result.Id));
                 await client.ArchivePullPayment(storeId, result.Id);
                 result = await unauthenticated.GetPullPayment(result.Id);
                 Assert.True(result.Archived);
@@ -681,15 +681,8 @@ namespace BTCPayServer.Tests
 
         private async Task AssertHttpError(int code, Func<Task> act)
         {
-            try
-            {
-                // Eventually all exception should be GreenFieldAPIException
-                var ex = await Assert.ThrowsAsync<HttpRequestException>(act);
-                Assert.Contains(code.ToString(), ex.Message);
-            }
-            catch (ThrowsException e) when (e.InnerException is GreenFieldAPIException ex && ex.HttpCode == code)
-            {
-            }
+            var ex = await Assert.ThrowsAsync<GreenFieldAPIException>(act);
+            Assert.Equal(code, ex.HttpCode);
         }
 
         [Fact(Timeout = TestTimeout)]
@@ -715,12 +708,12 @@ namespace BTCPayServer.Tests
                 Assert.Equal(apiKeyProfileUserData.Email, user.RegisterDetails.Email);
                 Assert.Contains("ServerAdmin", apiKeyProfileUserData.Roles);
 
-                await Assert.ThrowsAsync<HttpRequestException>(async () => await clientInsufficient.GetCurrentUser());
+                await AssertHttpError(403, async () => await clientInsufficient.GetCurrentUser());
                 await clientServer.GetCurrentUser();
                 await clientProfile.GetCurrentUser();
                 await clientBasic.GetCurrentUser();
 
-                await Assert.ThrowsAsync<HttpRequestException>(async () =>
+                await AssertHttpError(403, async () =>
                     await clientInsufficient.CreateUser(new CreateApplicationUserRequest()
                     {
                         Email = $"{Guid.NewGuid()}@g.com",
@@ -1453,11 +1446,9 @@ namespace BTCPayServer.Tests
                 Assert.Single(info.NodeURIs);
                 Assert.NotEqual(0, info.BlockHeight);
 
-                var err = await Assert.ThrowsAsync<GreenFieldAPIException>(async () => await client.GetLightningNodeChannels("BTC"));
-                Assert.Equal(503, err.HttpCode);
+                await AssertAPIError("ligthning-node-unavailable", () => client.GetLightningNodeChannels("BTC"));
                 // Not permission for the store!
-                var err2 = await Assert.ThrowsAsync<HttpRequestException>(async () => await client.GetLightningNodeChannels(user.StoreId, "BTC"));
-                Assert.Contains("403", err2.Message);
+                await AssertAPIError("missing-permission", () => client.GetLightningNodeChannels(user.StoreId, "BTC"));
                 var invoiceData = await client.CreateLightningInvoice("BTC", new CreateLightningInvoiceRequest()
                 {
                     Amount = LightMoney.Satoshis(1000),
@@ -1470,8 +1461,7 @@ namespace BTCPayServer.Tests
 
                 client = await user.CreateClient($"{Policies.CanUseLightningNodeInStore}:{user.StoreId}");
                 // Not permission for the server
-                err2 = await Assert.ThrowsAsync<HttpRequestException>(async () => await client.GetLightningNodeChannels("BTC"));
-                Assert.Contains("403", err2.Message);
+                await AssertAPIError("missing-permission", () => client.GetLightningNodeChannels("BTC"));
 
                 var data = await client.GetLightningNodeChannels(user.StoreId, "BTC");
                 Assert.Equal(2, data.Count());
@@ -1521,7 +1511,7 @@ namespace BTCPayServer.Tests
                 await client.GetLightningNodeInfo(user.StoreId, "BTC");
                 // But if not admin anymore, nope
                 await user.MakeAdmin(false);
-                await AssertAPIError("insufficient-api-permissions", () => client.GetLightningNodeInfo(user.StoreId, "BTC"));
+                await AssertAPIError("missing-permission", () => client.GetLightningNodeInfo(user.StoreId, "BTC"));
             }
         }
 

--- a/BTCPayServer/Controllers/GreenField/ApiKeysController.cs
+++ b/BTCPayServer/Controllers/GreenField/ApiKeysController.cs
@@ -77,12 +77,11 @@ namespace BTCPayServer.Controllers.GreenField
         [Authorize(Policy = Policies.Unrestricted, AuthenticationSchemes = AuthenticationSchemes.Greenfield)]
         public async Task<IActionResult> RevokeKey(string apikey)
         {
-            if (string.IsNullOrEmpty(apikey))
-                return NotFound();
-            if (await _apiKeyRepository.Remove(apikey, _userManager.GetUserId(User)))
+            if (!string.IsNullOrEmpty(apikey) &&
+                await _apiKeyRepository.Remove(apikey, _userManager.GetUserId(User)))
                 return Ok();
             else
-                return NotFound();
+                return this.CreateAPIError("apikey-not-found", "This apikey does not exists");
         }
 
         private static ApiKeyData FromModel(APIKeyData data)

--- a/BTCPayServer/Controllers/GreenField/GreenFieldUtils.cs
+++ b/BTCPayServer/Controllers/GreenField/GreenFieldUtils.cs
@@ -34,5 +34,9 @@ namespace BTCPayServer.Controllers.GreenField
         {
             return controller.StatusCode(httpCode, new GreenfieldAPIError(errorCode, errorMessage));
         }
+        public static IActionResult CreateAPIPermissionError(this ControllerBase controller, string missingPermission, string message = null)
+        {
+            return controller.StatusCode(403, new GreenfieldPermissionAPIError(missingPermission, message));
+        }
     }
 }

--- a/BTCPayServer/Controllers/GreenField/LightningNodeApiController.cs
+++ b/BTCPayServer/Controllers/GreenField/LightningNodeApiController.cs
@@ -269,7 +269,7 @@ namespace BTCPayServer.Controllers.GreenField
         }
         protected JsonHttpException ErrorShouldBeAdminForInternalNode()
         {
-            return new JsonHttpException(this.CreateAPIError(403, "insufficient-api-permissions", "The user should be admin to use the internal lightning node"));
+            return new JsonHttpException(this.CreateAPIError(403, "missing-permission", "The user should be admin to use the internal lightning node"));
         }
 
         private LightningInvoiceData ToModel(LightningInvoice invoice)

--- a/BTCPayServer/Hosting/BTCPayServerServices.cs
+++ b/BTCPayServer/Hosting/BTCPayServerServices.cs
@@ -472,6 +472,7 @@ namespace BTCPayServer.Hosting
 
         public static IApplicationBuilder UsePayServer(this IApplicationBuilder app)
         {
+            app.UseMiddleware<GreenfieldMiddleware>();
             app.UseMiddleware<BTCPayMiddleware>();
             return app;
         }

--- a/BTCPayServer/Hosting/GreenfieldMiddleware.cs
+++ b/BTCPayServer/Hosting/GreenfieldMiddleware.cs
@@ -1,0 +1,69 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using BTCPayServer.Client.Models;
+using BTCPayServer.Security.GreenField;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
+using Microsoft.Extensions.Options;
+using Newtonsoft.Json;
+
+namespace BTCPayServer.Hosting
+{
+    public class GreenfieldMiddleware
+    {
+        private readonly RequestDelegate _next;
+        private readonly IOptions<MvcNewtonsoftJsonOptions> _mvcOptions;
+
+        public GreenfieldMiddleware(RequestDelegate next, IOptions<MvcNewtonsoftJsonOptions> mvcOptions)
+        {
+            _next = next;
+            _mvcOptions = mvcOptions;
+        }
+
+        public async Task Invoke(HttpContext httpContext)
+        {
+            await _next(httpContext);
+            if (!httpContext.Response.HasStarted &&
+                !IsJson(httpContext.Response.ContentType) &&
+                !IsHtml(httpContext.Response.ContentType) &&
+                !httpContext.GetIsBitpayAPI() &&
+                (httpContext.Response.StatusCode == 401 || httpContext.Response.StatusCode == 403))
+            {
+                if (httpContext.Response.StatusCode == 403 &&
+                    httpContext.Items.TryGetValue(GreenFieldAuthorizationHandler.RequestedPermissionKey, out var p) &&
+                    p is string policy)
+                {
+                    var outputObj = new GreenfieldPermissionAPIError(policy);
+                    await WriteError(httpContext, outputObj);
+                }
+                if (httpContext.Response.StatusCode == 401)
+                {
+                    var outputObj = new GreenfieldAPIError("unauthenticated", "Authentication is required for accessing this endpoint");
+                    await WriteError(httpContext, outputObj);
+                }
+            }
+        }
+
+        private async Task WriteError(HttpContext httpContext, object outputObj)
+        {
+            string output = JsonConvert.SerializeObject(outputObj, _mvcOptions.Value.SerializerSettings);
+            var outputBytes = new UTF8Encoding(false).GetBytes(output);
+            httpContext.Response.Headers.Add("Content-Type", "application/json");
+            httpContext.Response.Headers.Add("Content-Length", outputBytes.Length.ToString(CultureInfo.InvariantCulture));
+            await httpContext.Response.Body.WriteAsync(outputBytes, 0, outputBytes.Length);
+        }
+        private bool IsHtml(string contentType)
+        {
+            return contentType?.StartsWith("text/html", StringComparison.OrdinalIgnoreCase) is true;
+        }
+        private bool IsJson(string contentType)
+        {
+            return contentType?.StartsWith("application/json", StringComparison.OrdinalIgnoreCase) is true;
+        }
+    }
+}

--- a/BTCPayServer/Security/GreenField/GreenFieldAuthorizationHandler.cs
+++ b/BTCPayServer/Security/GreenField/GreenFieldAuthorizationHandler.cs
@@ -1,5 +1,6 @@
 using System.Buffers;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Text;
 using System.Threading.Tasks;
 using BTCPayServer.Client;
@@ -121,18 +122,9 @@ namespace BTCPayServer.Security.GreenField
             if (success)
             {
                 context.Succeed(requirement);
-            }else
-            {
-                Controllers.ManageController.AddApiKeyViewModel.PermissionValueItem.PermissionDescriptions.TryGetValue(policy, out var policyDescription);
-                var outputObj = new GreenfieldPermissionAPIError(policy, policyDescription.Description);
-                string output = JsonConvert.SerializeObject(outputObj);
-                var outputBytes = new UTF8Encoding(false).GetBytes(output);
-
-                _HttpContext.Response.StatusCode = 403;
-                _HttpContext.Response.Headers.Add("Content-Type", "application/json");
-                _HttpContext.Response.Headers.Add("Content-Length", outputBytes.Length.ToString());
-                await _HttpContext.Response.Body.WriteAsync(outputBytes, 0, outputBytes.Length);
             }
+            _HttpContext.Items[RequestedPermissionKey] = policy;
         }
+        public const string RequestedPermissionKey = nameof(RequestedPermissionKey);
     }
 }

--- a/BTCPayServer/Security/GreenField/GreenFieldAuthorizationHandler.cs
+++ b/BTCPayServer/Security/GreenField/GreenFieldAuthorizationHandler.cs
@@ -123,7 +123,8 @@ namespace BTCPayServer.Security.GreenField
                 context.Succeed(requirement);
             }else
             {
-                var outputObj = new GreenfieldPermissionAPIError(policy);
+                Controllers.ManageController.AddApiKeyViewModel.PermissionValueItem.PermissionDescriptions.TryGetValue(policy, out var policyDescription);
+                var outputObj = new GreenfieldPermissionAPIError(policy, policyDescription.Description);
                 string output = JsonConvert.SerializeObject(outputObj);
                 var outputBytes = new UTF8Encoding(false).GetBytes(output);
 

--- a/BTCPayServer/Views/AppsPublic/PointOfSale/Print.cshtml
+++ b/BTCPayServer/Views/AppsPublic/PointOfSale/Print.cshtml
@@ -81,7 +81,7 @@ else
                             ItemCode = item.Id
                         }, Context.Request.Scheme, Context.Request.Host.ToString()));
                         var lnUrl = LNURL.EncodeUri(lnurlEndpoint, "payRequest", supported.UseBech32Scheme);
-                        <a href="@lnUrl"><vc:qr-code data="@lnUrl.ToString().ToUpperInvariant()" /></a>
+                        <a href="@lnUrl" rel="noreferrer noopener"><vc:qr-code data="@lnUrl.ToString().ToUpperInvariant()" /></a>
                     }
                 }
             </div>


### PR DESCRIPTION
This PR makes the Greenfield API tell us which API permissions we are lacking for the request to work (avoiding `403 Forbidden`).

This is needed because of:
- An integration can now know what the user needs to do to make the integration work. He needs to use a better API key, but for normies to figure out which permission can be a pain. The integration can help the user give the correct advise.
- A developer will waste less time on silly API permission mistakes

This PR offers 2 solutions. Obviously **we should only keep 1 of the 2 solutions**.

**Solution 1**
Add an extra response header `X-Missing-API-Permission`. This is clean and does not affect the body. I.e. if some other output were to happen afterwards, it's not an issue.

**Solution 2**
Write the response by hand. This is less clean, but it is what you would expect from an API. Previously there was no body, so this becomes the only output and we CAN do it manually.

I have kept both so we can discuss and make a choice.

Note: This is not a security issue as we are publicly documenting this stuff anyway. It just helps API users figure out what is wrong and what is expected of them to fix.

Would love your inputs @NicolasDorier  and @Kukks. You may have better practise solutions, though mine works and gets the job done.

@Zaxounette and @britttttk This is going to be used in combination with Zapier so we can tell the user what permission he needs to make their automation/Zap work. We talked about this on the Zapier demo call.