### PR TITLE
adds payouts settings button

### DIFF
--- a/BTCPayServer/Views/UIStorePullPayments/Payouts.cshtml
+++ b/BTCPayServer/Views/UIStorePullPayments/Payouts.cshtml
@@ -72,7 +72,12 @@
 <div id="descriptor" class="collapse">
     <div class="d-flex px-4 py-4 mb-4 bg-tile rounded">
         <div class="flex-fill">
-            <p class="mb-3">Payouts allow you to process pull payments, in the form of refunds, salary payouts, or withdrawals.</p>
+            <p class="mb-3">
+                Payouts allow you to process pull payments, in the form of refunds, salary payouts, or withdrawals.
+                You can also
+                <a id="PayoutProcessors" asp-action="ConfigureStorePayoutProcessors" asp-controller="UIPayoutProcessors" asp-route-storeId="@storeId">configure payout processors</a>
+                to automate payouts.
+            </p>
             <a href="https://docs.btcpayserver.org/Payouts/" target="_blank" rel="noreferrer noopener">Learn More</a>
         </div>
         <button type="button" class="btn-close ms-auto" data-bs-toggle="collapse" data-bs-target="#descriptor" aria-expanded="false" aria-label="Close">
@@ -95,13 +100,6 @@
         <a class="alert-link p-0" asp-action="ConfigureStorePayoutProcessors" asp-controller="UIPayoutProcessors" asp-route-storeId="@storeId">Configure now</a>
     </div>
 }
-
-<div class="d-flex flex-wrap align-items-center justify-content-between gap-3 mb-4">
-    <h2 class="mb-0">@ViewData["Title"]</h2>
-    <a id="PayoutProcessors" asp-action="ConfigureStorePayoutProcessors" asp-controller="UIPayoutProcessors" asp-route-storeId="@storeId" class="btn btn-secondary d-flex align-items-center">
-        Settings                
-    </a>
-</div>
 
 <form method="post" id="Payouts">
     <input type="hidden" asp-for="PaymentMethodId" />

--- a/BTCPayServer/Views/UIStorePullPayments/Payouts.cshtml
+++ b/BTCPayServer/Views/UIStorePullPayments/Payouts.cshtml
@@ -96,6 +96,13 @@
     </div>
 }
 
+<div class="d-flex flex-wrap align-items-center justify-content-between mb-2">
+    <h2 class="mt-1 mb-4">@ViewData["Title"]</h2>
+    <a id="PayoutProcessors" asp-action="ConfigureStorePayoutProcessors" asp-controller="UIPayoutProcessors" asp-route-storeId="@storeId" class="btn btn-secondary">
+        Settings                
+    </a>
+</div>
+
 <form method="post" id="Payouts">
     <input type="hidden" asp-for="PaymentMethodId" />
     <input type="hidden" asp-for="PayoutState" />

--- a/BTCPayServer/Views/UIStorePullPayments/Payouts.cshtml
+++ b/BTCPayServer/Views/UIStorePullPayments/Payouts.cshtml
@@ -98,7 +98,7 @@
 
 <div class="d-flex flex-wrap align-items-center justify-content-between gap-3 mb-4">
     <h2 class="mb-0">@ViewData["Title"]</h2>
-    <a id="PayoutProcessors" asp-action="ConfigureStorePayoutProcessors" asp-controller="UIPayoutProcessors" asp-route-storeId="@storeId" class="btn btn-secondary">
+    <a id="PayoutProcessors" asp-action="ConfigureStorePayoutProcessors" asp-controller="UIPayoutProcessors" asp-route-storeId="@storeId" class="btn btn-secondary d-flex align-items-center">
         Settings                
     </a>
 </div>

--- a/BTCPayServer/Views/UIStorePullPayments/Payouts.cshtml
+++ b/BTCPayServer/Views/UIStorePullPayments/Payouts.cshtml
@@ -96,8 +96,8 @@
     </div>
 }
 
-<div class="d-flex flex-wrap align-items-center justify-content-between mb-2">
-    <h2 class="mt-1 mb-4">@ViewData["Title"]</h2>
+<div class="d-flex flex-wrap align-items-center justify-content-between gap-3 mb-4">
+    <h2 class="mb-0">@ViewData["Title"]</h2>
     <a id="PayoutProcessors" asp-action="ConfigureStorePayoutProcessors" asp-controller="UIPayoutProcessors" asp-route-storeId="@storeId" class="btn btn-secondary">
         Settings                
     </a>
@@ -115,7 +115,7 @@
                        asp-route-payoutState="@Model.PayoutState"
                        asp-route-paymentMethodId="@state.ToString()"
                        asp-route-pullPaymentId="@Model.PullPaymentId"
-                       class="btcpay-pill position-relative @(state.ToString() == Model.PaymentMethodId ? "active" : "")"
+                       class="btcpay-pill position-relative me-0 @(state.ToString() == Model.PaymentMethodId ? "active" : "")"
                        id="@state.ToString()-view"
                        role="tab">
                         @state.ToPrettyString()


### PR DESCRIPTION
It's not the most attractive thing right now with the "Actions" drop-down button right below it, but I think regardless of whether "Settings" is a link to the `Store Settings > Payouts` or we end up rolling the settings into the Payouts view like the Wallet views ... it's a necessary addition. 

Mirrors the functionality we have on Notifications as well.

Also, the `Actions` button will be remove/improved along with similar buttons in the near future, so this is a temporary problem.

<img width="1210" alt="Screen Shot 2022-06-10 at 8 03 12 PM" src="https://user-images.githubusercontent.com/6250771/173170285-e2322242-a6f4-42f8-aa59-021e7e6168f6.png">
