### PR TITLE
Sticky header updates

### DIFF
--- a/BTCPayServer/TagHelpers/StickyHeader.cs
+++ b/BTCPayServer/TagHelpers/StickyHeader.cs
@@ -1,0 +1,30 @@
+using System.Text;
+using System.Text.Encodings.Web;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Razor.TagHelpers;
+
+namespace BTCPayServer.TagHelpers;
+
+[HtmlTargetElement("sticky-header")]
+public class StickyHeader : TagHelper
+{
+    private readonly HtmlEncoder _htmlEncoder;
+    
+    [HtmlAttributeName("class")]
+    public string CssClass { get; set; }
+    
+    public StickyHeader(HtmlEncoder htmlEncoder)
+    {
+        _htmlEncoder = htmlEncoder;
+    }
+    
+    public override async Task ProcessAsync(TagHelperContext context, TagHelperOutput output)
+    {
+        var content = await output.GetChildContentAsync(NullHtmlEncoder.Default);
+        var additionalClasses = string.IsNullOrEmpty(CssClass) ? "" : $" {_htmlEncoder.Encode(CssClass)}";
+        output.TagName = null;
+        output.Content.SetHtmlContent("<div class=\"sticky-header-setup\"></div>" +
+            $"<header class=\"sticky-header{additionalClasses}\">{content.GetContent()}</header>" +
+            "<script>const { offsetHeight } = document.querySelector('.sticky-header-setup + .sticky-header');document.documentElement.style.scrollPaddingTop = `calc(${offsetHeight}px + var(--btcpay-space-m))`;</script>");
+    }
+}

--- a/BTCPayServer/Views/UIApps/UpdateCrowdfund.cshtml
+++ b/BTCPayServer/Views/UIApps/UpdateCrowdfund.cshtml
@@ -18,8 +18,7 @@
 }
 
 <form method="post">
-    <div class="sticky-header-setup"></div>
-    <header class="sticky-header d-sm-flex align-items-center justify-content-between">
+    <sticky-header class="d-sm-flex align-items-center justify-content-between">
         <h2 class="mb-0">@ViewData["Title"]</h2>
         <div class="d-flex gap-3 mt-3 mt-sm-0">
             <button type="submit" class="btn btn-primary order-sm-1" id="SaveSettings">Save</button>   
@@ -29,11 +28,7 @@
             }
             <a class="btn btn-secondary" asp-action="ListInvoices" asp-controller="UIInvoice" asp-route-storeId="@Model.StoreId" asp-route-searchterm="@Model.SearchTerm">Invoices</a>
         </div>
-    </header>
-    <script>
-        const { offsetHeight } = document.querySelector('.sticky-header-setup + .sticky-header');
-        document.documentElement.style.scrollPaddingTop = `calc(${offsetHeight}px + var(--btcpay-space-m))`;
-    </script>
+    </sticky-header>
 
     <partial name="_StatusMessage" />
 

--- a/BTCPayServer/Views/UIApps/UpdatePointOfSale.cshtml
+++ b/BTCPayServer/Views/UIApps/UpdatePointOfSale.cshtml
@@ -6,19 +6,14 @@
 }
 
 <form method="post">
-    <div class="sticky-header-setup"></div>
-    <header class="sticky-header d-sm-flex align-items-center justify-content-between">
+    <sticky-header class="d-sm-flex align-items-center justify-content-between">
         <h2 class="mb-0">@ViewData["Title"]</h2>
         <div class="d-flex gap-3 mt-3 mt-sm-0">
             <button type="submit" class="btn btn-primary order-sm-1" id="SaveSettings">Save</button>
             <a class="btn btn-secondary" asp-action="ViewPointOfSale" asp-controller="UIAppsPublic" asp-route-appId="@Model.Id" id="ViewApp" target="app_@Model.AppId">View</a>
             <a class="btn btn-secondary" asp-action="ListInvoices" asp-controller="UIInvoice" asp-route-searchterm="@Model.SearchTerm">Invoices</a>
         </div>
-    </header>
-    <script>
-        const { offsetHeight } = document.querySelector('.sticky-header-setup + .sticky-header');
-        document.documentElement.style.scrollPaddingTop = `calc(${offsetHeight}px + var(--btcpay-space-m))`;
-    </script>
+    </sticky-header>
 
     <partial name="_StatusMessage" />
 

--- a/BTCPayServer/Views/UIInvoice/CreateInvoice.cshtml
+++ b/BTCPayServer/Views/UIInvoice/CreateInvoice.cshtml
@@ -25,9 +25,12 @@
     </script>
 }
 
-<partial name="_StatusMessage" />
+<sticky-header class="d-flex align-items-center justify-content-between">
+    <h2 class="mb-0">@ViewData["Title"]</h2>
+    <input type="submit" value="Create" class="btn btn-primary" id="Create" />
+</sticky-header>
 
-<h2 class="mt-1 mb-4">@ViewData["Title"]</h2>
+<partial name="_StatusMessage" />
 
 <div class="row">
     <div class="col-xl-8 col-xxl-constrain">
@@ -58,98 +61,95 @@
                     <input asp-for="Currency" currency-selection class="form-control" />
                     <span asp-validation-for="Currency" class="text-danger"></span>
                 </div>
