### PR TITLE
Fix performance issue on dashboard for big wallets

### DIFF
--- a/BTCPayServer/Components/StoreNumbers/Default.cshtml
+++ b/BTCPayServer/Components/StoreNumbers/Default.cshtml
@@ -8,16 +8,19 @@
         </header>
         <div class="h3">@Model.PayoutsPending</div>
     </div>
-    <div class="store-number">
-        <header>
-            <h6>TXs in the last @Model.TransactionDays days</h6>
-            @if (Model.Transactions > 0)
-            {
-                <a asp-controller="UIWallets" asp-action="WalletTransactions" asp-route-walletId="@Model.WalletId">View All</a>
-            }
-        </header>
-        <div class="h3">@Model.Transactions</div>
-    </div>
+	@if (Model.Transactions is not null)
+	{
+		<div class="store-number">
+			<header>
+				<h6>TXs in the last @Model.TransactionDays days</h6>
+				@if (Model.Transactions.Value > 0)
+				{
+					<a asp-controller="UIWallets" asp-action="WalletTransactions" asp-route-walletId="@Model.WalletId">View All</a>
+				}
+			</header>
+        <div class="h3">@Model.Transactions.Value</div>
+		</div>
+	}
     <div class="store-number">
         <header>
             <h6>Refunds Issued</h6>

--- a/BTCPayServer/Components/StoreNumbers/StoreNumbersViewModel.cs
+++ b/BTCPayServer/Components/StoreNumbers/StoreNumbersViewModel.cs
@@ -8,7 +8,7 @@ public class StoreNumbersViewModel
     public StoreData Store { get; set; }
     public WalletId WalletId { get; set; }
     public int PayoutsPending { get; set; }
-    public int Transactions { get; set; }
+    public int? Transactions { get; set; }
     public int RefundsIssued { get; set; }
     public int TransactionDays { get; set; }
 }


### PR DESCRIPTION
We were retrieving all transactions just for counting them. Needless to say that if the user has 100K transactions, he would get issues.

Not only this, NBXplorer might not be available at all, in which case the user would see an error 500.