### PR TITLE
added inputmode attr to relevant form input fields

### DIFF
--- a/BTCPayServer/Views/UIApps/TemplateEditor.cshtml
+++ b/BTCPayServer/Views/UIApps/TemplateEditor.cshtml
@@ -89,7 +89,7 @@
                             </div>
                             <div class="form-group">
                                 <label class="form-label">Inventory (leave blank to not use inventory feature)</label>
-                                <input type="number" min="0" step="1" class="form-control mb-2" v-model="editingItem.inventory" ref="txtInventory"/>
+                                <input type="number" inputmode="numeric" min="0" step="1" class="form-control mb-2" v-model="editingItem.inventory" ref="txtInventory"/>
                             </div>
                             <div class="form-group">
                                 <label class="form-label">Id (leave blank to generate from title)</label>

--- a/BTCPayServer/Views/UIApps/UpdateCrowdfund.cshtml
+++ b/BTCPayServer/Views/UIApps/UpdateCrowdfund.cshtml
@@ -80,7 +80,7 @@
             <div class="d-flex justify-content-between">
                 <div class="form-group flex-fill me-4">
                     <label asp-for="TargetAmount" class="form-label"></label>
-                    <input asp-for="TargetAmount" class="form-control" />
+                    <input inputmode="decimal" asp-for="TargetAmount" class="form-control" />
                     <span asp-validation-for="TargetAmount" class="text-danger"></span>
                 </div>
                 <div class="form-group">
@@ -124,7 +124,7 @@
                 <div class="form-group mb-0">
                     <label asp-for="ResetEvery" class="form-label"></label>
                     <div class="input-group">
