### PR TITLE
Added custodian account trade support

### DIFF
--- a/BTCPayServer.Abstractions/Custodians/Client/AssetQuoteResult.cs
+++ b/BTCPayServer.Abstractions/Custodians/Client/AssetQuoteResult.cs
@@ -2,17 +2,18 @@ namespace BTCPayServer.Abstractions.Custodians.Client;
 
 public class AssetQuoteResult
 {
-    public string FromAsset { get; }
-    
-    public string ToAsset { get; }
-    public decimal Bid { get; }
-    public decimal Ask { get; }
+    public string FromAsset { get; set; }
+    public string ToAsset { get; set; }
+    public decimal Bid { get; set; }
+    public decimal Ask { get; set; }
+
+    public AssetQuoteResult() { }
 
     public AssetQuoteResult(string fromAsset, string toAsset,decimal bid, decimal ask)
     {
-        this.FromAsset = fromAsset;
-        this.ToAsset = toAsset;
-        this.Bid = bid;
-        this.Ask = ask;
+        FromAsset = fromAsset;
+        ToAsset = toAsset;
+        Bid = bid;
+        Ask = ask;
     }
 }

--- a/BTCPayServer.Abstractions/Custodians/Client/AssetQuoteResult.cs
+++ b/BTCPayServer.Abstractions/Custodians/Client/AssetQuoteResult.cs
@@ -1,4 +1,4 @@
-namespace BTCPayServer.Abstractions.Custodians;
+namespace BTCPayServer.Abstractions.Custodians.Client;
 
 public class AssetQuoteResult
 {

--- a/BTCPayServer.Abstractions/Custodians/Client/MarketTradeResult.cs
+++ b/BTCPayServer.Abstractions/Custodians/Client/MarketTradeResult.cs
@@ -1,7 +1,7 @@
 using System.Collections.Generic;
 using BTCPayServer.Client.Models;
 
-namespace BTCPayServer.Abstractions.Custodians;
+namespace BTCPayServer.Abstractions.Custodians.Client;
 
 /**
  * The result of a market trade. Used as a return type for custodians implementing ICanTrade

--- a/BTCPayServer.Abstractions/Custodians/Client/WithdrawResult.cs
+++ b/BTCPayServer.Abstractions/Custodians/Client/WithdrawResult.cs
@@ -2,7 +2,7 @@ using System;
 using System.Collections.Generic;
 using BTCPayServer.Client.Models;
 
-namespace BTCPayServer.Abstractions.Custodians;
+namespace BTCPayServer.Abstractions.Custodians.Client;
 
 public class WithdrawResult
 {

--- a/BTCPayServer.Abstractions/Custodians/ICanTrade.cs
+++ b/BTCPayServer.Abstractions/Custodians/ICanTrade.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using BTCPayServer.Abstractions.Custodians.Client;
 using BTCPayServer.Client.Models;
 using Newtonsoft.Json.Linq;
 

--- a/BTCPayServer.Abstractions/Custodians/ICanWithdraw.cs
+++ b/BTCPayServer.Abstractions/Custodians/ICanWithdraw.cs
@@ -1,5 +1,6 @@
 using System.Threading;
 using System.Threading.Tasks;
+using BTCPayServer.Abstractions.Custodians.Client;
 using Newtonsoft.Json.Linq;
 
 namespace BTCPayServer.Abstractions.Custodians;

--- a/BTCPayServer.Client/BTCPayServerClient.CustodianAccounts.cs
+++ b/BTCPayServer.Client/BTCPayServerClient.CustodianAccounts.cs
@@ -56,9 +56,14 @@ namespace BTCPayServer.Client
             return await HandleResponse<DepositAddressData>(response);
         }
 
-        public virtual async Task<MarketTradeResponseData> TradeMarket(string storeId, string accountId, TradeRequestData request, CancellationToken token = default)
+        public virtual async Task<MarketTradeResponseData> MarketTradeCustodianAccountAsset(string storeId, string accountId, TradeRequestData request, CancellationToken token = default)
         {
-            var response = await _httpClient.SendAsync(CreateHttpRequest($"api/v1/stores/{storeId}/custodian-accounts/{accountId}/trades/market", bodyPayload: request, method: HttpMethod.Post), token);
+            
+            //var response = await _httpClient.SendAsync(CreateHttpRequest("api/v1/users", null, request, HttpMethod.Post), token);
+            //return await HandleResponse<ApplicationUserData>(response);
+            var internalRequest = CreateHttpRequest($"api/v1/stores/{storeId}/custodian-accounts/{accountId}/trades/market", null,
+                    request, HttpMethod.Post);
+            var response = await _httpClient.SendAsync(internalRequest, token);
             return await HandleResponse<MarketTradeResponseData>(response);
         }
 

--- a/BTCPayServer.Client/BTCPayServerClient.CustodianAccounts.cs
+++ b/BTCPayServer.Client/BTCPayServerClient.CustodianAccounts.cs
@@ -78,7 +78,6 @@ namespace BTCPayServer.Client
             var queryPayload = new Dictionary<string, object>();
             queryPayload.Add("fromAsset", fromAsset);
             queryPayload.Add("toAsset", toAsset);
-
             var response = await _httpClient.SendAsync(CreateHttpRequest($"api/v1/stores/{storeId}/custodian-accounts/{accountId}/trades/quote", queryPayload), token);
             return await HandleResponse<TradeQuoteResponseData>(response);
         }

--- a/BTCPayServer.Client/Models/AssetPairData.cs
+++ b/BTCPayServer.Client/Models/AssetPairData.cs
@@ -16,17 +16,11 @@ public class AssetPairData
         MinimumTradeQty = minimumTradeQty;
     }
 
-    public string getPairCode()
-    {
-        return ToString();
-    }
-    
+    [JsonProperty]
     public string AssetBought { set; get; }
 
-    public string AssetSold { set; get; }
-    
     [JsonProperty]
-    public string Pair => ToString();
+    public string AssetSold { set; get; }
 
     [JsonProperty]
     public decimal MinimumTradeQty { set; get; }

--- a/BTCPayServer.Client/Models/AssetPairData.cs
+++ b/BTCPayServer.Client/Models/AssetPairData.cs
@@ -1,20 +1,37 @@
+using Newtonsoft.Json;
+
 namespace BTCPayServer.Client.Models;
 
+[JsonObject(MemberSerialization.OptIn)]
 public class AssetPairData
 {
     public AssetPairData()
     {
     }
     
-    public AssetPairData(string assetBought, string assetSold)
+    public AssetPairData(string assetBought, string assetSold, decimal minimumTradeQty)
     {
         AssetBought = assetBought;
         AssetSold = assetSold;
+        MinimumTradeQty = minimumTradeQty;
+    }
+
+    public string getPairCode()
+    {
+        return ToString();
     }
     
     public string AssetBought { set; get; }
-    public string AssetSold { set; get; }
 
+    public string AssetSold { set; get; }
+    
+    [JsonProperty]
+    public string Pair => ToString();
+
+    [JsonProperty]
+    public decimal MinimumTradeQty { set; get; }
+
+    
     public override string ToString()
     {
         return AssetBought + "/" + AssetSold;

--- a/BTCPayServer.Client/Models/CustodianData.cs
+++ b/BTCPayServer.Client/Models/CustodianData.cs
@@ -6,7 +6,7 @@ public class CustodianData
 {
     public string Code { get; set; }
     public string Name { get; set; }
-    public List<AssetPairData> TradableAssetPairs { get; set; }
+    public Dictionary<string, AssetPairData> TradableAssetPairs { get; set; }
     public string[] WithdrawablePaymentMethods { get; set; }
     public string[] DepositablePaymentMethods { get; set; }
     

--- a/BTCPayServer.Client/Models/CustodianData.cs
+++ b/BTCPayServer.Client/Models/CustodianData.cs
@@ -1,10 +1,12 @@
+using System.Collections.Generic;
+
 namespace BTCPayServer.Client.Models;
 
 public class CustodianData
 {
     public string Code { get; set; }
     public string Name { get; set; }
-    public string[] TradableAssetPairs { get; set; }
+    public List<AssetPairData> TradableAssetPairs { get; set; }
     public string[] WithdrawablePaymentMethods { get; set; }
     public string[] DepositablePaymentMethods { get; set; }
     

--- a/BTCPayServer.Tests/GreenfieldAPITests.cs
+++ b/BTCPayServer.Tests/GreenfieldAPITests.cs
@@ -2890,6 +2890,10 @@ namespace BTCPayServer.Tests
             
             // TODO Test: Trade with percentage qty
             
+            // Test: Trade with wrong decimal format (example: JavaScript scientific format)
+            var wrongQtyTradeRequest = new TradeRequestData {FromAsset = MockCustodian.TradeFromAsset, ToAsset = MockCustodian.TradeToAsset, Qty = "6.1e-7"};
+            await AssertApiError(400,"bad-qty-format", async () => await tradeClient.MarketTradeCustodianAccountAsset(storeId, accountId, wrongQtyTradeRequest));
+            
             // Test: Trade, wrong assets method
             var wrongAssetsTradeRequest = new TradeRequestData {FromAsset = "WRONG", ToAsset = MockCustodian.TradeToAsset, Qty = MockCustodian.TradeQtyBought.ToString(CultureInfo.InvariantCulture)};
             await AssertHttpError(WrongTradingPairException.HttpCode, async () => await tradeClient.MarketTradeCustodianAccountAsset(storeId, accountId, wrongAssetsTradeRequest));
@@ -2901,8 +2905,8 @@ namespace BTCPayServer.Tests
             await AssertHttpError(403, async () => await tradeClient.MarketTradeCustodianAccountAsset("WRONG-STORE-ID", accountId, tradeRequest));
             
             // Test: Trade, correct assets, wrong amount
-            var wrongQtyTradeRequest = new TradeRequestData {FromAsset = MockCustodian.TradeFromAsset, ToAsset = MockCustodian.TradeToAsset, Qty = "0.01"};
-            await AssertApiError(400, "insufficient-funds", async () => await tradeClient.MarketTradeCustodianAccountAsset(storeId, accountId, wrongQtyTradeRequest));
+            var insufficientFundsTradeRequest = new TradeRequestData {FromAsset = MockCustodian.TradeFromAsset, ToAsset = MockCustodian.TradeToAsset, Qty = "0.01"};
+            await AssertApiError(400, "insufficient-funds", async () => await tradeClient.MarketTradeCustodianAccountAsset(storeId, accountId, insufficientFundsTradeRequest));
 
 
             // Test: GetTradeQuote, unauth

--- a/BTCPayServer.Tests/GreenfieldAPITests.cs
+++ b/BTCPayServer.Tests/GreenfieldAPITests.cs
@@ -2859,13 +2859,13 @@ namespace BTCPayServer.Tests
             
             // Test: Trade, unauth
             var tradeRequest = new TradeRequestData {FromAsset = MockCustodian.TradeFromAsset, ToAsset = MockCustodian.TradeToAsset, Qty = MockCustodian.TradeQtyBought.ToString(CultureInfo.InvariantCulture)};
-            await AssertHttpError(401, async () => await unauthClient.TradeMarket(storeId, accountId, tradeRequest));
+            await AssertHttpError(401, async () => await unauthClient.MarketTradeCustodianAccountAsset(storeId, accountId, tradeRequest));
             
             // Test: Trade, auth, but wrong permission
-            await AssertHttpError(403, async () => await managerClient.TradeMarket(storeId, accountId, tradeRequest));
+            await AssertHttpError(403, async () => await managerClient.MarketTradeCustodianAccountAsset(storeId, accountId, tradeRequest));
             
             // Test: Trade, correct permission, correct assets, correct amount
-            var newTradeResult = await tradeClient.TradeMarket(storeId, accountId, tradeRequest);
+            var newTradeResult = await tradeClient.MarketTradeCustodianAccountAsset(storeId, accountId, tradeRequest);
             Assert.NotNull(newTradeResult);
             Assert.Equal(accountId, newTradeResult.AccountId);
             Assert.Equal(mockCustodian.Code, newTradeResult.CustodianCode);
@@ -2886,23 +2886,23 @@ namespace BTCPayServer.Tests
             
             // Test: GetTradeQuote, SATS
             var satsTradeRequest = new TradeRequestData {FromAsset = MockCustodian.TradeFromAsset, ToAsset = "SATS", Qty = MockCustodian.TradeQtyBought.ToString(CultureInfo.InvariantCulture)};
-            await AssertApiError(400, "use-asset-synonym", async () => await tradeClient.TradeMarket(storeId, accountId, satsTradeRequest));
+            await AssertApiError(400, "use-asset-synonym", async () => await tradeClient.MarketTradeCustodianAccountAsset(storeId, accountId, satsTradeRequest));
             
             // TODO Test: Trade with percentage qty
             
             // Test: Trade, wrong assets method
             var wrongAssetsTradeRequest = new TradeRequestData {FromAsset = "WRONG", ToAsset = MockCustodian.TradeToAsset, Qty = MockCustodian.TradeQtyBought.ToString(CultureInfo.InvariantCulture)};
-            await AssertHttpError(WrongTradingPairException.HttpCode, async () => await tradeClient.TradeMarket(storeId, accountId, wrongAssetsTradeRequest));
+            await AssertHttpError(WrongTradingPairException.HttpCode, async () => await tradeClient.MarketTradeCustodianAccountAsset(storeId, accountId, wrongAssetsTradeRequest));
 
             // Test: wrong account ID
-            await AssertHttpError(404, async () => await tradeClient.TradeMarket(storeId, "WRONG-ACCOUNT-ID", tradeRequest));
+            await AssertHttpError(404, async () => await tradeClient.MarketTradeCustodianAccountAsset(storeId, "WRONG-ACCOUNT-ID", tradeRequest));
             
             // Test: wrong store ID
-            await AssertHttpError(403, async () => await tradeClient.TradeMarket("WRONG-STORE-ID", accountId, tradeRequest));
+            await AssertHttpError(403, async () => await tradeClient.MarketTradeCustodianAccountAsset("WRONG-STORE-ID", accountId, tradeRequest));
             
             // Test: Trade, correct assets, wrong amount
             var wrongQtyTradeRequest = new TradeRequestData {FromAsset = MockCustodian.TradeFromAsset, ToAsset = MockCustodian.TradeToAsset, Qty = "0.01"};
-            await AssertApiError(400, "insufficient-funds", async () => await tradeClient.TradeMarket(storeId, accountId, wrongQtyTradeRequest));
+            await AssertApiError(400, "insufficient-funds", async () => await tradeClient.MarketTradeCustodianAccountAsset(storeId, accountId, wrongQtyTradeRequest));
 
 
             // Test: GetTradeQuote, unauth

--- a/BTCPayServer.Tests/MockCustodian/MockCustodian.cs
+++ b/BTCPayServer.Tests/MockCustodian/MockCustodian.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using BTCPayServer.Abstractions.Custodians;
+using BTCPayServer.Abstractions.Custodians.Client;
 using BTCPayServer.Abstractions.Form;
 using BTCPayServer.Client.Models;
 using Newtonsoft.Json.Linq;

--- a/BTCPayServer.Tests/MockCustodian/MockCustodian.cs
+++ b/BTCPayServer.Tests/MockCustodian/MockCustodian.cs
@@ -76,7 +76,7 @@ public class MockCustodian : ICustodian, ICanDeposit, ICanTrade, ICanWithdraw
     public List<AssetPairData> GetTradableAssetPairs()
     {
         var r = new List<AssetPairData>();
-        r.Add(new AssetPairData("BTC", "EUR"));
+        r.Add(new AssetPairData("BTC", "EUR", (decimal) 0.0001));
         return r;
     }
 

--- a/BTCPayServer/Components/MainNav/Default.cshtml
+++ b/BTCPayServer/Components/MainNav/Default.cshtml
@@ -109,7 +109,7 @@
                                         </li>
                                     }
                                     <li class="nav-item">
-                                        <a asp-area="" asp-controller="UICustodianAccounts" asp-action="CreateCustodianAccount" asp-route-storeId="@Model.Store.Id" class="nav-link js-scroll-trigger @ViewData.IsActivePage(CustodianAccountsNavPages.Create)" id="StoreNav-CreateApp">
+                                        <a asp-area="" asp-controller="UICustodianAccounts" asp-action="CreateCustodianAccount" asp-route-storeId="@Model.Store.Id" class="nav-link js-scroll-trigger @ViewData.IsActivePage(CustodianAccountsNavPages.Create)" id="StoreNav-CreateCustodianAccount">
                                             <vc:icon symbol="new"/>
                                             <span>Add Custodian</span>
                                             <span class="badge bg-warning ms-1" style="font-size:10px;">Experimental</span>

--- a/BTCPayServer/Controllers/GreenField/GreenfieldCustodianAccountController.cs
+++ b/BTCPayServer/Controllers/GreenField/GreenfieldCustodianAccountController.cs
@@ -231,7 +231,7 @@ namespace BTCPayServer.Controllers.Greenfield
         [HttpPost("~/api/v1/stores/{storeId}/custodian-accounts/{accountId}/trades/market")]
         [Authorize(Policy = Policies.CanTradeCustodianAccount,
             AuthenticationSchemes = AuthenticationSchemes.Greenfield)]
-        public async Task<IActionResult> TradeMarket(string storeId, string accountId,
+        public async Task<IActionResult> MarketTradeCustodianAccountAsset(string storeId, string accountId,
             TradeRequestData request, CancellationToken cancellationToken = default)
         {
             // TODO add SATS check everywhere. We cannot change to 'BTC' ourselves because the qty / price would be different too.

--- a/BTCPayServer/Controllers/GreenField/GreenfieldCustodianAccountController.cs
+++ b/BTCPayServer/Controllers/GreenField/GreenfieldCustodianAccountController.cs
@@ -6,6 +6,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using BTCPayServer.Abstractions.Constants;
 using BTCPayServer.Abstractions.Custodians;
+using BTCPayServer.Abstractions.Custodians.Client;
 using BTCPayServer.Abstractions.Extensions;
 using BTCPayServer.Abstractions.Form;
 using BTCPayServer.Client;

--- a/BTCPayServer/Controllers/GreenField/GreenfieldCustodianController.cs
+++ b/BTCPayServer/Controllers/GreenField/GreenfieldCustodianController.cs
@@ -40,7 +40,12 @@ namespace BTCPayServer.Controllers.Greenfield
             if (custodian is ICanTrade tradableCustodian)
             {
                 var tradableAssetPairs = tradableCustodian.GetTradableAssetPairs();
-                result.TradableAssetPairs = tradableAssetPairs;
+                var tradableAssetPairsDict = new Dictionary<string, AssetPairData>(tradableAssetPairs.Count);
+                foreach (var tradableAssetPair in tradableAssetPairs)
+                {
+                    tradableAssetPairsDict.Add(tradableAssetPair.ToString(), tradableAssetPair);
+                }
+                result.TradableAssetPairs = tradableAssetPairsDict;
             }
 
             if (custodian is ICanDeposit depositableCustodian)

--- a/BTCPayServer/Controllers/GreenField/GreenfieldCustodianController.cs
+++ b/BTCPayServer/Controllers/GreenField/GreenfieldCustodianController.cs
@@ -40,12 +40,7 @@ namespace BTCPayServer.Controllers.Greenfield
             if (custodian is ICanTrade tradableCustodian)
             {
                 var tradableAssetPairs = tradableCustodian.GetTradableAssetPairs();
-                var tradableAssetPairStrings = new string[tradableAssetPairs.Count];
-                for (int i = 0; i < tradableAssetPairs.Count; i++)
-                {
-                    tradableAssetPairStrings[i] = tradableAssetPairs[i].ToString();
-                }
-                result.TradableAssetPairs = tradableAssetPairStrings;
+                result.TradableAssetPairs = tradableAssetPairs;
             }
 
             if (custodian is ICanDeposit depositableCustodian)

--- a/BTCPayServer/Controllers/GreenField/LocalBTCPayServerClient.cs
+++ b/BTCPayServer/Controllers/GreenField/LocalBTCPayServerClient.cs
@@ -221,7 +221,7 @@ namespace BTCPayServer.Controllers.Greenfield
             TradeRequestData request, CancellationToken cancellationToken = default)
         {
             return GetFromActionResult<MarketTradeResponseData>(
-                await _greenfieldCustodianAccountController.MarketTradeCustodianAccountAsset(storeId, accountId, request, cancellationToken));
+                await GetController<GreenfieldCustodianAccountController>().MarketTradeCustodianAccountAsset(storeId, accountId, request, cancellationToken));
         }
 
         public override async Task<StoreWebhookData> CreateWebhook(string storeId, CreateStoreWebhookRequest create,

--- a/BTCPayServer/Controllers/GreenField/LocalBTCPayServerClient.cs
+++ b/BTCPayServer/Controllers/GreenField/LocalBTCPayServerClient.cs
@@ -484,6 +484,8 @@ namespace BTCPayServer.Controllers.Greenfield
                     throw new GreenfieldValidationException(validationErrors.ToArray());
                 case BadRequestObjectResult { Value: GreenfieldAPIError error }:
                     throw new GreenfieldAPIException(400, error);
+                case ObjectResult { Value: GreenfieldAPIError error }:
+                    throw new GreenfieldAPIException(400, error);
                 case NotFoundResult _:
                     throw new GreenfieldAPIException(404, new GreenfieldAPIError("not-found", ""));
                 default:

--- a/BTCPayServer/Controllers/GreenField/LocalBTCPayServerClient.cs
+++ b/BTCPayServer/Controllers/GreenField/LocalBTCPayServerClient.cs
@@ -90,7 +90,8 @@ namespace BTCPayServer.Controllers.Greenfield
             else
             {
                 context.User =
-                    new ClaimsPrincipal(new ClaimsIdentity(new List<Claim>()
+                    new ClaimsPrincipal(new ClaimsIdentity(
+                        new List<Claim>()
                         {
                             new(_identityOptions.CurrentValue.ClaimsIdentity.RoleClaimType, Roles.ServerAdmin)
                         },
@@ -205,7 +206,7 @@ namespace BTCPayServer.Controllers.Greenfield
             public Task<AuthorizationResult> AuthorizeAsync(ClaimsPrincipal user, object resource, string policyName)
             {
                 return AuthorizeAsync(user, resource,
-                    new List<IAuthorizationRequirement>(new[] {new PolicyRequirement(policyName)}));
+                    new List<IAuthorizationRequirement>(new[] { new PolicyRequirement(policyName) }));
             }
         }
 
@@ -213,6 +214,14 @@ namespace BTCPayServer.Controllers.Greenfield
             Dictionary<string, object> queryPayload = null, HttpMethod method = null)
         {
             throw new NotSupportedException("This method is not supported by the LocalBTCPayServerClient.");
+        }
+
+
+        public override async Task<MarketTradeResponseData> MarketTradeCustodianAccountAsset(string storeId, string accountId,
+            TradeRequestData request, CancellationToken cancellationToken = default)
+        {
+            return GetFromActionResult<MarketTradeResponseData>(
+                await _greenfieldCustodianAccountController.MarketTradeCustodianAccountAsset(storeId, accountId, request, cancellationToken));
         }
 
         public override async Task<StoreWebhookData> CreateWebhook(string storeId, CreateStoreWebhookRequest create,
@@ -461,8 +470,8 @@ namespace BTCPayServer.Controllers.Greenfield
             return result switch
             {
                 JsonResult jsonResult => (T)jsonResult.Value,
-                OkObjectResult {Value: T res} => res,
-                OkObjectResult {Value: JValue res} => res.Value<T>(),
+                OkObjectResult { Value: T res } => res,
+                OkObjectResult { Value: JValue res } => res.Value<T>(),
                 _ => default
             };
         }
@@ -471,9 +480,9 @@ namespace BTCPayServer.Controllers.Greenfield
         {
             switch (result)
             {
-                case UnprocessableEntityObjectResult {Value: List<GreenfieldValidationError> validationErrors}:
+                case UnprocessableEntityObjectResult { Value: List<GreenfieldValidationError> validationErrors }:
                     throw new GreenfieldValidationException(validationErrors.ToArray());
-                case BadRequestObjectResult {Value: GreenfieldAPIError error}:
+                case BadRequestObjectResult { Value: GreenfieldAPIError error }:
                     throw new GreenfieldAPIException(400, error);
                 case NotFoundResult _:
                     throw new GreenfieldAPIException(404, new GreenfieldAPIError("not-found", ""));
@@ -1086,7 +1095,7 @@ namespace BTCPayServer.Controllers.Greenfield
         }
 
         public override async Task<PointOfSaleAppData> CreatePointOfSaleApp(
-           string storeId,
+            string storeId,
             CreatePointOfSaleAppRequest request, CancellationToken token = default)
         {
             return GetFromActionResult<PointOfSaleAppData>(

--- a/BTCPayServer/Controllers/UICustodianAccountsController.cs
+++ b/BTCPayServer/Controllers/UICustodianAccountsController.cs
@@ -471,8 +471,8 @@ namespace BTCPayServer.Controllers
             }
             catch (GreenfieldAPIException e)
             {
-                // TODO how to we return the same response as the original?
-                return BadRequest(e);
+                var result = new ObjectResult(e.APIError) { StatusCode = e.HttpCode };
+                return result;
             }
         }
 

--- a/BTCPayServer/Controllers/UICustodianAccountsController.cs
+++ b/BTCPayServer/Controllers/UICustodianAccountsController.cs
@@ -437,17 +437,12 @@ namespace BTCPayServer.Controllers
                             {
                                 var quote = await tradingCustodian.GetQuoteForAssetAsync(assetToTrade, assetToTradeInto,
                                     config, default);
-
-                                // Should we use "bid" or "ask"? Depends on the pair... are we buying or selling?
+                                
                                 // TODO Ask is normally a higher number than Bid!! Let's check this!! Maybe a Unit Test?
-                                vm.Price = quote.Ask;
-
-                                // vm.FormattedPrice =
-                                //     _currencyNameTable.DisplayFormatCurrency(vm.Price, assetToTrade);
-                                // vm.FormattedFiatValue =
-                                //     _currencyNameTable.DisplayFormatCurrency(pair.Value.Qty * quote.Bid,
-                                //         pair.Value.FiatAsset);
-                                // vm.FiatValue = vm.Qty * vm.Price;
+                                vm.Ask = quote.Ask;
+                                vm.Bid = quote.Bid;
+                                vm.FromAsset = quote.FromAsset;
+                                vm.ToAsset = quote.ToAsset;
                             }
                             catch (WrongTradingPairException)
                             {

--- a/BTCPayServer/Controllers/UICustodianAccountsController.cs
+++ b/BTCPayServer/Controllers/UICustodianAccountsController.cs
@@ -331,8 +331,7 @@ namespace BTCPayServer.Controllers
             return View(vm);
         }
 
-
-        [HttpGet("/stores/{storeId}/custodian-accounts/{accountId}/delete")]
+        [HttpPost("/stores/{storeId}/custodian-accounts/{accountId}/delete")]
         public async Task<IActionResult> DeleteCustodianAccount(string storeId, string accountId)
         {
             var custodianAccount = await _custodianAccountRepository.FindById(storeId, accountId);
@@ -345,7 +344,7 @@ namespace BTCPayServer.Controllers
             if (isDeleted)
             {
                 TempData[WellKnownTempData.SuccessMessage] = "Custodian account deleted";
-                return RedirectToAction("Dashboard", "UIStores", new { storeId });
+                return RedirectToAction(nameof(UIStoresController.Dashboard), "UIStores", new { storeId });
             }
 
             TempData[WellKnownTempData.ErrorMessage] = "Could not delete custodian account";

--- a/BTCPayServer/Controllers/UICustodianAccountsController.cs
+++ b/BTCPayServer/Controllers/UICustodianAccountsController.cs
@@ -91,8 +91,9 @@ namespace BTCPayServer.Controllers
             }
 
             var store = GetCurrentStore();
-            var storeBlob = BTCPayServer.Data.StoreDataExtensions.GetStoreBlob(store);
+            var storeBlob = StoreDataExtensions.GetStoreBlob(store);
             var defaultCurrency = storeBlob.DefaultCurrency;
+            vm.DustThresholdInFiat = 1;
             vm.StoreDefaultFiat = defaultCurrency;
             try
             {
@@ -114,7 +115,6 @@ namespace BTCPayServer.Controllers
                     );
                 }
 
-
                 if (custodian is ICanTrade tradingCustodian)
                 {
                     var config = custodianAccount.GetBlob();
@@ -124,8 +124,14 @@ namespace BTCPayServer.Controllers
                     {
                         var asset = pair.Key;
                         var assetBalance = assetBalances[asset];
-                        assetBalance.TradableAssetPairs =
-                            tradableAssetPairs.Where(o => o.AssetBought == asset || o.AssetSold == asset);
+                        var tradableAssetPairsList =
+                            tradableAssetPairs.Where(o => o.AssetBought == asset || o.AssetSold == asset).ToList();
+                        var tradableAssetPairsDict = new Dictionary<string, AssetPairData>(tradableAssetPairsList.Count);
+                        foreach (var assetPair in tradableAssetPairsList)
+                        {
+                            tradableAssetPairsDict.Add(assetPair.ToString(), assetPair);
+                        }
+                        assetBalance.TradableAssetPairs = tradableAssetPairsDict;
 
                         if (asset.Equals(defaultCurrency))
                         {

--- a/BTCPayServer/Models/CustodianAccountViewModels/AssetBalanceInfo.cs
+++ b/BTCPayServer/Models/CustodianAccountViewModels/AssetBalanceInfo.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using BTCPayServer.Client.Models;
 
@@ -14,7 +13,7 @@ public class AssetBalanceInfo
     public string FormattedQty { get; set; }
     public string FormattedFiatValue { get; set; }
     public decimal FiatValue { get; set; }
-    public IEnumerable<AssetPairData> TradableAssetPairs { get; set; }
+    public Dictionary<string, AssetPairData> TradableAssetPairs { get; set; }
     public bool CanWithdraw { get; set; }
     public bool CanDeposit { get; set; }
     public string FormattedBid { get; set; }

--- a/BTCPayServer/Models/CustodianAccountViewModels/AssetBalanceInfo.cs
+++ b/BTCPayServer/Models/CustodianAccountViewModels/AssetBalanceInfo.cs
@@ -11,8 +11,9 @@ public class AssetBalanceInfo
     public decimal? Bid { get; set; }
     public decimal? Ask { get; set; }
     public decimal Qty { get; set; }
-    public string FiatAsset { get; set; }
+    public string FormattedQty { get; set; }
     public string FormattedFiatValue { get; set; }
+    public decimal FiatValue { get; set; }
     public IEnumerable<AssetPairData> TradableAssetPairs { get; set; }
     public bool CanWithdraw { get; set; }
     public bool CanDeposit { get; set; }

--- a/BTCPayServer/Models/CustodianAccountViewModels/TradePrepareViewModel.cs
+++ b/BTCPayServer/Models/CustodianAccountViewModels/TradePrepareViewModel.cs
@@ -1,3 +1,5 @@
+using BTCPayServer.Abstractions.Custodians.Client;
+
 namespace BTCPayServer.Models.CustodianAccountViewModels;
 
 public class TradePrepareViewModel

--- a/BTCPayServer/Models/CustodianAccountViewModels/TradePrepareViewModel.cs
+++ b/BTCPayServer/Models/CustodianAccountViewModels/TradePrepareViewModel.cs
@@ -1,0 +1,7 @@
+namespace BTCPayServer.Models.CustodianAccountViewModels;
+
+public class TradePrepareViewModel
+{
+    public decimal MaxQtyToTrade { get; set; }
+    public decimal? Price { get; set; }
+}

--- a/BTCPayServer/Models/CustodianAccountViewModels/TradePrepareViewModel.cs
+++ b/BTCPayServer/Models/CustodianAccountViewModels/TradePrepareViewModel.cs
@@ -2,8 +2,8 @@ using BTCPayServer.Abstractions.Custodians.Client;
 
 namespace BTCPayServer.Models.CustodianAccountViewModels;
 
-public class TradePrepareViewModel
+public class TradePrepareViewModel : AssetQuoteResult
 {
     public decimal MaxQtyToTrade { get; set; }
-    public decimal? Price { get; set; }
+    
 }

--- a/BTCPayServer/Models/CustodianAccountViewModels/ViewCustodianAccountBalancesViewModel.cs
+++ b/BTCPayServer/Models/CustodianAccountViewModels/ViewCustodianAccountBalancesViewModel.cs
@@ -9,6 +9,7 @@ namespace BTCPayServer.Models.CustodianAccountViewModels
         public string AssetBalanceExceptionMessage { get; set; }
         
         public string StoreDefaultFiat { get; set; }
+        public decimal DustThresholdInFiat { get; set; }
         public bool CanDeposit { get; set; }
     }
 }

--- a/BTCPayServer/Models/CustodianAccountViewModels/ViewCustodianAccountBalancesViewModel.cs
+++ b/BTCPayServer/Models/CustodianAccountViewModels/ViewCustodianAccountBalancesViewModel.cs
@@ -1,0 +1,14 @@
+using System;
+using System.Collections.Generic;
+
+namespace BTCPayServer.Models.CustodianAccountViewModels
+{
+    public class ViewCustodianAccountBalancesViewModel
+    {
+        public Dictionary<string,AssetBalanceInfo> AssetBalances { get; set; }
+        public string AssetBalanceExceptionMessage { get; set; }
+        
+        public string StoreDefaultFiat { get; set; }
+        public bool CanDeposit { get; set; }
+    }
+}

--- a/BTCPayServer/Models/CustodianAccountViewModels/ViewCustodianAccountViewModel.cs
+++ b/BTCPayServer/Models/CustodianAccountViewModels/ViewCustodianAccountViewModel.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Collections.Generic;
 using BTCPayServer.Abstractions.Custodians;
 using BTCPayServer.Data;
 
@@ -9,8 +7,6 @@ namespace BTCPayServer.Models.CustodianAccountViewModels
     {
         public ICustodian Custodian { get; set; }
         public CustodianAccountData CustodianAccount { get; set; }
-        public Dictionary<string,AssetBalanceInfo> AssetBalances { get; set; }
-        public Exception GetAssetBalanceException { get; set; }
-        public string DefaultCurrency { get; set; }
+
     }
 }

--- a/BTCPayServer/Views/Shared/_Form.cshtml
+++ b/BTCPayServer/Views/Shared/_Form.cshtml
@@ -3,7 +3,7 @@
 @foreach (var fieldset in Model.Fieldsets)
 {
     <fieldset>
-        <legend>@fieldset.Label</legend>
+        <legend class="h3 mt-4 mb-3">@fieldset.Label</legend>
         @foreach (var field in fieldset.Fields)
         {
 @if ("text".Equals(field.Type))
@@ -22,7 +22,7 @@
             </label>
         }
 
-        <input class="form-control @(@field.IsValid() ? "" : "is-invalid")" id="@field.Name" type="text" required="@field.Required" name="@field.Name" value="@field.Value" aria-describedby="HelpText@field.Name"/>
+        <input class="form-control @(field.IsValid() ? "" : "is-invalid")" id="@field.Name" type="text" required="@field.Required" name="@field.Name" value="@field.Value" aria-describedby="HelpText@field.Name"/>
         <small id="HelpText@field.Name" class="form-text text-muted">
             @field.HelpText
         </small>

--- a/BTCPayServer/Views/UICustodianAccounts/CreateCustodianAccount.cshtml
+++ b/BTCPayServer/Views/UICustodianAccounts/CreateCustodianAccount.cshtml
@@ -16,8 +16,10 @@
 <div class="row">
     <div class="col-xl-8 col-xxl-constrain">
         <form asp-action="CreateCustodianAccount">
-            <div asp-validation-summary="ModelOnly" class="text-danger"></div>
-            
+            @if (!ViewContext.ModelState.IsValid)
+            {
+                <div asp-validation-summary="ModelOnly" class="text-danger"></div>
+            }
             @if (!string.IsNullOrEmpty(Model.SelectedCustodian))
             {
                 <partial name="_FormTopMessages" model="Model.ConfigForm" />

--- a/BTCPayServer/Views/UICustodianAccounts/EditCustodianAccount.cshtml
+++ b/BTCPayServer/Views/UICustodianAccounts/EditCustodianAccount.cshtml
@@ -1,5 +1,6 @@
 ﻿@using BTCPayServer.Views.Apps
 @using BTCPayServer.Abstractions.Extensions
+@using BTCPayServer.Abstractions.Models
 @model BTCPayServer.Models.CustodianAccountViewModels.EditCustodianAccountViewModel
 @{
     ViewData.SetActivePage(AppsNavPages.Update, "Edit custodian account");
@@ -34,8 +35,10 @@
                 <input type="submit" value="Continue" class="btn btn-primary" id="Save"/>
             </div>
         </form>
-        <a asp-action="DeleteCustodianAccount" asp-route-storeId="@Model.CustodianAccount.StoreId" asp-route-accountId="@Model.CustodianAccount.Id" class="btn btn-outline-danger" role="button" id="DeleteCustodianAccountConfig">
+        <a asp-action="DeleteCustodianAccount" asp-route-storeId="@Model.CustodianAccount.StoreId" asp-route-accountId="@Model.CustodianAccount.Id" class="btn btn-outline-danger" role="button" id="DeleteCustodianAccountConfig" data-bs-toggle="modal" data-bs-target="#ConfirmModal" data-description="The custodian account <strong>@Model.CustodianAccount.Name</strong> will be permanently deleted." data-confirm-input="DELETE">
             <span class="fa fa-trash"></span> Delete this custodian account
         </a>
     </div>
 </div>
+
+<partial name="_Confirm" model="@(new ConfirmModel("Delete custodian account", "The custodian account will be permanently deleted.", "Delete"))" />

--- a/BTCPayServer/Views/UICustodianAccounts/EditCustodianAccount.cshtml
+++ b/BTCPayServer/Views/UICustodianAccounts/EditCustodianAccount.cshtml
@@ -15,9 +15,11 @@
 
 <div class="row">
     <div class="col-xl-8 col-xxl-constrain">
-        <form asp-action="EditCustodianAccount">
-            <div asp-validation-summary="ModelOnly" class="text-danger"></div>
-            
+        <form asp-action="EditCustodianAccount" class="mb-5">
+            @if (!ViewContext.ModelState.IsValid)
+            {
+                <div asp-validation-summary="ModelOnly" class="text-danger"></div>
+            }
             <partial name="_FormTopMessages" model="Model.ConfigForm"/>
 
             <div class="form-group">
@@ -32,5 +34,8 @@
                 <input type="submit" value="Continue" class="btn btn-primary" id="Save"/>
             </div>
         </form>
+        <a asp-action="DeleteCustodianAccount" asp-route-storeId="@Model.CustodianAccount.StoreId" asp-route-accountId="@Model.CustodianAccount.Id" class="btn btn-outline-danger" role="button" id="DeleteCustodianAccountConfig">
+            <span class="fa fa-trash"></span> Delete this custodian account
+        </a>
     </div>
 </div>

--- a/BTCPayServer/Views/UICustodianAccounts/ViewCustodianAccount.cshtml
+++ b/BTCPayServer/Views/UICustodianAccounts/ViewCustodianAccount.cshtml
@@ -1,4 +1,4 @@
-@using BTCPayServer.Views.Apps
+﻿@using BTCPayServer.Views.Apps
 @using BTCPayServer.Abstractions.Extensions
 @using BTCPayServer.Abstractions.Custodians
 @model BTCPayServer.Models.CustodianAccountViewModels.ViewCustodianAccountViewModel
@@ -186,7 +186,12 @@
                                 <label class="form-label">
                                     Convert
                                     <div class="input-group has-validation">
-                                        <input name="Qty" type="number" min="0" step="any" :max="trade.maxQtyToTrade" :min="minQtyToTrade" class="form-control qty" v-bind:class="{ 'is-invalid': trade.qty < minQtyToTrade || trade.qty > trade.maxQtyToTrade }" v-model="trade.qty"/>
+                                    <!--
+                                    getMinQtyToTrade() = {{ getMinQtyToTrade(this.trade.assetToTradeInto, this.trade.assetToTrade) }}
+                                    <br/>
+                                    Max Qty to Trade = {{ trade.maxQtyToTrade }}
+                                    -->
+                                        <input name="Qty" type="number" min="0" step="any" :max="trade.maxQtyToTrade" :min="getMinQtyToTrade()" class="form-control qty" v-bind:class="{ 'is-invalid': trade.qty < getMinQtyToTrade() || trade.qty > trade.maxQtyToTrade }" v-model="trade.qty"/>
                                         <select name="FromAsset" v-model="trade.assetToTrade" class="form-control">
                                             <option v-for="option in availableAssetsToTrade" v-bind:value="option">
                                                 {{ option }}
@@ -237,6 +242,60 @@
                             After the trade
                             {{ trade.maxQtyToTrade - trade.qty }} {{ trade.assetToTrade }} will remain in your account.
                         </p>
+                        
+                        <!--
+                        <p>
+                            trade.priceForPair = {{ trade.priceForPair }}
+                        </p>
+                        <table>
+                            <thead>
+                            <tr>
+                                <th>From</th>
+                                <th>To</th>
+                                <th>Min Qty to Trade</th>
+                                <th>Price</th>
+                            </tr>
+                            </thead>
+                            <tbody>
+                            <tr>
+                                <td>EUR</td>
+                                <td>BTC</td>
+                                <td>{{getMinQtyToTrade('EUR', 'BTC')}}</td>
+                                <td>{{trade.priceForPair['EUR/BTC']}}</td>
+                            </tr>
+                            <tr>
+                                <td>BTC</td>
+                                <td>EUR</td>
+                                <td>{{getMinQtyToTrade('BTC', 'EUR')}}</td>
+                                <td>{{trade.priceForPair['BTC/EUR']}}</td>
+                            </tr>
+                            <tr>
+                                <td>EUR</td>
+                                <td>LTC</td>
+                                <td>{{getMinQtyToTrade('EUR', 'LTC')}}</td>
+                                <td>{{trade.priceForPair['EUR/LTC']}}</td>
+                            </tr>
+                            <tr>
+                                <td>LTC</td>
+                                <td>EUR</td>
+                                <td>{{getMinQtyToTrade('LTC', 'EUR')}}</td>
+                                <td>{{trade.priceForPair['LTC/EUR']}}</td>
+                            </tr>
+                            <tr>
+                                <td>BTC</td>
+                                <td>LTC</td>
+                                <td>{{getMinQtyToTrade('BTC', 'LTC')}}</td>
+                                <td>{{trade.priceForPair['BTC/LTC']}}</td>
+                            </tr>
+                            <tr>
+                                <td>LTC</td>
+                                <td>BTC</td>
+                                <td>{{getMinQtyToTrade('LTC', 'BTC')}}</td>
+                                <td>{{trade.priceForPair['LTC/BTC']}}</td>
+                            </tr>
+                            </tbody>
+                        </table>
+                        -->
                         <small class="form-text text-muted">Final results may vary due to trading fees and slippage.</small>
                     </div>
                     <div v-if="trade.results !== null">

--- a/BTCPayServer/Views/UICustodianAccounts/ViewCustodianAccount.cshtml
+++ b/BTCPayServer/Views/UICustodianAccounts/ViewCustodianAccount.cshtml
@@ -173,11 +173,11 @@
                         <p v-if="trade.errorMsg" class="alert alert-danger">{{ trade.errorMsg }}</p>
 
                         <div class="row mb-2 trade-qty">
-                            <div class="col-5">
+                            <div class="col-side">
                                 <label class="form-label">
                                     Convert
                                     <div class="input-group">
-                                        <input name="Qty" type="number" min="0" :max="trade.maxQtyToTrade" class="form-control" v-model="trade.qty"/>
+                                        <input name="Qty" type="number" min="0" step="any" :max="trade.maxQtyToTrade" class="form-control qty" v-model="trade.qty"/>
                                         <select name="FromAsset" v-model="trade.assetToTrade" class="form-control">
                                             <option v-for="option in availableAssetsToTrade" v-bind:value="option">
                                                 {{ option }}
@@ -186,18 +186,18 @@
                                     </div>
                                 </label>
                             </div>
-                            <div class="col-2 text-center">
+                            <div class="col-center text-center">
                                 &nbsp;
                                 <br/>
-                                <button type="button" class="btn btn-secondary" v-on:click="swapTradeAssets()" aria-label="Swap assets">
+                                <button type="button" class="btn btn-secondary btn-square" v-on:click="swapTradeAssets()" aria-label="Swap assets">
                                     <i class="fa fa-arrows-h" aria-hidden="true"></i>
                                 </button>
                             </div>
-                            <div class="col-5">
+                            <div class="col-side">
                                 <label class="form-label">
                                     Into
                                     <div class="input-group">
-                                        <input disabled="disabled" type="number" class="form-control" v-model="tradeQtyToReceive"/>
+                                        <input disabled="disabled" type="number" class="form-control qty" v-model="tradeQtyToReceive"/>
                                         <select name="ToAsset" v-model="trade.assetToTradeInto" class="form-control">
                                             <option v-for="option in availableAssetsToTradeInto" v-bind:value="option">
                                                 {{ option }}
@@ -247,10 +247,10 @@
                             </tr>
                             </thead>
                             <tbody>
-                            <tr v-for="entry in trade.results.ledgerEntries" v-bind:class="{ 'table-success': entry.qty > 0, 'table-danger': entry.qty < 0 }">
-                                <td class="text-end"><span v-if="entry.qty > 0">+</span> {{ entry.qty }}</td>
-                                <td>{{ entry.asset }}</td>
-                                <td>
+                            <tr v-for="entry in trade.results.ledgerEntries">
+                                <td class="text-end" v-bind:class="{ 'text-success': entry.qty > 0, 'text-danger': entry.qty < 0 }"><span v-if="entry.qty > 0">+</span>{{ entry.qty }}</td>
+                                <td v-bind:class="{ 'text-success': entry.qty > 0, 'text-danger': entry.qty < 0 }">{{ entry.asset }}</td>
+                                <td v-bind:class="{ 'text-success': entry.qty > 0, 'text-danger': entry.qty < 0 }">
                                     <span v-if="entry.type !== 'Trade'">{{ entry.type}}</span>
                                 </td>
                             </tr>

--- a/BTCPayServer/Views/UICustodianAccounts/ViewCustodianAccount.cshtml
+++ b/BTCPayServer/Views/UICustodianAccounts/ViewCustodianAccount.cshtml
@@ -1,4 +1,4 @@
-﻿@using BTCPayServer.Views.Apps
+@using BTCPayServer.Views.Apps
 @using BTCPayServer.Abstractions.Extensions
 @using BTCPayServer.Abstractions.Custodians
 @model BTCPayServer.Models.CustodianAccountViewModels.ViewCustodianAccountViewModel
@@ -227,7 +227,7 @@
                             </div>
                         </div>
 
-                        <p>
+                        <p v-if="trade.price">
                             <br/>
                             1 {{ trade.assetToTradeInto }} = {{ trade.price }} {{ trade.assetToTrade }}
                             <br/>

--- a/BTCPayServer/Views/UICustodianAccounts/ViewCustodianAccount.cshtml
+++ b/BTCPayServer/Views/UICustodianAccounts/ViewCustodianAccount.cshtml
@@ -198,7 +198,7 @@
                             <div class="col-center text-center">
                                 &nbsp;
                                 <br/>
-                                <button type="button" class="btn btn-secondary btn-square" v-on:click="swapTradeAssets()" aria-label="Swap assets">
+                                <button v-if="canSwapTradeAssets()" type="button" class="btn btn-secondary btn-square" v-on:click="swapTradeAssets()" aria-label="Swap assets">
                                     <i class="fa fa-arrows-h" aria-hidden="true"></i>
                                 </button>
                             </div>

--- a/BTCPayServer/Views/UICustodianAccounts/ViewCustodianAccount.cshtml
+++ b/BTCPayServer/Views/UICustodianAccounts/ViewCustodianAccount.cshtml
@@ -50,6 +50,15 @@
                 </p>
 
                 <h2>Balances</h2>
+                
+                <div class="form-check">
+                  <input class="form-check-input" type="checkbox" v-model="hideDustAmounts" id="flexCheckDefault">
+                  <label class="form-check-label" for="flexCheckDefault" >
+                      Hide holdings worth less than {{ account.dustThresholdInFiat }} {{ account.storeDefaultFiat }}.
+                  </label>
+                </div>
+                
+                
                 <div class="table-responsive">
                     <table class="table table-hover table-responsive-md">
                         <thead>
@@ -173,11 +182,11 @@
                         <p v-if="trade.errorMsg" class="alert alert-danger">{{ trade.errorMsg }}</p>
 
                         <div class="row mb-2 trade-qty">
-                            <div class="col-side">
+                            <div class="col-side">  
                                 <label class="form-label">
                                     Convert
-                                    <div class="input-group">
-                                        <input name="Qty" type="number" min="0" step="any" :max="trade.maxQtyToTrade" class="form-control qty" v-model="trade.qty"/>
+                                    <div class="input-group has-validation">
+                                        <input name="Qty" type="number" min="0" step="any" :max="trade.maxQtyToTrade" :min="minQtyToTrade" class="form-control qty" v-bind:class="{ 'is-invalid': trade.qty < minQtyToTrade || trade.qty > trade.maxQtyToTrade }" v-model="trade.qty"/>
                                         <select name="FromAsset" v-model="trade.assetToTrade" class="form-control">
                                             <option v-for="option in availableAssetsToTrade" v-bind:value="option">
                                                 {{ option }}
@@ -224,18 +233,11 @@
                             <br/>
                             1 {{ trade.assetToTrade }} = {{ 1 / trade.price }} {{ trade.assetToTradeInto }}
                         </p>
-                        <p>
+                        <p v-if="canExecuteTrade">
                             After the trade
                             {{ trade.maxQtyToTrade - trade.qty }} {{ trade.assetToTrade }} will remain in your account.
                         </p>
                         <small class="form-text text-muted">Final results may vary due to trading fees and slippage.</small>
-
-                        <p>
-                            <span v-if="trade.isUpdating">
-                                Updating quote...
-                            </span>
-                            &nbsp;
-                        </p>
                     </div>
                     <div v-if="trade.results !== null">
                         <p class="alert alert-success">Successfully traded {{ trade.results.fromAsset}} into {{ trade.results.toAsset}}.</p>
@@ -260,6 +262,13 @@
                     </div>
                 </div>
                 <div class="modal-footer" v-if="!trade.isExecuting">
+                    
+                    <div class="modal-footer-left">
+                        <span v-if="trade.isUpdating">
+                            Updating quote...
+                        </span>
+                    </div>
+                    
                     <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">
                         <span v-if="trade.results">Close</span>
                         <span v-if="!trade.results">Cancel</span>

--- a/BTCPayServer/Views/UICustodianAccounts/ViewCustodianAccount.cshtml
+++ b/BTCPayServer/Views/UICustodianAccounts/ViewCustodianAccount.cshtml
@@ -10,42 +10,34 @@
     <partial name="_ValidationScriptsPartial"/>
 }
 
-
-<partial name="_StatusMessage"/>
-
 <style>
     .trade-qty label{display: block; }
 </style>
 
 <div id="custodianAccountView" v-cloak>
-
     <div class="sticky-header-setup"></div>
-    <div class="sticky-header d-sm-flex align-items-center justify-content-between">
+    <div class="sticky-header d-flex flex-wrap gap-3 align-items-center justify-content-between">
         <h2 class="mb-0">
             @ViewData["Title"]
         </h2>
-        <div class="d-flex gap-3 mt-3 mt-sm-0">
-            <a class="btn btn-primary mt-3 mt-sm-0" role="button" v-if="account && account.canDeposit" v-on:click="openDepositModal()" href="#">
+        <div class="d-flex flex-wrap gap-3">
+            <a class="btn btn-primary" role="button" v-if="account && account.canDeposit" v-on:click="openDepositModal()" href="#">
                 <span class="fa fa-download"></span> Deposit
             </a>
-            <a asp-action="EditCustodianAccount" asp-route-storeId="@Model.CustodianAccount.StoreId" asp-route-accountId="@Model.CustodianAccount.Id" class="btn btn-primary mt-3 mt-sm-0" role="button" id="EditCustodianAccountConfig">
+            <a asp-action="EditCustodianAccount" asp-route-storeId="@Model.CustodianAccount.StoreId" asp-route-accountId="@Model.CustodianAccount.Id" class="btn btn-primary" role="button" id="EditCustodianAccountConfig">
                 <span class="fa fa-gear"></span> Configure
-            </a>
-            <a asp-action="DeleteCustodianAccount" asp-route-storeId="@Model.CustodianAccount.StoreId" asp-route-accountId="@Model.CustodianAccount.Id" class="btn btn-danger mt-3 mt-sm-0" role="button" id="DeleteCustodianAccountConfig">
-                <span class="fa fa-trash"></span> Delete
             </a>
             <!--
             <button type="submit" class="btn btn-primary order-sm-1" id="SaveSettings">Save</button>
             <a class="btn btn-secondary" id="ViewApp" target="app_" href="/apps/MQ2sCVsmQ95JBZ4aZDtoSwMAnBY/pos">View</a>
             -->
         </div>
-
     </div>
 
+    <partial name="_StatusMessage"/>
 
     <div class="row">
         <div class="col-xl-12">
-
             <div v-if="!account" class="loading d-flex justify-content-center p-3">
                 <div class="spinner-border text-light" role="status">
                     <span class="visually-hidden">Loading...</span>

--- a/BTCPayServer/Views/UICustodianAccounts/ViewCustodianAccount.cshtml
+++ b/BTCPayServer/Views/UICustodianAccounts/ViewCustodianAccount.cshtml
@@ -13,177 +13,275 @@
 
 <partial name="_StatusMessage"/>
 
-<div class="sticky-header-setup"></div>
-<div class="sticky-header d-sm-flex align-items-center justify-content-between">
-    <h2 class="mb-0">
-        @ViewData["Title"]
-    </h2>
-    <div class="d-flex gap-3 mt-3 mt-sm-0">
-        <a asp-action="EditCustodianAccount" asp-route-storeId="@Model.CustodianAccount.StoreId" asp-route-accountId="@Model.CustodianAccount.Id" class="btn btn-primary mt-3 mt-sm-0" role="button" id="EditCustodianAccountConfig">
-            <span class="fa fa-gear"></span> Configure
-        </a>
-        <a asp-action="DeleteCustodianAccount" asp-route-storeId="@Model.CustodianAccount.StoreId" asp-route-accountId="@Model.CustodianAccount.Id" class="btn btn-danger mt-3 mt-sm-0" role="button" id="DeleteCustodianAccountConfig">
-            <span class="fa fa-trash"></span> Delete
-        </a>
-        <!--
-        <button type="submit" class="btn btn-primary order-sm-1" id="SaveSettings">Save</button>
-        <a class="btn btn-secondary" id="ViewApp" target="app_" href="/apps/MQ2sCVsmQ95JBZ4aZDtoSwMAnBY/pos">View</a>
-        -->
+<style>
+    .trade-qty label{display: block; }
+</style>
+
+<div id="custodianAccountView" v-cloak>
+
+    <div class="sticky-header-setup"></div>
+    <div class="sticky-header d-sm-flex align-items-center justify-content-between">
+        <h2 class="mb-0">
+            @ViewData["Title"]
+        </h2>
+        <div class="d-flex gap-3 mt-3 mt-sm-0">
+            <a class="btn btn-primary mt-3 mt-sm-0" role="button" v-if="account && account.canDeposit" v-on:click="openDepositModal()" href="#">
+                <span class="fa fa-download"></span> Deposit
+            </a>
+            <a asp-action="EditCustodianAccount" asp-route-storeId="@Model.CustodianAccount.StoreId" asp-route-accountId="@Model.CustodianAccount.Id" class="btn btn-primary mt-3 mt-sm-0" role="button" id="EditCustodianAccountConfig">
+                <span class="fa fa-gear"></span> Configure
+            </a>
+            <a asp-action="DeleteCustodianAccount" asp-route-storeId="@Model.CustodianAccount.StoreId" asp-route-accountId="@Model.CustodianAccount.Id" class="btn btn-danger mt-3 mt-sm-0" role="button" id="DeleteCustodianAccountConfig">
+                <span class="fa fa-trash"></span> Delete
+            </a>
+            <!--
+            <button type="submit" class="btn btn-primary order-sm-1" id="SaveSettings">Save</button>
+            <a class="btn btn-secondary" id="ViewApp" target="app_" href="/apps/MQ2sCVsmQ95JBZ4aZDtoSwMAnBY/pos">View</a>
+            -->
+        </div>
+
     </div>
 
-</div>
 
-<div class="row">
-    <div class="col-xl-12">
+    <div class="row">
+        <div class="col-xl-12">
 
-        @if (@Model.GetAssetBalanceException != null)
-        {
-            <p class="alert alert-danger">
-                @Model.GetAssetBalanceException.Message
-            </p>
-        }
+            <div v-if="!account" class="loading d-flex justify-content-center p-3">
+                <div class="spinner-border text-light" role="status">
+                    <span class="visually-hidden">Loading...</span>
+                </div>
+            </div>
 
-        <h2>Balances</h2>
-        <div class="table-responsive">
-            <table class="table table-hover table-responsive-md">
-                <thead>
-                <tr>
-                    <th>Asset</th>
-                    <th class="text-end">Balance</th>
-                    <th class="text-end">Unit Price (Bid)</th>
-                    <th class="text-end">Unit Price (Ask)</th>
-                    <th class="text-end">Fiat Value</th>
-                    <th class="text-end">Actions</th>
-                </tr>
-                </thead>
-                <tbody>
-                @if (Model.AssetBalances != null && Model.AssetBalances.Count > 0)
-                {
-                    @foreach (var pair in Model.AssetBalances.OrderBy(key => key.Key))
-                    {
+            <div v-if="account">
+                <p class="alert alert-danger" v-if="account.assetBalanceExceptionMessage">
+                    {{ account.assetBalanceExceptionMessage }}
+                </p>
+
+                <h2>Balances</h2>
+                <div class="table-responsive">
+                    <table class="table table-hover table-responsive-md">
+                        <thead>
                         <tr>
-                            <td>@pair.Key</td>
+                            <th>Asset</th>
+                            <th class="text-end">Balance</th>
+                            <th class="text-end">Unit Price (Bid)</th>
+                            <th class="text-end">Unit Price (Ask)</th>
+                            <th class="text-end">Fiat Value</th>
+                            <th class="text-end">Actions</th>
+                        </tr>
+                        </thead>
+                        <tbody>
+                        <tr v-for="row in sortedAssetRows" :key="row.asset">
+                            <td>{{ row.asset }}</td>
                             <!-- TODO format as number? How? -->
-                            <th class="text-end">@pair.Value.Qty</th>
+                            <th class="text-end">{{ row.formattedQty }}</th>
                             <th class="text-end">
-                                @pair.Value.FormattedBid
+                                {{ row.formattedBid }}
                             </th>
                             <th class="text-end">
-                                @pair.Value.FormattedAsk
+                                {{ row.formattedAsk }}
                             </th>
                             <th class="text-end">
-                                @(pair.Value.FormattedFiatValue)
+                                {{ row.formattedFiatValue }}
                             </th>
                             <th class="text-end">
-                                @if (pair.Value.TradableAssetPairs != null)
-                                {
-                                    <a data-bs-toggle="modal" data-bs-target="#tradeModal" href="#">Trade</a>
-                                }
-                                @if (pair.Value.CanDeposit)
-                                {
-                                    <a data-bs-toggle="modal" data-bs-target="#depositModal" href="#">Deposit</a>
-                                }
-                                @if (pair.Value.CanWithdraw)
-                                {
-                                    <a data-bs-toggle="modal" data-bs-target="#withdrawModal" href="#">Withdraw</a>
-                                }
+                                <a v-if="row.tradableAssetPairs" v-on:click="openTradeModal(row)" href="#">Trade</a>
+                                <a v-if="row.canDeposit" v-on:click="openDepositModal(row)" href="#">Deposit</a>
+                                <a v-if="row.canWithdraw" v-on:click="openWithdrawModal(row)" href="#">Withdraw</a>
                             </th>
                         </tr>
+                        <tr v-if="account.assetBalances.length === 0">
+                            <td colspan="999" class="text-center">No assets are stored with this custodian (yet).</td>
+                        </tr>
+                        <tr v-if="account.assetBalanceExceptionMessage !== null">
+                            <td colspan="999" class="text-center">An error occured while loading assets and balances.</td>
+                        </tr>
+                        </tbody>
+                    </table>
+                </div>
+
+
+                <h2>Features</h2>
+                <p>The @Model?.Custodian.Name custodian supports:</p>
+                <ul>
+                    <li>Viewing asset account</li>
+                    @if (Model?.Custodian is ICanTrade)
+                    {
+                        <li>Trading</li>
                     }
-                }
-                else if (Model.GetAssetBalanceException == null)
-                {
-                    <tr>
-                        <td colspan="999" class="text-center">No assets are stored with this custodian (yet).</td>
-                    </tr>
-                }
-                else
-                {
-                    <tr>
-                        <td colspan="999" class="text-center">An error occured while loading assets and balances.</td>
-                    </tr>
-                }
-                </tbody>
-            </table>
-        </div>
-
-
-        <h2>Features</h2>
-        <p>The @Model.Custodian.Name custodian supports:</p>
-        <ul>
-            <li>Viewing asset balances</li>
-            @if (Model.Custodian is ICanTrade)
-            {
-                <li>Trading (Greenfield API only, for now)</li>
-            }
-            @if (Model.Custodian is ICanDeposit)
-            {
-                <li>Depositing (Greenfield API only, for now)</li>
-            }
-            @if (Model.Custodian is ICanWithdraw)
-            {
-                <li>Withdrawing (Greenfield API only, for now)</li>
-            }
-        </ul>
-
-
-    </div>
-</div>
-
-
-<div class="modal" tabindex="-1" role="dialog" id="withdrawModal">
-    <div class="modal-dialog" role="document">
-        <div class="modal-content">
-            <div class="modal-header">
-                <h5 class="modal-title">Withdraw</h5>
-                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close">
-                    <vc:icon symbol="close"/>
-                </button>
-            </div>
-            <div class="modal-body">
-                <p>Withdrawals are coming soon, but if you need this today, you can use our <a rel="noopener noreferrer" href="https://docs.btcpayserver.org/API/Greenfield/v1/" target="_blank">Greenfield API "Withdraw to store wallet" endpoint</a> to execute a withdrawal.</p>
-            </div>
-            <div class="modal-footer">
-                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+                    @if (Model?.Custodian is ICanDeposit)
+                    {
+                        <li>Depositing (Greenfield API only, for now)</li>
+                    }
+                    @if (Model?.Custodian is ICanWithdraw)
+                    {
+                        <li>Withdrawing (Greenfield API only, for now)</li>
+                    }
+                </ul>
             </div>
         </div>
     </div>
-</div>
 
-<div class="modal" tabindex="-1" role="dialog" id="depositModal">
-    <div class="modal-dialog" role="document">
-        <div class="modal-content">
-            <div class="modal-header">
-                <h5 class="modal-title">Deposit</h5>
-                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close">
-                    <vc:icon symbol="close"/>
-                </button>
+
+    <div class="modal" tabindex="-1" role="dialog" id="withdrawModal">
+        <div class="modal-dialog" role="document">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title">Withdraw</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close">
+                        <vc:icon symbol="close"/>
+                    </button>
+                </div>
+                <div class="modal-body">
+                    <p>Withdrawals are coming soon, but if you need this today, you can use our <a rel="noopener noreferrer" href="https://docs.btcpayserver.org/API/Greenfield/v1/" target="_blank">Greenfield API "Withdraw to store wallet" endpoint</a> to execute a withdrawal.</p>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+                </div>
             </div>
-            <div class="modal-body">
-                <p>Deposits are coming soon, but if you need this today, you can use our <a rel="noopener noreferrer" href="https://docs.btcpayserver.org/API/Greenfield/v1/" target="_blank">Greenfield API "Get a deposit address for custodian" endpoint</a> to get a deposit address to send your assets to.</p>
+        </div>
+    </div>
+
+    <div class="modal" tabindex="-1" role="dialog" id="depositModal">
+        <div class="modal-dialog" role="document">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title">Deposit</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close">
+                        <vc:icon symbol="close"/>
+                    </button>
+                </div>
+                <div class="modal-body">
+                    <p>Deposits are coming soon, but if you need this today, you can use our <a rel="noopener noreferrer" href="https://docs.btcpayserver.org/API/Greenfield/v1/" target="_blank">Greenfield API "Get a deposit address for custodian" endpoint</a> to get a deposit address to send your assets to.</p>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+                </div>
             </div>
-            <div class="modal-footer">
-                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
-            </div>
+        </div>
+    </div>
+
+    <div class="modal" tabindex="-1" role="dialog" id="tradeModal" :data-bs-keyboard="!trade.isExecuting">
+        <div class="modal-dialog" role="document">
+            <form class="modal-content" v-on:submit="onTradeSubmit" method="post" asp-action="Trade" asp-route-accountId="@Model?.CustodianAccount?.Id" asp-route-storeId="@Model?.CustodianAccount?.StoreId">
+                <div class="modal-header">
+                    <h5 class="modal-title">Trade {{ trade.qty }} {{ trade.assetToTrade }} into {{ trade.assetToTradeInto }}</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close" v-if="!trade.isExecuting">
+                        <vc:icon symbol="close"/>
+                    </button>
+                </div>
+                <div class="modal-body">
+                    <div class="loading d-flex justify-content-center p-3" v-if="trade.isExecuting">
+                        <div class="spinner-border text-light" role="status">
+                            <span class="visually-hidden">Loading...</span>
+                        </div>
+                    </div>
+
+                    <div v-if="!trade.isExecuting && trade.results === null">
+                        <p v-if="trade.errorMsg" class="alert alert-danger">{{ trade.errorMsg }}</p>
+
+                        <div class="row mb-2 trade-qty">
+                            <div class="col-5">
+                                <label class="form-label">
+                                    Convert
+                                    <div class="input-group">
+                                        <input name="Qty" type="number" min="0" :max="trade.maxQtyToTrade" class="form-control" v-model="trade.qty"/>
+                                        <select name="FromAsset" v-model="trade.assetToTrade" class="form-control">
+                                            <option v-for="option in availableAssetsToTrade" v-bind:value="option">
+                                                {{ option }}
+                                            </option>
+                                        </select>
+                                    </div>
+                                </label>
+                            </div>
+                            <div class="col-2 text-center">
+                                &nbsp;
+                                <br/>
+                                <button type="button" class="btn btn-secondary" v-on:click="swapTradeAssets()" aria-label="Swap assets">
+                                    <i class="fa fa-arrows-h" aria-hidden="true"></i>
+                                </button>
+                            </div>
+                            <div class="col-5">
+                                <label class="form-label">
+                                    Into
+                                    <div class="input-group">
+                                        <input disabled="disabled" type="number" class="form-control" v-model="tradeQtyToReceive"/>
+                                        <select name="ToAsset" v-model="trade.assetToTradeInto" class="form-control">
+                                            <option v-for="option in availableAssetsToTradeInto" v-bind:value="option">
+                                                {{ option }}
+                                            </option>
+                                        </select>
+                                    </div>
+                                </label>
+                            </div>
+                        </div>
+                        <div>
+                            <div class="btn-group" role="group" aria-label="Set qty to a percentage of holdings">
+                                <button v-on:click="setTradeQtyPercent(10)" class="btn btn-secondary" type="button">10%</button>
+                                <button v-on:click="setTradeQtyPercent(25)" class="btn btn-secondary" type="button">25%</button>
+                                <button v-on:click="setTradeQtyPercent(50)" class="btn btn-secondary" type="button">50%</button>
+                                <button v-on:click="setTradeQtyPercent(75)" class="btn btn-secondary" type="button">75%</button>
+                                <button v-on:click="setTradeQtyPercent(90)" class="btn btn-secondary" type="button">90%</button>
+                                <button v-on:click="setTradeQtyPercent(100)" class="btn btn-secondary" type="button">100%</button>
+                            </div>
+                        </div>
+
+                        <p>
+                            <br/>
+                            1 {{ trade.assetToTradeInto }} = {{ trade.price }} {{ trade.assetToTrade }}
+                            <br/>
+                            1 {{ trade.assetToTrade }} = {{ 1 / trade.price }} {{ trade.assetToTradeInto }}
+                        </p>
+                        <p>
+                            After the trade
+                            {{ trade.maxQtyToTrade - trade.qty }} {{ trade.assetToTrade }} will remain in your account.
+                        </p>
+                        <small class="form-text text-muted">Final results may vary due to trading fees and slippage.</small>
+
+                        <p>
+                            <span v-if="trade.isUpdating">
+                                Updating quote...
+                            </span>
+                            &nbsp;
+                        </p>
+                    </div>
+                    <div v-if="trade.results !== null">
+                        <p class="alert alert-success">Successfully traded {{ trade.results.fromAsset}} into {{ trade.results.toAsset}}.</p>
+                        <table class="table table-striped">
+                            <thead>
+                            <tr>
+                                <th colspan="2">Asset</th>
+                                <th>Comment</th>
+                            </tr>
+                            </thead>
+                            <tbody>
+                            <tr v-for="entry in trade.results.ledgerEntries" v-bind:class="{ 'table-success': entry.qty > 0, 'table-danger': entry.qty < 0 }">
+                                <td class="text-end"><span v-if="entry.qty > 0">+</span> {{ entry.qty }}</td>
+                                <td>{{ entry.asset }}</td>
+                                <td>
+                                    <span v-if="entry.type !== 'Trade'">{{ entry.type}}</span>
+                                </td>
+                            </tr>
+                            </tbody>
+                        </table>
+                        <p>Trade ID: {{ trade.results.tradeId }}</p>
+                    </div>
+                </div>
+                <div class="modal-footer" v-if="!trade.isExecuting">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">
+                        <span v-if="trade.results">Close</span>
+                        <span v-if="!trade.results">Cancel</span>
+                    </button>
+                    <button v-if="canExecuteTrade" type="submit" class="btn btn-primary">Execute</button>
+                </div>
+            </form>
         </div>
     </div>
 </div>
 
-<div class="modal" tabindex="-1" role="dialog" id="tradeModal">
-    <div class="modal-dialog" role="document">
-        <div class="modal-content">
-            <div class="modal-header">
-                <h5 class="modal-title">Trade</h5>
-                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close">
-                    <vc:icon symbol="close"/>
-                </button>
-            </div>
-            <div class="modal-body">
-                <p>Trades are coming soon, but if you need this today, you can use our <a rel="noopener noreferrer" href="https://docs.btcpayserver.org/API/Greenfield/v1/" target="_blank"> Greenfield API "Trade one asset for another" endpoint</a> to convert an asset to another via a market order.</p>
-            </div>
-            <div class="modal-footer">
-                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
-            </div>
-        </div>
-    </div>
-</div>
+<script src="~/vendor/vuejs/vue.min.js" asp-append-version="true"></script>
+<script type="text/javascript">
+var ajaxBalanceUrl = "@Url.Action("ViewCustodianAccountAjax", "UICustodianAccounts", new { storeId = Model?.CustodianAccount.StoreId, accountId = Model?.CustodianAccount.Id })";
+var ajaxTradePrepareUrl = "@Url.Action("GetTradePrepareAjax", "UICustodianAccounts", new { storeId = Model?.CustodianAccount.StoreId, accountId = Model?.CustodianAccount.Id })";
+</script>
+<script src="~/js/custodian-account.js" asp-append-version="true"></script>

--- a/BTCPayServer/wwwroot/js/custodian-account.js
+++ b/BTCPayServer/wwwroot/js/custodian-account.js
@@ -1,0 +1,270 @@
+new Vue({
+    el: '#custodianAccountView',
+    data: {
+        account: null,
+        modals: {
+            trade: null,
+            withdraw: null,
+            deposit: null
+        },
+        trade: {
+            row: null,
+            results: null,
+            errorMsg: null,
+            isExecuting: false,
+            isUpdating: false,
+            updateTradePriceXhr: null,
+            priceRefresherInterval: null,
+
+            assetToTrade: null,
+            assetToTradeInto: null,
+            qty: null,
+            maxQtyToTrade: null,
+            price: null
+        }
+
+    },
+    computed: {
+        tradeQtyToReceive: function () {
+            return this.trade.qty / this.trade.price;
+        },
+        canExecuteTrade: function () {
+            return this.trade.price !== null && this.trade.assetToTrade !== null && this.trade.assetToTradeInto !== null && !this.trade.isExecuting && this.trade.results === null;
+        },
+        availableAssetsToTrade: function () {
+            let r = [];
+            if (this.account?.assetBalances) {
+                r = Object.keys(this.account?.assetBalances);
+            }
+            return r;
+        },
+        availableAssetsToTradeInto: function () {
+            let r = [];
+            let pairs = this.account?.assetBalances?.[this.trade.assetToTrade]?.tradableAssetPairs;
+            if (pairs) {
+                for (let i = 0; i < pairs.length; i++) {
+                    let pair = pairs[i];
+                    if (pair.assetBought === this.trade.assetToTrade) {
+                        r.push(pair.assetSold);
+                    } else if (pair.assetSold === this.trade.assetToTrade) {
+                        r.push(pair.assetBought);
+                    }
+                }
+            }
+            return r;
+        },
+        sortedAssetRows: function () {
+            if (this.account?.assetBalances) {
+                let rows = Object.values(this.account.assetBalances);
+                rows = rows.sort(function (a, b) {
+                    return b.fiatValue - a.fiatValue;
+                });
+                return rows;
+            }
+        }
+    },
+    methods: {
+        setTradeQtyPercent: function (percent) {
+            this.trade.qty = percent / 100 * this.trade.maxQtyToTrade;
+        },
+        openTradeModal: function (row) {
+            let _this = this;
+            this.trade.row = row
+            this.trade.results = null;
+
+            this.trade.assetToTrade = row.asset;
+            if (row.asset === this.account.storeDefaultFiat) {
+                this.trade.assetToTradeInto = "BTC";
+            } else {
+                this.trade.assetToTradeInto = this.account.storeDefaultFiat;
+            }
+            this.trade.qty = row.qty;
+            this.trade.maxQtyToTrade = row.qty;
+            this.trade.price = row.bid;
+
+            if (this.modals.trade === null) {
+                this.modals.trade = new window.bootstrap.Modal('#tradeModal');
+
+                // Disable price refreshing when modal closes...
+                const tradeModelElement = document.getElementById('tradeModal')
+                tradeModelElement.addEventListener('hide.bs.modal', event => {
+                    _this.setTradePriceRefresher(false);
+                });
+            }
+
+            this.setTradePriceRefresher(true);
+            this.modals.trade.show();
+        },
+        openWithdrawModal: function (row) {
+            if (this.modals.withdraw === null) {
+                this.modals.withdraw = new window.bootstrap.Modal('#withdrawModal');
+            }
+            this.modals.withdraw.show();
+        },
+        openDepositModal: function (row) {
+            if (this.modals.deposit === null) {
+                this.modals.deposit = new window.bootstrap.Modal('#depositModal');
+            }
+            this.modals.deposit.show();
+        },
+        onTradeSubmit: function (e) {
+            e.preventDefault();
+
+            let form = jQuery(e.currentTarget);
+            let url = form.attr('action');
+            let method = form.attr('method');
+
+            this.trade.isExecuting = true;
+
+            // Prevent the modal from closing by clicking outside or via the keyboard
+            this.modals.trade._config.backdrop = 'static';
+            this.modals.trade._config.keyboard = false;
+
+            let _this = this;
+
+            let token = $("input[name='__RequestVerificationToken']").val();
+            window.jQuery.ajax({
+                method: method,
+                url: url,
+                headers: {
+                    "RequestVerificationToken": token
+                },
+                contentType : 'application/json',
+                data: JSON.stringify({
+                    fromAsset: _this.trade.assetToTrade,
+                    toAsset: _this.trade.assetToTradeInto,
+                    qty: _this.trade.qty
+                }),
+                success: function (data) {
+                    _this.trade.results = data;
+                    _this.trade.errorMsg = null;
+
+                    _this.setTradePriceRefresher(false);
+                    _this.refreshAccountBalances();
+                },
+                complete: function (xhr, status) {
+                    _this.modals.trade._config.backdrop = true;
+                    _this.modals.trade._config.keyboard = true;
+
+                    _this.trade.isExecuting = false;
+                },
+                error: function (xhr, textStatus, errorThrown) {
+                    let errorMsg = "Error";
+
+                    debugger;
+                    if(xhr.responseText){
+                        try {
+                            let data = JSON.parse(xhr.responseText);
+                            errorMsg = data.error;
+                        }catch(e){}
+                    }
+                    
+                    // TODO parse response + get error message from that
+                    _this.trade.errorMsg = errorMsg;
+                }
+            });
+
+        },
+
+        setTradePriceRefresher: function (enabled) {
+            if (enabled) {
+                // Update immediately...
+                this.updateTradePrice();
+
+                // And keep updating every few seconds...
+                let _this = this;
+                this.trade.priceRefresherInterval = setInterval(function () {
+                    _this.updateTradePrice();
+                }, 5000);
+
+            } else {
+                clearInterval(this.trade.priceRefresherInterval);
+            }
+        },
+
+        updateTradePrice: function () {
+            if (!this.trade.assetToTrade || !this.trade.assetToTradeInto) {
+                // We need to know the 2 assets or we cannot do anything...
+                return;
+            }
+
+            this.trade.isUpdating = true;
+
+            if (this.isAjaxRunning(this.trade.updateTradePriceXhr)) {
+                // Previous request is still running. No need to hammer the seerver.
+                console.log("Previous request is still running. No need to hammer the seerver.");
+                return;
+            }
+
+            let _this = this;
+            this.trade.updateTradePriceXhr = window.jQuery.ajax({
+                method: "get",
+                url: window.ajaxTradePrepareUrl,
+                data: {
+                    assetToTrade: _this.trade.assetToTrade,
+                    assetToTradeInto: _this.trade.assetToTradeInto
+                },
+                success: function (data) {
+                    _this.trade.maxQtyToTrade = data.maxQtyToTrade;
+
+                    // By default trade everything
+                    if (_this.trade.qty === null) {
+                        _this.trade.qty = _this.trade.maxQtyToTrade;
+                    }
+
+                    // Cannot trade more than what we have
+                    if (data.maxQtyToTrade < _this.trade.qty) {
+                        _this.trade.qty = _this.trade.maxQtyToTrade;
+                    }
+
+                    _this.trade.price = data.price;
+                    // _this.trade.results = data;
+                    // _this.trade.errorMsg = null;
+                },
+                complete: function () {
+                    _this.trade.isUpdating = false;
+                },
+                error: function (xhr, textStatus, errorThrown) {
+                    // Do nothing
+                }
+            });
+        },
+
+        swapTradeAssets: function () {
+            let tmp = this.trade.assetToTrade;
+            this.trade.assetToTrade = this.trade.assetToTradeInto;
+            this.trade.assetToTradeInto = tmp;
+            this.trade.qty = null;
+            this.trade.price = 1 / this.trade.price;
+
+            this.killAjaxIfRunning(this.trade.updateTradePriceXhr);
+
+            // Update the price asap, so we can continue
+            this.updateTradePrice();
+        },
+        isAjaxRunning: function (xhr) {
+            return xhr && xhr.readyState > 0 && xhr.readyState < 4;
+        },
+        killAjaxIfRunning: function (xhr) {
+            if (this.isAjaxRunning(xhr)) {
+                xhr.abort();
+            }
+        },
+        refreshAccountBalances: function(){
+            let _this = this;
+            fetch(window.ajaxBalanceUrl).then(function (response) {
+                return response.json();
+            }).then(function (result) {
+                _this.account = result;
+            });
+        }
+    },
+    created: function () {
+        this.refreshAccountBalances();
+    },
+
+    mounted: function () {
+        // Runs when the app is ready
+
+    }
+});

--- a/BTCPayServer/wwwroot/js/custodian-account.js
+++ b/BTCPayServer/wwwroot/js/custodian-account.js
@@ -89,7 +89,7 @@ new Vue({
             }
             return null;
         },
-        getMinQtyToTrade: function (assetToTrade, assetToTradeInto) {
+        getMinQtyToTrade: function (assetToTrade = this.trade.assetToTrade, assetToTradeInto = this.trade.assetToTradeInto) {
             if (assetToTrade && assetToTradeInto && this.account?.assetBalances) {
                 for (let asset in this.account.assetBalances) {
                     let row = this.account.assetBalances[asset];

--- a/BTCPayServer/wwwroot/js/custodian-account.js
+++ b/BTCPayServer/wwwroot/js/custodian-account.js
@@ -148,16 +148,12 @@ new Vue({
                 },
                 error: function (xhr, textStatus, errorThrown) {
                     let errorMsg = "Error";
-
-                    debugger;
                     if(xhr.responseText){
                         try {
                             let data = JSON.parse(xhr.responseText);
-                            errorMsg = data.error;
+                            errorMsg = data.message;
                         }catch(e){}
                     }
-                    
-                    // TODO parse response + get error message from that
                     _this.trade.errorMsg = errorMsg;
                 }
             });

--- a/BTCPayServer/wwwroot/js/custodian-account.js
+++ b/BTCPayServer/wwwroot/js/custodian-account.js
@@ -15,14 +15,12 @@ new Vue({
             isUpdating: false,
             updateTradePriceXhr: null,
             priceRefresherInterval: null,
-
             assetToTrade: null,
             assetToTradeInto: null,
             qty: null,
             maxQtyToTrade: null,
             price: null
         }
-
     },
     computed: {
         tradeQtyToReceive: function () {
@@ -69,9 +67,9 @@ new Vue({
         },
         openTradeModal: function (row) {
             let _this = this;
-            this.trade.row = row
+            this.trade.row = row;
             this.trade.results = null;
-
+            this.trade.errorMsg = null;
             this.trade.assetToTrade = row.asset;
             if (row.asset === this.account.storeDefaultFiat) {
                 this.trade.assetToTradeInto = "BTC";

--- a/BTCPayServer/wwwroot/main/site.css
+++ b/BTCPayServer/wwwroot/main/site.css
@@ -546,3 +546,5 @@ svg.icon-note {
 #tradeModal .trade-qty .col-side {
     flex: 1;
 }
+
+.modal-footer .modal-footer-left{ margin-right: auto; }

--- a/BTCPayServer/wwwroot/main/site.css
+++ b/BTCPayServer/wwwroot/main/site.css
@@ -528,3 +528,21 @@ svg.icon-note {
         margin-right: 0;
     }
 }
+
+#tradeModal .qty{ width: 53%; }
+#tradeModal .btn-square{ padding: 0; width: 2.5rem; height: 2.5rem; }
+
+#tradeModal .trade-qty {
+    display: flex;
+    justify-content: space-between;
+}
+
+#tradeModal .trade-qty .col-center {
+    flex: 0 0 2rem;
+    padding-left: 0;
+    padding-right: 0;
+}
+
+#tradeModal .trade-qty .col-side {
+    flex: 1;
+}

--- a/BTCPayServer/wwwroot/swagger/v1/swagger.template.custodians.json
+++ b/BTCPayServer/wwwroot/swagger/v1/swagger.template.custodians.json
@@ -647,24 +647,28 @@
                 "example": {
                     "code": "kraken",
                     "name": "Kraken",
-                    "tradableAssetPairs": [
-                        {
-                            "pair": "BTC/USD",
+                    "tradableAssetPairs": {
+                        "BTC/USD": {
+                            "assetBought": "BTC",
+                            "assetSold": "USD",
                             "minimumTradeQty": 0.001
                         },
-                        {
-                            "pair": "BTC/EUR",
+                        "BTC/EUR": {
+                            "assetBought": "BTC",
+                            "assetSold": "EUR",
                             "minimumTradeQty": 0.001
                         },
-                        {
-                            "pair": "LTC/USD",
+                        "LTC/USD": {
+                            "assetBought": "LTC",
+                            "assetSold": "USD",
                             "minimumTradeQty": 0.05
                         },
-                        {
-                            "pair": "LTC/EUR",
+                        "LTC/EUR": {
+                            "assetBought": "LTC",
+                            "assetSold": "EUR",
                             "minimumTradeQty": 0.05
                         }
-                    ],
+                    },
                     "withdrawablePaymentMethods": [
                         "BTC-OnChain",
                         "LTC-OnChain"
@@ -1054,7 +1058,8 @@
                     }
                 },
                 "example": {
-                    "pair": "BTC/USD",
+                    "assetBought": "BTC",
+                    "assetSold": "USD",
                     "minimumTradeQty": 0.0001
                 }
             },

--- a/BTCPayServer/wwwroot/swagger/v1/swagger.template.custodians.json
+++ b/BTCPayServer/wwwroot/swagger/v1/swagger.template.custodians.json
@@ -637,18 +637,33 @@
                     },
                     "tradableAssetPairs": {
                         "type": "array",
-                        "description": "A list of tradable asset pairs, or NULL if the custodian cannot trades/convert assets.",
-                        "nullable": true
+                        "description": "A list of tradable asset pair objects, or NULL if the custodian cannot trades/convert assets.",
+                        "nullable": true,
+                        "items": {
+                            "$ref": "#/components/schemas/AssetPairData"
+                        }
                     }
                 },
                 "example": {
                     "code": "kraken",
                     "name": "Kraken",
                     "tradableAssetPairs": [
-                        "BTC/USD",
-                        "BTC/EUR",
-                        "LTC/USD",
-                        "LTC/EUR"
+                        {
+                            "pair": "BTC/USD",
+                            "minimumTradeQty": 0.001
+                        },
+                        {
+                            "pair": "BTC/EUR",
+                            "minimumTradeQty": 0.001
+                        },
+                        {
+                            "pair": "LTC/USD",
+                            "minimumTradeQty": 0.05
+                        },
+                        {
+                            "pair": "LTC/EUR",
+                            "minimumTradeQty": 0.05
+                        }
                     ],
                     "withdrawablePaymentMethods": [
                         "BTC-OnChain",
@@ -1021,6 +1036,26 @@
                 "example": {
                     "asset": "BTC",
                     "qty": 1.23456
+                }
+            },
+            "AssetPairData": {
+                "type": "object",
+                "description": "An asset pair we can trade.",
+                "properties": {
+                    "pair": {
+                        "type": "string",
+                        "description": "The name of the asset pair.",
+                        "nullable": false
+                    },
+                    "minimumTradeQty": {
+                        "type": "number",
+                        "description": "The smallest amount we can buy or sell.",
+                        "nullable": false
+                    }
+                },
+                "example": {
+                    "pair": "BTC/USD",
+                    "minimumTradeQty": 0.0001
                 }
             },
             "LedgerEntryType": {


### PR DESCRIPTION
- Custodian Account UI completely redone using Vue JS
- Trade support using a modal
- Dropdowns to change the "from" and "to" asset. Comes prefilled when you clicked the "trade" link for the asset.
- Price auto-updates every few seconds
- Easy access buttons to enter 10 ,25, 50, 75, 90 or 100% of assets to convert
- Easy button to swap assets from / to
- Indicator showing the estimated qty you will receive
- Indicator showing you the qty to remain after the trade
- During execution, the modal cannot be closed or canceled
- On trade success you get full ledger details of all the changes to your custodian account + your account holdings auto-refresh

Minor TODOs:
- Hiding small holdings / dust amounts would be nice
- Prevent the selection of an asset to trade, if you only have dust amount

**Account view**
<img width="1630" alt="Screenshot 2022-07-18 at 00 05 08" src="https://user-images.githubusercontent.com/71019/179426597-51990eb2-e714-441a-9cd1-ffb796be8fe8.png">

**Trade modal**
<img width="588" alt="Screenshot 2022-07-18 at 00 05 20" src="https://user-images.githubusercontent.com/71019/179426609-b7fe826a-ba24-4343-a235-d014735277d6.png">

**Asset selection, both from and to assets can be changed, incl a "swap left/right" button**
<img width="525" alt="Screenshot 2022-07-18 at 00 11 46" src="https://user-images.githubusercontent.com/71019/179426740-acf95d94-30e7-4d0d-86b0-f9f10a69b825.png">

**Trade is executing, loading spinner**
<img width="589" alt="Screenshot 2022-07-18 at 00 05 44" src="https://user-images.githubusercontent.com/71019/179426614-15c1bc0d-5cd1-4473-9bd6-bb19a85e9468.png">

**Trade completed**
<img width="542" alt="Screenshot 2022-07-18 at 00 09 41" src="https://user-images.githubusercontent.com/71019/179426676-9d5fc29e-8539-4cbb-a152-4f6270fe0f20.png">

