### PR TITLE
Pull payment fixes

### DIFF
--- a/BTCPayServer/Controllers/UIStorePullPaymentsController.PullPayments.cs
+++ b/BTCPayServer/Controllers/UIStorePullPaymentsController.PullPayments.cs
@@ -187,7 +187,7 @@ namespace BTCPayServer.Controllers
                 return RedirectToAction("PaymentMethods", "Stores", new { storeId });
             }
 
-            var vm = this.ParseListQuery(new PullPaymentsModel()
+            var vm = this.ParseListQuery(new PullPaymentsModel
             {
                 Skip = skip,
                 Count = count,
@@ -275,12 +275,12 @@ namespace BTCPayServer.Controllers
             string pullPaymentId)
         {
             await _pullPaymentService.Cancel(new HostedServices.PullPaymentHostedService.CancelRequest(pullPaymentId));
-            this.TempData.SetStatusMessageModel(new StatusMessageModel()
+            TempData.SetStatusMessageModel(new StatusMessageModel()
             {
                 Message = "Pull payment archived",
                 Severity = StatusMessageModel.StatusSeverity.Success
             });
-            return RedirectToAction(nameof(PullPayments), new { storeId = storeId });
+            return RedirectToAction(nameof(PullPayments), new { storeId });
         }
 
         [Authorize(Policy = Policies.CanModifyStoreSettings, AuthenticationSchemes = AuthenticationSchemes.Cookie)]

--- a/BTCPayServer/Controllers/UIStorePullPaymentsController.PullPayments.cs
+++ b/BTCPayServer/Controllers/UIStorePullPaymentsController.PullPayments.cs
@@ -184,7 +184,7 @@ namespace BTCPayServer.Controllers
                     Message = "You must enable at least one payment method before creating a pull payment.",
                     Severity = StatusMessageModel.StatusSeverity.Error
                 });
-                return RedirectToAction("PaymentMethods", "Stores", new { storeId });
+                return RedirectToAction(nameof(UIStoresController.GeneralSettings), "UIStores", new { storeId });
             }
 
             var vm = this.ParseListQuery(new PullPaymentsModel

--- a/BTCPayServer/Data/Payouts/LightningLike/UILightningLikePayoutController.cs
+++ b/BTCPayServer/Data/Payouts/LightningLike/UILightningLikePayoutController.cs
@@ -21,7 +21,7 @@ using Microsoft.Extensions.Options;
 
 namespace BTCPayServer.Data.Payouts.LightningLike
 {
-    [Authorize(AuthenticationSchemes = AuthenticationSchemes.Cookie)]
+    [Authorize(AuthenticationSchemes = AuthenticationSchemes.Cookie, Policy = Policies.CanModifyStoreSettings)]
     [AutoValidateAntiforgeryToken]
     public class UILightningLikePayoutController : Controller
     {

--- a/BTCPayServer/Views/UILightningLikePayout/ConfirmLightningPayout.cshtml
+++ b/BTCPayServer/Views/UILightningLikePayout/ConfirmLightningPayout.cshtml
@@ -18,7 +18,7 @@
                 </li>
                 <form method="post" class="list-group-item justify-content-center" id="pay-invoices-form">
                     <button type="submit" class="btn btn-primary xmx-2" style="min-width:25%;" id="Pay">Pay</button>
-                    <button type="button" class="btn btn-secondary mx-2" onclick="history.back(); return false;" style="min-width:25%;">Go back</button>
+                    <a asp-controller="UIStorePullPayments" asp-action="Payouts" asp-route-storeId="@Context.GetStoreData().Id" class="btn btn-secondary mx-2 px-4">Cancel</a>
                 </form>
             }
         </ul>

--- a/BTCPayServer/Views/UILightningLikePayout/ConfirmLightningPayout.cshtml
+++ b/BTCPayServer/Views/UILightningLikePayout/ConfirmLightningPayout.cshtml
@@ -12,12 +12,11 @@
             @foreach (var item in Model)
             {
                 <li class="list-group-item d-flex justify-content-between align-items-center">
-                    <div data-bs-toggle="tooltip" class="text-break" title="@item.Destination">@item.Destination</div>
-
+                    <div class="text-break" style="max-width:60em;">@item.Destination</div>
                     <span class="text-capitalize badge bg-secondary">@item.Amount @cryptoCode</span>
                 </li>
                 <form method="post" class="list-group-item justify-content-center" id="pay-invoices-form">
-                    <button type="submit" class="btn btn-primary xmx-2" style="min-width:25%;" id="Pay">Pay</button>
+                    <button type="submit" class="btn btn-primary px-5" id="Pay">Pay</button>
                     <a asp-controller="UIStorePullPayments" asp-action="Payouts" asp-route-storeId="@Context.GetStoreData().Id" class="btn btn-secondary mx-2 px-4">Cancel</a>
                 </form>
             }


### PR DESCRIPTION
Fixes #3490 plus a redirect and missing store context for Lightning payouts.

Note: Is there a reason for `UILightningLikePayoutController` to sit in `BTCPayServer/Data/Payouts/LightningLike` instead of the controllers directory?