### PR TITLE
Fix paid invoice filter

### DIFF
--- a/BTCPayServer/Views/UIInvoice/ListInvoices.cshtml
+++ b/BTCPayServer/Views/UIInvoice/ListInvoices.cshtml
@@ -281,7 +281,7 @@
 
         <div class="dropdown-menu dropdown-menu-end" aria-labelledby="SearchOptionsToggle">
             <a class="dropdown-item" asp-action="ListInvoices" asp-route-storeId="@Model.StoreId" asp-route-count="@Model.Count" asp-route-searchTerm="status:invalid@{@storeIds}">Invalid Invoices</a>
-            <a class="dropdown-item" asp-action="ListInvoices" asp-route-storeId="@Model.StoreId" asp-route-count="@Model.Count" asp-route-searchTerm="status:processing,status:settled@{@storeIds}">Paid Invoices</a>
+            <a class="dropdown-item" asp-action="ListInvoices" asp-route-storeId="@Model.StoreId" asp-route-count="@Model.Count" asp-route-searchTerm="status:paid,status:confirmed,status:complete@{@storeIds}">Paid Invoices</a>
             <a class="dropdown-item" asp-action="ListInvoices" asp-route-storeId="@Model.StoreId" asp-route-count="@Model.Count" asp-route-searchTerm="exceptionstatus:paidLate@{@storeIds}">Paid Late Invoices</a>
             <a class="dropdown-item" asp-action="ListInvoices" asp-route-storeId="@Model.StoreId" asp-route-count="@Model.Count" asp-route-searchTerm="exceptionstatus:paidPartial@{@storeIds}">Paid Partial Invoices</a>
             <a class="dropdown-item" asp-action="ListInvoices" asp-route-storeId="@Model.StoreId" asp-route-count="@Model.Count" asp-route-searchTerm="exceptionstatus:paidOver@{@storeIds}">Paid Over Invoices</a>
@@ -327,10 +327,9 @@
             </div>
         </span>
     </div>
-
+    <div style="clear:both"></div>
     @if (Model.Total > 0)
     {
-        <div style="clear:both"></div>
         <div class="table-responsive">
             <table id="invoices" class="table table-hover">
                 <thead>
@@ -403,11 +402,10 @@
                                 else
                                 {
                                     <span class="badge badge-@invoice.Status.Status.ToModernStatus().ToString().ToLower()">
-                                        @invoice.Status.Status.ToModernStatus().ToString() @*  @invoice.Status.ToString().ToLower()  *@
+                                        @invoice.Status.Status.ToModernStatus().ToString()
                                         @if (invoice.Status.ExceptionStatus != InvoiceExceptionStatus.None)
                                         {
-                                            @String.Format("({0})", @invoice.Status.ExceptionStatus.ToString())
-                                            ;
+                                            @($"({invoice.Status.ExceptionStatus.ToString()})")
                                         }
                                     </span>
                                 }


### PR DESCRIPTION
Fixes #3434 by reverting the filter changes done [here](https://github.com/btcpayserver/btcpayserver/commit/ec68d2a0e67421a433e7b256b2d19e19b0785b8a#diff-b7a89b0b45f062f004cdfe6ca8484f6ca519044f63485fd15986af5f7dd5ec76L219).

The new labels are only used in the UI ­— when filtering one needs to use the old labels, as the filter docs in the view already suggest.