-             </div>
-                <div class="form-group">
-                    <label asp-for="OrderId" class="form-label"></label>
-                    <input asp-for="OrderId" class="form-control" />
-                    <span asp-validation-for="OrderId" class="text-danger"></span>
-                </div>
-                <div class="form-group">
-                    <label asp-for="ItemDesc" class="form-label"></label>
-                    <input asp-for="ItemDesc" class="form-control" />
-                    <span asp-validation-for="ItemDesc" class="text-danger"></span>
-                </div>
-                <div class="form-group mb-4">
-                    <label asp-for="SupportedTransactionCurrencies" class="form-label"></label>
-                    @foreach (var item in Model.AvailablePaymentMethods)
-                    {
-                        <div class="form-check mb-2">
-                            <label class="form-check-label">
-                                <input name="SupportedTransactionCurrencies" class="form-check-input" checked="checked" type="checkbox" value="@item.Value">
-                                @item.Text
-                            </label>
-                        </div>
-                    }
-                    <span asp-validation-for="SupportedTransactionCurrencies" class="text-danger"></span>
-                </div>
-                <div class="form-group">
-                    <label asp-for="DefaultPaymentMethod" class="form-label"></label>
-                    <select asp-for="DefaultPaymentMethod" asp-items="Model.AvailablePaymentMethods" class="form-select">
-                        <option value="" selected>Use the store’s default</option>
-                    </select>
-                    <span asp-validation-for="DefaultPaymentMethod" class="text-danger"></span>
-                </div>
-                <h4 class="mt-5 mb-4">Customer Information</h4>
-                <div class="form-group">
-                    <label asp-for="BuyerEmail" class="form-label"></label>
-                    <input asp-for="BuyerEmail" class="form-control" />
-                    <span asp-validation-for="BuyerEmail" class="text-danger"></span>
-                </div>
-                <div class="form-group">
-                    <label asp-for="RequiresRefundEmail" class="form-label"></label>
-                    <select asp-for="RequiresRefundEmail" asp-items="@Html.GetEnumSelectList<RequiresRefundEmail>()" class="form-select"></select>
-                    <span asp-validation-for="RequiresRefundEmail" class="text-danger"></span>
-                </div>
+            </div>
+            <div class="form-group">
+                <label asp-for="OrderId" class="form-label"></label>
+                <input asp-for="OrderId" class="form-control" />
+                <span asp-validation-for="OrderId" class="text-danger"></span>
+            </div>
+            <div class="form-group">
+                <label asp-for="ItemDesc" class="form-label"></label>
+                <input asp-for="ItemDesc" class="form-control" />
+                <span asp-validation-for="ItemDesc" class="text-danger"></span>
+            </div>
+            <div class="form-group mb-4">
+                <label asp-for="SupportedTransactionCurrencies" class="form-label"></label>
+                @foreach (var item in Model.AvailablePaymentMethods)
+                {
+                    <div class="form-check mb-2">
+                        <label class="form-check-label">
+                            <input name="SupportedTransactionCurrencies" class="form-check-input" checked="checked" type="checkbox" value="@item.Value">
+                            @item.Text
+                        </label>
+                    </div>
+                }
+                <span asp-validation-for="SupportedTransactionCurrencies" class="text-danger"></span>
+            </div>
+            <div class="form-group">
+                <label asp-for="DefaultPaymentMethod" class="form-label"></label>
+                <select asp-for="DefaultPaymentMethod" asp-items="Model.AvailablePaymentMethods" class="form-select">
+                    <option value="" selected>Use the store’s default</option>
+                </select>
+                <span asp-validation-for="DefaultPaymentMethod" class="text-danger"></span>
+            </div>
+            <h4 class="mt-5 mb-4">Customer Information</h4>
+            <div class="form-group">
+                <label asp-for="BuyerEmail" class="form-label"></label>
+                <input asp-for="BuyerEmail" class="form-control" />
+                <span asp-validation-for="BuyerEmail" class="text-danger"></span>
+            </div>
+            <div class="form-group">
+                <label asp-for="RequiresRefundEmail" class="form-label"></label>
+                <select asp-for="RequiresRefundEmail" asp-items="@Html.GetEnumSelectList<RequiresRefundEmail>()" class="form-select"></select>
+                <span asp-validation-for="RequiresRefundEmail" class="text-danger"></span>
+            </div>
 
