### PR TITLE
Add ability to clear tx label filter

### DIFF
--- a/BTCPayServer/Views/UIWallets/WalletTransactions.cshtml
+++ b/BTCPayServer/Views/UIWallets/WalletTransactions.cshtml
@@ -89,6 +89,10 @@
                         <a asp-route-labelFilter="@label.Text" class="badge position-relative text-white flex-grow-0" style="background-color:@label.Color;color:@label.TextColor !important;">@label.Text</a>
                     }
                 </div>
+                @if (Context.Request.Query.ContainsKey("labelFilter"))
+                {
+                    <a asp-route-labelFilter="" class="btn btn-primary d-flex align-items-center">Clear filter</a>
+                }
             </div>
         }
         <div class="dropdown ms-auto">

--- a/BTCPayServer/Views/UIWallets/WalletTransactions.cshtml
+++ b/BTCPayServer/Views/UIWallets/WalletTransactions.cshtml
@@ -91,7 +91,7 @@
                 </div>
                 @if (Context.Request.Query.ContainsKey("labelFilter"))
                 {
-                    <a asp-route-labelFilter="" class="btn btn-primary d-flex align-items-center">Clear filter</a>
+                    <a asp-route-labelFilter="" class="btn btn-secondary d-flex align-items-center">Clear filter</a>
                 }
             </div>
         }


### PR DESCRIPTION
I noticed there is no way to clear tx label filter after you set it without manually removing it from the query string which is not great. This PR adds a button to clear the filter.

![Capture](https://user-images.githubusercontent.com/1934678/154617946-bafe6228-c083-4b3c-ad46-89ff664bb179.PNG)
![Capture2](https://user-images.githubusercontent.com/1934678/154617949-94f60517-553f-44fa-bd20-cd33e4429c8f.PNG)
