### PR TITLE
Improve Lightning test scripts

### DIFF
--- a/BTCPayServer.Tests/docker-compose.yml
+++ b/BTCPayServer.Tests/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "3"    
+version: "3"
 
 # Run `docker-compose up dev` for bootstrapping your development environment
 # Doing so will expose NBXplorer, Bitcoind RPC and postgres port to the host so that tests can Run,
@@ -33,7 +33,7 @@ services:
     links:
       - dev
       - selenium
-    extra_hosts: 
+    extra_hosts:
       - "tests:127.0.0.1"
     volumes:
       - "sshd_datadir:/root/.ssh"
@@ -41,7 +41,7 @@ services:
       - "merchant_lightningd_datadir:/etc/merchant_lightningd_datadir"
 
   # The dev container is not actually used, it is just handy to run `docker-compose up dev` to start all services
-  dev: 
+  dev:
     image: alpine:3.7
     command: [ "/bin/sh", "-c", "trap : TERM INT; while :; do echo Ready to code and debug like a rockstar!!!; sleep 2073600; done & wait" ]
     links:
@@ -66,7 +66,7 @@ services:
     volumes:
         - "sshd_datadir:/root/.ssh"
 
-  devlnd: 
+  devlnd:
     image: btcpayserver/bitcoin:22.0
     environment:
       BITCOIN_NETWORK: regtest
@@ -90,7 +90,7 @@ services:
     restart: unless-stopped
     ports:
       - "32838:32838"
-    expose: 
+    expose:
       - "32838"
     environment:
       NBXPLORER_NETWORK: regtest
@@ -127,7 +127,7 @@ services:
         zmqpubrawtx=tcp://0.0.0.0:28333
         deprecatedrpc=signrawtransaction
         fallbackfee=0.0002
-    ports: 
+    ports:
       - "43782:43782"
       - "39388:39388"
     expose:
@@ -142,7 +142,7 @@ services:
     image: btcpayserver/lightning:v0.10.1-1-dev
     stop_signal: SIGKILL
     restart: unless-stopped
-    environment: 
+    environment:
       EXPOSE_TCP: "true"
       LIGHTNINGD_CHAIN: "btc"
       LIGHTNINGD_NETWORK: "regtest"
@@ -190,7 +190,7 @@ services:
   merchant_lightningd:
     image: btcpayserver/lightning:v0.10.1-1-dev
     stop_signal: SIGKILL
-    environment: 
+    environment:
       EXPOSE_TCP: "true"
       LIGHTNINGD_CHAIN: "btc"
       LIGHTNINGD_NETWORK: "regtest"
@@ -249,7 +249,9 @@ services:
     ports:
       - "35531:8080"
     expose:
+      - "8080"
       - "9735"
+      - "10009"
     volumes:
       - "merchant_lnd_datadir:/data"
       - "bitcoin_datadir:/deps/.bitcoin"
@@ -274,7 +276,7 @@ services:
         bitcoind.rpcpass=DwubwWsoo3
         bitcoind.zmqpubrawblock=tcp://bitcoind:28332
         bitcoind.zmqpubrawtx=tcp://bitcoind:28333
-        externalip=customer_lnd:10009
+        externalip=customer_lnd:9735
         bitcoin.defaultchanconfs=1
         no-macaroons=1
         debuglevel=debug
@@ -284,6 +286,7 @@ services:
       - "35532:8080"
     expose:
       - "8080"
+      - "9735"
       - "10009"
     volumes:
       - "customer_lnd_datadir:/root/.lnd"

--- a/BTCPayServer.Tests/docker-customer-lncli.sh
+++ b/BTCPayServer.Tests/docker-customer-lncli.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+container_id="$(docker ps -q --filter label=com.docker.compose.project=btcpayservertests --filter label=com.docker.compose.service=customer_lnd)"
+docker exec -ti $container_id lncli --no-macaroons --rpcserver localhost:10008 "$@"

--- a/BTCPayServer.Tests/docker-lightning-channel-setup.sh
+++ b/BTCPayServer.Tests/docker-lightning-channel-setup.sh
@@ -3,67 +3,102 @@
 # Commands
 BCMD=./docker-bitcoin-cli.sh
 GCMD=./docker-bitcoin-generate.sh
