### PR TITLE
Fix nav height issue on mobile devices

### DIFF
--- a/BTCPayServer/wwwroot/main/layout.css
+++ b/BTCPayServer/wwwroot/main/layout.css
@@ -419,6 +419,14 @@
         outline: 0;
         transform: translateX(-100%);
         transition: transform var(--btcpay-transition-duration-fast) ease-in-out;
+        /* Fixes https://github.com/btcpayserver/btcpayserver/issues/3807 */
+        height: calc(100vh - var(--mobile-header-height)); /* This line is a fallback for browsers which don't support "fill-available" */
+        height: -moz-available;
+        height: -webkit-fill-available;
+        height: fill-available;
+        /* Since we can't do "calc(fill-available - var(--mobile-header-height));" I'm using "padding-bottom" instead */
+        padding-bottom: var(--mobile-header-height);
+        /* END FIX */
     }
 
     #mainNav.show {


### PR DESCRIPTION
close #3807

The reason this bug happen is that when we use "100vh" to set height (which is the default for the sidebar nav) the browser bar is not counted towards the height of the screen as long as it's in view so 100vh actually ends up giving us a height which is bigger than the visible height of the screen. This is a well-known issue and I've run into it before. See here for details:

https://stackoverflow.com/questions/37112218/css3-100vh-not-constant-in-mobile-browser
https://ilxanlar.medium.com/you-shouldnt-rely-on-css-100vh-and-here-s-why-1b4721e74487

|Before|After|
|---|---|
|![before](https://user-images.githubusercontent.com/1934678/174694171-b54e79b3-1caa-4298-917a-22ee8b6894ee.PNG)|![after](https://user-images.githubusercontent.com/1934678/174694190-8563af05-c645-4ee5-8cef-44bb1059dd69.PNG)|