### PR TITLE
Home sweet home

### DIFF
--- a/BTCPayServer.Tests/Extensions.cs
+++ b/BTCPayServer.Tests/Extensions.cs
@@ -23,7 +23,6 @@ namespace BTCPayServer.Tests
             s.Driver.FindElement(By.Id("Email")).SendKeys(email);
             s.Driver.FindElement(By.Id("Password")).SendKeys("123456");
             s.Driver.FindElement(By.Id("LoginButton")).Click();
-            s.Driver.AssertNoError();
         }
 
         public static void AssertNoError(this IWebDriver driver)

--- a/BTCPayServer.Tests/Extensions.cs
+++ b/BTCPayServer.Tests/Extensions.cs
@@ -23,6 +23,7 @@ namespace BTCPayServer.Tests
             s.Driver.FindElement(By.Id("Email")).SendKeys(email);
             s.Driver.FindElement(By.Id("Password")).SendKeys("123456");
             s.Driver.FindElement(By.Id("LoginButton")).Click();
+            s.Driver.AssertNoError();
         }
 
         public static void AssertNoError(this IWebDriver driver)

--- a/BTCPayServer.Tests/SeleniumTests.cs
+++ b/BTCPayServer.Tests/SeleniumTests.cs
@@ -382,11 +382,14 @@ namespace BTCPayServer.Tests
             s.Driver.FindElement(By.Id("SetupGuide-Store")).Click();
             Assert.Contains("/stores/create", s.Driver.Url);
 
-            s.CreateNewStore();
+            (_, string storeId) = s.CreateNewStore();
+            
+            // should redirect to store
             s.GoToUrl("/");
 
+            Assert.Contains($"/stores/{storeId}", s.Driver.Url);
             Assert.True(s.Driver.PageSource.Contains("id=\"StoreSelectorDropdown\""), "Store selector dropdown should be present");
-            Assert.False(s.Driver.PageSource.Contains("id=\"SetupGuide\""), "Setup guide should not be present");
+            Assert.True(s.Driver.PageSource.Contains("id=\"SetupGuide\""), "Store setup guide should be present");
         }
 
         [Fact(Timeout = TestTimeout)]
@@ -503,6 +506,7 @@ namespace BTCPayServer.Tests
 
             // Let's add Bob as a guest to alice's store
             s.LogIn(alice);
+            s.Driver.AssertNoError();
             s.GoToUrl(storeUrl + "/users");
             s.Driver.FindElement(By.Id("Email")).SendKeys(bob + Keys.Enter);
             Assert.Contains("User added successfully", s.Driver.PageSource);
@@ -518,6 +522,7 @@ namespace BTCPayServer.Tests
             // Alice should be able to delete the store
             s.Logout();
             s.LogIn(alice);
+            s.Driver.AssertNoError();
             s.GoToStore(StoreNavPages.GeneralSettings);
             s.Driver.FindElement(By.Id("DeleteStore")).Click();
             s.Driver.WaitForElement(By.Id("ConfirmInput")).SendKeys("DELETE");

--- a/BTCPayServer.Tests/SeleniumTests.cs
+++ b/BTCPayServer.Tests/SeleniumTests.cs
@@ -506,7 +506,6 @@ namespace BTCPayServer.Tests
 
             // Let's add Bob as a guest to alice's store
             s.LogIn(alice);
-            s.Driver.AssertNoError();
             s.GoToUrl(storeUrl + "/users");
             s.Driver.FindElement(By.Id("Email")).SendKeys(bob + Keys.Enter);
             Assert.Contains("User added successfully", s.Driver.PageSource);
@@ -522,7 +521,6 @@ namespace BTCPayServer.Tests
             // Alice should be able to delete the store
             s.Logout();
             s.LogIn(alice);
-            s.Driver.AssertNoError();
             s.GoToStore(StoreNavPages.GeneralSettings);
             s.Driver.FindElement(By.Id("DeleteStore")).Click();
             s.Driver.WaitForElement(By.Id("ConfirmInput")).SendKeys("DELETE");

