### PR TITLE
[Greenfield] Fix create/update payment requests expiry field and allow null currency field (Fix #3222)

### DIFF
--- a/BTCPayServer.Client/Models/PaymentRequestBaseData.cs
+++ b/BTCPayServer.Client/Models/PaymentRequestBaseData.cs
@@ -12,7 +12,8 @@ namespace BTCPayServer.Client.Models
         [JsonProperty(ItemConverterType = typeof(NumericStringJsonConverter))]
         public decimal Amount { get; set; }
         public string Currency { get; set; }
-        public DateTime? ExpiryDate { get; set; }
+        [JsonConverter(typeof(NBitcoin.JsonConverters.DateTimeToUnixTimeConverter))]
+        public DateTimeOffset? ExpiryDate { get; set; }
         public string Title { get; set; }
         public string Description { get; set; }
         public string Email { get; set; }

--- a/BTCPayServer.Tests/GreenfieldAPITests.cs
+++ b/BTCPayServer.Tests/GreenfieldAPITests.cs
@@ -905,7 +905,7 @@ namespace BTCPayServer.Tests
                 //create payment request
 
                 //validation errors
-                await AssertValidationError(new[] { "Amount", "Currency" }, async () =>
+                await AssertValidationError(new[] { "Amount" }, async () =>
                 {
                     await client.CreatePaymentRequest(user.StoreId, new CreatePaymentRequestRequest() { Title = "A" });
                 });

--- a/BTCPayServer/Controllers/GreenField/PaymentRequestsController.cs
+++ b/BTCPayServer/Controllers/GreenField/PaymentRequestsController.cs
@@ -84,7 +84,7 @@ namespace BTCPayServer.Controllers.GreenField
             {
                 return validationResult;
             }
-
+            request.Currency ??= StoreData.GetStoreBlob().DefaultCurrency;
             var pr = new PaymentRequestData()
             {
                 StoreDataId = storeId,
@@ -95,7 +95,7 @@ namespace BTCPayServer.Controllers.GreenField
             pr = await _paymentRequestRepository.CreateOrUpdatePaymentRequest(pr);
             return Ok(FromModel(pr));
         }
-
+        public Data.StoreData StoreData => HttpContext.GetStoreData();
         [HttpPut("~/api/v1/stores/{storeId}/payment-requests/{paymentRequestId}")]
         [Authorize(Policy = Policies.CanModifyPaymentRequests,
             AuthenticationSchemes = AuthenticationSchemes.Greenfield)]
@@ -107,7 +107,7 @@ namespace BTCPayServer.Controllers.GreenField
             {
                 return validationResult;
             }
-
+            request.Currency ??= StoreData.GetStoreBlob().DefaultCurrency;
             var pr = await _paymentRequestRepository.FindPaymentRequests(
                 new PaymentRequestQuery() { StoreId = storeId, Ids = new[] { paymentRequestId } });
             if (pr.Total == 0)
@@ -130,10 +130,11 @@ namespace BTCPayServer.Controllers.GreenField
                 ModelState.AddModelError(nameof(data.Amount), "Please provide an amount greater than 0");
             }
 
-            if (string.IsNullOrEmpty(data.Currency) ||
+            if (!string.IsNullOrEmpty(data.Currency) &&
                 _currencyNameTable.GetCurrencyData(data.Currency, false) == null)
                 ModelState.AddModelError(nameof(data.Currency), "Invalid currency");
-
+            if (string.IsNullOrEmpty(data.Currency))
+                data.Currency = null;
             if (string.IsNullOrEmpty(data.Title))
                 ModelState.AddModelError(nameof(data.Title), "Title is required");
 

--- a/BTCPayServer/Controllers/PaymentRequestController.cs
+++ b/BTCPayServer/Controllers/PaymentRequestController.cs
@@ -97,10 +97,11 @@ namespace BTCPayServer.Controllers
         [HttpPost("/stores/{storeId}/payment-requests/edit/{payReqId?}")]
         public async Task<IActionResult> EditPaymentRequest(string payReqId, UpdatePaymentRequestViewModel viewModel)
         {
-            if (string.IsNullOrEmpty(viewModel.Currency) ||
+            if (!string.IsNullOrEmpty(viewModel.Currency) &&
                 _Currencies.GetCurrencyData(viewModel.Currency, false) == null)
                 ModelState.AddModelError(nameof(viewModel.Currency), "Invalid currency");
-
+            if (string.IsNullOrEmpty(viewModel.Currency))
+                viewModel.Currency = null;
             var store = GetCurrentStore();
             var paymentRequest = GetCurrentPaymentRequest();
             if (paymentRequest == null && !string.IsNullOrEmpty(payReqId))
@@ -128,7 +129,7 @@ namespace BTCPayServer.Controllers
             blob.Description = viewModel.Description;
             blob.Amount = viewModel.Amount;
             blob.ExpiryDate = viewModel.ExpiryDate?.ToUniversalTime();
-            blob.Currency = viewModel.Currency;
+            blob.Currency = viewModel.Currency ?? store.GetStoreBlob().DefaultCurrency;
             blob.EmbeddedCSS = viewModel.EmbeddedCSS;
             blob.CustomCSSLink = viewModel.CustomCSSLink;
             blob.AllowCustomPaymentAmounts = viewModel.AllowCustomPaymentAmounts;

--- a/BTCPayServer/Models/PaymentRequestViewModels/ListPaymentRequestsViewModel.cs
+++ b/BTCPayServer/Models/PaymentRequestViewModels/ListPaymentRequestsViewModel.cs
@@ -36,7 +36,7 @@ namespace BTCPayServer.Models.PaymentRequestViewModels
             Amount = blob.Amount;
             Currency = blob.Currency;
             Description = blob.Description;
-            ExpiryDate = blob.ExpiryDate;
+            ExpiryDate = blob.ExpiryDate?.UtcDateTime;
             Email = blob.Email;
             CustomCSSLink = blob.CustomCSSLink;
             EmbeddedCSS = blob.EmbeddedCSS;
@@ -88,7 +88,7 @@ namespace BTCPayServer.Models.PaymentRequestViewModels
             Amount = blob.Amount;
             Currency = blob.Currency;
             Description = blob.Description;
-            ExpiryDate = blob.ExpiryDate;
+            ExpiryDate = blob.ExpiryDate?.UtcDateTime;
             Email = blob.Email;
             EmbeddedCSS = blob.EmbeddedCSS;
             CustomCSSLink = blob.CustomCSSLink;

--- a/BTCPayServer/PaymentRequest/PaymentRequestHub.cs
+++ b/BTCPayServer/PaymentRequest/PaymentRequestHub.cs
@@ -182,7 +182,7 @@ namespace BTCPayServer.PaymentRequest
                 {
                     QueueExpiryTask(
                         updated.PaymentRequestId,
-                        expiry.Value,
+                        expiry.Value.UtcDateTime,
                         cancellationToken);
                 }
             }

--- a/BTCPayServer/Views/PaymentRequest/EditPaymentRequest.cshtml
+++ b/BTCPayServer/Views/PaymentRequest/EditPaymentRequest.cshtml
@@ -31,8 +31,8 @@
                 <span asp-validation-for="Amount" class="text-danger"></span>
             </div>
             <div class="form-group">
-                <label asp-for="Currency" class="form-label" data-required></label>
-                <input asp-for="Currency" class="form-control" required />
+                <label asp-for="Currency" class="form-label"></label>
+                <input asp-for="Currency" class="form-control" />
                 <span asp-validation-for="Currency" class="text-danger"></span>
             </div>
 


### PR DESCRIPTION
The expiry field wasn't using the proper jsonconverter.
On top of it, we required the `currency` property to be set, but an empty currency (store's default) should be allowed.

I also updated the edit payment request page to not require the currency.

Fix #3222