### PR TITLE
Add ability to set default payment method for pay button

### DIFF
--- a/BTCPayServer/Controllers/UIPublicController.cs
+++ b/BTCPayServer/Controllers/UIPublicController.cs
@@ -67,7 +67,8 @@ namespace BTCPayServer.Controllers
                     NotificationEmail = model.NotifyEmail,
                     NotificationURL = model.ServerIpn,
                     RedirectURL = model.BrowserRedirect,
-                    FullNotifications = true
+                    FullNotifications = true,
+                    DefaultPaymentMethod = model.DefaultPaymentMethod
                 }, store, HttpContext.Request.GetAbsoluteRoot(), cancellationToken: cancellationToken);
             }
             catch (BitpayHttpException e)

--- a/BTCPayServer/Controllers/UIStoresController.cs
+++ b/BTCPayServer/Controllers/UIStoresController.cs
@@ -430,13 +430,13 @@ namespace BTCPayServer.Controllers
             vm.DefaultPaymentMethod = chosen?.Value;
         }
 
-        CheckoutAppearanceViewModel.Format[] GetEnabledPaymentMethodChoices(Data.StoreData storeData)
+        PaymentMethodOptionViewModel.Format[] GetEnabledPaymentMethodChoices(Data.StoreData storeData)
         {
             var enabled = storeData.GetEnabledPaymentIds(_NetworkProvider);
             
             return enabled
                 .Select(o =>
-                    new CheckoutAppearanceViewModel.Format()
+                    new PaymentMethodOptionViewModel.Format()
                     {
                         Name = o.ToPrettyString(),
                         Value = o.ToString(),
@@ -444,7 +444,7 @@ namespace BTCPayServer.Controllers
                     }).ToArray();
         }
 
-        CheckoutAppearanceViewModel.Format? GetDefaultPaymentMethodChoice(Data.StoreData storeData)
+        PaymentMethodOptionViewModel.Format? GetDefaultPaymentMethodChoice(Data.StoreData storeData)
         {
             var enabled = storeData.GetEnabledPaymentIds(_NetworkProvider);
             var defaultPaymentId = storeData.GetDefaultPaymentId();

--- a/BTCPayServer/Controllers/UIStoresController.cs
+++ b/BTCPayServer/Controllers/UIStoresController.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Collections.Generic;
 using System.Globalization;
@@ -229,7 +230,7 @@ namespace BTCPayServer.Controllers
         }
 
         [HttpPost("{storeId}/rates")]
-        public async Task<IActionResult> Rates(RatesViewModel model, string command = null, string storeId = null, CancellationToken cancellationToken = default)
+        public async Task<IActionResult> Rates(RatesViewModel model, string? command = null, string? storeId = null, CancellationToken cancellationToken = default)
         {
             if (command == "scripting-on")
             {
@@ -243,7 +244,7 @@ namespace BTCPayServer.Controllers
             var exchanges = GetSupportedExchanges();
             model.SetExchangeRates(exchanges, model.PreferredExchange);
             model.StoreId = storeId ?? model.StoreId;
-            CurrencyPair[] currencyPairs = null;
+            CurrencyPair[]? currencyPairs = null;
             try
             {
                 currencyPairs = model.DefaultCurrencyPairs?
@@ -277,7 +278,7 @@ namespace BTCPayServer.Controllers
                     return View(model);
                 }
             }
-            RateRules rules = null;
+            RateRules? rules = null;
             if (model.ShowScripting)
             {
                 if (!RateRules.TryParse(model.Script, out rules, out var errors))
@@ -443,7 +444,7 @@ namespace BTCPayServer.Controllers
                     }).ToArray();
         }
 
-        CheckoutAppearanceViewModel.Format GetDefaultPaymentMethodChoice(Data.StoreData storeData)
+        CheckoutAppearanceViewModel.Format? GetDefaultPaymentMethodChoice(Data.StoreData storeData)
         {
             var enabled = storeData.GetEnabledPaymentIds(_NetworkProvider);
             var defaultPaymentId = storeData.GetDefaultPaymentId();
@@ -631,7 +632,7 @@ namespace BTCPayServer.Controllers
         }
 
         [HttpPost("{storeId}/settings")]
