### PR TITLE
Fix payment request redirect URL

### DIFF
--- a/BTCPayServer/Extensions/UrlHelperExtensions.cs
+++ b/BTCPayServer/Extensions/UrlHelperExtensions.cs
@@ -32,7 +32,7 @@ namespace Microsoft.AspNetCore.Mvc
             return urlHelper.GetUriByAction(
                 action: nameof(UIPaymentRequestController.ViewPaymentRequest),
                 controller: "UIPaymentRequest",
-                values: new { id = paymentRequestId },
+                values: new { payReqId = paymentRequestId },
                 scheme, host, pathbase);
         }
 
@@ -50,7 +50,7 @@ namespace Microsoft.AspNetCore.Mvc
             return urlHelper.GetUriByAction(
                 action: nameof(UIInvoiceController.Invoice),
                 controller: "UIInvoice",
-                values: new { invoiceId = invoiceId },
+                values: new { invoiceId },
                 scheme, host, pathbase);
         }
 
@@ -59,7 +59,7 @@ namespace Microsoft.AspNetCore.Mvc
             return urlHelper.GetUriByAction(
                 action: nameof(UIInvoiceController.Checkout),
                 controller: "UIInvoice",
-                values: new { invoiceId = invoiceId },
+                values: new { invoiceId },
                 scheme, host, pathbase);
         }
 


### PR DESCRIPTION
As the parameter name changed to `payReqId` with the store-centric updates, we need to reflect this in the `UrlHelper` as well.