### PR TITLE
Removes redundant header on Theme view

### DIFF
--- a/BTCPayServer/Views/UIServer/Theme.cshtml
+++ b/BTCPayServer/Views/UIServer/Theme.cshtml
@@ -12,7 +12,6 @@
 <div class="row">
     <div class="col-xl-8 col-xxl-constrain">
         <form method="post">
-            <h4 class="mb-3">Custom theme</h4>
             <p>Use the default Light or Dark Themes, or provide a CSS theme file below.</p>
             @if (!ViewContext.ModelState.IsValid)
             {


### PR DESCRIPTION
Another dead simple PR addressing an issue @bolatovumar noticed in https://github.com/btcpayserver/btcpayserver/discussions/3466.

Removes redundant "Custom Theme" header underneath "Theme" header

<img width="904" alt="Screen Shot 2022-02-16 at 11 10 11 PM" src="https://user-images.githubusercontent.com/6250771/154424106-828cb88c-9dcc-442d-9b14-e25e425670dc.png">

