### PR TITLE
Fix "Copy Link" button on pull payment and payment request pages

### DIFF
--- a/BTCPayServer/wwwroot/js/copy-to-clipboard.js
+++ b/BTCPayServer/wwwroot/js/copy-to-clipboard.js
@@ -7,7 +7,7 @@ const confirmCopy = (el, message) => {
 
 window.copyToClipboard = function (e, data) {
     e.preventDefault();
-    const item = e.target.closest('[data-clipboard]') || e.target.closest('[data-clipboard-target]');
+    const item = e.target.closest('[data-clipboard]') || e.target.closest('[data-clipboard-target]') || e.target;
     const confirm = item.querySelector('[data-clipboard-confirm]') || item;
     const message = confirm.getAttribute('data-clipboard-confirm') || 'Copied ✔';
     if (!confirm.dataset.clipboardInitial) {


### PR DESCRIPTION
close #3499

Seems like the issue was first introduced in this PR where the selector was updated to work on one page but broke it for other pages: https://github.com/btcpayserver/btcpayserver/pull/3251