### PR TITLE
Fixes Stray "<" in Auth Request View

### DIFF
--- a/BTCPayServer/Views/UIManage/AuthorizeAPIKey.cshtml
+++ b/BTCPayServer/Views/UIManage/AuthorizeAPIKey.cshtml
@@ -18,7 +18,6 @@
     <input type="hidden" asp-for="ApplicationName" value="@Model.ApplicationName"/>
     <input type="hidden" asp-for="SelectiveStores" value="@Model.SelectiveStores"/>
     <input type="hidden" asp-for="ApplicationIdentifier" value="@Model.ApplicationIdentifier"/>
-<
     <div class="row">
         <div class="col-lg-12 section-heading">
             <h3>Authorization Request</h3>


### PR DESCRIPTION
Was still in @dennisreimann's repo, but shouldn't be a problem due to such a simple fix.

Original bug:
![image](https://user-images.githubusercontent.com/6250771/151474839-f192f89d-090a-4945-bab5-5520a926800c.png)
