### PR TITLE
Use the store's default currency when creating entities

### DIFF
--- a/BTCPayServer.Tests/ApiKeysTests.cs
+++ b/BTCPayServer.Tests/ApiKeysTests.cs
@@ -189,6 +189,7 @@ namespace BTCPayServer.Tests
                 (await apiKeyRepo.GetKey(accessToken)).GetBlob().Permissions);
 
             //let's test the app identifier system
+            TestLogs.LogInformation("Checking app identifier system");
             authUrl = BTCPayServerClient.GenerateAuthorizeUri(s.ServerUri,
                 new[] { Policies.CanModifyStoreSettings, Policies.CanModifyServerSettings }, false, true, (appidentifier, new Uri(callbackUrl))).ToString();
 

--- a/BTCPayServer.Tests/SeleniumTests.cs
+++ b/BTCPayServer.Tests/SeleniumTests.cs
@@ -749,7 +749,12 @@ namespace BTCPayServer.Tests
             s.Driver.FindElement(By.Id("CreatePaymentRequest")).Click();
             s.Driver.FindElement(By.Id("Title")).SendKeys("Pay123");
             s.Driver.FindElement(By.Id("Amount")).SendKeys("700");
-            s.Driver.FindElement(By.Id("Currency")).SendKeys("BTC");
+
+            var currencyInput = s.Driver.FindElement(By.Id("Currency"));
+            Assert.Equal("USD", currencyInput.GetAttribute("value"));
+            currencyInput.Clear();
+            currencyInput.SendKeys("BTC");
+            
             s.Driver.FindElement(By.Id("SaveButton")).Click();
             s.Driver.FindElement(By.Id("ViewPaymentRequest")).Click();
             s.Driver.SwitchTo().Window(s.Driver.WindowHandles.Last());
@@ -1613,6 +1618,12 @@ namespace BTCPayServer.Tests
             s.Driver.FindElement(By.Id("Name")).SendKeys("PP1");
             s.Driver.FindElement(By.Id("Amount")).Clear();
             s.Driver.FindElement(By.Id("Amount")).SendKeys("0.0000001");
+            
+            var currencyInput = s.Driver.FindElement(By.Id("Currency"));
+            Assert.Equal("USD", currencyInput.GetAttribute("value"));
+            currencyInput.Clear();
+            currencyInput.SendKeys("BTC");
+            
             s.Driver.FindElement(By.Id("Create")).Click();
             s.Driver.FindElement(By.LinkText("View")).Click();
             s.Driver.FindElement(By.Id("Destination")).SendKeys(lnurl);

--- a/BTCPayServer/Controllers/UIInvoiceController.UI.cs
+++ b/BTCPayServer/Controllers/UIInvoiceController.UI.cs
@@ -949,6 +949,7 @@ namespace BTCPayServer.Controllers
             {
                 Stores = stores,
                 StoreId = model?.StoreId,
+                Currency = HttpContext.GetStoreData()?.GetStoreBlob().DefaultCurrency,
                 AvailablePaymentMethods = GetPaymentMethodsSelectList()
             };
 

--- a/BTCPayServer/Controllers/UIInvoiceController.UI.cs
+++ b/BTCPayServer/Controllers/UIInvoiceController.UI.cs
@@ -914,18 +914,6 @@ namespace BTCPayServer.Controllers
         [BitpayAPIConstraint(false)]
         public async Task<IActionResult> CreateInvoice(InvoicesModel? model = null)
         {
-            var stores = new SelectList(
-                await _StoreRepository.GetStoresByUserId(GetUserId()),
-                nameof(StoreData.Id),
-                nameof(StoreData.StoreName),
-                new SearchString(model?.SearchTerm).GetFilterArray("storeid")?.ToArray().FirstOrDefault()
-            );
-            if (!stores.Any())
-            {
-                TempData[WellKnownTempData.ErrorMessage] = "You need to create at least one store before creating a transaction";
-                return RedirectToAction(nameof(UIHomeController.Index), "UIHome");
-            }
-
             if (model?.StoreId != null)
             {
                 var store = await _StoreRepository.FindStore(model.StoreId, GetUserId());
@@ -944,11 +932,15 @@ namespace BTCPayServer.Controllers
 
                 HttpContext.SetStoreData(store);
             }
+            else
+            {
+                TempData[WellKnownTempData.ErrorMessage] = "You need to select a store before creating an invoice.";
+                return RedirectToAction(nameof(UIHomeController.Index), "UIHome");
+            }
 
             var vm = new CreateInvoiceModel
             {
-                Stores = stores,
-                StoreId = model?.StoreId,
+                StoreId = model.StoreId,
                 Currency = HttpContext.GetStoreData()?.GetStoreBlob().DefaultCurrency,
                 AvailablePaymentMethods = GetPaymentMethodsSelectList()
             };
@@ -962,8 +954,6 @@ namespace BTCPayServer.Controllers
         [BitpayAPIConstraint(false)]
         public async Task<IActionResult> CreateInvoice(CreateInvoiceModel model, CancellationToken cancellationToken)
         {
-            var stores = await _StoreRepository.GetStoresByUserId(GetUserId());
-            model.Stores = new SelectList(stores, nameof(StoreData.Id), nameof(StoreData.StoreName), model.StoreId);
             model.AvailablePaymentMethods = GetPaymentMethodsSelectList();
             var store = HttpContext.GetStoreData();
             if (!ModelState.IsValid)

--- a/BTCPayServer/Controllers/UIPaymentRequestController.cs
+++ b/BTCPayServer/Controllers/UIPaymentRequestController.cs
@@ -89,10 +89,14 @@ namespace BTCPayServer.Controllers
                 return NotFound();
             }
 
-            return View(nameof(EditPaymentRequest), new UpdatePaymentRequestViewModel(paymentRequest)
+            var vm = new UpdatePaymentRequestViewModel(paymentRequest)
             {
                 StoreId = store.Id
-            });
+            };
+
+            vm.Currency ??= store.GetStoreBlob().DefaultCurrency;
+
+            return View(nameof(EditPaymentRequest), vm);
         }
 
         [HttpPost("/stores/{storeId}/payment-requests/edit/{payReqId?}")]

