### PR TITLE
Use ArgumentNullException.ThrowIfNull everywhere

### DIFF
--- a/BTCPayServer.Abstractions/Security/ContentSecurityPolicies.cs
+++ b/BTCPayServer.Abstractions/Security/ContentSecurityPolicies.cs
@@ -96,8 +96,7 @@ namespace BTCPayServer.Security
         /// <param name="script"></param>
         public void AllowInline(string script)
         {
-            if (script is null)
-                throw new ArgumentNullException(nameof(script));
+            ArgumentNullException.ThrowIfNull(script);
             var sha = GetSha256(script);
             Add("script-src", $"'sha256-{sha}'");
         }

--- a/BTCPayServer.Common/BTCPayNetworkProvider.cs
+++ b/BTCPayServer.Common/BTCPayNetworkProvider.cs
@@ -121,8 +121,7 @@ namespace BTCPayServer
         }
         public T GetNetwork<T>(string cryptoCode) where T : BTCPayNetworkBase
         {
-            if (cryptoCode == null)
-                throw new ArgumentNullException(nameof(cryptoCode));
+            ArgumentNullException.ThrowIfNull(cryptoCode);
             if (!_Networks.TryGetValue(cryptoCode.ToUpperInvariant(), out BTCPayNetworkBase network))
             {
                 if (cryptoCode == "XBT")

--- a/BTCPayServer.Rating/CurrencyNameTable.cs
+++ b/BTCPayServer.Rating/CurrencyNameTable.cs
@@ -145,8 +145,7 @@ namespace BTCPayServer.Services.Rates
 
         public CurrencyData GetCurrencyData(string currency, bool useFallback)
         {
-            if (currency == null)
-                throw new ArgumentNullException(nameof(currency));
+            ArgumentNullException.ThrowIfNull(currency);
             CurrencyData result;
             if (!_Currencies.TryGetValue(currency.ToUpperInvariant(), out result))
             {

--- a/BTCPayServer.Rating/CurrencyPair.cs
+++ b/BTCPayServer.Rating/CurrencyPair.cs
@@ -7,10 +7,8 @@ namespace BTCPayServer.Rating
     {
         public CurrencyPair(string left, string right)
         {
-            if (right == null)
-                throw new ArgumentNullException(nameof(right));
-            if (left == null)
-                throw new ArgumentNullException(nameof(left));
+            ArgumentNullException.ThrowIfNull(right);
+            ArgumentNullException.ThrowIfNull(left);
             Right = right.ToUpperInvariant();
             Left = left.ToUpperInvariant();
         }
@@ -25,8 +23,7 @@ namespace BTCPayServer.Rating
         }
         public static bool TryParse(string str, out CurrencyPair value)
         {
-            if (str == null)
-                throw new ArgumentNullException(nameof(str));
+            ArgumentNullException.ThrowIfNull(str);
             value = null;
             str = str.Trim();
             if (str.Length > 12)

--- a/BTCPayServer.Rating/ExchangeRates.cs
+++ b/BTCPayServer.Rating/ExchangeRates.cs
@@ -232,10 +232,8 @@ namespace BTCPayServer.Rating
     {
         public PairRate(CurrencyPair currencyPair, BidAsk bidAsk)
         {
-            if (currencyPair == null)
-                throw new ArgumentNullException(nameof(currencyPair));
-            if (bidAsk == null)
-                throw new ArgumentNullException(nameof(bidAsk));
+            ArgumentNullException.ThrowIfNull(currencyPair);
+            ArgumentNullException.ThrowIfNull(bidAsk);
             this.CurrencyPair = currencyPair;
             this.BidAsk = bidAsk;
         }

--- a/BTCPayServer.Rating/Providers/BackgroundFetcherRateProvider.cs
+++ b/BTCPayServer.Rating/Providers/BackgroundFetcherRateProvider.cs
@@ -85,8 +85,7 @@ namespace BTCPayServer.Services.Rates
 
         public BackgroundFetcherRateProvider(IRateProvider inner)
         {
-            if (inner == null)
-                throw new ArgumentNullException(nameof(inner));
+            ArgumentNullException.ThrowIfNull(inner);
             _Inner = inner;
         }
 

--- a/BTCPayServer.Rating/Providers/ExchangeSharpRateProvider.cs
+++ b/BTCPayServer.Rating/Providers/ExchangeSharpRateProvider.cs
@@ -15,8 +15,7 @@ namespace BTCPayServer.Services.Rates
         readonly HttpClient _httpClient;
         public ExchangeSharpRateProvider(HttpClient httpClient, bool reverseCurrencyPair = false)
         {
-            if (httpClient == null)
-                throw new ArgumentNullException(nameof(httpClient));
+            ArgumentNullException.ThrowIfNull(httpClient);
             ReverseCurrencyPair = reverseCurrencyPair;
             _httpClient = httpClient;
         }

--- a/BTCPayServer.Rating/Providers/FallbackRateProvider.cs
+++ b/BTCPayServer.Rating/Providers/FallbackRateProvider.cs
@@ -11,8 +11,7 @@ namespace BTCPayServer.Services.Rates
         readonly IRateProvider[] _Providers;
         public FallbackRateProvider(IRateProvider[] providers)
         {
-            if (providers == null)
-                throw new ArgumentNullException(nameof(providers));
+            ArgumentNullException.ThrowIfNull(providers);
             _Providers = providers;
         }
 

--- a/BTCPayServer.Rating/Providers/HttpClientRequestMaker.cs
+++ b/BTCPayServer.Rating/Providers/HttpClientRequestMaker.cs
@@ -96,10 +96,8 @@ namespace BTCPayServer.Services.Rates
 
         public HttpClientRequestMaker(IAPIRequestHandler api, HttpClient httpClient, CancellationToken cancellationToken)
         {
-            if (api == null)
-                throw new ArgumentNullException(nameof(api));
-            if (httpClient == null)
-                throw new ArgumentNullException(nameof(httpClient));
+            ArgumentNullException.ThrowIfNull(api);
+            ArgumentNullException.ThrowIfNull(httpClient);
             this.api = api;
             _httpClient = httpClient;
             _cancellationToken = cancellationToken;

--- a/BTCPayServer.Rating/Services/RateFetcher.cs
+++ b/BTCPayServer.Rating/Services/RateFetcher.cs
@@ -41,8 +41,7 @@ namespace BTCPayServer.Services.Rates
 
         public Dictionary<CurrencyPair, Task<RateResult>> FetchRates(HashSet<CurrencyPair> pairs, RateRules rules, CancellationToken cancellationToken)
         {
-            if (rules == null)
-                throw new ArgumentNullException(nameof(rules));
+            ArgumentNullException.ThrowIfNull(rules);
 
             var fetchingRates = new Dictionary<CurrencyPair, Task<RateResult>>();
             var fetchingExchanges = new Dictionary<string, Task<QueryRateResult>>();
@@ -67,8 +66,7 @@ namespace BTCPayServer.Services.Rates
 
         public Task<RateResult> FetchRate(RateRule rateRule, CancellationToken cancellationToken)
         {
-            if (rateRule == null)
-                throw new ArgumentNullException(nameof(rateRule));
+            ArgumentNullException.ThrowIfNull(rateRule);
             var fetchingExchanges = new Dictionary<string, Task<QueryRateResult>>();
             var dependentQueries = new List<Task<QueryRateResult>>();
             foreach (var requiredExchange in rateRule.ExchangeRates)

--- a/BTCPayServer/Configuration/ExternalConnectionString.cs
+++ b/BTCPayServer/Configuration/ExternalConnectionString.cs
@@ -147,8 +147,7 @@ namespace BTCPayServer.Configuration
         }
         public static bool TryParse(string str, out ExternalConnectionString result, out string error)
         {
-            if (str == null)
-                throw new ArgumentNullException(nameof(str));
+            ArgumentNullException.ThrowIfNull(str);
             error = null;
             result = null;
             var resultTemp = new ExternalConnectionString();

--- a/BTCPayServer/Controllers/Macaroons.cs
+++ b/BTCPayServer/Controllers/Macaroons.cs
@@ -19,8 +19,7 @@ namespace BTCPayServer.Controllers
         }
         public static async Task<Macaroons> GetFromDirectoryAsync(string directoryPath)
         {
-            if (directoryPath == null)
-                throw new ArgumentNullException(nameof(directoryPath));
+            ArgumentNullException.ThrowIfNull(directoryPath);
             Macaroons macaroons = new Macaroons();
             if (!Directory.Exists(directoryPath))
                 throw new DirectoryNotFoundException("Macaroons directory not found");

--- a/BTCPayServer/Data/Payouts/BitcoinLike/AddressClaimDestination.cs
+++ b/BTCPayServer/Data/Payouts/BitcoinLike/AddressClaimDestination.cs
@@ -9,8 +9,7 @@ namespace BTCPayServer.Data
 
         public AddressClaimDestination(BitcoinAddress bitcoinAddress)
         {
-            if (bitcoinAddress == null)
-                throw new ArgumentNullException(nameof(bitcoinAddress));
+            ArgumentNullException.ThrowIfNull(bitcoinAddress);
             _bitcoinAddress = bitcoinAddress;
         }
         public BitcoinAddress Address => _bitcoinAddress;

--- a/BTCPayServer/Data/Payouts/BitcoinLike/UriClaimDestination.cs
+++ b/BTCPayServer/Data/Payouts/BitcoinLike/UriClaimDestination.cs
@@ -11,8 +11,7 @@ namespace BTCPayServer.Data
 
         public UriClaimDestination(BitcoinUrlBuilder bitcoinUrl)
         {
-            if (bitcoinUrl == null)
-                throw new ArgumentNullException(nameof(bitcoinUrl));
+            ArgumentNullException.ThrowIfNull(bitcoinUrl);
             if (bitcoinUrl.Address is null)
                 throw new ArgumentException(nameof(bitcoinUrl));
             _bitcoinUrl = bitcoinUrl;

--- a/BTCPayServer/Data/StoreDataExtensions.cs
+++ b/BTCPayServer/Data/StoreDataExtensions.cs
@@ -68,8 +68,7 @@ namespace BTCPayServer.Data
 
         public static IEnumerable<ISupportedPaymentMethod> GetSupportedPaymentMethods(this StoreData storeData, BTCPayNetworkProvider networks)
         {
-            if (storeData == null)
-                throw new ArgumentNullException(nameof(storeData));
+            ArgumentNullException.ThrowIfNull(storeData);
 #pragma warning disable CS0618
             bool btcReturned = false;
 

--- a/BTCPayServer/DerivationSchemeParser.cs
+++ b/BTCPayServer/DerivationSchemeParser.cs
@@ -15,8 +15,7 @@ namespace BTCPayServer
 
         public DerivationSchemeParser(BTCPayNetwork expectedNetwork)
         {
-            if (expectedNetwork == null)
-                throw new ArgumentNullException(nameof(expectedNetwork));
+            ArgumentNullException.ThrowIfNull(expectedNetwork);
             BtcPayNetwork = expectedNetwork;
         }
 
@@ -44,8 +43,7 @@ namespace BTCPayServer
                 }
             }
             
-            if (str == null)
-                throw new ArgumentNullException(nameof(str));
+            ArgumentNullException.ThrowIfNull(str);
             str = str.Trim();
             var outputDescriptor = OutputDescriptor.Parse(str, Network);
             switch(outputDescriptor)
@@ -95,8 +93,7 @@ namespace BTCPayServer
         public DerivationStrategyBase ParseElectrum(string str)
         {
 
-            if (str == null)
-                throw new ArgumentNullException(nameof(str));
+            ArgumentNullException.ThrowIfNull(str);
             str = str.Trim();
             var data = Network.GetBase58CheckEncoder().DecodeData(str);
             if (data.Length < 4)
@@ -123,8 +120,7 @@ namespace BTCPayServer
 
         public DerivationStrategyBase Parse(string str)
         {
-            if (str == null)
-                throw new ArgumentNullException(nameof(str));
+            ArgumentNullException.ThrowIfNull(str);
             str = str.Trim();
 
             HashSet<string> hintedLabels = new HashSet<string>();

--- a/BTCPayServer/DerivationSchemeSettings.cs
+++ b/BTCPayServer/DerivationSchemeSettings.cs
@@ -15,10 +15,8 @@ namespace BTCPayServer
     {
         public static DerivationSchemeSettings Parse(string derivationStrategy, BTCPayNetwork network)
         {
-            if (network == null)
-                throw new ArgumentNullException(nameof(network));
-            if (derivationStrategy == null)
-                throw new ArgumentNullException(nameof(derivationStrategy));
+            ArgumentNullException.ThrowIfNull(network);
+            ArgumentNullException.ThrowIfNull(derivationStrategy);
             var result = new DerivationSchemeSettings();
             result.Network = network;
             var parser = new DerivationSchemeParser(network);
@@ -32,10 +30,8 @@ namespace BTCPayServer
 
         public static bool TryParseFromJson(string config, BTCPayNetwork network, out DerivationSchemeSettings strategy)
         {
-            if (network == null)
-                throw new ArgumentNullException(nameof(network));
-            if (config == null)
-                throw new ArgumentNullException(nameof(config));
+            ArgumentNullException.ThrowIfNull(network);
+            ArgumentNullException.ThrowIfNull(config);
             strategy = null;
             try
             {
@@ -90,10 +86,8 @@ namespace BTCPayServer
         public static bool TryParseFromWalletFile(string fileContents, BTCPayNetwork network, out DerivationSchemeSettings settings)
         {
             settings = null;
-            if (fileContents == null)
-                throw new ArgumentNullException(nameof(fileContents));
-            if (network == null)
-                throw new ArgumentNullException(nameof(network));
+            ArgumentNullException.ThrowIfNull(fileContents);
+            ArgumentNullException.ThrowIfNull(network);
             var result = new DerivationSchemeSettings();
             var derivationSchemeParser = new DerivationSchemeParser(network);
             JObject jobj = null;
@@ -247,10 +241,8 @@ namespace BTCPayServer
 
         public DerivationSchemeSettings(DerivationStrategyBase derivationStrategy, BTCPayNetwork network)
         {
-            if (network == null)
-                throw new ArgumentNullException(nameof(network));
-            if (derivationStrategy == null)
-                throw new ArgumentNullException(nameof(derivationStrategy));
+            ArgumentNullException.ThrowIfNull(network);
+            ArgumentNullException.ThrowIfNull(derivationStrategy);
             AccountDerivation = derivationStrategy;
             Network = network;
             AccountKeySettings = derivationStrategy.GetExtPubKeys().Select(c => new AccountKeySettings()

--- a/BTCPayServer/EventAggregator.cs
+++ b/BTCPayServer/EventAggregator.cs
@@ -81,8 +81,7 @@ namespace BTCPayServer
 
         public void Publish(object evt, Type evtType)
         {
-            if (evt == null)
-                throw new ArgumentNullException(nameof(evt));
+            ArgumentNullException.ThrowIfNull(evt);
             List<Action<object>> actionList = new List<Action<object>>();
             lock (_Subscriptions)
             {

--- a/BTCPayServer/Events/InvoiceNeedUpdateEvent.cs
+++ b/BTCPayServer/Events/InvoiceNeedUpdateEvent.cs
@@ -6,8 +6,7 @@ namespace BTCPayServer.Events
     {
         public InvoiceNeedUpdateEvent(string invoiceId)
         {
-            if (invoiceId == null)
-                throw new ArgumentNullException(nameof(invoiceId));
+            ArgumentNullException.ThrowIfNull(invoiceId);
             InvoiceId = invoiceId;
         }
 

--- a/BTCPayServer/ExplorerClientProvider.cs
+++ b/BTCPayServer/ExplorerClientProvider.cs
@@ -83,8 +83,7 @@ namespace BTCPayServer
 
         public ExplorerClient GetExplorerClient(BTCPayNetworkBase network)
         {
-            if (network == null)
-                throw new ArgumentNullException(nameof(network));
+            ArgumentNullException.ThrowIfNull(network);
             return GetExplorerClient(network.CryptoCode);
         }
 

--- a/BTCPayServer/Extensions.cs
+++ b/BTCPayServer/Extensions.cs
@@ -215,8 +215,7 @@ namespace BTCPayServer
 
         public static bool IsLocalNetwork(string server)
         {
-            if (server == null)
-                throw new ArgumentNullException(nameof(server));
+            ArgumentNullException.ThrowIfNull(server);
             if (Uri.CheckHostName(server) == UriHostNameType.Dns)
             {
                 return server.EndsWith(".internal", StringComparison.OrdinalIgnoreCase) ||

--- a/BTCPayServer/Extensions/SSHClientExtensions.cs
+++ b/BTCPayServer/Extensions/SSHClientExtensions.cs
@@ -10,8 +10,7 @@ namespace BTCPayServer
     {
         public static async Task<SshClient> ConnectAsync(this SSHSettings sshSettings, CancellationToken cancellationToken = default)
         {
-            if (sshSettings == null)
-                throw new ArgumentNullException(nameof(sshSettings));
+            ArgumentNullException.ThrowIfNull(sshSettings);
             TaskCompletionSource<SshClient> tcs = new TaskCompletionSource<SshClient>(TaskCreationOptions.RunContinuationsAsynchronously);
             new Thread(() =>
             {
@@ -58,10 +57,8 @@ namespace BTCPayServer
 
         public static Task<SSHCommandResult> RunBash(this SshClient sshClient, string command, TimeSpan? timeout = null)
         {
-            if (sshClient == null)
-                throw new ArgumentNullException(nameof(sshClient));
-            if (command == null)
-                throw new ArgumentNullException(nameof(command));
+            ArgumentNullException.ThrowIfNull(sshClient);
+            ArgumentNullException.ThrowIfNull(command);
             command = $"bash -c '{command.EscapeSingleQuotes()}'";
             var sshCommand = sshClient.CreateCommand(command);
             if (timeout is TimeSpan v)
@@ -106,8 +103,7 @@ namespace BTCPayServer
 
         public static async Task DisconnectAsync(this SshClient sshClient, CancellationToken cancellationToken = default)
         {
-            if (sshClient == null)
-                throw new ArgumentNullException(nameof(sshClient));
+            ArgumentNullException.ThrowIfNull(sshClient);
 
             TaskCompletionSource<bool> tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             new Thread(() =>

--- a/BTCPayServer/HostedServices/InvoiceWatcher.cs
+++ b/BTCPayServer/HostedServices/InvoiceWatcher.cs
@@ -235,8 +235,7 @@ namespace BTCPayServer.HostedServices
 
         private void Watch(string invoiceId)
         {
-            if (invoiceId == null)
-                throw new ArgumentNullException(nameof(invoiceId));
+            ArgumentNullException.ThrowIfNull(invoiceId);
 
             if (!_WatchRequests.Writer.TryWrite(invoiceId))
             {

--- a/BTCPayServer/HostedServices/PullPaymentHostedService.cs
+++ b/BTCPayServer/HostedServices/PullPaymentHostedService.cs
@@ -41,14 +41,12 @@ namespace BTCPayServer.HostedServices
         {
             public CancelRequest(string pullPaymentId)
             {
-                if (pullPaymentId == null)
-                    throw new ArgumentNullException(nameof(pullPaymentId));
+                ArgumentNullException.ThrowIfNull(pullPaymentId);
                 PullPaymentId = pullPaymentId;
             }
             public CancelRequest(string[] payoutIds)
             {
-                if (payoutIds == null)
-                    throw new ArgumentNullException(nameof(payoutIds));
+                ArgumentNullException.ThrowIfNull(payoutIds);
                 PayoutIds = payoutIds;
             }
             public string PullPaymentId { get; set; }
@@ -91,8 +89,7 @@ namespace BTCPayServer.HostedServices
         }
         public async Task<string> CreatePullPayment(CreatePullPayment create)
         {
-            if (create == null)
-                throw new ArgumentNullException(nameof(create));
+            ArgumentNullException.ThrowIfNull(create);
             if (create.Amount <= 0.0m)
                 throw new ArgumentException("Amount out of bound", nameof(create));
             using var ctx = this._dbContextFactory.CreateContext();
@@ -137,10 +134,8 @@ namespace BTCPayServer.HostedServices
         {
             public PayoutRequest(TaskCompletionSource<ClaimRequest.ClaimResponse> completionSource, ClaimRequest request)
             {
-                if (request == null)
-                    throw new ArgumentNullException(nameof(request));
-                if (completionSource == null)
-                    throw new ArgumentNullException(nameof(completionSource));
+                ArgumentNullException.ThrowIfNull(request);
+                ArgumentNullException.ThrowIfNull(completionSource);
                 Completion = completionSource;
                 ClaimRequest = request;
             }
@@ -536,10 +531,8 @@ namespace BTCPayServer.HostedServices
         {
             public InternalPayoutPaidRequest(TaskCompletionSource<PayoutPaidRequest.PayoutPaidResult> completionSource, PayoutPaidRequest request)
             {
-                if (request == null)
-                    throw new ArgumentNullException(nameof(request));
-                if (completionSource == null)
-                    throw new ArgumentNullException(nameof(completionSource));
+                ArgumentNullException.ThrowIfNull(request);
+                ArgumentNullException.ThrowIfNull(completionSource);
                 Completion = completionSource;
                 Request = request;
             }

--- a/BTCPayServer/Models/GetTokensResponse.cs
+++ b/BTCPayServer/Models/GetTokensResponse.cs
@@ -16,8 +16,7 @@ namespace BTCPayServer.Models
         readonly BitTokenEntity[] _Tokens;
         public GetTokensResponse(BitTokenEntity[] tokens)
         {
-            if (tokens == null)
-                throw new ArgumentNullException(nameof(tokens));
+            ArgumentNullException.ThrowIfNull(tokens);
             this._Tokens = tokens;
         }
 

--- a/BTCPayServer/Payments/IPaymentFilter.cs
+++ b/BTCPayServer/Payments/IPaymentFilter.cs
@@ -83,16 +83,13 @@ namespace BTCPayServer.Payments
         }
         public static IPaymentFilter Where(Func<PaymentMethodId, bool> predicate)
         {
-            if (predicate == null)
-                throw new ArgumentNullException(nameof(predicate));
+            ArgumentNullException.ThrowIfNull(predicate);
             return new PredicateFilter(predicate);
         }
         public static IPaymentFilter Or(IPaymentFilter a, IPaymentFilter b)
         {
-            if (a == null)
-                throw new ArgumentNullException(nameof(a));
-            if (b == null)
-                throw new ArgumentNullException(nameof(b));
+            ArgumentNullException.ThrowIfNull(a);
+            ArgumentNullException.ThrowIfNull(b);
             return new OrPaymentFilter(a, b);
         }
         public static IPaymentFilter Never()
@@ -101,14 +98,12 @@ namespace BTCPayServer.Payments
         }
         public static IPaymentFilter Any(IPaymentFilter[] filters)
         {
-            if (filters == null)
-                throw new ArgumentNullException(nameof(filters));
+            ArgumentNullException.ThrowIfNull(filters);
             return new CompositePaymentFilter(filters);
         }
         public static IPaymentFilter WhereIs(PaymentMethodId paymentMethodId)
         {
-            if (paymentMethodId == null)
-                throw new ArgumentNullException(nameof(paymentMethodId));
+            ArgumentNullException.ThrowIfNull(paymentMethodId);
             return new PaymentIdFilter(paymentMethodId);
         }
     }

--- a/BTCPayServer/Payments/Lightning/LightningListener.cs
+++ b/BTCPayServer/Payments/Lightning/LightningListener.cs
@@ -415,8 +415,7 @@ namespace BTCPayServer.Payments.Lightning
                                         PaymentService paymentService,
                                         Logs logs)
         {
-            if (connectionString == null)
-                throw new ArgumentNullException(nameof(connectionString));
+            ArgumentNullException.ThrowIfNull(connectionString);
             Logs = logs;
             this._invoiceRepository = invoiceRepository;
             _eventAggregator = eventAggregator;

--- a/BTCPayServer/Payments/Lightning/LightningSupportedPaymentMethod.cs
+++ b/BTCPayServer/Payments/Lightning/LightningSupportedPaymentMethod.cs
@@ -37,8 +37,7 @@ namespace BTCPayServer.Payments.Lightning
 
         public void SetLightningUrl(LightningConnectionString connectionString)
         {
-            if (connectionString == null)
-                throw new ArgumentNullException(nameof(connectionString));
+            ArgumentNullException.ThrowIfNull(connectionString);
 #pragma warning disable CS0618 // Type or member is obsolete
             LightningConnectionString = connectionString.ToString();
 #pragma warning restore CS0618 // Type or member is obsolete

--- a/BTCPayServer/Payments/PayJoin/PayJoinEndpointController.cs
+++ b/BTCPayServer/Payments/PayJoin/PayJoinEndpointController.cs
@@ -59,10 +59,8 @@ namespace BTCPayServer.Payments.PayJoin
             public static UTXODeterministicComparer Instance => _Instance;
             public int Compare([AllowNull] UTXO x, [AllowNull] UTXO y)
             {
-                if (x == null)
-                    throw new ArgumentNullException(nameof(x));
-                if (y == null)
-                    throw new ArgumentNullException(nameof(y));
+                ArgumentNullException.ThrowIfNull(x);
+                ArgumentNullException.ThrowIfNull(y);
                 Span<byte> tmpx = stackalloc byte[32];
                 Span<byte> tmpy = stackalloc byte[32];
                 x.Outpoint.Hash.ToBytes(tmpx);

--- a/BTCPayServer/Payments/PaymentMethodId.cs
+++ b/BTCPayServer/Payments/PaymentMethodId.cs
@@ -13,17 +13,14 @@ namespace BTCPayServer.Payments
     {
         public PaymentMethodId? FindNearest(PaymentMethodId[] others)
         {
-            if (others is null)
-                throw new ArgumentNullException(nameof(others));
+            ArgumentNullException.ThrowIfNull(others);
             return others.FirstOrDefault(f => f == this) ??
                    others.FirstOrDefault(f => f.CryptoCode == CryptoCode);
         }
         public PaymentMethodId(string cryptoCode, PaymentType paymentType)
         {
-            if (cryptoCode == null)
-                throw new ArgumentNullException(nameof(cryptoCode));
-            if (paymentType == null)
-                throw new ArgumentNullException(nameof(paymentType));
+            ArgumentNullException.ThrowIfNull(cryptoCode);
+            ArgumentNullException.ThrowIfNull(paymentType);
             PaymentType = paymentType;
             CryptoCode = cryptoCode.ToUpperInvariant();
         }

--- a/BTCPayServer/Payments/PaymentTypes.Bitcoin.cs
+++ b/BTCPayServer/Payments/PaymentTypes.Bitcoin.cs
@@ -44,10 +44,8 @@ namespace BTCPayServer.Payments
 
         public override ISupportedPaymentMethod DeserializeSupportedPaymentMethod(BTCPayNetworkBase network, JToken value)
         {
-            if (network == null)
-                throw new ArgumentNullException(nameof(network));
-            if (value == null)
-                throw new ArgumentNullException(nameof(value));
+            ArgumentNullException.ThrowIfNull(network);
+            ArgumentNullException.ThrowIfNull(value);
             var net = (BTCPayNetwork)network;
             if (value is JObject jobj)
             {
@@ -61,8 +59,7 @@ namespace BTCPayServer.Payments
 
         public override string GetTransactionLink(BTCPayNetworkBase network, string txId)
         {
-            if (txId == null)
-                throw new ArgumentNullException(nameof(txId));
+            ArgumentNullException.ThrowIfNull(txId);
             if (network?.BlockExplorerLink == null)
                 return null;
             txId = txId.Split('-').First();

--- a/BTCPayServer/SSH/SSHFingerprint.cs
+++ b/BTCPayServer/SSH/SSHFingerprint.cs
@@ -10,8 +10,7 @@ namespace BTCPayServer.SSH
     {
         public static bool TryParse(string str, out SSHFingerprint fingerPrint)
         {
-            if (str == null)
-                throw new ArgumentNullException(nameof(str));
+            ArgumentNullException.ThrowIfNull(str);
             fingerPrint = null;
             str = str.Trim();
             try
@@ -77,10 +76,8 @@ namespace BTCPayServer.SSH
 
         public bool Match(byte[] shortFingerprint, byte[] hostKey)
         {
-            if (shortFingerprint == null)
-                throw new ArgumentNullException(nameof(shortFingerprint));
-            if (hostKey == null)
-                throw new ArgumentNullException(nameof(hostKey));
+            ArgumentNullException.ThrowIfNull(shortFingerprint);
+            ArgumentNullException.ThrowIfNull(hostKey);
             if (_ShortFingerprint != null)
                 return Utils.ArrayEqual(shortFingerprint, _ShortFingerprint);
             return Utils.ArrayEqual(_FullHash, NBitcoin.Crypto.Hashes.SHA256(hostKey));

--- a/BTCPayServer/Security/Bitpay/TokenRepository.cs
+++ b/BTCPayServer/Security/Bitpay/TokenRepository.cs
@@ -21,8 +21,7 @@ namespace BTCPayServer.Security.Bitpay
         readonly ApplicationDbContextFactory _Factory;
         public TokenRepository(ApplicationDbContextFactory dbFactory)
         {
-            if (dbFactory == null)
-                throw new ArgumentNullException(nameof(dbFactory));
+            ArgumentNullException.ThrowIfNull(dbFactory);
             _Factory = dbFactory;
         }
 

--- a/BTCPayServer/Security/PolicyRequirement.cs
+++ b/BTCPayServer/Security/PolicyRequirement.cs
@@ -7,8 +7,7 @@ namespace BTCPayServer.Security
     {
         public PolicyRequirement(string policy)
         {
-            if (policy == null)
-                throw new ArgumentNullException(nameof(policy));
+            ArgumentNullException.ThrowIfNull(policy);
             Policy = policy;
         }
         public string Policy { get; }

--- a/BTCPayServer/Services/BTCPayNetworkJsonSerializerSettings.cs
+++ b/BTCPayServer/Services/BTCPayNetworkJsonSerializerSettings.cs
@@ -45,20 +45,17 @@ namespace BTCPayServer.Services
 
         public JsonSerializerSettings GetSerializer(Network network)
         {
-            if (network == null)
-                throw new ArgumentNullException(nameof(network));
+            ArgumentNullException.ThrowIfNull(network);
             return GetSerializer(network.NetworkSet.CryptoCode);
         }
         public JsonSerializerSettings GetSerializer(BTCPayNetwork network)
         {
-            if (network == null)
-                throw new ArgumentNullException(nameof(network));
+            ArgumentNullException.ThrowIfNull(network);
             return GetSerializer(network.CryptoCode);
         }
         public JsonSerializerSettings GetSerializer(string cryptoCode)
         {
-            if (cryptoCode == null)
-                throw new ArgumentNullException(nameof(cryptoCode));
+            ArgumentNullException.ThrowIfNull(cryptoCode);
             _Serializers.TryGetValue(cryptoCode, out var serializer);
             return serializer;
         }

--- a/BTCPayServer/Services/DelayedTransactionBroadcaster.cs
+++ b/BTCPayServer/Services/DelayedTransactionBroadcaster.cs
@@ -33,8 +33,7 @@ namespace BTCPayServer.Services
             Data.ApplicationDbContextFactory dbContextFactory,
             Logs logs)
         {
-            if (explorerClientProvider == null)
-                throw new ArgumentNullException(nameof(explorerClientProvider));
+            ArgumentNullException.ThrowIfNull(explorerClientProvider);
             _networkProvider = networkProvider;
             _explorerClientProvider = explorerClientProvider;
             _dbContextFactory = dbContextFactory;
@@ -43,10 +42,8 @@ namespace BTCPayServer.Services
 
         public async Task Schedule(DateTimeOffset broadcastTime, Transaction transaction, BTCPayNetwork network)
         {
-            if (transaction == null)
-                throw new ArgumentNullException(nameof(transaction));
-            if (network == null)
-                throw new ArgumentNullException(nameof(network));
+            ArgumentNullException.ThrowIfNull(transaction);
+            ArgumentNullException.ThrowIfNull(network);
             using (var db = _dbContextFactory.CreateContext())
             {
                 db.PlannedTransactions.Add(new PlannedTransaction()

--- a/BTCPayServer/Services/Fees/NBxplorerFeeProvider.cs
+++ b/BTCPayServer/Services/Fees/NBxplorerFeeProvider.cs
@@ -10,8 +10,7 @@ namespace BTCPayServer.Services.Fees
     {
         public NBXplorerFeeProviderFactory(ExplorerClientProvider explorerClients)
         {
-            if (explorerClients == null)
-                throw new ArgumentNullException(nameof(explorerClients));
+            ArgumentNullException.ThrowIfNull(explorerClients);
             _ExplorerClients = explorerClients;
         }
 
@@ -27,8 +26,7 @@ namespace BTCPayServer.Services.Fees
     {
         public NBXplorerFeeProvider(NBXplorerFeeProviderFactory parent, ExplorerClient explorerClient)
         {
-            if (explorerClient == null)
-                throw new ArgumentNullException(nameof(explorerClient));
+            ArgumentNullException.ThrowIfNull(explorerClient);
             _Factory = parent;
             _ExplorerClient = explorerClient;
         }

--- a/BTCPayServer/Services/Invoices/InvoiceRepository.cs
+++ b/BTCPayServer/Services/Invoices/InvoiceRepository.cs
@@ -114,8 +114,7 @@ namespace BTCPayServer.Services.Invoices
 
         public async Task<AppData[]> GetAppsTaggingStore(string storeId)
         {
-            if (storeId == null)
-                throw new ArgumentNullException(nameof(storeId));
+            ArgumentNullException.ThrowIfNull(storeId);
             using (var ctx = _applicationDbContextFactory.CreateContext())
             {
                 return await ctx.Apps.Where(a => a.StoreDataId == storeId && a.TagAllInvoices).ToArrayAsync();

--- a/BTCPayServer/Services/Invoices/PaymentMethodDictionary.cs
+++ b/BTCPayServer/Services/Invoices/PaymentMethodDictionary.cs
@@ -32,8 +32,7 @@ namespace BTCPayServer.Services.Invoices
         }
         public bool TryGetValue(PaymentMethodId paymentMethodId, out PaymentMethod data)
         {
-            if (paymentMethodId == null)
-                throw new ArgumentNullException(nameof(paymentMethodId));
+            ArgumentNullException.ThrowIfNull(paymentMethodId);
             return _Inner.TryGetValue(paymentMethodId, out data);
         }
 
@@ -56,15 +55,13 @@ namespace BTCPayServer.Services.Invoices
 
         public PaymentMethod TryGet(PaymentMethodId paymentMethodId)
         {
-            if (paymentMethodId == null)
-                throw new ArgumentNullException(nameof(paymentMethodId));
+            ArgumentNullException.ThrowIfNull(paymentMethodId);
             _Inner.TryGetValue(paymentMethodId, out var value);
             return value;
         }
         public PaymentMethod TryGet(string network, PaymentType paymentType)
         {
-            if (network == null)
-                throw new ArgumentNullException(nameof(network));
+            ArgumentNullException.ThrowIfNull(network);
             var id = new PaymentMethodId(network, paymentType);
             return TryGet(id);
         }

--- a/BTCPayServer/Services/Labels/Label.cs
+++ b/BTCPayServer/Services/Labels/Label.cs
@@ -34,8 +34,7 @@ namespace BTCPayServer.Services.Labels
         }
         public static Label Parse(string str)
         {
-            if (str == null)
-                throw new ArgumentNullException(nameof(str));
+            ArgumentNullException.ThrowIfNull(str);
             if (str.StartsWith("{", StringComparison.InvariantCultureIgnoreCase))
             {
                 var jObj = JObject.Parse(str);

--- a/BTCPayServer/Services/Labels/LabelFactory.cs
+++ b/BTCPayServer/Services/Labels/LabelFactory.cs
@@ -40,8 +40,7 @@ namespace BTCPayServer.Services.Labels
         const string DefaultColor = "#000";
         private ColoredLabel CreateLabel(LabelData uncoloredLabel, string color, HttpRequest request)
         {
-            if (uncoloredLabel == null)
-                throw new ArgumentNullException(nameof(uncoloredLabel));
+            ArgumentNullException.ThrowIfNull(uncoloredLabel);
             color = color ?? DefaultColor;
 
             ColoredLabel coloredLabel = new ColoredLabel()

--- a/BTCPayServer/Services/LightningClientFactoryService.cs
+++ b/BTCPayServer/Services/LightningClientFactoryService.cs
@@ -15,10 +15,8 @@ namespace BTCPayServer.Services
 
         public ILightningClient Create(LightningConnectionString lightningConnectionString, BTCPayNetwork network)
         {
-            if (lightningConnectionString == null)
-                throw new ArgumentNullException(nameof(lightningConnectionString));
-            if (network == null)
-                throw new ArgumentNullException(nameof(network));
+            ArgumentNullException.ThrowIfNull(lightningConnectionString);
+            ArgumentNullException.ThrowIfNull(network);
             return new Lightning.LightningClientFactory(network.NBitcoinNetwork)
             {
                 HttpClient = _httpClientFactory.CreateClient($"{network.CryptoCode}: Lightning client")

--- a/BTCPayServer/Services/Mails/ServerEmailSender.cs
+++ b/BTCPayServer/Services/Mails/ServerEmailSender.cs
@@ -10,8 +10,7 @@ namespace BTCPayServer.Services.Mails
                                 IBackgroundJobClient backgroundJobClient,
                                 Logs logs) : base(backgroundJobClient, logs)
         {
-            if (settingsRepository == null)
-                throw new ArgumentNullException(nameof(settingsRepository));
+            ArgumentNullException.ThrowIfNull(settingsRepository);
             SettingsRepository = settingsRepository;
         }
 

--- a/BTCPayServer/Services/Notifications/NotificationScopes.cs
+++ b/BTCPayServer/Services/Notifications/NotificationScopes.cs
@@ -12,8 +12,7 @@ namespace BTCPayServer.Services.Notifications
     {
         public StoreScope(string storeId)
         {
-            if (storeId == null)
-                throw new ArgumentNullException(nameof(storeId));
+            ArgumentNullException.ThrowIfNull(storeId);
             StoreId = storeId;
         }
         public string StoreId { get; }
@@ -22,8 +21,7 @@ namespace BTCPayServer.Services.Notifications
     {
         public UserScope(string userId)
         {
-            if (userId == null)
-                throw new ArgumentNullException(nameof(userId));
+            ArgumentNullException.ThrowIfNull(userId);
             UserId = userId;
         }
         public string UserId { get; }

--- a/BTCPayServer/Services/Notifications/NotificationSender.cs
+++ b/BTCPayServer/Services/Notifications/NotificationSender.cs
@@ -33,10 +33,8 @@ namespace BTCPayServer.Services.Notifications
 
         public async Task SendNotification(NotificationScope scope, BaseNotification notification)
         {
-            if (scope == null)
-                throw new ArgumentNullException(nameof(scope));
-            if (notification == null)
-                throw new ArgumentNullException(nameof(notification));
+            ArgumentNullException.ThrowIfNull(scope);
+            ArgumentNullException.ThrowIfNull(notification);
             var users = await GetUsers(scope, notification.Identifier);
             await using (var db = _contextFactory.CreateContext())
             {

--- a/BTCPayServer/Services/Stores/StoreRepository.cs
+++ b/BTCPayServer/Services/Stores/StoreRepository.cs
@@ -35,8 +35,7 @@ namespace BTCPayServer.Services.Stores
 
         public async Task<StoreData> FindStore(string storeId, string userId)
         {
-            if (userId == null)
-                throw new ArgumentNullException(nameof(userId));
+            ArgumentNullException.ThrowIfNull(userId);
             await using var ctx = _ContextFactory.CreateContext();
             return (await ctx
                     .UserStore
@@ -62,8 +61,7 @@ namespace BTCPayServer.Services.Stores
         }
         public async Task<StoreUser[]> GetStoreUsers(string storeId)
         {
-            if (storeId == null)
-                throw new ArgumentNullException(nameof(storeId));
+            ArgumentNullException.ThrowIfNull(storeId);
             using (var ctx = _ContextFactory.CreateContext())
             {
                 return await ctx
@@ -183,8 +181,7 @@ namespace BTCPayServer.Services.Stores
                 throw new ArgumentException("id should be empty", nameof(storeData.StoreName));
             if (string.IsNullOrEmpty(storeData.StoreName))
                 throw new ArgumentException("name should not be empty", nameof(storeData.StoreName));
-            if (ownerId == null)
-                throw new ArgumentNullException(nameof(ownerId));
+            ArgumentNullException.ThrowIfNull(ownerId);
             using (var ctx = _ContextFactory.CreateContext())
             {
                 storeData.Id = Encoders.Base58.EncodeData(RandomUtils.GetBytes(32));
@@ -221,10 +218,8 @@ namespace BTCPayServer.Services.Stores
 
         public async Task<WebhookDeliveryData> GetWebhookDelivery(string storeId, string webhookId, string deliveryId)
         {
-            if (webhookId == null)
-                throw new ArgumentNullException(nameof(webhookId));
-            if (storeId == null)
-                throw new ArgumentNullException(nameof(storeId));
+            ArgumentNullException.ThrowIfNull(webhookId);
+            ArgumentNullException.ThrowIfNull(storeId);
             using var ctx = _ContextFactory.CreateContext();
             return await ctx.StoreWebhooks
                 .Where(d => d.StoreId == storeId && d.WebhookId == webhookId)
@@ -251,10 +246,8 @@ namespace BTCPayServer.Services.Stores
 
         public async Task<WebhookDeliveryData[]> GetWebhookDeliveries(string storeId, string webhookId, int? count)
         {
-            if (webhookId == null)
-                throw new ArgumentNullException(nameof(webhookId));
-            if (storeId == null)
-                throw new ArgumentNullException(nameof(storeId));
+            ArgumentNullException.ThrowIfNull(webhookId);
+            ArgumentNullException.ThrowIfNull(storeId);
             using var ctx = _ContextFactory.CreateContext();
             IQueryable<WebhookDeliveryData> req = ctx.StoreWebhooks
                 .Where(s => s.StoreId == storeId && s.WebhookId == webhookId)
@@ -268,10 +261,8 @@ namespace BTCPayServer.Services.Stores
 
         public async Task<string> CreateWebhook(string storeId, WebhookBlob blob)
         {
-            if (storeId == null)
-                throw new ArgumentNullException(nameof(storeId));
-            if (blob == null)
-                throw new ArgumentNullException(nameof(blob));
+            ArgumentNullException.ThrowIfNull(storeId);
+            ArgumentNullException.ThrowIfNull(blob);
             using var ctx = _ContextFactory.CreateContext();
             WebhookData data = new WebhookData();
             data.Id = Encoders.Base58.EncodeData(RandomUtils.GetBytes(16));
@@ -289,10 +280,8 @@ namespace BTCPayServer.Services.Stores
 
         public async Task<WebhookData> GetWebhook(string storeId, string webhookId)
         {
-            if (webhookId == null)
-                throw new ArgumentNullException(nameof(webhookId));
-            if (storeId == null)
-                throw new ArgumentNullException(nameof(storeId));
+            ArgumentNullException.ThrowIfNull(webhookId);
+            ArgumentNullException.ThrowIfNull(storeId);
             using var ctx = _ContextFactory.CreateContext();
             return await ctx.StoreWebhooks
                 .Where(s => s.StoreId == storeId && s.WebhookId == webhookId)
@@ -301,8 +290,7 @@ namespace BTCPayServer.Services.Stores
         }
         public async Task<WebhookData> GetWebhook(string webhookId)
         {
-            if (webhookId == null)
-                throw new ArgumentNullException(nameof(webhookId));
+            ArgumentNullException.ThrowIfNull(webhookId);
             using var ctx = _ContextFactory.CreateContext();
             return await ctx.StoreWebhooks
                 .Where(s => s.WebhookId == webhookId)
@@ -311,10 +299,8 @@ namespace BTCPayServer.Services.Stores
         }
         public async Task DeleteWebhook(string storeId, string webhookId)
         {
-            if (webhookId == null)
-                throw new ArgumentNullException(nameof(webhookId));
-            if (storeId == null)
-                throw new ArgumentNullException(nameof(storeId));
+            ArgumentNullException.ThrowIfNull(webhookId);
+            ArgumentNullException.ThrowIfNull(storeId);
             using var ctx = _ContextFactory.CreateContext();
             var hook = await ctx.StoreWebhooks
                 .Where(s => s.StoreId == storeId && s.WebhookId == webhookId)
@@ -328,12 +314,9 @@ namespace BTCPayServer.Services.Stores
 
         public async Task UpdateWebhook(string storeId, string webhookId, WebhookBlob webhookBlob)
         {
-            if (webhookId == null)
-                throw new ArgumentNullException(nameof(webhookId));
-            if (storeId == null)
-                throw new ArgumentNullException(nameof(storeId));
-            if (webhookBlob == null)
-                throw new ArgumentNullException(nameof(webhookBlob));
+            ArgumentNullException.ThrowIfNull(webhookId);
+            ArgumentNullException.ThrowIfNull(storeId);
+            ArgumentNullException.ThrowIfNull(webhookBlob);
             using var ctx = _ContextFactory.CreateContext();
             var hook = await ctx.StoreWebhooks
                 .Where(s => s.StoreId == storeId && s.WebhookId == webhookId)

--- a/BTCPayServer/Services/WalletRepository.cs
+++ b/BTCPayServer/Services/WalletRepository.cs
@@ -18,8 +18,7 @@ namespace BTCPayServer.Services
 
         public async Task SetWalletInfo(WalletId walletId, WalletBlobInfo blob)
         {
-            if (walletId == null)
-                throw new ArgumentNullException(nameof(walletId));
+            ArgumentNullException.ThrowIfNull(walletId);
             using (var ctx = _ContextFactory.CreateContext())
             {
                 var walletData = new WalletData() { Id = walletId.ToString() };
@@ -40,8 +39,7 @@ namespace BTCPayServer.Services
 
         public async Task<Dictionary<string, WalletTransactionInfo>> GetWalletTransactionsInfo(WalletId walletId, string[] transactionIds = null)
         {
-            if (walletId == null)
-                throw new ArgumentNullException(nameof(walletId));
+            ArgumentNullException.ThrowIfNull(walletId);
             using (var ctx = _ContextFactory.CreateContext())
             {
                 return (await ctx.WalletTransactions
@@ -55,8 +53,7 @@ namespace BTCPayServer.Services
 
         public async Task<WalletBlobInfo> GetWalletInfo(WalletId walletId)
         {
-            if (walletId == null)
-                throw new ArgumentNullException(nameof(walletId));
+            ArgumentNullException.ThrowIfNull(walletId);
             using (var ctx = _ContextFactory.CreateContext())
             {
                 var data = await ctx.Wallets
@@ -69,10 +66,8 @@ namespace BTCPayServer.Services
 
         public async Task SetWalletTransactionInfo(WalletId walletId, string transactionId, WalletTransactionInfo walletTransactionInfo)
         {
-            if (walletId == null)
-                throw new ArgumentNullException(nameof(walletId));
-            if (transactionId == null)
-                throw new ArgumentNullException(nameof(transactionId));
+            ArgumentNullException.ThrowIfNull(walletId);
+            ArgumentNullException.ThrowIfNull(transactionId);
             using (var ctx = _ContextFactory.CreateContext())
             {
                 var walletData = new WalletTransactionData() { WalletDataId = walletId.ToString(), TransactionId = transactionId };

--- a/BTCPayServer/Services/Wallets/BTCPayWallet.cs
+++ b/BTCPayServer/Services/Wallets/BTCPayWallet.cs
@@ -46,10 +46,8 @@ namespace BTCPayServer.Services.Wallets
         public BTCPayWallet(ExplorerClient client, IMemoryCache memoryCache, BTCPayNetwork network,
             ApplicationDbContextFactory dbContextFactory, Logs logs)
         {
-            if (client == null)
-                throw new ArgumentNullException(nameof(client));
-            if (memoryCache == null)
-                throw new ArgumentNullException(nameof(memoryCache));
+            ArgumentNullException.ThrowIfNull(client);
+            ArgumentNullException.ThrowIfNull(memoryCache);
             Logs = logs;
             _Client = client;
             _Network = network;
@@ -73,8 +71,7 @@ namespace BTCPayServer.Services.Wallets
 
         public async Task<KeyPathInformation> ReserveAddressAsync(DerivationStrategyBase derivationStrategy)
         {
-            if (derivationStrategy == null)
-                throw new ArgumentNullException(nameof(derivationStrategy));
+            ArgumentNullException.ThrowIfNull(derivationStrategy);
             var pathInfo = await _Client.GetUnusedAsync(derivationStrategy, DerivationFeature.Deposit, 0, true).ConfigureAwait(false);
             // Might happen on some broken install
             if (pathInfo == null)
@@ -87,8 +84,7 @@ namespace BTCPayServer.Services.Wallets
 
         public async Task<(BitcoinAddress, KeyPath)> GetChangeAddressAsync(DerivationStrategyBase derivationStrategy)
         {
-            if (derivationStrategy == null)
-                throw new ArgumentNullException(nameof(derivationStrategy));
+            ArgumentNullException.ThrowIfNull(derivationStrategy);
             var pathInfo = await _Client.GetUnusedAsync(derivationStrategy, DerivationFeature.Change, 0, false).ConfigureAwait(false);
             // Might happen on some broken install
             if (pathInfo == null)
@@ -109,8 +105,7 @@ namespace BTCPayServer.Services.Wallets
 
         public async Task<TransactionResult> GetTransactionAsync(uint256 txId, bool includeOffchain = false, CancellationToken cancellation = default(CancellationToken))
         {
-            if (txId == null)
-                throw new ArgumentNullException(nameof(txId));
+            ArgumentNullException.ThrowIfNull(txId);
             var tx = await _Client.GetTransactionAsync(txId, cancellation);
             if (tx is null && includeOffchain)
             {
@@ -252,8 +247,7 @@ namespace BTCPayServer.Services.Wallets
 
         public async Task<ReceivedCoin[]> GetUnspentCoins(DerivationStrategyBase derivationStrategy, CancellationToken cancellation = default(CancellationToken))
         {
-            if (derivationStrategy == null)
-                throw new ArgumentNullException(nameof(derivationStrategy));
+            ArgumentNullException.ThrowIfNull(derivationStrategy);
             return (await GetUTXOChanges(derivationStrategy, cancellation))
                           .GetUnspentUTXOs()
                           .Select(c => new ReceivedCoin()

--- a/BTCPayServer/Services/Wallets/BTCPayWalletProvider.cs
+++ b/BTCPayServer/Services/Wallets/BTCPayWalletProvider.cs
@@ -20,8 +20,7 @@ namespace BTCPayServer.Services.Wallets
                                     BTCPayNetworkProvider networkProvider,
                                     Logs logs)
         {
-            if (client == null)
-                throw new ArgumentNullException(nameof(client));
+            ArgumentNullException.ThrowIfNull(client);
             this.Logs = logs;
             _Client = client;
             _NetworkProvider = networkProvider;
@@ -40,14 +39,12 @@ namespace BTCPayServer.Services.Wallets
 
         public BTCPayWallet GetWallet(BTCPayNetworkBase network)
         {
-            if (network == null)
-                throw new ArgumentNullException(nameof(network));
+            ArgumentNullException.ThrowIfNull(network);
             return GetWallet(network.CryptoCode);
         }
         public BTCPayWallet GetWallet(string cryptoCode)
         {
-            if (cryptoCode == null)
-                throw new ArgumentNullException(nameof(cryptoCode));
+            ArgumentNullException.ThrowIfNull(cryptoCode);
             _Wallets.TryGetValue(cryptoCode.ToUpperInvariant(), out var result);
             return result;
         }

--- a/BTCPayServer/WalletId.cs
+++ b/BTCPayServer/WalletId.cs
@@ -9,8 +9,7 @@ namespace BTCPayServer
         static readonly Regex _WalletStoreRegex = new Regex("^S-([a-zA-Z0-9]{30,60})-([a-zA-Z]{2,5})$");
         public static bool TryParse(string str, out WalletId walletId)
         {
-            if (str == null)
-                throw new ArgumentNullException(nameof(str));
+            ArgumentNullException.ThrowIfNull(str);
             walletId = null;
             WalletId w = new WalletId();
             var match = _WalletStoreRegex.Match(str);


### PR DESCRIPTION
The diff is large, but it can be reproduced by using this regex/replace in VS.

Regex: `\n(\s*)if\s?\((.*) (==|is) null\s?\)\s*\n\s*throw new ArgumentNullException\(nameof\(.*\)\);`
Replace `\n$1ArgumentNullException.ThrowIfNull($2);`

We can't do on the `BTCPayServer.Client` library because it is not net6.0 only.