--- a/BTCPayServer/Components/MainNav/Default.cshtml
+++ b/BTCPayServer/Components/MainNav/Default.cshtml
@@ -43,13 +43,13 @@
                         </ul>
                     </div>
                 </div>
-                <div class="accordion-item" permission="@Policies.CanModifyStoreSettings">
-                    <header class="accordion-header" id="Nav-Wallets-Header">
+                <div class="accordion-item">
+                    <header class="accordion-header" id="Nav-Wallets-Header" permission="@Policies.CanModifyStoreSettings">
                         <div class="accordion-button">
                             Wallets
                         </div>
                     </header>
-                    <div id="Nav-Wallets" class="accordion-collapse" aria-labelledby="Nav-Wallets-Header">
+                    <div id="Nav-Wallets" class="accordion-collapse" aria-labelledby="Nav-Wallets-Header" permission="@Policies.CanModifyStoreSettings">
                         <div class="accordion-body">
                             <ul class="navbar-nav">
                                 @foreach (var scheme in Model.DerivationSchemes.OrderBy(scheme => scheme.Collapsed))
@@ -106,7 +106,7 @@
                         <div id="Nav-Payments" class="accordion-collapse collapse show" aria-labelledby="Nav-Payments-Header">
                             <div class="accordion-body">
                                 <ul class="navbar-nav">
-                                    <li class="nav-item" permission="@Policies.CanModifyStoreSettings">
+                                    <li class="nav-item" permission="@Policies.CanViewInvoices">
                                         <a asp-area="" asp-controller="UIInvoice" asp-action="ListInvoices" asp-route-storeId="@Model.Store.Id" class="nav-link js-scroll-trigger @ViewData.IsActiveCategory(typeof(InvoiceNavPages))" id="StoreNav-Invoices">
                                             <vc:icon symbol="invoice"/>
                                             <span>Invoices</span>
@@ -118,13 +118,13 @@
                                             <span>Requests</span>
                                         </a>
                                     </li>
-                                    <li class="nav-item">
+                                    <li class="nav-item" permission="@Policies.CanViewStoreSettings">
                                         <a asp-area="" asp-controller="UIStorePullPayments" asp-action="PullPayments" asp-route-storeId="@Model.Store.Id" class="nav-link @ViewData.IsActivePage(StoreNavPages.PullPayments)" id="StoreNav-PullPayments">
                                             <vc:icon symbol="payment-2"/>
                                             <span>Pull Payments</span>
                                         </a>
                                     </li>
-                                    <li class="nav-item">
+                                    <li class="nav-item" permission="@Policies.CanViewStoreSettings">
                                         <a asp-area="" asp-controller="UIStorePullPayments" asp-action="Payouts" asp-route-storeId="@Model.Store.Id" class="nav-link @ViewData.IsActivePage(StoreNavPages.Payouts)" id="StoreNav-Payouts">
                                             <vc:icon symbol="payment-2"/>
                                             <span>Payouts</span>

--- a/BTCPayServer/Components/StoreSelector/Default.cshtml
+++ b/BTCPayServer/Components/StoreSelector/Default.cshtml
@@ -1,5 +1,29 @@
+@inject BTCPayServer.Services.BTCPayServerEnvironment _env
+@inject SignInManager<ApplicationUser> _signInManager
 @model BTCPayServer.Components.StoreSelector.StoreSelectorViewModel
 @addTagHelper *, BundlerMinifier.TagHelpers
+
+@functions {
+    @* ReSharper disable once CSharpWarnings::CS1998 *@
+    private async Task LogoContent()
+    {
+        var logoSrc = $"{ViewContext.HttpContext.Request.PathBase}/img/logo.svg";
+        <svg xmlns="http://www.w3.org/2000/svg" role="img" alt="BTCPay Server" class="logo"><use href="@logoSrc#small" class="logo-small" /><use href="@logoSrc#large" class="logo-large" /></svg>
+        @if (_env.NetworkType != NBitcoin.ChainName.Mainnet)
+        {
+            <span class="badge bg-warning ms-1 ms-sm-0" style="font-size:10px;">@_env.NetworkType.ToString()</span>
+        }
+    }
+}
+
+@if (Model.CurrentStoreId == null)
+{
+    <a href="~/" class="navbar-brand py-2 js-scroll-trigger">@{await LogoContent();}</a>
+}
+else
+{
+    <a asp-controller="UIStores" asp-action="Dashboard" asp-route-storeId="@Model.CurrentStoreId" class="navbar-brand py-2 js-scroll-trigger">@{await LogoContent();}</a>
+}
 
 <div id="StoreSelector">
     @if (Model.Options.Count > 0)
