### PR TITLE
Notifications: Fix mark all as seen return URL

### DIFF
--- a/BTCPayServer/Components/Notifications/Dropdown.cshtml
+++ b/BTCPayServer/Components/Notifications/Dropdown.cshtml
@@ -11,9 +11,9 @@
             <span class="badge rounded-pill bg-danger p-1 ms-1" id="NotificationsBadge">@Model.UnseenCount</span>
         </button>
         <div class="dropdown-menu text-center" id="NotificationsDropdown" aria-labelledby="NotificationsHandle">
-            <div class="d-flex align-items-center justify-content-between py-3 px-4 border-bottom border-light">
+            <div class="d-flex gap-3 align-items-center justify-content-between py-3 px-4 border-bottom border-light">
                 <h5 class="m-0">Notifications</h5>
-                <form id="notificationsForm" asp-controller="UINotifications" asp-action="MarkAllAsSeen" asp-route-returnUrl="@Context.Request.GetCurrentPathWithQueryString()" method="post">
+                <form id="notificationsForm" asp-controller="UINotifications" asp-action="MarkAllAsSeen" asp-route-returnUrl="@Model.ReturnUrl" method="post">
                     <button class="btn btn-link p-0" type="submit">Mark all as seen</button>
                 </form>
             </div>

--- a/BTCPayServer/Components/Notifications/Notications.cs
+++ b/BTCPayServer/Components/Notifications/Notications.cs
@@ -16,9 +16,10 @@ namespace BTCPayServer.Components.Notifications
             _notificationManager = notificationManager;
         }
 
-        public async Task<IViewComponentResult> InvokeAsync(string appearance)
+        public async Task<IViewComponentResult> InvokeAsync(string appearance, string returnUrl)
         {
             var vm = await _notificationManager.GetSummaryNotifications(UserClaimsPrincipal);
+            vm.ReturnUrl = returnUrl;
             var viewName = _views.Contains(appearance) ? appearance : _views[0];
             return View(viewName, vm);
         }

--- a/BTCPayServer/Components/Notifications/NotificationsViewModel.cs
+++ b/BTCPayServer/Components/Notifications/NotificationsViewModel.cs
@@ -5,6 +5,7 @@ namespace BTCPayServer.Components.Notifications
 {
     public class NotificationsViewModel
     {
+        public string ReturnUrl { get; set; }
         public int UnseenCount { get; set; }
         public List<NotificationViewModel> Last5 { get; set; }
     }

--- a/BTCPayServer/Controllers/UINotificationsController.cs
+++ b/BTCPayServer/Controllers/UINotificationsController.cs
@@ -43,9 +43,9 @@ namespace BTCPayServer.Controllers
         }
 
         [HttpGet]
-        public IActionResult GetNotificationDropdownUI()
+        public IActionResult GetNotificationDropdownUI(string returnUrl)
         {
-            return ViewComponent("Notifications", new { appearance = "Dropdown" });
+            return ViewComponent("Notifications", new { appearance = "Dropdown", returnUrl });
         }
 
         [HttpGet]

--- a/BTCPayServer/Views/Shared/_Layout.cshtml
+++ b/BTCPayServer/Views/Shared/_Layout.cshtml
@@ -1,3 +1,8 @@
+@using BTCPayServer.Abstractions.Extensions
+@using Microsoft.AspNetCore.Mvc.TagHelpers
+@using BTCPayServer.Components.StoreSelector
+@using BTCPayServer.Components.MainNav
+@using BTCPayServer.TagHelpers
 @inject BTCPayServer.Services.BTCPayServerEnvironment _env
 @inject SignInManager<ApplicationUser> _signInManager
 @inject UserManager<ApplicationUser> _userManager
@@ -5,6 +10,7 @@
 @inject BTCPayServer.Services.PoliciesSettings PoliciesSettings
 
 @{
+    var notificationsReturnUrl = Context.Request.GetCurrentPathWithQueryString();
     var notificationDisabled = PoliciesSettings.DisableInstantNotifications;
     if (!notificationDisabled)
     {
@@ -25,7 +31,7 @@
         <vc:store-selector />
         @if (_signInManager.IsSignedIn(User))
         {
-            <vc:notifications appearance="Dropdown"/>
+            <vc:notifications appearance="Dropdown" return-url="@notificationsReturnUrl" />
         }
         <button id="mainMenuToggle" class="mainMenuButton" type="button" data-bs-toggle="offcanvas" data-bs-target="#mainNav" aria-controls="mainNav" aria-expanded="false" aria-label="Toggle navigation">
             <span>Menu</span>
@@ -76,7 +82,7 @@
                 const { host, protocol } = window.location;
                 var wsUri = "@_linkGenerator.GetPathByAction("SubscribeUpdates", "UINotifications", pathBase: Context.Request.PathBase)";
 				wsUri = (protocol === "https:" ? "wss:" : "ws:") + "//" + host + wsUri;
-                const newDataEndpoint = "@_linkGenerator.GetPathByAction("GetNotificationDropdownUI", "UINotifications", pathBase: Context.Request.PathBase)";
+                const newDataEndpoint = "@_linkGenerator.GetPathByAction("GetNotificationDropdownUI", "UINotifications", pathBase: Context.Request.PathBase, values: new { returnUrl = notificationsReturnUrl })";
                 try {
                     socket = new WebSocket(wsUri);
                     socket.onmessage = e => {


### PR DESCRIPTION
Fixes the return URL for the case in which the dropdown content got replaced after a notification update: As the refresh request is done via AJAX, the return URL previously was `/notifications/getnotificationdropdownui` (the `Context.Request.GetCurrentPathWithQueryString()` value of the AJAX action).

This resulted in the user landing on a mostly empty screen, only item being the notification bell:

![grafik](https://user-images.githubusercontent.com/886/172897408-f99952ee-cc9b-4623-8ce1-3d82fe7a5c8c.png)

We need to pass in the URL of the actual current page as the return URL.

Bug reports on Mattermost:

- https://chat.btcpayserver.org/btcpayserver/pl/fw36w4trf383jmzudy418hwzdo
- https://chat.btcpayserver.org/btcpayserver/pl/erah78jc1bn65n5fycwp3r7mzr