### PR TITLE
Bump z-index on header

### DIFF
--- a/BTCPayServer/wwwroot/main/layout.css
+++ b/BTCPayServer/wwwroot/main/layout.css
@@ -19,7 +19,7 @@
     --icon-size: 1.5rem;
     
     height: var(--header-height);
-    z-index: 1;
+    z-index: 9999999;
 }
 
 #mainMenuHead  {


### PR DESCRIPTION
Any element that's a child of the sibling of the BTCPay header which has a z-index defined will take precedence of the notifications dropdown element. To fix this issue we either need to bump the z-index on the header element itself OR move the notifications dropdown into its own element that is a sibling of the header rather than its child (more work).

Please let me know if there might be a reason why we would not want to bump the z-index on the header.

close #3377