### PR TITLE
Fix payment request archival actions

### DIFF
--- a/BTCPayServer.Tests/SeleniumTests.cs
+++ b/BTCPayServer.Tests/SeleniumTests.cs
@@ -705,9 +705,7 @@ namespace BTCPayServer.Tests
             s.Driver.FindElement(By.Id("Amount")).SendKeys("700");
             s.Driver.FindElement(By.Id("Currency")).SendKeys("BTC");
             s.Driver.FindElement(By.Id("SaveButton")).Click();
-            var aaa = s.Driver.PageSource;
-            var url = s.Driver.Url;
-            s.Driver.FindElement(By.Id("ViewAppButton")).Click();
+            s.Driver.FindElement(By.Id("ViewPaymentRequest")).Click();
             s.Driver.SwitchTo().Window(s.Driver.WindowHandles.Last());
             Assert.Equal("Amount due", s.Driver.FindElement(By.CssSelector("[data-test='amount-due-title']")).Text);
             Assert.Equal("Pay Invoice",
@@ -730,6 +728,21 @@ namespace BTCPayServer.Tests
             s.Driver.AssertElementNotFound(By.CssSelector("[data-test='status']"));
             Assert.Equal("Pay Invoice",
                 s.Driver.FindElement(By.CssSelector("[data-test='pay-button']")).Text.Trim());
+            s.Driver.SwitchTo().Window(s.Driver.WindowHandles.First());
+            
+            // archive (from details page)
+            var payReqId = s.Driver.Url.Split('/').Last();
+            s.Driver.FindElement(By.Id("ArchivePaymentRequest")).Click();
+            Assert.Contains("The payment request has been archived", s.FindAlertMessage().Text);
+            Assert.DoesNotContain("Pay123", s.Driver.PageSource);
+            s.Driver.FindElement(By.Id("SearchDropdownToggle")).Click();
+            s.Driver.FindElement(By.Id("SearchIncludeArchived")).Click();
+            Assert.Contains("Pay123", s.Driver.PageSource);
+            
+            // unarchive (from list)
+            s.Driver.FindElement(By.Id($"ToggleArchival-{payReqId}")).Click();
+            Assert.Contains("The payment request has been unarchived", s.FindAlertMessage().Text);
+            Assert.Contains("Pay123", s.Driver.PageSource);
         }
 
         [Fact(Timeout = TestTimeout)]

--- a/BTCPayServer/Controllers/UIPaymentRequestController.cs
+++ b/BTCPayServer/Controllers/UIPaymentRequestController.cs
@@ -336,9 +336,9 @@ namespace BTCPayServer.Controllers
                 model.Archived = !model.Archived;
                 await EditPaymentRequest(payReqId, model);
                 TempData[WellKnownTempData.SuccessMessage] = model.Archived
-                    ? "The payment request has been archived and will no longer appear in the  payment request list by default again."
-                    : "The payment request has been unarchived and will appear in the  payment request list by default.";
-                return RedirectToAction("GetPaymentRequests");
+                    ? "The payment request has been archived and will no longer appear in the payment request list by default again."
+                    : "The payment request has been unarchived and will appear in the payment request list by default.";
+                return RedirectToAction("GetPaymentRequests", new { storeId = store.Id });
             }
 
             return NotFound();

--- a/BTCPayServer/Views/UIPaymentRequest/EditPaymentRequest.cshtml
+++ b/BTCPayServer/Views/UIPaymentRequest/EditPaymentRequest.cshtml
@@ -111,26 +111,26 @@
                 </div>
             </div>
 
-            <div class="form-group mt-4">
+            <div class="form-group mt-4 d-flex gap-3">
                 <button type="submit" class="btn btn-primary" id="SaveButton">
                     @(string.IsNullOrEmpty(Model.Id) ? "Create" : "Save")
                 </button>
                 @if (!string.IsNullOrEmpty(Model.Id))
                 {
-                    <a class="btn btn-secondary" target="_blank" asp-action="ViewPaymentRequest" asp-route-payReqId="@Model.Id" id="ViewAppButton">View</a>
+                    <a class="btn btn-secondary" target="_blank" asp-action="ViewPaymentRequest" asp-route-payReqId="@Model.Id" id="ViewPaymentRequest">View</a>
                     <a class="btn btn-secondary"
                        target="_blank"
                        asp-action="ListInvoices"
                        asp-controller="UIInvoice"
                        asp-route-searchterm="@($"orderid:{PaymentRequestRepository.GetOrderIdForPaymentRequest(Model.Id)}")">Invoices</a>
-                    <a class="btn btn-secondary" asp-route-payReqId="@Model.Id" asp-action="ClonePaymentRequest" id="@Model.Id">Clone</a>
+                    <a class="btn btn-secondary" asp-route-payReqId="@Model.Id" asp-action="ClonePaymentRequest" id="ClonePaymentRequest">Clone</a>
                     @if (!Model.Archived)
                     {
-                        <a class="btn btn-secondary" data-bs-toggle="tooltip" title="Archive this payment request so that it does not appear in the payment request list by default" asp-controller="UIPaymentRequest" asp-action="TogglePaymentRequestArchival" asp-route-payReqId="@Model.Id">Archive</a>
+                        <a class="btn btn-secondary" data-bs-toggle="tooltip" title="Archive this payment request so that it does not appear in the payment request list by default" asp-controller="UIPaymentRequest" asp-action="TogglePaymentRequestArchival" asp-route-payReqId="@Model.Id" id="ArchivePaymentRequest">Archive</a>
                     }
                     else
                     {
-                        <a class="btn btn-secondary" data-bs-toggle="tooltip" title="Unarchive this payment request" asp-controller="UIPaymentRequest" asp-action="TogglePaymentRequestArchival" asp-route-payReqId="@Model.Id">Unarchive</a>
+                        <a class="btn btn-secondary" data-bs-toggle="tooltip" title="Unarchive this payment request" asp-controller="UIPaymentRequest" asp-action="TogglePaymentRequestArchival" asp-route-payReqId="@Model.Id" id="UnarchivePaymentRequest">Unarchive</a>
                     }
                 }
             </div>

