### PR TITLE
Checkout UI fix

### DIFF
--- a/BTCPayServer/Views/UIStores/CheckoutAppearance.cshtml
+++ b/BTCPayServer/Views/UIStores/CheckoutAppearance.cshtml
@@ -55,20 +55,20 @@
                 <input asp-for="RedirectAutomatically" type="checkbox" class="form-check-input" />
                 <label asp-for="RedirectAutomatically" class="form-check-label"></label>
             </div>
-			<h3 class="mb-3">Public receipt</h3>
-            <div class="form-check my-1">
+            
+			<h3 class="mt-5 mb-3">Public receipt</h3>
+            <div class="form-check my-3">
                 <input asp-for="ReceiptOptions.Enabled" type="checkbox" class="form-check-input" />
                 <label asp-for="ReceiptOptions.Enabled" class="form-check-label"></label>
             </div>
-			<div class="form-check my-1">
+			<div class="form-check my-3">
                 <input asp-for="ReceiptOptions.ShowPayments" type="checkbox" class="form-check-input" />
                 <label asp-for="ReceiptOptions.ShowPayments" class="form-check-label"></label>
             </div>
-			<div class="form-check my-1">
+			<div class="form-check my-3">
                 <input asp-for="ReceiptOptions.ShowQR" type="checkbox" class="form-check-input" />
                 <label asp-for="ReceiptOptions.ShowQR" class="form-check-label"></label>
             </div>
-
 
             <h3 class="mt-5 mb-3">Language</h3>
             <div class="form-group">

--- a/BTCPayServer/wwwroot/checkout/css/default.css
+++ b/BTCPayServer/wwwroot/checkout/css/default.css
@@ -9157,14 +9157,6 @@ strong {
     padding: 1em 30px;
 }
 
-    .bp-view#paid {
-        padding-bottom: 0;
-    }
-
-        .bp-view#paid.pad {
-            padding-bottom: 30px;
-        }
-
     .bp-view.enter-contact-email {
         padding-left: 40px;
         padding-right: 40px;

--- a/BTCPayServer/wwwroot/checkout/css/themes/legacy.css
+++ b/BTCPayServer/wwwroot/checkout/css/themes/legacy.css
@@ -9210,14 +9210,6 @@ strong {
     width: 100%;
 }
 
-    .bp-view#paid {
-        padding-bottom: 0;
-    }
-
-        .bp-view#paid.pad {
-            padding-bottom: 30px;
-        }
-
     .bp-view.enter-contact-email {
         padding-left: 40px;
         padding-right: 40px;


### PR DESCRIPTION
Fixes a UI glitch which @NicolasDorier spotted [here](https://chat.btcpayserver.org/btcpayserver/pl/nuotm3sstb8zbgbogkohbe5msh).

## Before

![1-before](https://user-images.githubusercontent.com/886/182576228-4ccca068-639b-4033-8284-1bab51f11152.png)

## After

![1-after](https://user-images.githubusercontent.com/886/182576262-5ae701be-e672-4028-9aad-63dadb7452b6.png)



Also unifies the public receipt form spacings with the rest of the chackout appearance page.

## Before

![before](https://user-images.githubusercontent.com/886/182576404-38f77fbf-5a8b-468d-8d1c-6381a22896ce.png)

## After

![after](https://user-images.githubusercontent.com/886/182576428-662537a3-d9b8-4242-90d3-f19a779374be.png)


