### PR TITLE
Add no rate found error message in Invoices

### DIFF
--- a/BTCPayServer/Controllers/UIInvoiceController.cs
+++ b/BTCPayServer/Controllers/UIInvoiceController.cs
@@ -311,7 +311,7 @@ namespace BTCPayServer.Controllers
                         errors.AppendLine(
                             "Warning: No wallet has been linked to your BTCPay Store. See the following link for more information on how to connect your store and wallet. (https://docs.btcpayserver.org/WalletSetup/)");
                     else
-                        errors.AppendLine("Warning: You have payment methods configured but the rate is not available. See logs below:");
+                        errors.AppendLine("Warning: You have payment methods configured but none of them match any of the requested payment methods or the rate is not available. See logs below:");
                     foreach (var error in logs.ToList())
                     {
                         errors.AppendLine(error.ToString());

--- a/BTCPayServer/Controllers/UIInvoiceController.cs
+++ b/BTCPayServer/Controllers/UIInvoiceController.cs
@@ -311,7 +311,7 @@ namespace BTCPayServer.Controllers
                         errors.AppendLine(
                             "Warning: No wallet has been linked to your BTCPay Store. See the following link for more information on how to connect your store and wallet. (https://docs.btcpayserver.org/WalletSetup/)");
                     else
-                        errors.AppendLine("Warning: You have payment methods configured but none of them match any of the requested payment methods (e.g., you requested on-chain BTC invoice but don't have an on-chain wallet configured)");
+                        errors.AppendLine("Warning: You have payment methods configured but the rate is not available. See logs below:");
                     foreach (var error in logs.ToList())
                     {
                         errors.AppendLine(error.ToString());


### PR DESCRIPTION
Hello,

This fixes the issue raised by @Kukks in https://github.com/btcpayserver/btcpayserver/issues/4030. 

I noticed that there is a checkbox is the UI to show supported payment methods so else statement can only say "rate is not available" and point the end user to check the logs. 

The "if" above the changed else takes care of instance where there are no supported payment methods configured.