### PR TITLE
UI: Fix cancel plugin command

### DIFF
--- a/BTCPayServer/Controllers/UIServerController.Plugins.cs
+++ b/BTCPayServer/Controllers/UIServerController.Plugins.cs
@@ -66,6 +66,7 @@ namespace BTCPayServer.Controllers
 
             return RedirectToAction("ListPlugins");
         }
+        
         [HttpPost("server/plugins/cancel")]
         public IActionResult CancelPluginCommands(
             [FromServices] PluginService pluginService, string plugin)
@@ -93,7 +94,6 @@ namespace BTCPayServer.Controllers
                 }
                 else
                 {
-
                     pluginService.InstallPlugin(plugin);
                 }
                 TempData.SetStatusMessageModel(new StatusMessageModel()

--- a/BTCPayServer/Views/UIServer/ListPlugins.cshtml
+++ b/BTCPayServer/Views/UIServer/ListPlugins.cshtml
@@ -292,13 +292,11 @@
                         }
                     </div>
                     <div class="card-footer border-0 pb-3">
-                        @{ var pending = Model.Commands.Any(tuple => tuple.plugin.Equals(plugin.Identifier, StringComparison.InvariantCultureIgnoreCase)); }
-                        @if (pending)
+                        @{ var pending = Model.Commands.LastOrDefault(tuple => tuple.plugin.Equals(plugin.Identifier, StringComparison.InvariantCultureIgnoreCase)); }
+                        @if (!pending.Equals(default))
                         {
-                            var (command, _) = Model.Commands.Last(tuple => tuple.plugin.Equals(plugin.Identifier, StringComparison.InvariantCultureIgnoreCase));
-
                             <form asp-action="CancelPluginCommands" asp-route-plugin="@plugin.Identifier">
-                                <button type="submit" class="btn btn-outline-secondary">Cancel pending @command</button>
+                                <button type="submit" class="btn btn-outline-secondary">Cancel pending @pending.command</button>
                             </form>
                         }
                         else if (DependenciesMet(plugin.Dependencies))

--- a/BTCPayServer/Views/UIServer/ListPlugins.cshtml
+++ b/BTCPayServer/Views/UIServer/ListPlugins.cshtml
@@ -291,20 +291,15 @@
                             </ul>
                         }
                     </div>
-                    @{
-                        var pending = Model.Commands.Any(tuple => tuple.plugin.Equals(plugin.Identifier, StringComparison.InvariantCultureIgnoreCase));
-                        var pluginCommands = Model.Commands.GroupBy(tuple => tuple.plugin.Equals(plugin.Identifier, StringComparison.InvariantCultureIgnoreCase));
-                    }
                     <div class="card-footer border-0 pb-3">
+                        @{ var pending = Model.Commands.Any(tuple => tuple.plugin.Equals(plugin.Identifier, StringComparison.InvariantCultureIgnoreCase)); }
                         @if (pending)
                         {
-                            @foreach (var command in pluginCommands)
-                            {
-                                
-                                <form asp-action="CancelPluginCommands" asp-route-plugin="@plugin.Identifier">
-                                    <button type="submit" class="btn btn-outline-secondary">Cancel pending @command.Last().command</button>
-                                </form>
-                            }
+                            var (command, _) = Model.Commands.Last(tuple => tuple.plugin.Equals(plugin.Identifier, StringComparison.InvariantCultureIgnoreCase));
+
+                            <form asp-action="CancelPluginCommands" asp-route-plugin="@plugin.Identifier">
+                                <button type="submit" class="btn btn-outline-secondary">Cancel pending @command</button>
+                            </form>
                         }
                         else if (DependenciesMet(plugin.Dependencies))
                         {


### PR DESCRIPTION
As installing a plugin also adds the delete/uninstall command, we just select the last action, which is the one the user triggered. 

Fixes #3890.

The alternative would have been to display both actions, but that's just an implementation details here. This would look werid to the user, who just clicked the install button ….

![grafik](https://user-images.githubusercontent.com/886/176123280-1957ebaf-750f-4750-8a22-c14b7f0c4fc0.png)
