### PR TITLE
API docs: Fix duplicate speed policy schema

### DIFF
--- a/BTCPayServer/wwwroot/swagger/v1/swagger.template.invoices.json
+++ b/BTCPayServer/wwwroot/swagger/v1/swagger.template.invoices.json
@@ -1089,22 +1089,6 @@
                     }
                 }
             },
-            "SpeedPolicy": {
-                "type": "string",
-                "description": "`\"HighSpeed\"`: 0 confirmations (1 confirmation if RBF enabled in transaction)   \n`\"MediumSpeed\"`: 1 confirmation   \n`\"LowMediumSpeed\"`: 2 confirmations   \n`\"LowSpeed\"`: 6 confirmations\n",
-                "x-enumNames": [
-                    "HighSpeed",
-                    "MediumSpeed",
-                    "LowSpeed",
-                    "LowMediumSpeed"
-                ],
-                "enum": [
-                    "HighSpeed",
-                    "MediumSpeed",
-                    "LowSpeed",
-                    "LowMediumSpeed"
-                ]
-            },
             "InvoicePaymentMethodDataModel": {
                 "type": "object",
                 "additionalProperties": false,

--- a/BTCPayServer/wwwroot/swagger/v1/swagger.template.json
+++ b/BTCPayServer/wwwroot/swagger/v1/swagger.template.json
@@ -55,7 +55,22 @@
                 "example": 1592312018,
                 "description": "A unix timestamp in seconds"
             },
-
+            "SpeedPolicy": {
+                "type": "string",
+                "description": "`\"HighSpeed\"`: 0 confirmations (1 confirmation if RBF enabled in transaction)   \n`\"MediumSpeed\"`: 1 confirmation   \n`\"LowMediumSpeed\"`: 2 confirmations   \n`\"LowSpeed\"`: 6 confirmations\n",
+                "x-enumNames": [
+                    "HighSpeed",
+                    "MediumSpeed",
+                    "LowSpeed",
+                    "LowMediumSpeed"
+                ],
+                "enum": [
+                    "HighSpeed",
+                    "MediumSpeed",
+                    "LowSpeed",
+                    "LowMediumSpeed"
+                ]
+            },
             "TimeSpan": {
                 "type": "number",
                 "format": "int32",

--- a/BTCPayServer/wwwroot/swagger/v1/swagger.template.stores.json
+++ b/BTCPayServer/wwwroot/swagger/v1/swagger.template.stores.json
@@ -404,22 +404,6 @@
                     }
                 }
             },
-            "SpeedPolicy": {
-                "type": "string",
-                "description": "",
-                "x-enumNames": [
-                    "HighSpeed",
-                    "MediumSpeed",
-                    "LowSpeed",
-                    "LowMediumSpeed"
-                ],
-                "enum": [
-                    "HighSpeed",
-                    "MediumSpeed",
-                    "LowSpeed",
-                    "LowMediumSpeed"
-                ]
-            },
             "NetworkFeeMode": {
                 "type": "string",
                 "description": "Check whether network fee should be added to the invoice if on-chain payment is used. ([More information](https://docs.btcpayserver.org/FAQ/Stores/#add-network-fee-to-invoice-vary-with-mining-fees))",


### PR DESCRIPTION
See the additional discussion in #3877. As we merged the Swagger JSON files for the docs, the duplicate store speed policy schema overwrote the updated invoice speed policy schema. This is now fixed by using a unified schema.