### PR TITLE
Ensure store button shows up correctly before store is created

### DIFF
--- a/BTCPayServer/wwwroot/main/layout.css
+++ b/BTCPayServer/wwwroot/main/layout.css
@@ -591,7 +591,8 @@
     #StoreSelector {
         order: 2;
         margin-top: var(--btcpay-space-m);
-        width: 100%;
+        /* Make sure we are actually taking up all of the space or else you end up with this: https://github.com/btcpayserver/btcpayserver/issues/3972 */
+        min-width: 100%;
     }
     
     #mainMenuToggle,


### PR DESCRIPTION
|Before|After|
|---|---|
|![before](https://user-images.githubusercontent.com/1934678/183276794-cd9a5ccc-b045-4e04-8909-abf974222d0c.PNG)|![after](https://user-images.githubusercontent.com/1934678/183276801-a3194a43-a21e-4d55-804d-1de6d9024b10.PNG)|

fix #3972