### PR TITLE
Can disable cert check for email server

### DIFF
--- a/BTCPayServer.Client/Models/EmailSettingsData.cs
+++ b/BTCPayServer.Client/Models/EmailSettingsData.cs
@@ -25,4 +25,5 @@ public class EmailSettingsData
     {
         get; set;
     }
+    public bool DisableCertificateCheck { get; set; }
 }

--- a/BTCPayServer/Services/Mails/EmailSettings.cs
+++ b/BTCPayServer/Services/Mails/EmailSettings.cs
@@ -68,7 +68,7 @@ namespace BTCPayServer.Services.Mails
             using var connectCancel = new CancellationTokenSource(10000);
             try
             {
-                if (Extensions.IsLocalNetwork(Server))
+                if (DisableCertificateCheck)
                 {
                     client.CheckCertificateRevocation = false;
 #pragma warning disable CA5359 // Do Not Disable Certificate Validation

--- a/BTCPayServer/Services/MigrationSettings.cs
+++ b/BTCPayServer/Services/MigrationSettings.cs
@@ -31,5 +31,6 @@ namespace BTCPayServer.Services
         public bool LighingAddressSettingRename { get; set; }
         public bool LighingAddressDatabaseMigration { get; set; }
         public bool AddStoreToPayout { get; set; }
+        public bool MigrateEmailServerDisableTLSCerts { get; set; }
     }
 }

--- a/BTCPayServer/Views/Shared/EmailsBody.cshtml
+++ b/BTCPayServer/Views/Shared/EmailsBody.cshtml
@@ -70,6 +70,21 @@
                 }
             </div>
             <input asp-for="PasswordSet" type="hidden"/>
+			<div class="my-4">
+                <button class="btn btn-link text-primary p-0" type="button" id="AdvancedSettingsButton" data-bs-toggle="collapse" data-bs-target="#AdvancedSettings" aria-expanded="false" aria-controls="AdvancedSettings">
+                    Advanced settings
+                </button>
+                <div id="AdvancedSettings" class="collapse">
+                    <div class="pt-3 pb-1">
+                        <div class="form-group">
+                            <div class="form-check">
+                                <input asp-for="Settings.DisableCertificateCheck" class="form-check-input" />
+                                <label asp-for="Settings.DisableCertificateCheck" class="form-check-label">Disable TLS certificate security checks</label>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
             <button type="submit" class="btn btn-primary mt-2" name="command" value="Save" id="Save">Save</button>
         </div>
     </div>


### PR DESCRIPTION
This is meant to address https://github.com/btcpayserver/btcpayserver/discussions/3895 reported by @michnovka

We were before silently removing cert check when the hostname was considered local.
If we have an option for it, then it doesn't make sense to have such silent behavior anymore.

It is migrating old stores with local hostnames to skip cert check so it doesn't blow up unexpectedly for them.

![image](https://user-images.githubusercontent.com/3020646/176366123-779d7488-149c-407a-92b7-fb518a612ea3.png)
