### PR TITLE
Prevent initial scroll to section nav

### DIFF
--- a/BTCPayServer/Views/Shared/_NavLayout.cshtml
+++ b/BTCPayServer/Views/Shared/_NavLayout.cshtml
@@ -22,7 +22,7 @@
     <script>
         (function () {
             const activeEl = document.querySelector('#SectionNav .nav .active')
-            if (activeEl) activeEl.scrollIntoView({ inline: 'center' })
+            if (activeEl) activeEl.scrollIntoView({ block: 'end', inline: 'center' })
         })()
     </script>
 }

--- a/BTCPayServer/wwwroot/main/layout.css
+++ b/BTCPayServer/wwwroot/main/layout.css
@@ -357,9 +357,10 @@
 @media (max-width: 991px) {
     :root {
         --header-height: var(--mobile-header-height);
+        --content-padding-top: var(--btcpay-space-m);
 
         /* Prevent anchors from disappearing underneath the fixed header */
-        scroll-padding: var(--header-height);
+        scroll-padding: calc(var(--header-height) + var(--content-padding-top));
     }
     
     #mainMenu {
@@ -472,7 +473,7 @@
 
     #mainContent > section {
         margin-top: var(--header-height);
-        padding: var(--btcpay-space-m) var(--btcpay-space-m) var(--btcpay-space-xl);
+        padding: var(--content-padding-top) var(--btcpay-space-m) var(--btcpay-space-xl);
     }
 
     #SectionNav {

--- a/BTCPayServer/wwwroot/main/layout.css
+++ b/BTCPayServer/wwwroot/main/layout.css
@@ -357,6 +357,9 @@
 @media (max-width: 991px) {
     :root {
         --header-height: var(--mobile-header-height);
+
+        /* Prevent anchors from disappearing underneath the fixed header */
+        scroll-padding: var(--header-height);
     }
     
     #mainMenu {


### PR DESCRIPTION
On pages taht contain a section nav (sub navigation) the previous `scrollIntoView` led to an initial scroll position start at the section nav. See the store or server settings for examples.

This fixes it so that the scroll vertical position always starts at 0.

## Before

![image](https://user-images.githubusercontent.com/886/152499423-84f4c6d7-fbe5-443a-b9ee-240f8198cc3d.png)


## After

![image](https://user-images.githubusercontent.com/886/152499202-9cd389dd-adca-488f-9dc6-c5c28eda8264.png)