-                        <input type="number" asp-for="ResetEveryAmount" placeholder="Amount" class="form-control">
+                        <input type="number" inputmode="numeric" asp-for="ResetEveryAmount" placeholder="Amount" class="form-control">
                         <select class="form-select" asp-for="ResetEvery">
                             @foreach (var opt in Model.ResetEveryValues)
                             {

--- a/BTCPayServer/Views/UIApps/UpdatePointOfSale.cshtml
+++ b/BTCPayServer/Views/UIApps/UpdatePointOfSale.cshtml
@@ -312,7 +312,7 @@
             </div>
             <div class="form-group">
                 <label class="form-label">Inventory (leave blank to not use inventory feature)</label>
-                <input type="number" step="1" class="js-product-inventory form-control mb-2" value="{inventory}" />
+                <input type="number" inputmode="numeric" step="1" class="js-product-inventory form-control mb-2" value="{inventory}" />
             </div>
             <div class="form-group d-flex align-items-center">
                 <input type="checkbox" class="btcpay-toggle me-2" value="{disabled}" />

--- a/BTCPayServer/Views/UIPaymentRequest/EditPaymentRequest.cshtml
+++ b/BTCPayServer/Views/UIPaymentRequest/EditPaymentRequest.cshtml
@@ -45,7 +45,7 @@
             <div class="d-flex justify-content-between">
                 <div class="form-group flex-fill me-4">
                     <label asp-for="Amount" class="form-label" data-required></label>
-                    <input type="number" step="any" asp-for="Amount" class="form-control" required />
+                    <input type="number" inputmode="decimal" step="any" asp-for="Amount" class="form-control" required />
                     <span asp-validation-for="Amount" class="text-danger"></span>
                 </div>
                 <div class="form-group">

--- a/BTCPayServer/Views/UIPaymentRequest/ViewPaymentRequest.cshtml
+++ b/BTCPayServer/Views/UIPaymentRequest/ViewPaymentRequest.cshtml
@@ -112,7 +112,7 @@
                                         <div class="row">
                                             <div class="col col-12 col-sm-6 col-md-12">
                                                 <div class="input-group">
-                                                    <input type="number" class="form-control text-end hide-number-spin" name="amount" value="@Model.AmountDue" @if (!Model.AllowCustomPaymentAmounts) { @("readonly") } max="@Model.AmountDue" step="any" placeholder="Amount" required />
+                                                    <input type="number" inputmode="decimal" class="form-control text-end hide-number-spin" name="amount" value="@Model.AmountDue" @if (!Model.AllowCustomPaymentAmounts) { @("readonly") } max="@Model.AmountDue" step="any" placeholder="Amount" required />
                                                     <span class="input-group-text">@Model.Currency.ToUpper()</span>
                                                 </div>
                                             </div>
@@ -154,7 +154,7 @@
                                     <div class="row">
                                         <div class="col col-12 col-sm-6 col-md-12">
                                             <div class="input-group">
-                                                <input type="number" class="form-control text-end hide-number-spin" v-model="customAmount" :readonly="!srvModel.allowCustomPaymentAmounts" :max="srvModel.amountDue" placeholder="Amount" step="any" required />
+                                                <input type="number" inputmode="decimal" class="form-control text-end hide-number-spin" v-model="customAmount" :readonly="!srvModel.allowCustomPaymentAmounts" :max="srvModel.amountDue" placeholder="Amount" step="any" required />
                                                 <span class="input-group-text">{{currency}}</span>
                                             </div>
                                         </div>

--- a/BTCPayServer/Views/UIPullPayment/ViewPullPayment.cshtml
+++ b/BTCPayServer/Views/UIPullPayment/ViewPullPayment.cshtml
@@ -72,7 +72,7 @@
 
                             <div class="col-12 mb-3 col-sm-6 mb-sm-0 col-lg-3">
                                 <div class="input-group">
-                                    <input type="number" class="form-control form-control-lg text-end hide-number-spin" asp-for="ClaimedAmount" max="@Model.AmountDue" min="@Model.MinimumClaim" step="any" placeholder="Amount" required>
+                                    <input type="number" inputmode="decimal" class="form-control form-control-lg text-end hide-number-spin" asp-for="ClaimedAmount" max="@Model.AmountDue" min="@Model.MinimumClaim" step="any" placeholder="Amount" required>
                                     <span class="input-group-text px-3">@Model.Currency.ToUpper()</span>
                                 </div>
                             </div>

--- a/BTCPayServer/Views/UIServer/CreateTemporaryFileUrl.cshtml
+++ b/BTCPayServer/Views/UIServer/CreateTemporaryFileUrl.cshtml
@@ -21,7 +21,7 @@
             <div class="form-group">
                 <label asp-for="TimeAmount" class="form-label"></label>
                 <div class="input-group">
-                    <input type="number" asp-for="TimeAmount" class="form-control">
+                    <input type="number" inputmode="decimal" asp-for="TimeAmount" class="form-control">
                     <select asp-for="TimeType" asp-items="@Html.GetEnumSelectList<UIServerController.CreateTemporaryFileUrlViewModel.TmpFileTimeType>()" class="form-select"></select>
                 </div>
 

--- a/BTCPayServer/Views/UIWallets/WalletSend.cshtml
+++ b/BTCPayServer/Views/UIWallets/WalletSend.cshtml
@@ -74,7 +74,7 @@
                         <input asp-for="Outputs[0].Amount" type="number" step="any" min="0" asp-format="{0}" class="form-control output-amount hide-number-spin" />
                         <div class="input-group-text fiat-value" style="display:none;">
                             <span class="input-group-text p-0">=</span>
-                            <input type="number" class="input-group-text fiat-value-edit-input py-0 hide-number-spin" min="0" step="any" style="max-width:100px" />
+                            <input type="number" inputmode="decimal" class="input-group-text fiat-value-edit-input py-0 hide-number-spin" min="0" step="any" style="max-width:100px" />
                             <span class="input-group-text p-0">@Model.Fiat</span>
                         </div>
                     </div>
@@ -111,7 +111,7 @@
                                     <input asp-for="Outputs[index].Amount" type="number" min="0" step="any" asp-format="{0}" class="form-control output-amount hide-number-spin" />
                                     <div class="input-group-text fiat-value" style="display:none;">
                                         <span class="input-group-text p-0">=</span>
-                                        <input type="number" class="input-group-text fiat-value-edit-input py-0 hide-number-spin" min="0" step="any" style="max-width:100px" />
+                                        <input type="number" inputmode="decimal" class="input-group-text fiat-value-edit-input py-0 hide-number-spin" min="0" step="any" style="max-width:100px" />
                                         <span class="input-group-text p-0">@Model.Fiat</span>
                                     </div>
                                 </div>


### PR DESCRIPTION
When making changes to numerical amounts in various input fields across the BTCPay Server app on iOS devices, I noticed the decimal pad is not shown when selecting the form input.  It seems even though the form input `type` is number, the system still defaults to the normal keyboard, but on the number page, which is technically fine.  However, adding the `inputmode` attribute set to `decimal` or `numeric` will prompt the system to display the decimal pad or number pad instead when the input field is selected.

This should only impact iOS devices, and Android devices should remain the same since they already show the decimal pad for the input fields in question.

old
![Pasted image 20220325213053](https://user-images.githubusercontent.com/18316226/160243768-d916f350-59f8-48c8-9023-91f86dc2feac.png)
new
![Pasted image 20220325213235](https://user-images.githubusercontent.com/18316226/160243775-ec74992b-83e7-46a8-a384-0fb5f21c9750.png)

references:  [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/inputmode), [Caniuse](https://caniuse.com/input-inputmode)