### PR TITLE
Reference correct payment type definition for webhook events in Swagger docs

### DIFF
--- a/BTCPayServer/wwwroot/swagger/v1/swagger.template.webhooks.json
+++ b/BTCPayServer/wwwroot/swagger/v1/swagger.template.webhooks.json
@@ -744,7 +744,7 @@
                             },
                             "payment": {
                                 "description": "Details about the payment",
-                                "$ref": "#/components/schemas/InvoicePaymentMethodDataModel"
+                                "$ref": "#/components/schemas/Payment"
                             }
                         }
                     }


### PR DESCRIPTION
Swagger docs for `InvoiceReceivedPayment` and `InvoicePaymentSettled` webhook types are pointing to the wrong type for the `payment` field on these events. This PR points to the correct type.

|Before|After|
|---|---|
|![before](https://user-images.githubusercontent.com/1934678/152102166-2483b7fd-9bb1-4669-8f1e-96b5bc63695c.PNG)|![after](https://user-images.githubusercontent.com/1934678/152102175-fd4c89fb-14d4-4169-a389-05c45a913c4b.PNG)|


fix #3369