### PR TITLE
Improve performance of Invoice count

### DIFF
--- a/BTCPayServer/Services/Invoices/InvoiceRepository.cs
+++ b/BTCPayServer/Services/Invoices/InvoiceRepository.cs
@@ -646,8 +646,18 @@ namespace BTCPayServer.Services.Invoices
 
             if (queryObject.StoreId != null && queryObject.StoreId.Length > 0)
             {
-                var stores = queryObject.StoreId.ToHashSet().ToArray();
-                query = query.Where(i => stores.Contains(i.StoreDataId));
+                if (queryObject.StoreId.Length > 1)
+                {
+                    var stores = queryObject.StoreId.ToHashSet().ToArray();
+                    query = query.Where(i => stores.Contains(i.StoreDataId));
+                }
+                // Big performant improvement to use Where rather than Contains when possible
+                // In our test, the first gives  720.173 ms vs 40.735 ms
+                else
+                {
+                    var storeId = queryObject.StoreId.First();
+                    query = query.Where(i => i.StoreDataId == storeId);
+                }
             }
 
             if (!string.IsNullOrEmpty(queryObject.TextSearch))


### PR DESCRIPTION
Using Contains will result in the following query:

```
query          | SELECT COUNT(*)::INT                                                                                                                                                                                                                                                                                 +
               | FROM "UserStore" AS u                                                                                                                                                                                                                                                                                +
               | INNER JOIN "Stores" AS s ON u."StoreDataId" = s."Id"                                                                                                                                                                                                                                                 +
               | INNER JOIN "Invoices" AS i ON s."Id" = i."StoreDataId"                                                                                                                                                                                                                                               +
               | WHERE ((u."ApplicationUserId" = $1) AND NOT (i."Archived")) AND (i."StoreDataId" = ANY ($2) OR ((i."StoreDataId" IS NULL) AND (array_position($2, $3) IS NOT NULL)))
```
Without Contains

```
query          | SELECT COUNT(*)::INT                                                                                                                                                                                                                                                                                 +
               | FROM "UserStore" AS u                                                                                                                                                                                                                                                                                +
               | INNER JOIN "Stores" AS s ON u."StoreDataId" = s."Id"                                                                                                                                                                                                                                                 +
               | INNER JOIN "Invoices" AS i ON s."Id" = i."StoreDataId"                                                                                                                                                                                                                                               +
               | WHERE ((u."ApplicationUserId" = $1) AND NOT (i."Archived")) AND (i."StoreDataId" = $2)
```

Tested on our mainnet demo instance, the first request takes `720.173 ms` to run, while the other only take `40.735 ms`.

I am using `pg_stat_statements` to find the queries slowing down the server right now...