### PR TITLE
Improve performance of on chain transaction listing for big wallets

### DIFF
--- a/BTCPayServer.Client/Models/TransactionStatus.cs
+++ b/BTCPayServer.Client/Models/TransactionStatus.cs
@@ -3,7 +3,6 @@ namespace BTCPayServer.Client.Models
     public enum TransactionStatus
     {
         Unconfirmed,
-        Confirmed,
-        Replaced
+        Confirmed
     }
 }

--- a/BTCPayServer.Tests/BTCPayServerTester.cs
+++ b/BTCPayServer.Tests/BTCPayServerTester.cs
@@ -75,6 +75,10 @@ namespace BTCPayServer.Tests
         {
             get; set;
         }
+        public string ExplorerPostgres
+        {
+            get; set;
+        }
 
         IWebHost _Host;
         public int Port
@@ -154,6 +158,9 @@ namespace BTCPayServer.Tests
                 config.AppendLine($"mysql=" + MySQL);
             else if (!String.IsNullOrEmpty(Postgres))
                 config.AppendLine($"postgres=" + Postgres);
+
+            if (!string.IsNullOrEmpty(ExplorerPostgres))
+                config.AppendLine($"explorer.postgres=" + ExplorerPostgres);
             var confPath = Path.Combine(chainDirectory, "settings.config");
             await File.WriteAllTextAsync(confPath, config.ToString());
 

--- a/BTCPayServer.Tests/ServerTester.cs
+++ b/BTCPayServer.Tests/ServerTester.cs
@@ -50,6 +50,7 @@ namespace BTCPayServer.Tests
                 // since in dev we already can have some users / stores registered, while on CI database is being initalized
                 // for the first time and first registered user gets admin status by default
                 Postgres = GetEnvironment("TESTS_POSTGRES", "User ID=postgres;Include Error Detail=true;Host=127.0.0.1;Port=39372;Database=btcpayserver"),
+                ExplorerPostgres = GetEnvironment("TESTS_EXPLORER_POSTGRES", "User ID=postgres;Include Error Detail=true;Host=127.0.0.1;Port=39372;Database=nbxplorer"),
                 MySQL = GetEnvironment("TESTS_MYSQL", "User ID=root;Host=127.0.0.1;Port=33036;Database=btcpayserver")
             };
             if (newDb)

--- a/BTCPayServer.Tests/docker-compose.altcoins.yml
+++ b/BTCPayServer.Tests/docker-compose.altcoins.yml
@@ -18,6 +18,7 @@ services:
       TESTS_LTCNBXPLORERURL: http://nbxplorer:32838/
       TESTS_DB: "Postgres"
       TESTS_POSTGRES: User ID=postgres;Include Error Detail=true;Host=postgres;Port=5432;Database=btcpayserver
+      TESTS_EXPLORER_POSTGRES: User ID=postgres;Include Error Detail=true;Host=postgres;Port=5432;Database=nbxplorer
       TESTS_HOSTNAME: tests
       TESTS_RUN_EXTERNAL_INTEGRATION: ${TESTS_RUN_EXTERNAL_INTEGRATION:-"false"}
       TESTS_AzureBlobStorageConnectionString: ${TESTS_AzureBlobStorageConnectionString:-none}

--- a/BTCPayServer.Tests/docker-compose.yml
+++ b/BTCPayServer.Tests/docker-compose.yml
@@ -16,6 +16,7 @@ services:
       TESTS_BTCNBXPLORERURL: http://nbxplorer:32838/
       TESTS_DB: "Postgres"
       TESTS_POSTGRES: User ID=postgres;Include Error Detail=true;Host=postgres;Port=5432;Database=btcpayserver
+      TESTS_EXPLORER_POSTGRES: User ID=postgres;Include Error Detail=true;Host=postgres;Port=5432;Database=nbxplorer
       TESTS_HOSTNAME: tests
       TESTS_RUN_EXTERNAL_INTEGRATION: ${TESTS_RUN_EXTERNAL_INTEGRATION:-"false"}
       TESTS_AzureBlobStorageConnectionString: ${TESTS_AzureBlobStorageConnectionString:-none}

