### PR TITLE
add exception check to shopify UI Controller

### DIFF
--- a/BTCPayServer/Plugins/Shopify/UIShopifyController.cs
+++ b/BTCPayServer/Plugins/Shopify/UIShopifyController.cs
@@ -164,11 +164,11 @@ namespace BTCPayServer.Plugins.Shopify
                     order = await client.GetOrder(orderId);
                 }
 
-                 return Ok(new
-                    {
-                        invoiceId = firstInvoiceSettled.Id,
-                        status = firstInvoiceSettled.Status.ToString().ToLowerInvariant()
-                    });
+                return Ok(new
+                {
+                    invoiceId = firstInvoiceSettled.Id,
+                    status = firstInvoiceSettled.Status.ToString().ToLowerInvariant()
+                });
             }
 
             if (checkOnly)
@@ -248,12 +248,20 @@ namespace BTCPayServer.Plugins.Shopify
                                 "Shopify rejected provided credentials, please correct values and try again";
                             return View(vm);
                         }
-
-                        var scopesGranted = await apiClient.CheckScopes();
-                        if (!scopesGranted.Contains("read_orders") || !scopesGranted.Contains("write_orders"))
+                        try
+                        {
+                            var scopesGranted = await apiClient.CheckScopes();
+                            if (!scopesGranted.Contains("read_orders") || !scopesGranted.Contains("write_orders"))
+                            {
+                                TempData[WellKnownTempData.ErrorMessage] =
+                                    "Please grant the private app permissions for read_orders, write_orders";
+                                return View(vm);
+                            }
+                        }
+                        catch (System.NullReferenceException)
                         {
                             TempData[WellKnownTempData.ErrorMessage] =
-                                "Please grant the private app permissions for read_orders, write_orders";
+                                       "Please verify your Shopify Store Name.";
                             return View(vm);
                         }
 


### PR DESCRIPTION
Fix for issue #3853 

The Shopify plugin crashes and returns a 500 error if an incorrect URL is entered during setup. Added a try-catch block to check, works locally with regtest.

![image](https://user-images.githubusercontent.com/2165320/173571729-595e1f30-2dbb-4539-b573-0af00f826c5c.png)
