### PR TITLE
Fixed LND admin macaroon hexdump command

### DIFF
--- a/BTCPayServer/Views/Stores/SetupLightningNode.cshtml
+++ b/BTCPayServer/Views/Stores/SetupLightningNode.cshtml
@@ -174,7 +174,7 @@
                                 The path to the LND data directory may vary, the following examples assume <code>/root/.lnd</code>.
                             </p>
                             <p class="mb-2">The <code>macaroon</code> parameter expects the HEX value, it can be obtained using this command:</p>
-                            <pre class="mb-4">xxd -plain /root/.lnd/data/chain/bitcoin/mainnet/admin.macaroon | tr -d '\n'</pre>
+                            <pre class="mb-4">xxd -p -c 256 /root/.lnd/data/chain/bitcoin/mainnet/admin.macaroon | tr -d '\n'</pre>
                             <p class="mb-2">
                                 You can omit <code>certthumbprint</code> if the certificate is trusted by your machine.<br/>
                                 The <code>certthumbprint</code> can be obtained using this command:


### PR DESCRIPTION
Argument `-plain` didn't work for me in the LND container, but `-p` did. 
The error I got was `xxd: invalid number 'ain'`

Added the `-c 256` for better readability. This param maxes out at 256.