-CCMD=./docker-customer-lightning-cli.sh
-MCMD=./docker-merchant-lightning-cli.sh
+C_LN=./docker-customer-lncli.sh
+M_LN=./docker-merchant-lncli.sh
+C_CL=./docker-customer-lightning-cli.sh
+M_CL=./docker-merchant-lightning-cli.sh
 
 function channel_count () {
-  local cmd=$1; local id=$2;
-  local count=$($cmd listchannels | jq -r ".channels | map(select(.destination == \"$id\")) | length | tonumber") 2>/dev/null
+  local cmd="$1"; local id="$2";
+  if [[ $cmd =~ "lightning-cli" ]]; then
+    local count=$($cmd listchannels | jq -r ".channels | map(select(.destination == \"$id\" and .active == true)) | length | tonumber") 2>/dev/null
+  elif [[ $cmd =~ "lncli" ]]; then
+    local count=$($cmd listchannels | jq -r ".channels | map(select(.remote_pubkey == \"$id\" and .active == true)) | length | tonumber") 2>/dev/null
+  fi
   return $count
+}
+
+function connect () {
+  local cmd="$1"; local uri="$2"; local desc="$3";
+  local connid=`$cmd connect $uri` 2>/dev/null
+  if [[ $connid =~ "already connected" ]]; then
+    printf "%s %s\n\r" "✅" "$desc"
+  else
+    printf "%s %s\n\r" $([[ $uri =~ ^$(echo $connid | jq -r '.id')* ]] && echo "✅" || echo "❌") "$desc"
+  fi
 }
 
 function create_channel () {
-  local cmd=$1; local id=$2;
-  local btcaddr=$($cmd newaddr | jq -r '.address')
-  $BCMD sendtoaddress $btcaddr 0.15 >/dev/null
-  $GCMD 10 >/dev/null
-  local fundres=$($cmd fundchannel $id 14500000 5000 | jq -r '.channel_id')
-  $GCMD 20 >/dev/null
-  sleep 2
-  channel_count $cmd $id
+  local cmd="$1"; local id="$2"; local desc="$3"; local opts="$4";
+  channel_count "$cmd" "$id"
   local count=$?
-  return $count
+  if [[ $count -eq 0 ]]; then
+    # fund onchain wallet
+    if [[ $cmd =~ "lightning-cli" ]]; then
+      local btcaddr=$($cmd newaddr | jq -r '.bech32')
+    elif [[ $cmd =~ "lncli" ]]; then
+      local btcaddr=$($cmd newaddress p2wkh | jq -r '.address')
+    fi
+    $BCMD sendtoaddress $btcaddr 0.615 >/dev/null
+    $GCMD 10 >/dev/null
+    # open channel
+    if [[ $cmd =~ "lightning-cli" ]]; then
+      $cmd -k fundchannel id=$id amount=5000000 push_msat=2450000 $opts >/dev/null
+    elif [[ $cmd =~ "lncli" ]]; then
+      $cmd openchannel $id 5000000 2450000 $opts >/dev/null
+    fi
+    $GCMD 20 >/dev/null
+    sleep 1
+    channel_count "$cmd" "$id"
+    local count=$?
+  fi
+  printf "%s %s\n\r" $([[ $count -gt 0 ]] && echo "✅" || echo "❌") "$desc"
 }
 
-# General information
-cinfo=$($CCMD getinfo | jq '.' 2>/dev/null)
-minfo=$($MCMD getinfo | jq '.' 2>/dev/null)
-cid=$(echo $cinfo | jq -r '.id')
-mid=$(echo $minfo | jq -r '.id')
-caddr=$(echo $cinfo | jq -r '.address[] | "\(.address):\(.port)"')
-maddr=$(echo $minfo | jq -r '.address[] | "\(.address):\(.port)"')
+# Nodes
+c_cl_info=$($C_CL getinfo | jq '.' 2>/dev/null)
+m_cl_info=$($M_CL getinfo | jq '.' 2>/dev/null)
+c_cl_id=$(echo $c_cl_info | jq -r '.id')
+m_cl_id=$(echo $m_cl_info | jq -r '.id')
+c_cl_addr=$(echo $c_cl_info | jq -r '.address[] | "\(.address):\(.port)"')
+m_cl_addr=$(echo $m_cl_info | jq -r '.address[] | "\(.address):\(.port)"')
+c_cl_uri=$(echo "$c_cl_id@$c_cl_addr")
+m_cl_uri=$(echo "$m_cl_id@$m_cl_addr")
 
