### PR TITLE
API: Add Lightning Payment info endpoint

### DIFF
--- a/BTCPayServer.Client/BTCPayServer.Client.csproj
+++ b/BTCPayServer.Client/BTCPayServer.Client.csproj
@@ -29,7 +29,7 @@
   </ItemGroup>
     <ItemGroup>
       <PackageReference Include="NBitcoin" Version="7.0.1" />
-      <PackageReference Include="BTCPayServer.Lightning.Common" Version="1.3.1" />
+      <PackageReference Include="BTCPayServer.Lightning.Common" Version="1.3.2" />
       <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     </ItemGroup>
   <ItemGroup>

--- a/BTCPayServer.Client/BTCPayServerClient.Lightning.Internal.cs
+++ b/BTCPayServer.Client/BTCPayServerClient.Lightning.Internal.cs
@@ -65,6 +65,17 @@ namespace BTCPayServer.Client
             return await HandleResponse<LightningPaymentData>(response);
         }
 
+        public virtual async Task<LightningPaymentData> GetLightningPayment(string cryptoCode,
+            string paymentHash, CancellationToken token = default)
+        {
+            if (paymentHash == null)
+                throw new ArgumentNullException(nameof(paymentHash));
+            var response = await _httpClient.SendAsync(
+                CreateHttpRequest($"api/v1/server/lightning/{cryptoCode}/payments/{paymentHash}",
+                    method: HttpMethod.Get), token);
+            return await HandleResponse<LightningPaymentData>(response);
+        }
+
         public virtual async Task<LightningInvoiceData> GetLightningInvoice(string cryptoCode,
             string invoiceId, CancellationToken token = default)
         {

--- a/BTCPayServer.Client/BTCPayServerClient.Lightning.Store.cs
+++ b/BTCPayServer.Client/BTCPayServerClient.Lightning.Store.cs
@@ -67,6 +67,17 @@ namespace BTCPayServer.Client
             await HandleResponse(response);
         }
 
