### PR TITLE
Fix webhooks test

### DIFF
--- a/BTCPayServer.Tests/SeleniumTests.cs
+++ b/BTCPayServer.Tests/SeleniumTests.cs
@@ -968,7 +968,7 @@ namespace BTCPayServer.Tests
             server.Done();
 
             TestLogs.LogInformation("Let's see if we can delete store with some webhooks inside");
-            s.GoToStore(StoreNavPages.General);
+            s.GoToStore();
             s.Driver.FindElement(By.Id("DeleteStore")).Click();
             s.Driver.WaitForElement(By.Id("ConfirmInput")).SendKeys("DELETE");
             s.Driver.FindElement(By.Id("ConfirmContinue")).Click();

--- a/BTCPayServer/Views/UIInvoice/Invoice.cshtml
+++ b/BTCPayServer/Views/UIInvoice/Invoice.cshtml
@@ -344,6 +344,7 @@
                                     <a asp-action="WebhookDelivery"
                                        asp-route-invoiceId="@Model.Id"
                                        asp-route-deliveryId="@delivery.Id"
+                                       class="delivery-content"
                                        target="_blank">
                                         @delivery.Id
                                     </a>
@@ -365,7 +366,7 @@
                             <td class="text-end">
                                 <button id="#redeliver-@delivery.Id"
                                         type="submit"
-                                        class="btn btn-link p-0">
+                                        class="btn btn-link p-0 redeliver">
                                     Redeliver
                                 </button>
                             </td>


### PR DESCRIPTION
Re-adds two classes used by the tests, that got removed in #3716.