### PR TITLE
Hide empty plugins section

### DIFF
--- a/BTCPayServer/Components/MainNav/Default.cshtml
+++ b/BTCPayServer/Components/MainNav/Default.cshtml
@@ -197,17 +197,26 @@
                 </div>
             </div>
             <script>
-                const navCollapsed = window.localStorage.getItem('btcpay-nav-collapsed')
-                const collapsed = navCollapsed ? JSON.parse(navCollapsed) : []
-                collapsed.forEach(id => {
-                    const el = document.getElementById(id)
-                    const btn = el && el.previousElementSibling.querySelector(`[aria-controls="${id}"]`)
-                    if (el && btn) {
-                        el.classList.remove('show')
-                        btn.classList.add('collapsed')
-                        btn.setAttribute('aria-expanded', 'false')
+                (() => {
+                    // apply collapse settings
+                    const navCollapsed = window.localStorage.getItem('btcpay-nav-collapsed')
+                    const collapsed = navCollapsed ? JSON.parse(navCollapsed) : []
+                    collapsed.forEach(id => {
+                        const el = document.getElementById(id)
+                        const btn = el && el.previousElementSibling.querySelector(`[aria-controls="${id}"]`)
+                        if (el && btn) {
+                            el.classList.remove('show')
+                            btn.classList.add('collapsed')
+                            btn.setAttribute('aria-expanded', 'false')
+                        }
+                    })
+                    // hide empty plugins drawer
+                    const pluginsItem = document.getElementById('Nav-Plugins').closest('.accordion-item')
+                    const pluginsContent = pluginsItem.querySelector('.navbar-nav').innerHTML.trim()
+                    if (pluginsContent === '') {
+                        pluginsItem.setAttribute('hidden', true)
                     }
-                })
+                })()
             </script>
         }
         else if (Env.IsSecure)


### PR DESCRIPTION
Closes #3617. Implementation of @bolatovumar's [proposal](https://github.com/btcpayserver/btcpayserver/issues/3617#issuecomment-1094173005) - we might be able to replace it with a better solution, that would avoid rendering that section in the first place. For now that solves the issue though.