+        public virtual async Task<LightningPaymentData> GetLightningPayment(string storeId, string cryptoCode,
+            string paymentHash, CancellationToken token = default)
+        {
+            if (paymentHash == null)
+                throw new ArgumentNullException(nameof(paymentHash));
+            var response = await _httpClient.SendAsync(
+                CreateHttpRequest($"api/v1/stores/{storeId}/lightning/{cryptoCode}/payments/{paymentHash}",
+                    method: HttpMethod.Get), token);
+            return await HandleResponse<LightningPaymentData>(response);
+        }
+
         public virtual async Task<LightningInvoiceData> GetLightningInvoice(string storeId, string cryptoCode,
             string invoiceId, CancellationToken token = default)
         {

--- a/BTCPayServer.Client/Models/LightningPaymentData.cs
+++ b/BTCPayServer.Client/Models/LightningPaymentData.cs
@@ -1,11 +1,28 @@
+using System;
 using BTCPayServer.Client.JsonConverters;
 using BTCPayServer.Lightning;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
 
 namespace BTCPayServer.Client.Models
 {
     public class LightningPaymentData
     {
+        public string Id { get; set; }
+
+        public string PaymentHash { get; set; }
+
+        [JsonConverter(typeof(StringEnumConverter))]
+        public LightningPaymentStatus Status { get; set; }
+
+        [JsonProperty("BOLT11")]
+        public string BOLT11 { get; set; }
+        
+        public string Preimage { get; set; }
+
+        [JsonConverter(typeof(NBitcoin.JsonConverters.DateTimeToUnixTimeConverter))]
+        public DateTimeOffset? CreatedAt { get; set; }
+        
         [JsonConverter(typeof(LightMoneyJsonConverter))]
         public LightMoney TotalAmount { get; set; }
 

--- a/BTCPayServer.Tests/GreenfieldAPITests.cs
+++ b/BTCPayServer.Tests/GreenfieldAPITests.cs
@@ -1547,7 +1547,7 @@ namespace BTCPayServer.Tests
             Assert.Single(info.NodeURIs);
             Assert.NotEqual(0, info.BlockHeight);
 
-            await AssertAPIError("ligthning-node-unavailable", () => client.GetLightningNodeChannels("BTC"));
+            await AssertAPIError("lightning-node-unavailable", () => client.GetLightningNodeChannels("BTC"));
             // Not permission for the store!
             await AssertAPIError("missing-permission", () => client.GetLightningNodeChannels(user.StoreId, "BTC"));
             var invoiceData = await client.CreateLightningInvoice("BTC", new CreateLightningInvoiceRequest()

--- a/BTCPayServer/BTCPayServer.csproj
+++ b/BTCPayServer/BTCPayServer.csproj
@@ -48,7 +48,7 @@
   <ItemGroup>
     <PackageReference Include="BIP78.Sender" Version="0.2.2" />
     <PackageReference Include="BTCPayServer.Hwi" Version="2.0.2" />
-    <PackageReference Include="BTCPayServer.Lightning.All" Version="1.3.3" />
+    <PackageReference Include="BTCPayServer.Lightning.All" Version="1.3.4" />
     <PackageReference Include="BuildBundlerMinifier" Version="3.2.449" />
     <PackageReference Include="BundlerMinifier.Core" Version="3.2.435" />
     <PackageReference Include="BundlerMinifier.TagHelpers" Version="3.2.435" />

--- a/BTCPayServer/Controllers/GreenField/GreenfieldLightningNodeApiController.Internal.cs
+++ b/BTCPayServer/Controllers/GreenField/GreenfieldLightningNodeApiController.Internal.cs
@@ -79,6 +79,14 @@ namespace BTCPayServer.Controllers.Greenfield
 
         [Authorize(Policy = Policies.CanUseInternalLightningNode,
             AuthenticationSchemes = AuthenticationSchemes.Greenfield)]
+        [HttpGet("~/api/v1/server/lightning/{cryptoCode}/payments/{paymentHash}")]
+        public override Task<IActionResult> GetPayment(string cryptoCode, string paymentHash)
+        {
+            return base.GetPayment(cryptoCode, paymentHash);
+        }
+
+        [Authorize(Policy = Policies.CanUseInternalLightningNode,
+            AuthenticationSchemes = AuthenticationSchemes.Greenfield)]
         [HttpGet("~/api/v1/server/lightning/{cryptoCode}/invoices/{id}")]
         public override Task<IActionResult> GetInvoice(string cryptoCode, string id)
         {

--- a/BTCPayServer/Controllers/GreenField/GreenfieldLightningNodeApiController.Store.cs
+++ b/BTCPayServer/Controllers/GreenField/GreenfieldLightningNodeApiController.Store.cs
@@ -80,6 +80,14 @@ namespace BTCPayServer.Controllers.Greenfield
 
         [Authorize(Policy = Policies.CanUseLightningNodeInStore,
             AuthenticationSchemes = AuthenticationSchemes.Greenfield)]
+        [HttpGet("~/api/v1/stores/{storeId}/lightning/{cryptoCode}/payments/{paymentHash}")]
+        public override Task<IActionResult> GetPayment(string cryptoCode, string paymentHash)
+        {
+            return base.GetPayment(cryptoCode, paymentHash);
+        }
+
+        [Authorize(Policy = Policies.CanUseLightningNodeInStore,
+            AuthenticationSchemes = AuthenticationSchemes.Greenfield)]
         [HttpPost("~/api/v1/stores/{storeId}/lightning/{cryptoCode}/invoices/pay")]
         public override Task<IActionResult> PayInvoice(string cryptoCode, PayLightningInvoiceRequest lightningInvoice)
         {

--- a/BTCPayServer/wwwroot/swagger/v1/swagger.template.lightning.common.json
+++ b/BTCPayServer/wwwroot/swagger/v1/swagger.template.lightning.common.json
@@ -80,6 +80,32 @@
                 "type": "object",
                 "additionalProperties": false,
                 "properties": {
+                    "id": {
+                        "type": "string",
+                        "description": "The payment's ID"
+                    },
+                    "status": {
+                        "$ref": "#/components/schemas/LightningPaymentStatus"
+                    },
+                    "BOLT11": {
+                        "type": "string",
+                        "description": "The BOLT11 representation of the payment",
+                        "nullable": false
+                    },
+                    "paymentHash": {
+                        "type": "string",
+                        "description": "The payment hash",
+                        "nullable": false
+                    },
+                    "preimage": {
+                        "type": "string",
+                        "description": "The payment preimage (available when status is complete)"
+                    },
+                    "createdAt": {
+                        "description": "The unix timestamp when the payment got created",
+                        "nullable": true,
+                        "allOf": [ {"$ref": "#/components/schemas/UnixTimestamp"}]
+                    },
                     "totalAmount": {
                         "type": "string",
                         "description": "The total amount (including fees) in millisatoshi"
@@ -137,6 +163,22 @@
                     "Unpaid",
                     "Paid",
                     "Expired"
+                ]
+            },
+            "LightningPaymentStatus": {
+                "type": "string",
+                "description": "",
+                "x-enumNames": [
+                    "Unknown",
+                    "Pending",
+                    "Complete",
+                    "Failed"
+                ],
+                "enum": [
+                    "Unknown",
+                    "Pending",
+                    "Complete",
+                    "Failed"
                 ]
             },
             "LightningNodeInformationData": {

--- a/BTCPayServer/wwwroot/swagger/v1/swagger.template.lightning.internal.json
+++ b/BTCPayServer/wwwroot/swagger/v1/swagger.template.lightning.internal.json
@@ -283,6 +283,65 @@
             }
         },
 
+        "/api/v1/server/lightning/{cryptoCode}/payments/{paymentHash}": {
+            "get": {
+                "tags": [
+                    "Lightning (Internal Node)"
+                ],
+                "summary": "Get payment",
+                "parameters": [
+                    {
+                        "name": "cryptoCode",
+                        "in": "path",
+                        "required": true,
+                        "description": "The cryptoCode of the lightning-node to query",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "example": "BTC"
+                    },
+                    {
+                        "name": "paymentHash",
+                        "in": "path",
+                        "required": true,
+                        "description": "The payment hash of the lightning payment.",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "description": "View information about the requested lightning payment",
+                "operationId": "InternalLightningNodeApi_GetPayment",
+                "responses": {
+                    "200": {
+                        "description": "Lightning payment data",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/LightningPaymentData"
+                                }
+                            }
+                        }
+                    },
+                    "503": {
+                        "description": "Unable to access the lightning node"
+                    },
+                    "404": {
+                        "description": "The lightning node configuration or the specified invoice was not found "
+                    }
+                },
+                "security": [
+                    {
+                        "API_Key": [
+                            "btcpay.server.canuseinternallightningnode"
+                        ],
+                        "Basic": []
+                    }
+                ]
+            }
+        },
+
+
         "/api/v1/server/lightning/{cryptoCode}/invoices/{id}": {
             "get": {
                 "tags": [

--- a/BTCPayServer/wwwroot/swagger/v1/swagger.template.lightning.store.json
+++ b/BTCPayServer/wwwroot/swagger/v1/swagger.template.lightning.store.json
@@ -331,6 +331,73 @@
             }
         },
 
+        "/api/v1/stores/{storeId}/lightning/{cryptoCode}/payments/{paymentHash}": {
+            "get": {
+                "tags": [
+                    "Lightning (Store)"
+                ],
+                "summary": "Get payment",
+                "parameters": [
+                    {
+                        "name": "cryptoCode",
+                        "in": "path",
+                        "required": true,
+                        "description": "The cryptoCode of the lightning-node to query",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "example": "BTC"
+                    },
+                    {
+                        "name": "storeId",
+                        "in": "path",
+                        "required": true,
+                        "description": "The store id with the lightning-node configuration to query",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "paymentHash",
+                        "in": "path",
+                        "required": true,
+                        "description": "The payment hash of the lightning payment.",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "description": "View information about the requested lightning payment",
+                "operationId": "StoreLightningNodeApi_GetPayment",
+                "responses": {
+                    "200": {
+                        "description": "Lightning payment data",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/LightningPaymentData"
+                                }
+                            }
+                        }
+                    },
+                    "503": {
+                        "description": "Unable to access the lightning node"
+                    },
+                    "404": {
+                        "description": "The lightning node configuration or the specified invoice was not found "
+                    }
+                },
+                "security": [
+                    {
+                        "API_Key": [
+                            "btcpay.store.canuselightningnode"
+                        ],
+                        "Basic": []
+                    }
+                ]
+            }
+        },
+        
         "/api/v1/stores/{storeId}/lightning/{cryptoCode}/invoices/{id}": {
             "get": {
                 "tags": [


### PR DESCRIPTION
Based on btcpayserver/BTCPayServer.Lightning#64, this adds the API endpoints for accessing payment info by the payment hash. Requires the feature to be present in the Lightning lib, putting it out as a draft until then.