### PR TITLE
Minor update to Lightning Address view

### DIFF
--- a/BTCPayServer/Views/UILNURL/EditLightningAddress.cshtml
+++ b/BTCPayServer/Views/UILNURL/EditLightningAddress.cshtml
@@ -114,8 +114,8 @@
                         <tr>
                             <td>
                                 <div class="input-group" data-clipboard="@address">
-                                    <input type="text" class="form-control copy-cursor lightning-address-value"  readonly="readonly" value="@address"/>
-                                    <button type="button" class="btn btn-outline-secondary" data-clipboard-confirm>Copy</button>
+                                    <span class="p-0 me-3">@address</span>
+                                    <button type="button" class="btn btn-link p-0" data-clipboard-confirm>Copy</button>
                                 </div>
 
                             </td>
@@ -135,7 +135,7 @@
                             </td>
                             <td class="text-end">
                                 <button type="submit" title="Remove" name="command" value="@($"remove:{Model.Items[index].Username}")"
-                                        class="btn btn-link px-0 remove" data-bs-toggle="modal" data-bs-target="#ConfirmModal" data-description="The Lightning Address <strong>@address</strong> will be removed." data-confirm-input="REMOVE">
+                                        class="btn btn-link p-0 remove" data-bs-toggle="modal" data-bs-target="#ConfirmModal" data-description="The Lightning Address <strong>@address</strong> will be removed." data-confirm-input="REMOVE">
                                     Remove
                                 </button>
                             </td>


### PR DESCRIPTION
Was debating if it made sense to break the three "settings" types into their own columns with the same conditional to show in the row if there is a value submitted, but opted not to for this first iteration, but if there's a strong vote to do so, will revisit to implement.

Current:
<img width="993" alt="Screen Shot 2022-05-05 at 9 44 25 AM" src="https://user-images.githubusercontent.com/6250771/166972946-633d9cc6-cbfb-47c3-a43a-0bd5bafd2431.png">

Update:
<img width="996" alt="Screen Shot 2022-05-05 at 9 43 54 AM" src="https://user-images.githubusercontent.com/6250771/166972966-b9a60762-d9cb-4a07-8cd7-f596e361d5d0.png">