-                <h4 class="mt-5 mb-2">Additional Options</h4>
-                <div class="form-group">
-                    <div class="accordion" id="additional">
-                        <div class="accordion-item">
-                            <h2 class="accordion-header" id="additional-pos-data-header">
-                                <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#additional-pos-data" aria-expanded="false" aria-controls="additional-pos-data">
-                                    Point Of Sale Data
-                                    <vc:icon symbol="caret-down" />
-                                </button>
-                            </h2>
-                            <div id="additional-pos-data" class="accordion-collapse collapse" aria-labelledby="additional-pos-data-header">
-                                <p>Custom data to correlate the invoice with an order. This data can be a simple text, number or JSON object, e.g. <code>{ "orderId": 615, "product": "Pizza" }</code></p>
-                                <div class="form-group">
-                                    <label asp-for="PosData" class="form-label"></label>
-                                    <input asp-for="PosData" class="form-control" />
-                                    <span asp-validation-for="PosData" class="text-danger"></span>
-                                </div>
+            <h4 class="mt-5 mb-2">Additional Options</h4>
+            <div class="form-group">
+                <div class="accordion" id="additional">
+                    <div class="accordion-item">
+                        <h2 class="accordion-header" id="additional-pos-data-header">
+                            <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#additional-pos-data" aria-expanded="false" aria-controls="additional-pos-data">
+                                Point Of Sale Data
+                                <vc:icon symbol="caret-down" />
+                            </button>
+                        </h2>
+                        <div id="additional-pos-data" class="accordion-collapse collapse" aria-labelledby="additional-pos-data-header">
+                            <p>Custom data to correlate the invoice with an order. This data can be a simple text, number or JSON object, e.g. <code>{ "orderId": 615, "product": "Pizza" }</code></p>
+                            <div class="form-group">
+                                <label asp-for="PosData" class="form-label"></label>
+                                <input asp-for="PosData" class="form-control" />
+                                <span asp-validation-for="PosData" class="text-danger"></span>
                             </div>
                         </div>
-                        <div class="accordion-item">
-                            <h2 class="accordion-header" id="additional-notifications-header">
-                                <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#additional-notifications" aria-expanded="false" aria-controls="additional-notifications">
-                                    Invoice Notifications
-                                    <vc:icon symbol="caret-down" />
-                                </button>
-                            </h2>
-                            <div id="additional-notifications" class="accordion-collapse collapse" aria-labelledby="additional-notifications-header">
-                                <div class="accordion-body">
-                                    <div class="form-group">
-                                        <label asp-for="NotificationUrl" class="form-label"></label>
-                                        <input asp-for="NotificationUrl" class="form-control" />
-                                        <span asp-validation-for="NotificationUrl" class="text-danger"></span>
-                                    </div>
-                                    <div class="form-group">
-                                        <label asp-for="NotificationEmail" class="form-label"></label>
-                                        <input asp-for="NotificationEmail" class="form-control" />
-                                        <span asp-validation-for="NotificationEmail" class="text-danger"></span>
-                                        <p id="InvoiceEmailHelpBlock" class="form-text text-muted">
-                                            Receive updates for this invoice.
-                                        </p>
-                                    </div>
+                    </div>
+                    <div class="accordion-item">
+                        <h2 class="accordion-header" id="additional-notifications-header">
+                            <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#additional-notifications" aria-expanded="false" aria-controls="additional-notifications">
+                                Invoice Notifications
+                                <vc:icon symbol="caret-down" />
+                            </button>
+                        </h2>
+                        <div id="additional-notifications" class="accordion-collapse collapse" aria-labelledby="additional-notifications-header">
+                            <div class="accordion-body">
+                                <div class="form-group">
+                                    <label asp-for="NotificationUrl" class="form-label"></label>
+                                    <input asp-for="NotificationUrl" class="form-control" />
+                                    <span asp-validation-for="NotificationUrl" class="text-danger"></span>
+                                </div>
+                                <div class="form-group">
+                                    <label asp-for="NotificationEmail" class="form-label"></label>
+                                    <input asp-for="NotificationEmail" class="form-control" />
+                                    <span asp-validation-for="NotificationEmail" class="text-danger"></span>
+                                    <p id="InvoiceEmailHelpBlock" class="form-text text-muted">
+                                        Receive updates for this invoice.
+                                    </p>
                                 </div>
                             </div>
                         </div>
                     </div>
                 </div>
-                <div class="form-group mt-4">
-                    <input type="submit" value="Create" class="btn btn-primary" id="Create" />
-                </div>
+            </div>
         </form>
     </div>
 </div>

--- a/BTCPayServer/Views/UIInvoice/Invoice.cshtml
+++ b/BTCPayServer/Views/UIInvoice/Invoice.cshtml
@@ -41,41 +41,37 @@
 }
 
 <div class="invoice-details">