-printf "Customer ID: %s@%s\n\r" $cid $caddr
-printf "Merchant ID: %s@%s\n\r" $mid $maddr
+c_ln_info=$($C_LN getinfo | jq '.' 2>/dev/null)
+m_ln_info=$($M_LN getinfo | jq '.' 2>/dev/null)
+c_ln_id=$(echo $c_ln_info | jq -r '.identity_pubkey' 2>/dev/null)
+m_ln_id=$(echo $m_ln_info | jq -r '.identity_pubkey' 2>/dev/null)
+c_ln_uri=$(echo $c_ln_info | jq -r '.uris[]' 2>/dev/null)
+m_ln_uri=$(echo $m_ln_info | jq -r '.uris[]' 2>/dev/null)
+
+printf "\n\rNodes\n\r-----\n\r"
+printf "Merchant c-lightning: %s\n\r" $m_cl_uri
+printf "Merchant LND:         %s\n\r" $m_ln_uri
+printf "Customer c-lightning: %s\n\r" $c_cl_uri
+printf "Customer LND:         %s\n\r" $c_ln_uri
 
 # Connections
-printf "\n\rConnecting both parties …\n\r"
+printf "\n\rConnecting all parties\n\r----------------------\n\r"
 
-cconnid=$($CCMD connect "$mid@$maddr" | jq -r '.id' 2>/dev/null)
-mconnid=$($MCMD connect "$cid@$caddr" | jq -r '.id' 2>/dev/null)
-
-printf "Customer to merchant %s\n\r" $([[ $cconnid == $mid ]] && echo "succeeded" || echo "failed")
-printf "Merchant to customer %s\n\r" $([[ $mconnid == $cid ]] && echo "succeeded" || echo "failed")
+connect $M_CL $c_cl_uri "Merchant (c-lightning) to Customer (c-lightning)"
+connect $M_CL $c_ln_uri "Merchant (c-lightning) to Customer (LND)"
+connect $M_CL $m_ln_uri "Merchant (c-lightning) to Merchant (LND)"
+connect $C_CL $m_cl_uri "Customer (c-lightning) to Merchant (c-lightning)"
+connect $C_CL $m_ln_uri "Customer (c-lightning) to Merchant (LND)"
+connect $C_CL $c_ln_uri "Customer (c-lightning) to Customer (LND)"
+connect $M_LN $c_cl_uri "Merchant (LND) to Customer (c-lightning)"
+connect $M_LN $c_cl_uri "Merchant (LND) to Customer (c-lightning)"
+connect $M_LN $c_ln_uri "Merchant (LND) to Customer (LND)"
+connect $C_LN $m_cl_uri "Customer (LND) to Merchant (c-lightning)"
+connect $C_LN $c_cl_uri "Customer (LND) to Customer (c-lightning)"
+connect $C_LN $m_ln_uri "Customer (LND) to Merchant (LND)"
 
 # Channels
-printf "\n\rChecking channels …\n\r"
-channel_count $CCMD $mid
-cchanscount=$?
-channel_count $MCMD $cid
-mchanscount=$?
+printf "\n\rEstablishing channels\n\r----------------------\n\r"
 
