### PR TITLE
Fix UI to match Shopify's

### DIFF
--- a/BTCPayServer/Plugins/Shopify/Models/ShopifySettings.cs
+++ b/BTCPayServer/Plugins/Shopify/Models/ShopifySettings.cs
@@ -8,11 +8,11 @@ namespace BTCPayServer.Plugins.Shopify.Models
     {
         [Display(Name = "Shop Name")]
         public string ShopName { get; set; }
-        
-        [Display(Name = "Api Key (Apps->Develop Apps-> Create app)")]
+
+        [Display(Name = "Api Key")]
         public string ApiKey { get; set; }
-        
-        [Display(Name = "Api Secret Key")]
+
+        [Display(Name = "Admin API access token")]
         public string Password { get; set; }
 
         public bool CredentialsPopulated()


### PR DESCRIPTION
With recent changes in https://github.com/btcpayserver/btcpayserver/commit/e449ca2c95d8f6927f30959fc663fb0a6f5cb397 we forgot to update our UI in BTCPay to match exact wording on Shopify's end which leads to confusion when people are entering the credentials. I was tricked, so did one more person that helped me test the integration, while I fixed this in docs (soon PR) this should be fixed in the UI as well.

![Screenshot 2022-03-31 at 14 54 31](https://user-images.githubusercontent.com/36959754/161059927-79351742-9ace-4b5d-a05b-dbd61646ec2c.png)

