### PR TITLE
Improve payouts UI

### DIFF
--- a/BTCPayServer/Data/Payouts/LightningLike/UILightningLikePayoutController.cs
+++ b/BTCPayServer/Data/Payouts/LightningLike/UILightningLikePayoutController.cs
@@ -12,6 +12,7 @@ using BTCPayServer.Payments;
 using BTCPayServer.Payments.Lightning;
 using BTCPayServer.Security;
 using BTCPayServer.Services;
+using BTCPayServer.Services.Rates;
 using BTCPayServer.Services.Stores;
 using LNURL;
 using Microsoft.AspNetCore.Authorization;
@@ -35,6 +36,7 @@ namespace BTCPayServer.Data.Payouts.LightningLike
         private readonly IOptions<LightningNetworkOptions> _options;
         private readonly IAuthorizationService _authorizationService;
         private readonly StoreRepository _storeRepository;
+        private readonly CurrencyNameTable _currencyNameTable;
 
         public UILightningLikePayoutController(ApplicationDbContextFactory applicationDbContextFactory,
             UserManager<ApplicationUser> userManager,
@@ -42,6 +44,7 @@ namespace BTCPayServer.Data.Payouts.LightningLike
             IEnumerable<IPayoutHandler> payoutHandlers,
             BTCPayNetworkProvider btcPayNetworkProvider,
             StoreRepository storeRepository,
+            CurrencyNameTable currencyNameTable,
             LightningClientFactoryService lightningClientFactoryService,
             IOptions<LightningNetworkOptions> options, IAuthorizationService authorizationService)
         {
@@ -53,6 +56,7 @@ namespace BTCPayServer.Data.Payouts.LightningLike
             _lightningClientFactoryService = lightningClientFactoryService;
             _options = options;
             _storeRepository = storeRepository;
+            _currencyNameTable = currencyNameTable;
             _authorizationService = authorizationService;
         }
 
@@ -137,7 +141,7 @@ namespace BTCPayServer.Data.Payouts.LightningLike
                     {
                         PayoutId = payoutData.Id,
                         Result = PayResult.Error,
-                        Message = $"The BOLT11 invoice amount did not match the payout's amount ({boltAmount} instead of {payoutBlob.CryptoAmount})",
+                        Message = $"The BOLT11 invoice amount ({_currencyNameTable.DisplayFormatCurrency(boltAmount, pmi.CryptoCode)}) did not match the payout's amount ({_currencyNameTable.DisplayFormatCurrency(payoutBlob.CryptoAmount.GetValueOrDefault(), pmi.CryptoCode)})",
                         Destination = payoutBlob.Destination
                     });
                     return;