-    <partial name="_StatusMessage" />
-    <div class="row mb-5">
-        <h2 class="col col-xl-6 mb-4 mb-xl-0">@ViewData["Title"]</h2>
-        <div class="col col-xl-6 mb-2 mb-xl-0 text-xl-end">
-            <div class="d-inline-flex">
-                @if (Model.ShowCheckout)
-                {
-                    <a asp-action="Checkout" class="invoice-checkout-link btn btn-primary text-nowrap ms-2" asp-route-invoiceId="@Model.Id">
-                        <i class="fa fa-qrcode"></i>
-                        Checkout
-                    </a>
-                }
-                @if (Model.CanRefund)
-                {
-                    <a id="refundlink" class="btn btn-success text-nowrap" asp-action="Refund" asp-route-invoiceId="@Context.GetRouteValue("invoiceId")"><span class="fa fa-undo"></span> Issue Refund</a>
-                }
-                else
-                {
-                    <button href="#" class="btn btn-secondary text-nowrap" data-bs-toggle="tooltip" title="You can only refund an invoice that has been settled. Please wait for the transaction to confirm on the blockchain before attempting to refund it." disabled><span class="fa fa-undo me-1"></span> Issue refund</button>
-                }
-                <form class="p-0 ms-3" asp-action="ToggleArchive" asp-route-invoiceId="@Model.Id" method="post">
-                    <button type="submit" class="btn @(Model.Archived ? "btn-warning" : "btn btn-danger")" id="btn-archive-toggle">
-                        @if (Model.Archived)
-                        {
-                            <span class="text-nowrap" data-bs-toggle="tooltip" title="Unarchive this invoice">Unarchive</span>
-                        }
-                        else
-                        {
-                            <span class="text-nowrap" data-bs-toggle="tooltip" title="Archive this invoice so that it does not appear in the invoice list by default"><i class="fa fa-archive me-1"></i> Archive</span>
-                        }
-                    </button>
-                </form>
-            </div>
+    <sticky-header class="d-md-flex align-items-center justify-content-between">
+        <h2 class="mb-0">@ViewData["Title"]</h2>
+        <div class="d-flex gap-3 mt-3 mt-md-0">
+            @if (Model.ShowCheckout)
+            {
+                <a asp-action="Checkout" class="invoice-checkout-link btn btn-primary text-nowrap" asp-route-invoiceId="@Model.Id">Checkout</a>
+            }
+            @if (Model.CanRefund)
+            {
+                <a id="refundlink" class="btn btn-success text-nowrap" asp-action="Refund" asp-route-invoiceId="@Context.GetRouteValue("invoiceId")">Issue Refund</a>
+            }
+            else
+            {
+                <button href="#" class="btn btn-secondary text-nowrap" data-bs-toggle="tooltip" title="You can only refund an invoice that has been settled. Please wait for the transaction to confirm on the blockchain before attempting to refund it." disabled>Issue refund</button>
+            }
+            <form asp-action="ToggleArchive" asp-route-invoiceId="@Model.Id" method="post">
+                <button type="submit" class="btn @(Model.Archived ? "btn-warning" : "btn btn-danger")" id="btn-archive-toggle">
+                    @if (Model.Archived)
+                    {
+                        <span class="text-nowrap" data-bs-toggle="tooltip" title="Unarchive this invoice">Unarchive</span>
+                    }
+                    else
+                    {
+                        <span class="text-nowrap" data-bs-toggle="tooltip" title="Archive this invoice so that it does not appear in the invoice list by default"><i class="fa fa-archive me-1"></i> Archive</span>
+                    }
+                </button>
+            </form>
         </div>
-    </div>
+    </sticky-header>
+
+    <partial name="_StatusMessage" />
 
     <div class="row justify-content-between">
         <div class="col-md-5">

--- a/BTCPayServer/Views/UIInvoice/ListInvoices.cshtml
+++ b/BTCPayServer/Views/UIInvoice/ListInvoices.cshtml
@@ -181,9 +181,7 @@
 
 @Html.HiddenFor(a => a.Count)
 
-<partial name="_StatusMessage" />
-
-<div class="d-sm-flex align-items-center justify-content-between mb-4">
+<sticky-header class="d-sm-flex align-items-center justify-content-between">
     <h2 class="mb-0">
         @ViewData["Title"]
         <small>
@@ -196,7 +194,9 @@
         <span class="fa fa-plus"></span>
         Create Invoice
     </a>
-</div>
+</sticky-header>
+
+<partial name="_StatusMessage" />
 
 <partial name="InvoiceStatusChangePartial" />
 

--- a/BTCPayServer/Views/UIManage/_Nav.cshtml
+++ b/BTCPayServer/Views/UIManage/_Nav.cshtml
@@ -1,7 +1,6 @@
 @inject SignInManager<ApplicationUser> SignInManager
 
-<div class="sticky-header-setup"></div>
-<header class="sticky-header mb-l">
+<sticky-header class="mb-l">
     <h2 class="mt-1 mb-2 mb-lg-4">Account Settings</h2>
     <nav id="SectionNav">
         <div class="nav">
@@ -14,8 +13,4 @@
             <vc:ui-extension-point location="user-nav" model="@Model"/>
         </div>
     </nav>
-</header>
-<script>
-    const { offsetHeight } = document.querySelector('.sticky-header-setup + .sticky-header');
-    document.documentElement.style.scrollPaddingTop = `calc(${offsetHeight}px + var(--btcpay-space-m))`;
-</script>
+</sticky-header>

--- a/BTCPayServer/Views/UIPaymentRequest/EditPaymentRequest.cshtml
+++ b/BTCPayServer/Views/UIPaymentRequest/EditPaymentRequest.cshtml
@@ -15,9 +15,37 @@
     <bundle name="wwwroot/bundles/payment-request-admin-bundle.min.js" asp-append-version="true"></bundle>
 }
 
