### PR TITLE
After login, redirect user to the main page even if root app configured

### DIFF
--- a/BTCPayServer.Tests/AltcoinTests/AltcoinTests.cs
+++ b/BTCPayServer.Tests/AltcoinTests/AltcoinTests.cs
@@ -350,7 +350,7 @@ namespace BTCPayServer.Tests
                 var user = s.Server.NewAccount();
                 await user.GrantAccessAsync();
                 s.GoToLogin();
-                s.Login(user.RegisterDetails.Email, user.RegisterDetails.Password);
+                s.LogIn(user.RegisterDetails.Email, user.RegisterDetails.Password);
                 user.RegisterDerivationScheme("BTC");
                 await s.Server.ExplorerNode.GenerateAsync(1);
 

--- a/BTCPayServer.Tests/ApiKeysTests.cs
+++ b/BTCPayServer.Tests/ApiKeysTests.cs
@@ -43,7 +43,7 @@ namespace BTCPayServer.Tests
             await user.GrantAccessAsync();
             await user.MakeAdmin(false);
             s.GoToLogin();
-            s.Login(user.RegisterDetails.Email, user.RegisterDetails.Password);
+            s.LogIn(user.RegisterDetails.Email, user.RegisterDetails.Password);
             s.GoToProfile(ManageNavPages.APIKeys);
             s.Driver.FindElement(By.Id("AddApiKey")).Click();
 
@@ -53,7 +53,7 @@ namespace BTCPayServer.Tests
             await user.MakeAdmin();
             s.Logout();
             s.GoToLogin();
-            s.Login(user.RegisterDetails.Email, user.RegisterDetails.Password);
+            s.LogIn(user.RegisterDetails.Email, user.RegisterDetails.Password);
             s.GoToProfile(ManageNavPages.APIKeys);
             s.Driver.FindElement(By.Id("AddApiKey")).Click();
             Assert.Contains("btcpay.server.canmodifyserversettings", s.Driver.PageSource);
@@ -196,7 +196,7 @@ namespace BTCPayServer.Tests
             await user.MakeAdmin(false);
             s.Logout();
             s.GoToLogin();
-            s.Login(user.RegisterDetails.Email, user.RegisterDetails.Password);
+            s.LogIn(user.RegisterDetails.Email, user.RegisterDetails.Password);
             s.GoToProfile(ManageNavPages.APIKeys);
             s.Driver.FindElement(By.Id("AddApiKey")).Click();
             int checkedPermissionCount = 0;

--- a/BTCPayServer.Tests/SeleniumTester.cs
+++ b/BTCPayServer.Tests/SeleniumTester.cs
@@ -349,7 +349,7 @@ namespace BTCPayServer.Tests
             Driver.FindElement(By.Id("Nav-Logout")).Click();
         }
 
-        public void Login(string user, string password)
+        public void LogIn(string user, string password)
         {
             Driver.FindElement(By.Id("Email")).SendKeys(user);
             Driver.FindElement(By.Id("Password")).SendKeys(password);

--- a/BTCPayServer/Controllers/UIHomeController.cs
+++ b/BTCPayServer/Controllers/UIHomeController.cs
@@ -63,6 +63,12 @@ namespace BTCPayServer.Controllers
             SignInManager = signInManager;
         }
 
+        [HttpGet("home")]
+        public Task<IActionResult> Home()
+        {
+            return Index();
+        }
+
         [Route("")]
         [DomainMappingConstraint]
         public async Task<IActionResult> Index()

--- a/BTCPayServer/Views/UIServer/Policies.cshtml
+++ b/BTCPayServer/Views/UIServer/Policies.cshtml
@@ -121,7 +121,7 @@
         <select asp-for="RootAppId" asp-items="@(new SelectList(ViewBag.AppsList, nameof(SelectListItem.Value), nameof(SelectListItem.Text), Model.RootAppId))" class="form-select w-auto"></select>
         @if (!Model.DomainToAppMapping.Any())
         {
-            <button type="submit" name="command" value="add-domain" class="btn btn-link px-0">Map specific domains to specific apps</button>
+            <button id="AddDomainButton" type="submit" name="command" value="add-domain" class="btn btn-link px-0">Map specific domains to specific apps</button>
         }
     </div>
 
@@ -129,7 +129,7 @@
     {
         <h5 class="mt-5 mb-0">
             Domain to app mapping
-            <button type="submit" name="command" value="add-domain" class="btn btn-secondary btn-sm ms-2">Add domain mapping</button>
+            <button id="AddDomainButton" type="submit" name="command" value="add-domain" class="btn btn-secondary btn-sm ms-2">Add domain mapping</button>
         </h5>
         <div class="list-group list-group-flush mb-2">
             @for (var index = 0; index < Model.DomainToAppMapping.Count; index++)
@@ -201,7 +201,7 @@
         </div>
     </div>
 
-    <button type="submit" class="btn btn-primary" name="command" value="Save">Save</button>
+    <button id="SaveButton" type="submit" class="btn btn-primary" name="command" value="Save">Save</button>
 </form>
 
 @section PageFootContent {


### PR DESCRIPTION
Actual:
* Configure an app on the root of your website
* Logout from BTCPay
* Login in from BTCPay (by manually browsing to /login)
* Get redirected to the app page

Expected:
* Get redirected to the home page of btcpay. If the user logged in to BTCPay, it is unlikely for using the app which has been set on to `/`.
