### PR TITLE
Fix Monero exchange rate

### DIFF
--- a/BTCPayServer.Common/Altcoins/Monero/BTCPayNetworkProvider.Monero.cs
+++ b/BTCPayServer.Common/Altcoins/Monero/BTCPayNetworkProvider.Monero.cs
@@ -18,7 +18,7 @@ namespace BTCPayServer
                 DefaultRateRules = new[]
                 {
                     "XMR_X = XMR_BTC * BTC_X",
-                    "XMR_BTC = kraken(XMR_BTC)"
+                    "XMR_BTC = kraken(BTC_XMR)"
                 },
                 CryptoImagePath = "/imlegacy/monero.svg",
                 UriScheme = "monero"


### PR DESCRIPTION
It appears something changed with Kraken, but the previous XMR_BTC exchange rate is the amount of XMR per BTC (i.e. 157), instead of the inverse (i.e. 0.0063) now.

Changing to BTC_XMR fixes it to the proper exchange rate necessary for the calculation.