### PR TITLE
Lightning payment info and fee handling

### DIFF
--- a/BTCPayServer.Client/BTCPayServer.Client.csproj
+++ b/BTCPayServer.Client/BTCPayServer.Client.csproj
@@ -28,8 +28,8 @@
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
   </ItemGroup>
     <ItemGroup>
-      <PackageReference Include="NBitcoin" Version="6.0.19" />
-      <PackageReference Include="BTCPayServer.Lightning.Common" Version="1.3.0" />
+      <PackageReference Include="NBitcoin" Version="7.0.1" />
+      <PackageReference Include="BTCPayServer.Lightning.Common" Version="1.3.1" />
       <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     </ItemGroup>
   <ItemGroup>

--- a/BTCPayServer.Client/BTCPayServerClient.Lightning.Internal.cs
+++ b/BTCPayServer.Client/BTCPayServerClient.Lightning.Internal.cs
@@ -54,8 +54,7 @@ namespace BTCPayServer.Client
             return await HandleResponse<string>(response);
         }
 
-
-        public virtual async Task PayLightningInvoice(string cryptoCode, PayLightningInvoiceRequest request,
+        public virtual async Task<LightningPaymentData> PayLightningInvoice(string cryptoCode, PayLightningInvoiceRequest request,
             CancellationToken token = default)
         {
             if (request == null)
@@ -63,7 +62,7 @@ namespace BTCPayServer.Client
             var response = await _httpClient.SendAsync(
                 CreateHttpRequest($"api/v1/server/lightning/{cryptoCode}/invoices/pay", bodyPayload: request,
                     method: HttpMethod.Post), token);
-            await HandleResponse(response);
+            return await HandleResponse<LightningPaymentData>(response);
         }
 
         public virtual async Task<LightningInvoiceData> GetLightningInvoice(string cryptoCode,

--- a/BTCPayServer.Client/Models/LightningPaymentData.cs
+++ b/BTCPayServer.Client/Models/LightningPaymentData.cs
@@ -1,0 +1,15 @@
+using BTCPayServer.Client.JsonConverters;
+using BTCPayServer.Lightning;
+using Newtonsoft.Json;
+
+namespace BTCPayServer.Client.Models
+{
+    public class LightningPaymentData
+    {
+        [JsonConverter(typeof(LightMoneyJsonConverter))]
+        public LightMoney TotalAmount { get; set; }
+
+        [JsonConverter(typeof(LightMoneyJsonConverter))]
+        public LightMoney FeeAmount { get; set; }
+    }
+}

--- a/BTCPayServer.Client/Models/PayLightningInvoiceRequest.cs
+++ b/BTCPayServer.Client/Models/PayLightningInvoiceRequest.cs
@@ -1,4 +1,7 @@
+#nullable enable
+using BTCPayServer.Client.JsonConverters;
 using BTCPayServer.JsonConverters;
+using NBitcoin;
 using Newtonsoft.Json;
 
 namespace BTCPayServer.Client.Models
@@ -10,5 +13,8 @@ namespace BTCPayServer.Client.Models
         
         [JsonProperty(ItemConverterType = typeof(NumericStringJsonConverter))]
         public float? MaxFeePercent { get; set; }
+        
+        [JsonConverter(typeof(MoneyJsonConverter))]
+        public Money? MaxFeeFlat { get; set; }
     }
 }

--- a/BTCPayServer.Client/Models/PayLightningInvoiceRequest.cs
+++ b/BTCPayServer.Client/Models/PayLightningInvoiceRequest.cs
@@ -1,8 +1,14 @@
+using BTCPayServer.JsonConverters;
+using Newtonsoft.Json;
+
 namespace BTCPayServer.Client.Models
 {
     public class PayLightningInvoiceRequest
     {
-        [Newtonsoft.Json.JsonProperty("BOLT11")]
+        [JsonProperty("BOLT11")]
         public string BOLT11 { get; set; }
+        
+        [JsonProperty(ItemConverterType = typeof(NumericStringJsonConverter))]
+        public float? MaxFeePercent { get; set; }
     }
 }

--- a/BTCPayServer.Rating/BTCPayServer.Rating.csproj
+++ b/BTCPayServer.Rating/BTCPayServer.Rating.csproj
@@ -6,7 +6,7 @@
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.0.1" />
     <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.7" />
-    <PackageReference Include="NBitcoin" Version="6.0.19" />
+    <PackageReference Include="NBitcoin" Version="7.0.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="DigitalRuby.ExchangeSharp" Version="0.6.3" />
   </ItemGroup>

--- a/BTCPayServer/BTCPayServer.csproj
+++ b/BTCPayServer/BTCPayServer.csproj
@@ -48,7 +48,7 @@
   <ItemGroup>
     <PackageReference Include="BIP78.Sender" Version="0.2.2" />
     <PackageReference Include="BTCPayServer.Hwi" Version="2.0.2" />
-    <PackageReference Include="BTCPayServer.Lightning.All" Version="1.3.0" />
+    <PackageReference Include="BTCPayServer.Lightning.All" Version="1.3.2" />
     <PackageReference Include="BuildBundlerMinifier" Version="3.2.449" />
     <PackageReference Include="BundlerMinifier.Core" Version="3.2.435" />
     <PackageReference Include="BundlerMinifier.TagHelpers" Version="3.2.435" />