-<partial name="_StatusMessage" />
+<sticky-header class="@(string.IsNullOrEmpty(Model.Id) ? "d-flex" : "d-xl-flex") align-items-center justify-content-between">
+    <h2 class="mb-0">@ViewData["Title"]</h2>
+    @if (string.IsNullOrEmpty(Model.Id))
+    {
+        <button type="submit" class="btn btn-primary" id="SaveButton">Create</button>
+    }
+    else
+    {
+        <div class="d-flex flex-wrap gap-3 mt-3 mt-xl-0">
+            <button type="submit" class="btn btn-primary order-xl-1" id="SaveButton">Save</button>
+        
+            <a class="btn btn-secondary" target="_blank" asp-action="ViewPaymentRequest" asp-route-payReqId="@Model.Id" id="ViewPaymentRequest">View</a>
+            <a class="btn btn-secondary"
+               target="_blank"
+               asp-action="ListInvoices"
+               asp-controller="UIInvoice"
+               asp-route-searchterm="@($"orderid:{PaymentRequestRepository.GetOrderIdForPaymentRequest(Model.Id)}")">Invoices</a>
+            <a class="btn btn-secondary" asp-route-payReqId="@Model.Id" asp-action="ClonePaymentRequest" id="ClonePaymentRequest">Clone</a>
+            @if (!Model.Archived)
+            {
+                <a class="btn btn-secondary" data-bs-toggle="tooltip" title="Archive this payment request so that it does not appear in the payment request list by default" asp-controller="UIPaymentRequest" asp-action="TogglePaymentRequestArchival" asp-route-payReqId="@Model.Id" id="ArchivePaymentRequest">Archive</a>
+            }
+            else
+            {
+                <a class="btn btn-secondary" data-bs-toggle="tooltip" title="Unarchive this payment request" asp-controller="UIPaymentRequest" asp-action="TogglePaymentRequestArchival" asp-route-payReqId="@Model.Id" id="UnarchivePaymentRequest">Unarchive</a>
+            }
+        </div>
+    }
+</sticky-header>
 
-<h2 class="mt-1 mb-4">@ViewData["Title"]</h2>
+<partial name="_StatusMessage" />
 
 <form method="post" action="@Url.Action("EditPaymentRequest", "UIPaymentRequest", new { storeId = Model.StoreId, payReqId = Model.Id }, Context.Request.Scheme)">
     <div class="row">
@@ -109,30 +137,6 @@
                         </div>
                     </div>
                 </div>
-            </div>
-
-            <div class="form-group mt-4 d-flex gap-3">
-                <button type="submit" class="btn btn-primary" id="SaveButton">
-                    @(string.IsNullOrEmpty(Model.Id) ? "Create" : "Save")
-                </button>
-                @if (!string.IsNullOrEmpty(Model.Id))
-                {
-                    <a class="btn btn-secondary" target="_blank" asp-action="ViewPaymentRequest" asp-route-payReqId="@Model.Id" id="ViewPaymentRequest">View</a>
-                    <a class="btn btn-secondary"
-                       target="_blank"
-                       asp-action="ListInvoices"
-                       asp-controller="UIInvoice"
-                       asp-route-searchterm="@($"orderid:{PaymentRequestRepository.GetOrderIdForPaymentRequest(Model.Id)}")">Invoices</a>
-                    <a class="btn btn-secondary" asp-route-payReqId="@Model.Id" asp-action="ClonePaymentRequest" id="ClonePaymentRequest">Clone</a>
-                    @if (!Model.Archived)
-                    {
-                        <a class="btn btn-secondary" data-bs-toggle="tooltip" title="Archive this payment request so that it does not appear in the payment request list by default" asp-controller="UIPaymentRequest" asp-action="TogglePaymentRequestArchival" asp-route-payReqId="@Model.Id" id="ArchivePaymentRequest">Archive</a>
-                    }
-                    else
-                    {
-                        <a class="btn btn-secondary" data-bs-toggle="tooltip" title="Unarchive this payment request" asp-controller="UIPaymentRequest" asp-action="TogglePaymentRequestArchival" asp-route-payReqId="@Model.Id" id="UnarchivePaymentRequest">Unarchive</a>
-                    }
-                }
             </div>
         </div>
     </div>

--- a/BTCPayServer/Views/UIPaymentRequest/GetPaymentRequests.cshtml
+++ b/BTCPayServer/Views/UIPaymentRequest/GetPaymentRequests.cshtml
@@ -5,9 +5,7 @@
     ViewData["Title"] = "Payment Requests";
 }
 
-<partial name="_StatusMessage" />
-
-<div class="d-sm-flex align-items-center justify-content-between mb-4">
+<sticky-header class="d-sm-flex align-items-center justify-content-between">
     <h2 class="mb-0">
         @ViewData["Title"]
         <small>
@@ -20,7 +18,9 @@
         <span class="fa fa-plus"></span>
         Create Payment Request
     </a>
-</div>
+</sticky-header>
+
+<partial name="_StatusMessage" />
 
 <div class="row mb-2">
     <div class="col col-lg-8 col-xl-6 mr-auto">

--- a/BTCPayServer/Views/UIServer/_Nav.cshtml
+++ b/BTCPayServer/Views/UIServer/_Nav.cshtml
@@ -1,8 +1,7 @@
 ﻿@using BTCPayServer.Configuration
 @inject BTCPayServerOptions _btcPayServerOptions
 
-<div class="sticky-header-setup"></div>
-<header class="sticky-header mb-l">
+<sticky-header class="mb-l">
     <h2 class="mt-1 mb-2 mb-lg-4">Server Settings</h2>
     <nav id="SectionNav">
         <div class="nav">
@@ -21,8 +20,4 @@
             <vc:ui-extension-point location="server-nav" model="@Model"/>
         </div>
     </nav>
