### PR TITLE
Added field "StoreId" to a Payment Request in Greenfield

### DIFF
--- a/BTCPayServer.Client/Models/PaymentRequestBaseData.cs
+++ b/BTCPayServer.Client/Models/PaymentRequestBaseData.cs
@@ -8,6 +8,7 @@ namespace BTCPayServer.Client.Models
 {
     public class PaymentRequestBaseData
     {
+        public string StoreId { get; set; }
         [JsonProperty(ItemConverterType = typeof(NumericStringJsonConverter))]
         public decimal Amount { get; set; }
         public string Currency { get; set; }

--- a/BTCPayServer.Tests/GreenfieldAPITests.cs
+++ b/BTCPayServer.Tests/GreenfieldAPITests.cs
@@ -937,6 +937,7 @@ namespace BTCPayServer.Tests
                 //get payment request
                 var paymentRequest = await viewOnly.GetPaymentRequest(user.StoreId, newPaymentRequest.Id);
                 Assert.Equal(newPaymentRequest.Title, paymentRequest.Title);
+                Assert.Equal(newPaymentRequest.StoreId, user.StoreId);
 
                 //update payment request
                 var updateRequest = JObject.FromObject(paymentRequest).ToObject<UpdatePaymentRequestRequest>();

--- a/BTCPayServer/Controllers/GreenField/PaymentRequestsController.cs
+++ b/BTCPayServer/Controllers/GreenField/PaymentRequestsController.cs
@@ -150,6 +150,7 @@ namespace BTCPayServer.Controllers.GreenField
             {
                 Created = data.Created,
                 Id = data.Id,
+                StoreId = data.StoreDataId,
                 Status = data.Status,
                 Archived = data.Archived,
                 Amount = blob.Amount,

--- a/BTCPayServer/wwwroot/swagger/v1/swagger.template.payment-requests.json
+++ b/BTCPayServer/wwwroot/swagger/v1/swagger.template.payment-requests.json
@@ -289,6 +289,10 @@
                         "description":  "The id of the payment request",
                         "nullable": false
                     },
+                    "storeId": {
+                        "type": "string",
+                        "description": "The store identifier that the payment request belongs to"
+                    },
                     "status": {
                         "type": "string",
                         "enum": [ "Pending", "Completed" ,"Expired"],


### PR DESCRIPTION
Payment Requests do not have a field `StoreId`, so I added it, incl test + Swagger