### PR TITLE
Move TagHelpers to Abstractions

### DIFF
--- a/BTCPayServer.Abstractions/BTCPayServer.Abstractions.csproj
+++ b/BTCPayServer.Abstractions/BTCPayServer.Abstractions.csproj
@@ -39,6 +39,5 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\BTCPayServer.Client\BTCPayServer.Client.csproj" />
-    <ProjectReference Include="..\BTCPayServer.Rating\BTCPayServer.Rating.csproj" />
   </ItemGroup>
 </Project>

--- a/BTCPayServer.Abstractions/BTCPayServer.Abstractions.csproj
+++ b/BTCPayServer.Abstractions/BTCPayServer.Abstractions.csproj
@@ -39,5 +39,6 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\BTCPayServer.Client\BTCPayServer.Client.csproj" />
+    <ProjectReference Include="..\BTCPayServer.Rating\BTCPayServer.Rating.csproj" />
   </ItemGroup>
 </Project>

--- a/BTCPayServer.Abstractions/TagHelpers/CSPA.cs
+++ b/BTCPayServer.Abstractions/TagHelpers/CSPA.cs
@@ -1,7 +1,8 @@
 using System;
 using BTCPayServer.Security;
 using Microsoft.AspNetCore.Razor.TagHelpers;
-namespace BTCPayServer.TagHelpers;
+
+namespace BTCPayServer.Abstractions.TagHelpers;
 
 /// <summary>
 /// Add sha256- to allow inline event handlers in a:href=javascript:

--- a/BTCPayServer.Abstractions/TagHelpers/CSPEventTagHelper.cs
+++ b/BTCPayServer.Abstractions/TagHelpers/CSPEventTagHelper.cs
@@ -2,8 +2,8 @@ using System.Collections.Generic;
 using System.Linq;
 using BTCPayServer.Security;
 using Microsoft.AspNetCore.Razor.TagHelpers;
-namespace BTCPayServer.TagHelpers;
 
+namespace BTCPayServer.Abstractions.TagHelpers;
 
 /// <summary>
 /// Add 'unsafe-hashes' and sha256- to allow inline event handlers in CSP

--- a/BTCPayServer.Abstractions/TagHelpers/CSPInlineScriptTagHelper.cs
+++ b/BTCPayServer.Abstractions/TagHelpers/CSPInlineScriptTagHelper.cs
@@ -1,8 +1,8 @@
 using BTCPayServer.Security;
 using Microsoft.AspNetCore.Razor.TagHelpers;
 using NBitcoin;
-namespace BTCPayServer.TagHelpers;
 
+namespace BTCPayServer.Abstractions.TagHelpers;
 
 /// <summary>
 /// Add a nonce-* so the inline-script can pass CSP rule when they are rendered server-side

--- a/BTCPayServer.Abstractions/TagHelpers/CSPTemplate.cs
+++ b/BTCPayServer.Abstractions/TagHelpers/CSPTemplate.cs
@@ -1,7 +1,8 @@
 using System.Threading.Tasks;
 using BTCPayServer.Security;
 using Microsoft.AspNetCore.Razor.TagHelpers;
-namespace BTCPayServer.TagHelpers;
+
+namespace BTCPayServer.Abstractions.TagHelpers;
 
 /// <summary>
 /// Add sha256- to allow inline event handlers in CSP

--- a/BTCPayServer.Abstractions/TagHelpers/CurrenciesSuggestionsTagHelper.cs
+++ b/BTCPayServer.Abstractions/TagHelpers/CurrenciesSuggestionsTagHelper.cs
@@ -1,9 +1,9 @@
-using BTCPayServer.Services.Rates;
-using System.Linq;
-using Microsoft.AspNetCore.Razor.TagHelpers;
 using System.Collections.Generic;
+using System.Linq;
+using BTCPayServer.Services.Rates;
+using Microsoft.AspNetCore.Razor.TagHelpers;
 
