### PR TITLE
Fix mobile content z-index

### DIFF
--- a/BTCPayServer/wwwroot/main/layout.css
+++ b/BTCPayServer/wwwroot/main/layout.css
@@ -495,10 +495,6 @@
         transform: translate(-50%, -50%) rotate(-45deg);
     }
 
-    #mainContent {
-        z-index: 0;
-    }
-
     #SectionNav {
         --scroll-indicator-spacing: var(--btcpay-space-m);
         position: relative;


### PR DESCRIPTION
I think we added this before taking proper care of the main menu z-index. Now that that is fixed we can remove the z-index of the content area, which fixes #3504.