### PR TITLE
LNURL: Use Lightning description template in LNURL metadata

### DIFF
--- a/BTCPayServer/Controllers/UIAppsPublicController.cs
+++ b/BTCPayServer/Controllers/UIAppsPublicController.cs
@@ -219,7 +219,7 @@ namespace BTCPayServer.Controllers
                     Currency = settings.Currency,
                     Price = price,
                     BuyerEmail = email,
-                    OrderId = orderId,
+                    OrderId = orderId ?? AppService.GetPosOrderId(appId),
                     NotificationURL =
                             string.IsNullOrEmpty(notificationUrl) ? settings.NotificationUrl : notificationUrl,
                     RedirectURL = !string.IsNullOrEmpty(redirectUrl) ? redirectUrl

--- a/BTCPayServer/Services/Apps/AppService.cs
+++ b/BTCPayServer/Services/Apps/AppService.cs
@@ -270,6 +270,7 @@ namespace BTCPayServer.Services.Apps
             return entity.Status == InvoiceStatusLegacy.Complete || entity.Status == InvoiceStatusLegacy.Confirmed || entity.Status == InvoiceStatusLegacy.Paid;
         }
 
+        public static string GetPosOrderId(string appId) => $"pos-app_{appId}";
         public static string GetCrowdfundOrderId(string appId) => $"crowdfund-app_{appId}";
         public static string GetAppInternalTag(string appId) => $"APP#{appId}";
         public static string[] GetAppInternalTags(InvoiceEntity invoice)


### PR DESCRIPTION
Unifies the invoice description for the Lightning and LNURL payment methods and fixes #3634.

#3655 brought up a similar topic. In [efc1a0d](https://github.com/btcpayserver/btcpayserver/pull/3667/commits/efc1a0d6688c64678c799e52b0da81dc2faf5240) I unified the LNURL meta data with the Lightning invoice meta data, so that individual POS item purchases can be tracked using the invoice meta data.

[de47d3a](https://github.com/btcpayserver/btcpayserver/pull/3667/commits/de47d3a71e8f31352fd523e8daabf243543df58f) adds an order ID for individual POS item purchases. This is so that it is consistent with the Crowdfund order IDs and it is also used in the previously mentioned commit.