### PR TITLE
Make users table responsive

### DIFF
--- a/BTCPayServer/Views/UIServer/ListUsers.cshtml
+++ b/BTCPayServer/Views/UIServer/ListUsers.cshtml
@@ -40,54 +40,55 @@
         Add User
     </a>
 </div>
-
-<table class="table table-hover">
-    <thead>
-    <tr>
-        <th>
-            <a
-                asp-action="ListUsers"
-                asp-route-sortOrder="@(nextUserEmailSortOrder ?? "asc")"
-                class="text-nowrap"
-                title="@(nextUserEmailSortOrder == "desc" ? sortByAsc : sortByDesc)"
-            >
-                Email
-                <span class="fa @(sortIconClass)" />
-            </a>
-        </th>
-        <th>Created</th>
-        <th>Verified</th>
-        <th class="text-end">Actions</th>
-    </tr>
-    </thead>
-    <tbody>
-    @foreach (var user in Model.Users)
-    {
+<div class="table-responsive">
+    <table class="table table-hover">
+        <thead>
         <tr>
-            <td class="d-flex align-items-center">
-                <span class="me-2">@user.Email</span>
-                @foreach (var role in user.Roles)
-                {
-                    <span class="badge bg-info">@Model.Roles[role]</span>
-                }
-            </td>
-            <td>@user.Created?.ToBrowserDate()</td>
-            <td class="text-center">
-                @if (user.Verified)
-                {
-                    <span class="text-success fa fa-check"></span>
-                }
-                else
-                {
-                    <span class="text-danger fa fa-times"></span>
-                }
-            </td>
-            <td class="text-end">
-                <a asp-action="User" asp-route-userId="@user.Id">Edit</a> <span> - </span> <a asp-action="DeleteUser" asp-route-userId="@user.Id">Remove</a>
-            </td>
+            <th>
+                <a
+                    asp-action="ListUsers"
+                    asp-route-sortOrder="@(nextUserEmailSortOrder ?? "asc")"
+                    class="text-nowrap"
+                    title="@(nextUserEmailSortOrder == "desc" ? sortByAsc : sortByDesc)"
+                >
+                    Email
+                    <span class="fa @(sortIconClass)" />
+                </a>
+            </th>
+            <th>Created</th>
+            <th>Verified</th>
+            <th class="text-end">Actions</th>
         </tr>
-    }
-    </tbody>
-</table>
+        </thead>
+        <tbody>
+        @foreach (var user in Model.Users)
+        {
+            <tr>
+                <td class="d-flex align-items-center">
+                    <span class="me-2">@user.Email</span>
+                    @foreach (var role in user.Roles)
+                    {
+                        <span class="badge bg-info">@Model.Roles[role]</span>
+                    }
+                </td>
+                <td>@user.Created?.ToBrowserDate()</td>
+                <td class="text-center">
+                    @if (user.Verified)
+                    {
+                        <span class="text-success fa fa-check"></span>
+                    }
+                    else
+                    {
+                        <span class="text-danger fa fa-times"></span>
+                    }
+                </td>
+                <td class="text-end">
+                    <a asp-action="User" asp-route-userId="@user.Id">Edit</a> <span> - </span> <a asp-action="DeleteUser" asp-route-userId="@user.Id">Remove</a>
+                </td>
+            </tr>
+        }
+        </tbody>
+    </table>
+</div>
 
 <vc:pager view-model="Model"></vc:pager>


### PR DESCRIPTION
Made the users list table responsive just like our other tables so that it doesn't overspill out of the container on mobile.

|Before (table overspills the container)|After (can swipe table horizontally)|
|---|---|
|![users-mobile-before](https://user-images.githubusercontent.com/1934678/150724271-437f6e51-5e86-4e15-9a48-b103da8ea1a7.PNG)|![users-mobile](https://user-images.githubusercontent.com/1934678/150724285-ec69ca8d-5455-4f62-b206-14470dec97b7.PNG)|