### PR TITLE
Change implementation of the Smtp server

### DIFF
--- a/BTCPayServer.Tests/UnitTest1.cs
+++ b/BTCPayServer.Tests/UnitTest1.cs
@@ -2724,7 +2724,6 @@ namespace BTCPayServer.Tests
                  Password = "admin@admin.com",
                  Port = 1234,
                  Server = "admin.com",
-                 EnableSSL = true
                 });
                 Assert.Equal("admin@admin.com",(await Assert.IsType<ServerEmailSender>(await emailSenderFactory.GetEmailSender()).GetEmailSettings()).Login);
                 Assert.Equal("admin@admin.com",(await Assert.IsType<StoreEmailSender>(await emailSenderFactory.GetEmailSender(acc.StoreId)).GetEmailSettings()).Login);
@@ -2739,8 +2738,7 @@ namespace BTCPayServer.Tests
                     Login = "store@store.com",
                     Password = "store@store.com",
                     Port = 1234,
-                    Server = "store.com",
-                    EnableSSL = true
+                    Server = "store.com"
                 }), ""));
                 
                 Assert.Equal("store@store.com",(await Assert.IsType<StoreEmailSender>(await emailSenderFactory.GetEmailSender(acc.StoreId)).GetEmailSettings()).Login);

--- a/BTCPayServer/BTCPayServer.csproj
+++ b/BTCPayServer/BTCPayServer.csproj
@@ -56,6 +56,7 @@
     <PackageReference Include="Fido2.AspNet" Version="2.0.1" />
     <PackageReference Include="HtmlSanitizer" Version="5.0.372" />
     <PackageReference Include="LNURL" Version="0.0.14" />
+    <PackageReference Include="MailKit" Version="3.0.0" />
     <PackageReference Include="McMaster.NETCore.Plugins.Mvc" Version="1.4.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Filter" Version="1.1.2" />
     <PackageReference Include="Microsoft.NetCore.Analyzers" Version="3.3.2">

--- a/BTCPayServer/Controllers/ServerController.cs
+++ b/BTCPayServer/Controllers/ServerController.cs
@@ -32,6 +32,7 @@ using Microsoft.AspNetCore.Mvc.Rendering;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using MimeKit;
 using NBitcoin;
 using NBitcoin.DataEncoders;
 using Renci.SshNet;
@@ -1025,10 +1026,11 @@ namespace BTCPayServer.Controllers
                         TempData[WellKnownTempData.ErrorMessage] = "Required fields missing";
                         return View(model);
                     }
-                    using (var client = model.Settings.CreateSmtpClient())
-                    using (var message = model.Settings.CreateMailMessage(new MailAddress(model.TestEmail), "BTCPay test", "BTCPay test"))
+                    using (var client = await model.Settings.CreateSmtpClient())
+                    using (var message = model.Settings.CreateMailMessage(new MailboxAddress(model.TestEmail, model.TestEmail), "BTCPay test", "BTCPay test", false))
                     {
-                        await client.SendMailAsync(message);
+                        await client.SendAsync(message);
+                        await client.DisconnectAsync(true);
                     }
                     TempData[WellKnownTempData.SuccessMessage] = "Email sent to " + model.TestEmail + ", please, verify you received it";
                 }

--- a/BTCPayServer/Controllers/StoresController.Email.cs
+++ b/BTCPayServer/Controllers/StoresController.Email.cs
@@ -5,6 +5,7 @@ using BTCPayServer.Data;
 using BTCPayServer.Models.ServerViewModels;
 using BTCPayServer.Services.Mails;
 using Microsoft.AspNetCore.Mvc;
+using MimeKit;
 
 namespace BTCPayServer.Controllers
 {
@@ -41,9 +42,10 @@ namespace BTCPayServer.Controllers
                         TempData[WellKnownTempData.ErrorMessage] = "Required fields missing";
                         return View(model);
                     }
-                    var client = model.Settings.CreateSmtpClient();
-                    var message = model.Settings.CreateMailMessage(new MailAddress(model.TestEmail), "BTCPay test", "BTCPay test");
-                    await client.SendMailAsync(message);
+                    using var client = await model.Settings.CreateSmtpClient();
+                    var message = model.Settings.CreateMailMessage(new MailboxAddress(model.TestEmail, model.TestEmail), "BTCPay test", "BTCPay test", false);
+                    await client.SendAsync(message);
+                    await client.DisconnectAsync(true);
                     TempData[WellKnownTempData.SuccessMessage] = "Email sent to " + model.TestEmail + ", please, verify you received it";
                 }
                 catch (Exception ex)

--- a/BTCPayServer/Services/Mails/EmailSettings.cs
+++ b/BTCPayServer/Services/Mails/EmailSettings.cs
@@ -77,7 +77,7 @@ namespace BTCPayServer.Services.Mails
             using var connectCancel = new CancellationTokenSource(10000);
             try
             {
-                await client.ConnectAsync(Server, Port.Value, MailKit.Security.SecureSocketOptions.StartTlsWhenAvailable, connectCancel.Token);
+                await client.ConnectAsync(Server, Port.Value, MailKit.Security.SecureSocketOptions.Auto, connectCancel.Token);
                 await client.AuthenticateAsync(Login, Password, connectCancel.Token);
             }
             catch

--- a/BTCPayServer/Services/Mails/EmailSettings.cs
+++ b/BTCPayServer/Services/Mails/EmailSettings.cs
@@ -1,7 +1,10 @@
 using System.ComponentModel.DataAnnotations;
 using System.Net;
-using System.Net.Mail;
 using Newtonsoft.Json;
