### PR TITLE
Remove payment methods not currently configured when creating invoice

### DIFF
--- a/BTCPayServer.Tests/BTCPayServer.Tests.csproj
+++ b/BTCPayServer.Tests/BTCPayServer.Tests.csproj
@@ -23,7 +23,7 @@
     <PackageReference Include="Newtonsoft.Json.Schema" Version="3.0.14" />
     <PackageReference Include="Selenium.Support" Version="3.141.0" />
     <PackageReference Include="Selenium.WebDriver" Version="3.141.0" />
-    <PackageReference Include="Selenium.WebDriver.ChromeDriver" Version="96.0.4664.4500" />
+    <PackageReference Include="Selenium.WebDriver.ChromeDriver" Version="98.0.4758.10200" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>

--- a/BTCPayServer.Tests/SeleniumTests.cs
+++ b/BTCPayServer.Tests/SeleniumTests.cs
@@ -386,6 +386,10 @@ namespace BTCPayServer.Tests
             await s.StartAsync();
             s.RegisterNewUser(true);
             s.CreateNewStore();
+            s.GoToInvoices();
+            s.Driver.FindElement(By.Id("CreateNewInvoice")).Click();
+            // Should give us an error message if we try to create an invoice before adding a wallet
+            Assert.Contains("To create an invoice, you need to", s.Driver.PageSource);
             s.AddDerivationScheme();
             s.GoToInvoices();
             s.CreateInvoice();

--- a/BTCPayServer/Controllers/UIInvoiceController.UI.cs
+++ b/BTCPayServer/Controllers/UIInvoiceController.UI.cs
@@ -883,9 +883,12 @@ namespace BTCPayServer.Controllers
 
         private SelectList GetPaymentMethodsSelectList()
         {
-            return new SelectList(_paymentMethodHandlerDictionary.Distinct().SelectMany(handler =>
-                    handler.GetSupportedPaymentMethods()
-                        .Select(id => new SelectListItem(id.ToPrettyString(), id.ToString()))),
+            var store = GetCurrentStore();
+            var excludeFilter = store.GetStoreBlob().GetExcludedPaymentMethods();
+
+            return new SelectList(store.GetSupportedPaymentMethods(_NetworkProvider)
+                        .Where(s => !excludeFilter.Match(s.PaymentId))
+                        .Select(method => new SelectListItem(method.PaymentId.ToPrettyString(), method.PaymentId.ToString())),
                 nameof(SelectListItem.Value),
                 nameof(SelectListItem.Text));
         }

--- a/BTCPayServer/Controllers/UIInvoiceController.UI.cs
+++ b/BTCPayServer/Controllers/UIInvoiceController.UI.cs
@@ -930,7 +930,7 @@ namespace BTCPayServer.Controllers
                     TempData.SetStatusMessageModel(new StatusMessageModel
                     {
                         Severity = StatusMessageModel.StatusSeverity.Error,
-                        Html = $"To create an invoice, you need to <a href='{Url.Action(nameof(UIStoresController.SetupWallet), "UIStores", new { cryptoCode = "BTC", storeId = store.Id })}' class='alert-link'>set up a wallet</a> first",
+                        Html = $"To create an invoice, you need to <a href='{Url.Action(nameof(UIStoresController.SetupWallet), "UIStores", new { cryptoCode = _NetworkProvider.DefaultNetwork.CryptoCode, storeId = store.Id })}' class='alert-link'>set up a wallet</a> first",
                         AllowDismiss = false
                     });
                 }
@@ -968,7 +968,7 @@ namespace BTCPayServer.Controllers
                 TempData.SetStatusMessageModel(new StatusMessageModel
                 {
                     Severity = StatusMessageModel.StatusSeverity.Error,
-                    Html = $"To create an invoice, you need to <a href='{Url.Action(nameof(UIStoresController.SetupWallet), "UIStores", new { cryptoCode = "BTC", storeId = store.Id })}' class='alert-link'>set up a wallet</a> first",
+                    Html = $"To create an invoice, you need to <a href='{Url.Action(nameof(UIStoresController.SetupWallet), "UIStores", new { cryptoCode = _NetworkProvider.DefaultNetwork.CryptoCode, storeId = store.Id })}' class='alert-link'>set up a wallet</a> first",
                     AllowDismiss = false
                 });
                 return View(model);

--- a/BTCPayServer/Controllers/UIInvoiceController.UI.cs
+++ b/BTCPayServer/Controllers/UIInvoiceController.UI.cs
@@ -913,6 +913,17 @@ namespace BTCPayServer.Controllers
                 var store = await _StoreRepository.FindStore(model.StoreId, GetUserId());
                 if (store == null)
                     return NotFound();
+
+                if (!store.GetSupportedPaymentMethods(_NetworkProvider).Any())
+                {
+                    TempData.SetStatusMessageModel(new StatusMessageModel
+                    {
+                        Severity = StatusMessageModel.StatusSeverity.Error,
+                        Html = $"To create an invoice, you need to <a href='{Url.Action(nameof(UIStoresController.SetupWallet), "UIStores", new { cryptoCode = "BTC", storeId = store.Id })}' class='alert-link'>set up a wallet</a> first",
+                        AllowDismiss = false
+                    });
+                }
+
                 HttpContext.SetStoreData(store);
             }
 
