### PR TITLE
Add v1.6.0 to the What's New modal

### DIFF
--- a/BTCPayServer/Views/UIStores/Dashboard.cshtml
+++ b/BTCPayServer/Views/UIStores/Dashboard.cshtml
@@ -32,10 +32,14 @@
                 </button>
             </div>
             <div class="modal-body">
-                <h5 class="alert-heading">Updated in v1.5.0</h5>
+                <h5 class="alert-heading">Updated in <a href="https://blog.btcpayserver.org/btcpay-server-1-6-0/" target="_blank" rel="noreferrer noopener">v1.6.0</a></h5>
+                <p class="mb-2">The dashboard now contains your Lightning balances and services, as well as Point of Sale statistics.</p>
+                <p class="mb-0">We've also added invoice receipts and LNURL withdraw for payouts.</p>
+                <hr style="height:1px;background-color:var(--btcpay-body-text-muted);margin:var(--btcpay-space-m) 0;" />
+                <h5 class="alert-heading">Updated in <a href="https://blog.btcpayserver.org/btcpay-server-1-5-0/" target="_blank" rel="noreferrer noopener">v1.5.0</a></h5>
                 <p class="mb-0">Stores now have a neat dashboard like the one you see here! 🗠🎉</p>
                 <hr style="height:1px;background-color:var(--btcpay-body-text-muted);margin:var(--btcpay-space-m) 0;" />
-                <h5 class="alert-heading">Updated in v1.4.0</h5>
+                <h5 class="alert-heading">Updated in <a href="https://blog.btcpayserver.org/btcpay-server-1-4-0/" target="_blank" rel="noreferrer noopener">v1.4.0</a></h5>
                 <p class="mb-2">Invoice states have been updated to match the Greenfield API:</p>
                 <ul class="list-unstyled mb-md-0">
                     <li>


### PR DESCRIPTION
The blog post is in the making, the `v1.6.0` will link to it.

![whats-new](https://user-images.githubusercontent.com/886/177518764-85680f94-56e3-4c2f-913e-6c2b3cfd9a37.png)
