### PR TITLE
Delete LN addresses on store delete

### DIFF
--- a/BTCPayServer/Controllers/UILNURLController.cs
+++ b/BTCPayServer/Controllers/UILNURLController.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Globalization;
@@ -26,7 +25,6 @@ using BTCPayServer.Services.Stores;
 using LNURL;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.AspNetCore.Routing;
 using NBitcoin;
 using NBitcoin.Crypto;
@@ -147,35 +145,6 @@ namespace BTCPayServer
 
             public EditLightningAddressItem Add { get; set; }
             public List<EditLightningAddressItem> Items { get; set; } = new List<EditLightningAddressItem>();
-        }
-
-        public class LightningAddressSettings
-        {
-            public class LightningAddressItem
-            {
-                public string StoreId { get; set; }
-                [Display(Name = "Invoice currency")]
-                public string CurrencyCode { get; set; }
-
-                [Display(Name = "Min sats")]
-                [Range(1, double.PositiveInfinity)]
-                public decimal? Min { get; set; }
-
-                [Display(Name = "Max sats")]
-                [Range(1, double.PositiveInfinity)]
-                public decimal? Max { get; set; }
-            }
-
-            public ConcurrentDictionary<string, LightningAddressItem> Items { get; set; } =
-                new ConcurrentDictionary<string, LightningAddressItem>();
-
-            public ConcurrentDictionary<string, string[]> StoreToItemMap { get; set; } =
-                new ConcurrentDictionary<string, string[]>();
-
-            public override string ToString()
-            {
-                return null;
-            }
         }
 
         private async Task<LightningAddressSettings> GetSettings()

--- a/BTCPayServer/Hosting/MigrationStartupTask.cs
+++ b/BTCPayServer/Hosting/MigrationStartupTask.cs
@@ -171,7 +171,7 @@ namespace BTCPayServer.Hosting
                 }
                 if (!settings.LighingAddressSettingRename)
                 {
-                    await MigrateLighingAddressSettingRename();
+                    await MigrateLightningAddressSettingRename();
                     settings.LighingAddressSettingRename = true;
                     await _Settings.UpdateSetting(settings);
                 }
@@ -183,7 +183,7 @@ namespace BTCPayServer.Hosting
             }
         }
 
-        private async Task MigrateLighingAddressSettingRename()
+        private async Task MigrateLightningAddressSettingRename()
         {
            var old = await _Settings.GetSettingAsync<LightningAddressSettings>("BTCPayServer.LNURLController+LightningAddressSettings");
            if (old is not null)

--- a/BTCPayServer/Hosting/MigrationStartupTask.cs
+++ b/BTCPayServer/Hosting/MigrationStartupTask.cs
@@ -185,10 +185,10 @@ namespace BTCPayServer.Hosting
 
         private async Task MigrateLighingAddressSettingRename()
         {
-           var old = await _Settings.GetSettingAsync<UILNURLController.LightningAddressSettings>("BTCPayServer.LNURLController+LightningAddressSettings");
+           var old = await _Settings.GetSettingAsync<LightningAddressSettings>("BTCPayServer.LNURLController+LightningAddressSettings");
            if (old is not null)
            {
-              await _Settings.UpdateSetting(old, nameof(UILNURLController.LightningAddressSettings));
+              await _Settings.UpdateSetting(old, nameof(LightningAddressSettings));
            }
         }
 

--- a/BTCPayServer/LightningAddressSettings.cs
+++ b/BTCPayServer/LightningAddressSettings.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Collections.Concurrent;
+using System.ComponentModel.DataAnnotations;
+
+namespace BTCPayServer
+{
+    public class LightningAddressSettings
+        {
+            public class LightningAddressItem
+            {
+                public string StoreId { get; set; }
+                [Display(Name = "Invoice currency")]
+                public string CurrencyCode { get; set; }
+
+                [Display(Name = "Min sats")]
+                [Range(1, double.PositiveInfinity)]
+                public decimal? Min { get; set; }
+
+                [Display(Name = "Max sats")]
+                [Range(1, double.PositiveInfinity)]
+                public decimal? Max { get; set; }
+            }
+
+            public ConcurrentDictionary<string, LightningAddressItem> Items { get; set; } =
+                new ConcurrentDictionary<string, LightningAddressItem>();
+
+            public ConcurrentDictionary<string, string[]> StoreToItemMap { get; set; } =
+                new ConcurrentDictionary<string, string[]>();
+
+            public override string ToString()
+            {
+                return null;
+            }
+        }
+}

--- a/BTCPayServer/Services/MigrationSettings.cs
+++ b/BTCPayServer/Services/MigrationSettings.cs
@@ -29,5 +29,6 @@ namespace BTCPayServer.Services
         public bool MigratePayoutDestinationId { get; set; }
         public bool AddInitialUserBlob { get; set; }
         public bool LighingAddressSettingRename { get; set; }
+        public bool UnreachableLightningAddressRemove { get; set; }
     }
 }


### PR DESCRIPTION
fixes #3596 by deleting LN URL addresses associated with a store when it's deleted. Also added a startup task to delete LN URL addresses which do not belong to any store.