--- a/BTCPayServer/Views/UIPaymentRequest/GetPaymentRequests.cshtml
+++ b/BTCPayServer/Views/UIPaymentRequest/GetPaymentRequests.cshtml
@@ -32,13 +32,13 @@
                 <button type="submit" class="btn btn-secondary text-nowrap" title="Search invoice">
                     <span class="fa fa-search"></span> Search
                 </button>
-                <button type="button" class="btn btn-secondary dropdown-toggle dropdown-toggle-split" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                <button type="button" class="btn btn-secondary dropdown-toggle dropdown-toggle-split" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false" id="SearchDropdownToggle">
                     <span class="visually-hidden">Toggle Dropdown</span>
                 </button>
-                <div class="dropdown-menu dropdown-menu-end">
-                    <a class="dropdown-item" asp-action="GetPaymentRequests" asp-route-storeId="@Context.GetStoreData().Id" asp-route-count="@Model.Count" asp-route-searchTerm="includearchived:true">Include Archived Payment Reqs</a>
+                <div class="dropdown-menu dropdown-menu-end" aria-labelledby="SearchDropdownToggle">
+                    <a class="dropdown-item" asp-action="GetPaymentRequests" asp-route-storeId="@Context.GetStoreData().Id" asp-route-count="@Model.Count" asp-route-searchTerm="includearchived:true" id="SearchIncludeArchived">Include Archived</a>
                     <div role="separator" class="dropdown-divider"></div>
-                    <a class="dropdown-item" href="?searchTerm=">Unfiltered</a>
+                    <a class="dropdown-item" href="?searchTerm=" id="SearchUnfiltered">Unfiltered</a>
                 </div>
             </div>
             <span asp-validation-for="SearchTerm" class="text-danger"></span>
@@ -69,7 +69,7 @@
                             <td class="text-end">@item.Amount @item.Currency</td>
                             <td class="text-end">@item.Status</td>
                             <td class="text-end">
-                                <a asp-action="EditPaymentRequest" asp-route-storeId="@item.StoreId" asp-route-payReqId="@item.Id">Edit</a>
+                                <a asp-action="EditPaymentRequest" asp-route-storeId="@item.StoreId" asp-route-payReqId="@item.Id" id="Edit-@item.Id">Edit</a>
                                 <span> - </span>
                                 <a asp-action="ViewPaymentRequest" asp-route-payReqId="@item.Id">View</a>
                                 <span> - </span>
@@ -77,9 +77,9 @@
                                 <span> - </span>
                                 <a target="_blank" asp-action="PayPaymentRequest" asp-route-payReqId="@item.Id">Pay</a>
                                 <span> - </span>
-                                <a target="_blank" asp-action="ClonePaymentRequest" asp-route-storeId="@item.StoreId" asp-route-payReqId="@item.Id">Clone</a>
+                                <a target="_blank" asp-action="ClonePaymentRequest" asp-route-storeId="@item.StoreId" asp-route-payReqId="@item.Id" id="Clone-@item.Id">Clone</a>
                                 <span> - </span>
-                                <a asp-action="TogglePaymentRequestArchival" asp-route-storeId="@item.StoreId" asp-route-payReqId="@item.Id">@(item.Archived ? "Unarchive" : "Archive")</a>
+                                <a asp-action="TogglePaymentRequestArchival" asp-route-storeId="@item.StoreId" asp-route-payReqId="@item.Id" id="ToggleArchival-@item.Id">@(item.Archived ? "Unarchive" : "Archive")</a>
                             </td>
                         </tr>
                     }


### PR DESCRIPTION
The redirect after archive/unarchive was broken because of the missing storeId parameter. Tests added.