### PR TITLE
Invoice summary: Fix indentation and heading levels

### DIFF
--- a/BTCPayServer/Views/Shared/Lightning/ViewLightningLikePaymentData.cshtml
+++ b/BTCPayServer/Views/Shared/Lightning/ViewLightningLikePaymentData.cshtml
@@ -19,10 +19,9 @@
     }).Where(model => model != null);
 }
 
-
 @if (offchainPayments.Any())
 {
-    <h3>Off-Chain payments</h3>
+    <h5>Off-Chain Payments</h5>
     <table class="table table-hover">
         <thead class="thead-inverse">
             <tr>

--- a/BTCPayServer/Views/Shared/Monero/ViewMoneroLikePaymentData.cshtml
+++ b/BTCPayServer/Views/Shared/Monero/ViewMoneroLikePaymentData.cshtml
@@ -31,7 +31,7 @@
 
 @if (onchainPayments.Any())
 {
-    <h3>Monero payments</h3>
+    <h5>Monero Payments</h5>
     <table class="table table-hover">
         <thead class="thead-inverse">
         <tr>

--- a/BTCPayServer/Views/Shared/Zcash/ViewZcashLikePaymentData.cshtml
+++ b/BTCPayServer/Views/Shared/Zcash/ViewZcashLikePaymentData.cshtml
@@ -31,7 +31,7 @@
 
 @if (onchainPayments.Any())
 {
-    <h3>Zcash payments</h3>
+    <h5>Zcash Payments</h5>
     <table class="table table-hover">
         <thead class="thead-inverse">
         <tr>

--- a/BTCPayServer/Views/UIInvoice/Invoice.cshtml
+++ b/BTCPayServer/Views/UIInvoice/Invoice.cshtml
@@ -145,23 +145,23 @@
             <tr>
                 <th class="fw-semibold">Order Id</th>
                 <td>
-					@if (!string.IsNullOrEmpty(Model.TypedMetadata.OrderUrl))
-					{
-						<a href="@Model.TypedMetadata.OrderUrl" rel="noreferrer noopener" target="_blank">
-							@if (string.IsNullOrEmpty(Model.TypedMetadata.OrderId))
-							{
-								<span>View Order</span>
-							}
-							else
-							{
-								@Model.TypedMetadata.OrderId
-							}
-						</a>
-					}
-					else
-					{
-						<span>@Model.TypedMetadata.OrderId</span>
-					}
+                    @if (!string.IsNullOrEmpty(Model.TypedMetadata.OrderUrl))
+                    {
+                        <a href="@Model.TypedMetadata.OrderUrl" rel="noreferrer noopener" target="_blank">
+                            @if (string.IsNullOrEmpty(Model.TypedMetadata.OrderId))
+                            {
+                                <span>View Order</span>
+                            }
+                            else
+                            {
+                                @Model.TypedMetadata.OrderId
+                            }
+                        </a>
+                    }
+                    else
+                    {
+                        <span>@Model.TypedMetadata.OrderId</span>
+                    }
                 </td>
             </tr>
         }
@@ -412,12 +412,14 @@
     </div>
 }
 </div>
+
+<h3 class="mb-0">Invoice Summary</h3>
 <partial name="ListInvoicesPaymentsPartial" model="(Model, true)"/>
 
 @if (Model.Deliveries.Count != 0)
 {
+    <h3 class="mb-3 mt-4">Webhooks</h3>
     <div class="table-responsive-xl">
-        <h3 class="mb-3 mt-4">Webhooks</h3>
         <table class="table table-hover table-responsive-md mb-5">
             <thead class="thead-inverse">
             <tr>
@@ -491,8 +493,8 @@
 
 @if ((Model.Refunds?.Count ?? 0) > 0)
 {
+    <h3 class="mb-3 mt-4">Refunds</h3>
     <div class="table-responsive-xl">
-        <h3 class="mb-3 mt-4">Refunds</h3>
         <table class="table table-hover table-responsive-md mb-5">
             <thead class="thead-inverse">
             <tr>

--- a/BTCPayServer/Views/UIInvoice/ListInvoices.cshtml
+++ b/BTCPayServer/Views/UIInvoice/ListInvoices.cshtml
@@ -8,6 +8,15 @@
 		storeIds = string.Empty;
 }
 
+@section PageHeadContent
+{
+    <style>
+        .invoice-payments {
+            padding-left: var(--btcpay-space-l);
+        }
+    </style>
+}
+
 @section PageFootContent {
     @*Without async, somehow selenium do not manage to click on links in this page*@
     <script src="~/modal/btcpay.js" asp-append-version="true" async></script>

--- a/BTCPayServer/Views/UIInvoice/ListInvoicesPaymentsPartial.cshtml
+++ b/BTCPayServer/Views/UIInvoice/ListInvoicesPaymentsPartial.cshtml
@@ -3,7 +3,6 @@
 @{ var invoice = Model.Invoice; }
 
 <div class="invoice-payments table-responsive">
-    <h5 class="mb-0">Invoice Summary</h5>
     <table class="table table-hover mt-3 mb-4">
         <thead class="thead-inverse">
             <tr>

--- a/BTCPayServer/wwwroot/main/site.css
+++ b/BTCPayServer/wwwroot/main/site.css
@@ -114,9 +114,6 @@ h2 small .fa-question-circle-o {
 }
 
 /* Invoices */
-.invoice-payments {
-    padding: var(--btcpay-space-m) var(--btcpay-space-l);
-}
 .invoice-details-row {
     background: var(--btcpay-bg-tile);
 }


### PR DESCRIPTION
UI fixes for the payment summary partials, which are used on the invoices list and details page.

## Before

![grafik](https://user-images.githubusercontent.com/886/178254109-616aa297-d470-4222-b554-8e3df148a861.png)


## After

![grafik](https://user-images.githubusercontent.com/886/178253973-73b48e83-7170-4496-b536-0da399709de0.png)
