### PR TITLE
Creating and editing a payment request now redirects to list view upon completion

### DIFF
--- a/BTCPayServer.Tests/SeleniumTests.cs
+++ b/BTCPayServer.Tests/SeleniumTests.cs
@@ -758,6 +758,7 @@ namespace BTCPayServer.Tests
             currencyInput.SendKeys("BTC");
             
             s.Driver.FindElement(By.Id("SaveButton")).Click();
+            s.Driver.FindElement(By.XPath($"//a[starts-with(@id, 'Edit-')]")).Click();
             s.Driver.FindElement(By.Id("ViewPaymentRequest")).Click();
             s.Driver.SwitchTo().Window(s.Driver.WindowHandles.Last());
             Assert.Equal("Amount due", s.Driver.FindElement(By.CssSelector("[data-test='amount-due-title']")).Text);
@@ -768,6 +769,7 @@ namespace BTCPayServer.Tests
             s.Driver.SwitchTo().Window(s.Driver.WindowHandles.First());
             s.Driver.ExecuteJavaScript("document.getElementById('ExpiryDate').value = '2021-01-21T21:00:00.000Z'");
             s.Driver.FindElement(By.Id("SaveButton")).Click();
+            s.Driver.FindElement(By.XPath($"//a[starts-with(@id, 'Edit-')]")).Click();
             s.Driver.SwitchTo().Window(s.Driver.WindowHandles.Last());
             s.Driver.Navigate().Refresh();
             Assert.Equal("Expired", s.Driver.WaitForElement(By.CssSelector("[data-test='status']")).Text);
@@ -776,6 +778,7 @@ namespace BTCPayServer.Tests
             s.Driver.SwitchTo().Window(s.Driver.WindowHandles.First());
             s.Driver.FindElement(By.Id("ClearExpiryDate")).Click();
             s.Driver.FindElement(By.Id("SaveButton")).Click();
+            s.Driver.FindElement(By.XPath($"//a[starts-with(@id, 'Edit-')]")).Click();
             s.Driver.SwitchTo().Window(s.Driver.WindowHandles.Last());
             s.Driver.Navigate().Refresh();
             s.Driver.AssertElementNotFound(By.CssSelector("[data-test='status']"));

--- a/BTCPayServer/Controllers/UIPaymentRequestController.cs
+++ b/BTCPayServer/Controllers/UIPaymentRequestController.cs
@@ -139,7 +139,8 @@ namespace BTCPayServer.Controllers
             blob.AllowCustomPaymentAmounts = viewModel.AllowCustomPaymentAmounts;
 
             data.SetBlob(blob);
-            if (string.IsNullOrEmpty(payReqId))
+            var isNewPaymentRequest = string.IsNullOrEmpty(payReqId);
+            if (isNewPaymentRequest)
             {
                 data.Created = DateTimeOffset.UtcNow;
             }
@@ -147,8 +148,8 @@ namespace BTCPayServer.Controllers
             data = await _PaymentRequestRepository.CreateOrUpdatePaymentRequest(data);
             _EventAggregator.Publish(new PaymentRequestUpdated { Data = data, PaymentRequestId = data.Id, });
 
-            TempData[WellKnownTempData.SuccessMessage] = "Saved";
-            return RedirectToAction(nameof(EditPaymentRequest), new { storeId = store.Id, payReqId = data.Id });
+            TempData[WellKnownTempData.SuccessMessage] = $"Payment request [{viewModel.Title}] {(isNewPaymentRequest ? "created" : "updated")} successfully";
+            return RedirectToAction(nameof(GetPaymentRequests), new { storeId = store.Id, payReqId = data.Id });
         }
 
         [HttpGet("{payReqId}")]


### PR DESCRIPTION
Create and edit now redirect to list view. Both actions use the same method. Also updated notification message.

- xUnit: Kept extraneous redirect value so xUnit tests pass w/o modification. If there is a better alternative please let me know and I will fix. The tests won't have access to the new payment req id otherwise, but could maybe expose via ViewData but that seems messier.  I noticed Invoices and Pull Payments don't have these same tests.

> return RedirectToAction(nameof(GetPaymentRequests), new { storeId = store.Id, **payReqId = data.Id** });

- New notification message:
![image](https://user-images.githubusercontent.com/100967048/172064564-049316b1-a750-4efb-ba5f-a8f98b4b6dd6.png)

#3803 