### PR TITLE
Lightning balance: Handle null values

### DIFF
--- a/BTCPayServer.Client/BTCPayServer.Client.csproj
+++ b/BTCPayServer.Client/BTCPayServer.Client.csproj
@@ -28,7 +28,7 @@
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
   </ItemGroup>
     <ItemGroup>
-      <PackageReference Include="BTCPayServer.Lightning.Common" Version="1.3.6" />
+      <PackageReference Include="BTCPayServer.Lightning.Common" Version="1.3.7" />
       <PackageReference Include="NBitcoin" Version="7.0.1" />
       <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     </ItemGroup>

--- a/BTCPayServer/BTCPayServer.csproj
+++ b/BTCPayServer/BTCPayServer.csproj
@@ -48,7 +48,7 @@
   <ItemGroup>
     <PackageReference Include="BIP78.Sender" Version="0.2.2" />
     <PackageReference Include="BTCPayServer.Hwi" Version="2.0.2" />
-    <PackageReference Include="BTCPayServer.Lightning.All" Version="1.3.10" />
+    <PackageReference Include="BTCPayServer.Lightning.All" Version="1.3.11" />
     <PackageReference Include="BuildBundlerMinifier" Version="3.2.449" />
     <PackageReference Include="BundlerMinifier.Core" Version="3.2.435" />
     <PackageReference Include="BundlerMinifier.TagHelpers" Version="3.2.435" />

