### PR TITLE
API endpoint for getting the custodian account config form

### DIFF
--- a/BTCPayServer.Client/BTCPayServerClient.CustodianAccounts.cs
+++ b/BTCPayServer.Client/BTCPayServerClient.CustodianAccounts.cs
@@ -89,5 +89,11 @@ namespace BTCPayServer.Client
             var response = await _httpClient.SendAsync(CreateHttpRequest($"api/v1/stores/{storeId}/custodian-accounts/{accountId}/withdrawals/{paymentMethod}/{withdrawalId}", method: HttpMethod.Get), token);
             return await HandleResponse<WithdrawalResponseData>(response);
         }
+
+        public virtual async Task<Form> GetCustodianAccountConfigForm(string storeId, string accountId, CancellationToken token = default)
+        {
+            var response = await _httpClient.SendAsync(CreateHttpRequest($"api/v1/stores/{storeId}/custodian-accounts/{accountId}/config", method: HttpMethod.Get), token);
+            return await HandleResponse<Form>(response);
+        }
     }
 }

--- a/BTCPayServer.Tests/GreenfieldAPITests.cs
+++ b/BTCPayServer.Tests/GreenfieldAPITests.cs
@@ -817,6 +817,7 @@ namespace BTCPayServer.Tests
             return ex;
         }
 
+        [Obsolete("Use AssertApiError() instead, as it also checks the API error code")]
         private async Task AssertHttpError(int code, Func<Task> act)
         {
             var ex = await Assert.ThrowsAsync<GreenfieldAPIException>(act);
@@ -2704,7 +2705,16 @@ namespace BTCPayServer.Tests
             Assert.Equal(singleViewerCustodianAccount.CustodianCode, custodian.Code);
             Assert.Null(singleViewerCustodianAccount.Config);
 
-
+            // Fetching the config form for 1 custodian account
+            // Unauth
+            await AssertApiError(401, "forbidden", async () => await unauthClient.GetCustodianAccountConfigForm(storeId, accountId));
+            
+            // Auth, but wrong permission
+            // TODO complete this
+            
+            // Correct auth: you get the config form
+            // TODO complete this
+            
 
             // Test updating the custodian account we created
             var updateCustodianAccountRequest = createCustodianAccountRequest;

--- a/BTCPayServer/Controllers/GreenField/GreenfieldCustodianAccountController.cs
+++ b/BTCPayServer/Controllers/GreenField/GreenfieldCustodianAccountController.cs
@@ -91,22 +91,22 @@ namespace BTCPayServer.Controllers.Greenfield
             return Ok(custodianAccount);
         }
         
-        // [HttpGet("~/api/v1/stores/{storeId}/custodian-accounts/{accountId}/config")]
-        // [Authorize(Policy = Policies.CanManageCustodianAccounts,
-        //     AuthenticationSchemes = AuthenticationSchemes.Greenfield)]
-        // public async Task<IActionResult> FetchCustodianAccountConfigForm(string storeId, string accountId,
-        //     [FromQuery] string locale = "en-US", CancellationToken cancellationToken = default)
-        // {
-        //     // TODO this endpoint needs tests
-        //     var custodianAccountData = await GetCustodianAccount(storeId, accountId);
-        //     var custodianAccount = await ToModel(custodianAccountData, false, cancellationToken);
-        //     
-        //     var custodian = GetCustodianByCode(custodianAccount.CustodianCode);
-        //     var form = await custodian.GetConfigForm(custodianAccount.Config, locale, cancellationToken);
-        //         
-        //     return Ok(form);
-        // }
-        //
+        [HttpGet("~/api/v1/stores/{storeId}/custodian-accounts/{accountId}/config")]
+        [Authorize(Policy = Policies.CanManageCustodianAccounts,
+            AuthenticationSchemes = AuthenticationSchemes.Greenfield)]
+        public async Task<IActionResult> FetchCustodianAccountConfigForm(string storeId, string accountId,
+            [FromQuery] string locale = "en-US", CancellationToken cancellationToken = default)
+        {
+            // TODO this endpoint needs tests
+            var custodianAccountData = await GetCustodianAccount(storeId, accountId);
+            var custodianAccount = await ToModel(custodianAccountData, false, cancellationToken);
+            
+            var custodian = GetCustodianByCode(custodianAccount.CustodianCode);
+            var form = await custodian.GetConfigForm(custodianAccount.Config, locale, cancellationToken);
+                
+            return Ok(form);
+        }
+        
         // [HttpPost("~/api/v1/stores/{storeId}/custodian-accounts/{accountId}/config")]
         // [Authorize(Policy = Policies.CanManageCustodianAccounts,
         //     AuthenticationSchemes = AuthenticationSchemes.Greenfield)]


### PR DESCRIPTION
This PR is a WIP for a new API endpoint to get the custodian account config form.

It is perhaps a low priority, but may lead to moving the `Form` classes, and since those are going to be re-used, may have a bigger impact.