### PR TITLE
Do not show the Send button if in the send wallet view

### DIFF
--- a/BTCPayServer/Components/WalletNav/Default.cshtml
+++ b/BTCPayServer/Components/WalletNav/Default.cshtml
@@ -15,7 +15,7 @@
         </div>
     </a>
     <div class="d-flex gap-3 mt-3 mt-sm-0" permission="@Policies.CanModifyStoreSettings">
-        @if (!Model.Network.ReadonlyWallet)
+        @if (!Model.Network.ReadonlyWallet && ViewData.IsActivePage(WalletsNavPages.Send) is null)
         {
             <a class="btn btn-primary" asp-controller="UIWallets" asp-action="WalletSend" asp-route-walletId="@Model.WalletId" id="WalletNav-Send">Send</a>
         }


### PR DESCRIPTION
Ping @dstrukt 

Myself and another user I know got tricked into clicking on "Send" in the page when we wanted to click on "Send transaction".
This PR is removing the button when we are on the send view so we can't fuck up and lose everything.

Before:
![image](https://user-images.githubusercontent.com/3020646/176458909-3fd0cd63-4fa2-4e08-b79f-96335cf93c78.png)

After:
![image](https://user-images.githubusercontent.com/3020646/176459027-0519b1cc-c594-42b5-a5bb-dc765321e48a.png)