--- a/BTCPayServer/Controllers/UIStorePullPaymentsController.PullPayments.cs
+++ b/BTCPayServer/Controllers/UIStorePullPaymentsController.PullPayments.cs
@@ -76,10 +76,11 @@ namespace BTCPayServer.Controllers
                 });
                 return RedirectToAction(nameof(UIStoresController.GeneralSettings), "UIStores", new { storeId });
             }
+            
             return View(new NewPullPaymentModel
             {
                 Name = "",
-                Currency = "BTC",
+                Currency = CurrentStore.GetStoreBlob().DefaultCurrency,
                 CustomCSSLink = "",
                 EmbeddedCSS = "",
                 PaymentMethodItems = paymentMethods.Select(id => new SelectListItem(id.ToPrettyString(), id.ToString(), true))

--- a/BTCPayServer/Models/InvoicingModels/CreateInvoiceModel.cs
+++ b/BTCPayServer/Models/InvoicingModels/CreateInvoiceModel.cs
@@ -64,12 +64,6 @@ namespace BTCPayServer.Models.InvoicingModels
             get; set;
         }
 
-        [DisplayName("Store")]
-        public SelectList Stores
-        {
-            get; set;
-        }
-
         [DisplayName("Supported Transaction Currencies")]
         public List<string> SupportedTransactionCurrencies
         {

--- a/BTCPayServer/Views/UIInvoice/CreateInvoice.cshtml
+++ b/BTCPayServer/Views/UIInvoice/CreateInvoice.cshtml
@@ -25,7 +25,6 @@
     </script>
 }
 
-
 <form asp-action="CreateInvoice" method="post" id="create-invoice-form">
     <div class="sticky-header-setup"></div>
     <div class="sticky-header d-flex align-items-center justify-content-between">
@@ -41,16 +40,6 @@
             @if (Model.StoreId != null)
             {
                 <input type="hidden" asp-for="StoreId" />
-            }
-            else
-            {
-                <div class="form-group">
-                    <label asp-for="Stores" class="form-label"></label>
-                    <select asp-for="StoreId" asp-items="Model.Stores" class="form-select"></select>
-                    <span asp-validation-for="StoreId" class="text-danger"></span>
-                </div>
-
-                <h4 class="mt-5 mb-4">Invoice Details</h4>
             }
             <div class="d-flex justify-content-between">
                 <div class="form-group flex-fill me-4">

--- a/BTCPayServer/Views/UIStorePullPayments/NewPullPayment.cshtml
+++ b/BTCPayServer/Views/UIStorePullPayments/NewPullPayment.cshtml
@@ -32,8 +32,8 @@
             </div>
             <div class="row">
                 <div class="form-group col-8">
-                    <label asp-for="Amount" class="form-label"></label>
-                    <input inputmode="decimal" asp-for="Amount" class="form-control"/>
+                    <label asp-for="Amount" class="form-label" data-required></label>
+                    <input asp-for="Amount" class="form-control" inputmode="decimal" />
                     <span asp-validation-for="Amount" class="text-danger"></span>
                 </div>
                 <div class="form-group col-4">
@@ -63,7 +63,7 @@
                 <span asp-validation-for="Description" class="text-danger"></span>
             </div>
 
-            <h5 class="mt-4 mb-2">Additional Options</h5>
+            <h4 class="mt-5 mb-2">Additional Options</h4>
             <div class="form-group">
                 <div class="accordion" id="additional">
                     <div class="accordion-item">


### PR DESCRIPTION
Prefills the invoice/paymentrequest/pull payment creation forms currency inputs with the store's default currency.

Also cleans up an old code path we had for the invoice creation, in which the store was selectable. We don't offer that anymore and invoices are created explicitely for one store.

Closes #3581. Closes #3582.