-namespace BTCPayServer.TagHelpers
+namespace BTCPayServer.Abstractions.TagHelpers
 {
     [HtmlTargetElement("input", Attributes = "currency-selection")]
     public class CurrenciesSuggestionsTagHelper : TagHelper

--- a/BTCPayServer.Abstractions/TagHelpers/PermissionTagHelper.cs
+++ b/BTCPayServer.Abstractions/TagHelpers/PermissionTagHelper.cs
@@ -3,8 +3,8 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Razor.TagHelpers;
 using Microsoft.Extensions.Logging;
-namespace BTCPayServer.TagHelpers;
 
+namespace BTCPayServer.Abstractions.TagHelpers;
 
 [HtmlTargetElement(Attributes = nameof(Permission))]
 public class PermissionTagHelper : TagHelper

--- a/BTCPayServer.Abstractions/TagHelpers/SVGUse.cs
+++ b/BTCPayServer.Abstractions/TagHelpers/SVGUse.cs
@@ -1,11 +1,10 @@
 using System.Text.Encodings.Web;
 using Microsoft.AspNetCore.Mvc.Razor.TagHelpers;
-using Microsoft.AspNetCore.Mvc.Rendering;
 using Microsoft.AspNetCore.Mvc.Routing;
 using Microsoft.AspNetCore.Mvc.ViewFeatures;
 using Microsoft.AspNetCore.Razor.TagHelpers;
 
-namespace BTCPayServer.TagHelpers;
+namespace BTCPayServer.Abstractions.TagHelpers;
 
 // Make sure that <svg><use href=/ are correctly working if rootpath is present
 [HtmlTargetElement("use", Attributes = "href")]

--- a/BTCPayServer.Abstractions/TagHelpers/SrvModel.cs
+++ b/BTCPayServer.Abstractions/TagHelpers/SrvModel.cs
@@ -1,9 +1,9 @@
 using BTCPayServer.Abstractions.Services;
 using BTCPayServer.Security;
-using BTCPayServer.Services;
 using Microsoft.AspNetCore.Razor.TagHelpers;
 using NBitcoin;
-namespace BTCPayServer.TagHelpers;
+
+namespace BTCPayServer.Abstractions.TagHelpers;
 
 [HtmlTargetElement("srv-model")]
 public class SrvModel : TagHelper

--- a/BTCPayServer/Components/AppSales/Default.cshtml
+++ b/BTCPayServer/Components/AppSales/Default.cshtml
@@ -1,6 +1,4 @@
 @using BTCPayServer.Services.Apps
-@using BTCPayServer.TagHelpers
-@using Microsoft.AspNetCore.Mvc.TagHelpers
 @using BTCPayServer.Components.AppSales
 @model BTCPayServer.Components.AppSales.AppSalesViewModel
 

--- a/BTCPayServer/Components/MainNav/Default.cshtml
+++ b/BTCPayServer/Components/MainNav/Default.cshtml
@@ -6,24 +6,18 @@
 @using BTCPayServer.Views.PaymentRequest
 @using BTCPayServer.Views.Wallets
 @using BTCPayServer.Abstractions.Extensions
-@using BTCPayServer.Abstractions.Contracts
 @using BTCPayServer.Client
 @using BTCPayServer.Components.Icon
 @using BTCPayServer.Components.ThemeSwitch
 @using BTCPayServer.Components.UIExtensionPoint
-@using BTCPayServer.Security
 @using BTCPayServer.Services
-@using BTCPayServer.TagHelpers
 @using BTCPayServer.Views.CustodianAccounts
-@using Microsoft.AspNetCore.Mvc.TagHelpers
-@inject BTCPayServer.Services.BTCPayServerEnvironment Env
+@inject BTCPayServerEnvironment Env
 @inject SignInManager<ApplicationUser> SignInManager
 @inject PoliciesSettings PoliciesSettings
 @inject ThemeSettings Theme
 
 @model BTCPayServer.Components.MainNav.MainNavViewModel
-@addTagHelper *, BundlerMinifier.TagHelpers
-
 
 <nav id="mainNav" class="d-flex flex-column justify-content-between">
     <div class="accordion px-3 px-lg-4">

--- a/BTCPayServer/Components/Notifications/Dropdown.cshtml
+++ b/BTCPayServer/Components/Notifications/Dropdown.cshtml
@@ -1,7 +1,6 @@
 @using BTCPayServer.Views.Notifications
 @using BTCPayServer.Abstractions.Extensions
 @model BTCPayServer.Components.Notifications.NotificationsViewModel
-@addTagHelper *, BundlerMinifier.TagHelpers
 
 <div id="Notifications">
     @if (Model.UnseenCount > 0)

--- a/BTCPayServer/Components/Notifications/List.cshtml
+++ b/BTCPayServer/Components/Notifications/List.cshtml
@@ -1,6 +1,5 @@
 @using BTCPayServer.Abstractions.Extensions
 @model BTCPayServer.Components.Notifications.NotificationsViewModel
-@addTagHelper *, BundlerMinifier.TagHelpers
 
 <div id="NotificationsList">
     @foreach (var n in Model.Last5)

--- a/BTCPayServer/Components/Notifications/Recent.cshtml
+++ b/BTCPayServer/Components/Notifications/Recent.cshtml
@@ -1,8 +1,6 @@
 @model BTCPayServer.Components.Notifications.NotificationsViewModel
-@addTagHelper *, BundlerMinifier.TagHelpers
 
 <div id="NotificationsRecent">
-    
     @if (Model.Last5.Any())
     {
         <div class="d-flex align-items-center justify-content-between mb-3">

--- a/BTCPayServer/Components/StoreLightningBalance/Default.cshtml
+++ b/BTCPayServer/Components/StoreLightningBalance/Default.cshtml
@@ -1,5 +1,3 @@
-@using BTCPayServer.Lightning
-@using BTCPayServer.TagHelpers
 @model BTCPayServer.Components.StoreLightningBalance.StoreLightningBalanceViewModel
 
 <div id="StoreLightningBalance-@Model.Store.Id" class="widget store-lightning-balance">

--- a/BTCPayServer/Components/StoreLightningServices/Default.cshtml
+++ b/BTCPayServer/Components/StoreLightningServices/Default.cshtml
@@ -1,4 +1,3 @@
-@using Microsoft.AspNetCore.Mvc.TagHelpers
 @model BTCPayServer.Components.StoreLightningServices.StoreLightningServicesViewModel
 
 @if (Model.Services != null && Model.Services.Any())

--- a/BTCPayServer/Components/StoreSelector/Default.cshtml
+++ b/BTCPayServer/Components/StoreSelector/Default.cshtml
@@ -1,7 +1,6 @@
 @inject BTCPayServer.Services.BTCPayServerEnvironment _env
 @inject SignInManager<ApplicationUser> _signInManager
 @model BTCPayServer.Components.StoreSelector.StoreSelectorViewModel
-@addTagHelper *, BundlerMinifier.TagHelpers
 @functions {
     @* ReSharper disable once CSharpWarnings::CS1998 *@
 	#pragma warning disable 1998

--- a/BTCPayServer/Components/WalletNav/Default.cshtml
+++ b/BTCPayServer/Components/WalletNav/Default.cshtml
@@ -2,10 +2,8 @@
 @using BTCPayServer.Client
 @using BTCPayServer.Views.Wallets
 @using BTCPayServer.Abstractions.Extensions
-@inject BTCPayNetworkProvider _btcPayNetworkProvider
 
 @model BTCPayServer.Components.WalletNav.WalletNavViewModel
-@addTagHelper *, BundlerMinifier.TagHelpers
 
 <div class="d-sm-flex align-items-center justify-content-between">
     <a asp-controller="UIWallets" asp-action="WalletTransactions" asp-route-walletId="@Model.WalletId" class="unobtrusive-link">

--- a/BTCPayServer/TagHelpers/CurrenciesSuggestionsTagHelper.cs
+++ b/BTCPayServer/TagHelpers/CurrenciesSuggestionsTagHelper.cs
@@ -3,7 +3,7 @@ using System.Linq;
 using BTCPayServer.Services.Rates;
 using Microsoft.AspNetCore.Razor.TagHelpers;
 
-namespace BTCPayServer.Abstractions.TagHelpers
+namespace BTCPayServer.TagHelpers
 {
     [HtmlTargetElement("input", Attributes = "currency-selection")]
     public class CurrenciesSuggestionsTagHelper : TagHelper

--- a/BTCPayServer/Views/Shared/LayoutFoot.cshtml
+++ b/BTCPayServer/Views/Shared/LayoutFoot.cshtml
@@ -1,4 +1,2 @@
-﻿@addTagHelper *, BundlerMinifier.TagHelpers
-
-<bundle name="wwwroot/bundles/bootstrap-bundle.min.js" asp-append-version="true" />
+﻿<bundle name="wwwroot/bundles/bootstrap-bundle.min.js" asp-append-version="true" />
 <bundle name="wwwroot/bundles/main-bundle.min.js" asp-append-version="true" />

--- a/BTCPayServer/Views/Shared/LayoutHead.cshtml
+++ b/BTCPayServer/Views/Shared/LayoutHead.cshtml
@@ -1,5 +1,4 @@
 @inject BTCPayServer.Services.PoliciesSettings PoliciesSettings
-@addTagHelper *, BundlerMinifier.TagHelpers
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 <link rel="icon" href="~/favicon.ico" type="image/x-icon">

--- a/BTCPayServer/Views/Shared/LayoutHeadTheme.cshtml
+++ b/BTCPayServer/Views/Shared/LayoutHeadTheme.cshtml
@@ -1,7 +1,6 @@
 @using BTCPayServer.Abstractions.Extensions
 @using BTCPayServer.Services
 @inject ThemeSettings Theme
-@addTagHelper *, BundlerMinifier.TagHelpers
 
 @if (Theme.CustomTheme)
 {

--- a/BTCPayServer/Views/Shared/PayButton/Enable.cshtml
+++ b/BTCPayServer/Views/Shared/PayButton/Enable.cshtml
@@ -1,5 +1,4 @@
 @using BTCPayServer.Views.Stores
-@using Microsoft.AspNetCore.Mvc.TagHelpers
 @{
 	ViewData.SetActivePage(StoreNavPages.PayButton, "Pay Button", Context.GetStoreData().Id);
 }

--- a/BTCPayServer/Views/Shared/PayButton/NavExtension.cshtml
+++ b/BTCPayServer/Views/Shared/PayButton/NavExtension.cshtml
@@ -1,7 +1,5 @@
 @using BTCPayServer.Client
 @using BTCPayServer.Views.Stores
-@using Microsoft.AspNetCore.Mvc.TagHelpers
-@using BTCPayServer.TagHelpers
 
 @{ var store = Context.GetStoreData(); }
 

--- a/BTCPayServer/Views/Shared/PayButton/PayButton.cshtml
+++ b/BTCPayServer/Views/Shared/PayButton/PayButton.cshtml
@@ -1,7 +1,5 @@
 @inject Security.ContentSecurityPolicies csp 
 @using BTCPayServer.Views.Stores
-@using Microsoft.AspNetCore.Mvc.TagHelpers
-@using BTCPayServer.TagHelpers
 @model BTCPayServer.Plugins.PayButton.Models.PayButtonViewModel
 @{
     ViewData.SetActivePage(StoreNavPages.PayButton, "Pay Button", Context.GetStoreData().Id);

--- a/BTCPayServer/Views/Shared/PayButton/_ViewImports.cshtml
+++ b/BTCPayServer/Views/Shared/PayButton/_ViewImports.cshtml
@@ -1,4 +1,3 @@
 @using BTCPayServer.Abstractions.Extensions
 @using BTCPayServer.Plugins.PayButton.Views
 @namespace BTCPayServer.Plugins.PayButton.Views
-@addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers

--- a/BTCPayServer/Views/Shared/_Layout.cshtml
+++ b/BTCPayServer/Views/Shared/_Layout.cshtml
@@ -1,8 +1,6 @@
 @using BTCPayServer.Abstractions.Extensions
-@using Microsoft.AspNetCore.Mvc.TagHelpers
 @using BTCPayServer.Components.StoreSelector
 @using BTCPayServer.Components.MainNav
-@using BTCPayServer.TagHelpers
 @inject BTCPayServer.Services.BTCPayServerEnvironment _env
 @inject SignInManager<ApplicationUser> _signInManager
 @inject UserManager<ApplicationUser> _userManager

--- a/BTCPayServer/Views/Shared/_LayoutPos.cshtml
+++ b/BTCPayServer/Views/Shared/_LayoutPos.cshtml
@@ -1,8 +1,6 @@
-@addTagHelper *, BundlerMinifier.TagHelpers
 @inject BTCPayServer.Services.ThemeSettings Theme
 
 @using BTCPayServer.Services.Apps
-@using BTCPayServer.Abstractions.Contracts
 @using BTCPayServer.Abstractions.Extensions
 @model BTCPayServer.Models.AppViewModels.ViewPointOfSaleViewModel
 

--- a/BTCPayServer/Views/Shared/_ValidationScriptsPartial.cshtml
+++ b/BTCPayServer/Views/Shared/_ValidationScriptsPartial.cshtml
@@ -1,3 +1,1 @@
-@addTagHelper *, BundlerMinifier.TagHelpers
-
 <bundle name="wwwroot/bundles/jqueryvalidate-bundle.min.js" asp-append-version="true" />

--- a/BTCPayServer/Views/UIAccount/_ViewImports.cshtml
+++ b/BTCPayServer/Views/UIAccount/_ViewImports.cshtml
@@ -1,3 +1,2 @@
 ﻿@using BTCPayServer.Views.Wallets
 @using BTCPayServer.Models.WalletViewModels
-@addTagHelper *, BundlerMinifier.TagHelpers

--- a/BTCPayServer/Views/UIApps/UpdateCrowdfund.cshtml
+++ b/BTCPayServer/Views/UIApps/UpdateCrowdfund.cshtml
@@ -1,4 +1,3 @@
-@addTagHelper *, BundlerMinifier.TagHelpers
 @using System.Globalization
 @using BTCPayServer.Abstractions.Models
 @model UpdateCrowdfundViewModel

--- a/BTCPayServer/Views/UIApps/UpdatePointOfSale.cshtml
+++ b/BTCPayServer/Views/UIApps/UpdatePointOfSale.cshtml
@@ -1,6 +1,5 @@
 @using BTCPayServer.Services.Apps
 @using BTCPayServer.Abstractions.Models
-@addTagHelper *, BundlerMinifier.TagHelpers
 @model UpdatePointOfSaleViewModel
 @{
     ViewData.SetActivePage(AppsNavPages.Update, "Update Point of Sale", Model.Id);

--- a/BTCPayServer/Views/UIAppsPublic/ViewCrowdfund.cshtml
+++ b/BTCPayServer/Views/UIAppsPublic/ViewCrowdfund.cshtml
@@ -1,5 +1,4 @@
 @model BTCPayServer.Models.AppViewModels.ViewCrowdfundViewModel
-@addTagHelper *, BundlerMinifier.TagHelpers
 @inject ISettingsRepository SettingsRepository
 @using BTCPayServer.Abstractions.Contracts
 @using BTCPayServer.Models.AppViewModels

--- a/BTCPayServer/Views/UICustodianAccounts/CreateCustodianAccount.cshtml
+++ b/BTCPayServer/Views/UICustodianAccounts/CreateCustodianAccount.cshtml
@@ -1,5 +1,4 @@
 ﻿@using BTCPayServer.Views.Apps
-@using Microsoft.AspNetCore.Mvc.TagHelpers
 @using BTCPayServer.Abstractions.Extensions
 @model BTCPayServer.Models.CustodianAccountViewModels.CreateCustodianAccountViewModel
 @{

--- a/BTCPayServer/Views/UICustodianAccounts/EditCustodianAccount.cshtml
+++ b/BTCPayServer/Views/UICustodianAccounts/EditCustodianAccount.cshtml
@@ -1,5 +1,4 @@
 ﻿@using BTCPayServer.Views.Apps
-@using Microsoft.AspNetCore.Mvc.TagHelpers
 @using BTCPayServer.Abstractions.Extensions
 @model BTCPayServer.Models.CustodianAccountViewModels.EditCustodianAccountViewModel
 @{

--- a/BTCPayServer/Views/UICustodianAccounts/ViewCustodianAccount.cshtml
+++ b/BTCPayServer/Views/UICustodianAccounts/ViewCustodianAccount.cshtml
@@ -1,5 +1,4 @@
 ﻿@using BTCPayServer.Views.Apps
-@using Microsoft.AspNetCore.Mvc.TagHelpers
 @using BTCPayServer.Abstractions.Extensions
 @using BTCPayServer.Abstractions.Custodians
 @model BTCPayServer.Models.CustodianAccountViewModels.ViewCustodianAccountViewModel

--- a/BTCPayServer/Views/UIInvoice/Checkout.cshtml
+++ b/BTCPayServer/Views/UIInvoice/Checkout.cshtml
@@ -1,9 +1,6 @@
-@addTagHelper *, BundlerMinifier.TagHelpers
 @inject BTCPayServer.Services.LanguageService langService
-@inject BTCPayNetworkProvider BTCPayNetworkProvider
 @inject BTCPayServer.Services.BTCPayServerEnvironment env
 @inject PaymentMethodHandlerDictionary PaymentMethodHandlerDictionary
-@using NBitcoin
 @model PaymentModel
 @{
     Layout = null;

--- a/BTCPayServer/Views/UIInvoice/InvoiceReceipt.cshtml
+++ b/BTCPayServer/Views/UIInvoice/InvoiceReceipt.cshtml
@@ -2,8 +2,6 @@
 @using BTCPayServer.Client
 @using BTCPayServer.Client.Models
 @using BTCPayServer.Services.Rates
-@using BTCPayServer.TagHelpers
-@using Microsoft.AspNetCore.Mvc.TagHelpers
 @inject BTCPayServer.Services.BTCPayServerEnvironment env
 @inject BTCPayServer.Services.ThemeSettings Theme
 @inject CurrencyNameTable CurrencyNameTable

--- a/BTCPayServer/Views/UIPaymentRequest/EditPaymentRequest.cshtml
+++ b/BTCPayServer/Views/UIPaymentRequest/EditPaymentRequest.cshtml
@@ -1,7 +1,6 @@
 @using BTCPayServer.Services.PaymentRequests
 @using System.Globalization
 @model BTCPayServer.Models.PaymentRequestViewModels.UpdatePaymentRequestViewModel
-@addTagHelper *, BundlerMinifier.TagHelpers
 @{
     ViewData.SetActivePage(PaymentRequestsNavPages.Create, $"{(string.IsNullOrEmpty(Model.Id) ? "Create" : "Edit")} Payment Request", Model.Id);
 }

--- a/BTCPayServer/Views/UIPaymentRequest/ViewPaymentRequest.cshtml
+++ b/BTCPayServer/Views/UIPaymentRequest/ViewPaymentRequest.cshtml
@@ -1,15 +1,9 @@
 @using BTCPayServer.Services.Invoices
 @using BTCPayServer.Client.Models
-@using BTCPayServer.Abstractions.Contracts
 @using BTCPayServer.Client
 @using BTCPayServer.Components.ThemeSwitch
-@using BTCPayServer.TagHelpers
-@using BundlerMinifier.TagHelpers
-@using Microsoft.AspNetCore.Mvc.TagHelpers
 @model BTCPayServer.Models.PaymentRequestViewModels.ViewPaymentRequestViewModel
-@addTagHelper *, BundlerMinifier.TagHelpers
 @inject BTCPayServer.Services.BTCPayServerEnvironment env
-@inject ISettingsRepository _settingsRepository
 @inject BTCPayServer.Services.ThemeSettings Theme
 @{
     ViewData["Title"] = Model.Title;

--- a/BTCPayServer/Views/UIPublicLightningNodeInfo/ShowLightningNodeInfo.cshtml
+++ b/BTCPayServer/Views/UIPublicLightningNodeInfo/ShowLightningNodeInfo.cshtml
@@ -1,9 +1,4 @@
-@addTagHelper *, BundlerMinifier.TagHelpers
-@inject ISettingsRepository _settingsRepository
-
-@using BTCPayServer.Abstractions.Contracts
 @using BTCPayServer.Abstractions.Extensions
-@using BTCPayServer.Lightning
 @model BTCPayServer.Controllers.ShowLightningNodeInfoViewModel
 @inject BTCPayServer.Services.ThemeSettings Theme
 @{

--- a/BTCPayServer/Views/UIPullPayment/ViewPullPayment.cshtml
+++ b/BTCPayServer/Views/UIPullPayment/ViewPullPayment.cshtml
@@ -5,12 +5,8 @@
 @using BTCPayServer.Client
 @using BTCPayServer.Components.ThemeSwitch
 @using BTCPayServer.Payments
-@using Microsoft.AspNetCore.Mvc.TagHelpers
-@using BundlerMinifier.TagHelpers
-@using BTCPayServer.TagHelpers
 @model BTCPayServer.Models.ViewPullPaymentModel
 
-@addTagHelper *, BundlerMinifier.TagHelpers
 @{
     ViewData["Title"] = Model.Title;
     Layout = null;

--- a/BTCPayServer/Views/UIStores/Dashboard.cshtml
+++ b/BTCPayServer/Views/UIStores/Dashboard.cshtml
@@ -4,8 +4,6 @@
 @using BTCPayServer.Components.StoreRecentInvoices
 @using BTCPayServer.Components.StoreRecentTransactions
 @using BTCPayServer.Components.StoreWalletBalance
-@using BTCPayServer.TagHelpers
-@using Microsoft.AspNetCore.Mvc.TagHelpers
 @using BTCPayServer.Components.AppSales
 @using BTCPayServer.Components.AppTopItems
 @model StoreDashboardViewModel;

--- a/BTCPayServer/Views/UIStores/GenerateWallet.cshtml
+++ b/BTCPayServer/Views/UIStores/GenerateWallet.cshtml
@@ -1,5 +1,4 @@
 @model WalletSetupViewModel
-@addTagHelper *, BundlerMinifier.TagHelpers
 @{
     var isHotWallet = Model.Method == WalletSetupMethod.HotWallet;
     var type = isHotWallet ? "Hot" : "Watch-Only";

--- a/BTCPayServer/Views/UIStores/GenerateWalletOptions.cshtml
+++ b/BTCPayServer/Views/UIStores/GenerateWalletOptions.cshtml
@@ -1,5 +1,4 @@
 @model WalletSetupViewModel
-@addTagHelper *, BundlerMinifier.TagHelpers
 @{
     Layout = "_LayoutWalletSetup";
     ViewData.SetActivePage(StoreNavPages.OnchainSettings, $"Generate {Model.CryptoCode} Wallet", Context.GetStoreData().Id);

--- a/BTCPayServer/Views/UIStores/ImportWallet/ConfirmAddresses.cshtml
+++ b/BTCPayServer/Views/UIStores/ImportWallet/ConfirmAddresses.cshtml
@@ -1,5 +1,4 @@
 @model WalletSetupViewModel
-@addTagHelper *, BundlerMinifier.TagHelpers
 @{
     Layout = "_LayoutWalletSetup";
     ViewData.SetActivePage(StoreNavPages.OnchainSettings, "Confirm addresses", Context.GetStoreData().Id);

--- a/BTCPayServer/Views/UIStores/ImportWallet/File.cshtml
+++ b/BTCPayServer/Views/UIStores/ImportWallet/File.cshtml
@@ -1,5 +1,4 @@
 @model WalletSetupViewModel
-@addTagHelper *, BundlerMinifier.TagHelpers
 @{
     Layout = "_LayoutWalletSetup";
     ViewData.SetActivePage(StoreNavPages.OnchainSettings, "Import your wallet file", Context.GetStoreData().Id);

--- a/BTCPayServer/Views/UIStores/ImportWallet/Hardware.cshtml
+++ b/BTCPayServer/Views/UIStores/ImportWallet/Hardware.cshtml
@@ -1,5 +1,4 @@
 @model WalletSetupViewModel
-@addTagHelper *, BundlerMinifier.TagHelpers
 @{
     Layout = "_LayoutWalletSetup";
     ViewData.SetActivePage(StoreNavPages.OnchainSettings, "Connect your hardware wallet", Context.GetStoreData().Id);

--- a/BTCPayServer/Views/UIStores/ImportWallet/Scan.cshtml
+++ b/BTCPayServer/Views/UIStores/ImportWallet/Scan.cshtml
@@ -1,5 +1,4 @@
 @model WalletSetupViewModel
-@addTagHelper *, BundlerMinifier.TagHelpers
 @{
     Layout = "_LayoutWalletSetup";
     ViewData.SetActivePage(StoreNavPages.OnchainSettings, "Scan QR code", Context.GetStoreData().Id);

--- a/BTCPayServer/Views/UIStores/ImportWallet/Seed.cshtml
+++ b/BTCPayServer/Views/UIStores/ImportWallet/Seed.cshtml
@@ -1,5 +1,4 @@
 @model WalletSetupViewModel
-@addTagHelper *, BundlerMinifier.TagHelpers
 @{
     Layout = "_LayoutWalletSetup";
     ViewData.SetActivePage(StoreNavPages.OnchainSettings, "Enter the wallet seed", Context.GetStoreData().Id);

--- a/BTCPayServer/Views/UIStores/ImportWallet/Xpub.cshtml
+++ b/BTCPayServer/Views/UIStores/ImportWallet/Xpub.cshtml
@@ -1,5 +1,4 @@
 @model WalletSetupViewModel
-@addTagHelper *, BundlerMinifier.TagHelpers
 @{
     Layout = "_LayoutWalletSetup";
     ViewData.SetActivePage(StoreNavPages.OnchainSettings, "Enter your extended public key", Context.GetStoreData().Id);

--- a/BTCPayServer/Views/UIStores/ImportWalletOptions.cshtml
+++ b/BTCPayServer/Views/UIStores/ImportWalletOptions.cshtml
@@ -1,6 +1,5 @@
 @model WalletSetupViewModel
 @inject BTCPayNetworkProvider BTCPayNetworkProvider
-@addTagHelper *, BundlerMinifier.TagHelpers
 @{
     Layout = "_LayoutWalletSetup";
     ViewData.SetActivePage(StoreNavPages.OnchainSettings, $"Import {Model.CryptoCode} Wallet", Context.GetStoreData().Id);

--- a/BTCPayServer/Views/UIWallets/SignWithSeed.cshtml
+++ b/BTCPayServer/Views/UIWallets/SignWithSeed.cshtml
@@ -1,5 +1,4 @@
 @using BTCPayServer.Controllers
-@using Microsoft.AspNetCore.Mvc.TagHelpers
 @model SignWithSeedViewModel
 @{
     var walletId = Context.GetRouteValue("walletId").ToString();

--- a/BTCPayServer/Views/UIWallets/WalletPSBT.cshtml
+++ b/BTCPayServer/Views/UIWallets/WalletPSBT.cshtml
@@ -1,9 +1,5 @@
-﻿@using Microsoft.AspNetCore.Mvc.TagHelpers
-@using BTCPayServer.Controllers
-@using BTCPayServer.TagHelpers
-@using BundlerMinifier.TagHelpers
+﻿@using BTCPayServer.Controllers
 @model WalletPSBTViewModel
-@addTagHelper *, BundlerMinifier.TagHelpers
 @{
     var walletId = Context.GetRouteValue("walletId").ToString();
     var cancelUrl = Model.ReturnUrl ?? Url.Action(nameof(UIWalletsController.WalletTransactions), new { walletId });

--- a/BTCPayServer/Views/UIWallets/WalletPSBTCombine.cshtml
+++ b/BTCPayServer/Views/UIWallets/WalletPSBTCombine.cshtml
@@ -1,5 +1,4 @@
 @using BTCPayServer.Controllers
-@using Microsoft.AspNetCore.Mvc.TagHelpers
 @model WalletPSBTCombineViewModel
 @{
     var walletId = Context.GetRouteValue("walletId").ToString();

--- a/BTCPayServer/Views/UIWallets/WalletPSBTDecoded.cshtml
+++ b/BTCPayServer/Views/UIWallets/WalletPSBTDecoded.cshtml
@@ -1,9 +1,5 @@
 @using BTCPayServer.Controllers
-@using BTCPayServer.TagHelpers
-@using Microsoft.AspNetCore.Mvc.TagHelpers
-@using BundlerMinifier.TagHelpers
 @model WalletPSBTViewModel
-@addTagHelper *, BundlerMinifier.TagHelpers
 @{
 	var walletId = Context.GetRouteValue("walletId").ToString();
     var cancelUrl = Model.ReturnUrl ?? Url.Action(nameof(UIWalletsController.WalletTransactions), new { walletId });

--- a/BTCPayServer/Views/UIWallets/WalletReceive.cshtml
+++ b/BTCPayServer/Views/UIWallets/WalletReceive.cshtml
@@ -1,7 +1,5 @@
-﻿@addTagHelper *, BundlerMinifier.TagHelpers
-@inject BTCPayServer.Services.BTCPayServerEnvironment env
+﻿@inject BTCPayServer.Services.BTCPayServerEnvironment env
 @using BTCPayServer.Controllers
-@using Microsoft.AspNetCore.Mvc.TagHelpers
 @using BTCPayServer.Components.QRCode
 @model BTCPayServer.Controllers.WalletReceiveViewModel
 @{

--- a/BTCPayServer/Views/UIWallets/WalletSend.cshtml
+++ b/BTCPayServer/Views/UIWallets/WalletSend.cshtml
@@ -1,9 +1,5 @@
-@addTagHelper *, BundlerMinifier.TagHelpers
 @inject BTCPayServer.Security.ContentSecurityPolicies csp
 @using Microsoft.AspNetCore.Mvc.ModelBinding
-@using Microsoft.AspNetCore.Mvc.TagHelpers
-@using BTCPayServer.TagHelpers
-@using BundlerMinifier.TagHelpers
 @using BTCPayServer.Controllers
 @model WalletSendModel
 @{

--- a/BTCPayServer/Views/UIWallets/WalletSendVault.cshtml
+++ b/BTCPayServer/Views/UIWallets/WalletSendVault.cshtml
@@ -1,6 +1,4 @@
 @using BTCPayServer.Controllers
-@using BTCPayServer.TagHelpers
-@using Microsoft.AspNetCore.Mvc.TagHelpers
 @model WalletSendVaultModel
 @{
     var walletId = Context.GetRouteValue("walletId").ToString();

--- a/BTCPayServer/Views/UIWallets/WalletSigningOptions.cshtml
+++ b/BTCPayServer/Views/UIWallets/WalletSigningOptions.cshtml
@@ -1,8 +1,6 @@
 @using BTCPayServer.Controllers
-@using Microsoft.AspNetCore.Mvc.TagHelpers
 @model WalletSigningOptionsModel
 @inject BTCPayNetworkProvider BTCPayNetworkProvider
-@addTagHelper *, BundlerMinifier.TagHelpers
 @{
     var walletId = WalletId.Parse(Context.GetRouteValue("walletId").ToString());
     var cancelUrl = Model.ReturnUrl ?? Url.Action(nameof(UIWalletsController.WalletTransactions), new { walletId });

--- a/BTCPayServer/Views/UIWallets/_ViewImports.cshtml
+++ b/BTCPayServer/Views/UIWallets/_ViewImports.cshtml
@@ -1,4 +1,3 @@
 ﻿@using BTCPayServer.Abstractions.Extensions
 @using BTCPayServer.Views.Wallets
 @using BTCPayServer.Models.WalletViewModels
-@addTagHelper *, BundlerMinifier.TagHelpers

--- a/BTCPayServer/_ViewImports.cshtml
+++ b/BTCPayServer/_ViewImports.cshtml
@@ -12,4 +12,5 @@
 @inject Safe Safe
 @addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
 @addTagHelper *, BTCPayServer
+@addTagHelper *, BTCPayServer.Abstractions
 @addTagHelper *, BundlerMinifier.TagHelpers


### PR DESCRIPTION
Makes them available for use in plugins. Also cleans up the tag helper references in the view code: As we have it in the root view imports, the individual directives in the views are superfluous.