@@ -208,7 +212,7 @@ namespace BTCPayServer.Data.Payouts.LightningLike
                         switch (claim.destination)
                         {
                             case LNURLPayClaimDestinaton lnurlPayClaimDestinaton:
-                                var endpoint = LNURL.LNURL.Parse(lnurlPayClaimDestinaton.LNURL, out var tag);
+                                var endpoint = LNURL.LNURL.Parse(lnurlPayClaimDestinaton.LNURL, out _);
                                 var lightningPayoutHandler = (LightningLikePayoutHandler)payoutHandler;
                                 var httpClient = lightningPayoutHandler.CreateClient(endpoint);
                                 var lnurlInfo =
@@ -217,7 +221,7 @@ namespace BTCPayServer.Data.Payouts.LightningLike
                                 var lm = new LightMoney(blob.CryptoAmount.Value, LightMoneyUnit.BTC);
                                 if (lm > lnurlInfo.MaxSendable || lm < lnurlInfo.MinSendable)
                                 {
-                                    results.Add(new ResultVM()
+                                    results.Add(new ResultVM
                                     {
                                         PayoutId = payoutData.Id,
                                         Result = PayResult.Error,

--- a/BTCPayServer/Views/UILightningLikePayout/ConfirmLightningPayout.cshtml
+++ b/BTCPayServer/Views/UILightningLikePayout/ConfirmLightningPayout.cshtml
@@ -5,20 +5,19 @@
     var cryptoCode = Context.GetRouteValue("cryptoCode");
 }
 
-<h2 class="mt-1 mb-4">@ViewData["Title"]</h2>
+<h2 class="mt-1 mb-2">@ViewData["Title"]</h2>
 <div class="row">
     <div class="col-md-12">
-        <ul class="list-group">
+        <ul class="list-group list-group-flush">
             @foreach (var item in Model)
             {
-                <li class="list-group-item d-flex justify-content-between align-items-center">
-                    <div class="text-break" style="max-width:60em;">@item.Destination</div>
-                    <span class="text-capitalize badge bg-secondary">@item.Amount @cryptoCode</span>
+                <li class="list-group-item py-4 px-0">
+                    <div class="text-break">@item.Destination</div>
+                    <form method="post" class="mt-4 mb-1" id="pay-invoices-form">
+                        <button type="submit" class="btn btn-primary" id="Pay">Pay @item.Amount @cryptoCode</button>
+                        <a asp-controller="UIStorePullPayments" asp-action="Payouts" asp-route-storeId="@Context.GetStoreData().Id" class="btn btn-secondary mx-2 px-4">Cancel</a>
+                    </form>
                 </li>
-                <form method="post" class="list-group-item justify-content-center" id="pay-invoices-form">
-                    <button type="submit" class="btn btn-primary px-5" id="Pay">Pay</button>
-                    <a asp-controller="UIStorePullPayments" asp-action="Payouts" asp-route-storeId="@Context.GetStoreData().Id" class="btn btn-secondary mx-2 px-4">Cancel</a>
-                </form>
             }
         </ul>
     </div>

--- a/BTCPayServer/Views/UILightningLikePayout/LightningPayoutResult.cshtml
+++ b/BTCPayServer/Views/UILightningLikePayout/LightningPayoutResult.cshtml
@@ -8,15 +8,14 @@
 <h2 class="mt-1 mb-4">@ViewData["Title"]</h2>
 @foreach (var item in Model)
 {
-    <div class="alert alert-@(item.Result == PayResult.Ok ? "success" : "danger") d-flex justify-content-between align-items-center mb-3" role="alert">
-        @if (item.Result == PayResult.Ok)
-        {
-            <div class="text-break me-3" title="@item.Destination">@item.Destination</div>
-        }
-        else
-        {
-            <div class="text-break me-3" title="@item.Destination">@item.Destination: @item.Message (@item.Result)</div>
-        }
-        <span class="badge fs-5">@(item.Result == PayResult.Ok ? "Sent" : "Failed")</span>
+    <div class="alert alert-@(item.Result == PayResult.Ok ? "success" : "danger") mb-3" role="alert">
+        <h5 class="alert-heading">
+            @(item.Result == PayResult.Ok ? "Sent" : "Failed")
+            @if (!string.IsNullOrEmpty(item.Message))
+            {
+                <span>- @item.Message</span>
+            }
+        </h5>
+        <div class="text-break me-3" title="@item.Destination">@item.Destination</div>
     </div>
 }

--- a/BTCPayServer/Views/UIStorePullPayments/Payouts.cshtml
+++ b/BTCPayServer/Views/UIStorePullPayments/Payouts.cshtml
@@ -127,7 +127,7 @@
                     @state.Key.GetStateString() 
                     @if (state.Value > 0)
                     {
-                        <span class="badge rounded-pill border fw-semibold ms-1">@state.Value</span>
+                        <span class="badge rounded-pill border fw-semibold ms-1 bg-tile">@state.Value</span>
                     }
                 </a>
             }

--- a/BTCPayServer/Views/UIStorePullPayments/Payouts.cshtml
+++ b/BTCPayServer/Views/UIStorePullPayments/Payouts.cshtml
@@ -39,6 +39,15 @@
     }
 }
 
+@section PageHeadContent {
+    <style>
+        #Payouts .badge.rounded-pill {
+            font-size: var(--btcpay-font-size-s);
+            color: inherit;
+        }
+    </style>
+}
+
 @section PageFootContent {
     <script>
         delegate('click', '.selectAll', e => {
@@ -66,7 +75,7 @@
 }
 <h2 class="mt-1 mb-4">@ViewData["Title"]</h2>
 
-<form method="post">
+<form method="post" id="Payouts">
     <input type="hidden" asp-for="PaymentMethodId"/>
     <input type="hidden" asp-for="PayoutState"/>
     <div class="d-flex justify-content-between mb-4">
@@ -84,7 +93,7 @@
                         @state.ToPrettyString()
                         @if (Model.PaymentMethodCount.TryGetValue(state.ToString(), out var count) && count > 0)
                         {
-                            <span class="position-absolute top-0 start-100 translate-middle badge rounded-pill border bg-secondary fw-bold">@count</span>
+                            <span class="badge rounded-pill fw-semibold pe-0">@count</span>
                         }
                     </a>
                 </li>
@@ -116,7 +125,10 @@
                    asp-route-paymentMethodId="@Model.PaymentMethodId"
                    class="nav-link @(state.Key == Model.PayoutState ? "active" : "")" role="tab">
                     @state.Key.GetStateString() 
-                    <span class="badge rounded-pill border bg-secondary fw-bold">@state.Value</span>
+                    @if (state.Value > 0)
+                    {
+                        <span class="badge rounded-pill border fw-semibold ms-1">@state.Value</span>
+                    }
                 </a>
             }
         </div>

--- a/BTCPayServer/Views/UIStorePullPayments/Payouts.cshtml
+++ b/BTCPayServer/Views/UIStorePullPayments/Payouts.cshtml
@@ -52,10 +52,6 @@
 
 <partial name="_StatusMessage"/>
 
-@{
-
-}
-
 @if (_payoutProcessorFactories.Any(factory => factory.GetSupportedPaymentMethods().Contains(paymentMethodId)) && !(await _payoutProcessorService.GetProcessors(new PayoutProcessorService.PayoutProcessorQuery()
 {
     Stores = new[] {storeId},
@@ -82,13 +78,13 @@
                        asp-route-payoutState="@Model.PayoutState"
                        asp-route-paymentMethodId="@state.ToString()"
                        asp-route-pullPaymentId="@Model.PullPaymentId"
-                       class="btcpay-pill @(state.ToString() == Model.PaymentMethodId ? "active" : "")"
+                       class="btcpay-pill position-relative @(state.ToString() == Model.PaymentMethodId ? "active" : "")"
                        id="@state.ToString()-view"
                        role="tab">
                         @state.ToPrettyString()
                         @if (Model.PaymentMethodCount.TryGetValue(state.ToString(), out var count) && count > 0)
                         {
-                            <span>(@count)</span>
+                            <span class="position-absolute top-0 start-100 translate-middle badge rounded-pill border bg-secondary fw-bold">@count</span>
                         }
                     </a>
                 </li>
@@ -119,7 +115,8 @@
                    asp-route-pullPaymentId="@Model.PullPaymentId"
                    asp-route-paymentMethodId="@Model.PaymentMethodId"
                    class="nav-link @(state.Key == Model.PayoutState ? "active" : "")" role="tab">
-                    @state.Key.GetStateString() (@state.Value)
+                    @state.Key.GetStateString() 
+                    <span class="badge rounded-pill border bg-secondary fw-bold">@state.Value</span>
                 </a>
             }
         </div>

--- a/BTCPayServer/wwwroot/main/themes/default-dark.css
+++ b/BTCPayServer/wwwroot/main/themes/default-dark.css
@@ -41,6 +41,7 @@
   --btcpay-secondary: transparent;
   --btcpay-secondary-text-active: var(--btcpay-primary);
   --btcpay-secondary-border: var(--btcpay-neutral-700);
+  --btcpay-secondary-rgb: 22, 27, 34;
   --btcpay-light: var(--btcpay-neutral-800);
   --btcpay-light-accent: var(--btcpay-black);
   --btcpay-light-text: var(--btcpay-neutral-200);


### PR DESCRIPTION
Some UI improvements for the payouts section. /cc @dstrukt 

## List

Made the numbers badges so that they are more noticeable.

![grafik](https://user-images.githubusercontent.com/886/171140079-ec2fee86-9afa-4f4c-b763-6f6d154731a2.png)


## Confirm

Reworked the list to make it look nicer and the button text to be clearer.

![payouts-confirm](https://user-images.githubusercontent.com/886/171045460-1614396c-a327-401f-823e-32611bab784b.png)


## Result

Made the status a headline and added a message with details to that.

![payout-results](https://user-images.githubusercontent.com/886/171045398-e9c41b0e-6cc9-4b96-98d1-fda3c878cb4e.png)


