### PR TITLE
Remove `Store ID` from Store Settings & various minor UI tweaks

### DIFF
--- a/BTCPayServer/Views/UIInvoice/Invoice.cshtml
+++ b/BTCPayServer/Views/UIInvoice/Invoice.cshtml
@@ -106,7 +106,7 @@
             <button href="#" class="btn btn-secondary text-nowrap" data-bs-toggle="tooltip" title="You can only refund an invoice that has been settled. Please wait for the transaction to confirm on the blockchain before attempting to refund it." disabled>Issue refund</button>
         }
         <form asp-action="ToggleArchive" asp-route-invoiceId="@Model.Id" method="post">
-            <button type="submit" class="btn @(Model.Archived ? "btn-warning" : "btn btn-danger")" id="btn-archive-toggle">
+            <button type="submit" class="btn btn-secondary" id="btn-archive-toggle">
                 @if (Model.Archived)
                 {
                     <span class="text-nowrap" data-bs-toggle="tooltip" title="Unarchive this invoice">Unarchive</span>

--- a/BTCPayServer/Views/UIServer/ListUsers.cshtml
+++ b/BTCPayServer/Views/UIServer/ListUsers.cshtml
@@ -23,7 +23,7 @@
     var sortByAsc = "Sort by ascending...";
 }
 
-<div class="d-flex align-items-center justify-content-between mb-4">
+<div class="d-flex align-items-center justify-content-between mb-3">
     <h3 class="mb-0">@ViewData["Title"]</h3>
     <a asp-action="CreateUser" class="btn btn-primary" role="button" id="CreateUser">
         <span class="fa fa-plus"></span>
@@ -31,7 +31,7 @@
     </a>
 </div>
 
-<form asp-action="ListUsers" asp-route-sortOrder="@(userEmailSortOrder)" style="max-width:960px" class="mb-4">
+<form asp-action="ListUsers" asp-route-sortOrder="@(userEmailSortOrder)" style="max-width:640px">
     <div class="input-group">
         <input asp-for="SearchTerm" class="form-control" placeholder="Search by email..." />
         <button type="submit" class="btn btn-secondary" title="Search by email">

--- a/BTCPayServer/wwwroot/main/layout.css
+++ b/BTCPayServer/wwwroot/main/layout.css
@@ -553,7 +553,7 @@
         --header-height: var(--desktop-header-height);
         --content-padding-top: 5rem;
         --content-padding-bottom: 5rem;
-        --content-padding-horizontal: var(--btcpay-space-xl);
+        --content-padding-horizontal: 5rem;
     }
     
     #mainMenu {


### PR DESCRIPTION
More tweaks while working on Figma mocks.

- Removes `Store ID` from Store Settings, as it's no longer necessary, and has been mentioned a few times we should remove
<img width="832" alt="Screen Shot 2022-06-17 at 5 15 45 PM" src="https://user-images.githubusercontent.com/6250771/174414669-9ffa048a-e32f-41dc-8f81-27cd5cfcf555.png">

- Adjusts main container left & right padding to `80px;` for the largest breakpoint

- Changes `danger` styling on the `Archive` button on Invoice Detail view to our secondary button style .. the `danger` styling suggests an error when simply Archiving an invoice is not an error or reason to be concerned, like Deleting a store, etc..

<img width="590" alt="Screen Shot 2022-06-17 at 5 11 04 PM" src="https://user-images.githubusercontent.com/6250771/174414469-5836d413-a376-4ead-94c4-039f13b90a83.png">

- Updates the `max-width` & margin of the user search input, looks a bit nicer
