### PR TITLE
API docs: Fix server base path

### DIFF
--- a/BTCPayServer/wwwroot/swagger/v1/swagger.template.json
+++ b/BTCPayServer/wwwroot/swagger/v1/swagger.template.json
@@ -15,7 +15,7 @@
     },
     "servers": [
         {
-            "url": "https://btcpay.example.com/api/v1",
+            "url": "/",
             "description": "BTCPay Server Greenfield API"
         }
     ],


### PR DESCRIPTION
Introduced in #4041. Fixes #4059.

Thanks for the pointer, @bolatovumar!