--- a/BTCPayServer/Components/StoreRecentTransactions/StoreRecentTransactions.cs
+++ b/BTCPayServer/Components/StoreRecentTransactions/StoreRecentTransactions.cs
@@ -27,7 +27,6 @@ public class StoreRecentTransactions : ViewComponent
     private readonly BTCPayWalletProvider _walletProvider;
 
     public BTCPayNetworkProvider NetworkProvider { get; }
-    public NBXplorerConnectionFactory ConnectionFactory { get; }
 
     public StoreRecentTransactions(
         StoreRepository storeRepo,
@@ -38,7 +37,6 @@ public class StoreRecentTransactions : ViewComponent
     {
         _storeRepo = storeRepo;
         NetworkProvider = networkProvider;
-        ConnectionFactory = connectionFactory;
         _walletProvider = walletProvider;
         _dbContextFactory = dbContextFactory;
         CryptoCode = networkProvider.DefaultNetwork.CryptoCode;
@@ -52,57 +50,20 @@ public class StoreRecentTransactions : ViewComponent
         var transactions = new List<StoreRecentTransactionViewModel>();
         if (derivationSettings?.AccountDerivation is not null)
         {
-            if (ConnectionFactory.Available)
-            {
-                var wallet_id = derivationSettings.GetNBXWalletId();
-                await using var conn = await ConnectionFactory.OpenConnection();
-                var rows = await conn.QueryAsync(
-                    "SELECT t.tx_id, t.seen_at, to_btc(balance_change::NUMERIC) balance_change, (t.blk_id IS NOT NULL) confirmed " +
-                    "FROM get_wallets_recent(@wallet_id, @code, @interval, 5, 0) " +
-                    "JOIN txs t USING (code, tx_id) " +
-                    "ORDER BY seen_at DESC;",
-                    new
-                    {
-                        wallet_id,
-                        code = CryptoCode,
-                        interval = TimeSpan.FromDays(31)
-                    });
-                var network = derivationSettings.Network;
-                foreach (var r in rows)
+            var network = derivationSettings.Network;
+            var wallet = _walletProvider.GetWallet(network);
+            var allTransactions = await wallet.FetchTransactionHistory(derivationSettings.AccountDerivation, 0, 5, TimeSpan.FromDays(31.0));
+            transactions = allTransactions
+                .Select(tx => new StoreRecentTransactionViewModel
                 {
-                    var seenAt = new DateTimeOffset(((DateTime)r.seen_at));
-                    var balanceChange = new Money((decimal)r.balance_change, MoneyUnit.BTC);
-                    transactions.Add(new StoreRecentTransactionViewModel()
-                    {
-                        Timestamp = seenAt,
-                        Id = r.tx_id,
-                        Balance = balanceChange.ShowMoney(network),
-                        IsConfirmed = r.confirmed,
-                        Link = string.Format(CultureInfo.InvariantCulture, network.BlockExplorerLink, r.tx_id),
-                        Positive = balanceChange.GetValue(network) >= 0,
-                    });
-                }
-            }
-            else
-            {
-                var network = derivationSettings.Network;
-                var wallet = _walletProvider.GetWallet(network);
-                var allTransactions = await wallet.FetchTransactions(derivationSettings.AccountDerivation);
-                transactions = allTransactions.UnconfirmedTransactions.Transactions
-                    .Concat(allTransactions.ConfirmedTransactions.Transactions).ToArray()
-                    .OrderByDescending(t => t.Timestamp)
-                    .Take(5)
-                    .Select(tx => new StoreRecentTransactionViewModel
-                    {
-                        Id = tx.TransactionId.ToString(),
-                        Positive = tx.BalanceChange.GetValue(network) >= 0,
-                        Balance = tx.BalanceChange.ShowMoney(network),
-                        IsConfirmed = tx.Confirmations != 0,
-                        Link = string.Format(CultureInfo.InvariantCulture, network.BlockExplorerLink, tx.TransactionId.ToString()),
-                        Timestamp = tx.Timestamp
-                    })
-                    .ToList();
-            }
+                    Id = tx.TransactionId.ToString(),
+                    Positive = tx.BalanceChange.GetValue(network) >= 0,
+                    Balance = tx.BalanceChange.ShowMoney(network),
+                    IsConfirmed = tx.Confirmations != 0,
+                    Link = string.Format(CultureInfo.InvariantCulture, network.BlockExplorerLink, tx.TransactionId.ToString()),
+                    Timestamp = tx.SeenAt
+                })
+                .ToList();
         }
 
 

--- a/BTCPayServer/Services/Wallets/BTCPayWalletProvider.cs
+++ b/BTCPayServer/Services/Wallets/BTCPayWalletProvider.cs
@@ -18,6 +18,7 @@ namespace BTCPayServer.Services.Wallets
                                     IOptions<MemoryCacheOptions> memoryCacheOption,
                                     Data.ApplicationDbContextFactory dbContextFactory,
                                     BTCPayNetworkProvider networkProvider,
+                                    NBXplorerConnectionFactory nbxplorerConnectionFactory,
                                     Logs logs)
         {
             ArgumentNullException.ThrowIfNull(client);
@@ -31,7 +32,7 @@ namespace BTCPayServer.Services.Wallets
                 var explorerClient = _Client.GetExplorerClient(network.CryptoCode);
                 if (explorerClient == null)
                     continue;
-                _Wallets.Add(network.CryptoCode.ToUpperInvariant(), new BTCPayWallet(explorerClient, new MemoryCache(_Options), network, dbContextFactory, Logs));
+                _Wallets.Add(network.CryptoCode.ToUpperInvariant(), new BTCPayWallet(explorerClient, new MemoryCache(_Options), network, dbContextFactory,  nbxplorerConnectionFactory, Logs));
             }
         }
 

