### PR TITLE
Fix VSCode launch.json for .NET 6

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,7 +10,7 @@
             "request": "launch",
             "preLaunchTask": "build",
             // If you have changed target frameworks, make sure to update the program path.
-            "program": "${workspaceFolder}/BTCPayServer/bin/Debug/netcoreapp3.1/BTCPayServer.dll",
+            "program": "${workspaceFolder}/BTCPayServer/bin/Debug/net6.0/BTCPayServer.dll",
             "args": [],
             "cwd": "${workspaceFolder}/BTCPayServer",
             "stopAtEntry": false,


### PR DESCRIPTION
BTCPay doesn't launch anymore in VSCode since the .NET 6 upgrade. This PR fixes the issue by updating the reference to the DLL in `launch.json` file.