### PR TITLE
Redirect to invoice details instead of list upon creation

### DIFF
--- a/BTCPayServer.Tests/CheckoutUITests.cs
+++ b/BTCPayServer.Tests/CheckoutUITests.cs
@@ -37,9 +37,6 @@ namespace BTCPayServer.Tests
             s.Driver.AssertElementNotFound(By.Id("emailAddressFormInput"));
             s.GoToHome();
             s.CreateInvoice();
-            s.Driver.FindElement(By.ClassName("invoice-details-link")).Click();
-            s.Driver.AssertNoError();
-            s.Driver.Navigate().Back();
             s.Driver.FindElement(By.ClassName("invoice-checkout-link")).Click();
             Assert.NotEmpty(s.Driver.FindElements(By.Id("checkoutCtrl")));
 
@@ -102,9 +99,6 @@ namespace BTCPayServer.Tests
 
             // Now create an invoice that doesn't require a refund email
             s.CreateInvoice(100, "USD", "", null, false);
-            s.Driver.FindElement(By.ClassName("invoice-details-link")).Click();
-            s.Driver.AssertNoError();
-            s.Driver.Navigate().Back();
             s.Driver.FindElement(By.ClassName("invoice-checkout-link")).Click();
             Assert.NotEmpty(s.Driver.FindElements(By.Id("checkoutCtrl")));
             s.Driver.AssertElementNotFound(By.Id("emailAddressFormInput"));
@@ -115,9 +109,6 @@ namespace BTCPayServer.Tests
 
             // Now create an invoice that requires refund email but already has one set, email input shouldn't show up
             s.CreateInvoice(100, "USD", "a@g.com", null, true);
-            s.Driver.FindElement(By.ClassName("invoice-details-link")).Click();
-            s.Driver.AssertNoError();
-            s.Driver.Navigate().Back();
             s.Driver.FindElement(By.ClassName("invoice-checkout-link")).Click();
             Assert.NotEmpty(s.Driver.FindElements(By.Id("checkoutCtrl")));
             s.Driver.AssertElementNotFound(By.Id("emailAddressFormInput"));

--- a/BTCPayServer.Tests/SeleniumTests.cs
+++ b/BTCPayServer.Tests/SeleniumTests.cs
@@ -417,24 +417,23 @@ namespace BTCPayServer.Tests
             s.AddDerivationScheme();
             s.GoToInvoices();
             s.CreateInvoice();
-            s.Driver.FindElement(By.ClassName("changeInvoiceStateToggle")).Click();
+            s.Driver.FindElement(By.Id("markStatusDropdownMenuButton")).Click();
             s.Driver.FindElements(By.ClassName("changeInvoiceState"))[0].Click();
             TestUtils.Eventually(() => Assert.Contains("Invalid (marked)", s.Driver.PageSource));
             s.Driver.Navigate().Refresh();
 
-            s.Driver.FindElement(By.ClassName("changeInvoiceStateToggle")).Click();
+            s.Driver.FindElement(By.Id("markStatusDropdownMenuButton")).Click();
             s.Driver.FindElements(By.ClassName("changeInvoiceState"))[0].Click();
             TestUtils.Eventually(() => Assert.Contains("Settled (marked)", s.Driver.PageSource));
 
-            s.Driver.FindElement(By.ClassName("invoice-details-link")).Click();
-            Assert.Contains("Settled (marked)", s.Driver.PageSource);
+            s.Driver.Navigate().Refresh();
 
-            s.Driver.FindElement(By.ClassName("changeInvoiceStateToggle")).Click();
+            s.Driver.FindElement(By.Id("markStatusDropdownMenuButton")).Click();
             s.Driver.FindElements(By.ClassName("changeInvoiceState"))[0].Click();
             TestUtils.Eventually(() => Assert.Contains("Invalid (marked)", s.Driver.PageSource));
             s.Driver.Navigate().Refresh();
 
-            s.Driver.FindElement(By.ClassName("changeInvoiceStateToggle")).Click();
+            s.Driver.FindElement(By.Id("markStatusDropdownMenuButton")).Click();
             s.Driver.FindElements(By.ClassName("changeInvoiceState"))[0].Click();
             TestUtils.Eventually(() => Assert.Contains("Settled (marked)", s.Driver.PageSource));
         }
@@ -562,7 +561,7 @@ namespace BTCPayServer.Tests
             Assert.Contains("There are no invoices matching your criteria.", s.Driver.PageSource);
             var invoiceId = s.CreateInvoice();
             s.FindAlertMessage();
-            s.Driver.FindElement(By.ClassName("invoice-details-link")).Click();
+            
             var invoiceUrl = s.Driver.Url;
 
             //let's test archiving an invoice

--- a/BTCPayServer/Controllers/UIInvoiceController.UI.cs
+++ b/BTCPayServer/Controllers/UIInvoiceController.UI.cs
@@ -1,6 +1,5 @@
 #nullable enable
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
@@ -33,7 +32,6 @@ using Microsoft.EntityFrameworkCore;
 using NBitcoin;
 using NBitpayClient;
 using NBXplorer;
-using NBXplorer.Models;
 using Newtonsoft.Json.Linq;
 using BitpayCreateInvoiceRequest = BTCPayServer.Models.BitpayCreateInvoiceRequest;
 using StoreData = BTCPayServer.Data.StoreData;
@@ -86,6 +84,7 @@ namespace BTCPayServer.Controllers
         }
 
         [HttpGet("invoices/{invoiceId}")]
+        [HttpGet("/stores/{storeId}/invoices/${invoiceId}")]
         [Authorize(Policy = Policies.CanViewInvoices, AuthenticationSchemes = AuthenticationSchemes.Cookie)]
         public async Task<IActionResult> Invoice(string invoiceId)
         {
@@ -1100,7 +1099,8 @@ namespace BTCPayServer.Controllers
 
                 TempData[WellKnownTempData.SuccessMessage] = $"Invoice {result.Data.Id} just created!";
                 CreatedInvoiceId = result.Data.Id;
-                return RedirectToAction(nameof(ListInvoices), new { result.Data.StoreId });
+
+                return RedirectToAction(nameof(Invoice), new { storeId = result.Data.StoreId, invoiceId = result.Data.Id });
             }
             catch (BitpayHttpException ex)
             {


### PR DESCRIPTION
We keep the invoice filters sticky in a cookie so that the user doesn't have to set them again every time they visit the invoices page. However, this results in an issue where the invoice which you just created will not be shown to you if you have filters apply which exclude this newly created invoice.

To get around this issue we can either go to the invoice details page on invoice creation OR clear the cookie or override it somehow for that one time. I took the first approach here since it's kind of weird to clear the cookie or not respect it just in one special case.

close #3909