@@ -12,11 +36,11 @@
                     <li>
                         @if (option.WalletId != null)
                         {
-                            <a asp-controller="UIWallets" asp-action="WalletTransactions" asp-route-walletId="@option.WalletId" class="dropdown-item@(option.Selected ? " active" : "")" id="StoreSelectorMenuItem-@option.Value">@option.Text</a>
+                            <a asp-controller="UIWallets" asp-action="WalletTransactions" asp-route-walletId="@option.WalletId" class="dropdown-item@(option.Selected ? " active" : "")" id="StoreSelectorMenuItem-@option.Value">@(string.IsNullOrEmpty(option.Text) ? "Unnamed Store" : option.Text)</a>
                         }
                         else
                         {
-                            <a asp-controller="UIStores" asp-action="Dashboard" asp-route-storeId="@option.Value" class="dropdown-item@(option.Selected ? " active" : "")" id="StoreSelectorMenuItem-@option.Value">@option.Text</a>
+                            <a asp-controller="UIStores" asp-action="Dashboard" asp-route-storeId="@option.Value" class="dropdown-item@(option.Selected ? " active" : "")" id="StoreSelectorMenuItem-@option.Value">@(string.IsNullOrEmpty(option.Text) ? "Unnamed Store" : option.Text)</a>
                         }
                     </li>
                 }
@@ -25,7 +49,7 @@
             </ul>
         </div>
     }
-    else
+    else if (_signInManager.IsSignedIn(User))
     {
         <a asp-controller="UIUserStores" asp-action="CreateStore" class="btn btn-primary w-100 rounded-pill" id="StoreSelectorCreate">Create Store</a>
     }

--- a/BTCPayServer/Components/StoreSelector/Default.cshtml
+++ b/BTCPayServer/Components/StoreSelector/Default.cshtml
@@ -14,15 +14,24 @@
             <span class="badge bg-warning ms-1 ms-sm-0" style="font-size:10px;">@_env.NetworkType.ToString()</span>
         }
     }
+
+    private string StoreName(string title)
+    {
+        return string.IsNullOrEmpty(title) ? "Unnamed Store" : title;
+    }
 }
 
 @if (Model.CurrentStoreId == null)
 {
     <a href="~/" class="navbar-brand py-2 js-scroll-trigger">@{await LogoContent();}</a>
 }
-else
+else if (Model.CurrentStoreIsOwner)
 {
     <a asp-controller="UIStores" asp-action="Dashboard" asp-route-storeId="@Model.CurrentStoreId" class="navbar-brand py-2 js-scroll-trigger">@{await LogoContent();}</a>
+}
+else
+{
+    <a asp-controller="UIInvoice" asp-action="ListInvoices" asp-route-storeId="@Model.CurrentStoreId" class="navbar-brand py-2 js-scroll-trigger">@{await LogoContent();}</a>
 }
 
 <div id="StoreSelector">