-        public async Task<IActionResult> GeneralSettings(GeneralSettingsViewModel model, string command = null)
+        public async Task<IActionResult> GeneralSettings(GeneralSettingsViewModel model, string? command = null)
         {
             bool needUpdate = false;
             if (CurrentStore.StoreName != model.StoreName)
@@ -762,7 +763,7 @@ namespace BTCPayServer.Controllers
                 TempData[WellKnownTempData.ErrorMessage] = "Failure to revoke this token.";
             else
                 TempData[WellKnownTempData.SuccessMessage] = "Token revoked";
-            return RedirectToAction(nameof(ListTokens), new { storeId = token.StoreId });
+            return RedirectToAction(nameof(ListTokens), new { storeId = token?.StoreId });
         }
 
         [HttpGet]
@@ -797,7 +798,7 @@ namespace BTCPayServer.Controllers
                 Id = model.PublicKey == null ? null : NBitpayClient.Extensions.BitIdExtensions.GetBitIDSIN(new PubKey(model.PublicKey).Compress())
             };
 
-            string pairingCode = null;
+            string? pairingCode = null;
             if (model.PublicKey == null)
             {
                 tokenRequest.PairingCode = await _TokenRepository.CreatePairingCodeAsync();
@@ -822,7 +823,7 @@ namespace BTCPayServer.Controllers
             });
         }
 
-        public string GeneratedPairingCode { get; set; }
+        public string? GeneratedPairingCode { get; set; }
         public WebhookSender WebhookNotificationManager { get; }
         public IDataProtector DataProtector { get; }
 
@@ -895,7 +896,7 @@ namespace BTCPayServer.Controllers
         [HttpGet]
         [Route("/api-access-request")]
         [AllowAnonymous]
-        public async Task<IActionResult> RequestPairing(string pairingCode, string selectedStore = null)
+        public async Task<IActionResult> RequestPairing(string pairingCode, string? selectedStore = null)
         {
             var userId = GetUserId();
             if (userId == null)
@@ -971,9 +972,9 @@ namespace BTCPayServer.Controllers
             }
         }
 
-        private string GetUserId()
+        private string? GetUserId()
         {
-            if (User.Identity.AuthenticationType != AuthenticationSchemes.Cookie)
+            if (User.Identity?.AuthenticationType != AuthenticationSchemes.Cookie)
                 return null;
             return _UserManager.GetUserId(User);
         }
