### PR TITLE
Improve payout processors UI

### DIFF
--- a/BTCPayServer/PayoutProcessors/Lightning/UILightningAutomatedPayoutProcessorsController.cs
+++ b/BTCPayServer/PayoutProcessors/Lightning/UILightningAutomatedPayoutProcessorsController.cs
@@ -101,10 +101,10 @@ public class UILightningAutomatedPayoutProcessorsController : Controller
             Id = activeProcessor.Id,
             Processed = tcs
         });
-        TempData.SetStatusMessageModel(new StatusMessageModel()
+        TempData.SetStatusMessageModel(new StatusMessageModel
         {
             Severity = StatusMessageModel.StatusSeverity.Success,
-            Message = $"Processor updated."
+            Message = "Processor updated."
         });
         await tcs.Task;
         return RedirectToAction("ConfigureStorePayoutProcessors", "UiPayoutProcessors", new {storeId});
@@ -121,11 +121,12 @@ public class UILightningAutomatedPayoutProcessorsController : Controller
         {
             IntervalMinutes = blob.Interval.TotalMinutes;
         }
+        
         public double IntervalMinutes { get; set; }
 
         public AutomatedPayoutBlob ToBlob()
         {
-            return new AutomatedPayoutBlob() { Interval = TimeSpan.FromMinutes(IntervalMinutes) };
+            return new AutomatedPayoutBlob { Interval = TimeSpan.FromMinutes(IntervalMinutes) };
         }
     }
 }

--- a/BTCPayServer/PayoutProcessors/OnChain/UIOnChainAutomatedPayoutProcessorsController.cs
+++ b/BTCPayServer/PayoutProcessors/OnChain/UIOnChainAutomatedPayoutProcessorsController.cs
@@ -114,10 +114,10 @@ public class UIOnChainAutomatedPayoutProcessorsController : Controller
             Id = activeProcessor.Id,
             Processed = tcs
         });
-        TempData.SetStatusMessageModel(new StatusMessageModel()
+        TempData.SetStatusMessageModel(new StatusMessageModel
         {
             Severity = StatusMessageModel.StatusSeverity.Success,
-            Message = $"Processor updated."
+            Message = "Processor updated."
         });
         await tcs.Task;
         return RedirectToAction("ConfigureStorePayoutProcessors", "UiPayoutProcessors", new {storeId});
@@ -138,7 +138,7 @@ public class UIOnChainAutomatedPayoutProcessorsController : Controller
 
         public AutomatedPayoutBlob ToBlob()
         {
-            return new AutomatedPayoutBlob() { Interval = TimeSpan.FromMinutes(IntervalMinutes) };
+            return new AutomatedPayoutBlob { Interval = TimeSpan.FromMinutes(IntervalMinutes) };
         }
     }
 }

--- a/BTCPayServer/Views/UILightningAutomatedPayoutProcessors/Configure.cshtml
+++ b/BTCPayServer/Views/UILightningAutomatedPayoutProcessors/Configure.cshtml
@@ -6,22 +6,23 @@
     ViewData.SetActivePage("PayoutProcessors", "Lightning Payout Processor", Context.GetStoreData().Id);
 }
 <div class="row">
-    
-        <div class="col-xl-8 col-xxl-constrain">
-            <div class="d-flex align-items-center justify-content-between mb-3">
-                <h3 class="mb-0">@ViewData["Title"]</h3>
-            </div>
-            <p>Set a schedule for automated Lightning Network Payouts.</p>
-            @if (!ViewContext.ModelState.IsValid)
+    <div class="col-xl-8 col-xxl-constrain">
+        <div class="d-flex align-items-center justify-content-between mb-3">
+            <h3 class="mb-0">@ViewData["Title"]</h3>
+        </div>
+        <p>Set a schedule for automated Lightning Network Payouts.</p>
+        @if (!ViewContext.ModelState.IsValid)
         {
             <div asp-validation-summary="All" class="text-danger"></div>
         }
         <form method="post">
             <div class="form-group">
-                <label asp-for="IntervalMinutes" class="form-label">Set interval in minutes.</label>
-                <input asp-for="IntervalMinutes" class="form-control">
+                <label asp-for="IntervalMinutes" class="form-label" data-required>Interval</label>
+                <div class="input-group">
+                    <input asp-for="IntervalMinutes" class="form-control" inputmode="numeric" style="max-width:10ch;">
+                    <span class="input-group-text">minutes</span>
+                </div>
             </div>
-
             <button name="command" type="submit" class="btn btn-primary mt-2" value="Save" id="Save">Save</button>
         </form>
     </div>

--- a/BTCPayServer/Views/UIOnChainAutomatedPayoutProcessors/Configure.cshtml
+++ b/BTCPayServer/Views/UIOnChainAutomatedPayoutProcessors/Configure.cshtml
@@ -3,25 +3,26 @@
 @{
     ViewData["NavPartialName"] = "../UIStores/_Nav";
     Layout = "../Shared/_NavLayout.cshtml";
-    ViewData.SetActivePage("PayoutProcessors", "OnChain Payout Processor", Context.GetStoreData().Id);
+    ViewData.SetActivePage("PayoutProcessors", "On-Chain Payout Processor", Context.GetStoreData().Id);
 }
 <div class="row">
