### PR TITLE
Minor tweak to Payout UI

### DIFF
--- a/BTCPayServer/Views/UIStorePullPayments/Payouts.cshtml
+++ b/BTCPayServer/Views/UIStorePullPayments/Payouts.cshtml
@@ -127,7 +127,7 @@
                     @state.Key.GetStateString() 
                     @if (state.Value > 0)
                     {
-                        <span class="badge rounded-pill border fw-semibold ms-1 bg-tile">@state.Value</span>
+                        <span class="badge rounded-pill fw-semibold ms-1 bg-tile">@state.Value</span>
                     }
                 </a>
             }

--- a/BTCPayServer/Views/UIStorePullPayments/Payouts.cshtml
+++ b/BTCPayServer/Views/UIStorePullPayments/Payouts.cshtml
@@ -127,7 +127,7 @@
                     @state.Key.GetStateString() 
                     @if (state.Value > 0)
                     {
-                        <span class="badge rounded-pill fw-semibold ms-1 bg-tile">@state.Value</span>
+                        <span class="badge rounded-pill fw-semibold ms-1 bg-medium">@state.Value</span>
                     }
                 </a>
             }

--- a/BTCPayServer/wwwroot/main/bootstrap/bootstrap.css
+++ b/BTCPayServer/wwwroot/main/bootstrap/bootstrap.css
@@ -10922,6 +10922,15 @@ input[type="number"].hide-number-spin {
   -moz-appearance: textfield;
 }
 
+/* custom bg and border classes */
+.bg-medium {
+  background-color: var(--btcpay-body-bg-medium);
+}
+
+.border-medium {
+  border-color: var(--btcpay-body-border-medium);
+}
+
 /* set color for text on background */
 .bg-primary {
   color: var(--btcpay-primary-text);


### PR DESCRIPTION
Had to keep tweaking it :) 

Currently, I've removed the `.border` class, but still want to change the `.bg-tile` to the equivalent of `var(--btcpay-neutral-800);` but wasn't sure which bootstrap class would be best to use cc @dennisreimann?

Will make that change based on your suggestion, rebase, and submit for approval.

Will ideally look like this:

<img width="746" alt="Screen Shot 2022-06-05 at 4 43 06 AM" src="https://user-images.githubusercontent.com/6250771/172048971-2d4a0087-b831-4ea0-9907-6d8e164f5195.png">
