### PR TITLE
Do not send email twice for bitpay API, log whether IPN is an ExtendedNotification. (Fix #968)

### DIFF
--- a/BTCPayServer/Events/InvoiceIPNEvent.cs
+++ b/BTCPayServer/Events/InvoiceIPNEvent.cs
@@ -2,16 +2,17 @@ namespace BTCPayServer.Events
 {
     public class InvoiceIPNEvent : IHasInvoiceId
     {
-        public InvoiceIPNEvent(string invoiceId, int? eventCode, string name)
+        public InvoiceIPNEvent(string invoiceId, int? eventCode, string name, bool extendedNotification)
         {
             InvoiceId = invoiceId;
             EventCode = eventCode;
             Name = name;
+            ExtendedNotification = extendedNotification;
         }
 
         public int? EventCode { get; set; }
         public string Name { get; set; }
-
+        public bool ExtendedNotification { get; }
         public string InvoiceId { get; set; }
         public string Error { get; set; }
 
@@ -20,7 +21,17 @@ namespace BTCPayServer.Events
             string ipnType = "IPN";
             if (EventCode.HasValue)
             {
-                ipnType = $"IPN ({EventCode.Value} {Name})";
+                string suffix = string.Empty;
+                if (ExtendedNotification)
+                    suffix = " ExtendedNotification";
+                ipnType = $"IPN ({EventCode.Value} {Name}{suffix})";
+            }
+            else
+            {
+                string suffix = string.Empty;
+                if (ExtendedNotification)
+                    suffix = " (ExtendedNotification)";
+                ipnType += suffix;
             }
             if (Error == null)
                 return $"{ipnType} sent for invoice {InvoiceId}";


### PR DESCRIPTION
Fix https://github.com/btcpayserver/btcpayserver/issues/968

Emails were sent twice because IPN for an event can fire twice if `ExtendedNotification` and `FullNotification` are `true`.
On top of this, since it was confusing for some people to have two IPN for same event, I decided to show in the invoice logs whether the IPN is the extended one or not.

This will prevent people filling issues and us further losing time on this deprecated API.

Last, I removed a confusing piece of code in the `BitpayIPNSender` which was meant to send events one after another to the server.
However, now we use the `MultiProcessingQueue`, this is redundant.