-</header>
-<script>
-    const { offsetHeight } = document.querySelector('.sticky-header-setup + .sticky-header');
-    document.documentElement.style.scrollPaddingTop = `calc(${offsetHeight}px + var(--btcpay-space-m))`;
-</script>
+</sticky-header>

--- a/BTCPayServer/Views/UIStorePullPayments/NewPullPayment.cshtml
+++ b/BTCPayServer/Views/UIStorePullPayments/NewPullPayment.cshtml
@@ -14,9 +14,12 @@
     <bundle name="wwwroot/bundles/pull-payment-admin-bundle.min.js" asp-append-version="true"></bundle>
 }
 
-<partial name="_StatusMessage" />
+<sticky-header class="d-flex align-items-center justify-content-between">
+    <h2 class="mb-0">@ViewData["Title"]</h2>
+    <input type="submit" value="Create" class="btn btn-primary" id="Create"/>
+</sticky-header>
 
-<h2 class="mt-1 mb-4">@ViewData["Title"]</h2>
+<partial name="_StatusMessage" />
 
 <form
     method="post"
@@ -110,10 +113,6 @@
                         </div>
 					</div>
                 </div>
-            </div>
-
-            <div class="form-group">
-                <input type="submit" value="Create" class="btn btn-primary" id="Create"/>
             </div>
         </div>
     </div>

--- a/BTCPayServer/Views/UIStorePullPayments/PullPayments.cshtml
+++ b/BTCPayServer/Views/UIStorePullPayments/PullPayments.cshtml
@@ -1,7 +1,8 @@
-@using BTCPayServer.Views.Stores
+﻿@using BTCPayServer.Views.Stores
 @using BTCPayServer.Abstractions.Extensions
 @using BTCPayServer.Client
 @using BTCPayServer.Client.Models
+@using ExchangeSharp
 @model BTCPayServer.Models.WalletViewModels.PullPaymentsModel
 @{
     ViewData.SetActivePage(StoreNavPages.PullPayments, "Pull Payments", Context.GetStoreData().Id);
@@ -35,9 +36,7 @@
     </style>
 }
 
-<partial name="_StatusMessage" />
-
-<div class="d-flex align-items-center justify-content-between mb-2">
+<sticky-header class="d-flex align-items-center justify-content-between">
     <h2 class="mb-0">
         @ViewData["Title"]
         <small>
@@ -49,7 +48,9 @@
     <a permission="@Policies.CanModifyStoreSettings" asp-action="NewPullPayment" asp-route-storeId="@Context.GetRouteValue("storeId")" class="btn btn-primary" role="button" id="NewPullPayment">
         <span class="fa fa-plus"></span> Create Pull Payment
     </a>
-</div>
+</sticky-header>
+
+<partial name="_StatusMessage" />
 
 <ul class="nav nav-pills border bg-tile" style="border-radius: 4px;">
     @foreach (var state in Enum.GetValues(typeof(PullPaymentState)).Cast<PullPaymentState>())
@@ -174,7 +175,7 @@
 }
 else
 {
-    <p class="text-secondary mt-3">
-        There are no pull payments yet.
+    <p class="text-secondary mt-4">
+        There are no @Model.ActiveState.ToStringLowerInvariant() pull payments yet.
     </p>
 }

--- a/BTCPayServer/Views/UIStorePullPayments/PullPayments.cshtml
+++ b/BTCPayServer/Views/UIStorePullPayments/PullPayments.cshtml
@@ -52,118 +52,114 @@
 
 <partial name="_StatusMessage" />
 
