### PR TITLE
Make sure the SubscribeAsync handlers are executed in order

### DIFF
--- a/BTCPayServer.Tests/UnitTest1.cs
+++ b/BTCPayServer.Tests/UnitTest1.cs
@@ -569,7 +569,7 @@ namespace BTCPayServer.Tests
             bool paid = false;
             bool confirmed = false;
             bool completed = false;
-            while (!completed || !confirmed)
+            while (!completed || !confirmed || !receivedPayment)
             {
                 var request = await callbackServer.GetNextRequest();
                 if (request.ContainsKey("event"))
@@ -584,7 +584,9 @@ namespace BTCPayServer.Tests
                             receivedPayment = true;
                             break;
                         case InvoiceEvent.PaidInFull:
-                            Assert.True(receivedPayment);
+                            // TODO, we should check that ReceivedPayment is sent after PaidInFull
+                            // for now, we can't ensure this because the ReceivedPayment events isn't sent by the
+                            // InvoiceWatcher, contrary to all other events
                             tester.ExplorerNode.Generate(6);
                             paid = true;
                             break;

--- a/BTCPayServer/HostedServices/BitpayIPNSender.cs
+++ b/BTCPayServer/HostedServices/BitpayIPNSender.cs
@@ -270,20 +270,20 @@ namespace BTCPayServer.HostedServices
                        e.Name == InvoiceEvent.ExpiredPaidPartial
                      )
                     {
-                        _ = Notify(invoice, e, false, sendMail);
+                        await Notify(invoice, e, false, sendMail);
                         sendMail = false;
                     }
                 }
 
                 if (e.Name == InvoiceEvent.Confirmed)
                 {
-                    _ = Notify(invoice, e, false, sendMail);
+                    await Notify(invoice, e, false, sendMail);
                     sendMail = false;
                 }
 
                 if (invoice.ExtendedNotifications)
                 {
-                    _ = Notify(invoice, e, true, sendMail);
+                    await Notify(invoice, e, true, sendMail);
                     sendMail = false;
                 }
             }));

--- a/BTCPayServer/Payments/Bitcoin/NBXplorerListener.cs
+++ b/BTCPayServer/Payments/Bitcoin/NBXplorerListener.cs
@@ -80,25 +80,25 @@ namespace BTCPayServer.Payments.Bitcoin
         {
             _RunningTask = new TaskCompletionSource<bool>();
             _Cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-            leases.Add(_Aggregator.SubscribeAsync<Events.NBXplorerStateChangedEvent>(async nbxplorerEvent =>
+            leases.Add(_Aggregator.Subscribe<Events.NBXplorerStateChangedEvent>(nbxplorerEvent =>
             {
                 if (nbxplorerEvent.NewState == NBXplorerState.Ready)
                 {
                     var wallet = _Wallets.GetWallet(nbxplorerEvent.Network);
                     if (_Wallets.IsAvailable(wallet.Network))
                     {
-                        await Listen(wallet);
+                        _ = Listen(wallet);
                     }
                 }
             }));
 
-            _ListenPoller = new Timer(async s =>
+            _ListenPoller = new Timer(s =>
             {
                 foreach (var wallet in _Wallets.GetWallets())
                 {
                     if (_Wallets.IsAvailable(wallet.Network))
                     {
-                        await Listen(wallet);
+                        _ =  Listen(wallet);
                     }
                 }
             }, null, 0, (int)PollInterval.TotalMilliseconds);


### PR DESCRIPTION
When using `eventAggregator.Subscribe`, it is expected that the handler treat events sequentially.

However, `eventAggregator.SubscribeAsync` wasn't treating the events sequentially, and we would occasionally get events sent out of order, making `CanSendIPN` fail time to time.

This PR fix `eventAggregator.SubscribeAsync` so that the handler always treat one event at a time. Also, it await the `Notify` of the `BitpayIPNSender` to make sure that events are sent sequentially.