### PR TITLE
Enhance Store email capability

### DIFF
--- a/BTCPayServer/Controllers/GreenField/GreenfieldInvoiceController.cs
+++ b/BTCPayServer/Controllers/GreenField/GreenfieldInvoiceController.cs
@@ -12,6 +12,7 @@ using BTCPayServer.Services;
 using BTCPayServer.Services.Invoices;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Cors;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
 using NBitcoin;
@@ -389,7 +390,13 @@ namespace BTCPayServer.Controllers.Greenfield
                 ReceivedDate = paymentEntity.ReceivedTime.DateTime
             };
         }
+
         private InvoiceData ToModel(InvoiceEntity entity)
+        {
+            return ToModel(entity, _linkGenerator, Request);
+        }
+
+        public static InvoiceData ToModel(InvoiceEntity entity, LinkGenerator linkGenerator, HttpRequest request)
         {
             var statuses = new List<InvoiceStatus>();
             var state = entity.GetInvoiceState();
@@ -411,7 +418,7 @@ namespace BTCPayServer.Controllers.Greenfield
                 Amount = entity.Price,
                 Type = entity.Type,
                 Id = entity.Id,
-                CheckoutLink = _linkGenerator.CheckoutLink(entity.Id, Request.Scheme, Request.Host, Request.PathBase),
+                CheckoutLink = linkGenerator.CheckoutLink(entity.Id, request.Scheme, request.Host, request.PathBase),
                 Status = entity.Status.ToModernStatus(),
                 AdditionalStatus = entity.ExceptionStatus,
                 Currency = entity.Currency,

--- a/BTCPayServer/Controllers/GreenField/GreenfieldInvoiceController.cs
+++ b/BTCPayServer/Controllers/GreenField/GreenfieldInvoiceController.cs
@@ -396,7 +396,7 @@ namespace BTCPayServer.Controllers.Greenfield
             return ToModel(entity, _linkGenerator, Request);
         }
 
-        public static InvoiceData ToModel(InvoiceEntity entity, LinkGenerator linkGenerator, HttpRequest request)
+        public static InvoiceData ToModel(InvoiceEntity entity, LinkGenerator linkGenerator, HttpRequest? request)
         {
             var statuses = new List<InvoiceStatus>();
             var state = entity.GetInvoiceState();
@@ -418,7 +418,7 @@ namespace BTCPayServer.Controllers.Greenfield
                 Amount = entity.Price,
                 Type = entity.Type,
                 Id = entity.Id,
-                CheckoutLink = linkGenerator.CheckoutLink(entity.Id, request.Scheme, request.Host, request.PathBase),
+                CheckoutLink = request is null? null: linkGenerator.CheckoutLink(entity.Id, request.Scheme, request.Host, request.PathBase),
                 Status = entity.Status.ToModernStatus(),
                 AdditionalStatus = entity.ExceptionStatus,
                 Currency = entity.Currency,

--- a/BTCPayServer/HostedServices/StoreEmailRuleProcessorSender.cs
+++ b/BTCPayServer/HostedServices/StoreEmailRuleProcessorSender.cs
@@ -92,6 +92,6 @@ public class StoreEmailRuleProcessorSender : EventHostedServiceBase
             .Replace("{Invoice.Price}", i.Amount.ToString(CultureInfo.InvariantCulture))
             .Replace("{Invoice.Currency}", i.Currency)
             .Replace("{Invoice.Status}", i.Status.ToString())
-            .Replace("{Invoice.AdditionalStatus}", i.AdditionalStatus.ToString())
+            .Replace("{Invoice.AdditionalStatus}", i.AdditionalStatus.ToString());
     }
 }

--- a/BTCPayServer/HostedServices/StoreEmailRuleProcessorSender.cs
+++ b/BTCPayServer/HostedServices/StoreEmailRuleProcessorSender.cs
@@ -1,14 +1,18 @@
 using System;
+using System.Globalization;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using BTCPayServer.Controllers;
 using BTCPayServer.Data;
+using BTCPayServer.Controllers.Greenfield;
 using BTCPayServer.Events;