-<ul class="nav nav-pills border bg-tile" style="border-radius: 4px;">
-    @foreach (var state in Enum.GetValues(typeof(PullPaymentState)).Cast<PullPaymentState>())
-    {
-        <li class="nav-item py-0">
+<nav id="SectionNav" class="mb-3">
+    <div class="nav">
+        @foreach (var state in Enum.GetValues(typeof(PullPaymentState)).Cast<PullPaymentState>())
+        {
             <a id="@state-view"
                 asp-action="PullPayments"
                 asp-route-storeId="@Context.GetRouteValue("storeId")"
                 asp-route-pullPaymentState="@state"
-                class="nav-link me-1 @(state == Model.ActiveState ? "active" : "")" role="tab">@state</a>
-        </li>
-    }
-</ul>
+                class="nav-link @(state == Model.ActiveState ? "active" : "")" role="tab">@state</a>
+        }
+    </div>
+</nav>
 
 @if (Model.PullPayments.Any())
 {
-    <div class="row">
+    @foreach (var pp in Model.PullPayments)
+    {
+        <script id="tooptip_template_@pp.Id" type="text/template">
+            <span>Awaiting:&nbsp;<span class="float-end">@pp.Progress.Awaiting</span></span>
+            <br />
+            <span>Completed:&nbsp;<span class="float-end">@pp.Progress.Completed</span></span>
+            <br />
+            <span>Limit:&nbsp;<span class="float-end">@pp.Progress.Limit</span></span>
+            @if (pp.Progress.ResetIn != null)
+            {
+                <br />
+                <span>Resets in:&nbsp;<span class="float-end">@pp.Progress.ResetIn</span></span>
+            }
+            @if (pp.Progress.EndIn != null)
+            {
+                <br />
+                <span>Expires in:&nbsp;<span class="float-end">@pp.Progress.EndIn</span></span>
+            }
+        </script>
+    }
+    <table class="table table-hover table-responsive-lg">
+        <thead class="thead-inverse">
+        <tr>
+            <th scope="col">
+                <a
+                    asp-action="PullPayments"
+                    asp-route-sortOrder="@(nextStartDateSortOrder ?? "asc")"
+                    asp-route-pullPaymentState="@Model.ActiveState"
+                    class="text-nowrap"
+                    title="@(nextStartDateSortOrder == "desc" ? sortByAsc : sortByDesc)">
+                    Start
+                    <span class="fa @(sortIconClass)"></span>
+                </a>
+            </th>
+            <th scope="col">Name</th>
+            <th scope="col">Refunded</th>
+            <th scope="col" class="text-end" >Actions</th>
+        </tr>
+        </thead>
+        <tbody>
         @foreach (var pp in Model.PullPayments)
         {
-            <script id="tooptip_template_@pp.Id" type="text/template">
-                <span>Awaiting:&nbsp;<span class="float-end">@pp.Progress.Awaiting</span></span>
-                <br />
-                <span>Completed:&nbsp;<span class="float-end">@pp.Progress.Completed</span></span>
-                <br />
-                <span>Limit:&nbsp;<span class="float-end">@pp.Progress.Limit</span></span>
-                @if (pp.Progress.ResetIn != null)
-                {
-                    <br />
-                    <span>Resets in:&nbsp;<span class="float-end">@pp.Progress.ResetIn</span></span>
-                }
-                @if (pp.Progress.EndIn != null)
-                {
-                    <br />
-                    <span>Expires in:&nbsp;<span class="float-end">@pp.Progress.EndIn</span></span>
-                }
-            </script>
+            <tr>
+                <td>@pp.StartDate.ToBrowserDate()</td>
+                <td>@pp.Name</td>
+                <td class="align-middle">
+                    <div class="progress ppProgress" data-pp="@pp.Id" data-bs-toggle="tooltip" data-bs-html="true">
+                        <div class="progress-bar" role="progressbar" aria-valuenow="@pp.Progress.CompletedPercent"
+                             aria-valuemin="0" aria-valuemax="100" style="white-space: nowrap; overflow: hidden; text-overflow: ellipsis; width:@(pp.Progress.CompletedPercent)%;">
+                        </div>
+                        <div class="progress-bar" role="progressbar" aria-valuenow="@pp.Progress.AwaitingPercent"
+                             aria-valuemin="0" aria-valuemax="100" style="background-color:orange; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; width:@(pp.Progress.AwaitingPercent)%;">
+                        </div>
+                    </div>
+                </td>
+                <td class="text-end">
+                    <a asp-action="ViewPullPayment"
+                       asp-controller="UIPullPayment"
+                       asp-route-pullPaymentId="@pp.Id">
+                        View
+                    </a> -
+                    <a class="pp-payout"
+                       asp-action="Payouts"
+                       asp-route-storeId="@Context.GetRouteValue("storeId")"
+                       asp-route-pullPaymentId="@pp.Id">
+                        Payouts
+                    </a>
+                    @if (!pp.Archived)
+                    {
+                       <span permission="@Policies.CanModifyStoreSettings"> - </span>
+                        <a asp-action="ArchivePullPayment"
+                        permission="@Policies.CanModifyStoreSettings" 
+                        asp-route-storeId="@Context.GetRouteValue("storeId")"
+                        asp-route-pullPaymentId="@pp.Id"
+                        data-bs-toggle="modal"
+                        data-bs-target="#ConfirmModal"
+                        data-description="Do you really want to archive the pull payment <strong>@pp.Name</strong>?">
+                            Archive
+                        </a> 
+                    }
+                </td>
+            </tr>
         }
-        <div class="col-md-12">
-            <table class="table table-hover table-responsive-lg">
-                <thead class="thead-inverse">
-                <tr>
-                    <th scope="col">
-                        <a
-                            asp-action="PullPayments"
-                            asp-route-sortOrder="@(nextStartDateSortOrder ?? "asc")"
-                            asp-route-pullPaymentState="@Model.ActiveState"
-                            class="text-nowrap"
-                            title="@(nextStartDateSortOrder == "desc" ? sortByAsc : sortByDesc)">
-                            Start
-                            <span class="fa @(sortIconClass)"></span>
-                        </a>
-                    </th>
-                    <th scope="col">Name</th>
-                    <th scope="col">Refunded</th>
-                    <th scope="col" class="text-end" >Actions</th>
-                </tr>
-                </thead>
-                <tbody>
-                @foreach (var pp in Model.PullPayments)
-                {
-                    <tr>
-                        <td>@pp.StartDate.ToBrowserDate()</td>
-                        <td>@pp.Name</td>
-                        <td class="align-middle">
-                            <div class="progress ppProgress" data-pp="@pp.Id" data-bs-toggle="tooltip" data-bs-html="true">
-                                <div class="progress-bar" role="progressbar" aria-valuenow="@pp.Progress.CompletedPercent"
-                                     aria-valuemin="0" aria-valuemax="100" style="white-space: nowrap; overflow: hidden; text-overflow: ellipsis; width:@(pp.Progress.CompletedPercent)%;">
-                                </div>
-                                <div class="progress-bar" role="progressbar" aria-valuenow="@pp.Progress.AwaitingPercent"
-                                     aria-valuemin="0" aria-valuemax="100" style="background-color:orange; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; width:@(pp.Progress.AwaitingPercent)%;">
-                                </div>
-                            </div>
-                        </td>
-                        <td class="text-end">
-                            <a asp-action="ViewPullPayment"
-                               asp-controller="UIPullPayment"
-                               asp-route-pullPaymentId="@pp.Id">
-                                View
-                            </a> -
-                            <a class="pp-payout"
-                               asp-action="Payouts"
-                               asp-route-storeId="@Context.GetRouteValue("storeId")"
-                               asp-route-pullPaymentId="@pp.Id">
-                                Payouts
-                            </a>
-                            @if (!pp.Archived)
-                            {
-                               <span permission="@Policies.CanModifyStoreSettings"> - </span>
-                                <a asp-action="ArchivePullPayment"
-                                permission="@Policies.CanModifyStoreSettings" 
-                                asp-route-storeId="@Context.GetRouteValue("storeId")"
-                                asp-route-pullPaymentId="@pp.Id"
-                                data-bs-toggle="modal"
-                                data-bs-target="#ConfirmModal"
-                                data-description="Do you really want to archive the pull payment <strong>@pp.Name</strong>?">
-                                    Archive
-                                </a> 
-                            }
-                        </td>
-                    </tr>
-                }
-                </tbody>
-            </table>
+        </tbody>
+    </table>
 
-        </div>
-        <vc:pager view-model="Model"/>
-    </div>
+    <vc:pager view-model="Model"/>
 
     <partial name="_Confirm" model="@(new ConfirmModel("Archive pull payment", "Do you really want to archive the pull payment?", "Archive"))"/>
 
-@section PageFootContent {
-    <script>
-            var ppProgresses = document.getElementsByClassName("ppProgress");
+    @section PageFootContent {
+        <script>
+         const ppProgresses = document.getElementsByClassName("ppProgress");
             for (var i = 0; i < ppProgresses.length; i++) {
                 var pp = ppProgresses[i];
                 var ppId = pp.getAttribute("data-pp");
@@ -171,7 +167,7 @@
                 pp.setAttribute("title", template.innerHTML);
             }
         </script>
-}
+    }
 }
 else
 {

--- a/BTCPayServer/Views/UIStores/_Nav.cshtml
+++ b/BTCPayServer/Views/UIStores/_Nav.cshtml
@@ -3,8 +3,8 @@
 @{
     var storeId = Context.GetStoreData()?.Id;
 }
-<div class="sticky-header-setup"></div>
-<header class="sticky-header mb-l">
+
+<sticky-header class="mb-l">
     <h2 class="mt-1 mb-2 mb-lg-4">Store Settings</h2>
     <nav id="SectionNav">
         <div class="nav">
@@ -18,8 +18,4 @@
             <vc:ui-extension-point location="store-nav" model="@Model"/>
         </div>
     </nav>
-</header>
-<script>
-    const { offsetHeight } = document.querySelector('.sticky-header-setup + .sticky-header');
-    document.documentElement.style.scrollPaddingTop = `calc(${offsetHeight}px + var(--btcpay-space-m))`;
-</script>
+</sticky-header>

--- a/BTCPayServer/Views/UIWallets/_Nav.cshtml
+++ b/BTCPayServer/Views/UIWallets/_Nav.cshtml
@@ -5,11 +5,6 @@
     var wallet = walletId != null ? WalletId.Parse(walletId) : new WalletId(storeId, cryptoCode);
 }
 
