### PR TITLE
Change default BOLT11 expiry from 30 days to 1 day

### DIFF
--- a/BTCPayServer.Tests/GreenfieldAPITests.cs
+++ b/BTCPayServer.Tests/GreenfieldAPITests.cs
@@ -496,9 +496,9 @@ namespace BTCPayServer.Tests
                 Amount = 12.3m,
                 Currency = "BTC",
                 PaymentMethods = new[] { "BTC" },
-                BOLT11Expiration = TimeSpan.FromDays(31.0)
+                BOLT11Expiration = TimeSpan.FromDays(2.0)
             });
-            Assert.Equal(TimeSpan.FromDays(31.0), test2.BOLT11Expiration);
+            Assert.Equal(TimeSpan.FromDays(2.0), test2.BOLT11Expiration);
 
             TestLogs.LogInformation("Can't archive without knowing the walletId");
             var ex = await AssertAPIError("missing-permission", async () => await client.ArchivePullPayment("lol", result.Id));
@@ -507,7 +507,7 @@ namespace BTCPayServer.Tests
             await AssertAPIError("unauthenticated", async () => await unauthenticated.ArchivePullPayment(storeId, result.Id));
             await client.ArchivePullPayment(storeId, result.Id);
             result = await unauthenticated.GetPullPayment(result.Id);
-            Assert.Equal(TimeSpan.FromDays(30.0), result.BOLT11Expiration);
+            Assert.Equal(TimeSpan.FromDays(1.0), result.BOLT11Expiration);
             Assert.True(result.Archived);
             var pps = await client.GetPullPayments(storeId);
             result = Assert.Single(pps);

--- a/BTCPayServer/Data/StoreBlob.cs
+++ b/BTCPayServer/Data/StoreBlob.cs
@@ -23,7 +23,7 @@ namespace BTCPayServer.Data
         public StoreBlob()
         {
             InvoiceExpiration = TimeSpan.FromMinutes(15);
-            RefundBOLT11Expiration = TimeSpan.FromDays(30);
+            RefundBOLT11Expiration = TimeSpan.FromDays(1);
             MonitoringExpiration = TimeSpan.FromDays(1);
             PaymentTolerance = 0;
             ShowRecommendedFee = true;

--- a/BTCPayServer/HostedServices/PullPaymentHostedService.cs
+++ b/BTCPayServer/HostedServices/PullPaymentHostedService.cs
@@ -127,7 +127,7 @@ namespace BTCPayServer.HostedServices
                     Email = null,
                     EmbeddedCSS = create.EmbeddedCSS,
                 },
-                BOLT11Expiration = create.BOLT11Expiration ?? TimeSpan.FromDays(30.0)
+                BOLT11Expiration = create.BOLT11Expiration ?? TimeSpan.FromDays(1.0)
             });
             ctx.PullPayments.Add(o);
             await ctx.SaveChangesAsync();

--- a/BTCPayServer/Models/WalletViewModels/PullPaymentsModel.cs
+++ b/BTCPayServer/Models/WalletViewModels/PullPaymentsModel.cs
@@ -63,7 +63,7 @@ namespace BTCPayServer.Models.WalletViewModels
         public IEnumerable<SelectListItem> PaymentMethodItems { get; set; }
         [Display(Name = "Minimum acceptable expiration time for BOLT11 for refunds")]
         [Range(1, 365 * 10)]
-        public long BOLT11Expiration { get; set; } = 30;
+        public long BOLT11Expiration { get; set; } = 1;
         [Display(Name = "Automatically approve claims")]
         public bool AutoApproveClaims { get; set; } = false;
     }


### PR DESCRIPTION
See https://github.com/btcpayserver/btcpayserver/discussions/3686


Update the default BOLT11 invoice expiration time from 30 days to 1 day but I'm not sure if that's enough. Looks like the default as specified in BOLT11 is 3600 seconds i.e. 1 hour. I wonder if we should change it to be the same.

We could also allow the user to specify the default value not just in days but in days/hours/minutes/seconds as needed.

![Capture](https://user-images.githubusercontent.com/1934678/170178500-7ae1cfa0-0b0e-4ba0-9d06-c82d4744cd9c.PNG)

https://github.com/lightning/bolts/blob/master/11-payment-encoding.md

