### PR TITLE
Fix webhook "Send specific events" display issue

### DIFF
--- a/BTCPayServer/Views/UIStores/ModifyWebhook.cshtml
+++ b/BTCPayServer/Views/UIStores/ModifyWebhook.cshtml
@@ -140,5 +140,7 @@
         delegate('change', '#Everything', function (e) {
             e.target.dataset.value = e.target.value;
         });
+
+        document.querySelector('#Everything').dataset.value = @Html.Raw(Json.Serialize(Model.Everything));
     </script>
 }


### PR DESCRIPTION
"Send specific events" list now displays correctly when modifying a webhook that has specific trigger events selected. Previously, the select list change event was not fired on page load.

Tested on Chrome, Firefox, IE, Edge

![image](https://user-images.githubusercontent.com/100967048/178400773-ac971730-a554-46f8-8c0f-bddb3b6b6706.png)

#3958