-    
-        <div class="col-xl-8 col-xxl-constrain">
-            <div class="d-flex align-items-center justify-content-between mb-3">
-                <h3 class="mb-0">@ViewData["Title"]</h3>
-            </div>
-            <p>Set a schedule for automated On-Chain Bitcoin Payouts. </p>
-            @if (!ViewContext.ModelState.IsValid)
+    <div class="col-xl-8 col-xxl-constrain">
+        <div class="d-flex align-items-center justify-content-between mb-3">
+            <h3 class="mb-0">@ViewData["Title"]</h3>
+        </div>
+        <p>Set a schedule for automated On-Chain Bitcoin Payouts. </p>
+        @if (!ViewContext.ModelState.IsValid)
         {
             <div asp-validation-summary="All" class="text-danger"></div>
         }
         <form method="post">
             <div class="form-group">
-                <label asp-for="IntervalMinutes" class="form-label">Set interval in minutes.</label>
-                <input asp-for="IntervalMinutes" class="form-control">
+                <label asp-for="IntervalMinutes" class="form-label" data-required>Interval</label>
+                <div class="input-group">
+                    <input asp-for="IntervalMinutes" class="form-control" inputmode="numeric" style="max-width:10ch;">
+                    <span class="input-group-text">minutes</span>
+                </div>
             </div>
-
             <button name="command" type="submit" class="btn btn-primary mt-2" value="Save" id="Save">Save</button>
         </form>
     </div>

--- a/BTCPayServer/Views/UIPayoutProcessors/ConfigureStorePayoutProcessors.cshtml
+++ b/BTCPayServer/Views/UIPayoutProcessors/ConfigureStorePayoutProcessors.cshtml
@@ -15,50 +15,39 @@
 
         @if (Model.Any())
         {
-            foreach (var processorsView  in Model)
+            foreach (var processorsView in Model)
             {
-                <div class="row">
-                    <h4>@processorsView.Factory.FriendlyName</h4>
-                    <div class="row">
-                        <div class="col">
-                            <table class="table table-hover">
-                                <thead>
-                                <tr>
-                                    <th>Payment Method</th>
-                                    <th class="text-end">Actions</th>
-                                </tr>
-                                </thead>
-                                <tbody>
-                                @foreach (var conf in processorsView.Configured)
+                <h4 class="mt-5">@processorsView.Factory.FriendlyName</h4>
+                <table class="table table-hover mt-0">
+                    <thead>
+                    <tr>
+                        <th>Payment Method</th>
+                        <th class="text-end">Actions</th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    @foreach (var conf in processorsView.Configured)
+                    {
+                        <tr>
+                            <td>
+                                @conf.Key.ToPrettyString()
+                            </td>
+                            <td class="text-end">
+                                @if (conf.Value is null)
                                 {
-                                    <tr>
-                                        <td>
-                                            @conf.Key.ToPrettyString()
-
-                                        </td>
-
-                                        <td class="text-end">
-                                            @if (conf.Value is null)
-                                            {
-                                                <a href="@processorsView.Factory.ConfigureLink(storeId, conf.Key, Context.Request)">Configure</a>
-                                            }
-                                            else
-                                            {
-                                                <a href="@processorsView.Factory.ConfigureLink(storeId, conf.Key, Context.Request)">Modify</a>
-                                                <a asp-action="Remove" asp-route-storeId="@storeId" asp-route-id="@conf.Value.Id" data-bs-toggle="modal" data-bs-target="#ConfirmModal" data-description="The Payout Processor @processorsView.Factory.Processor for @conf.Key.CryptoCode will be removed from your store." >Remove</a>
-                                          
-                                            }
-                                        </td>
-                                    </tr>
+                                    <a href="@processorsView.Factory.ConfigureLink(storeId, conf.Key, Context.Request)">Configure</a>
                                 }
-
-
-                                </tbody>
-                            </table>
-                        </div>
-                    </div>
-
-                </div>
+                                else
+                                {
+                                    <a href="@processorsView.Factory.ConfigureLink(storeId, conf.Key, Context.Request)">Modify</a>
+                                    <span>-</span>
+                                    <a asp-action="Remove" asp-route-storeId="@storeId" asp-route-id="@conf.Value.Id" data-bs-toggle="modal" data-bs-target="#ConfirmModal" data-description="The Payout Processor @processorsView.Factory.Processor for @conf.Key.CryptoCode will be removed from your store.">Remove</a>
+                                }
+                            </td>
+                        </tr>
+                    }
+                    </tbody>
+                </table>
             }
         }
         else


### PR DESCRIPTION
Some quick fixes, closes https://github.com/btcpayserver/btcpayserver/issues/3697.

@dstrukt This doesn't integrate both options on one page and I think this might not even be desired: iirc @Kukks separated the configuration options to make the payout processors extendable by plugins. Let's revisit the concept once we gain more insights here.