### PR TITLE
QR container display fixes

### DIFF
--- a/BTCPayServer.Tests/ApiKeysTests.cs
+++ b/BTCPayServer.Tests/ApiKeysTests.cs
@@ -204,7 +204,10 @@ namespace BTCPayServer.Tests
                 s.Driver.ScrollTo(checkbox);
                 checkbox.Click();
             }
-            s.Driver.FindElement(By.Id("Generate")).Click();
+
+            var generate = s.Driver.FindElement(By.Id("Generate"));
+            s.Driver.ScrollTo(generate);
+            generate.Click();
             var allAPIKey = s.FindAlertMessage().FindElement(By.TagName("code")).Text;
             
             TestLogs.LogInformation("Checking API key permissions");

--- a/BTCPayServer/Views/UIManage/LoginCodes.cshtml
+++ b/BTCPayServer/Views/UIManage/LoginCodes.cshtml
@@ -4,8 +4,10 @@
 }
 <h3 class="mb-3">@ViewData["Title"]</h3>
 <p>Easily log into BTCPay Server on another device using a simple login code from an already authenticated device.</p>
-<div class="d-inline-flex flex-column qr-container" style="width:256px">
-    <vc:qr-code data="@Model" /> 
+<div class="d-inline-flex flex-column" style="width:256px">
+    <div class="qr-container mb-2">
+        <vc:qr-code data="@Model"/>
+    </div>
     <input type="hidden" value="@Model" id="logincode">
     <p class="text-center text-muted mb-1" id="progress">Valid for 60 seconds</p>
     <div class="progress only-for-js" data-bs-toggle="tooltip" data-bs-placement="top">

--- a/BTCPayServer/Views/UIPublicLightningNodeInfo/ShowLightningNodeInfo.cshtml
+++ b/BTCPayServer/Views/UIPublicLightningNodeInfo/ShowLightningNodeInfo.cshtml
@@ -58,7 +58,7 @@
                                 {
                                     var nodeInfo = Model.NodeInfo[i];
                                     <div class="tab-pane fade @(i == 0 ? "show active" : "")" id="nodeInfo-@nodeInfo.Id" role="tabpanel" aria-labelledby="nodeInfo-tab-@nodeInfo.Id">
-                                        <div class="qr-container my-4">
+                                        <div class="qr-container my-4 w-100">
                                             <img alt="@Model.CryptoCode" class="qr-icon" src="@Model.CryptoImage"/>
                                             <vc:qr-code data="@nodeInfo.ToString()"/>
                                         </div>

--- a/BTCPayServer/wwwroot/main/qrcode.css
+++ b/BTCPayServer/wwwroot/main/qrcode.css
@@ -11,7 +11,9 @@
 
 .qr-container {
     position: relative;
-    display: inline-block;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
 }
 
 .qr-container svg {


### PR DESCRIPTION
Consistently centers the container contents. The LN Node Public page looks broken right now, this PR fixes it:

![image](https://user-images.githubusercontent.com/886/156590576-0299aa26-38b7-45fb-9227-a702fecc0b3d.png)