+using MailKit.Net.Smtp;
+using MimeKit;
+using System.Threading.Tasks;
+using System.Threading;
 
 namespace BTCPayServer.Services.Mails
 {
@@ -41,42 +44,47 @@ namespace BTCPayServer.Services.Mails
             get; set;
         }
 
-        [Display(Name = "Enable SSL")]
-        public bool EnableSSL
-        {
-            get; set;
-        }
-
         public bool IsComplete()
         {
+            return !string.IsNullOrWhiteSpace(Server) &&
+                   Port is int &&
+                   !string.IsNullOrWhiteSpace(Login) &&
+                   !string.IsNullOrWhiteSpace(Password);
+        }
+
+        public MimeMessage CreateMailMessage(MailboxAddress to, string subject, string message, bool isHtml)
+        {
+            var bodyBuilder = new BodyBuilder();
+            if (isHtml)
+            {
+                bodyBuilder.HtmlBody = message;
+            }
+            else
+            {
+                bodyBuilder.TextBody = message;
+            }
+
+            return new MimeMessage(
+                from : new[] { new MailboxAddress(From, !string.IsNullOrWhiteSpace(FromDisplay) ? From : FromDisplay) }, 
+                to: new[] { to },
+                subject,
+                bodyBuilder.ToMessageBody());
+        }
+
+        public async Task<SmtpClient> CreateSmtpClient()
+        {
+            SmtpClient client = new SmtpClient();
+            using var connectCancel = new CancellationTokenSource(10000);
             try
             {
-                using var smtp = CreateSmtpClient();
-                return true;
+                await client.ConnectAsync(Server, Port.Value, MailKit.Security.SecureSocketOptions.StartTlsWhenAvailable, connectCancel.Token);
+                await client.AuthenticateAsync(Login, Password, connectCancel.Token);
             }
-            catch { }
-            return false;
-        }
-
-        public MailMessage CreateMailMessage(MailAddress to, string subject, string message)
-        {
-            return new MailMessage(
-                from: new MailAddress(From, FromDisplay),
-                to: to)
+            catch
             {
-                Subject = subject,
-                Body = message
-            };
-        }
-
-        public SmtpClient CreateSmtpClient()
-        {
-            SmtpClient client = new SmtpClient(Server, Port.Value);
-            client.EnableSsl = EnableSSL;
-            client.UseDefaultCredentials = false;
-            client.Credentials = new NetworkCredential(Login, Password);
-            client.DeliveryMethod = SmtpDeliveryMethod.Network;
-            client.Timeout = 10000;
+                client.Dispose();
+                throw;
+            }
             return client;
         }
     }

--- a/BTCPayServer/Views/Shared/EmailsBody.cshtml
+++ b/BTCPayServer/Views/Shared/EmailsBody.cshtml
@@ -9,11 +9,11 @@
                     Quick Fill
                 </button>
                 <div class="dropdown-menu" aria-labelledby="QuickFillDropdownToggle">
-                    <a class="dropdown-item" href="" data-server="smtp.gmail.com" data-port="587" data-enablessl="true">Gmail.com</a>
-                    <a class="dropdown-item" href="" data-server="mail.yahoo.com" data-port="587" data-enablessl="true">Yahoo.com</a>
-                    <a class="dropdown-item" href="" data-server="smtp.mailgun.org" data-port="587" data-enablessl="true">Mailgun</a>
-                    <a class="dropdown-item" href="" data-server="smtp.office365.com" data-port="587" data-enablessl="true">Office365</a>
-                    <a class="dropdown-item" href="" data-server="smtp.sendgrid.net" data-port="587" data-enablessl="true">SendGrid</a>
+                    <a class="dropdown-item" href="" data-server="smtp.gmail.com" data-port="587">Gmail.com</a>
+                    <a class="dropdown-item" href="" data-server="mail.yahoo.com" data-port="587">Yahoo.com</a>
+                    <a class="dropdown-item" href="" data-server="smtp.mailgun.org" data-port="587">Mailgun</a>
+                    <a class="dropdown-item" href="" data-server="smtp.office365.com" data-port="587">Office365</a>
+                    <a class="dropdown-item" href="" data-server="smtp.sendgrid.net" data-port="587">SendGrid</a>
                 </div>
             </div>
         </div>
@@ -74,10 +74,6 @@
                         <button type="submit" class="btn btn-danger" name="command" value="ResetPassword">Reset</button>
                     </div>
                 }
-            </div>
-            <div class="form-group">
-                <label asp-for="Settings.EnableSSL" class="form-label"></label>
-                <input asp-for="Settings.EnableSSL" type="checkbox" data-fill="enablessl" class="btcpay-toggle ms-2" />
             </div>
             <input asp-for="PasswordSet" type="hidden"/>
             <button type="submit" class="btn btn-primary" name="command" value="Save">Save</button>


### PR DESCRIPTION
Many people in support are complaining about the smtp client not working really well.
Turns out SmtpClient of dotnet is [obsolete](https://docs.microsoft.com/en-us/dotnet/api/system.net.mail.smtpclient?view=net-6.0) and don't support new TLS version (see https://developpaper.com/system-net-mail-smtpclient-failed-to-send-email-through-ssl-tls-protocol/)

>At present, the latest version is TLS 1.3, and other available versions are TLS 1.2 and TLS 1.1. TLS 1.1 is planned to be abandoned in 2020

I chose mailkit instead, a general purpose email library, still maintained nowadays, MIT license, 32.2 million downloads.

A nice positive point: It automatically detect the protocol (SSL, STARTTLS) so we can even get rid of one of the settings! (No more enable SSL checkbox)