### PR TITLE
Bumping LND to 0.14.2-beta

### DIFF
--- a/BTCPayServer.Tests/docker-compose.altcoins.yml
+++ b/BTCPayServer.Tests/docker-compose.altcoins.yml
@@ -235,7 +235,7 @@ services:
       - "5432"
 
   merchant_lnd:
-    image: btcpayserver/lnd:v0.14.1-beta
+    image: btcpayserver/lnd:v0.14.2-beta
     restart: unless-stopped
     environment:
       LND_CHAIN: "btc"
@@ -269,7 +269,7 @@ services:
       - bitcoind
 
   customer_lnd:
-    image: btcpayserver/lnd:v0.14.1-beta
+    image: btcpayserver/lnd:v0.14.2-beta
     restart: unless-stopped
     environment:
       LND_CHAIN: "btc"

--- a/BTCPayServer.Tests/docker-compose.yml
+++ b/BTCPayServer.Tests/docker-compose.yml
@@ -223,7 +223,7 @@ services:
       - "5432"
 
   merchant_lnd:
-    image: btcpayserver/lnd:v0.14.1-beta
+    image: btcpayserver/lnd:v0.14.2-beta
     restart: unless-stopped
     environment:
       LND_CHAIN: "btc"
@@ -257,7 +257,7 @@ services:
       - bitcoind
 
   customer_lnd:
-    image: btcpayserver/lnd:v0.14.1-beta
+    image: btcpayserver/lnd:v0.14.2-beta
     restart: unless-stopped
     environment:
       LND_CHAIN: "btc"


### PR DESCRIPTION
I've tagged LND 0.14.2 release and Docker image is available on https://hub.docker.com/layers/btcpayserver/lnd/v0.14.2-beta/images/sha256-b133dc14f36cd046364767fb876aa625f62987ea9503c85da89b533463a0800b?context=explore

Used it in BTCPayServer.Lightning library and it's good to go:
https://github.com/btcpayserver/BTCPayServer.Lightning/pull/53

@NicolasDorier test if it works for you for local dev and if it does I'm opening PR against BTCPayServer-Docker repo.