### PR TITLE
Do not show balance if can't get the balance

### DIFF
--- a/BTCPayServer/Components/StoreWalletBalance/Default.cshtml
+++ b/BTCPayServer/Components/StoreWalletBalance/Default.cshtml
@@ -4,11 +4,14 @@
 <div id="StoreWalletBalance-@Model.Store.Id" class="widget store-wallet-balance">
     <h6 class="mb-2">Wallet Balance</h6>
     <header class="mb-3">
-        <div class="balance">
-            <h3 class="d-inline-block me-1">@Model.Balance</h3>
-            <span class="text-secondary fw-semibold">@Model.CryptoCode</span>
-        </div>
-        <div class="btn-group mt-1" role="group" aria-label="Filter">
+		@if (Model.Balance is not null)
+		{
+			<div class="balance">
+				<h3 class="d-inline-block me-1">@Model.Balance</h3>
+				<span class="text-secondary fw-semibold">@Model.CryptoCode</span>
+			</div>
+		}
+		<div class="btn-group mt-1" role="group" aria-label="Filter">
             <input type="radio" class="btn-check" name="filter" id="filter-week" value="week" @(Model.Type == WalletHistogramType.Week ? "checked" : "")>
             <label class="btn btn-link" for="filter-week">1W</label>
             <input type="radio" class="btn-check" name="filter" id="filter-month" value="month" @(Model.Type == WalletHistogramType.Month ? "checked" : "")>
@@ -24,7 +27,8 @@
             const baseUrl = @Safe.Json(Url.Action("WalletHistogram", "UIWallets", new { walletId = Model.WalletId, type = WalletHistogramType.Week }));
             const render = data => {
                 const { series, labels, balance } = data;
-                document.querySelector(`#${id} h3`).innerText = balance;
+                if (balance)
+                    document.querySelector(`#${id} h3`).innerText = balance;
                 const min = Math.min(...series);
                 const max = Math.max(...series);
                 const low = Math.max(min - ((max - min) / 5), 0);

--- a/BTCPayServer/Components/StoreWalletBalance/StoreWalletBalance.cs
+++ b/BTCPayServer/Components/StoreWalletBalance/StoreWalletBalance.cs
@@ -43,7 +43,7 @@ public class StoreWalletBalance : ViewComponent
             WalletId = walletId,
             Series = data?.Series,
             Labels = data?.Labels,
-            Balance = data?.Balance ?? 0,
+            Balance = data?.Balance,
             Type = DefaultType
         };
 

--- a/BTCPayServer/Components/StoreWalletBalance/StoreWalletBalanceViewModel.cs
+++ b/BTCPayServer/Components/StoreWalletBalance/StoreWalletBalanceViewModel.cs
@@ -6,7 +6,7 @@ namespace BTCPayServer.Components.StoreWalletBalance;
 
 public class StoreWalletBalanceViewModel
 {
-    public decimal Balance { get; set; }
+    public decimal? Balance { get; set; }
     public string CryptoCode { get; set; }
     public StoreData Store { get; set; }
     public WalletId WalletId { get; set; }


### PR DESCRIPTION
If users don't use the postgres backend for nbx, we would show 0 balance resulting in increase chances of heart attacks for our users.