### PR TITLE
Remove right to admins to bypass permissions to modify/view invoices or stores

### DIFF
--- a/BTCPayServer/Security/CookieAuthorizationHandler.cs
+++ b/BTCPayServer/Security/CookieAuthorizationHandler.cs
@@ -127,20 +127,14 @@ namespace BTCPayServer.Security
                     if (isAdmin)
                         success = true;
                     break;
-                case Policies.CanViewInvoices:
-                    if (store == null || store.Role == StoreRoles.Owner || isAdmin)
-                        success = true;
-                    break;
                 case Policies.CanModifyStoreSettings:
-                    if (store != null && (store.Role == StoreRoles.Owner || isAdmin))
+                    if (store != null && (store.Role == StoreRoles.Owner))
                         success = true;
                     break;
+                case Policies.CanViewInvoices:
                 case Policies.CanViewStoreSettings:
-                    if (store != null || isAdmin)
-                        success = true;
-                    break;
                 case Policies.CanCreateInvoice:
-                    if (store != null || isAdmin)
+                    if (store != null)
                         success = true;
                     break;
                 case Policies.CanViewProfile:


### PR DESCRIPTION
I did that long ago, but I doubt anybody is using it, and I fear that the fact nobody know it exists, we might end up in a situation where a selenium test work (or doesn't work) just because of this hidden feature.