### PR TITLE
Added refund fields to invoice export

### DIFF
--- a/BTCPayServer/Controllers/UIInvoiceController.UI.cs
+++ b/BTCPayServer/Controllers/UIInvoiceController.UI.cs
@@ -971,7 +971,7 @@ namespace BTCPayServer.Controllers
         [BitpayAPIConstraint(false)]
         public async Task<IActionResult> Export(string format, string? searchTerm = null, int timezoneOffset = 0)
         {
-            var model = new InvoiceExport(_CurrencyNameTable);
+            var model = new InvoiceExport(_CurrencyNameTable, _paymentHostedService, _jsonSerializerSettings);
 
             InvoiceQuery invoiceQuery = GetInvoiceQuery(searchTerm, timezoneOffset);
             invoiceQuery.StoreId = new[] { GetCurrentStore().Id };

--- a/BTCPayServer/Controllers/UIInvoiceController.UI.cs
+++ b/BTCPayServer/Controllers/UIInvoiceController.UI.cs
@@ -975,6 +975,7 @@ namespace BTCPayServer.Controllers
 
             InvoiceQuery invoiceQuery = GetInvoiceQuery(searchTerm, timezoneOffset);
             invoiceQuery.StoreId = new[] { GetCurrentStore().Id };
+            invoiceQuery.IncludeRefunds = true;
             invoiceQuery.Skip = 0;
             invoiceQuery.Take = int.MaxValue;
             var invoices = await _InvoiceRepository.GetInvoices(invoiceQuery);

--- a/BTCPayServer/Controllers/UIInvoiceController.cs
+++ b/BTCPayServer/Controllers/UIInvoiceController.cs
@@ -46,6 +46,7 @@ namespace BTCPayServer.Controllers
         private readonly ExplorerClientProvider _ExplorerClients;
         private readonly UIWalletsController _walletsController;
         private readonly LinkGenerator _linkGenerator;
+        private readonly BTCPayNetworkJsonSerializerSettings _jsonSerializerSettings;
 
         public WebhookSender WebhookNotificationManager { get; }
 
@@ -65,7 +66,8 @@ namespace BTCPayServer.Controllers
             LanguageService languageService,
             ExplorerClientProvider explorerClients,
             UIWalletsController walletsController,
-            LinkGenerator linkGenerator)
+            LinkGenerator linkGenerator,
+            BTCPayNetworkJsonSerializerSettings jsonSerializerSettings)
         {
             _CurrencyNameTable = currencyNameTable ?? throw new ArgumentNullException(nameof(currencyNameTable));
             _StoreRepository = storeRepository ?? throw new ArgumentNullException(nameof(storeRepository));
@@ -82,6 +84,7 @@ namespace BTCPayServer.Controllers
             this._ExplorerClients = explorerClients;
             _walletsController = walletsController;
             _linkGenerator = linkGenerator;
+            _jsonSerializerSettings = jsonSerializerSettings;
         }
 
 

--- a/BTCPayServer/Services/Invoices/Export/InvoiceExport.cs
+++ b/BTCPayServer/Services/Invoices/Export/InvoiceExport.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using BTCPayServer.Services.Rates;
 using CsvHelper.Configuration;
 using Newtonsoft.Json;
+using BTCPayServer.Data;
 
 namespace BTCPayServer.Services.Invoices.Export
 {
@@ -68,6 +69,9 @@ namespace BTCPayServer.Services.Invoices.Export
                 var paidAfterNetworkFees = pdata.GetValue() - payment.NetworkFee;
                 invoiceDue -= paidAfterNetworkFees * pmethod.Rate;
 
+                // Only gets first refund, if available
+                var refund = invoice.Refunds.FirstOrDefault()?.PullPaymentData?.GetBlob();
+
                 var target = new ExportInvoiceHolder
                 {
                     ReceivedDate = payment.ReceivedTime.UtcDateTime,
@@ -99,7 +103,9 @@ namespace BTCPayServer.Services.Invoices.Export
                     InvoiceItemDesc = invoice.Metadata.ItemDesc,
                     InvoicePrice = invoice.Price,
                     InvoiceCurrency = invoice.Currency,
-                    BuyerEmail = invoice.Metadata.BuyerEmail
+                    BuyerEmail = invoice.Metadata.BuyerEmail,
+                    RefundAmount = (refund is not null) ? refund.Limit.ToString(CultureInfo.InvariantCulture) : string.Empty,
+                    RefundCurrency = (refund is not null) ? refund.Currency : string.Empty            
                 };
 
                 exportList.Add(target);
@@ -138,5 +144,7 @@ namespace BTCPayServer.Services.Invoices.Export
         public string InvoiceStatus { get; set; }
         public string InvoiceExceptionStatus { get; set; }
         public string BuyerEmail { get; set; }
+        public string RefundAmount { get; set; }
+        public string RefundCurrency { get; set; }
     }
 }


### PR DESCRIPTION
Draft-only, will wait for feedback before proceeding.

Notes:
- Only first refund is included, if available. There can be multiple refunds, however. See ticket for clarification.
- .IncludeRefunds not added into InvoiceQuery call because does not filter the list
- Added as strings; there are a mix of number and string for currency fields. Can change if needed
- Added to end of list in order to not break client-side integrations
- If no refunds, field will be empty instead of 0 to indicate no refund present

![image](https://user-images.githubusercontent.com/100967048/178827022-8b03a034-6c67-4aaf-9b6b-542895cdf653.png)

#3597 