### PR TITLE
[Greenfield] if some json property are invalid, throw nice error instead of an exception (Fix #2795)

### DIFF
--- a/BTCPayServer.Client/BTCPayServerClient.cs
+++ b/BTCPayServer.Client/BTCPayServerClient.cs
@@ -18,7 +18,6 @@ namespace BTCPayServer.Client
         private readonly string _username;
         private readonly string _password;
         private readonly HttpClient _httpClient;
-
         public Uri Host => _btcpayHost;
 
         public string APIKey => _apiKey;
@@ -82,6 +81,13 @@ namespace BTCPayServer.Client
             HttpMethod method = null, CancellationToken cancellationToken = default)
         {
             using var resp = await _httpClient.SendAsync(CreateHttpRequest(path, queryPayload, method), cancellationToken);
+            return await HandleResponse<T>(resp);
+        }
+        public async Task<T> SendHttpRequest<T>(string path,
+        object bodyPayload = null,
+        HttpMethod method = null, CancellationToken cancellationToken = default)
+        {
+            using var resp = await _httpClient.SendAsync(CreateHttpRequest(path: path, bodyPayload: bodyPayload, method: method), cancellationToken);
             return await HandleResponse<T>(resp);
         }
         protected virtual HttpRequestMessage CreateHttpRequest(string path,

--- a/BTCPayServer.Tests/GreenfieldAPITests.cs
+++ b/BTCPayServer.Tests/GreenfieldAPITests.cs
@@ -1592,6 +1592,9 @@ namespace BTCPayServer.Tests
             Assert.Equal(firstAddress, (await viewOnlyClient.PreviewProposedStoreOnChainPaymentMethodAddresses(store.Id, "BTC",
                 new UpdateOnChainPaymentMethodRequest() { Enabled = true, DerivationScheme = xpub })).Addresses.First().Address);
 
+            await AssertValidationError(new[] { "accountKeyPath" }, () => viewOnlyClient.SendHttpRequest<GreenfieldValidationError[]>(path: $"api/v1/stores/{store.Id}/payment-methods/Onchain/BTC/preview", method: HttpMethod.Post,
+                                                                          bodyPayload: JObject.Parse("{\"accountKeyPath\": \"0/1\"}")));
+
             var method = await client.UpdateStoreOnChainPaymentMethod(store.Id, "BTC",
                 new UpdateOnChainPaymentMethodRequest() { Enabled = true, DerivationScheme = xpub });
 

--- a/BTCPayServer/Filters/JsonObjectExceptionFilter.cs
+++ b/BTCPayServer/Filters/JsonObjectExceptionFilter.cs
@@ -14,7 +14,7 @@ namespace BTCPayServer.Filters
         {
             if (context.Exception is NBitcoin.JsonConverters.JsonObjectException jsonObject)
             {
-                context.Result = new ObjectResult(new GreenfieldValidationError(jsonObject.Path, jsonObject.Message)) { StatusCode = 400 };
+                context.Result = new ObjectResult(new[] { new GreenfieldValidationError(jsonObject.Path, jsonObject.Message) }) { StatusCode = 422 };
                 context.ExceptionHandled = true;
             }
         }

--- a/BTCPayServer/Hosting/Startup.cs
+++ b/BTCPayServer/Hosting/Startup.cs
@@ -122,6 +122,7 @@ namespace BTCPayServer.Hosting
                  if (!Configuration.GetOrDefault<bool>("nocsp", false))
                      o.Filters.Add(new ContentSecurityPolicyAttribute(CSPTemplate.AntiXSS));
                  o.Filters.Add(new JsonHttpExceptionFilter());
+                 o.Filters.Add(new JsonObjectExceptionFilter());
              })
             .ConfigureApiBehaviorOptions(options =>
             {

--- a/BTCPayServer/wwwroot/swagger/v1/swagger.template.stores-payment-methods.on-chain.json
+++ b/BTCPayServer/wwwroot/swagger/v1/swagger.template.stores-payment-methods.on-chain.json
@@ -360,13 +360,20 @@
                     }
                 ],
                 "description": "View addresses of a proposed payment method of the store",
-                "operationId": "StoreOnChainPaymentMethods_GetOnChainPaymentMethodPreview",
+                "operationId": "StoreOnChainPaymentMethods_POSTOnChainPaymentMethodPreview",
                 "requestBody": {
                     "x-name": "request",
                     "content": {
                         "application/json": {
                             "schema": {
-                                "$ref": "#/components/schemas/OnChainPaymentMethodDataPreview"
+                                "type": "object",
+                                "properties": {
+                                    "derivationScheme": {
+                                        "type": "string",
+                                        "description": "The derivation scheme",
+                                        "example": "xpub..."
+                                    }
+                                }
                             }
                         }
                     },


### PR DESCRIPTION
Fix https://github.com/btcpayserver/btcpayserver/issues/2795

I also fixed the documentation, where we document properties that aren't needed for the POST preview addresses.
I didn't change the method as it is more work to do and I'm lazy, and I use this to test whether not failing to parse a json property show a nice error message.