### PR TITLE
Migrate to .net6.0

### DIFF
--- a/BTCPayServer.Abstractions/BTCPayServer.Abstractions.csproj
+++ b/BTCPayServer.Abstractions/BTCPayServer.Abstractions.csproj
@@ -31,10 +31,10 @@
     <None Include="icon.png" Pack="true" PackagePath="\" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.19" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="3.1.19" />
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="3.1.18" />
-    <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="3.2.7" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="6.0.1" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="6.0.1" />
+    <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="6.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\BTCPayServer.Client\BTCPayServer.Client.csproj" />

--- a/BTCPayServer.Abstractions/Contracts/BaseDbContextFactory.cs
+++ b/BTCPayServer.Abstractions/Contracts/BaseDbContextFactory.cs
@@ -24,7 +24,7 @@ namespace BTCPayServer.Abstractions.Contracts
 
         class CustomNpgsqlMigrationsSqlGenerator : NpgsqlMigrationsSqlGenerator
         {
-            public CustomNpgsqlMigrationsSqlGenerator(MigrationsSqlGeneratorDependencies dependencies, IMigrationsAnnotationProvider annotations, Npgsql.EntityFrameworkCore.PostgreSQL.Infrastructure.Internal.INpgsqlOptions opts) : base(dependencies, annotations, opts)
+            public CustomNpgsqlMigrationsSqlGenerator(MigrationsSqlGeneratorDependencies dependencies, Npgsql.EntityFrameworkCore.PostgreSQL.Infrastructure.Internal.INpgsqlOptions opts) : base(dependencies, opts)
             {
             }
 
@@ -90,7 +90,7 @@ namespace BTCPayServer.Abstractions.Contracts
                         .ReplaceService<IMigrationsSqlGenerator, CustomNpgsqlMigrationsSqlGenerator>();
                     break;
                 case DatabaseType.MySQL:
-                    builder.UseMySql(_options.Value.ConnectionString, o =>
+                    builder.UseMySql(_options.Value.ConnectionString, ServerVersion.AutoDetect(_options.Value.ConnectionString), o =>
                     {
                         o.EnableRetryOnFailure(10);
                             

--- a/BTCPayServer.Client/BTCPayServer.Client.csproj
+++ b/BTCPayServer.Client/BTCPayServer.Client.csproj
@@ -27,7 +27,7 @@
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
   </ItemGroup>
     <ItemGroup>
-      <PackageReference Include="NBitcoin" Version="6.0.17" />
+      <PackageReference Include="NBitcoin" Version="6.0.18" />
       <PackageReference Include="BTCPayServer.Lightning.Common" Version="1.2.8" />
       <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     </ItemGroup>

--- a/BTCPayServer.Data/BTCPayServer.Data.csproj
+++ b/BTCPayServer.Data/BTCPayServer.Data.csproj
@@ -1,13 +1,13 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="../Build/Version.csproj" Condition="Exists('../Build/Version.csproj')" />
   <Import Project="../Build/Common.csproj" />
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="3.1.19">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="3.1.19" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="6.0.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\BTCPayServer.Abstractions\BTCPayServer.Abstractions.csproj" />

--- a/BTCPayServer.PluginPacker/BTCPayServer.PluginPacker.csproj
+++ b/BTCPayServer.PluginPacker/BTCPayServer.PluginPacker.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
       <OutputType>Exe</OutputType>
-      <TargetFramework>netcoreapp3.1</TargetFramework>
+      <TargetFramework>net6.0</TargetFramework>
       <Version>1.0.0.0</Version>
       <PackAsTool>true</PackAsTool>
       <ToolCommandName>btcpay-plugin</ToolCommandName>

--- a/BTCPayServer.Plugins.Test/BTCPayServer.Plugins.Test.csproj
+++ b/BTCPayServer.Plugins.Test/BTCPayServer.Plugins.Test.csproj
@@ -1,6 +1,6 @@
-<Project Sdk="Microsoft.NET.Sdk.Razor">
+﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <PreserveCompilationContext>false</PreserveCompilationContext>
     <GenerateEmbeddedFilesManifest>true</GenerateEmbeddedFilesManifest>
@@ -13,7 +13,9 @@
       <EmbeddedResource Include="Resources\**" />
     </ItemGroup>
     <ItemGroup>
-      <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="3.1.19">
+      <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.1">
+        <PrivateAssets>all</PrivateAssets>
+        <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>
     </ItemGroup>
 </Project>

--- a/BTCPayServer.Rating/BTCPayServer.Rating.csproj
+++ b/BTCPayServer.Rating/BTCPayServer.Rating.csproj
@@ -4,9 +4,9 @@
 
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.11.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.0.1" />
     <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.7" />
-    <PackageReference Include="NBitcoin" Version="6.0.15" />
+    <PackageReference Include="NBitcoin" Version="6.0.18" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="DigitalRuby.ExchangeSharp" Version="0.6.3" />
   </ItemGroup>

--- a/BTCPayServer.Tests/BTCPayServer.Tests.csproj
+++ b/BTCPayServer.Tests/BTCPayServer.Tests.csproj
@@ -19,13 +19,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="Newtonsoft.Json.Schema" Version="3.0.14" />
     <PackageReference Include="Selenium.Support" Version="3.141.0" />
     <PackageReference Include="Selenium.WebDriver" Version="3.141.0" />
     <PackageReference Include="Selenium.WebDriver.ChromeDriver" Version="96.0.4664.4500" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/BTCPayServer.Tests/Dockerfile
+++ b/BTCPayServer.Tests/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:3.1.413 AS builder
+FROM mcr.microsoft.com/dotnet/sdk:6.0.101-bullseye-slim AS builder
 
 RUN apt-get update && apt-get install -y --no-install-recommends chromium-driver \
     && rm -rf /var/lib/apt/lists/*

--- a/BTCPayServer/BTCPayServer.csproj
+++ b/BTCPayServer/BTCPayServer.csproj
@@ -1,4 +1,4 @@
- <Project Sdk="Microsoft.NET.Sdk.Web">
+﻿ <Project Sdk="Microsoft.NET.Sdk.Web">
   <Import Project="../Build/Version.csproj" Condition="Exists('../Build/Version.csproj')" />
   <Import Project="../Build/Common.csproj" />
 
@@ -64,7 +64,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
     <PackageReference Include="QRCoder" Version="1.4.3" />
-    <PackageReference Include="System.IO.Pipelines" Version="4.7.4" />
+    <PackageReference Include="System.IO.Pipelines" Version="6.0.1" />
     <PackageReference Include="NBitpayClient" Version="1.0.0.39" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="NicolasDorier.CommandLine" Version="1.0.0.2" />
@@ -75,7 +75,7 @@
     <PackageReference Include="Serilog.AspNetCore" Version="3.2.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="4.1.0" />
     <PackageReference Include="SSH.NET" Version="2016.1.0" />
-    <PackageReference Include="Text.Analyzers" Version="2.6.4">
+    <PackageReference Include="Text.Analyzers" Version="3.3.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
@@ -88,8 +88,8 @@
     <PackageReference Include="TwentyTwenty.Storage.Google" Version="2.12.1" />
     <PackageReference Include="TwentyTwenty.Storage.Local" Version="2.12.1" />
 		<PackageReference Include="YamlDotNet" Version="8.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="3.1.19" Condition="'$(RazorCompileOnBuild)' != 'true'" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.19" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="6.0.1" Condition="'$(RazorCompileOnBuild)' != 'true'" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.1" />
   </ItemGroup>
 
 	<ItemGroup>

--- a/BTCPayServer/Components/QRCode/QRCode.cs
+++ b/BTCPayServer/Components/QRCode/QRCode.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Drawing;
 using Microsoft.AspNetCore.Html;
 using Microsoft.AspNetCore.Mvc;
@@ -13,10 +14,11 @@ namespace BTCPayServer.Components.QRCode
 
         public IViewComponentResult Invoke(string data)
         {
-            
             QRCodeData qrCodeData = qrGenerator.CreateQrCode(data, QRCodeGenerator.ECCLevel.Q);
-            SvgQRCode qrCode = new SvgQRCode(qrCodeData);
-            return new HtmlContentViewComponentResult(new HtmlString(qrCode.GetGraphic(new Size(256,256), "#000", "#f5f5f7", true, SvgQRCode.SizingMode.ViewBoxAttribute)));
+            PngByteQRCode qrCode = new PngByteQRCode(qrCodeData);
+            var bytes = qrCode.GetGraphic(5, new byte[] { 0, 0, 0, 255 }, new byte[] { 0xf5, 0xf5, 0xf7, 255 }, true);
+            var b64 = Convert.ToBase64String(bytes);
+            return new HtmlContentViewComponentResult(new HtmlString($"<img height=\"256\" style=\"image-rendering: pixelated;image-rendering: -moz-crisp-edges;\" src=\"data:image/png;base64,{b64}\" />"));
         }
     }
 }

--- a/BTCPayServer/Controllers/GreenField/PaymentRequestsController.cs
+++ b/BTCPayServer/Controllers/GreenField/PaymentRequestsController.cs
@@ -89,7 +89,7 @@ namespace BTCPayServer.Controllers.GreenField
             {
                 StoreDataId = storeId,
                 Status = Client.Models.PaymentRequestData.PaymentRequestStatus.Pending,
-                Created = DateTimeOffset.Now
+                Created = DateTimeOffset.UtcNow
             };
             pr.SetBlob(request);
             pr = await _paymentRequestRepository.CreateOrUpdatePaymentRequest(pr);

--- a/BTCPayServer/ModelBinders/DateTimeOffsetModelBinder.cs
+++ b/BTCPayServer/ModelBinders/DateTimeOffsetModelBinder.cs
@@ -19,11 +19,6 @@ namespace BTCPayServer.ModelBinders
                 return Task.CompletedTask;
             }
             ValueProviderResult val = bindingContext.ValueProvider.GetValue(bindingContext.ModelName);
-            if (val == null)
-            {
-                return Task.CompletedTask;
-            }
-
             string v = val.FirstValue as string;
             if (v == null)
             {

--- a/BTCPayServer/ModelBinders/DerivationSchemeModelBinder.cs
+++ b/BTCPayServer/ModelBinders/DerivationSchemeModelBinder.cs
@@ -24,11 +24,6 @@ namespace BTCPayServer.ModelBinders
 
             ValueProviderResult val = bindingContext.ValueProvider.GetValue(
                 bindingContext.ModelName);
-            if (val == null)
-            {
-                return Task.CompletedTask;
-            }
-
             string key = val.FirstValue as string;
             if (key == null)
             {

--- a/BTCPayServer/ModelBinders/PaymentMethodIdModelBinder.cs
+++ b/BTCPayServer/ModelBinders/PaymentMethodIdModelBinder.cs
@@ -16,11 +16,6 @@ namespace BTCPayServer.ModelBinders
 
             ValueProviderResult val = bindingContext.ValueProvider.GetValue(
                 bindingContext.ModelName);
-            if (val == null)
-            {
-                return Task.CompletedTask;
-            }
-
             string key = val.FirstValue as string;
             if (key == null)
             {

--- a/BTCPayServer/ModelBinders/WalletIdModelBinder.cs
+++ b/BTCPayServer/ModelBinders/WalletIdModelBinder.cs
@@ -15,10 +15,6 @@ namespace BTCPayServer.ModelBinders
 
             ValueProviderResult val = bindingContext.ValueProvider.GetValue(
                 bindingContext.ModelName);
-            if (val == null)
-            {
-                return Task.CompletedTask;
-            }
 
             string key = val.FirstValue as string;
             if (key == null)

--- a/BTCPayServer/Security/GreenField/APIKeyExtensions.cs
+++ b/BTCPayServer/Security/GreenField/APIKeyExtensions.cs
@@ -14,13 +14,13 @@ namespace BTCPayServer.Security.GreenField
     {
         public static bool GetAPIKey(this HttpContext httpContext, out StringValues apiKey)
         {
+            apiKey = default;
             if (httpContext.Request.Headers.TryGetValue("Authorization", out var value) &&
                 value.ToString().StartsWith("token ", StringComparison.InvariantCultureIgnoreCase))
             {
                 apiKey = value.ToString().Substring("token ".Length);
                 return true;
             }
-
             return false;
         }
 

--- a/BTCPayServer/Services/Apps/AppService.cs
+++ b/BTCPayServer/Services/Apps/AppService.cs
@@ -18,7 +18,6 @@ using Microsoft.EntityFrameworkCore;
 using NBitcoin;
 using NBitcoin.DataEncoders;
 using Newtonsoft.Json.Linq;
-using NUglify.Helpers;
 using YamlDotNet.Core;
 using YamlDotNet.RepresentationModel;
 using YamlDotNet.Serialization;
@@ -547,7 +546,7 @@ namespace BTCPayServer.Services.Apps
                 if (string.IsNullOrEmpty(app.Id))
                 {
                     app.Id = Encoders.Base58.EncodeData(RandomUtils.GetBytes(20));
-                    app.Created = DateTimeOffset.Now;
+                    app.Created = DateTimeOffset.UtcNow;
                     await ctx.Apps.AddAsync(app);
                 }
                 else

--- a/BTCPayServer/Storage/Services/FileService.cs
+++ b/BTCPayServer/Storage/Services/FileService.cs
@@ -78,7 +78,7 @@ namespace BTCPayServer.Storage.Services
 
         private IStorageProviderService GetProvider(StorageSettings storageSettings)
         {
-            return _providers.FirstOrDefault((service) => service.StorageProvider().Equals(storageSettings.Provider));
+            return _providers.First((service) => service.StorageProvider().Equals(storageSettings.Provider));
         }
     }
 }

--- a/Build/Common.csproj
+++ b/Build/Common.csproj
@@ -1,8 +1,8 @@
 <Project>
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <TargetFramework Condition="'$(TargetFrameworkOverride)' != ''">$(TargetFrameworkOverride)</TargetFramework>
-    <NoWarn>NU1701,CA1816,CA1308,CA1810,CA2208,CA1303,CA2000,CA2016,CA1835,CA2249,CA9998</NoWarn>
+    <NoWarn>NU1701,CA1816,CA1308,CA1810,CA2208,CA1303,CA2000,CA2016,CA1835,CA2249,CA9998,CA1704</NoWarn>
     <LangVersion>8.0</LangVersion>
   </PropertyGroup>
 

--- a/amd64.Dockerfile
+++ b/amd64.Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:3.1.413-bullseye AS builder
+FROM mcr.microsoft.com/dotnet/sdk:6.0.101-bullseye-slim AS builder
 ENV DOTNET_CLI_TELEMETRY_OPTOUT=1
 WORKDIR /source
 COPY nuget.config nuget.config
@@ -20,7 +20,7 @@ COPY Build/Version.csproj Build/Version.csproj
 ARG CONFIGURATION_NAME=Release
 RUN cd BTCPayServer && dotnet publish --output /app/ --configuration ${CONFIGURATION_NAME}
 
-FROM mcr.microsoft.com/dotnet/aspnet:3.1.19-bullseye-slim
+FROM mcr.microsoft.com/dotnet/6.0.1-bullseye-slim
 
 RUN apt-get update && apt-get install -y --no-install-recommends iproute2 openssh-client \
     && rm -rf /var/lib/apt/lists/* 

--- a/arm32v7.Dockerfile
+++ b/arm32v7.Dockerfile
@@ -1,5 +1,5 @@
 # Note that we are using buster rather than bullseye. Somehow, raspberry pi 4 doesn't like bullseye.
-FROM mcr.microsoft.com/dotnet/sdk:3.1.413-buster AS builder
+FROM mcr.microsoft.com/dotnet/sdk:6.0.101-bullseye-slim AS builder
 ENV DOTNET_CLI_TELEMETRY_OPTOUT=1
 RUN apt-get update \
 	&& apt-get install -qq --no-install-recommends qemu qemu-user-static qemu-user binfmt-support
@@ -25,7 +25,7 @@ ARG CONFIGURATION_NAME=Release
 RUN cd BTCPayServer && dotnet publish --output /app/ --configuration ${CONFIGURATION_NAME}
 
 # Note that we are using buster rather than bullseye. Somehow, raspberry pi 4 doesn't like bullseye.
-FROM mcr.microsoft.com/dotnet/aspnet:3.1.19-buster-slim-arm32v7
+FROM mcr.microsoft.com/dotnet/aspnet:6.0.1-bullseye-slim-arm32v7
 COPY --from=builder /usr/bin/qemu-arm-static /usr/bin/qemu-arm-static
 RUN apt-get update && apt-get install -y --no-install-recommends iproute2 openssh-client \
     && rm -rf /var/lib/apt/lists/* 

--- a/arm64v8.Dockerfile
+++ b/arm64v8.Dockerfile
@@ -1,5 +1,5 @@
 # This is a manifest image, will pull the image with the same arch as the builder machine
-FROM mcr.microsoft.com/dotnet/sdk:3.1.413-bullseye AS builder
+FROM mcr.microsoft.com/dotnet/sdk:6.0.101-bullseye-slim AS builder
 ENV DOTNET_CLI_TELEMETRY_OPTOUT=1
 ENV LC_ALL en_US.UTF-8
 RUN apt-get update \
@@ -26,7 +26,7 @@ ARG CONFIGURATION_NAME=Release
 RUN cd BTCPayServer && dotnet publish --output /app/ --configuration ${CONFIGURATION_NAME}
 
 # Force the builder machine to take make an arm runtime image. This is fine as long as the builder does not run any program
-FROM mcr.microsoft.com/dotnet/aspnet:3.1.19-bullseye-slim-arm64v8
+FROM mcr.microsoft.com/dotnet/aspnet:6.0.1-bullseye-slim-arm64v8
 COPY --from=builder /usr/bin/qemu-aarch64-static /usr/bin/qemu-aarch64-static
 RUN apt-get update && apt-get install -y --no-install-recommends iproute2 openssh-client \
     && rm -rf /var/lib/apt/lists/* 


### PR DESCRIPTION
As every update we do, entity framework breaks again. There is currently a stack overflow exception thrown by EF.

- [x] We are stuck waiting for patch of entity framework (https://github.com/dotnet/efcore/issues/26629) (fixed in new version of ef)

I hope migrating from EF to Dapper this year, if we can stop supporting mysql and sqlite.