### PR TITLE
LNURL controller refactoring

### DIFF
--- a/BTCPayServer.Tests/BTCPayServer.Tests.csproj
+++ b/BTCPayServer.Tests/BTCPayServer.Tests.csproj
@@ -23,7 +23,7 @@
     <PackageReference Include="Newtonsoft.Json.Schema" Version="3.0.14" />
     <PackageReference Include="Selenium.Support" Version="4.1.1" />
     <PackageReference Include="Selenium.WebDriver" Version="4.1.1" />
-    <PackageReference Include="Selenium.WebDriver.ChromeDriver" Version="103.0.5060.5300" />
+    <PackageReference Include="Selenium.WebDriver.ChromeDriver" Version="104.0.5112.7900" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>

--- a/BTCPayServer/Views/UIWallets/WalletSend.cshtml
+++ b/BTCPayServer/Views/UIWallets/WalletSend.cshtml
@@ -221,9 +221,6 @@
                     <div class="form-check">
                         <input asp-for="AlwaysIncludeNonWitnessUTXO" class="form-check-input"/>
                         <label asp-for="AlwaysIncludeNonWitnessUTXO" class="form-check-label"></label>
-                        <a href="https://medium.com/@@jmacato/wasabi-wallets-advisory-for-trezor-users-7d942c727f92" target="_blank" rel="noreferrer noopener">
-                            <span class="fa fa-question-circle-o text-secondary" title="More information..."></span>
-                        </a>
                     </div>
                 </div>    
                 @if (Model.SupportRBF)


### PR DESCRIPTION
By moving the `amount is null` check up, this prevents cases in which the `paymentMethodDetails.GeneratedBoltAmount != amount` check fails because of amount being null.

I came across this while working on LNURL support in LNbank: Continuously resolving the LNURL/destination led to this case. I was reusing the destination instead of continuing with the resolved BOLT11, which is fixed since — however, the refactored version seems like a better approach to me and it also prevents the mentioned error from happening.