### PR TITLE
Allow resending verification email for users

### DIFF
--- a/BTCPayServer/Controllers/UIServerController.Users.cs
+++ b/BTCPayServer/Controllers/UIServerController.Users.cs
@@ -64,7 +64,6 @@ namespace BTCPayServer.Controllers
                     Email = u.Email,
                     Id = u.Id,
                     Verified = u.EmailConfirmed || !u.RequiresEmailConfirmation,
-                    RequiresEmailConfirmation = u.RequiresEmailConfirmation,
                     Created = u.Created,
                     Roles = u.UserRoles.Select(role => role.RoleId),
                     Disabled = u.LockoutEnabled && u.LockoutEnd != null && DateTimeOffset.UtcNow < u.LockoutEnd.Value.UtcDateTime

--- a/BTCPayServer/Controllers/UIServerController.Users.cs
+++ b/BTCPayServer/Controllers/UIServerController.Users.cs
@@ -285,14 +285,7 @@ namespace BTCPayServer.Controllers
             if (user == null)
                 return NotFound();
             
-            return View(
-                "Confirm", 
-                new ConfirmModel(
-                    "Send verification email",
-                    $"This will send a verification email to <strong>{user.Email}</strong>. Are you sure?",
-                    "Send"
-                )
-            );
+            return View("Confirm", new ConfirmModel("Send verification email", $"This will send a verification email to <strong>{user.Email}</strong>.", "Send"));
         }
 
         [HttpPost("server/users/{userId}/verification-email")]

--- a/BTCPayServer/Controllers/UIServerController.cs
+++ b/BTCPayServer/Controllers/UIServerController.cs
@@ -7,7 +7,6 @@ using System.IO;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
-using System.Net.Mail;
 using System.Threading.Tasks;
 using BTCPayServer.Abstractions.Constants;
 using BTCPayServer.Abstractions.Extensions;
@@ -61,6 +60,8 @@ namespace BTCPayServer.Controllers
         private readonly StoredFileRepository _StoredFileRepository;
         private readonly FileService _FileService;
         private readonly IEnumerable<IStorageProviderService> _StorageProviderServices;
+        private readonly LinkGenerator _linkGenerator;
+        private readonly EmailSenderFactory _emailSenderFactory;
 
         public UIServerController(
             UserManager<ApplicationUser> userManager,
@@ -79,7 +80,10 @@ namespace BTCPayServer.Controllers
             CheckConfigurationHostedService sshState,
             EventAggregator eventAggregator,
             IOptions<ExternalServicesOptions> externalServiceOptions,
-            Logs logs)
+            Logs logs,
+            LinkGenerator linkGenerator,
+            EmailSenderFactory emailSenderFactory
+        )
         {
             _Options = options;
             _StoredFileRepository = storedFileRepository;
@@ -98,6 +102,8 @@ namespace BTCPayServer.Controllers
             _eventAggregator = eventAggregator;
             _externalServiceOptions = externalServiceOptions;
             Logs = logs;
+            _linkGenerator = linkGenerator;
+            _emailSenderFactory = emailSenderFactory;
         }
 
         [Route("server/maintenance")]

--- a/BTCPayServer/Models/ServerViewModels/UsersViewModel.cs
+++ b/BTCPayServer/Models/ServerViewModels/UsersViewModel.cs
@@ -15,7 +15,6 @@ namespace BTCPayServer.Models.ServerViewModels
             public bool IsAdmin { get; set; }
             public DateTimeOffset? Created { get; set; }
             public IEnumerable<string> Roles { get; set; }
-            public bool RequiresEmailConfirmation { get; set; }
         }
         public List<UserViewModel> Users { get; set; } = new List<UserViewModel>();
         public override int CurrentPageCount => Users.Count;

--- a/BTCPayServer/Models/ServerViewModels/UsersViewModel.cs
+++ b/BTCPayServer/Models/ServerViewModels/UsersViewModel.cs
@@ -15,6 +15,7 @@ namespace BTCPayServer.Models.ServerViewModels
             public bool IsAdmin { get; set; }
             public DateTimeOffset? Created { get; set; }
             public IEnumerable<string> Roles { get; set; }
+            public bool RequiresEmailConfirmation { get; set; }
         }
         public List<UserViewModel> Users { get; set; } = new List<UserViewModel>();
         public override int CurrentPageCount => Users.Count;

--- a/BTCPayServer/Views/UIServer/ListUsers.cshtml
+++ b/BTCPayServer/Views/UIServer/ListUsers.cshtml
@@ -95,6 +95,9 @@
                     }
                 </td>
                 <td class="text-end">
+                    @if (user.RequiresEmailConfirmation && !user.Disabled) {
+                        <a asp-action="SendVerificationEmail" asp-route-userId="@user.Id">Resend verification email</a> <span>-</span>
+                    }
                     <a asp-action="User" asp-route-userId="@user.Id">Edit</a> <span> - </span> <a asp-action="DeleteUser" asp-route-userId="@user.Id">Remove</a>
                     - <a asp-action="ToggleUser"
                          asp-route-enable="@user.Disabled"

--- a/BTCPayServer/Views/UIServer/ListUsers.cshtml
+++ b/BTCPayServer/Views/UIServer/ListUsers.cshtml
@@ -96,7 +96,8 @@
                 </td>
                 <td class="text-end">
                     @if (!user.Verified && !user.Disabled) {
-                        <a asp-action="SendVerificationEmail" asp-route-userId="@user.Id">Resend verification email</a> <span>-</span>
+                        <a asp-action="SendVerificationEmail" asp-route-userId="@user.Id" data-bs-toggle="modal" data-bs-target="#ConfirmModal" data-description="This will send a verification email to <strong>@user.Email</strong>.">Resend verification email</a>
+                        <span>-</span>
                     }
                     <a asp-action="User" asp-route-userId="@user.Id">Edit</a> <span> - </span> <a asp-action="DeleteUser" asp-route-userId="@user.Id">Remove</a>
                     - <a asp-action="ToggleUser"
@@ -112,3 +113,5 @@
 </div>
 
 <vc:pager view-model="Model"></vc:pager>
+
+<partial name="_Confirm" model="@(new ConfirmModel("Send verification email", $"This will send a verification email to the user.", "Send"))" />

--- a/BTCPayServer/Views/UIServer/ListUsers.cshtml
+++ b/BTCPayServer/Views/UIServer/ListUsers.cshtml
@@ -95,7 +95,7 @@
                     }
                 </td>
                 <td class="text-end">
-                    @if (user.RequiresEmailConfirmation && !user.Disabled) {
+                    @if (!user.Verified && !user.Disabled) {
                         <a asp-action="SendVerificationEmail" asp-route-userId="@user.Id">Resend verification email</a> <span>-</span>
                     }
                     <a asp-action="User" asp-route-userId="@user.Id">Edit</a> <span> - </span> <a asp-action="DeleteUser" asp-route-userId="@user.Id">Remove</a>


### PR DESCRIPTION
This PR adds ability to resend a verification email to those users who may have lost the original email or it has timed out as described in #3645.

This partially addresses the issue described in #3645. In a follow-up PR I will add an ability for admins to change users email address in case they lost access to the original one they signed up with.