### PR TITLE
Fix CookieAuthHandler and guest permission to invoice's view

### DIFF
--- a/BTCPayServer.Tests/Extensions.cs
+++ b/BTCPayServer.Tests/Extensions.cs
@@ -28,10 +28,13 @@ namespace BTCPayServer.Tests
 
         public static void AssertNoError(this IWebDriver driver)
         {
-            if (!driver.PageSource.Contains("alert-danger"))
-                return;
-            foreach (var dangerAlert in driver.FindElements(By.ClassName("alert-danger")))
-                Assert.False(dangerAlert.Displayed, $"No alert should be displayed, but found this on {driver.Url}: {dangerAlert.Text}");
+            if (driver.PageSource.Contains("alert-danger"))
+            {
+                foreach (var dangerAlert in driver.FindElements(By.ClassName("alert-danger")))
+                    Assert.False(dangerAlert.Displayed, $"No alert should be displayed, but found this on {driver.Url}: {dangerAlert.Text}");
+            }
+            Assert.DoesNotContain("Access denied</h", driver.PageSource);
+            Assert.DoesNotContain("Page not found</h", driver.PageSource);
         }
 
         public static T AssertViewModel<T>(this IActionResult result)

--- a/BTCPayServer/Controllers/InvoiceController.UI.cs
+++ b/BTCPayServer/Controllers/InvoiceController.UI.cs
@@ -81,7 +81,7 @@ namespace BTCPayServer.Controllers
         }
 
         [HttpGet("invoices/{invoiceId}")]
-        [Authorize(Policy = Policies.CanModifyStoreSettings, AuthenticationSchemes = AuthenticationSchemes.Cookie)]
+        [Authorize(Policy = Policies.CanViewStoreSettings, AuthenticationSchemes = AuthenticationSchemes.Cookie)]
         public async Task<IActionResult> Invoice(string invoiceId)
         {
             var invoice = (await _InvoiceRepository.GetInvoices(new InvoiceQuery()

--- a/BTCPayServer/Security/CookieAuthorizationHandler.cs
+++ b/BTCPayServer/Security/CookieAuthorizationHandler.cs
@@ -68,13 +68,12 @@ namespace BTCPayServer.Security
             if (routeData != null)
             {
                 // resolve from app
-                if (routeData.Values.TryGetValue("appId", out var vAppId))
+                if (routeData.Values.TryGetValue("appId", out var vAppId) && vAppId is string appId)
                 {
-                    string appId = vAppId as string;
                     app = await _appService.GetAppDataIfOwner(userId, appId);
                     if (storeId == null)
                     {
-                        storeId = app?.StoreDataId;
+                        storeId = app?.StoreDataId ?? String.Empty;
                     }
                     else if (app?.StoreDataId != storeId)
                     {
@@ -82,13 +81,12 @@ namespace BTCPayServer.Security
                     }
                 }
                 // resolve from payment request
-                if (routeData.Values.TryGetValue("payReqId", out var vPayReqId))
+                if (routeData.Values.TryGetValue("payReqId", out var vPayReqId) && vPayReqId is string payReqId)
                 {
-                    string payReqId = vPayReqId as string;
                     paymentRequest = await _paymentRequestRepository.FindPaymentRequest(payReqId, userId);
                     if (storeId == null)
                     {
-                        storeId = paymentRequest?.StoreDataId;
+                        storeId = paymentRequest?.StoreDataId ?? String.Empty;
                     }
                     else if (paymentRequest?.StoreDataId != storeId)
                     {
@@ -96,13 +94,12 @@ namespace BTCPayServer.Security
                     }
                 }
                 // resolve from invoice
-                if (routeData.Values.TryGetValue("invoiceId", out var vInvoiceId))
+                if (routeData.Values.TryGetValue("invoiceId", out var vInvoiceId) && vInvoiceId is string invoiceId)
                 {
-                    string invoiceId = vInvoiceId as string;
                     invoice = await _invoiceRepository.GetInvoice(invoiceId);
                     if (storeId == null)
                     {
-                        storeId = invoice?.StoreId;
+                        storeId = invoice?.StoreId ?? String.Empty;
                     }
                     else if (invoice?.StoreId != storeId)
                     {
@@ -117,6 +114,8 @@ namespace BTCPayServer.Security
                 storeId = _httpContext.GetUserPrefsCookie()?.CurrentStoreId;
             }
 
+            if (string.IsNullOrEmpty(storeId))
+                storeId = null;
             if (storeId != null)
             {
                 store = await _storeRepository.FindStore(storeId, userId);


### PR DESCRIPTION
There was a vulnerability introduced on master.

One could bypass authorizations by providing an `invoiceId` that doesn't exists, but an authorized `storeId` in the pref cookie.
In such case, rather than sending an authorization error, we would just execute the action.
Unsure if it was exploitable or not, since the invoiceId and invoice context wouldn't be set, but I fixed it.

There was also a bug introduced, where a guest to the store can't see the invoice's page.
I was surprised the tests didn't catch this bug, and this was because the `AssertNoError` didn't make sure we weren't on some error 404 or permission error page.

@dennisreimann 