### PR TITLE
Adjust VSCode browser launch regex

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -17,7 +17,7 @@
             // Enable launching a web browser when ASP.NET Core starts. For more information: https://aka.ms/VSCode-CS-LaunchJson-WebBrowser
             "serverReadyAction": {
                 "action": "openExternally",
-                "pattern": "\\bListening on\\s+(https?://\\S+)"
+                "pattern": "\\bNow listening on:\\s+(https?://\\S+)"
             },
             "env": {
                 "ASPNETCORE_ENVIRONMENT": "Development"


### PR DESCRIPTION
VSCode stopped launching BTCPay in a new browser tab after this commit: https://github.com/btcpayserver/btcpayserver/commit/ab3aab9c226fee9df9065f23333ffccbadae70ea#diff-2baea61aec1a18e36f951b0060f693c9bd10d9610e2681d36277e79d101005bcR66

This is because the log message was updated and VSCode relies on the regex in `launch.json` to open the browser. This PR updates the regex to match the new log message which was introduced in the above commit.