### PR TITLE
Remove remaining "Back to list" CTAs

### DIFF
--- a/BTCPayServer/Views/Apps/CreateApp.cshtml
+++ b/BTCPayServer/Views/Apps/CreateApp.cshtml
@@ -26,7 +26,6 @@
             </div>
             <div class="form-group mt-4">
                 <input type="submit" value="Create" class="btn btn-primary" id="Create" />
-                <a asp-action="ListApps" asp-route-storeId="@Context.GetStoreData().Id" class="btn btn-link px-0 ms-3">Back to list</a>
             </div>
         </form>
     </div>

--- a/BTCPayServer/Views/Invoice/CreateInvoice.cshtml
+++ b/BTCPayServer/Views/Invoice/CreateInvoice.cshtml
@@ -148,7 +148,6 @@
             
             <div class="form-group mt-4">
                 <input type="submit" value="Create" class="btn btn-primary" id="Create" />
-                <a asp-action="ListInvoices" class="btn btn-link px-0 ms-3">Back to list</a>
             </div>
         </form>
     </div>


### PR DESCRIPTION
Trying to help clean up the content section of the app while @dennisreimann does the real heavy lifting.

Removes obsolete "back to list" CTAs on the create views not caught in my other two PRs:
- Invoices
- Apps

Caught the Payment Request one in the other open PR.

@dennisreimann This doesn't include the one you removed in Create Store view.