-<div class="sticky-header-setup"></div>
-<header class="sticky-header">
+<sticky-header>
     <vc:wallet-nav wallet-id="wallet"/>
-</header>
-<script>
-    const { offsetHeight } = document.querySelector('.sticky-header-setup + .sticky-header');
-    document.documentElement.style.scrollPaddingTop = `calc(${offsetHeight}px + var(--btcpay-space-m))`;
-</script>
+</sticky-header>

--- a/BTCPayServer/wwwroot/main/layout.css
+++ b/BTCPayServer/wwwroot/main/layout.css
@@ -349,8 +349,10 @@
     top: 0;
     z-index: 1020;
     background: var(--btcpay-body-bg);
-    padding-top: var(--content-padding-top);
-    padding-bottom: var(--btcpay-space-l);
+    /* pull it out of the content padding and adjust its inner padding to make up for that space */
+    margin-left: calc(var(--content-padding-horizontal) * -1);
+    margin-right: calc(var(--content-padding-horizontal) * -1);
+    padding: var(--content-padding-top) var(--content-padding-horizontal) var(--btcpay-space-l);
 }
 
 .sticky-header #SectionNav {


### PR DESCRIPTION
Makes the sticky header a tag helper and adds it to the remaining list and edit/detail views.

The only thing that needs some cleanup is the button area for editing payment requests: As @dstrukt also noted, this is too many buttons and we should move at least two of them.

![image](https://user-images.githubusercontent.com/886/154501642-5fdd523a-44b8-42be-9d0b-220206c535dc.png)

Leaving it up for discussion in todays design meeting.