### PR TITLE
Fix overflowing text in order ID field in invoices table

### DIFF
--- a/BTCPayServer/Views/UIInvoice/ListInvoices.cshtml
+++ b/BTCPayServer/Views/UIInvoice/ListInvoices.cshtml
@@ -348,7 +348,7 @@
                                 }
                                 else
                                 {
-                                    <span>@invoice.OrderId</span>
+                                    <span class="wraptextAuto">pos-app_HNDRn6Vr8GpVEjPHZRLAYzLVFY</span>
                                 }
                             </td>
                             <td class="text-break">@invoice.InvoiceId</td>


### PR DESCRIPTION
|Before|After|
|---|---|
|![Capture](https://user-images.githubusercontent.com/1934678/169449057-c1a6e797-d65e-4de1-9f6c-9fca10bc36fd.PNG)|![Capture2](https://user-images.githubusercontent.com/1934678/169449079-6504e9cd-4f97-42e4-85ba-66771988ae01.PNG)|

close #3714