### PR TITLE
Auto approve refunds

### DIFF
--- a/BTCPayServer/Controllers/UIInvoiceController.UI.cs
+++ b/BTCPayServer/Controllers/UIInvoiceController.UI.cs
@@ -224,7 +224,7 @@ namespace BTCPayServer.Controllers
         [Authorize(Policy = Policies.CanModifyStoreSettings, AuthenticationSchemes = AuthenticationSchemes.Cookie)]
         public async Task<IActionResult> Refund(string invoiceId, RefundModel model, CancellationToken cancellationToken)
         {
-            using var ctx = _dbContextFactory.CreateContext();
+            await using var ctx = _dbContextFactory.CreateContext();
 
             var invoice = GetCurrentInvoice();
             if (invoice == null)
@@ -288,21 +288,25 @@ namespace BTCPayServer.Controllers
                         Name = $"Refund {invoice.Id}",
                         PaymentMethodIds = new[] { paymentMethodId },
                         StoreId = invoice.StoreId,
-                        BOLT11Expiration = store.GetStoreBlob().RefundBOLT11Expiration
+                        BOLT11Expiration = store.GetStoreBlob().RefundBOLT11Expiration,
+                        //AutoApproveClaims = true
                     };
                     switch (model.SelectedRefundOption)
                     {
                         case "RateThen":
                             createPullPayment.Currency = paymentMethodId.CryptoCode;
                             createPullPayment.Amount = model.CryptoAmountThen;
+                            createPullPayment.AutoApproveClaims = true;
                             break;
                         case "CurrentRate":
                             createPullPayment.Currency = paymentMethodId.CryptoCode;
                             createPullPayment.Amount = model.CryptoAmountNow;
+                            createPullPayment.AutoApproveClaims = true;
                             break;
                         case "Fiat":
                             createPullPayment.Currency = invoice.Currency;
                             createPullPayment.Amount = model.FiatAmount;
+                            createPullPayment.AutoApproveClaims = false;
                             break;
                         case "Custom":
                             model.Title = "How much to refund?";
@@ -348,10 +352,11 @@ namespace BTCPayServer.Controllers
                     createPullPayment = new CreatePullPayment
                     {
                         Name = $"Refund {invoice.Id}",
-                        PaymentMethodIds = new[] { paymentMethodId },
+                        PaymentMethodIds = new[] {paymentMethodId},
                         StoreId = invoice.StoreId,
                         Currency = model.CustomCurrency,
-                        Amount = model.CustomAmount
+                        Amount = model.CustomAmount,
+                        AutoApproveClaims = paymentMethodId.CryptoCode == model.CustomCurrency
                     };
                     break;
                 default:


### PR DESCRIPTION
Since we can now auto-approve payouts as they are created, we can also make refunds almost fully automated beyond just creating the refund.

Since a refund can only be created by a store admin, there is no security dilemma. 

I am divided between making auto-approval for ALL refunds or only for those that payout payment method currency  ==  pull payment currency 

The main reason is that the user may be able to game it a bit and wait to submit the refund until the rates is in their favor.