### PR TITLE
Add Yadio exchange rate provider

### DIFF
--- a/BTCPayServer.Rating/Providers/YadioRateProvider.cs
+++ b/BTCPayServer.Rating/Providers/YadioRateProvider.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using BTCPayServer.Rating;
+using Newtonsoft.Json.Linq;
+using Newtonsoft.Json;
+
+namespace BTCPayServer.Services.Rates
+{
+    public class YadioRateProvider : IRateProvider
+    {
+        private readonly HttpClient _httpClient;
+        public YadioRateProvider(HttpClient httpClient)
+        {
+            _httpClient = httpClient ?? new HttpClient();
+        }
+
+        public async Task<PairRate[]> GetRatesAsync(CancellationToken cancellationToken)
+        {
+            var response = await _httpClient.GetAsync("https://api.yadio.io/exrates/BTC", cancellationToken);
+            response.EnsureSuccessStatusCode();
+            var jobj = await response.Content.ReadAsAsync<JObject>(cancellationToken);
+            var results = jobj["BTC"];
+            var list = new List<PairRate>();
+            foreach (var item in results)
+            {
+
+                string name = ((JProperty)item).Name;
+                int value = results[name].Value<int>();
+                
+                list.Add(new PairRate(new CurrencyPair("BTC", name), new BidAsk(value)));
+            }
+
+            return list.ToArray();
+        }
+    }
+}

--- a/BTCPayServer.Rating/Services/RateProviderFactory.cs
+++ b/BTCPayServer.Rating/Services/RateProviderFactory.cs
@@ -84,6 +84,7 @@ namespace BTCPayServer.Services.Rates
             yield return new AvailableRateProvider("coinbasepro", "Coinbase Pro", "https://api.pro.coinbase.com/products");
 
             yield return new AvailableRateProvider("argoneum", "Argoneum", "https://rates.argoneum.net/rates");
+            yield return new AvailableRateProvider("yadio", "Yadio", "https://api.yadio.io/exrates/BTC");
         }
         void InitExchanges()
         {
@@ -104,6 +105,7 @@ namespace BTCPayServer.Services.Rates
             Providers.Add("ripio", new RipioExchangeProvider(_httpClientFactory?.CreateClient("EXCHANGE_RIPIO")));
             Providers.Add("cryptomarket", new CryptoMarketExchangeRateProvider(_httpClientFactory?.CreateClient("EXCHANGE_CRYPTOMARKET")));
             Providers.Add("bitflyer", new BitflyerRateProvider(_httpClientFactory?.CreateClient("EXCHANGE_BITFLYER")));
+            Providers.Add("yadio", new YadioRateProvider(_httpClientFactory?.CreateClient("EXCHANGE_YADIO")));
             // Providers.Add("argoneum", new ArgoneumRateProvider(_httpClientFactory?.CreateClient("EXCHANGE_ARGONEUM")));
 
 

--- a/BTCPayServer.Tests/ThirdPartyTests.cs
+++ b/BTCPayServer.Tests/ThirdPartyTests.cs
@@ -126,6 +126,12 @@ namespace BTCPayServer.Tests
                         e => e.CurrencyPair == new CurrencyPair("BTC", "CLP") &&
                              e.BidAsk.Bid > 1.0m); // 1 BTC will always be more than 1 CLP
                 }
+                else if (name == "yadio")
+                {
+                    Assert.Contains(exchangeRates.ByExchange[name],
+                        e => e.CurrencyPair == new CurrencyPair("BTC", "LBP") &&
+                             e.BidAsk.Bid > 1.0m); // 1 BTC will always be more than 1 LBP (I hope)
+                }
                 else
                 {
                     if (name == "kraken")


### PR DESCRIPTION
Yadio is a service which provides exchange rates for many currencies such as the Lebanese Pound which have the real exchange rate which differs from the official rate significantly (32,525 LBP for USD real rate vs 1,510 official rate).

See more details here: https://yadio.io/info.html

See discussions here:
https://github.com/btcpayserver/btcpayserver/discussions/4001
https://github.com/btcpayserver/btcpayserver/discussions/2489#discussioncomment-3102370

Notice that this screenshot shows 766,245,075 LBP for 1 BTC when the using the official rate it's 35,366,556. It's a 21x difference.

![Capture](https://user-images.githubusercontent.com/1934678/185305023-663e9c5c-0b0e-4afa-9f73-73b2e8e5a13b.PNG)
