### PR TITLE
Link to local development environment instructions corrected

### DIFF
--- a/BTCPayServer.Tests/README.md
+++ b/BTCPayServer.Tests/README.md
@@ -1,7 +1,7 @@
 # Tooling
 
 This README describe some useful tooling that you may need during development and testing.
-To learn how to get started with your local development environment, read [our documentation](https://docs.btcpayserver.org/LocalDevelopment/).
+To learn how to get started with your local development environment, read [our documentation](https://docs.btcpayserver.org/Development/LocalDevelopment/).
 
 ## How to manually test payments
 


### PR DESCRIPTION
As noted here: https://github.com/btcpayserver/btcpayserver/issues/3590

The link to the local development environment instructions was broken and now is correct.