### PR TITLE
Bumping LND to 0.15.0-beta

### DIFF
--- a/BTCPayServer.Tests/docker-compose.altcoins.yml
+++ b/BTCPayServer.Tests/docker-compose.altcoins.yml
@@ -237,7 +237,7 @@ services:
       - "5432"
 
   merchant_lnd:
-    image: btcpayserver/lnd:v0.14.2-beta
+    image: btcpayserver/lnd:v0.15.0-beta
     restart: unless-stopped
     environment:
       LND_CHAIN: "btc"
@@ -272,7 +272,7 @@ services:
       - bitcoind
 
   customer_lnd:
-    image: btcpayserver/lnd:v0.14.2-beta
+    image: btcpayserver/lnd:v0.15.0-beta
     restart: unless-stopped
     environment:
       LND_CHAIN: "btc"

--- a/BTCPayServer.Tests/docker-compose.yml
+++ b/BTCPayServer.Tests/docker-compose.yml
@@ -225,7 +225,7 @@ services:
       - "5432"
 
   merchant_lnd:
-    image: btcpayserver/lnd:v0.14.2-beta
+    image: btcpayserver/lnd:v0.15.0-beta
     restart: unless-stopped
     environment:
       LND_CHAIN: "btc"
@@ -262,7 +262,7 @@ services:
       - bitcoind
 
   customer_lnd:
-    image: btcpayserver/lnd:v0.14.2-beta
+    image: btcpayserver/lnd:v0.15.0-beta
     restart: unless-stopped
     environment:
       LND_CHAIN: "btc"


### PR DESCRIPTION
I've tagged LND 0.15.0 release and Docker image is available on https://hub.docker.com/layers/lnd/btcpayserver/lnd/v0.15.0-beta/images/sha256-cd424119be24f0d37183441c9eb7dc69f41aec5300466772eb2a7240be17c55b?context=explore

Used it in BTCPayServer.Lightning library and it's good to go:
https://github.com/btcpayserver/BTCPayServer.Lightning/pull/88

@NicolasDorier test if it works for you for local dev and if it does I'm opening PR against BTCPayServer-Docker repo.