--- a/BTCPayServer/Controllers/GreenField/GreenfieldLightningNodeApiController.cs
+++ b/BTCPayServer/Controllers/GreenField/GreenfieldLightningNodeApiController.cs
@@ -178,8 +178,12 @@ namespace BTCPayServer.Controllers.Greenfield
             {
                 return this.CreateValidationError(ModelState);
             }
-
-            var result = await lightningClient.Pay(lightningInvoice.BOLT11, new PayInvoiceParams { MaxFeePercent = lightningInvoice.MaxFeePercent });
+            
+            var param = lightningInvoice?.MaxFeeFlat != null || lightningInvoice?.MaxFeePercent != null
+                ? new PayInvoiceParams { MaxFeePercent = lightningInvoice.MaxFeePercent, MaxFeeFlat = lightningInvoice.MaxFeeFlat }
+                : null;
+            var result = await lightningClient.Pay(lightningInvoice.BOLT11, param);
+            
             return result.Result switch
             {
                 PayResult.CouldNotFindRoute => this.CreateAPIError("could-not-find-route", "Impossible to find a route to the peer"),

--- a/BTCPayServer/Controllers/GreenField/LocalBTCPayServerClient.cs
+++ b/BTCPayServer/Controllers/GreenField/LocalBTCPayServerClient.cs
@@ -497,10 +497,11 @@ namespace BTCPayServer.Controllers.Greenfield
                 await _lightningNodeApiController.GetDepositAddress(cryptoCode));
         }
 
-        public override async Task PayLightningInvoice(string cryptoCode, PayLightningInvoiceRequest request,
+        public override async Task<LightningPaymentData> PayLightningInvoice(string cryptoCode, PayLightningInvoiceRequest request,
             CancellationToken token = default)
         {
-            HandleActionResult(await _lightningNodeApiController.PayInvoice(cryptoCode, request));
+            return GetFromActionResult<LightningPaymentData>(
+                await _lightningNodeApiController.PayInvoice(cryptoCode, request));
         }
 
         public override async Task<LightningInvoiceData> GetLightningInvoice(string cryptoCode, string invoiceId,
@@ -517,7 +518,6 @@ namespace BTCPayServer.Controllers.Greenfield
             return GetFromActionResult<LightningInvoiceData>(
                 await _lightningNodeApiController.CreateInvoice(cryptoCode, request));
         }
-
 
         private T GetFromActionResult<T>(IActionResult result)
         {

--- a/BTCPayServer/wwwroot/swagger/v1/swagger.template.lightning.common.json
+++ b/BTCPayServer/wwwroot/swagger/v1/swagger.template.lightning.common.json
@@ -162,6 +162,12 @@
                         "nullable": true,
                         "description": "The fee limit expressed as a percentage of the payment amount",
                         "example": "6.15"
+                    },
+                    "maxFeeFlat": {
+                        "type": "string",
+                        "nullable": true,
+                        "description": "The fee limit expressed as a fixed amount in satoshi",
+                        "example": "21"
                     }
                 }
             },

--- a/BTCPayServer/wwwroot/swagger/v1/swagger.template.lightning.common.json
+++ b/BTCPayServer/wwwroot/swagger/v1/swagger.template.lightning.common.json
@@ -70,6 +70,20 @@
                     }
                 }
             },
+            "LightningPaymentData": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "totalAmount": {
+                        "type": "string",
+                        "description": "The total amount (including fees) in millisatoshi"
+                    },
+                    "feeAmount": {
+                        "type": "string",
+                        "description": "The total fees in millisatoshi"
+                    }
+                }
+            },
             "LightningInvoiceData": {
                 "type": "object",
                 "additionalProperties": false,
@@ -141,6 +155,13 @@
                     "BOLT11": {
                         "type": "string",
                         "description": "The BOLT11 of the invoice to pay"
+                    },
+                    "maxFeePercent": {
+                        "type": "string",
+                        "format": "float",
+                        "nullable": true,
+                        "description": "The fee limit expressed as a percentage of the payment amount",
+                        "example": "6.15"
                     }
                 }
             },

--- a/BTCPayServer/wwwroot/swagger/v1/swagger.template.lightning.internal.json
+++ b/BTCPayServer/wwwroot/swagger/v1/swagger.template.lightning.internal.json
@@ -361,7 +361,14 @@
                 "operationId": "InternalLightningNodeApi_PayInvoice",
                 "responses": {
                     "200": {
-                        "description": "Successfully paid"
+                        "description": "Successfully paid",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/LightningPaymentData"
+                                }
+                            }
+                        }
                     },
                     "422": {
                         "description": "Unable to validate the request",

--- a/BTCPayServer/wwwroot/swagger/v1/swagger.template.lightning.store.json
+++ b/BTCPayServer/wwwroot/swagger/v1/swagger.template.lightning.store.json
@@ -428,7 +428,14 @@
                 "operationId": "StoreLightningNodeApi_PayInvoice",
                 "responses": {
                     "200": {
-                        "description": "Successfully paid"
+                        "description": "Successfully paid",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/LightningPaymentData"
+                                }
+                            }
+                        }
                     },
                     "422": {
                         "description": "Unable to validate the request",


### PR DESCRIPTION
Builds on the additions in btcpayserver/BTCPayServer.Lightning#59 and btcpayserver/BTCPayServer.Lightning#61. This PR is a draft until the latter is merged and integrated.

Adds payment information (total amount and fees) to the API response and allows to set an optional maximum fee percentage when paying.