--- a/BTCPayServer/Components/StoreLightningBalance/Default.cshtml
+++ b/BTCPayServer/Components/StoreLightningBalance/Default.cshtml
@@ -21,29 +21,36 @@
     }
     else
     {
-        <div class="balances d-flex flex-wrap">
-            <div class="balance me-3">
-                <h3 class="d-inline-block me-1">@Model.TotalOffchain</h3>
-                <span class="text-secondary fw-semibold text-nowrap">@Model.CryptoCode in channels</span>
-                @if (Model.TotalOffchain != LightMoney.Zero && Model.Balance.OffchainBalance != null)
-                {
+        <div class="balances d-flex flex-wrap gap-3">
+            @if (Model.TotalOffchain != LightMoney.Zero && Model.Balance.OffchainBalance != null)
+            {
+                <div class="balance">
+                    <h3 class="d-inline-block me-1">@Model.TotalOffchain</h3>
+                    <span class="text-secondary fw-semibold text-nowrap">@Model.CryptoCode in channels</span>
+
                     <div class="balance-details collapse" id="balanceDetailsOffchain">
-                        @if (Model.Balance.OffchainBalance.Opening != LightMoney.Zero)
+                        @if (Model.Balance.OffchainBalance.Opening != null && Model.Balance.OffchainBalance.Opening != LightMoney.Zero)
                         {
                             <div class="mt-2">
                                 <span class="fw-semibold">@Model.Balance.OffchainBalance.Opening</span>
                                 <span class="text-secondary text-nowrap">@Model.CryptoCode opening channels</span>
                             </div>
                         }
-                        <div class="mt-2">
-                            <span class="fw-semibold">@Model.Balance.OffchainBalance.Local</span>
-                            <span class="text-secondary text-nowrap">@Model.CryptoCode local balance</span>
-                        </div>
-                        <div class="mt-2">
-                            <span class="fw-semibold">@Model.Balance.OffchainBalance.Remote</span>
-                            <span class="text-secondary text-nowrap">@Model.CryptoCode remote balance</span>
-                        </div>
-                        @if (Model.Balance.OffchainBalance.Closing != LightMoney.Zero)
+                        @if (Model.Balance.OffchainBalance.Local != null)
+                        {
+                            <div class="mt-2">
+                                <span class="fw-semibold">@Model.Balance.OffchainBalance.Local</span>
+                                <span class="text-secondary text-nowrap">@Model.CryptoCode local balance</span>
+                            </div>
+                        }
+                        @if (Model.Balance.OffchainBalance.Remote != null)
+                        {
+                            <div class="mt-2">
+                                <span class="fw-semibold">@Model.Balance.OffchainBalance.Remote</span>
+                                <span class="text-secondary text-nowrap">@Model.CryptoCode remote balance</span>
+                            </div>
+                        }
+                        @if (Model.Balance.OffchainBalance.Closing != null && Model.Balance.OffchainBalance.Closing != LightMoney.Zero)
                         {
                             <div class="mt-2">
                                 <span class="fw-semibold">@Model.Balance.OffchainBalance.Closing</span>
@@ -51,29 +58,29 @@
                             </div>
                         }
                     </div>
-                }
-            </div>
-            <div class="balance">
-                <h3 class="d-inline-block me-1">@Model.TotalOnchain</h3>
-                <span class="text-secondary fw-semibold text-nowrap">@Model.CryptoCode on-chain</span>
-                @if (Model.TotalOnchain != LightMoney.Zero && Model.Balance.OnchainBalance != null)
-                {
+                </div>
+            }
+            @if (Model.TotalOnchain != LightMoney.Zero && Model.Balance.OnchainBalance != null)
+            {
+                <div class="balance">
+                    <h3 class="d-inline-block me-1">@Model.TotalOnchain</h3>
+                    <span class="text-secondary fw-semibold text-nowrap">@Model.CryptoCode on-chain</span>
                     <div class="balance-details collapse" id="balanceDetailsOnchain">
-                        @if (Model.Balance.OnchainBalance.Confirmed != LightMoney.Zero)
+                        @if (Model.Balance.OnchainBalance.Confirmed != null && Model.Balance.OnchainBalance.Confirmed != LightMoney.Zero)
                         {
                             <div class="mt-2">
                                 <span class="fw-semibold">@Model.Balance.OnchainBalance.Confirmed</span>
                                 <span class="text-secondary text-nowrap">@Model.CryptoCode confirmed</span>
                             </div>
                         }
-                        @if (Model.Balance.OnchainBalance.Unconfirmed != LightMoney.Zero)
+                        @if (Model.Balance.OnchainBalance.Unconfirmed != null && Model.Balance.OnchainBalance.Unconfirmed != LightMoney.Zero)
                         {
                             <div class="mt-2">
                                 <span class="fw-semibold">@Model.Balance.OnchainBalance.Unconfirmed</span>
                                 <span class="text-secondary text-nowrap">@Model.CryptoCode unconfirmed</span>
                             </div>
                         }
-                        @if (Model.Balance.OnchainBalance.Reserved != LightMoney.Zero)
+                        @if (Model.Balance.OnchainBalance.Reserved != null && Model.Balance.OnchainBalance.Reserved != LightMoney.Zero)
                         {
                             <div class="mt-2">
                                 <span class="fw-semibold">@Model.Balance.OnchainBalance.Reserved</span>
@@ -81,8 +88,8 @@
                             </div>
                         }
                     </div>
-                }
-            </div>
+                </div>
+            }
         </div>
         @if (Model.Balance.OffchainBalance != null && Model.Balance.OnchainBalance != null && (Model.TotalOffchain != LightMoney.Zero || Model.TotalOnchain != LightMoney.Zero))
         {

--- a/BTCPayServer/Components/StoreLightningBalance/StoreLightningBalance.cs
+++ b/BTCPayServer/Components/StoreLightningBalance/StoreLightningBalance.cs
@@ -61,13 +61,13 @@ public class StoreLightningBalance : ViewComponent
                 var balance = await lightningClient.GetBalance();
                 vm.Balance = balance;
                 vm.TotalOnchain = balance.OnchainBalance != null
-                    ? balance.OnchainBalance.Confirmed + balance.OnchainBalance.Reserved +
-                      balance.OnchainBalance.Unconfirmed
-                    : LightMoney.Zero;
+                    ? (balance.OnchainBalance.Confirmed?? 0) + (balance.OnchainBalance.Reserved ?? 0) +
+                      (balance.OnchainBalance.Unconfirmed ?? 0)
+                    : null;
                 vm.TotalOffchain = balance.OffchainBalance != null
-                    ? balance.OffchainBalance.Opening + balance.OffchainBalance.Local +
-                      balance.OffchainBalance.Closing
-                    : LightMoney.Zero;
+                    ? (balance.OffchainBalance.Opening?? 0) + (balance.OffchainBalance.Local?? 0) +
+                      (balance.OffchainBalance.Closing?? 0)
+                    : null;
             }
             catch (NotSupportedException)
             {


### PR DESCRIPTION
This way we can display only the values the underlying node supports, instead of pretending to know they are zero. See also btcpayserver/BTCPayServer.Lightning#81.