### PR TITLE
Add ability to mark auth handle as successful

### DIFF
--- a/BTCPayServer.Abstractions/Security/AuthorizationFilterHandle.cs
+++ b/BTCPayServer.Abstractions/Security/AuthorizationFilterHandle.cs
@@ -8,7 +8,7 @@ public class AuthorizationFilterHandle
     public AuthorizationHandlerContext Context { get; }
     public PolicyRequirement Requirement { get; }
     public HttpContext HttpContext { get; }
-    public bool Success { get; }
+    public bool Success { get; private set;  }
 
     public AuthorizationFilterHandle(
         AuthorizationHandlerContext context,
@@ -18,5 +18,10 @@ public class AuthorizationFilterHandle
         Context = context;
         Requirement = requirement;
         HttpContext = httpContext;
+    }
+
+    public void MarkSuccessful()
+    {
+        Success = true;
     }
 }


### PR DESCRIPTION
Without this, there is no way to let the handle finish with a successful state. I somehow missed to add this in #3977.