### PR TITLE
Adding description to speedPolicy parameter.

### DIFF
--- a/BTCPayServer/wwwroot/swagger/v1/swagger.template.invoices.json
+++ b/BTCPayServer/wwwroot/swagger/v1/swagger.template.invoices.json
@@ -1063,7 +1063,7 @@
             },
             "SpeedPolicy": {
                 "type": "string",
-                "description": "",
+                "description": "`\"HighSpeed\"`: 0 confirmations (1 confirmation if RBF enabled in transaction)   \n`\"MediumSpeed\"`: 1 confirmation   \n`\"LowMediumSpeed\"`: 2 confirmations   \n`\"LowSpeed\"`: 6 confirmations\n",
                 "x-enumNames": [
                     "HighSpeed",
                     "MediumSpeed",


### PR DESCRIPTION
Fixes #3808 

Proper description with explanation on how many confirmations the settings relate to.

![image](https://user-images.githubusercontent.com/1136761/173930844-61f74fc1-0086-4de0-9c2b-47a17a165ea9.png)

Note: for some reason the enum values are shown twice, but this is also true for the current 1.5.4.0 release so this "bug" was not introduced with my change here. I checked but I do not see why they should be duplicated. Also on the docs.btcpayserver.org page of the api docs this does not happen. 