### PR TITLE
Fix swagger validation errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -300,3 +300,5 @@ BTCPayServer/testpwd
 .DS_Store
 Packed Plugins
 Plugins/packed
+
+BTCPayServer/wwwroot/swagger/v1/openapi.json

--- a/BTCPayServer/wwwroot/swagger/v1/swagger.template.api-keys.json
+++ b/BTCPayServer/wwwroot/swagger/v1/swagger.template.api-keys.json
@@ -2,6 +2,7 @@
     "paths": {
         "/api/v1/api-keys/{apikey}": {
             "delete": {
+                "operationId": "ApiKeys_DeleteApiKey",
                 "tags": [
                     "API Keys"
                 ],
@@ -34,6 +35,7 @@
         },
         "/api/v1/api-keys/current": {
             "get": {
+                "operationId": "ApiKeys_GetCurrentApiKey",
                 "tags": [
                     "API Keys"
                 ],
@@ -58,6 +60,7 @@
                 ]
             },
             "delete": {
+                "operationId": "ApiKeys_DeleteCurrentApiKey",
                 "tags": [
                     "API Keys"
                 ],
@@ -84,6 +87,7 @@
         },
         "/api/v1/api-keys": {
             "post": {
+                "operationId": "ApiKeys_CreateApiKey",
                 "tags": [
                     "API Keys"
                 ],

--- a/BTCPayServer/wwwroot/swagger/v1/swagger.template.apps.json
+++ b/BTCPayServer/wwwroot/swagger/v1/swagger.template.apps.json
@@ -179,6 +179,17 @@
                 "operationId": "Apps_GetPointOfSaleApp",
                 "summary": "Get basic app data",
                 "description": "Returns basic app data shared between all types of apps",
+                "parameters": [
+                    {
+                        "name": "appId",
+                        "in": "path",
+                        "required": true,
+                        "description": "The app ID",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "Basic app data",
@@ -210,6 +221,17 @@
                 "operationId": "Apps_DeletePointOfSaleApp",
                 "summary": "Delete app",
                 "description": "Deletes apps with specified ID",
+                "parameters": [
+                    {
+                        "name": "appId",
+                        "in": "path",
+                        "required": true,
+                        "description": "The app ID",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "App was deleted"

--- a/BTCPayServer/wwwroot/swagger/v1/swagger.template.authorization.json
+++ b/BTCPayServer/wwwroot/swagger/v1/swagger.template.authorization.json
@@ -2,6 +2,7 @@
     "paths": {
         "/api-keys/authorize": {
             "get": {
+                "operationId": "ApiKeys_Authorize",
                 "tags": [
                     "Authorization"
                 ],

--- a/BTCPayServer/wwwroot/swagger/v1/swagger.template.custodians.json
+++ b/BTCPayServer/wwwroot/swagger/v1/swagger.template.custodians.json
@@ -1,5 +1,4 @@
 {
-    "x_experimental": true,
     "paths": {
         "/api/v1/custodians": {
             "get": {
@@ -34,6 +33,7 @@
         },
         "/api/v1/stores/{storeId}/custodian-accounts": {
             "get": {
+                "operationId": "Custodians_GetStoreCustodianAccounts",
                 "tags": [
                     "Custodians"
                 ],
@@ -79,6 +79,7 @@
                 }
             },
             "post": {
+                "operationId": "Custodians_AddStoreCustodianAccount",
                 "tags": [
                     "Custodians"
                 ],
@@ -123,6 +124,7 @@
         },
         "/api/v1/stores/{storeId}/custodian-accounts/{accountId}": {
             "get": {
+                "operationId": "Custodians_GetStoreCustodianAccount",
                 "tags": [
                     "Custodians"
                 ],
@@ -174,6 +176,7 @@
                 }
             },
             "put": {
+                "operationId": "Custodians_UpdateStoreCustodianAccount",
                 "tags": [
                     "Custodians"
                 ],
@@ -216,6 +219,7 @@
                 ]
             },
             "delete": {
+                "operationId": "Custodians_DeleteStoreCustodianAccount",
                 "tags": [
                     "Custodians"
                 ],
@@ -233,6 +237,7 @@
         },
         "/api/v1/stores/{storeId}/custodian-accounts/{accountId}/trades/quote": {
             "get": {
+                "operationId": "Custodians_GetStoreCustodianAccountTradeQuote",
                 "tags": [
                     "Custodians"
                 ],
@@ -306,6 +311,7 @@
         },
         "/api/v1/stores/{storeId}/custodian-accounts/{accountId}/trades/market": {
             "post": {
+                "operationId": "Custodians_StoreCustodianAccountTradeMarket",
                 "tags": [
                     "Custodians"
                 ],
@@ -371,6 +377,7 @@
         },
         "/api/v1/stores/{storeId}/custodian-accounts/{accountId}/addresses/{paymentMethod}": {
             "get": {
+                "operationId": "Custodians_GetStoreCustodianAccountDepositAddress",
                 "tags": [
                     "Custodians"
                 ],
@@ -445,6 +452,7 @@
         },
         "/api/v1/stores/{storeId}/custodian-accounts/{accountId}/withdrawals": {
             "post": {
+                "operationId": "Custodians_WithdrawFromStoreCustodianAccount",
                 "tags": [
                     "Custodians"
                 ],
@@ -531,6 +539,7 @@
         },
         "/api/v1/stores/{storeId}/custodian-accounts/{accountId}/withdrawals/{withdrawalId}": {
             "post": {
+                "operationId": "Custodians_GetStoreCustodianAccountWithdrawalInfo",
                 "tags": [
                     "Custodians"
                 ],
@@ -1062,14 +1071,6 @@
                     "assetSold": "USD",
                     "minimumTradeQty": 0.0001
                 }
-            },
-            "LedgerEntryType": {
-                "type": "string",
-                "enum": [
-                    "Trade",
-                    "Fee",
-                    "Withdrawal"
-                ]
             }
         }
     },

--- a/BTCPayServer/wwwroot/swagger/v1/swagger.template.invoices.json
+++ b/BTCPayServer/wwwroot/swagger/v1/swagger.template.invoices.json
@@ -34,7 +34,9 @@
                         "in": "query",
                         "required": false,
                         "description": "Array of statuses of invoices to be fetched",
-                        "$ref": "#/components/schemas/InvoiceStatus"
+                        "schema": {
+                            "$ref": "#/components/schemas/InvoiceStatus"
+                        }
                     },
                     {
                         "name": "textSearch",
@@ -50,14 +52,18 @@
                         "in": "query",
                         "required": false,
                         "description": "Start date of the period to retrieve invoices",
-                        "$ref": "#/components/schemas/UnixTimestamp"
+                        "schema": {
+                            "$ref": "#/components/schemas/UnixTimestamp"
+                        }
                     },
                     {
                         "name": "endDate",
                         "in": "query",
                         "required": false,
                         "description": "End date of the period to retrieve invoices",
-                        "$ref": "#/components/schemas/UnixTimestamp"
+                        "schema": {
+                            "$ref": "#/components/schemas/UnixTimestamp"
+                        }
                     },
                     {
                         "name": "skip",
@@ -641,17 +647,6 @@
                         "nullable": false,
                         "description": "Mark an invoice as completed or invalid.",
                         "$ref": "#/components/schemas/InvoiceStatusMark"
-                    }
-                }
-            },
-            "AddCustomerEmailRequest": {
-                "type": "object",
-                "additionalProperties": false,
-                "properties": {
-                    "email": {
-                        "type": "string",
-                        "nullable": false,
-                        "description": "Sets the customer email, if it was not set before."
                     }
                 }
             },

--- a/BTCPayServer/wwwroot/swagger/v1/swagger.template.json
+++ b/BTCPayServer/wwwroot/swagger/v1/swagger.template.json
@@ -2,14 +2,22 @@
     "openapi": "3.0.0",
     "info": {
         "title": "BTCPay Greenfield API",
+        "version": "v1",
         "description": "A full API to use your BTCPay Server",
         "contact": {
             "name": "BTCPay Server",
             "url": "https://btcpayserver.org"
         },
-        "version": "v1"
+        "license": {
+            "name": "MIT",
+            "url": "https://github.com/btcpayserver/btcpayserver/blob/master/LICENSE"
+        }
     },
     "servers": [
+        {
+            "url": "https://btcpay.example.com/api/v1",
+            "description": "BTCPay Server Greenfield API"
+        }
     ],
     "components": {
         "schemas": {
@@ -51,7 +59,7 @@
             },
             "UnixTimestamp": {
                 "type": "number",
-                "format": "Unix timestamp in seconds",
+                "format": "int32",
                 "example": 1592312018,
                 "description": "A unix timestamp in seconds"
             },

--- a/BTCPayServer/wwwroot/swagger/v1/swagger.template.misc.json
+++ b/BTCPayServer/wwwroot/swagger/v1/swagger.template.misc.json
@@ -104,6 +104,7 @@
                 "tags": [
                     "Miscelleneous"
                 ],
+                "operationId": "Invoice_Checkout",
                 "summary": "Invoice checkout",
                 "description": "View the checkout page of an invoice",
                 "responses": {

--- a/BTCPayServer/wwwroot/swagger/v1/swagger.template.payout-processors.json
+++ b/BTCPayServer/wwwroot/swagger/v1/swagger.template.payout-processors.json
@@ -114,17 +114,6 @@
                     "Payout Processors"
                 ],
                 "summary": "Get payout processors",
-                "parameters": [
-                    {
-                        "name": "storeId",
-                        "in": "path",
-                        "required": true,
-                        "description": "The store to fetch",
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
                 "description": "Get payout processors available in this instance",
                 "operationId": "PayoutProcessors_GetPayoutProcessors",
                 "responses": {
@@ -177,7 +166,7 @@
                     }
                 ],
                 "description": "Get configured store onchain automated payout processors",
-                "operationId": "GreenfieldStoreAutomatedOnChainPayoutProcessorsController_GetStoreOnChainAutomatedPayoutProcessors",
+                "operationId": "GreenfieldStoreAutomatedOnChainPayoutProcessorsController_GetStoreOnChainAutomatedPayoutProcessorsForPaymentMethod",
                 "responses": {
                     "200": {
                         "description": "configured processors",
@@ -234,7 +223,7 @@
                     }
                 ],
                 "description": "Update configured store onchain automated payout processors",
-                "operationId": "GreenfieldStoreAutomatedOnChainPayoutProcessorsController_UpdateStoreOnChainAutomatedPayoutProcessor",
+                "operationId": "GreenfieldStoreAutomatedOnChainPayoutProcessorsController_UpdateStoreOnChainAutomatedPayoutProcessorForPaymentMethod",
                 "requestBody": {
                     "x-name": "request",
                     "content": {
@@ -302,7 +291,7 @@
                     }
                 ],
                 "description": "Get configured store Lightning automated payout processors",
-                "operationId": "GreenfieldStoreAutomatedLightningPayoutProcessorsController_GetStoreLightningAutomatedPayoutProcessors",
+                "operationId": "GreenfieldStoreAutomatedLightningPayoutProcessorsController_GetStoreLightningAutomatedPayoutProcessorsForPaymentMethod",
                 "responses": {
                     "200": {
                         "description": "configured processors",
@@ -418,7 +407,7 @@
                     }
                 ],
                 "description": "Get configured store onchain automated payout processors",
-                "operationId": "GreenfieldStoreAutomatedOnChainPayoutProcessorsController_GetStoreOnChainAutomatedPayoutProcessors",
+                "operationId": "GreenfieldStoreAutomatedOnChainPayoutProcessorsController_GetStoreOnChainAutomatedTransferSenderFactory",
                 "responses": {
                     "200": {
                         "description": "configured processors",
@@ -463,19 +452,10 @@
                         "schema": {
                             "type": "string"
                         }
-                    },
-                    {
-                        "name": "paymentMethod",
-                        "in": "path",
-                        "required": true,
-                        "description": "A specific payment method to fetch",
-                        "schema": {
-                            "type": "string"
-                        }
                     }
                 ],
                 "description": "Update configured store onchain automated payout processors",
-                "operationId": "GreenfieldStoreAutomatedOnChainPayoutProcessorsController_UpdateStoreOnChainAutomatedPayoutProcessor",
+                "operationId": "GreenfieldStoreAutomatedOnChainPayoutProcessorsController_UpdateStoreOnChainAutomatedTransferSenderFactory",
                 "requestBody": {
                     "x-name": "request",
                     "content": {
@@ -534,7 +514,7 @@
                     }
                 ],
                 "description": "Get configured store Lightning automated payout processors",
-                "operationId": "GreenfieldStoreAutomatedLightningPayoutProcessorsController_GetStoreLightningAutomatedPayoutProcessors",
+                "operationId": "GreenfieldStoreAutomatedLightningPayoutProcessorsController_GetStoreLightningAutomatedTransferSenderFactory",
                 "responses": {
                     "200": {
                         "description": "configured processors",

--- a/BTCPayServer/wwwroot/swagger/v1/swagger.template.stores-email.json
+++ b/BTCPayServer/wwwroot/swagger/v1/swagger.template.stores-email.json
@@ -51,6 +51,17 @@
                     "Stores (Email)"
                 ],
                 "summary": "Update store email settings",
+                "parameters": [
+                    {
+                        "name": "storeId",
+                        "in": "path",
+                        "required": true,
+                        "description": "The store to update",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
                 "description": "Update a store's email settings",
                 "operationId": "Stores_UpdateStoreEmailSettings",
                 "requestBody": {
@@ -102,11 +113,23 @@
         },
         "/api/v1/stores/{storeId}/email/send": {
             "post": {
+                "operationId": "Stores_SendStoreEmail",
                 "tags": [
                     "Stores (Email)"
                 ],
                 "summary": "Send an email for a store",
                 "description": "Send an email using the store's SMTP server",
+                "parameters": [
+                    {
+                        "name": "storeId",
+                        "in": "path",
+                        "required": true,
+                        "description": "The store to send the email from",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
                 "requestBody": {
                     "x-name": "request",
                     "content": {
@@ -135,7 +158,7 @@
                 },
                 "security": [
                     {
-                        "API Key": [
+                        "API_Key": [
                             "btcpay.store.canmodifystoresettings"
                         ],
                         "Basic": []

--- a/BTCPayServer/wwwroot/swagger/v1/swagger.template.stores-payment-methods.lightning-network.json
+++ b/BTCPayServer/wwwroot/swagger/v1/swagger.template.stores-payment-methods.lightning-network.json
@@ -184,6 +184,7 @@
                 ]
             },
             "delete": {
+                "operationId": "StoreLightningNetworkPaymentMethods_DeleteLightningNetworkPaymentMethod",
                 "tags": [
                     "Store Payment Methods (Lightning Network)"
                 ],
@@ -261,7 +262,7 @@
                     },
                     "disableBOLT11PaymentOption": {
 
-                        "type": "boolean", 
+                        "type": "boolean",
                         "description": "Whether to disable generation of bolt11 invoices. Useful when wanting to only use LNURL Pay exclusively."
                     }
                 }

--- a/BTCPayServer/wwwroot/swagger/v1/swagger.template.stores-payment-methods.lnurl.json
+++ b/BTCPayServer/wwwroot/swagger/v1/swagger.template.stores-payment-methods.lnurl.json
@@ -184,6 +184,7 @@
                 ]
             },
             "delete": {
+                "operationId": "StoreLNURLPayPaymentMethods_DeleteLNURLPayPaymentMethod",
                 "tags": [
                     "Store Payment Methods (LNURL Pay)"
                 ],

--- a/BTCPayServer/wwwroot/swagger/v1/swagger.template.stores-payment-methods.on-chain.json
+++ b/BTCPayServer/wwwroot/swagger/v1/swagger.template.stores-payment-methods.on-chain.json
@@ -184,6 +184,7 @@
                 ]
             },
             "delete": {
+                "operationId": "StoreOnChainPaymentMethods_DeleteOnChainPaymentMethod",
                 "tags": [
                     "Store Payment Methods (On Chain)"
                 ],

--- a/BTCPayServer/wwwroot/swagger/v1/swagger.template.stores.json
+++ b/BTCPayServer/wwwroot/swagger/v1/swagger.template.stores.json
@@ -30,6 +30,7 @@
                 ]
             },
             "post": {
+                "operationId": "Stores_CreateStore",
                 "tags": [
                     "Stores"
                 ],
@@ -196,6 +197,7 @@
                 ]
             },
             "delete": {
+                "operationId": "Stores_DeleteStore",
                 "tags": [
                     "Stores"
                 ],

--- a/BTCPayServer/wwwroot/swagger/v1/swagger.template.users.json
+++ b/BTCPayServer/wwwroot/swagger/v1/swagger.template.users.json
@@ -18,6 +18,9 @@
                                 }
                             }
                         }
+                    },
+                    "404": {
+                        "description": "The user could not be found"
                     }
                 },
                 "security": [
@@ -39,6 +42,9 @@
                 "responses": {
                     "200": {
                         "description": "User and associated data deleted successfully"
+                    },
+                    "404": {
+                        "description": "The user could not be found"
                     }
                 },
                 "security": [
@@ -53,6 +59,7 @@
         },
         "/api/v1/users": {
             "get": {
+                "operationId": "Users_GetUsers",
                 "tags": [
                     "Users"
                 ],
@@ -80,6 +87,7 @@
                 ]
             },
             "post": {
+                "operationId": "Users_CreateUser",
                 "tags": [
                     "Users"
                 ],
@@ -158,6 +166,7 @@
         },
         "/api/v1/users/{idOrEmail}": {
             "get": {
+                "operationId": "Users_GetUser",
                 "tags": [
                     "Users"
                 ],
@@ -198,6 +207,7 @@
                 ]
             },
             "delete": {
+                "operationId": "Users_DeleteUser",
                 "tags": [
                     "Users"
                 ],
@@ -205,7 +215,7 @@
                 "description": "Delete a user.\n\nMust be an admin to perform this operation.\n\nAttempting to delete the only admin user will not succeed.\n\nAll data associated with the user will be deleted as well if the operation succeeds.",
                 "parameters": [
                     {
-                        "name": "userId",
+                        "name": "idOrEmail",
                         "in": "path",
                         "required": true,
                         "description": "The ID of the user to be deleted",
@@ -240,6 +250,7 @@
         },
         "/api/v1/users/{idOrEmail}/lock": {
             "delete": {
+                "operationId": "Users_ToggleUserLock",
                 "tags": [
                     "Users"
                 ],
@@ -247,7 +258,7 @@
                 "description": "Lock or unlock a user.\n\nMust be an admin to perform this operation.\n\nAttempting to lock the only admin user will not succeed.",
                 "parameters": [
                     {
-                        "name": "userId",
+                        "name": "idOrEmail",
                         "in": "path",
                         "required": true,
                         "description": "The ID of the user to be un/locked",

--- a/BTCPayServer/wwwroot/swagger/v1/swagger.template.webhooks.json
+++ b/BTCPayServer/wwwroot/swagger/v1/swagger.template.webhooks.json
@@ -18,7 +18,7 @@
                 ],
                 "summary": "Get webhooks of a store",
                 "description": "View webhooks of a store",
-                "operationId": "Webhokks_GetWebhooks",
+                "operationId": "Webhooks_GetWebhooks",
                 "responses": {
                     "200": {
                         "description": "List of webhooks",
@@ -29,6 +29,9 @@
                                 }
                             }
                         }
+                    },
+                    "404": {
+                        "description": "The key is not found for this list of webhooks"
                     }
                 },
                 "security": [
@@ -41,6 +44,7 @@
                 ]
             },
             "post": {
+                "operationId": "Webhooks_CreateWebhook",
                 "tags": [
                     "Webhooks"
                 ],
@@ -117,7 +121,7 @@
                 ],
                 "summary": "Get a webhook of a store",
                 "description": "View webhook of a store",
-                "operationId": "Webhokks_GetWebhook",
+                "operationId": "Webhooks_GetWebhook",
                 "responses": {
                     "200": {
                         "description": "A webhook",
@@ -143,6 +147,7 @@
                 ]
             },
             "put": {
+                "operationId": "Webhooks_UpdateWebhook",
                 "tags": [
                     "Webhooks"
                 ],
@@ -191,6 +196,7 @@
                 ]
             },
             "delete": {
+                "operationId": "Webhooks_DeleteWebhook",
                 "tags": [
                     "Webhooks"
                 ],
@@ -236,6 +242,7 @@
                 }
             ],
             "get": {
+                "operationId": "Webhooks_GetWebhookDeliveries",
                 "tags": [
                     "Webhooks"
                 ],
@@ -262,6 +269,9 @@
                                 }
                             }
                         }
+                    },
+                    "404": {
+                        "description": "The key is not found for this list of deliveries"
                     }
                 },
                 "security": [
@@ -305,6 +315,7 @@
                 }
             ],
             "get": {
+                "operationId": "Webhooks_GetWebhookDelivery",
                 "tags": [
                     "Webhooks"
                 ],
@@ -366,6 +377,7 @@
                 }
             ],
             "get": {
+                "operationId": "Webhooks_GetWebhookDeliveryRequests",
                 "tags": [
                     "Webhooks"
                 ],
@@ -428,6 +440,7 @@
                 }
             ],
             "post": {
+                "operationId": "Webhooks_RedeliverWebhookDelivery",
                 "tags": [
                     "Webhooks"
                 ],
@@ -787,6 +800,7 @@
     "x-webhooks": {
         "InvoiceCreated": {
             "post": {
+                "operationId": "Webhook_InvoiceCreated",
                 "summary": "InvoiceCreated",
                 "description": "A new invoice has been created",
                 "parameters": [
@@ -812,11 +826,13 @@
                             }
                         }
                     }
-                }
+                },
+                "responses": {}
             }
         },
         "InvoiceExpired": {
             "post": {
+                "operationId": "Webhook_InvoiceExpired",
                 "summary": "InvoiceExpired",
                 "description": "An invoice expired",
                 "parameters": [
@@ -842,11 +858,13 @@
                             }
                         }
                     }
-                }
+                },
+                "responses": {}
             }
         },
         "InvoiceReceivedPayment": {
             "post": {
+                "operationId": "Webhook_InvoiceReceivedPayment",
                 "summary": "InvoiceReceivedPayment",
                 "description": "An invoice received a payment",
                 "parameters": [
@@ -872,11 +890,13 @@
                             }
                         }
                     }
