### PR TITLE
Lightning: Catch and display external service errors

### DIFF
--- a/BTCPayServer/Configuration/ExternalServicesOptions.cs
+++ b/BTCPayServer/Configuration/ExternalServicesOptions.cs
@@ -7,6 +7,5 @@ namespace BTCPayServer.Configuration
     {
         public Dictionary<string, Uri> OtherExternalServices { get; set; } = new Dictionary<string, Uri>();
         public ExternalServices ExternalServices { get; set; } = new ExternalServices();
-
     }
 }

--- a/BTCPayServer/Controllers/UIStoresController.LightningLike.cs
+++ b/BTCPayServer/Controllers/UIStoresController.LightningLike.cs
@@ -49,13 +49,24 @@ namespace BTCPayServer.Controllers
             {
                 var services = _externalServiceOptions.Value.ExternalServices.ToList()
                     .Where(service => _externalServiceTypes.Contains(service.Type))
-                    .Select(async service => new AdditionalServiceViewModel
+                    .Select(async service =>
                     {
-                        DisplayName = service.DisplayName,
-                        ServiceName = service.ServiceName,
-                        CryptoCode = service.CryptoCode,
-                        Type = service.Type.ToString(),
-                        Link = await GetServiceLink(service)
+                        var model = new AdditionalServiceViewModel
+                        {
+                            DisplayName = service.DisplayName,
+                            ServiceName = service.ServiceName,
+                            CryptoCode = service.CryptoCode,
+                            Type = service.Type.ToString()
+                        };
+                        try
+                        {
+                            model.Link = await GetServiceLink(service);
+                        }
+                        catch (Exception exception)
+                        {
+                            model.Error = exception.Message;
+                        }
+                        return model;
                     })
                     .Select(t => t.Result)
                     .ToList();

--- a/BTCPayServer/Models/AdditionalServiceViewModel.cs
+++ b/BTCPayServer/Models/AdditionalServiceViewModel.cs
@@ -7,4 +7,5 @@ public class AdditionalServiceViewModel
     public string ServiceName { get; set; }
     public string CryptoCode { get; set; }
     public string Link { get; set; }
+    public string Error { get; set; }
 }

--- a/BTCPayServer/Views/UIStores/Lightning.cshtml
+++ b/BTCPayServer/Views/UIStores/Lightning.cshtml
@@ -45,7 +45,15 @@
             <div id="Services" class="services-list">
                 @foreach (var service in Model.Services)
                 {
-                    @if (string.IsNullOrEmpty(service.Link))
+                    @if (!string.IsNullOrEmpty(service.Error))
+                    {
+                        <div class="service" id="@($"Service-{service.ServiceName}")">
+                            <img src="@($"~/img/{service.Type.ToLower()}.png")" asp-append-version="true" alt="@service.DisplayName" />
+                            <h6>@service.DisplayName</h6>
+                            <small class="d-block mt-3 lh-sm fw-semibold text-danger">@service.Error</small>
+                        </div>
+                    }
+                    else if (string.IsNullOrEmpty(service.Link))
                     {
                         <a asp-controller="UIServer" asp-action="Service" asp-route-serviceName="@service.ServiceName" asp-route-cryptoCode="@service.CryptoCode" class="service" id="@($"Service-{service.ServiceName}")">
                             <img src="@($"~/img/{service.Type.ToLower()}.png")" asp-append-version="true" alt="@service.DisplayName" />


### PR DESCRIPTION
Prevent crashes like in #3700 and display the error to the user.

![grafik](https://user-images.githubusercontent.com/886/166670559-4ca6888a-275e-4b59-b8ac-e15eb43ccbc1.png)
