### PR TITLE
CircleCI: Update build image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,18 +27,18 @@ jobs:
   trigger_docs_build:
     machine:
         enabled: true
-        image: circleci/classic:201808-01
+        image: ubuntu-2004:202201-02
     steps:
       - run:
           command: |
-            curl -X POST -H "Authorization: token $GH_PAT"  -H "Accept: application/vnd.github.everest-preview+json"  -H "Content-Type: application/json" https://api.github.com/repos/btcpayserver/btcpayserver-doc/dispatches --data '{"event_type": "build_docs"}'
+            curl -X POST -H "Authorization: token $GH_PAT" -H "Accept: application/vnd.github.everest-preview+json" -H "Content-Type: application/json" https://api.github.com/repos/btcpayserver/btcpayserver-doc/dispatches --data '{"event_type": "build_docs"}'
 
   # publish jobs require $DOCKERHUB_REPO, $DOCKERHUB_USER, $DOCKERHUB_PASS defined
   amd64:
     machine:
         enabled: true
     steps:
-      - checkout  
+      - checkout
       - run:
           command: |
             LATEST_TAG=${CIRCLE_TAG:1} #trim v from tag
@@ -53,7 +53,7 @@ jobs:
     machine:
         enabled: true
     steps:
-      - checkout  
+      - checkout
       - run:
           command: |
             sudo docker run --rm --privileged multiarch/qemu-user-static:register --reset
@@ -69,7 +69,7 @@ jobs:
     machine:
         enabled: true
     steps:
-      - checkout  
+      - checkout
       - run:
           command: |
             sudo docker run --rm --privileged multiarch/qemu-user-static:register --reset
@@ -84,14 +84,10 @@ jobs:
   multiarch:
     machine:
       enabled: true
-      image: circleci/classic:201808-01
+      image: ubuntu-2004:202201-02
     steps:
       - run:
           command: |
-            # Turn on Experimental features
-            sudo mkdir $HOME/.docker
-            sudo sh -c 'echo "{ \"experimental\": \"enabled\" }" >> $HOME/.docker/config.json'
-            #
             sudo docker login --username=$DOCKERHUB_USER --password=$DOCKERHUB_PASS
             #
             LATEST_TAG=${CIRCLE_TAG:1} #trim v from tag
@@ -100,8 +96,7 @@ jobs:
             sudo docker manifest annotate $DOCKERHUB_REPO:$LATEST_TAG $DOCKERHUB_REPO:$LATEST_TAG-arm32v7 --os linux --arch arm --variant v7
             sudo docker manifest annotate $DOCKERHUB_REPO:$LATEST_TAG $DOCKERHUB_REPO:$LATEST_TAG-arm64v8 --os linux --arch arm64 --variant v8
             sudo docker manifest push $DOCKERHUB_REPO:$LATEST_TAG -p
-            
-            
+
             sudo docker manifest create --amend $DOCKERHUB_REPO:$LATEST_TAG-altcoins $DOCKERHUB_REPO:$LATEST_TAG-altcoins-amd64 $DOCKERHUB_REPO:$LATEST_TAG-altcoins-arm32v7 $DOCKERHUB_REPO:$LATEST_TAG-altcoins-arm64v8
             sudo docker manifest annotate $DOCKERHUB_REPO:$LATEST_TAG-altcoins $DOCKERHUB_REPO:$LATEST_TAG-altcoins-amd64 --os linux --arch amd64
             sudo docker manifest annotate $DOCKERHUB_REPO:$LATEST_TAG-altcoins $DOCKERHUB_REPO:$LATEST_TAG-altcoins-arm32v7 --os linux --arch arm --variant v7


### PR DESCRIPTION
CircleCI recently [deprecated build images](https://circleci.com/blog/ubuntu-14-16-image-deprecation/), including the classic ones we are using. I found this config working for me on another repo.