### PR TITLE
Add payouts docs link

### DIFF
--- a/BTCPayServer/Views/UIStorePullPayments/Payouts.cshtml
+++ b/BTCPayServer/Views/UIStorePullPayments/Payouts.cshtml
@@ -73,7 +73,14 @@
         <a class="alert-link p-0" asp-action="ConfigureStorePayoutProcessors" asp-controller="UIPayoutProcessors" asp-route-storeId="@storeId">Configure now</a>
     </div>
 }
-<h2 class="mt-1 mb-4">@ViewData["Title"]</h2>
+<h2 class="mt-1 mb-4">
+    @ViewData["Title"]
+    <small>
+        <a href="https://docs.btcpayserver.org/Payouts/" target="_blank" rel="noreferrer noopener">
+            <span class="fa fa-question-circle-o text-secondary" title="More information..."></span>
+        </a>
+    </small>
+</h2>
 
 <form method="post" id="Payouts">
     <input type="hidden" asp-for="PaymentMethodId"/>


### PR DESCRIPTION
I noticed we have a docs link for other pages but not for the payouts page. I don't know why it's not there (is there a reason?). I'm adding it in this PR if there is not a reason for why it wasn't added in the first place.