+using BTCPayServer.Services;
 using BTCPayServer.Services.Mails;
 using BTCPayServer.Services.Stores;
+using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.Logging;
-using MimeKit;
+using InvoiceData = BTCPayServer.Client.Models.InvoiceData;
 
 namespace BTCPayServer.HostedServices;
 
@@ -16,14 +20,19 @@ public class StoreEmailRuleProcessorSender : EventHostedServiceBase
 {
     private readonly StoreRepository _storeRepository;
     private readonly EmailSenderFactory _emailSenderFactory;
+    private readonly LinkGenerator _linkGenerator;
+    private readonly BTCPayServerEnvironment _environment;
 
     public StoreEmailRuleProcessorSender(StoreRepository storeRepository, EventAggregator eventAggregator,
         ILogger<InvoiceEventSaverService> logger,
-        EmailSenderFactory emailSenderFactory) : base(
+        EmailSenderFactory emailSenderFactory,
+        LinkGenerator linkGenerator, BTCPayServerEnvironment environment) : base(
         eventAggregator, logger)
     {
         _storeRepository = storeRepository;
         _emailSenderFactory = emailSenderFactory;
+        _linkGenerator = linkGenerator;
+        _environment = environment;
     }
 
     protected override void SubscribeToEvents()
@@ -54,17 +63,37 @@ public class StoreEmailRuleProcessorSender : EventHostedServiceBase
                     foreach (UIStoresController.StoreEmailRule actionableRule in actionableRules)
                     {
                         var recipients = actionableRule.To.Split(",", StringSplitOptions.RemoveEmptyEntries)
-                            .Select(o => { MailboxAddressValidator.TryParse(o, out var mb); return mb; })
+                            .Select(o =>
+                            {
+                                MailboxAddressValidator.TryParse(o, out var mb);
+                                return mb;
+                            })
                             .Where(o => o != null)
                             .ToList();
-                        if (actionableRule.CustomerEmail && MailboxAddressValidator.TryParse(invoiceEvent.Invoice.Metadata.BuyerEmail, out var bmb))
+                        if (actionableRule.CustomerEmail &&
+                            MailboxAddressValidator.TryParse(invoiceEvent.Invoice.Metadata.BuyerEmail, out var bmb))
                         {
                             recipients.Add(bmb);
                         }
-                        sender.SendEmail(recipients.ToArray(), null, null, actionableRule.Subject, actionableRule.Body);
+                        //TODO: FIX ME! how do we determine host when we have no context?
+                        var i = GreenfieldInvoiceController.ToModel(invoiceEvent.Invoice, _linkGenerator, null);
+                        sender.SendEmail(recipients.ToArray(), null, null, Interpolator(actionableRule.Subject, i),
+                            Interpolator(actionableRule.Body, i));
                     }
                 }
             }
         }
+    }
+
+    private string Interpolator(string str, InvoiceData i)
+    {
+        //TODO: we should switch to https://dotnetfiddle.net/MoqJFk later
+        return str.Replace("{Invoice.Id}", i.Id)
+            .Replace("{Invoice.StoreId}", i.StoreId)
+            .Replace("{Invoice.Price}", i.Amount.ToString(CultureInfo.InvariantCulture))
+            .Replace("{Invoice.Currency}", i.Currency)
+            .Replace("{Invoice.Currency}", i.Status.ToString())
+            .Replace("{Invoice.AdditionalStatus}", i.AdditionalStatus.ToString())
+            .Replace("{Invoice.CheckoutLink}", i.CheckoutLink);
     }
 }

--- a/BTCPayServer/HostedServices/StoreEmailRuleProcessorSender.cs
+++ b/BTCPayServer/HostedServices/StoreEmailRuleProcessorSender.cs
@@ -75,7 +75,6 @@ public class StoreEmailRuleProcessorSender : EventHostedServiceBase
                         {
                             recipients.Add(bmb);
                         }
