### PR TITLE
Wallet export UI fixes

### DIFF
--- a/BTCPayServer/Views/UIWallets/WalletTransactions.cshtml
+++ b/BTCPayServer/Views/UIWallets/WalletTransactions.cshtml
@@ -17,12 +17,19 @@
                 max-width: 200px;
             }
         }
+        
         /* pull actions area, so that it is besides the search form */
         @@media (min-width: 1200px) {
-            #Actions {
+            #Filter + #Dropdowns {
                 margin-top: -4rem;
+                float: right;
+            }
+            
+            #Filter + #Dropdowns #Actions {
+                order: 1;
             }
 		}
+		
         .unconf > * {
             opacity: 0.5;
         }
@@ -85,7 +92,7 @@
 {
     @if (Model.Labels.Any())
     {
-        <div class="col-xl-7 col-xxl-8 mb-4">
+        <div class="col-xl-7 col-xxl-8 mb-4" id="Filter">
             <div class="input-group">
                 <span class="input-group-text">Filter</span>
                 <div class="form-control d-flex flex-wrap gap-2 align-items-center">
@@ -101,8 +108,8 @@
             </div>
         </div>
     }
-    <div class="d-inline-flex align-items-center pb-2 float-xl-end mb-2 gap-3" id="Actions">
-        <div class="dropdown order-xl-1 ms-auto">
+    <div class="d-inline-flex align-items-center gap-3" id="Dropdowns">
+        <div class="dropdown ms-auto" id="Actions">
             <button class="btn btn-secondary dropdown-toggle" type="button" id="ActionsDropdownToggle" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                 Actions
             </button>
@@ -112,17 +119,14 @@
                 </form> 
             </div>
         </div>
-        <div class="dropdown d-inline-flex align-items-center gap-3">
-            <button class="btn btn-secondary dropdown-toggle order-xl-1" type="button" id="ExportDropdownToggle" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+        <div class="dropdown d-inline-flex align-items-center gap-3" id="Export">
+            <button class="btn btn-secondary dropdown-toggle" type="button" id="ExportDropdownToggle" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                 Export
             </button>
             <div class="dropdown-menu" aria-labelledby="ExportDropdownToggle">
                 <a asp-action="Export" asp-route-walletId="@walletId" asp-route-format="csv" asp-route-labelFilter="@labelFilter" class="dropdown-item export-link" target="_blank" id="ExportCSV">CSV</a>
                 <a asp-action="Export" asp-route-walletId="@walletId" asp-route-format="json" asp-route-labelFilter="@labelFilter" class="dropdown-item export-link" target="_blank" id="ExportJSON">JSON</a>
             </div>
-            <a href="https://docs.btcpayserver.org/Accounting/" target="_blank" rel="noreferrer noopener">
-                <span class="fa fa-question-circle-o text-secondary" title="More information..."></span>
-            </a>
         </div>
     </div>
     <div style="clear:both"></div>


### PR DESCRIPTION
Fixes as mentioned by @NicolasDorier in this [comment on Mattermost](https://chat.btcpayserver.org/btcpayserver/pl/y6jicnswf7d95pp5q4r8im8qfa):

- The actions and exports button in the wallet transactions aren't positioned properly in XXL (it should be just above the 'all' checkbox, but somehow is pushed on the far right)
- There is a accounting tooltip in the wallet transactions. I think it is a copy paste from invoices list, not meant to be here