### PR TITLE
Improves switch UI component consistency

### DIFF
--- a/BTCPayServer/Views/UIStores/LightningSettings.cshtml
+++ b/BTCPayServer/Views/UIStores/LightningSettings.cshtml
@@ -79,36 +79,47 @@
                     </div>
                     
                     <h3 class="mt-5 mb-3" id="ln-url">LNURL</h3>
-                    <div class="d-flex align-items-center">
+                    <div class="form-group d-flex align-items-center">
                         <input asp-for="LNURLEnabled" type="checkbox" class="btcpay-toggle me-3" data-bs-toggle="collapse" data-bs-target="#LNURLSettings" aria-expanded="@Model.LNURLEnabled" aria-controls="LNURLSettings"/>
                         <label asp-for="LNURLEnabled" class="form-label mb-0 me-1"></label>
                     </div>
+
                     <div class="collapse @(Model.LNURLEnabled ? "show" : "")" id="LNURLSettings">
                         <div class="form-group">
-                            <div class="d-flex align-items-center pt-4">
-                                <input type="checkbox" asp-for="LNURLBech32Mode" class="btcpay-toggle me-3"/>
-                                <label asp-for="LNURLBech32Mode" class="form-label mb-0 me-1"></label>
-                                <span asp-validation-for="LNURLBech32Mode" class="text-danger"></span>
-                            </div>
-                            <p class="form-text text-muted mb-0">For wallet compatibility: Bech32 encoded (classic) vs. cleartext URL (upcoming)</p>
+                            <label class="form-group d-flex align-items-center">
+                                <input type="checkbox" asp-for="LNURLBech32Mode" class="btcpay-toggle me-3" />
+                                <div class="">
+                                    <label asp-for="LNURLBech32Mode" class="form-label mb-0 me-1"></label>
+                                    <span asp-validation-for="LNURLBech32Mode" class="text-danger"></span>
+
+                                    <p class="form-text text-muted mb-0">For wallet compatibility: Bech32 encoded (classic) vs. cleartext URL (upcoming)</p>
+                                </div>
+                            </label>
                         </div>
+
                         <div class="form-group">
-                            <div class="d-flex align-items-center">
-                                <input type="checkbox" asp-for="LNURLStandardInvoiceEnabled" class="btcpay-toggle me-3"/>
-                                <label asp-for="LNURLStandardInvoiceEnabled" class="form-label mb-0 me-1"></label>
-                            </div>
-                            <p class="form-text text-muted mb-0">Required for Lightning Address, the pay button and apps.</p>
+                            <label class="form-group d-flex align-items-center">
+                                <input type="checkbox" asp-for="LNURLStandardInvoiceEnabled" class="btcpay-toggle me-3" />
+                                <div class="">
+                                    <label asp-for="LNURLStandardInvoiceEnabled" class="form-label mb-0 me-1"></label>
+                                    <p class="form-text text-muted mb-0">Required for Lightning Address, the pay button and apps.</p>
+                                </div>
+                            </label>
                         </div>
+
                         <div class="form-group">
-                            <div class="d-flex align-items-center">
-                                <input type="checkbox" asp-for="DisableBolt11PaymentMethod" class="btcpay-toggle me-3"/>
-                                <label asp-for="DisableBolt11PaymentMethod" class="form-label mb-0 me-1"></label>
-                            </div>
-                            <p class="form-text text-muted mb-0">Performance: Turn it off if users should pay only via LNURL.</p>
+                            <label class="form-group d-flex align-items-center">
+                                <input type="checkbox" asp-for="DisableBolt11PaymentMethod" class="btcpay-toggle me-3" />
+                                <div class="">
+                                    <label asp-for="DisableBolt11PaymentMethod" class="form-label mb-0 me-1"></label>
+                                    <p class="form-text text-muted mb-0">Performance: Turn it off if users should pay only via LNURL.</p>
+                                </div>
+                            </label>
                         </div>
-                        <div class="form-group mb-0 pb-2">
+
+                        <div class="form-group mb-3">
                             <div class="d-flex align-items-center">
-                                <input type="checkbox" asp-for="LUD12Enabled" class="btcpay-toggle me-3"/>
+                                <input type="checkbox" asp-for="LUD12Enabled" class="btcpay-toggle me-3" />
                                 <label asp-for="LUD12Enabled" class="form-label mb-0 me-1"></label>
                             </div>
                         </div>

--- a/BTCPayServer/Views/UIStores/ModifyWebhook.cshtml
+++ b/BTCPayServer/Views/UIStores/ModifyWebhook.cshtml
@@ -32,20 +32,22 @@
                 <p class="text-muted small form-text">The endpoint receiving the payload must validate the payload by checking that the HTTP header <code>BTCPAY-SIG</code> of the callback matches the HMAC256 of the secret on the payload's body bytes.</p>
             </div>
             <div class="form-group">
