### PR TITLE
[Greenfield] Let non-admin update LN payment method with internal node if it is unchanged (Fix #2860)

### DIFF
--- a/BTCPayServer.Tests/TestAccount.cs
+++ b/BTCPayServer.Tests/TestAccount.cs
@@ -526,5 +526,10 @@ retry:
             var repo = this.parent.PayTester.GetService<StoreRepository>();
             await repo.AddStoreUser(StoreId, userId, "Guest");
         }
+        public async Task AddOwner(string userId)
+        {
+            var repo = this.parent.PayTester.GetService<StoreRepository>();
+            await repo.AddStoreUser(StoreId, userId, "Owner");
+        }
     }
 }


### PR DESCRIPTION
Fix https://github.com/btcpayserver/btcpayserver/issues/2860

I also changed the error to a proper missing permission error if non admin attempt to change the connection string to internal node.