@@ -946,7 +957,7 @@ namespace BTCPayServer.Controllers
                 TempData.SetStatusMessageModel(new StatusMessageModel
                 {
                     Severity = StatusMessageModel.StatusSeverity.Error,
-                    Html = $"To create an invoice, you need to <a href='{Url.Action(nameof(UIStoresController.GeneralSettings), "UIStores", new { storeId = store.Id })}' class='alert-link'>set up a wallet</a> first",
+                    Html = $"To create an invoice, you need to <a href='{Url.Action(nameof(UIStoresController.SetupWallet), "UIStores", new { cryptoCode = "BTC", storeId = store.Id })}' class='alert-link'>set up a wallet</a> first",
                     AllowDismiss = false
                 });
                 return View(model);

--- a/BTCPayServer/Controllers/UIInvoiceController.UI.cs
+++ b/BTCPayServer/Controllers/UIInvoiceController.UI.cs
@@ -893,6 +893,14 @@ namespace BTCPayServer.Controllers
                 nameof(SelectListItem.Text));
         }
 
+        private bool AnyPaymentMethodAvailable(StoreData store)
+        {
+            var storeBlob = store.GetStoreBlob();
+            var excludeFilter = storeBlob.GetExcludedPaymentMethods();
+            
+            return store.GetSupportedPaymentMethods(_NetworkProvider).Where(s => !excludeFilter.Match(s.PaymentId)).Any();
+        }
+
         [HttpGet("/stores/{storeId}/invoices/create")]
         [HttpGet("invoices/create")]
         [Authorize(AuthenticationSchemes = AuthenticationSchemes.Cookie)]
@@ -917,7 +925,7 @@ namespace BTCPayServer.Controllers
                 if (store == null)
                     return NotFound();
 
-                if (!store.GetSupportedPaymentMethods(_NetworkProvider).Any())
+                if (!AnyPaymentMethodAvailable(store))
                 {
                     TempData.SetStatusMessageModel(new StatusMessageModel
                     {
@@ -955,7 +963,7 @@ namespace BTCPayServer.Controllers
                 return View(model);
             }
 
-            if (!store.GetSupportedPaymentMethods(_NetworkProvider).Any())
+            if (!AnyPaymentMethodAvailable(store))
             {
                 TempData.SetStatusMessageModel(new StatusMessageModel
                 {

--- a/BTCPayServer/Extensions.cs
+++ b/BTCPayServer/Extensions.cs
@@ -118,10 +118,7 @@ namespace BTCPayServer
 
         public static bool HasErrorMessage(this ITempDataDictionary tempData)
         {
-            return (
-                tempData.Peek("StatusMessageModel") != null &&
-                tempData.GetStatusMessageModel().Severity == StatusMessageModel.StatusSeverity.Error
-            );
+            return GetStatusMessageModel(tempData)?.Severity == StatusMessageModel.StatusSeverity.Error;
         }
 
         public static PaymentMethodId GetpaymentMethodId(this InvoiceCryptoInfo info)

--- a/BTCPayServer/Extensions.cs
+++ b/BTCPayServer/Extensions.cs
@@ -115,6 +115,15 @@ namespace BTCPayServer
                    tempData.Peek(WellKnownTempData.ErrorMessage) ??
                    tempData.Peek("StatusMessageModel")) != null;
         }
+
+        public static bool HasErrorMessage(this ITempDataDictionary tempData)
+        {
+            return (
+                tempData.Peek("StatusMessageModel") != null &&
+                tempData.GetStatusMessageModel().Severity == StatusMessageModel.StatusSeverity.Error
+            );
+        }
+
         public static PaymentMethodId GetpaymentMethodId(this InvoiceCryptoInfo info)
         {
             return new PaymentMethodId(info.CryptoCode, PaymentTypes.Parse(info.PaymentType));

--- a/BTCPayServer/Views/UIInvoice/CreateInvoice.cshtml
+++ b/BTCPayServer/Views/UIInvoice/CreateInvoice.cshtml
@@ -27,8 +27,6 @@
 
 <partial name="_StatusMessage" />
 
-@if (!TempData.HasErrorMessage()) 
-{
 <h2 class="mt-1 mb-4">@ViewData["Title"]</h2>
 
 <div class="row">
@@ -155,4 +153,3 @@
         </form>
     </div>
 </div>
-}

--- a/BTCPayServer/Views/UIInvoice/CreateInvoice.cshtml
+++ b/BTCPayServer/Views/UIInvoice/CreateInvoice.cshtml
@@ -27,6 +27,8 @@
 
 <partial name="_StatusMessage" />
 
+@if (!TempData.HasErrorMessage()) 
+{
 <h2 class="mt-1 mb-4">@ViewData["Title"]</h2>
 
 <div class="row">
@@ -153,3 +155,4 @@
         </form>
     </div>
 </div>
+}


### PR DESCRIPTION
This PR updates the "Create invoice" page to only include the payment methods available which are currently configured for the store.

Also added an error message with a link to create a wallet which shows up at the top of the page if there are no payment methods configured at all.

close #3380