### PR TITLE
Always use compressed pubkey for SIN (fix #3432)

### DIFF
--- a/BTCPayServer/Controllers/UIStoresController.cs
+++ b/BTCPayServer/Controllers/UIStoresController.cs
@@ -777,7 +777,7 @@ namespace BTCPayServer.Controllers
             var tokenRequest = new TokenRequest()
             {
                 Label = model.Label,
-                Id = model.PublicKey == null ? null : NBitpayClient.Extensions.BitIdExtensions.GetBitIDSIN(new PubKey(model.PublicKey))
+                Id = model.PublicKey == null ? null : NBitpayClient.Extensions.BitIdExtensions.GetBitIDSIN(new PubKey(model.PublicKey).Compress())
             };
 
             string pairingCode = null;


### PR DESCRIPTION
This change makes sure that even when somebody inputs an uncompressed public key into the "add token" page, the resulting SIN will be calculated from the _compressed_ key, since client libraries will also always use the compressed key for SIN generation.

(Note: There is no need to check `IsCompressed` first because `.Compress()` is just a no-op if the key is already compressed and doesn't throw an exception.)

This fixes #3432