@@ -34,13 +43,17 @@ else
                 @foreach (var option in Model.Options)
                 {
                     <li>
-                        @if (option.WalletId != null)
+                        @if (option.IsOwner && option.WalletId != null)
                         {
-                            <a asp-controller="UIWallets" asp-action="WalletTransactions" asp-route-walletId="@option.WalletId" class="dropdown-item@(option.Selected ? " active" : "")" id="StoreSelectorMenuItem-@option.Value">@(string.IsNullOrEmpty(option.Text) ? "Unnamed Store" : option.Text)</a>
+                            <a asp-controller="UIWallets" asp-action="WalletTransactions" asp-route-walletId="@option.WalletId" class="dropdown-item@(option.Selected ? " active" : "")" id="StoreSelectorMenuItem-@option.Value">@StoreName(option.Text)</a>
+                        }
+                        else if (option.IsOwner)
+                        {
+                            <a asp-controller="UIStores" asp-action="Dashboard" asp-route-storeId="@option.Value" class="dropdown-item@(option.Selected ? " active" : "")" id="StoreSelectorMenuItem-@option.Value">@StoreName(option.Text)</a>
                         }
                         else
                         {
-                            <a asp-controller="UIStores" asp-action="Dashboard" asp-route-storeId="@option.Value" class="dropdown-item@(option.Selected ? " active" : "")" id="StoreSelectorMenuItem-@option.Value">@(string.IsNullOrEmpty(option.Text) ? "Unnamed Store" : option.Text)</a>
+                            <a asp-controller="UIInvoice" asp-action="ListInvoices" asp-route-storeId="@option.Value" class="dropdown-item@(option.Selected ? " active" : "")" id="StoreSelectorMenuItem-@option.Value">@StoreName(option.Text)</a>
                         }
                     </li>
                 }

--- a/BTCPayServer/Components/StoreSelector/StoreSelector.cs
+++ b/BTCPayServer/Components/StoreSelector/StoreSelector.cs
@@ -43,6 +43,7 @@ namespace BTCPayServer.Components.StoreSelector
                         Text = store.StoreName,
                         Value = store.Id,
                         Selected = store.Id == currentStore?.Id,
+                        IsOwner = store.Role == StoreRoles.Owner,
                         WalletId = walletId
                     };
                 })
@@ -52,7 +53,8 @@ namespace BTCPayServer.Components.StoreSelector
             {
                 Options = options,
                 CurrentStoreId = currentStore?.Id,
-                CurrentDisplayName = currentStore?.StoreName
+                CurrentDisplayName = currentStore?.StoreName,
+                CurrentStoreIsOwner = currentStore?.Role == StoreRoles.Owner
             };
 
             return View(vm);

--- a/BTCPayServer/Components/StoreSelector/StoreSelectorViewModel.cs
+++ b/BTCPayServer/Components/StoreSelector/StoreSelectorViewModel.cs
@@ -7,11 +7,13 @@ namespace BTCPayServer.Components.StoreSelector
         public List<StoreSelectorOption> Options { get; set; }
         public string CurrentStoreId { get; set; }
         public string CurrentDisplayName { get; set; }
+        public bool CurrentStoreIsOwner { get; set; }
     }
 
     public class StoreSelectorOption
     {
         public bool Selected { get; set; }
+        public bool IsOwner { get; set; }
         public string Text { get; set; }
         public string Value { get; set; }
         public WalletId WalletId { get; set; }

--- a/BTCPayServer/Controllers/UIHomeController.cs
+++ b/BTCPayServer/Controllers/UIHomeController.cs
@@ -82,7 +82,9 @@ namespace BTCPayServer.Controllers
                     var store = await _storeRepository.FindStore(storeId, userId);
                     if (store != null)
                     {
-                        return RedirectToAction("Dashboard", "UIStores", new { storeId });
+                        return store.Role == StoreRoles.Owner 
+                            ? RedirectToAction("Dashboard", "UIStores", new { storeId }) 
+                            : RedirectToAction("ListInvoices", "UIInvoice", new { storeId });
                     }
                 }
                 

--- a/BTCPayServer/Controllers/UIHomeController.cs
+++ b/BTCPayServer/Controllers/UIHomeController.cs
@@ -78,14 +78,21 @@ namespace BTCPayServer.Controllers
                 var storeId = HttpContext.GetUserPrefsCookie()?.CurrentStoreId;
                 if (storeId != null)
                 {
+                    // verify store exists and redirect to it
                     var store = await _storeRepository.FindStore(storeId, userId);
                     if (store != null)
                     {
-                        HttpContext.SetStoreData(store);
+                        return RedirectToAction("Dashboard", "UIStores", new { storeId });
                     }
                 }
                 
                 var stores = await _storeRepository.GetStoresByUserId(userId);
