### PR TITLE
Changed API policy for calculating feeRate

### DIFF
--- a/BTCPayServer/Controllers/GreenField/StoreOnChainWalletsController.cs
+++ b/BTCPayServer/Controllers/GreenField/StoreOnChainWalletsController.cs
@@ -99,7 +99,7 @@ namespace BTCPayServer.Controllers.GreenField
             });
         }
         
-        [Authorize(Policy = Policies.CanModifyStoreSettings, AuthenticationSchemes = AuthenticationSchemes.Greenfield)]
+        [Authorize(Policy = Policies.CanViewStoreSettings, AuthenticationSchemes = AuthenticationSchemes.Greenfield)]
         [HttpGet("~/api/v1/stores/{storeId}/payment-methods/onchain/{cryptoCode}/wallet/feerate")]
         public async Task<IActionResult> GetOnChainFeeRate(string storeId, string cryptoCode, int? blockTarget = null)
         {

--- a/BTCPayServer/wwwroot/swagger/v1/swagger.template.stores-wallet.on-chain.json
+++ b/BTCPayServer/wwwroot/swagger/v1/swagger.template.stores-wallet.on-chain.json
@@ -115,7 +115,7 @@
                 "security": [
                     {
                         "API Key": [
-                            "btcpay.store.canmodifystoresettings"
+                            "btcpay.store.canviewstoresettings"
                         ],
                         "Basic": []
                     }


### PR DESCRIPTION
I don't really see the need for "CanModifyStoreSettings" here. IMHO "CanViewStoreSettings" would be better.
It's just about getting the feeRate, not that you're modifying the store or anything.

This is a sub-permission, so it should not be a breaking change.