### PR TITLE
Fix warning from CLI parser

### DIFF
--- a/run.ps1
+++ b/run.ps1
@@ -1,1 +1,1 @@
-dotnet run --no-launch-profile --no-build -c Release -p .\BTCPayServer\BTCPayServer.csproj -- $args
+dotnet run --no-launch-profile --no-build -c Release --project .\BTCPayServer\BTCPayServer.csproj -- $args

--- a/run.sh
+++ b/run.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-dotnet run --no-launch-profile --no-build -c Release -p "BTCPayServer/BTCPayServer.csproj" -- $@
+dotnet run --no-launch-profile --no-build -c Release --project "BTCPayServer/BTCPayServer.csproj" -- $@


### PR DESCRIPTION
`-p` is deprecated as an abbreviation for `--project`, and using `-p` generates a warning.

Source: https://docs.microsoft.com/en-us/dotnet/core/compatibility/sdk/6.0/deprecate-p-option-dotnet-run