-                <label class="d-flex align-items-center mb-2">
+                <label class="form-group d-flex align-items-center">
                     <input asp-for="AutomaticRedelivery" type="checkbox" class="btcpay-toggle me-3" />
-                    <span>Automatic redelivery</span>
+                    <div class="">
+                        <span>Automatic redelivery</span>
+                        <p class="text-muted small form-text mb-0">We will try to redeliver any failed delivery after 10 seconds, 1 minute and up to 6 times after 10 minutes</p>
+                        </div>
                 </label>
-                <p class="text-muted small form-text">We will try to redeliver any failed delivery after 10 seconds, 1 minute and up to 6 times after 10 minutes</p>
             </div>
             <div class="form-group">
                 <label class="d-flex align-items-center mb-2">
                     <input asp-for="Active" type="checkbox" class="btcpay-toggle me-3" />
-                    <span>Is enabled</span>
+                    <span>Enabled</span>
                 </label>
             </div>
 
-            <h3 class="mb-3">Events</h3>
+            <h3 class="mb-3 mt-5">Events</h3>
             <label asp-for="Everything" class="form-label">Which events would you like to trigger this webhook?</label>
             <select asp-for="Everything" class="form-select w-auto mb-3">
                 <option value="true">Send me everything</option>
@@ -54,7 +56,7 @@
             <div id="event-selector" class="collapse">
                 <div class="pb-3">
                     @foreach (var evt in new[]
-                   {
+                  {
                         ("A new invoice has been created", WebhookEventType.InvoiceCreated),
                         ("A new payment has been received", WebhookEventType.InvoiceReceivedPayment),
                         ("A payment has been settled", WebhookEventType.InvoicePaymentSettled),

--- a/BTCPayServer/Views/UIStores/Rates.cshtml
+++ b/BTCPayServer/Views/UIStores/Rates.cshtml
@@ -159,13 +159,15 @@
                 </div>
             }
             <div class="form-group">
-                <label class="d-flex align-items-center mb-2">
+                <label class="d-flex align-items-center">
                     <button type="submit" id="ShowScripting" class="btcpay-toggle me-3 @if (Model.ShowScripting) { @("btcpay-toggle--active") }" value="scripting-@(Model.ShowScripting ? "off" : "on")" name="command" data-bs-toggle="modal" data-bs-target="#ConfirmModal">@(Model.ShowScripting ? "Disable" : "Enable") advanced rate rule scripting</button>
-                    <span>Advanced rate rule scripting</span>
-                </label>    
-                <p class="text-muted small form-text">
-                    @(Model.ShowScripting ? "Disabling will delete your rate script." : "Enabling will modify your current rate sources. This is a feature for advanced users.")
-                </p>
+                    <div class="">
+                        <span>Advanced rate rule scripting</span>
+                        <p class="text-muted small form-text mb-0">
+                            @(Model.ShowScripting ? "Disabling will delete your rate script." : "Enabling will modify your current rate sources. This is a feature for advanced users.")
+                        </p>
+                    </div>
+                </label>
             </div>
             <div class="form-group">
                 <label asp-for="Spread" class="form-label"></label>
@@ -176,7 +178,7 @@
                 <span asp-validation-for="Spread" class="text-danger"></span>
             </div>
             <h3 class="mt-5 mb-3">Testing</h3>
-            
+
             <div class="form-group">
                 <label asp-for="ScriptTest" class="form-label">Currency pairs to test against your rule (e.g. <code>DOGE_USD,DOGE_CAD,BTC_CAD,BTC_USD</code>)</label>
                 <div class="d-flex">
@@ -184,8 +186,8 @@
                     <button name="command" value="Test" type="submit" class="btn btn-secondary ms-3" title="Test">Test</button>
                 </div>
                 <span asp-validation-for="ScriptTest" class="text-danger"></span>
-            </div>  
-                
+            </div>
+
             <h3 class="mt-5 mb-3">Default Currency Pairs</h3>
             <div class="form-group">
                 <label asp-for="DefaultCurrencyPairs" class="form-label">Query pairs via REST by querying <a asp-controller="BitpayRate" asp-action="GetRates2" asp-route-storeId="@Model.StoreId" target="_blank">this link</a> without the need to specify currencyPairs.</label>


### PR DESCRIPTION
Few places I noticed our switch component wasn't consistent.

Adjustments made in:
- Lightning Settings
- Store Settings > Modify Webhooks
- Store Settings > Rates

e.g.
<img width="589" alt="Screen Shot 2022-07-04 at 6 25 16 PM" src="https://user-images.githubusercontent.com/6250771/177231999-d224317f-64ad-439f-9b9a-d4ff3cc1c35b.png">
<img width="821" alt="Screen Shot 2022-07-04 at 6 25 26 PM" src="https://user-images.githubusercontent.com/6250771/177232001-d3f03884-0b62-4f6f-ade0-835326b727f7.png">
