### PR TITLE
Consistent and simplified button CTA text

### DIFF
--- a/BTCPayServer/Views/Account/SetPassword.cshtml
+++ b/BTCPayServer/Views/Account/SetPassword.cshtml
@@ -25,7 +25,6 @@
         <div class="modal-content border-0 p-3">
             <div class="modal-header align-items-center border-0 py-2">
                 <h4 class="modal-title">Set Password</h4>
-
             </div>
             <div class="modal-body">
                 <form method="post" asp-action="SetPassword">

--- a/BTCPayServer/Views/Account/SetPassword.cshtml
+++ b/BTCPayServer/Views/Account/SetPassword.cshtml
@@ -59,7 +59,7 @@
                         <input asp-for="ConfirmPassword" class="form-control"/>
                         <span asp-validation-for="ConfirmPassword" class="text-danger"></span>
                     </div>
-                    <button type="submit" class="btn btn-primary w-100 btn-lg" id="SetPassword">Set password</button>
+                    <button type="submit" class="btn btn-primary w-100 btn-lg" id="SetPassword">Set Password</button>
                 </form>
             </div>
         </div>

--- a/BTCPayServer/Views/Invoice/ListInvoices.cshtml
+++ b/BTCPayServer/Views/Invoice/ListInvoices.cshtml
@@ -192,7 +192,7 @@
     </h2>
     <a id="CreateNewInvoice" asp-action="CreateInvoice" asp-route-storeId="@Model.StoreId" asp-route-searchTerm="@Model.SearchTerm" class="btn btn-primary mt-3 mt-sm-0">
         <span class="fa fa-plus"></span>
-        Create an invoice
+        Create Invoice
     </a>
 </div>
 

--- a/BTCPayServer/Views/Manage/APIKeys.cshtml
+++ b/BTCPayServer/Views/Manage/APIKeys.cshtml
@@ -11,7 +11,7 @@
 </p>
 <a class="btn btn-primary" asp-action="AddApiKey" id="AddApiKey">
     <span class="fa fa-plus"></span>
-    Generate new key
+    Generate Key
 </a>
 @if (Model.ApiKeyDatas.Any())
 {

--- a/BTCPayServer/Views/Manage/ChangePassword.cshtml
+++ b/BTCPayServer/Views/Manage/ChangePassword.cshtml
@@ -25,7 +25,7 @@
                 <input asp-for="ConfirmPassword" class="form-control"/>
                 <span asp-validation-for="ConfirmPassword" class="text-danger"></span>
             </div>
-            <button type="submit" class="btn btn-primary" id="UpdatePassword">Update password</button>
+            <button type="submit" class="btn btn-primary" id="UpdatePassword">Update Password</button>
         </form>
     </div>
 </div>

--- a/BTCPayServer/Views/Manage/SetPassword.cshtml
+++ b/BTCPayServer/Views/Manage/SetPassword.cshtml
@@ -23,7 +23,7 @@
                 <input asp-for="ConfirmPassword" class="form-control" />
                 <span asp-validation-for="ConfirmPassword" class="text-danger"></span>
             </div>
-            <button type="submit" class="btn btn-primary">Set password</button>
+            <button type="submit" class="btn btn-primary">Set Password</button>
         </form>
     </div>
 </div>

--- a/BTCPayServer/Views/Manage/TwoFactorAuthentication.cshtml
+++ b/BTCPayServer/Views/Manage/TwoFactorAuthentication.cshtml
@@ -115,7 +115,7 @@
                 <button type="submit" class="btn btn-primary">
                     <span class="fa fa-plus"></span>
                     Add 
-                    <span class="d-none d-md-inline-block">security device</span>
+                    <span class="d-none d-md-inline-block">Device</span>
                 </button>
             </div>
         </form>

--- a/BTCPayServer/Views/PaymentRequest/GetPaymentRequests.cshtml
+++ b/BTCPayServer/Views/PaymentRequest/GetPaymentRequests.cshtml
@@ -18,7 +18,7 @@
     </h2>
     <a asp-action="EditPaymentRequest" asp-route-storeId="@Context.GetStoreData().Id" class="btn btn-primary mt-3 mt-sm-0" role="button" id="CreatePaymentRequest">
         <span class="fa fa-plus"></span>
-        Create a payment request
+        Create Payment Request
     </a>
 </div>
 

--- a/BTCPayServer/Views/StorePullPayments/PullPayments.cshtml
+++ b/BTCPayServer/Views/StorePullPayments/PullPayments.cshtml
@@ -46,7 +46,7 @@
         </small>
     </h2>
     <a permission="@Policies.CanModifyStoreSettings" asp-action="NewPullPayment" asp-route-storeId="@Context.GetRouteValue("storeId")" class="btn btn-primary" role="button" id="NewPullPayment">
-        <span class="fa fa-plus"></span> Create a new pull payment
+        <span class="fa fa-plus"></span> Create Pull Payment
     </a>
 </div>
 

--- a/BTCPayServer/Views/Stores/ListTokens.cshtml
+++ b/BTCPayServer/Views/Stores/ListTokens.cshtml
@@ -21,7 +21,7 @@
             <h3 class="mb-0">@ViewData["Title"]</h3>
             <a id="CreateNewToken" asp-action="CreateToken" class="btn btn-primary" role="button" asp-route-storeId="@Context.GetRouteValue("storeId")">
                 <span class="fa fa-plus"></span>
-                Create New Token
+                Create Token
             </a>
         </div>
 

--- a/BTCPayServer/Views/Stores/StoreUsers.cshtml
+++ b/BTCPayServer/Views/Stores/StoreUsers.cshtml
@@ -29,7 +29,7 @@
                     </select>
                 </div>
                 <div class="ms-3">
-                    <button type="submit" role="button" class="btn btn-primary"><span class="fa fa-plus"></span> Add user</button>
+                    <button type="submit" role="button" class="btn btn-primary"><span class="fa fa-plus"></span> Add User</button>
                 </div>
             </div>
         </form>

--- a/BTCPayServer/Views/Stores/Webhooks.cshtml
+++ b/BTCPayServer/Views/Stores/Webhooks.cshtml
@@ -8,7 +8,7 @@
     <h4 class="mb-0">@ViewData["Title"]</h4>
     <a id="CreateWebhook" asp-action="NewWebhook" class="btn btn-primary" role="button" asp-route-storeId="@Context.GetRouteValue("storeId")">
         <span class="fa fa-plus"></span>
-        Create a new webhook
+        Create Webhook
     </a>
 </div>
 <p>Webhooks allow BTCPay Server to send HTTP events related to your store to another server.</p>


### PR DESCRIPTION
Just doing some more auditing will working through remaining store-centric tasks. Purely button text, and 1 whitespace cleanup.

I went with the "Create Payment Request" uppercasing vs. "Create a payment request" as this was what was most consistent throughout the app with the exception of a few places in the commits ... but if we prefer the latter, I can make that change as well.

cc @pavlenex @Zaxounette 