-                        //TODO: FIX ME! how do we determine host when we have no context?
                         var i = GreenfieldInvoiceController.ToModel(invoiceEvent.Invoice, _linkGenerator, null);
                         sender.SendEmail(recipients.ToArray(), null, null, Interpolator(actionableRule.Subject, i),
                             Interpolator(actionableRule.Body, i));
@@ -92,8 +91,7 @@ public class StoreEmailRuleProcessorSender : EventHostedServiceBase
             .Replace("{Invoice.StoreId}", i.StoreId)
             .Replace("{Invoice.Price}", i.Amount.ToString(CultureInfo.InvariantCulture))
             .Replace("{Invoice.Currency}", i.Currency)
-            .Replace("{Invoice.Currency}", i.Status.ToString())
+            .Replace("{Invoice.Status}", i.Status.ToString())
             .Replace("{Invoice.AdditionalStatus}", i.AdditionalStatus.ToString())
-            .Replace("{Invoice.CheckoutLink}", i.CheckoutLink);
     }
 }

--- a/BTCPayServer/Views/UIStores/StoreEmails.cshtml
+++ b/BTCPayServer/Views/UIStores/StoreEmails.cshtml
@@ -59,7 +59,7 @@
                         </div>
                         <div class="form-group">
                             <label asp-for="Rules[index].Body" class="form-label" ></label>
-                            <textarea asp-for="Rules[index].Body" class="form-control richtext" rows="4"></textarea>
+                            <textarea asp-for="Rules[index].Body" class="form-control" rows="4"></textarea>
                             <span asp-validation-for="Rules[index].Body" class="text-danger"></span>
                         </div>
                     </li>
@@ -74,11 +74,6 @@
         }
     </div>
 </form>
-@section PageHeadContent {
-    <link href="~/vendor/summernote/summernote-bs5.css" rel="stylesheet" asp-append-version="true"/>
-}
-
 @section PageFootContent {
     <partial name="_ValidationScriptsPartial"/>
-    <script src="~/vendor/summernote/summernote-bs5.js" asp-append-version="true"></script>
 }

--- a/BTCPayServer/Views/UIStores/StoreEmails.cshtml
+++ b/BTCPayServer/Views/UIStores/StoreEmails.cshtml
@@ -59,7 +59,7 @@
                         </div>
                         <div class="form-group">
                             <label asp-for="Rules[index].Body" class="form-label" ></label>
-                            <textarea asp-for="Rules[index].Body" class="form-control" rows="4"></textarea>
+                            <textarea asp-for="Rules[index].Body" class="form-control richtext" rows="4"></textarea>
                             <span asp-validation-for="Rules[index].Body" class="text-danger"></span>
                         </div>
                     </li>
@@ -74,7 +74,11 @@
         }
     </div>
 </form>
+@section PageHeadContent {
+    <link href="~/vendor/summernote/summernote-bs5.css" rel="stylesheet" asp-append-version="true"/>
+}
 
 @section PageFootContent {
     <partial name="_ValidationScriptsPartial"/>
+    <script src="~/vendor/summernote/summernote-bs5.js" asp-append-version="true"></script>
 }

--- a/BTCPayServer/wwwroot/main/site.js
+++ b/BTCPayServer/wwwroot/main/site.js
@@ -58,7 +58,6 @@ document.addEventListener("DOMContentLoaded", function () {
             }));
         }
     });
-    
     // rich text editor
     if ($.summernote) {
         $('.richtext').summernote({


### PR DESCRIPTION
Currenty the new email rules can send an email when an invoice event occurs. However, there is currently no way to customize the email based on the invoice, making the feature a bit useless.

This PR:
* ~adds the rich text editor to the body input~
* allows you to use some of the properties from the Invoice (based on greenfield api properties. I've taken a imple approach for now using just  a string.replace mechanism, but we can update this to a dynamic linq approach so that users can customize further (e.g. `{Invoice.Metadata["something"].ToString().ToUpper()}`)

~NOT READY:
Since this all takes place as a background service, there is an issue around how to handle items such as the "checkout link", as we are not aware of the btcpay url at that moment. Thoughts? @nicolasdorier~
