### PR TITLE
PaymentReq "Created" field is not really a unix timestamp in JSON. Also renamed to "CreatedTime" like with invoices

### DIFF
--- a/BTCPayServer.Client/Models/PaymentRequestData.cs
+++ b/BTCPayServer.Client/Models/PaymentRequestData.cs
@@ -8,7 +8,8 @@ namespace BTCPayServer.Client.Models
     {
         [JsonConverter(typeof(StringEnumConverter))]
         public PaymentRequestData.PaymentRequestStatus Status { get; set; }
-        public DateTimeOffset Created { get; set; }
+        [JsonConverter(typeof(NBitcoin.JsonConverters.DateTimeToUnixTimeConverter))]
+        public DateTimeOffset CreatedTime { get; set; }
         public string Id { get; set; }
         public bool Archived { get; set; }
 

--- a/BTCPayServer.Client/Models/PaymentRequestData.cs
+++ b/BTCPayServer.Client/Models/PaymentRequestData.cs
@@ -9,7 +9,7 @@ namespace BTCPayServer.Client.Models
         [JsonConverter(typeof(StringEnumConverter))]
         public PaymentRequestData.PaymentRequestStatus Status { get; set; }
         [JsonConverter(typeof(NBitcoin.JsonConverters.DateTimeToUnixTimeConverter))]
-        public DateTimeOffset CreatedTime { get; set; }
+        public DateTimeOffset Created { get; set; }
         public string Id { get; set; }
         public bool Archived { get; set; }
 

--- a/BTCPayServer/wwwroot/swagger/v1/swagger.template.payment-requests.json
+++ b/BTCPayServer/wwwroot/swagger/v1/swagger.template.payment-requests.json
@@ -295,7 +295,7 @@
                         "description": "The status of the payment request",
                         "nullable": false
                     },
-                    "created": {
+                    "createdTime": {
                         "description": "The creation date of the payment request",
                         "allOf": [ {"$ref": "#/components/schemas/UnixTimestamp"}],
                         "nullable": false

--- a/BTCPayServer/wwwroot/swagger/v1/swagger.template.payment-requests.json
+++ b/BTCPayServer/wwwroot/swagger/v1/swagger.template.payment-requests.json
@@ -295,7 +295,7 @@
                         "description": "The status of the payment request",
                         "nullable": false
                     },
-                    "createdTime": {
+                    "created": {
                         "description": "The creation date of the payment request",
                         "allOf": [ {"$ref": "#/components/schemas/UnixTimestamp"}],
                         "nullable": false


### PR DESCRIPTION
Payment Requests have a field `Created` which should be a unix timestamp in seconds, but it is not. Current result is a string like `2021-12-21T09:21:06.8924122+00:00`, which is wrong.

This change makes it a unix timetsamp + renames `Created` to `CreatedTime` like it is with invoices.

This is a breaking change, but it does make things consistent.