### PR TITLE
Creating and editing a payment request now redirects to list view upon completion #3803

### DIFF
--- a/BTCPayServer/Controllers/UIPaymentRequestController.cs
+++ b/BTCPayServer/Controllers/UIPaymentRequestController.cs
@@ -139,7 +139,8 @@ namespace BTCPayServer.Controllers
             blob.AllowCustomPaymentAmounts = viewModel.AllowCustomPaymentAmounts;
 
             data.SetBlob(blob);
-            if (string.IsNullOrEmpty(payReqId))
+            var isNewPaymentRequest = string.IsNullOrEmpty(payReqId);
+            if (isNewPaymentRequest)
             {
                 data.Created = DateTimeOffset.UtcNow;
             }
@@ -147,8 +148,8 @@ namespace BTCPayServer.Controllers
             data = await _PaymentRequestRepository.CreateOrUpdatePaymentRequest(data);
             _EventAggregator.Publish(new PaymentRequestUpdated { Data = data, PaymentRequestId = data.Id, });
 
-            TempData[WellKnownTempData.SuccessMessage] = "Saved";
-            return RedirectToAction(nameof(EditPaymentRequest), new { storeId = store.Id, payReqId = data.Id });
+            TempData[WellKnownTempData.SuccessMessage] = $"Payment request [{viewModel.Title}] {(isNewPaymentRequest ? "created" : "updated")} successfully";
+            return RedirectToAction(nameof(GetPaymentRequests), new { storeId = store.Id });
         }
 
         [HttpGet("{payReqId}")]


### PR DESCRIPTION
Both actions use the same method. Also updated notification message to reflect create or edit action.

![image](https://user-images.githubusercontent.com/100967048/172026148-074b1840-7ef1-4aa3-ad53-4f27b5d2acfd.png)
