### PR TITLE
Fix secondary login view

### DIFF
--- a/BTCPayServer/Views/UIAccount/SecondaryLogin.cshtml
+++ b/BTCPayServer/Views/UIAccount/SecondaryLogin.cshtml
@@ -3,40 +3,18 @@
     ViewData["Title"] = "Two-factor/U2F authentication";
 }
 
-        @if (Model.LoginWith2FaViewModel != null && Model.LoginWithFido2ViewModel != null&& Model.LoginWithLNURLAuthViewModel != null)
-        {
-            <div asp-validation-summary="ModelOnly" class="text-danger"></div>
-        }
-        else if (Model.LoginWith2FaViewModel == null && Model.LoginWithFido2ViewModel == null && Model.LoginWithLNURLAuthViewModel == null)
-        {
-            <div class="row">
-                <div class="col-lg-12 section-heading">
-                    <h2 class="bg-danger">2FA and U2F/FIDO2 and LNURL-Auth Authentication Methods are not available. Please go to the https endpoint.</h2>
-                    <hr class="danger">
-                </div>
-            </div>
-        }
-
-        <div class="row justify-content-center">
-            @if (Model.LoginWith2FaViewModel != null)
-            {
-                <div class="col-sm-12 col-md-6">
-                    <partial name="LoginWith2fa" model="@Model.LoginWith2FaViewModel"/>
-                </div>
-            }
-            @if (Model.LoginWithFido2ViewModel != null)
-            {
-                <div class="col-sm-12 col-md-6">
-                    <partial name="LoginWithFido2" model="@Model.LoginWithFido2ViewModel"/>
-                </div>
-            }
-            @if (Model.LoginWithLNURLAuthViewModel != null)
-            {
-                <div class="col-sm-12 col-md-6">
-                    <partial name="LoginWithLNURLAuth" model="@Model.LoginWithLNURLAuthViewModel"/>
-                </div>
-            }
+@if (Model.LoginWith2FaViewModel != null && Model.LoginWithFido2ViewModel != null&& Model.LoginWithLNURLAuthViewModel != null)
+{
+    <div asp-validation-summary="ModelOnly" class="text-danger"></div>
+}
+else if (Model.LoginWith2FaViewModel == null && Model.LoginWithFido2ViewModel == null && Model.LoginWithLNURLAuthViewModel == null)
+{
+    <div class="row">
+        <div class="col-lg-12 section-heading">
+            <h2 class="bg-danger">2FA and U2F/FIDO2 and LNURL-Auth Authentication Methods are not available. Please go to the https endpoint.</h2>
+            <hr class="danger">
         </div>
+    </div>
 }
 
 <div class="row justify-content-center">
@@ -50,6 +28,12 @@
     {
         <div class="col-sm-12 col-md-6">
             <partial name="LoginWithFido2" model="@Model.LoginWithFido2ViewModel"/>
+        </div>
+    }
+    @if (Model.LoginWithLNURLAuthViewModel != null)
+    {
+        <div class="col-sm-12 col-md-6">
+            <partial name="LoginWithLNURLAuth" model="@Model.LoginWithLNURLAuthViewModel"/>
         </div>
     }
 </div>


### PR DESCRIPTION
There was a leftover `}` showing in the view and duplicated 2FA methods displayed. Potentially remainders of a resolved merge conflict.