### PR TITLE
Greenfield: Fix GetDepositAddress return type

### DIFF
--- a/BTCPayServer/Controllers/GreenField/GreenfieldLightningNodeApiController.cs
+++ b/BTCPayServer/Controllers/GreenField/GreenfieldLightningNodeApiController.cs
@@ -160,7 +160,8 @@ namespace BTCPayServer.Controllers.Greenfield
         public virtual async Task<IActionResult> GetDepositAddress(string cryptoCode, CancellationToken cancellationToken = default)
         {
             var lightningClient = await GetLightningClient(cryptoCode, true);
-            return Ok(new JValue((await lightningClient.GetDepositAddress(cancellationToken)).ToString()));
+            var addr = await lightningClient.GetDepositAddress(cancellationToken);
+            return Ok(new JValue(addr.ToString()));
         }
 
         public virtual async Task<IActionResult> GetPayment(string cryptoCode, string paymentHash, CancellationToken cancellationToken = default)

--- a/BTCPayServer/Controllers/GreenField/LocalBTCPayServerClient.cs
+++ b/BTCPayServer/Controllers/GreenField/LocalBTCPayServerClient.cs
@@ -601,6 +601,7 @@ namespace BTCPayServer.Controllers.Greenfield
             {
                 JsonResult jsonResult => (T)jsonResult.Value,
                 OkObjectResult { Value: T res } => res,
+                OkObjectResult { Value: JValue res } => res.Value<T>(),
                 _ => default
             };
         }


### PR DESCRIPTION
The local clients `GetFromActionResult` cannot handle the `JValue` return type, because it gets invoked with `GetFromActionResult<string>`.