--- a/BTCPayServer/Services/Wallets/Export/TransactionsExport.cs
+++ b/BTCPayServer/Services/Wallets/Export/TransactionsExport.cs
@@ -26,14 +26,14 @@ namespace BTCPayServer.Services.Wallets.Export
             _walletTransactionsInfo = walletTransactionsInfo;
         }
 
-        public string Process(IEnumerable<TransactionInformation> inputList, string fileFormat)
+        public string Process(IEnumerable<TransactionHistoryLine> inputList, string fileFormat)
         {
             var list = inputList.Select(tx =>
             {
                 var model = new ExportTransaction
                 {
                     TransactionId = tx.TransactionId.ToString(),
-                    Timestamp = tx.Timestamp,
+                    Timestamp = tx.SeenAt,
                     Amount = tx.BalanceChange.ShowMoney(_wallet.Network),
                     Currency = _wallet.Network.CryptoCode,
                     IsConfirmed = tx.Confirmations != 0

--- a/BTCPayServer/wwwroot/swagger/v1/swagger.template.stores-wallet.on-chain.json
+++ b/BTCPayServer/wwwroot/swagger/v1/swagger.template.stores-wallet.on-chain.json
@@ -689,13 +689,11 @@
                 "description": "",
                 "x-enumNames": [
                     "Unconfirmed",
-                    "Confirmed",
-                    "Replaced"
+                    "Confirmed"
                 ],
                 "enum": [
                     "Unconfirmed",
-                    "Confirmed",
-                    "Replaced"
+                    "Confirmed"
                 ]
             },
             "LabelData": {


### PR DESCRIPTION
This will improve performance dramatically for big wallets.
Before, anywhere we would query the wallet transactions, all the transactions from the wallet would be fetched from database, even if a subset of those were actually display or required.

Got reports for some install of the `/transactions` view and also the dashboard, which display only the 5 first transactions, taking 1 minute!

Breaking change:

* I needed to drop `TransactionStatus.Replaced` filter as the query database is already filtering those. While I could still support if if really needed (by falling back to the wasteful request if the filter is present), this make additional boilerplate, for a feature probably unused. If somebody complain, I will fallback on the old inefficient way. On top of it it wasn't tested.