### PR TITLE
Simple Lightning Node Selector Improvement

### DIFF
--- a/BTCPayServer/Views/Stores/SetupLightningNode.cshtml
+++ b/BTCPayServer/Views/Stores/SetupLightningNode.cshtml
@@ -53,6 +53,11 @@
             color: var(--btcpay-secondary);
             opacity: .5;
         }
+        
+        #LightningNodeTypeTablist label + input + label {
+            margin-left: var(--btcpay-space-m);
+        }
+        
         #LightningNodeTypeTabs ul {
             list-style: none;
             padding-left: 0;
@@ -75,7 +80,7 @@
         <label asp-for="LightningNodeType" for="@($"LightningNodeType-{LightningNodeType.Internal}")">Use internal node</label>
         
         <input asp-for="LightningNodeType" value="@LightningNodeType.Custom" type="radio" id="LightningNodeType-@LightningNodeType.Custom" data-bs-toggle="pill" data-bs-target="#CustomSetup" role="tab" aria-controls="CustomSetup" aria-selected="@(Model.LightningNodeType == LightningNodeType.Custom ? "true" : "false")">
-        <label class="ms-3" asp-for="LightningNodeType" for="@($"LightningNodeType-{LightningNodeType.Custom}")">Use custom node</label>
+        <label asp-for="LightningNodeType" for="@($"LightningNodeType-{LightningNodeType.Custom}")">Use custom node</label>
 
         <vc:ui-extension-point location="ln-payment-method-setup-tabhead" model="@Model"/>
     </div>

--- a/BTCPayServer/Views/Stores/SetupLightningNode.cshtml
+++ b/BTCPayServer/Views/Stores/SetupLightningNode.cshtml
@@ -35,9 +35,14 @@
             display: inline-block;
             padding: .75rem 2rem;
             color: var(--btcpay-primary);
-            font-weight:  var(--btcpay-font-weight-semibold);
+            font-weight: var(--btcpay-font-weight-semibold);
             border-radius: 1.5rem;
+            border: 1px solid var(--btcpay-secondary-border);
             cursor: pointer;
+            transition: color 0.15s ease-in-out, background-color 0.15s ease-in-out, border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
+        }
+        #LightningNodeTypeTablist label:hover {
+            border-color: var(--btcpay-secondary-border-hover);
         }
         #LightningNodeTypeTablist input[disabled]:checked + label {
             background: var(--btcpay-secondary);
@@ -70,7 +75,7 @@
         <label asp-for="LightningNodeType" for="@($"LightningNodeType-{LightningNodeType.Internal}")">Use internal node</label>
         
         <input asp-for="LightningNodeType" value="@LightningNodeType.Custom" type="radio" id="LightningNodeType-@LightningNodeType.Custom" data-bs-toggle="pill" data-bs-target="#CustomSetup" role="tab" aria-controls="CustomSetup" aria-selected="@(Model.LightningNodeType == LightningNodeType.Custom ? "true" : "false")">
-        <label asp-for="LightningNodeType" for="@($"LightningNodeType-{LightningNodeType.Custom}")">Use custom node</label>
+        <label class="ms-3" asp-for="LightningNodeType" for="@($"LightningNodeType-{LightningNodeType.Custom}")">Use custom node</label>
 
         <vc:ui-extension-point location="ln-payment-method-setup-tabhead" model="@Model"/>
     </div>


### PR DESCRIPTION
Never liked how it was just simple text only for the unselected tab, and we didn't create a custom component for this, so I thought the rounded tabs could be an effective method for the time being.

Will likely carry this out to the payouts view as well, but we might want to separate the CSS.

cc @dennisreimann This might be a component we'll want to create for the future when we shift our focus to the design system work.

The secondary vs. primary text color bothers me a bit on this screen as well, but I left it alone, feels like the current secondary text (top) should be white as well...?

Sidenote: Going to try to document which type of component should be used in each situation, e.g. (button, rounded tab, line tabbed, etc..). In the meantime, trying to make sure it's at least consistent.

<img width="1054" alt="Screen Shot 2022-01-09 at 3 04 40 AM" src="https://user-images.githubusercontent.com/6250771/148679613-c202b998-989d-4dfb-97a8-592bde8395cb.png">
