### PR TITLE
Add border for mobile menu

### DIFF
--- a/BTCPayServer/wwwroot/main/layout.css
+++ b/BTCPayServer/wwwroot/main/layout.css
@@ -17,6 +17,7 @@
     --button-height: 40px;
     --button-padding: 7px;
     --icon-size: 1.5rem;
+    --menu-border: 1px solid var(--btcpay-body-border-light);
     height: var(--header-height);
     z-index: 1031; /* needs a value between fixed and the offcanvas backdrop, see https://getbootstrap.com/docs/5.1/layout/z-index/ */
 }
@@ -391,6 +392,7 @@
         top: 0;
         left: 0;
         right: 0;
+        border-bottom: var(--menu-border);
     }
 
     #mainMenuHead  {
@@ -404,6 +406,7 @@
         left: 0;
         width: var(--sidebar-width);
         z-index: 1045;
+        border-right: var(--menu-border);
         color: var(--btcpay-body-text);
         visibility: hidden;
         background-color: inherit;
@@ -556,7 +559,7 @@
         left: 0;
         width: var(--sidebar-width);
         height: 100vh;
-        border-right: 1px solid var(--btcpay-body-border-light);
+        border-right: var(--menu-border);
     }
 
     #mainMenuHead {


### PR DESCRIPTION
In addition to #3469.

## Before

![menu-noborder](https://user-images.githubusercontent.com/886/154792316-baf84753-8e57-466d-8b16-8806c05d0229.png)

## After

![menu-bordered](https://user-images.githubusercontent.com/886/154792317-438baeec-3762-4f3a-b334-1b52c904dfc3.png)

