### PR TITLE
Fix null reference error when "destinations" field is not specified or empty when creating a new wallet transaction

### DIFF
--- a/BTCPayServer/Controllers/GreenField/GreenfieldStoreOnChainWalletsController.cs
+++ b/BTCPayServer/Controllers/GreenField/GreenfieldStoreOnChainWalletsController.cs
@@ -282,6 +282,16 @@ namespace BTCPayServer.Controllers.Greenfield
                 return this.CreateAPIError(503, "not-available", $"You need to allow non-admins to use hotwallets for their stores (in /server/policies)");
             }
 
+            if (request.Destinations == null || !request.Destinations.Any())
+            {
+                ModelState.AddModelError(
+                    nameof(request.Destinations),
+                    "At least one destination must be specified"
+                );
+
+                return this.CreateValidationError(ModelState);
+            }
+
             var explorerClient = _explorerClientProvider.GetExplorerClient(cryptoCode);
             var wallet = _btcPayWalletProvider.GetWallet(network);
 


### PR DESCRIPTION
fix #3537