### PR TITLE
Allow access to global invoices list

### DIFF
--- a/BTCPayServer/Controllers/UIInvoiceController.UI.cs
+++ b/BTCPayServer/Controllers/UIInvoiceController.UI.cs
@@ -800,7 +800,7 @@ namespace BTCPayServer.Controllers
         {
             model = this.ParseListQuery(model ?? new InvoicesModel());
             var fs = new SearchString(model.SearchTerm);
-            string? storeId = (model.StoreId ?? HttpContext.GetStoreData()?.Id);
+            string? storeId = model.StoreId;
             var storeIds = new HashSet<string>();
             if (fs.GetFilterArray("storeid") is string[] l)
             {


### PR DESCRIPTION
The recent changes in 19eea3a6154e73f7fc9d62ab20480134e95be3d5 prevent it to access a global/unfiltered list of invoices across all stores. This removes the fallback to the current store, which brings the global list back at `/invoices`.