### PR TITLE
Greenfield: Proper response for store not found

### DIFF
--- a/BTCPayServer/Controllers/GreenField/GreenfieldLightningNodeApiController.Store.cs
+++ b/BTCPayServer/Controllers/GreenField/GreenfieldLightningNodeApiController.Store.cs
@@ -7,11 +7,9 @@ using BTCPayServer.Client;
 using BTCPayServer.Client.Models;
 using BTCPayServer.Configuration;
 using BTCPayServer.Data;
-using BTCPayServer.HostedServices;
 using BTCPayServer.Lightning;
 using BTCPayServer.Payments;
 using BTCPayServer.Payments.Lightning;
-using BTCPayServer.Security;
 using BTCPayServer.Services;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Cors;
@@ -123,7 +121,7 @@ namespace BTCPayServer.Controllers.Greenfield
             var store = HttpContext.GetStoreData();
             if (store == null)
             {
-                throw new JsonHttpException(this.CreateAPIError(404, "unknown-store", "There is no store with this id"));
+                throw new JsonHttpException(StoreNotFound());
             }
             
             var id = new PaymentMethodId(cryptoCode, PaymentTypes.LightningLike);
@@ -147,6 +145,11 @@ namespace BTCPayServer.Controllers.Greenfield
                 return Task.FromResult(_lightningClientFactory.Create(internalLightningNode, network));
             }
             throw ErrorLightningNodeNotConfiguredForStore();
+        }
+        
+        private IActionResult StoreNotFound()
+        {
+            return this.CreateAPIError(404, "store-not-found", "The store was not found");
         }
     }
 }

--- a/BTCPayServer/Controllers/GreenField/GreenfieldLightningNodeApiController.Store.cs
+++ b/BTCPayServer/Controllers/GreenField/GreenfieldLightningNodeApiController.Store.cs
@@ -2,6 +2,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using BTCPayServer.Abstractions.Constants;
 using BTCPayServer.Abstractions.Contracts;
+using BTCPayServer.Abstractions.Extensions;
 using BTCPayServer.Client;
 using BTCPayServer.Client.Models;
 using BTCPayServer.Configuration;
@@ -113,14 +114,18 @@ namespace BTCPayServer.Controllers.Greenfield
         protected override Task<ILightningClient> GetLightningClient(string cryptoCode,
             bool doingAdminThings)
         {
-
             var network = _btcPayNetworkProvider.GetNetwork<BTCPayNetwork>(cryptoCode);
-            var store = HttpContext.GetStoreData();
-            if (store == null || network == null)
+            if (network == null)
             {
                 throw ErrorCryptoCodeNotFound();
             }
-
+            
+            var store = HttpContext.GetStoreData();
+            if (store == null)
+            {
+                throw new JsonHttpException(this.CreateAPIError(404, "unknown-store", "There is no store with this id"));
+            }
+            
             var id = new PaymentMethodId(cryptoCode, PaymentTypes.LightningLike);
             var existing = store.GetSupportedPaymentMethods(_btcPayNetworkProvider)
                 .OfType<LightningSupportedPaymentMethod>()


### PR DESCRIPTION
Previously the "network not configured" error message was also displayed when indeed the store could not be found. This is misleading, hence we should have a separate error for that case.