-                }
+                },
+                "responses": {}
             }
         },
         "InvoicePaymentSettled": {
             "post": {
+                "operationId": "Webhook_InvoicePaymentSettled",
                 "summary": "InvoicePaymentSettled",
                 "description": "An payment relating to an invoice has settled",
                 "parameters": [
@@ -902,11 +922,13 @@
                             }
                         }
                     }
-                }
+                },
+                "responses": {}
             }
         },
         "InvoiceProcessing": {
             "post": {
+                "operationId": "Webhook_InvoiceProcessing",
                 "summary": "InvoiceProcessing",
                 "description": "Triggers when an invoice is fully paid, but doesn't have the required amount of confirmations on the blockchain yet according to your store's settings.",
                 "parameters": [
@@ -932,11 +954,13 @@
                             }
                         }
                     }
-                }
+                },
+                "responses": {}
             }
         },
         "InvoiceInvalid": {
             "post": {
+                "operationId": "Webhook_InvoiceInvalid",
                 "summary": "InvoiceInvalid",
                 "description": "An invoice became invalid",
                 "parameters": [
@@ -962,11 +986,13 @@
                             }
                         }
                     }
-                }
+                },
+                "responses": {}
             }
         },
         "InvoiceSettled": {
             "post": {
+                "operationId": "Webhook_InvoiceSettled",
                 "summary": "InvoiceSettled",
                 "description": "Triggers when an invoice is considered settled and the merchant can proceed with the order's delivery. The invoice now has enough confirmations on the blockchain (if paid on-chain) according to your store's configuration.",
                 "parameters": [
@@ -992,7 +1018,8 @@
                             }
                         }
                     }
-                }
+                },
+                "responses": {}
             }
         }
     },


### PR DESCRIPTION
Combined the files with the same approach as in the docs:

`jq -rs 'reduce .[] as $item ({}; . * $item)' swagger.template.* > openapi.json`

Afterwards the bundled version can be validated using these commands:

`npx swagger-cli validate openapi.json && npx @redocly/cli lint openapi.json`