### PR TITLE
Redirect to payment method setup

### DIFF
--- a/BTCPayServer/Controllers/UIStorePullPaymentsController.PullPayments.cs
+++ b/BTCPayServer/Controllers/UIStorePullPaymentsController.PullPayments.cs
@@ -74,7 +74,7 @@ namespace BTCPayServer.Controllers
                     Message = "You must enable at least one payment method before creating a pull payment.",
                     Severity = StatusMessageModel.StatusSeverity.Error
                 });
-                return RedirectToAction(nameof(UIStoresController.GeneralSettings), "UIStores", new { storeId });
+                return RedirectToAction(nameof(UIStoresController.Dashboard), "UIStores", new { storeId });
             }
 
             return View(new NewPullPaymentModel
@@ -187,7 +187,7 @@ namespace BTCPayServer.Controllers
                     Message = "You must enable at least one payment method before creating a pull payment.",
                     Severity = StatusMessageModel.StatusSeverity.Error
                 });
-                return RedirectToAction(nameof(UIStoresController.GeneralSettings), "UIStores", new { storeId });
+                return RedirectToAction(nameof(UIStoresController.Dashboard), "UIStores", new { storeId });
             }
 
             var vm = this.ParseListQuery(new PullPaymentsModel
@@ -488,7 +488,7 @@ namespace BTCPayServer.Controllers
                     Message = "You must enable at least one payment method before creating a payout.",
                     Severity = StatusMessageModel.StatusSeverity.Error
                 });
-                return RedirectToAction(nameof(UIStoresController.GeneralSettings), "UIStores", new { storeId });
+                return RedirectToAction(nameof(UIStoresController.Dashboard), "UIStores", new { storeId });
             }
 
             var vm = this.ParseListQuery(new PayoutsModel


### PR DESCRIPTION
As discussed in btcpayserver/organization#87: Solves the progressive disclosure approach (brought up by @dstrukt in #3651) by simply redirecting to the right view in case no payment method is set up, yet.

This lands you on the dashboard, where in this case the setup guide is presented.

![grafik](https://user-images.githubusercontent.com/886/166996111-40202cf5-fad9-4d8b-a4b9-c7f49dda25de.png)

Closes #3651.