+                if (stores.Any())
+                {
+                    // redirect to first store
+                    storeId = stores.First().Id;
+                    return RedirectToAction("Dashboard", "UIStores", new { storeId });
+                }
                 
                 var vm = new HomeViewModel
                 {

--- a/BTCPayServer/Views/Shared/_Layout.cshtml
+++ b/BTCPayServer/Views/Shared/_Layout.cshtml
@@ -1,11 +1,11 @@
 @using BTCPayServer.Abstractions.Contracts
 @inject BTCPayServer.Services.BTCPayServerEnvironment _env
+@inject SignInManager<ApplicationUser> _signInManager
 @inject UserManager<ApplicationUser> _userManager
 @inject ISettingsRepository _settingsRepository
 @inject LinkGenerator _linkGenerator
 
 @{
-    var logoSrc = $"{ViewContext.HttpContext.Request.PathBase}/img/logo.svg";
     var notificationDisabled = (await _settingsRepository.GetPolicies()).DisableInstantNotifications;
     if (!notificationDisabled)
     {
@@ -23,15 +23,11 @@
 <body class="d-flex flex-column flex-lg-row min-vh-100">
 <header id="mainMenu" class="btcpay-header d-flex flex-column">
     <div id="mainMenuHead" class="d-flex flex-lg-wrap align-items-center justify-content-between py-2 px-3 py-lg-3 px-lg-4">
-        <a href="~/" class="navbar-brand py-2 js-scroll-trigger">
-            <svg xmlns="http://www.w3.org/2000/svg" role="img" alt="BTCPay Server" class="logo"><use href="@logoSrc#small" class="logo-small" /><use href="@logoSrc#large" class="logo-large" /></svg>
-            @if (_env.NetworkType != NBitcoin.ChainName.Mainnet)
-            {
-                <span class="badge bg-warning ms-1 ms-sm-0" style="font-size:10px;">@_env.NetworkType.ToString()</span>
-            }
-        </a>
         <vc:store-selector />
-        <vc:notifications appearance="Dropdown" />
+        @if (_signInManager.IsSignedIn(User))
+        {
+            <vc:notifications appearance="Dropdown"/>
+        }
         <button id="mainMenuToggle" class="mainMenuButton" type="button" data-bs-toggle="offcanvas" data-bs-target="#mainNav" aria-controls="mainNav" aria-expanded="false" aria-label="Toggle navigation">
             <span>Menu</span>
         </button>

--- a/BTCPayServer/Views/UIHome/Home.cshtml
+++ b/BTCPayServer/Views/UIHome/Home.cshtml
@@ -23,10 +23,6 @@
             flex: 1;
             padding: 1rem 0;
         }
-        
-        #NotificationsRecent .notification {
-            padding: var(--btcpay-space-s) var(--btcpay-space-m) !important;
-        }
     </style>
 }
 
@@ -34,19 +30,11 @@
 
 <h2>Welcome to your BTCPay Server</h2>
 
-@if (Model.HasStore)
-{
-    <div class="row">
-        <div class="col-lg-8 col-xl-6 pt-3">
-            <vc:notifications appearance="Recent" />
-        </div>
-    </div>
-}
-else
+@if (!Model.HasStore)
 {
     <div class="row">
         <div class="col-lg-9 col-xl-6">
-            <p class="lead text-secondary">To start accepting payments, set up a store and a wallet.</p>
+            <p class="lead text-secondary">To start accepting payments, set up a store.</p>
         
             <div class="list-group mt-4" id="SetupGuide">
                 <a asp-controller="UIUserStores" asp-action="CreateStore" id="SetupGuide-Store" class="list-group-item list-group-item-action d-flex align-items-center">


### PR DESCRIPTION
Updates to the home behaviour and logo link, as discussed in yesterdays design meeting:

* Display global homepage only if there is no store: It then contains the setup guide to create a store.
* Logo links to global home only if there is no store.
* Once there is a store, the logo links to the dashboard of the currently selected store 
* Home redirects to the currently selected store, if there is no selected store but at least one store, redirect to the first of the users stores.

We might change this when we create a global instance dashboard.
Until then, we discussed this to be the desired behaviour of the homepage and logo link.