### PR TITLE
Fix: Invoices from shopify had empty orderId (Fix #3769)

### DIFF
--- a/BTCPayServer/Plugins/Shopify/ApiModels/ShopifyOrder.cs
+++ b/BTCPayServer/Plugins/Shopify/ApiModels/ShopifyOrder.cs
@@ -6,9 +6,9 @@ namespace BTCPayServer.Plugins.Shopify.ApiModels
     public class ShopifyOrder
     {
         [JsonProperty("id")]
-        public string Id { get; set; }
+        public long Id { get; set; }
         [JsonProperty("order_number")]
-        public string OrderNumber { get; set; }
+        public long OrderNumber { get; set; }
         [JsonProperty("total_price")]
         public decimal TotalPrice { get; set; }
         [JsonProperty("total_outstanding")]

--- a/BTCPayServer/Plugins/Shopify/ShopifyApiClient.cs
+++ b/BTCPayServer/Plugins/Shopify/ShopifyApiClient.cs
@@ -102,7 +102,7 @@ namespace BTCPayServer.Plugins.Shopify
         public async Task<ShopifyOrder> GetOrder(string orderId)
         {
             var req = CreateRequest(_credentials.ShopName, HttpMethod.Get,
-                $"orders/{orderId}.json?fields=id,total_price,total_outstanding,currency,presentment_currency,transactions,financial_status");
+                $"orders/{orderId}.json?fields=id,order_number,total_price,total_outstanding,currency,presentment_currency,transactions,financial_status");
 
             var strResp = await SendRequest(req);
 


### PR DESCRIPTION
Fixing issue #3769.

Note that Shopify has two ids associated with orders the `order.id` and the `order.order_number`.
* `order.id` is an id used internally by shopify to uniquely identify an order in their system.
* `order.order_number` is to uniquely identify an order at the store's level.

Normally `order.order_number` is what is shown to the customer and merchant, as such it is the most important id used for tracking.

@BenGWeeks pointed out on https://github.com/btcpayserver/btcpayserver/issues/3636 that we were showing `order.id` of shopify in btcpay's `orderId` field. But since `order.id` from shopify is an internal id, this was very confusing for users. @Kukks tried to fix it in 21bd35accdab9768f9f43312ac4c82bccdbaee0d, but forgot to ask shopify's API to fetch the field.

As was planned by @Kukks, now this PR use `order.order_number` of shopify as btcpay's `orderId`.

Additionally, I saved `order.id` and `order.order_number` in the metadata of the invoices in case the user need it later.

I also removed `shopify` as an additional search term. The reason is that we already track `shopifySearchTerm` which has a prefix starting by `shopify`, as such any textsearch specifying `shopify` will already find the invoice.