-printf "Customer channel count to merchant: %d\n\r" $cchanscount
-printf "Merchant channel count to customer: %d\n\r" $mchanscount
-
-# Open channels if there are none, details: https://github.com/ElementsProject/lightning#opening-a-channel
-if [[ $cchanscount -eq 0 ]]; then
-  create_channel $CCMD $mid
-  cchanres=$?
-  printf "Establishing channel from customer to merchant %s\n\r" $([[ $cchanres -gt 0 ]] && echo "succeeded" || echo "failed")
-fi
-
-if [[ $mchanscount -eq 0 ]]; then
-  create_channel $MCMD $cid
-  mchanres=$?
-  printf "Establishing channel from merchant to customer %s\n\r" $([[ $mchanres -gt 0 ]] && echo "succeeded" || echo "failed")
-fi
+create_channel $C_CL $m_cl_id "Customer (c-lightning) to Merchant (c-lightning)"
+create_channel $C_CL $m_ln_id "Customer (c-lightning) to Merchant (LND)"
+create_channel $C_LN $c_cl_id "Customer (LND) to Customer (c-lightning)"
+create_channel $M_CL $m_ln_id "Merchant (c-lightning) to Merchant (LND)" "announce=false"
+create_channel $C_LN $m_ln_id "Customer (LND) to Merchant (LND)" --private

--- a/BTCPayServer.Tests/docker-lightning-channel-teardown.sh
+++ b/BTCPayServer.Tests/docker-lightning-channel-teardown.sh
@@ -1,12 +1,15 @@
 #!/bin/bash
-set -e
+
+./docker-customer-lncli.sh closeallchannels > /dev/null
+./docker-merchant-lncli.sh closeallchannels > /dev/null
+./docker-bitcoin-generate.sh 10 > /dev/null
 
 channels=$(./docker-merchant-lightning-cli.sh listchannels | jq -cr '.channels | map(.short_channel_id) | unique')
-printf "Channels: %s\n\r" $channels
 
 for chanid in $(echo "${channels}" | jq -cr '.[]')
 do
-    printf "Closing channel ID: %s\n\r" $chanid
-    ./docker-merchant-lightning-cli.sh close $chanid
-    ./docker-bitcoin-generate.sh 20 > /dev/null
+    ./docker-merchant-lightning-cli.sh close $chanid > /dev/null
 done
+./docker-bitcoin-generate.sh 10 > /dev/null
+
+printf "All channels closed!\r\n"

--- a/BTCPayServer.Tests/docker-merchant-lncli.sh
+++ b/BTCPayServer.Tests/docker-merchant-lncli.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+container_id="$(docker ps -q --filter label=com.docker.compose.project=btcpayservertests --filter label=com.docker.compose.service=merchant_lnd)"
+docker exec -ti $container_id lncli --no-macaroons --rpcserver localhost:10008 "$@"


### PR DESCRIPTION
Added `lncli.sh` scripts to access the LND nodes. Also integrated them in the setup and teardown scripts, which establishes/removes channel connections between the various Lightning nodes.

Example output of the setup script:

```
Nodes
-----
Merchant c-lightning: 02caba4ad78502059b4272edf640a550c8889abe21d92bd5830a6fa90914199df0@172.27.0.8:9735
Merchant LND:         0227b60ca8875846dc1b5e8564fba6f7e4dddda504f732259a78576d990b6e8f16@172.27.0.6:9735
Customer c-lightning: 02a183dfbfae35798f790d232e29e03780601bf55b9b6845f37585dc5c9f297eac@172.27.0.10:9735
Customer LND:         03e3dc08c611f9e68bcbec929719d3a17f02a63aeb98db63bcf55437d0fdcc61e6@172.27.0.7:9735

Connecting all parties
----------------------
✅ Merchant (c-lightning) to Customer (c-lightning)
✅ Merchant (c-lightning) to Customer (LND)
✅ Customer (c-lightning) to Merchant (c-lightning)
✅ Customer (c-lightning) to Merchant (LND)
✅ Merchant (LND) to Customer (c-lightning)
✅ Merchant (LND) to Customer (LND)
✅ Customer (LND) to Merchant (c-lightning)
✅ Customer (LND) to Merchant (LND)

Establishing channels
----------------------
✅ Customer (c-lightning) to Merchant (c-lightning)
✅ Customer (c-lightning) to Merchant (LND)
✅ Customer (LND) to Customer (c-lightning)
✅ Merchant (c-lightning) to Merchant (LND)
✅ Customer (LND) to Merchant (LND)
```