### PR TITLE
Removes `Plugins` tab from navigation on Server Settings

### DIFF
--- a/BTCPayServer/Views/UIServer/_Nav.cshtml
+++ b/BTCPayServer/Views/UIServer/_Nav.cshtml
@@ -17,7 +17,6 @@
             }
             <a asp-controller="UIServer" id="SectionNav-@ServerNavPages.Logs" class="nav-link @ViewData.IsActivePage(ServerNavPages.Logs)" asp-action="LogsView">Logs</a>
             <a asp-controller="UIServer" id="SectionNav-@ServerNavPages.Files" class="nav-link @ViewData.IsActivePage(ServerNavPages.Files)" asp-action="Files">Files</a>
-            <a asp-controller="UIServer" id="SectionNav-@ServerNavPages.Plugins" class="nav-link @ViewData.IsActivePage(ServerNavPages.Plugins)" asp-action="ListPlugins">Plugins</a>
             <vc:ui-extension-point location="server-nav" model="@Model"/>
         </div>
     </nav>


### PR DESCRIPTION
Maybe this was kept for the sake of redundancy, or some other reason I'm not privy to...? If so, apologies for this PR.

Otherwise, it's redundant, and the "manage plugins" link is easy to find in the left sidebar, so thought we could go ahead and remove it from the tab menu!