### PR TITLE
Removes `Invoice Summary` Section on Invoice List View

### DIFF
--- a/BTCPayServer/Views/UIInvoice/ListInvoices.cshtml
+++ b/BTCPayServer/Views/UIInvoice/ListInvoices.cshtml
@@ -409,17 +409,6 @@
                                 }
                                 &nbsp;
                                 <a asp-action="Invoice" class="invoice-details-link" asp-route-invoiceId="@invoice.InvoiceId">Details</a>
-                                <a class="only-for-js invoice-details-toggle" href="#">
-                                    <span title="Invoice Details Toggle" class="fa fa-1x fa-angle-double-down"></span>
-                                </a>
-                            </td>
-                        </tr>
-                        <tr id="invoice_details_@invoice.InvoiceId" class="invoice-details-row" style="display:none;">
-                            <td colspan="99" class="border-top-0">
-                                <div style="margin-left: 15px; margin-bottom: 0;">
-                                    @* Leaving this as partial because it abstracts complexity of Invoice Payments *@
-                                    <partial name="ListInvoicesPaymentsPartial" model="(invoice.Details, true)" />
-                                </div>
                             </td>
                         </tr>
                     }


### PR DESCRIPTION
As discussed in Design Call 32, but adding for discussion on Design Call 33.

- Removes `<tr>` section
- Removes accordion carrot CTA

Updated View:
<img width="1324" alt="Screen Shot 2022-05-05 at 6 45 37 AM" src="https://user-images.githubusercontent.com/6250771/166937255-9c169ed8-993f-43bc-a231-b65b5c48e7da.png">
