### PR TITLE
Fix visual bug when user clicks on "Create refund" without selecting an option

### DIFF
--- a/BTCPayServer/Controllers/UIInvoiceController.UI.cs
+++ b/BTCPayServer/Controllers/UIInvoiceController.UI.cs
@@ -311,7 +311,7 @@ namespace BTCPayServer.Controllers
                             model.RefundStep = RefundSteps.SelectCustomAmount;
                             return View(model);
                         default:
-                            ModelState.AddModelError(nameof(model.SelectedRefundOption), "Invalid choice");
+                            ModelState.AddModelError(nameof(model.SelectedRefundOption), "Please select an option before proceeding");
                             return View(model);
                     }
 

--- a/BTCPayServer/Views/UIInvoice/Refund.cshtml
+++ b/BTCPayServer/Views/UIInvoice/Refund.cshtml
@@ -64,8 +64,10 @@
                                 <small class="form-text text-muted">The specified amount with the specified currency, at the rate when the refund will be sent. </small>
                             </div>
                             <div class="form-group">
-                                <button id="ok" type="submit" class="btn btn-primary btn-lg w-100">Create refund</button>
                                 <span asp-validation-for="SelectedRefundOption" class="text-danger w-100"></span>
+                            </div>
+                            <div class="form-group">
+                                <button id="ok" type="submit" class="btn btn-primary btn-lg w-100">Create refund</button>
                             </div>
                             break;
                         case RefundSteps.SelectCustomAmount:

--- a/BTCPayServer/Views/UIInvoice/Refund.cshtml
+++ b/BTCPayServer/Views/UIInvoice/Refund.cshtml
@@ -1,4 +1,4 @@
-﻿@model RefundModel
+@model RefundModel
 @{
     ViewData["Title"] = "Refund";
 }
@@ -61,6 +61,7 @@
                             </div>
                             <div class="form-group">
                                 <button id="ok" type="submit" class="btn btn-primary btn-lg w-100">Create refund</button>
+                                <span asp-validation-for="SelectedRefundOption" class="text-danger w-100"></span>
                             </div>
                             break;
                         case RefundSteps.SelectCustomAmount:

--- a/BTCPayServer/Views/UIInvoice/Refund.cshtml
+++ b/BTCPayServer/Views/UIInvoice/Refund.cshtml
@@ -1,4 +1,4 @@
-@model RefundModel
+﻿@model RefundModel
 @{
     ViewData["Title"] = "Refund";
 }
@@ -13,6 +13,10 @@
                 <form method="post">
                     <input type="hidden" asp-for="RefundStep" value="@Model.RefundStep"/>
                     <input type="hidden" asp-for="Title" value="@Model.Title"/>
+                    <input type="hidden" asp-for="RateThenText" value="@Model.RateThenText"/>
+                    <input type="hidden" asp-for="CurrentRateText" value="@Model.CurrentRateText"/>
+                    <input type="hidden" asp-for="FiatText" value="@Model.FiatText"/>
+
                     @switch (Model.RefundStep)
                     {
                         case RefundSteps.SelectPaymentMethod:


### PR DESCRIPTION
|Before|After|
|---|---|
|![Capture2](https://user-images.githubusercontent.com/1934678/162557694-325a2432-6919-40b6-a9b7-4323a1d803f2.PNG)|![Capture](https://user-images.githubusercontent.com/1934678/162557700-e572c31c-5dbf-4bae-9451-98abb8060a30.PNG)|

fix #3621 