### PR TITLE
Change PriceProvider(Mona)

### DIFF
--- a/BTCPayServer.Common/Altcoins/BTCPayNetworkProvider.Monacoin.cs
+++ b/BTCPayServer.Common/Altcoins/BTCPayNetworkProvider.Monacoin.cs
@@ -17,7 +17,7 @@ namespace BTCPayServer
                 DefaultRateRules = new[]
                 {
                                 "MONA_X = MONA_BTC * BTC_X",
-                                "MONA_BTC = bittrex(MONA_BTC)"
+                                "MONA_BTC = bitbank(MONA_BTC)"
                 },
                 CryptoImagePath = "imlegacy/monacoin.png",
                 LightningImagePath = "imlegacy/mona-lightning.svg",


### PR DESCRIPTION
I want to change the price rate supply from bittrex to bitbank.
Bitbank has more volume in monacoin.