### PR TITLE
Update "Close Wallet & Lightning Setup" Path

### DIFF
--- a/BTCPayServer/Views/Shared/_Footer.cshtml
+++ b/BTCPayServer/Views/Shared/_Footer.cshtml
@@ -26,7 +26,7 @@
             </div>
             @if (User.Identity.IsAuthenticated)
             {
-                <div class="text-center text-xl-start">
+                <div class="text-center">
                     @_env.ToString()
                 </div>
             }

--- a/BTCPayServer/Views/UIStores/_LayoutWalletSetup.cshtml
+++ b/BTCPayServer/Views/UIStores/_LayoutWalletSetup.cshtml
@@ -13,7 +13,7 @@
 @section Navbar {
     @await RenderSectionAsync("Navbar", false)
 
-    <a asp-controller="UIStores" asp-action="GeneralSettings" asp-route-storeId="@Context.GetRouteValue("storeId")" class="cancel">
+    <a asp-controller="UIStores" asp-action="Dashboard" asp-route-storeId="@Context.GetRouteValue("storeId")" class="cancel">
         <vc:icon symbol="close" />
     </a>
 }


### PR DESCRIPTION
Used to redirect to Store Settings > General, now redirects to the Store's Dashboard.

I think this is the only change needed, and can't assign reviewers for whatever reason, so...

cc @dennisreimann @NicolasDorier 

Maybe in the future we could keep track of where the user might have come from previously... but that might be overkill.

Fixed one other issue:
- The copyright text wasn't centered on the full screen views (wallet/lightning), so removed the `text-xl-start` class.