### PR TITLE
Delete user preferences cookie on logout

### DIFF
--- a/BTCPayServer/Controllers/UIAccountController.cs
+++ b/BTCPayServer/Controllers/UIAccountController.cs
@@ -605,6 +605,7 @@ namespace BTCPayServer.Controllers
         public async Task<IActionResult> Logout()
         {
             await _signInManager.SignOutAsync();
+            HttpContext.DeleteUserPrefsCookie();
             _logger.LogInformation("User logged out.");
             return RedirectToAction(nameof(UIHomeController.Index), "UIHome");
         }

--- a/BTCPayServer/Extensions.cs
+++ b/BTCPayServer/Extensions.cs
@@ -425,6 +425,11 @@ namespace BTCPayServer
             return prefCookie;
         }
 
+        public static void DeleteUserPrefsCookie(this HttpContext ctx)
+        {
+            ctx.Response.Cookies.Delete(nameof(UserPrefsCookie));
+        }
+
         private static void SetCurrentStoreId(this HttpContext ctx, string storeId)
         {
             var prefCookie = ctx.GetUserPrefsCookie();


### PR DESCRIPTION
I think it is a good practice to remove those settings on logout. Otherwise they get persisted across multiple accounts, which might not be desired.