### PR TITLE
Redirect to dashboard instead of apps list on app delete

### DIFF
--- a/BTCPayServer.Tests/CrowdfundTests.cs
+++ b/BTCPayServer.Tests/CrowdfundTests.cs
@@ -32,6 +32,7 @@ namespace BTCPayServer.Tests
             await user.GrantAccessAsync();
             var user2 = tester.NewAccount();
             await user2.GrantAccessAsync();
+            var stores = user.GetController<UIStoresController>();
             var apps = user.GetController<UIAppsController>();
             var apps2 = user2.GetController<UIAppsController>();
             var vm = Assert.IsType<CreateAppViewModel>(Assert.IsType<ViewResult>(apps.CreateApp(user.StoreId)).Model);
@@ -56,7 +57,7 @@ namespace BTCPayServer.Tests
             Assert.IsType<NotFoundResult>(apps2.DeleteApp(appList.Apps[0].Id));
             Assert.IsType<ViewResult>(apps.DeleteApp(appList.Apps[0].Id));
             redirectToAction = Assert.IsType<RedirectToActionResult>(apps.DeleteAppPost(appList.Apps[0].Id).Result);
-            Assert.Equal(nameof(apps.ListApps), redirectToAction.ActionName);
+            Assert.Equal(nameof(stores.Dashboard), redirectToAction.ActionName);
             appList = await apps.ListApps(user.StoreId).AssertViewModelAsync<ListAppsViewModel>();
             Assert.Empty(appList.Apps);
         }

--- a/BTCPayServer.Tests/UnitTest1.cs
+++ b/BTCPayServer.Tests/UnitTest1.cs
@@ -1950,6 +1950,7 @@ namespace BTCPayServer.Tests
             await user.GrantAccessAsync();
             var user2 = tester.NewAccount();
             await user2.GrantAccessAsync();
+            var stores = user.GetController<UIStoresController>();
             var apps = user.GetController<UIAppsController>();
             var apps2 = user2.GetController<UIAppsController>();
             var vm = Assert.IsType<CreateAppViewModel>(Assert.IsType<ViewResult>(apps.CreateApp(user.StoreId)).Model);
@@ -1974,7 +1975,7 @@ namespace BTCPayServer.Tests
             Assert.IsType<NotFoundResult>(apps2.DeleteApp(appList.Apps[0].Id));
             Assert.IsType<ViewResult>(apps.DeleteApp(appList.Apps[0].Id));
             redirectToAction = Assert.IsType<RedirectToActionResult>(apps.DeleteAppPost(appList.Apps[0].Id).Result);
-            Assert.Equal(nameof(apps.ListApps), redirectToAction.ActionName);
+            Assert.Equal(nameof(stores.Dashboard), redirectToAction.ActionName);
             appList = Assert.IsType<ListAppsViewModel>(Assert.IsType<ViewResult>(apps.ListApps(user.StoreId).Result).Model);
             Assert.Empty(appList.Apps);
         }

--- a/BTCPayServer/Controllers/UIAppsController.cs
+++ b/BTCPayServer/Controllers/UIAppsController.cs
@@ -164,7 +164,7 @@ namespace BTCPayServer.Controllers
             if (await _appService.DeleteApp(app))
                 TempData[WellKnownTempData.SuccessMessage] = "App deleted successfully.";
 
-            return RedirectToAction(nameof(ListApps), new { storeId = app.StoreDataId });
+            return RedirectToAction(nameof(UIStoresController.Dashboard), "UIStores", new { storeId = app.StoreDataId });
         }
 
         async Task<string> GetStoreDefaultCurrentIfEmpty(string storeId, string currency)


### PR DESCRIPTION
Redirect to dashboard instead of apps list on app delete since we don't really actively maintain this view and this redirect is the only way to get to it currently (if you ignore the fact that user can just type out the URL).

close #3898