### PR TITLE
Allow pull payments denominated in SATS to be claimed

### DIFF
--- a/BTCPayServer/Data/Payouts/IClaimDestination.cs
+++ b/BTCPayServer/Data/Payouts/IClaimDestination.cs
@@ -1,5 +1,4 @@
 #nullable enable
-using NBitcoin;
 
 namespace BTCPayServer.Data
 {


### PR DESCRIPTION
Fixes #3750.

## Before

As there is a currency mismatch (BTC vs. SATS) the amounts were seen as different, even though they are actually the same.

![pp-before](https://user-images.githubusercontent.com/886/170247552-99d1f775-8bd2-465d-8fad-819ec2e4ef17.png)

## After

There can still be the implied vs. provided error case …

![pp-err](https://user-images.githubusercontent.com/886/170247777-f96f12bf-1c5d-451b-9c77-f510f3481a67.png)

… but if the amounts are actually the same, it now works.

![pp-succ](https://user-images.githubusercontent.com/886/170247845-ba36ff41-0ee5-4503-b9f3-7eab9b00d45f.png)

