### PR TITLE
A few tables in the Cart checkout are having bad widths and margins

### DIFF
--- a/BTCPayServer/Views/UIAppsPublic/PointOfSale/Cart.cshtml
+++ b/BTCPayServer/Views/UIAppsPublic/PointOfSale/Cart.cshtml
@@ -119,7 +119,7 @@
                 </button>
             </div>
             <div class="modal-body p-0">
-                <table id="js-cart-summary" class="table w-100 m-0">
+                <table id="js-cart-summary" class="table m-0">
                     <tbody class="my-3">
                         <tr>
                             <td colspan="2" class="border-top-0 h5">Summary</td>
@@ -276,7 +276,7 @@
             <a class="js-cart-destroy btn btn-danger pull-right" href="#" style="display: none;">Empty cart <i class="fa fa-trash fa-fw fa-lg"></i></a>
         </div>
 
-        <table id="js-cart-list" class="table table-responsive table-light w-100 m-0">
+        <table id="js-cart-list" class="table table-responsive table-light mt-0 mb-0">
             <thead>
                 <tr>
                     <th colspan="3" width="55%">Product</th>
@@ -291,7 +291,7 @@
             <tbody></tbody>
         </table>
 
-        <table id="js-cart-extra" class="table table-light w-100 m-0">
+        <table id="js-cart-extra" class="table table-light mt-0 mb-0">
             <thead></thead>
         </table>
 

--- a/BTCPayServer/Views/UIAppsPublic/PointOfSale/Cart.cshtml
+++ b/BTCPayServer/Views/UIAppsPublic/PointOfSale/Cart.cshtml
@@ -119,7 +119,7 @@
                 </button>
             </div>
             <div class="modal-body p-0">
-                <table id="js-cart-summary" class="table m-0">
+                <table id="js-cart-summary" class="table w-100 m-0">
                     <tbody class="my-3">
                         <tr>
                             <td colspan="2" class="border-top-0 h5">Summary</td>
@@ -276,7 +276,7 @@
             <a class="js-cart-destroy btn btn-danger pull-right" href="#" style="display: none;">Empty cart <i class="fa fa-trash fa-fw fa-lg"></i></a>
         </div>
 
-        <table id="js-cart-list" class="table table-responsive table-light mt-0 mb-0">
+        <table id="js-cart-list" class="table table-responsive table-light w-100 m-0">
             <thead>
                 <tr>
                     <th colspan="3" width="55%">Product</th>
@@ -291,7 +291,7 @@
             <tbody></tbody>
         </table>
 
-        <table id="js-cart-extra" class="table table-light mt-0 mb-0">
+        <table id="js-cart-extra" class="table table-light w-100 m-0">
             <thead></thead>
         </table>
 

--- a/BTCPayServer/wwwroot/main/bootstrap/bootstrap.css
+++ b/BTCPayServer/wwwroot/main/bootstrap/bootstrap.css
@@ -10844,12 +10844,12 @@ textarea.w-auto {
 }
 
 /* Pull tables out of the grid by their horizontal column padding */
-*:not([class^="table-responsive"]) > .table {
+main *:not([class^="table-responsive"]) > .table {
   width: calc(100% + 1rem);
   margin: 1.5rem -0.5rem;
 }
 
-[class^="table-responsive"] {
+main [class^="table-responsive"] {
   width: calc(100% + 1rem);
   margin: 1.5rem -0.5rem;
 }


### PR DESCRIPTION
There's a loose css that matches a lot of tables unnecessary and was causing some issues in the Cart checkout.

The css is this:
```
*:not([class^="table-responsive"]) > .table {
  width: calc(100% + 1rem);
  margin: 1.5rem -0.5rem;
}
```

I couldn't remove it cause it's probably there for a reason so that's why I explicitly fixed only the affected tables by adding some additional predefined classes.

Before:
No left/right margin.
<img width="437" alt="cart-before" src="https://user-images.githubusercontent.com/1769047/166881342-60804281-69fe-4cd0-9b51-be977402022e.png">

After:
Default margin.
<img width="444" alt="cart-after" src="https://user-images.githubusercontent.com/1769047/166881458-67318993-a283-4ef1-9dee-032547571e4b.png">

Before:
<img width="593" alt="confirmation-before" src="https://user-images.githubusercontent.com/1769047/166881388-121a6b99-d9bc-4f3f-8a28-8d3a48f9c646.png">

After:
<img width="571" alt="confirmation-after" src="https://user-images.githubusercontent.com/1769047/166881504-7c0e8715-01dc-4250-8a26-614c806cb2a3.png">

