### PR TITLE
Don't show "Set up a Lightning node" when LN is not supported

### DIFF
--- a/BTCPayServer/Controllers/UIStoresController.Dashboard.cs
+++ b/BTCPayServer/Controllers/UIStoresController.Dashboard.cs
@@ -24,13 +24,15 @@ namespace BTCPayServer.Controllers
 
             var walletEnabled = derivationSchemes.Any(scheme => !string.IsNullOrEmpty(scheme.Value) && scheme.Enabled);
             var lightningEnabled = lightningNodes.Any(ln => !string.IsNullOrEmpty(ln.Address) && ln.Enabled);
+            var cryptoCode = _NetworkProvider.DefaultNetwork.CryptoCode;
             var vm = new StoreDashboardViewModel
             {
                 WalletEnabled = walletEnabled,
                 LightningEnabled = lightningEnabled,
+                LightningSupported = _NetworkProvider.GetNetwork<BTCPayNetwork>(cryptoCode).SupportLightning,
                 StoreId = CurrentStore.Id,
                 StoreName = CurrentStore.StoreName,
-                CryptoCode = _NetworkProvider.DefaultNetwork.CryptoCode,
+                CryptoCode = cryptoCode,
                 IsSetUp = walletEnabled || lightningEnabled
             };
             

--- a/BTCPayServer/Models/StoreViewModels/StoreDashboardViewModel.cs
+++ b/BTCPayServer/Models/StoreViewModels/StoreDashboardViewModel.cs
@@ -10,6 +10,7 @@ public class StoreDashboardViewModel
     public string StoreName { get; set; }
     public bool WalletEnabled { get; set; }
     public bool LightningEnabled { get; set; }
+    public bool LightningSupported { get; set; }
     public bool IsSetUp { get; set; }
     public List<AppData> Apps { get; set; } = new();
 }

--- a/BTCPayServer/Views/Shared/LNURL/LightningAddressOption.cshtml
+++ b/BTCPayServer/Views/Shared/LNURL/LightningAddressOption.cshtml
@@ -9,7 +9,10 @@
         isLightningEnabled &&
         isLNUrlEnabled &&
         store.GetSupportedPaymentMethods(BTCPayNetworkProvider).OfType<LNURLPaySupportedPaymentMethod>().Any(type => type.CryptoCode == cryptoCode);
+    var network = BTCPayNetworkProvider.GetNetwork<BTCPayNetwork>(cryptoCode);
 }
+
+@if (network.SupportLightning) {
 <li class="list-group-item bg-tile" id="lightning-address-option">
     <div class="d-flex align-items-center">
         <span class="d-flex flex-wrap flex-fill flex-column flex-sm-row">
@@ -48,3 +51,5 @@
         </span>
     </div>
 </li>
+}
+

--- a/BTCPayServer/Views/UIStores/Dashboard.cshtml
+++ b/BTCPayServer/Views/UIStores/Dashboard.cshtml
@@ -162,24 +162,26 @@ else
                 </div>
             </div>
         }
-        @if (!Model.LightningEnabled)
-        {
-            <a asp-controller="UIStores" asp-action="SetupLightningNode" asp-route-storeId="@Model.StoreId" asp-route-cryptoCode="@Model.CryptoCode" id="SetupGuide-Lightning" class="list-group-item list-group-item-action d-flex align-items-center order-1">
-                <vc:icon symbol="new-wallet"/>
-                <div class="content">
-                    <h5 class="mb-0">Set up a Lightning node</h5>
+        @if (Model.LightningSupported) {
+            if (!Model.LightningEnabled)
+            {
+                <a asp-controller="UIStores" asp-action="SetupLightningNode" asp-route-storeId="@Model.StoreId" asp-route-cryptoCode="@Model.CryptoCode" id="SetupGuide-Lightning" class="list-group-item list-group-item-action d-flex align-items-center order-1">
+                    <vc:icon symbol="new-wallet"/>
+                    <div class="content">
+                        <h5 class="mb-0">Set up a Lightning node</h5>
+                    </div>
+                    <vc:icon symbol="caret-right"/>
+                </a>
+            }
+            else
+            {
+                <div class="list-group-item d-flex align-items-center" id="SetupGuide-LightningDone">
+                    <vc:icon symbol="done"/>
+                    <div class="content">
+                        <h5 class="mb-0 text-success">Set up a Lightning node</h5>
+                    </div>
                 </div>
-                <vc:icon symbol="caret-right"/>
-            </a>
-        }
-        else
-        {
-            <div class="list-group-item d-flex align-items-center" id="SetupGuide-LightningDone">
-                <vc:icon symbol="done"/>
-                <div class="content">
-                    <h5 class="mb-0 text-success">Set up a Lightning node</h5>
-                </div>
-            </div>
+            }
         }
     </div>
 }


### PR DESCRIPTION
We are currently showing some lightning setup stuff even in cases when `SupportLightning` variable for a network is set to `false` (i.e. this coin doesn't support Lightning).

This PR makes sure we don't do this.

See discussion here: https://github.com/btcpayserver/btcpayserver/discussions/3868