### PR TITLE
Open public app views in new tab/window

### DIFF
--- a/BTCPayServer/Views/UIApps/UpdateCrowdfund.cshtml
+++ b/BTCPayServer/Views/UIApps/UpdateCrowdfund.cshtml
@@ -27,7 +27,7 @@
             <button type="submit" class="btn btn-primary order-sm-1" id="SaveSettings">Save</button>   
             @if (Model.ModelWithMinimumData)
             {
-                <a class="btn btn-secondary" asp-action="ViewCrowdfund" asp-controller="UIAppsPublic" asp-route-appId="@Model.AppId" id="ViewApp" target="app_@Model.AppId">View</a>
+                <a class="btn btn-secondary" asp-action="ViewCrowdfund" asp-controller="UIAppsPublic" asp-route-appId="@Model.AppId" id="ViewApp" target="_blank">View</a>
             }
         </div>
     </div>

--- a/BTCPayServer/Views/UIApps/UpdatePointOfSale.cshtml
+++ b/BTCPayServer/Views/UIApps/UpdatePointOfSale.cshtml
@@ -11,7 +11,7 @@
         <h2 class="mb-0">@ViewData["Title"]</h2>
         <div class="d-flex gap-3 mt-3 mt-sm-0">
             <button type="submit" class="btn btn-primary order-sm-1" id="SaveSettings">Save</button>
-            <a class="btn btn-secondary" asp-action="ViewPointOfSale" asp-controller="UIAppsPublic" asp-route-appId="@Model.Id" id="ViewApp" target="app_@Model.AppId">View</a>
+            <a class="btn btn-secondary" asp-action="ViewPointOfSale" asp-controller="UIAppsPublic" asp-route-appId="@Model.Id" id="ViewApp" target="_blank">View</a>
         </div>
     </div>
 


### PR DESCRIPTION
Fixes behaviour differences across browsers: Instead of reusing potentially existing windows/tabs (which the browser might not switch to), we go back to what we had before and open a new tab/window whenever the "View" link is clicked.