@@ -1005,7 +1006,7 @@ namespace BTCPayServer.Controllers
             {
                 Price = null,
                 Currency = storeBlob.DefaultCurrency,
-                DefaultPaymentMethod = GetDefaultPaymentMethodChoice(store).Value,
+                DefaultPaymentMethod = GetDefaultPaymentMethodChoice(store)?.Value,
                 PaymentMethods = GetEnabledPaymentMethodChoices(store),
                 ButtonSize = 2,
                 UrlRoot = appUrl,

--- a/BTCPayServer/Controllers/UIStoresController.cs
+++ b/BTCPayServer/Controllers/UIStoresController.cs
@@ -1006,7 +1006,7 @@ namespace BTCPayServer.Controllers
             {
                 Price = null,
                 Currency = storeBlob.DefaultCurrency,
-                DefaultPaymentMethod = GetDefaultPaymentMethodChoice(store)?.Value,
+                DefaultPaymentMethod = String.Empty,
                 PaymentMethods = GetEnabledPaymentMethodChoices(store),
                 ButtonSize = 2,
                 UrlRoot = appUrl,

--- a/BTCPayServer/Data/StoreDataExtensions.cs
+++ b/BTCPayServer/Data/StoreDataExtensions.cs
@@ -38,7 +38,7 @@ namespace BTCPayServer.Data
             return paymentMethodIds;
         }
 
-        public static void SetDefaultPaymentId(this StoreData storeData, PaymentMethodId defaultPaymentId)
+        public static void SetDefaultPaymentId(this StoreData storeData, PaymentMethodId? defaultPaymentId)
         {
             storeData.DefaultCrypto = defaultPaymentId?.ToString();
         }

--- a/BTCPayServer/Models/StoreViewModels/CheckoutAppearanceViewModel.cs
+++ b/BTCPayServer/Models/StoreViewModels/CheckoutAppearanceViewModel.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
-using BTCPayServer.Payments;
 using BTCPayServer.Services;
 using Microsoft.AspNetCore.Mvc.Rendering;
 
@@ -10,18 +9,12 @@ namespace BTCPayServer.Models.StoreViewModels
 {
     public class CheckoutAppearanceViewModel
     {
-        public class Format
-        {
-            public string Name { get; set; }
-            public string Value { get; set; }
-            public PaymentMethodId PaymentId { get; set; }
-        }
         public SelectList PaymentMethods { get; set; }
 
         public void SetLanguages(LanguageService langService, string defaultLang)
         {
             defaultLang = langService.GetLanguages().Any(language => language.Code == defaultLang) ? defaultLang : "en";
-            var choices = langService.GetLanguages().Select(o => new Format() { Name = o.DisplayName, Value = o.Code }).ToArray().OrderBy(o => o.Name);
+            var choices = langService.GetLanguages().Select(o => new PaymentMethodOptionViewModel.Format() { Name = o.DisplayName, Value = o.Code }).ToArray().OrderBy(o => o.Name);
             var chosen = choices.FirstOrDefault(f => f.Value == defaultLang) ?? choices.FirstOrDefault();
             Languages = new SelectList(choices, nameof(chosen.Value), nameof(chosen.Name), chosen);
             DefaultLang = chosen.Value;

--- a/BTCPayServer/Models/StoreViewModels/PayButtonViewModel.cs
+++ b/BTCPayServer/Models/StoreViewModels/PayButtonViewModel.cs
@@ -13,6 +13,8 @@ namespace BTCPayServer.Models.StoreViewModels
         public string InvoiceId { get; set; }
         [Required]
         public string Currency { get; set; }
+        public string DefaultPaymentMethod { get; set; }
+        public CheckoutAppearanceViewModel.Format[] PaymentMethods { get; set; }
         public string CheckoutDesc { get; set; }
         public string OrderId { get; set; }
         public int ButtonSize { get; set; }

--- a/BTCPayServer/Models/StoreViewModels/PayButtonViewModel.cs
+++ b/BTCPayServer/Models/StoreViewModels/PayButtonViewModel.cs
@@ -14,7 +14,7 @@ namespace BTCPayServer.Models.StoreViewModels
         [Required]
         public string Currency { get; set; }
         public string DefaultPaymentMethod { get; set; }
-        public CheckoutAppearanceViewModel.Format[] PaymentMethods { get; set; }
+        public PaymentMethodOptionViewModel.Format[] PaymentMethods { get; set; }
         public string CheckoutDesc { get; set; }
         public string OrderId { get; set; }
         public int ButtonSize { get; set; }

--- a/BTCPayServer/Models/StoreViewModels/PaymentMethodOptionViewModel.cs
+++ b/BTCPayServer/Models/StoreViewModels/PaymentMethodOptionViewModel.cs
@@ -1,0 +1,14 @@
+using BTCPayServer.Payments;
+
+namespace BTCPayServer.Models.StoreViewModels
+{
+    public class PaymentMethodOptionViewModel
+    {
+        public class Format
+        {
+            public string Name { get; set; }
+            public string Value { get; set; }
+            public PaymentMethodId PaymentId { get; set; }
+        }
+    }
+}

--- a/BTCPayServer/Views/UIStores/PayButton.cshtml
+++ b/BTCPayServer/Views/UIStores/PayButton.cshtml
@@ -162,6 +162,7 @@
             <div class="form-group col-md-4" v-if="!srvModel.appIdEndpoint">
                 <label class="form-label" for="defaultPaymentMethod">Default Payment Method</label>
                 <select v-model="srvModel.defaultPaymentMethod" v-on:change="inputChanges" class="form-select" id="default-payment-method">
+                    <option value="" selected>Use the store’s default</option>
                     <option  v-for="pm in srvModel.paymentMethods" v-bind:value="pm.value">{{pm.name}}</option>
                 </select>
             </div>

--- a/BTCPayServer/Views/UIStores/PayButton.cshtml
+++ b/BTCPayServer/Views/UIStores/PayButton.cshtml
@@ -159,6 +159,12 @@
                        v-model="srvModel.currency" v-on:change="inputChanges"
                        :class="{'is-invalid': errors.has('currency') }">
             </div>
+            <div class="form-group col-md-4" v-if="!srvModel.appIdEndpoint">
+                <label class="form-label" for="defaultPaymentMethod">Default Payment Method</label>
+                <select v-model="srvModel.defaultPaymentMethod" v-on:change="inputChanges" class="form-select" id="default-payment-method">
+                    <option  v-for="pm in srvModel.paymentMethods" v-bind:value="pm.value">{{pm.name}}</option>
+                </select>
+            </div>
             <div class="form-group" v-if="!srvModel.appIdEndpoint">
                 <label class="form-label" for="description">Checkout Description</label>
                 <input name="checkoutDesc" type="text" class="form-control" id="description"

--- a/BTCPayServer/wwwroot/paybutton/paybutton.js
+++ b/BTCPayServer/wwwroot/paybutton/paybutton.js
@@ -84,6 +84,7 @@ function inputChanges(event, buttonSize) {
     let priceInputName = 'price';
     let app = srvModel.appIdEndpoint? srvModel.apps.find(value => value.id === srvModel.appIdEndpoint ): null;
     let allowCurrencySelection = true;
+    let allowDefaultPaymentMethodSelection = true;
     if (app) {
         if (app.appType.toLowerCase() === 'pointofsale') {
             actionUrl = `apps/${app.id}/pos`;
@@ -97,6 +98,7 @@ function inputChanges(event, buttonSize) {
         if (actionUrl !== 'api/v1/invoices') {
             priceInputName = 'amount';
             allowCurrencySelection = false;
+            allowDefaultPaymentMethodSelection = false;
             srvModel.useModal = false;
         }
     }
@@ -149,6 +151,15 @@ function inputChanges(event, buttonSize) {
         if (allowCurrencySelection) html += addSelectCurrency(srvModel.currency);
         html += addSlider(srvModel.price, srvModel.min, srvModel.max, srvModel.step, width);
         html += '  </div>\n';
+    }
+
+    if (
+        allowDefaultPaymentMethodSelection &&
+        // Only add default payment method to HTML if user explicitly selected it
+        event && event.target.id === 'default-payment-method'
+    ) 
+    {
+        html += addInput("defaultPaymentMethod", srvModel.defaultPaymentMethod)
     }
     
     html += srvModel.payButtonText

--- a/BTCPayServer/wwwroot/paybutton/paybutton.js
+++ b/BTCPayServer/wwwroot/paybutton/paybutton.js
@@ -156,8 +156,8 @@ function inputChanges(event, buttonSize) {
     if (
         allowDefaultPaymentMethodSelection &&
         // Only add default payment method to HTML if user explicitly selected it
-        event && event.target.id === 'default-payment-method'
-    ) 
+        event && event.target.id === 'default-payment-method' && event.target.value !== ""
+    )
     {
         html += addInput("defaultPaymentMethod", srvModel.defaultPaymentMethod)
     }


### PR DESCRIPTION
Added an option for setting a default payment method for pay button (e.g., you can set it to LN, or Doge or whatever by default instead of using whatever is the default option for the store).

The code for the default payment method in the generated HTML only shows up if user changes the selection from the default one. There is no need to include the default one in the HTML because that's what will be used anyway.

![Capture](https://user-images.githubusercontent.com/1934678/161413355-d37c0cd8-2f87-4737-b152-0701ca29b1e3.PNG)

close https://github.com/btcpayserver/btcpayserver/issues/3604