### PR TITLE
Re-do onchain label system

### DIFF
--- a/BTCPayServer.Client/Models/LabelData.cs
+++ b/BTCPayServer.Client/Models/LabelData.cs
@@ -12,6 +12,9 @@ namespace BTCPayServer.Client.Models
         [JsonProperty("text")]
         public string Text { get; set; }
 
+        [JsonProperty("color")]
+        public string Color { get; set; }
+
         [JsonExtensionData] public Dictionary<string, JToken> AdditionalData { get; set; }
     }
 }

--- a/BTCPayServer.Client/Models/LabelData.cs
+++ b/BTCPayServer.Client/Models/LabelData.cs
@@ -6,7 +6,10 @@ namespace BTCPayServer.Client.Models
 {
     public class LabelData
     {
+        [JsonProperty("type")]
         public string Type { get; set; }
+        
+        [JsonProperty("text")]
         public string Text { get; set; }
 
         [JsonExtensionData] public Dictionary<string, JToken> AdditionalData { get; set; }

--- a/BTCPayServer.Client/Models/OnChainWalletAddressData.cs
+++ b/BTCPayServer.Client/Models/OnChainWalletAddressData.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using NBitcoin;
 using NBitcoin.JsonConverters;
 using Newtonsoft.Json;
@@ -11,5 +12,6 @@ namespace BTCPayServer.Client.Models
         public KeyPath KeyPath { get; set; }
 
         public string PaymentLink { get; set; }
+        public List<LabelData> Labels { get; set; }
     }
 }

--- a/BTCPayServer.Client/Models/PatchOnChainTransactionRequest.cs
+++ b/BTCPayServer.Client/Models/PatchOnChainTransactionRequest.cs
@@ -3,10 +3,15 @@ using System.Collections.Generic;
 
 namespace BTCPayServer.Client.Models
 {
-    public class PatchOnChainTransactionRequest
+    public class PatchOnChainTransactionRequest: PatchLabelsRequest
     {
 
         public string? Comment { get; set; } = null;
+    }
+
+    public class PatchLabelsRequest
+    {
         public List<string>? Labels { get; set; } = null;
+        public List<string>? RemoveLabels { get; set; } = null;
     }
 }

--- a/BTCPayServer.Data/ApplicationDbContext.cs
+++ b/BTCPayServer.Data/ApplicationDbContext.cs
@@ -12,7 +12,6 @@ namespace BTCPayServer.Data
     {
         public ApplicationDbContext CreateDbContext(string[] args)
         {
-
             var builder = new DbContextOptionsBuilder<ApplicationDbContext>();
 
             builder.UseSqlite("Data Source=temp.db");
@@ -61,9 +60,11 @@ namespace BTCPayServer.Data
         public DbSet<UserStore> UserStore { get; set; }
         public DbSet<WalletData> Wallets { get; set; }
         public DbSet<WalletTransactionData> WalletTransactions { get; set; }
+        public DbSet<WalletScriptData> WalletScripts { get; set; }
+        public DbSet<WalletLabelData> WalletLabels { get; set; }
         public DbSet<WebhookDeliveryData> WebhookDeliveries { get; set; }
         public DbSet<WebhookData> Webhooks { get; set; }
-        public DbSet<LightningAddressData> LightningAddresses{ get; set; }
+        public DbSet<LightningAddressData> LightningAddresses { get; set; }
         public DbSet<PayoutProcessorData> PayoutProcessors { get; set; }
 
         protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
@@ -110,6 +111,8 @@ namespace BTCPayServer.Data
             BTCPayServer.Data.UserStore.OnModelCreating(builder);
             //WalletData.OnModelCreating(builder);
             WalletTransactionData.OnModelCreating(builder);
+            WalletScriptData.OnModelCreating(builder, Database);
+            WalletLabelData.OnModelCreating(builder, Database);
             WebhookDeliveryData.OnModelCreating(builder);
             LightningAddressData.OnModelCreating(builder);
             PayoutProcessorData.OnModelCreating(builder);
@@ -126,17 +129,19 @@ namespace BTCPayServer.Data
                 // This only supports millisecond precision, but should be sufficient for most use cases.
                 foreach (var entityType in builder.Model.GetEntityTypes())
                 {
-                    var properties = entityType.ClrType.GetProperties().Where(p => p.PropertyType == typeof(DateTimeOffset));
+                    var properties = entityType.ClrType.GetProperties()
+                        .Where(p => p.PropertyType == typeof(DateTimeOffset));
                     foreach (var property in properties)
                     {
                         builder
                             .Entity(entityType.Name)
                             .Property(property.Name)
-                            .HasConversion(new Microsoft.EntityFrameworkCore.Storage.ValueConversion.DateTimeOffsetToBinaryConverter());
+                            .HasConversion(
+                                new Microsoft.EntityFrameworkCore.Storage.ValueConversion.
+                                    DateTimeOffsetToBinaryConverter());
                     }
                 }
             }
         }
     }
-
 }

--- a/BTCPayServer.Data/Data/WalletData.cs
+++ b/BTCPayServer.Data/Data/WalletData.cs
@@ -17,6 +17,5 @@ namespace BTCPayServer.Data
 
     public class WalletBlobInfo
     {
-        public Dictionary<string, string> LabelColors { get; set; } = new Dictionary<string, string>();
     }
 }

--- a/BTCPayServer.Data/Data/WalletData.cs
+++ b/BTCPayServer.Data/Data/WalletData.cs
@@ -10,6 +10,8 @@ namespace BTCPayServer.Data
         public List<WalletTransactionData> WalletTransactions { get; set; }
 
         public byte[] Blob { get; set; }
+        public List<WalletScriptData> WalletScripts { get; set; }
+        public IEnumerable<WalletLabelData>? WalletLabels { get; set; }
     }
 
 

--- a/BTCPayServer.Data/Data/WalletLabelData.cs
+++ b/BTCPayServer.Data/Data/WalletLabelData.cs
@@ -9,6 +9,7 @@ public class WalletLabelData
     public string WalletDataId { get; set; }
     public string Label { get; set; }
     public string Data { get; set; }
+    
     internal static void OnModelCreating(ModelBuilder builder, DatabaseFacade databaseFacade)
     {
         builder.Entity<WalletLabelData>()

--- a/BTCPayServer.Data/Data/WalletLabelData.cs
+++ b/BTCPayServer.Data/Data/WalletLabelData.cs
@@ -1,0 +1,37 @@
+﻿using System.Collections.Generic;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+
+namespace BTCPayServer.Data;
+
+public class WalletLabelData
+{
+    public string WalletDataId { get; set; }
+    public string Label { get; set; }
+    public string Data { get; set; }
+    internal static void OnModelCreating(ModelBuilder builder, DatabaseFacade databaseFacade)
+    {
+        builder.Entity<WalletLabelData>()
+            .HasKey(o => new
+            {
+                o.WalletDataId,
+#pragma warning disable CS0618
+                o.Label
+#pragma warning restore CS0618
+            });
+        builder.Entity<WalletLabelData>()
+            .HasOne(o => o.WalletData)
+            .WithMany(w => w.WalletLabels).OnDelete(DeleteBehavior.Cascade);
+            
+        if (databaseFacade.IsNpgsql())
+        {
+            builder.Entity<WalletScriptData>()
+                .Property(o => o.Data)
+                .HasColumnType("JSONB");
+        }
+    }
+
+    public List<WalletTransactionData> WalletTransactions { get; set; }
+    public List<WalletScriptData> WalletScripts { get; set; }
+    public WalletData WalletData { get; set; }
+}

--- a/BTCPayServer.Data/Data/WalletScriptData.cs
+++ b/BTCPayServer.Data/Data/WalletScriptData.cs
@@ -12,6 +12,7 @@ public class WalletScriptData
     public string Data { get; set; }
     public List<WalletLabelData> WalletLabels { get; set; }
 
+    public List<WalletTransactionData> WalletTransactions { get; set; }
 
     internal static void OnModelCreating(ModelBuilder builder, DatabaseFacade databaseFacade)
     {
@@ -26,6 +27,10 @@ public class WalletScriptData
         builder.Entity<WalletScriptData>()
             .HasOne(o => o.WalletData)
             .WithMany(w => w.WalletScripts).OnDelete(DeleteBehavior.Cascade);
+        
+        builder.Entity<WalletScriptData>()
+            .HasMany<WalletTransactionData>(o => o.WalletTransactions)
+            .WithMany(w => w.WalletScripts);
             
         if (databaseFacade.IsNpgsql())
         {

--- a/BTCPayServer.Data/Data/WalletScriptData.cs
+++ b/BTCPayServer.Data/Data/WalletScriptData.cs
@@ -1,0 +1,37 @@
+﻿using System.Collections.Generic;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+
+namespace BTCPayServer.Data;
+
+public class WalletScriptData
+{
+    public string WalletDataId { get; set; }
+    public WalletData WalletData { get; set; }
+    public string Script { get; set; }
+    public string Data { get; set; }
+    public List<WalletLabelData> WalletLabels { get; set; }
+
+
+    internal static void OnModelCreating(ModelBuilder builder, DatabaseFacade databaseFacade)
+    {
+        builder.Entity<WalletScriptData>()
+            .HasKey(o => new
+            {
+                o.WalletDataId,
+#pragma warning disable CS0618
+                o.Script
+#pragma warning restore CS0618
+            });
+        builder.Entity<WalletScriptData>()
+            .HasOne(o => o.WalletData)
+            .WithMany(w => w.WalletScripts).OnDelete(DeleteBehavior.Cascade);
+            
+        if (databaseFacade.IsNpgsql())
+        {
+            builder.Entity<WalletScriptData>()
+                .Property(o => o.Data)
+                .HasColumnType("JSONB");
+        }
+    }
+}

--- a/BTCPayServer.Data/Data/WalletTransactionData.cs
+++ b/BTCPayServer.Data/Data/WalletTransactionData.cs
@@ -14,6 +14,7 @@ namespace BTCPayServer.Data
         public byte[] Blob { get; set; }
 
         public List<WalletLabelData> WalletLabels { get; set; }
+        public List<WalletScriptData> WalletScripts { get; set; }
 
         internal static void OnModelCreating(ModelBuilder builder)
         {

--- a/BTCPayServer.Data/Data/WalletTransactionData.cs
+++ b/BTCPayServer.Data/Data/WalletTransactionData.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 
 namespace BTCPayServer.Data
@@ -7,9 +9,11 @@ namespace BTCPayServer.Data
         public string WalletDataId { get; set; }
         public WalletData WalletData { get; set; }
         public string TransactionId { get; set; }
+        [Obsolete]
         public string Labels { get; set; }
         public byte[] Blob { get; set; }
 
+        public List<WalletLabelData> WalletLabels { get; set; }
 
         internal static void OnModelCreating(ModelBuilder builder)
         {

--- a/BTCPayServer.Data/Migrations/20220821172811_ScriptLabels.Designer.cs
+++ b/BTCPayServer.Data/Migrations/20220821172811_ScriptLabels.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using BTCPayServer.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,10 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace BTCPayServer.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20220821172811_ScriptLabels")]
+    partial class ScriptLabels
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "6.0.7");

--- a/BTCPayServer.Data/Migrations/20220821172811_ScriptLabels.cs
+++ b/BTCPayServer.Data/Migrations/20220821172811_ScriptLabels.cs
@@ -1,0 +1,183 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace BTCPayServer.Migrations
+{
+    public partial class ScriptLabels : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "Name",
+                table: "CustodianAccount",
+                type: "TEXT",
+                maxLength: 50,
+                nullable: false,
+                defaultValue: "",
+                oldClrType: typeof(string),
+                oldType: "TEXT",
+                oldMaxLength: 50,
+                oldNullable: true);
+
+            migrationBuilder.CreateTable(
+                name: "WalletLabels",
+                columns: table => new
+                {
+                    WalletDataId = table.Column<string>(type: "TEXT", nullable: false),
+                    Label = table.Column<string>(type: "TEXT", nullable: false),
+                    Data = table.Column<string>(type: "TEXT", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_WalletLabels", x => new { x.WalletDataId, x.Label });
+                    table.ForeignKey(
+                        name: "FK_WalletLabels_Wallets_WalletDataId",
+                        column: x => x.WalletDataId,
+                        principalTable: "Wallets",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "WalletScripts",
+                columns: table => new
+                {
+                    WalletDataId = table.Column<string>(type: "TEXT", nullable: false),
+                    Script = table.Column<string>(type: "TEXT", nullable: false),
+                    Data = table.Column<string>(type: "TEXT", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_WalletScripts", x => new { x.WalletDataId, x.Script });
+                    table.ForeignKey(
+                        name: "FK_WalletScripts_Wallets_WalletDataId",
+                        column: x => x.WalletDataId,
+                        principalTable: "Wallets",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "WalletLabelDataWalletTransactionData",
+                columns: table => new
+                {
+                    WalletLabelsWalletDataId = table.Column<string>(type: "TEXT", nullable: false),
+                    WalletLabelsLabel = table.Column<string>(type: "TEXT", nullable: false),
+                    WalletTransactionsWalletDataId = table.Column<string>(type: "TEXT", nullable: false),
+                    WalletTransactionsTransactionId = table.Column<string>(type: "TEXT", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_WalletLabelDataWalletTransactionData", x => new { x.WalletLabelsWalletDataId, x.WalletLabelsLabel, x.WalletTransactionsWalletDataId, x.WalletTransactionsTransactionId });
+                    table.ForeignKey(
+                        name: "FK_WalletLabelDataWalletTransactionData_WalletLabels_WalletLabelsWalletDataId_WalletLabelsLabel",
+                        columns: x => new { x.WalletLabelsWalletDataId, x.WalletLabelsLabel },
+                        principalTable: "WalletLabels",
+                        principalColumns: new[] { "WalletDataId", "Label" },
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_WalletLabelDataWalletTransactionData_WalletTransactions_WalletTransactionsWalletDataId_WalletTransactionsTransactionId",
+                        columns: x => new { x.WalletTransactionsWalletDataId, x.WalletTransactionsTransactionId },
+                        principalTable: "WalletTransactions",
+                        principalColumns: new[] { "WalletDataId", "TransactionId" },
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "WalletLabelDataWalletScriptData",
+                columns: table => new
+                {
+                    WalletLabelsWalletDataId = table.Column<string>(type: "TEXT", nullable: false),
+                    WalletLabelsLabel = table.Column<string>(type: "TEXT", nullable: false),
+                    WalletScriptsWalletDataId = table.Column<string>(type: "TEXT", nullable: false),
+                    WalletScriptsScript = table.Column<string>(type: "TEXT", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_WalletLabelDataWalletScriptData", x => new { x.WalletLabelsWalletDataId, x.WalletLabelsLabel, x.WalletScriptsWalletDataId, x.WalletScriptsScript });
+                    table.ForeignKey(
+                        name: "FK_WalletLabelDataWalletScriptData_WalletLabels_WalletLabelsWalletDataId_WalletLabelsLabel",
+                        columns: x => new { x.WalletLabelsWalletDataId, x.WalletLabelsLabel },
+                        principalTable: "WalletLabels",
+                        principalColumns: new[] { "WalletDataId", "Label" },
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_WalletLabelDataWalletScriptData_WalletScripts_WalletScriptsWalletDataId_WalletScriptsScript",
+                        columns: x => new { x.WalletScriptsWalletDataId, x.WalletScriptsScript },
+                        principalTable: "WalletScripts",
+                        principalColumns: new[] { "WalletDataId", "Script" },
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "WalletScriptDataWalletTransactionData",
+                columns: table => new
+                {
+                    WalletScriptsWalletDataId = table.Column<string>(type: "TEXT", nullable: false),
+                    WalletScriptsScript = table.Column<string>(type: "TEXT", nullable: false),
+                    WalletTransactionsWalletDataId = table.Column<string>(type: "TEXT", nullable: false),
+                    WalletTransactionsTransactionId = table.Column<string>(type: "TEXT", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_WalletScriptDataWalletTransactionData", x => new { x.WalletScriptsWalletDataId, x.WalletScriptsScript, x.WalletTransactionsWalletDataId, x.WalletTransactionsTransactionId });
+                    table.ForeignKey(
+                        name: "FK_WalletScriptDataWalletTransactionData_WalletScripts_WalletScriptsWalletDataId_WalletScriptsScript",
+                        columns: x => new { x.WalletScriptsWalletDataId, x.WalletScriptsScript },
+                        principalTable: "WalletScripts",
+                        principalColumns: new[] { "WalletDataId", "Script" },
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_WalletScriptDataWalletTransactionData_WalletTransactions_WalletTransactionsWalletDataId_WalletTransactionsTransactionId",
+                        columns: x => new { x.WalletTransactionsWalletDataId, x.WalletTransactionsTransactionId },
+                        principalTable: "WalletTransactions",
+                        principalColumns: new[] { "WalletDataId", "TransactionId" },
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_WalletLabelDataWalletScriptData_WalletScriptsWalletDataId_WalletScriptsScript",
+                table: "WalletLabelDataWalletScriptData",
+                columns: new[] { "WalletScriptsWalletDataId", "WalletScriptsScript" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_WalletLabelDataWalletTransactionData_WalletTransactionsWalletDataId_WalletTransactionsTransactionId",
+                table: "WalletLabelDataWalletTransactionData",
+                columns: new[] { "WalletTransactionsWalletDataId", "WalletTransactionsTransactionId" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_WalletScriptDataWalletTransactionData_WalletTransactionsWalletDataId_WalletTransactionsTransactionId",
+                table: "WalletScriptDataWalletTransactionData",
+                columns: new[] { "WalletTransactionsWalletDataId", "WalletTransactionsTransactionId" });
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "WalletLabelDataWalletScriptData");
+
+            migrationBuilder.DropTable(
+                name: "WalletLabelDataWalletTransactionData");
+
+            migrationBuilder.DropTable(
+                name: "WalletScriptDataWalletTransactionData");
+
+            migrationBuilder.DropTable(
+                name: "WalletLabels");
+
+            migrationBuilder.DropTable(
+                name: "WalletScripts");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Name",
+                table: "CustodianAccount",
+                type: "TEXT",
+                maxLength: 50,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "TEXT",
+                oldMaxLength: 50);
+        }
+    }
+}

--- a/BTCPayServer/Data/WalletTransactionDataExtensions.cs
+++ b/BTCPayServer/Data/WalletTransactionDataExtensions.cs
@@ -1,25 +1,22 @@
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using BTCPayServer.Client.Models;
 using BTCPayServer.Services.Labels;
 using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 using Newtonsoft.Json.Serialization;
+using Org.BouncyCastle.Tls;
 
 namespace BTCPayServer.Data
 {
-
     public static class WalletLabelDataExtensions
     {
         public static LabelData GetLabel(this WalletLabelData walletLabelData)
         {
-            return string.IsNullOrEmpty(walletLabelData.Data) ? new RawLabel(walletLabelData.Label) : Label.Parse(walletLabelData.Data);
+            return Label.Parse(walletLabelData.Data);
         }
-        
+
         public static string SetLabelData(this Label walletLabelData)
         {
-                return JsonConvert.SerializeObject(walletLabelData);
+            return JsonConvert.SerializeObject(walletLabelData);
         }
     }
     
@@ -36,6 +33,14 @@ namespace BTCPayServer.Data
     {
         public static int MaxCommentSize = 200;
 
+        public static WalletTransactionInfo GetWalletTransactionInfo(this byte[] blob)
+        {
+            if (blob == null || blob.Length == 0)
+                return new WalletTransactionInfo();
+            else
+                return JsonConvert.DeserializeObject<WalletTransactionInfo>(ZipUtils.Unzip(blob));
+        } 
+        
         public static WalletTransactionInfo GetBlobInfo(this WalletTransactionData walletTransactionData)
         {
             WalletTransactionInfo blobInfo;

--- a/BTCPayServer/Data/WalletTransactionDataExtensions.cs
+++ b/BTCPayServer/Data/WalletTransactionDataExtensions.cs
@@ -9,11 +9,28 @@ using Newtonsoft.Json.Serialization;
 
 namespace BTCPayServer.Data
 {
+
+    public static class WalletLabelDataExtensions
+    {
+        public static LabelData GetLabel(this WalletLabelData walletLabelData)
+        {
+            return string.IsNullOrEmpty(walletLabelData.Data) ? new RawLabel(walletLabelData.Label) : Label.Parse(walletLabelData.Data);
+        }
+        
+        public static string SetLabelData(this Label walletLabelData)
+        {
+                return JsonConvert.SerializeObject(walletLabelData);
+        }
+    }
+    
+    
+    
     public class WalletTransactionInfo
     {
         public string Comment { get; set; } = string.Empty;
-        [JsonIgnore]
-        public Dictionary<string, LabelData> Labels { get; set; } = new Dictionary<string, LabelData>();
+        // [JsonIgnore]
+        // [Obsolete]
+        // public Dictionary<string, LabelData> Labels { get; set; } = new Dictionary<string, LabelData>();
     }
     public static class WalletTransactionDataExtensions
     {
@@ -26,28 +43,28 @@ namespace BTCPayServer.Data
                 blobInfo = new WalletTransactionInfo();
             else
                 blobInfo = JsonConvert.DeserializeObject<WalletTransactionInfo>(ZipUtils.Unzip(walletTransactionData.Blob));
-            if (!string.IsNullOrEmpty(walletTransactionData.Labels))
-            {
-                if (walletTransactionData.Labels.StartsWith('['))
-                {
-                    foreach (var jtoken in JArray.Parse(walletTransactionData.Labels))
-                    {
-                        var l = jtoken.Type == JTokenType.String ? Label.Parse(jtoken.Value<string>())
-                                                                : Label.Parse(jtoken.ToString());
-                        blobInfo.Labels.TryAdd(l.Text, l);
-                    }
-                }
-                else
-                {
-                    // Legacy path
-                    foreach (var token in walletTransactionData.Labels.Split(',',
-                        StringSplitOptions.RemoveEmptyEntries))
-                    {
-                        var l = Label.Parse(token);
-                        blobInfo.Labels.TryAdd(l.Text, l);
-                    }
-                }
-            }
+            // if (!string.IsNullOrEmpty(walletTransactionData.Labels))
+            // {
+            //     if (walletTransactionData.Labels.StartsWith('['))
+            //     {
+            //         foreach (var jtoken in JArray.Parse(walletTransactionData.Labels))
+            //         {
+            //             var l = jtoken.Type == JTokenType.String ? Label.Parse(jtoken.Value<string>())
+            //                                                     : Label.Parse(jtoken.ToString());
+            //             blobInfo.Labels.TryAdd(l.Text, l);
+            //         }
+            //     }
+            //     else
+            //     {
+            //         // Legacy path
+            //         foreach (var token in walletTransactionData.Labels.Split(',',
+            //             StringSplitOptions.RemoveEmptyEntries))
+            //         {
+            //             var l = Label.Parse(token);
+            //             blobInfo.Labels.TryAdd(l.Text, l);
+            //         }
+            //     }
+            // }
             return blobInfo;
         }
         static JsonSerializerSettings LabelSerializerSettings = new JsonSerializerSettings()
@@ -59,15 +76,15 @@ namespace BTCPayServer.Data
         {
             if (blobInfo == null)
             {
-                walletTransactionData.Labels = string.Empty;
+                // walletTransactionData.Labels = string.Empty;
                 walletTransactionData.Blob = Array.Empty<byte>();
                 return;
             }
-            walletTransactionData.Labels = new JArray(
-                blobInfo.Labels.Select(l => JsonConvert.SerializeObject(l.Value, LabelSerializerSettings))
-                .Select(l => JObject.Parse(l))
-                .OfType<JToken>()
-                .ToArray()).ToString();
+            // walletTransactionData.Labels = new JArray(
+            //     blobInfo.Labels.Select(l => JsonConvert.SerializeObject(l.Value, LabelSerializerSettings))
+            //     .Select(l => JObject.Parse(l))
+            //     .OfType<JToken>()
+            //     .ToArray()).ToString();
             walletTransactionData.Blob = ZipUtils.Zip(JsonConvert.SerializeObject(blobInfo));
         }
     }

--- a/BTCPayServer/Payments/Bitcoin/NBXplorerListener.cs
+++ b/BTCPayServer/Payments/Bitcoin/NBXplorerListener.cs
@@ -397,6 +397,8 @@ namespace BTCPayServer.Payments.Bitcoin
                     }
                 }
             }
+            
+            
             return totalPayment;
         }
 

--- a/BTCPayServer/Payments/PayJoin/PayJoinEndpointController.cs
+++ b/BTCPayServer/Payments/PayJoin/PayJoinEndpointController.cs
@@ -504,14 +504,14 @@ namespace BTCPayServer.Payments.PayJoin
 
             await _btcPayWalletProvider.GetWallet(network).SaveOffchainTransactionAsync(ctx.OriginalTransaction);
             var labels = selectedUTXOs.GroupBy(pair => pair.Key.Hash).Select(utxo =>
-                    new KeyValuePair<uint256, List<(string color, Label label)>>(utxo.Key,
-                        new List<(string color, Label label)>()
+                    new KeyValuePair<uint256, List<Label>>(utxo.Key,
+                        new List<Label>()
                         {
                             UpdateTransactionLabel.PayjoinExposedLabelTemplate(invoice?.Id)
                         }))
                 .ToDictionary(pair => pair.Key, pair => pair.Value);
             
-            labels.Add(originalPaymentData.PayjoinInformation.CoinjoinTransactionHash, new List<(string color, Label label)>()
+            labels.Add(originalPaymentData.PayjoinInformation.CoinjoinTransactionHash, new List<Label>()
             {
                 UpdateTransactionLabel.PayjoinLabelTemplate()
             });

--- a/BTCPayServer/Services/Labels/Label.cs
+++ b/BTCPayServer/Services/Labels/Label.cs
@@ -11,6 +11,10 @@ namespace BTCPayServer.Services.Labels
 
     public abstract class Label : LabelData
     {
+        
+        [JsonIgnore]
+        public abstract string Id { get;}
+        
         public virtual Label Merge(LabelData other)
         {
             return this;
@@ -43,6 +47,8 @@ namespace BTCPayServer.Services.Labels
             rawLabel.Type = "raw";
             FixLegacy(jObj, (Label)rawLabel);
         }
+        
+        
         public static Label Parse(string str)
         {
             ArgumentNullException.ThrowIfNull(str);
@@ -51,13 +57,13 @@ namespace BTCPayServer.Services.Labels
                 var jObj = JObject.Parse(str);
                 string type = null;
                 // Legacy label
-                if (!jObj.ContainsKey("type"))
+                if (!jObj.ContainsKey("type") && !jObj.ContainsKey("Type"))
                 {
                     type = jObj["value"].Value<string>();
                 }
                 else
                 {
-                    type = jObj["type"].Value<string>();
+                    type = (jObj["type"] ?? jObj["Type"]).Value<string>();
                 }
 
                 switch (type)
@@ -99,6 +105,8 @@ namespace BTCPayServer.Services.Labels
         {
             Text = text;
         }
+
+        public override string Id { get { return Text; } } 
     }
     public class ReferenceLabel : Label
     {
@@ -114,6 +122,9 @@ namespace BTCPayServer.Services.Labels
         }
         [JsonProperty("ref")]
         public string Reference { get; set; }
+        
+        
+        public override string Id { get { return $"{Type}_{Reference}"; }  } 
     }
     public class PayoutLabel : Label
     {
@@ -125,6 +136,15 @@ namespace BTCPayServer.Services.Labels
 
         public Dictionary<string, List<string>> PullPaymentPayouts { get; set; } = new();
         public string WalletId { get; set; }
+        public string TransactionId { get; set; }
+
+        public override string Id
+        {
+            get
+            {
+                return $"{Type}_{TransactionId}";
+            }
+        }
 
         public override Label Merge(LabelData other)
         {

--- a/BTCPayServer/Services/Labels/Label.cs
+++ b/BTCPayServer/Services/Labels/Label.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using BTCPayServer.Client.Models;
+using BTCPayServer.HostedServices;
 using NBitcoin;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -11,30 +12,32 @@ namespace BTCPayServer.Services.Labels
 
     public abstract class Label : LabelData
     {
-        
-        [JsonIgnore]
-        public abstract string Id { get;}
-        
+
+        [JsonIgnore] public abstract string Id { get; }
+
         public virtual Label Merge(LabelData other)
         {
             return this;
         }
-        
+
         static void FixLegacy(JObject jObj, ReferenceLabel refLabel)
         {
             if (refLabel.Reference is null && jObj.ContainsKey("id"))
                 refLabel.Reference = jObj["id"].Value<string>();
             FixLegacy(jObj, (Label)refLabel);
         }
+
         static void FixLegacy(JObject jObj, PayoutLabel payoutLabel)
         {
             if (jObj.ContainsKey("id") && payoutLabel.PullPaymentPayouts.Count is 0)
             {
                 var pullPaymentId = jObj["pullPaymentId"]?.Value<string>() ?? string.Empty;
-                payoutLabel.PullPaymentPayouts.Add(pullPaymentId, new List<string>() { jObj["id"].Value<string>() });
+                payoutLabel.PullPaymentPayouts.Add(pullPaymentId, new List<string>() {jObj["id"].Value<string>()});
             }
+
             FixLegacy(jObj, (Label)payoutLabel);
         }
+
         static void FixLegacy(JObject jObj, Label label)
         {
             if (label.Type is null)
@@ -42,123 +45,127 @@ namespace BTCPayServer.Services.Labels
             if (label.Text is null)
                 label.Text = label.Type;
         }
+
         static void FixLegacy(JObject jObj, RawLabel rawLabel)
         {
             rawLabel.Type = "raw";
             FixLegacy(jObj, (Label)rawLabel);
         }
-        
-        
+
+
         public static Label Parse(string str)
         {
             ArgumentNullException.ThrowIfNull(str);
-            if (str.StartsWith("{", StringComparison.InvariantCultureIgnoreCase))
+            var jObj = JObject.Parse(str);
+            string type = null;
+            // Legacy label
+            if (!jObj.ContainsKey("type") && !jObj.ContainsKey("Type"))
             {
-                var jObj = JObject.Parse(str);
-                string type = null;
-                // Legacy label
-                if (!jObj.ContainsKey("type") && !jObj.ContainsKey("Type"))
-                {
-                    type = jObj["value"].Value<string>();
-                }
-                else
-                {
-                    type = (jObj["type"] ?? jObj["Type"]).Value<string>();
-                }
-
-                switch (type)
-                {
-                    case "raw":
-                        var rawLabel = JsonConvert.DeserializeObject<RawLabel>(str);
-                        FixLegacy(jObj, rawLabel);
-                        return rawLabel;
-                    case "invoice":
-                    case "payment-request":
-                    case "app":
-                    case "pj-exposed":
-                        var refLabel = JsonConvert.DeserializeObject<ReferenceLabel>(str);
-                        FixLegacy(jObj, refLabel);
-                        return refLabel;
-                    case "payout":
-                        var payoutLabel = JsonConvert.DeserializeObject<PayoutLabel>(str);
-                        FixLegacy(jObj, payoutLabel);
-                        return payoutLabel;
-                    default:
-                        // Legacy
-                        return new RawLabel(jObj["value"].Value<string>());
-                }
+                type = jObj["value"].Value<string>();
             }
             else
             {
-                return new RawLabel(str);
+                type = (jObj["type"] ?? jObj["Type"]).Value<string>();
             }
-        }
-    }
 
-    public class RawLabel : Label
-    {
-        public RawLabel()
-        {
-            Type = "raw";
-        }
-        public RawLabel(string text) : this()
-        {
-            Text = text;
-        }
-
-        public override string Id { get { return Text; } } 
-    }
-    public class ReferenceLabel : Label
-    {
-        public ReferenceLabel()
-        {
-
-        }
-        public ReferenceLabel(string type, string reference)
-        {
-            Text = type;
-            Reference = reference;
-            Type = type;
-        }
-        [JsonProperty("ref")]
-        public string Reference { get; set; }
-        
-        
-        public override string Id { get { return $"{Type}_{Reference}"; }  } 
-    }
-    public class PayoutLabel : Label
-    {
-        public PayoutLabel()
-        {
-            Type = "payout";
-            Text = "payout";
-        }
-
-        public Dictionary<string, List<string>> PullPaymentPayouts { get; set; } = new();
-        public string WalletId { get; set; }
-        public string TransactionId { get; set; }
-
-        public override string Id
-        {
-            get
+            switch (type)
             {
-                return $"{Type}_{TransactionId}";
+                case "raw":
+                    var rawLabel = JsonConvert.DeserializeObject<RawLabel>(str);
+                    FixLegacy(jObj, rawLabel);
+                    return rawLabel;
+                case "invoice":
+                case "payment-request":
+                case "app":
+                case "pj-exposed":
+                    var refLabel = JsonConvert.DeserializeObject<ReferenceLabel>(str);
+                    FixLegacy(jObj, refLabel);
+                    return refLabel;
+                case "payout":
+                    var payoutLabel = JsonConvert.DeserializeObject<PayoutLabel>(str);
+                    FixLegacy(jObj, payoutLabel);
+                    return payoutLabel;
+                default:
+                    // Legacy
+                    return new RawLabel(jObj["value"].Value<string>(), "");
             }
+
         }
 
-        public override Label Merge(LabelData other)
+        public class RawLabel : Label
         {
-            if (other is not PayoutLabel otherPayoutLabel) return base.Merge(other);
-            foreach (var pullPaymentPayout in otherPayoutLabel.PullPaymentPayouts)
+            public RawLabel()
             {
-                if (!PullPaymentPayouts.TryGetValue(pullPaymentPayout.Key, out var pullPaymentPayouts))
+                Type = "raw";
+            }
+
+            public RawLabel(string text, string color) : this()
+            {
+                Text = text;
+                Color = color;
+            }
+
+            public override string Id { get { return Text; } }
+        }
+
+        public class ReferenceLabel : Label
+        {
+            public ReferenceLabel()
+            {
+
+            }
+
+            public ReferenceLabel(string type, string reference, string color)
+            {
+                Text = type;
+                Reference = reference;
+                Type = type;
+                Color = color;
+            }
+
+            [JsonProperty("ref")] public string Reference { get; set; }
+
+
+            public override string Id { get { return $"{Type}_{Reference}"; } }
+        }
+
+        public class PayoutLabel : Label
+        {
+            public PayoutLabel()
+            {
+                Type = "payout";
+                Text = "payout";
+                Color = UpdateTransactionLabel.DefaultLabelColors["payout"];
+            }
+
+            public Dictionary<string, List<string>> PullPaymentPayouts { get; set; } = new();
+            public string WalletId { get; set; }
+            public string TransactionId { get; set; }
+
+            public override string Id
+            {
+                get
                 {
-                    pullPaymentPayouts = new List<string>();
-                    PullPaymentPayouts.Add(pullPaymentPayout.Key, pullPaymentPayouts);
+                    return $"{Type}_{TransactionId}";
                 }
-                pullPaymentPayouts.AddRange(pullPaymentPayout.Value);
             }
-            return base.Merge(other);
+
+            public override Label Merge(LabelData other)
+            {
+                if (other is not PayoutLabel otherPayoutLabel) return base.Merge(other);
+                foreach (var pullPaymentPayout in otherPayoutLabel.PullPaymentPayouts)
+                {
+                    if (!PullPaymentPayouts.TryGetValue(pullPaymentPayout.Key, out var pullPaymentPayouts))
+                    {
+                        pullPaymentPayouts = new List<string>();
+                        PullPaymentPayouts.Add(pullPaymentPayout.Key, pullPaymentPayouts);
+                    }
+
+                    pullPaymentPayouts.AddRange(pullPaymentPayout.Value);
+                }
+
+                return base.Merge(other);
+            }
         }
     }
 }

--- a/BTCPayServer/Services/WalletRepository.cs
+++ b/BTCPayServer/Services/WalletRepository.cs
@@ -2,13 +2,28 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using BTCPayServer.Client.Models;
 using BTCPayServer.Data;
+using BTCPayServer.Services.Labels;
+using BTCPayServer.Services.Wallets;
 using Microsoft.EntityFrameworkCore;
+using NBitcoin;
 
 namespace BTCPayServer.Services
 {
+
     public class WalletRepository
     {
+        public static Dictionary<string, string> DefaultLabelColors = new Dictionary<string, string>()
+        {
+            {"payjoin", "#51b13e"},
+            {"invoice", "#cedc21"},
+            {"payment-request", "#489D77"},
+            {"app", "#5093B6"},
+            {"pj-exposed", "#51b13e"},
+            {"payout", "#3F88AF"}
+        };
+
         private readonly ApplicationDbContextFactory _ContextFactory;
 
         public WalletRepository(ApplicationDbContextFactory contextFactory)
@@ -35,55 +50,337 @@ namespace BTCPayServer.Services
             }
         }
 
-        public async Task<Dictionary<string, WalletTransactionInfo>> GetWalletTransactionsInfo(WalletId walletId, string[] transactionIds = null)
+        // public async Task<Dictionary<string, WalletTransactionInfo>> GetWalletTransactionsInfo(WalletId walletId, string[] transactionIds = null)
+        // {
+        //     ArgumentNullException.ThrowIfNull(walletId);
+        //     using var ctx = _ContextFactory.CreateContext();
+        //     return (await ctx.WalletTransactions
+        //                     .Where(w => w.WalletDataId == walletId.ToString())
+        //                     .Where(data => transactionIds == null || transactionIds.Contains(data.TransactionId))
+        //                     .Select(w => w)
+        //                     .ToArrayAsync())
+        //                     .ToDictionary(w => w.TransactionId, w => w.GetBlobInfo());
+        // }
+
+        public async Task AddLabels(WalletId walletId, Label[] labels, string[] scripts, string[] txs)
         {
-            ArgumentNullException.ThrowIfNull(walletId);
-            using var ctx = _ContextFactory.CreateContext();
-            return (await ctx.WalletTransactions
-                            .Where(w => w.WalletDataId == walletId.ToString())
-                            .Where(data => transactionIds == null || transactionIds.Contains(data.TransactionId))
-                            .Select(w => w)
-                            .ToArrayAsync())
-                            .ToDictionary(w => w.TransactionId, w => w.GetBlobInfo());
+            var walletIdStr = walletId.ToString();
+            scripts ??= Array.Empty<string>();
+            txs ??= Array.Empty<string>();
+            await using var context = _ContextFactory.CreateContext();
+           var exist =  await context.Wallets.FindAsync(walletId.ToString());
+           if (exist is null)
+           {
+               var wd = new WalletData() {Id = walletId.ToString()};
+               wd.SetBlobInfo(new WalletBlobInfo());
+               await context.Wallets.AddAsync(wd);
+           }
+            
+            var labelToAdd = labels.ToDictionary(label => label.Id);
+            var labelIds = labelToAdd.Keys.ToArray();
+            var existingLabels = await 
+                context.WalletLabels
+                    .Include(data => data.WalletScripts)
+                    .Include(data => data.WalletTransactions)
+                    .Where(data => data.WalletDataId == walletIdStr && labelIds.Contains(data.Label)).ToDictionaryAsync(data => data.Label);
+            foreach (var label in labels)
+            {
+                if (!existingLabels.TryGetValue(label.Id, out var labelRecord))
+                {
+                    labelRecord = new WalletLabelData()
+                    {
+                        WalletDataId = walletIdStr, Label = label.Id, Data = label.SetLabelData()
+                    };
+                    await context.WalletLabels.AddAsync(labelRecord);
+                }
+
+                labelRecord.WalletScripts = new List<WalletScriptData>();
+                labelRecord.WalletTransactions = new List<WalletTransactionData>();
+                foreach (string script in scripts)
+                {
+                    if (labelRecord.WalletScripts.All(data => data.Script != script) is true)
+                    {
+                        var scriptData = new WalletScriptData() {WalletDataId = walletIdStr, Script = script};
+                        labelRecord.WalletScripts.Add(scriptData);
+                    }
+                }
+
+                foreach (string tx in txs)
+                {
+                    if (labelRecord.WalletTransactions.All(data => data.TransactionId != tx) is true)
+                    {
+                        var txData = new WalletTransactionData() {WalletDataId = walletIdStr, TransactionId = tx};
+                        labelRecord.WalletTransactions.Add(txData);
+                    }
+                }
+            }
+            await context.SaveChangesAsync();
+
         }
+        
+        public class WalletTransactionListDataResult
+        {
+            public Dictionary<string, string> TransactionComments { get; set; }
+            public Dictionary<string, List<WalletLabelData>> TransactionLabels { get; set; }
+        }
+
+        public async Task<WalletTransactionListDataResult> GetLabelsForTransactions(WalletId walletId, Dictionary<string, string[]> transactionsAndAllTheirInsAndOuts)
+        {
+            
+            var walletIdStr = walletId.ToString();
+            var txs = transactionsAndAllTheirInsAndOuts.Keys.ToArray();
+            var scripts = transactionsAndAllTheirInsAndOuts.Values.SelectMany(strings => strings).Distinct().ToArray();
+            await using var context = _ContextFactory.CreateContext();
+            var data = context.WalletLabels
+                .Include(data => data.WalletTransactions)
+                .Include(data => data.WalletScripts)
+                .Where(data => data.WalletDataId == walletIdStr)
+                .Where(data =>
+                    data.WalletTransactions.Any(transactionData => txs.Contains(transactionData.TransactionId)) ||
+                    data.WalletScripts.Any(scriptData => scripts.Contains(scriptData.Script))).ToList();
+
+            var txLabels = new Dictionary<string, List<WalletLabelData>>();
+            foreach (var tx in transactionsAndAllTheirInsAndOuts)
+            {
+                txLabels.Add(tx.Key, data.Where(labelData => labelData.WalletScripts.Any(scriptData =>
+                                                                 tx.Value.Contains(scriptData.Script)) ||
+                                                         labelData.WalletTransactions.Any(transactionData =>
+                                                             tx.Key ==
+                                                             transactionData.TransactionId)).ToList());
+            }
+            
+            var result = new WalletTransactionListDataResult()
+            {
+                TransactionComments = data.SelectMany(data => data.WalletTransactions).DistinctBy(data => data.TransactionId).ToDictionary(data => data.TransactionId, data => data.GetBlobInfo().Comment),
+                TransactionLabels = txLabels
+            };
+            return result;
+
+        }
+        
+        public class WalletScriptListDataResult
+        {
+            public Dictionary<string, List<WalletLabelData>> ScriptLabels { get; set; }
+        }
+        
+        
+        public class WalletUTXOListDataResult
+        {
+            public Dictionary<string, string>? TransactionComments { get; set; }
+            public Dictionary<ReceivedCoin, List<WalletLabelData>> UTXOLabels { get; set; }
+        }
+        
+         
+
+        public async Task<WalletUTXOListDataResult> GetLabelsForUTXOs(WalletId walletId, ReceivedCoin[] utxos)
+        {
+            var walletIdStr = walletId.ToString();
+            var scripts = utxos.Select(coin => coin.ScriptPubKey.ToString()).Distinct();
+            var txs = utxos.Select(coin => coin.OutPoint.Hash.ToString()).Distinct();    
+            
+            await using var context = _ContextFactory.CreateContext();
+            var data = context.WalletLabels
+                .Include(data => data.WalletTransactions)
+                .Include(data => data.WalletScripts)
+                .Where(data => data.WalletDataId == walletIdStr)
+                .Where(data =>
+                    data.WalletTransactions.Any(transactionData => txs.Contains(transactionData.TransactionId)) ||
+                    data.WalletScripts.Any(scriptData => scripts.Contains(scriptData.Script))).ToList();
+
+            Dictionary<ReceivedCoin, List<WalletLabelData>> coinToLabel = new();
+            foreach (var utxo in utxos)
+            {
+                coinToLabel.Add(utxo, data.Where(labelData => labelData.WalletScripts.Any(scriptData =>
+                                                                  scriptData.Script == utxo.ScriptPubKey.ToString()) ||
+                                                              labelData.WalletTransactions.Any(transactionData =>
+                                                                  utxo.OutPoint.Hash.ToString() ==
+                                                                  transactionData.TransactionId)).ToList());
+            }
+            
+            return new WalletUTXOListDataResult()
+            {
+                
+                TransactionComments = data.SelectMany(data => data.WalletTransactions)
+                    .DistinctBy(data => data.TransactionId)
+                    .ToDictionary(data => data.TransactionId, data => data.GetBlobInfo().Comment),
+                UTXOLabels = coinToLabel
+            };
+
+        }
+
+
+        public async Task<WalletScriptListDataResult> GetLabelsForScripts(WalletId walletId, string[] scripts)
+        {
+            await using var context = _ContextFactory.CreateContext();
+            var query = context.WalletScripts.Include(data => data.WalletLabels);
+          
+            var scriptsRes = await query
+                .Where(w => w.WalletDataId == walletId.ToString())
+                .Where(data => scripts == null || scripts.Contains(data.Script))
+                .AsSplitQuery()
+                .ToArrayAsync();
+            var result = new WalletScriptListDataResult()
+            {
+                ScriptLabels = scriptsRes.ToDictionary(data => data.Script, data =>  data.WalletLabels.DistinctBy(labelData => labelData.Label).ToList())
+            };
+            return result;
+        }
+        
 
         public async Task<WalletBlobInfo> GetWalletInfo(WalletId walletId)
         {
             ArgumentNullException.ThrowIfNull(walletId);
-            using var ctx = _ContextFactory.CreateContext();
+            await using var ctx = _ContextFactory.CreateContext();
             var data = await ctx.Wallets
                  .Where(w => w.Id == walletId.ToString())
                  .Select(w => w)
                  .FirstOrDefaultAsync();
-            return data?.GetBlobInfo() ?? new WalletBlobInfo();
+            var blob = data?.GetBlobInfo() ?? new WalletBlobInfo();
+            DefaultLabelColors.ToList().ForEach(x => blob.LabelColors.TryAdd(x.Key, x.Value));
+            return blob;
         }
 
-        public async Task SetWalletTransactionInfo(WalletId walletId, string transactionId, WalletTransactionInfo walletTransactionInfo)
+        // public async Task SetWalletTransactionInfo(WalletId walletId, string transactionId, WalletTransactionInfo walletTransactionInfo)
+        // {
+        //     ArgumentNullException.ThrowIfNull(walletId);
+        //     ArgumentNullException.ThrowIfNull(transactionId);
+        //     using var ctx = _ContextFactory.CreateContext();
+        //     var walletData = new WalletTransactionData() { WalletDataId = walletId.ToString(), TransactionId = transactionId };
+        //     walletData.SetBlobInfo(walletTransactionInfo);
+        //     var entity = await ctx.WalletTransactions.AddAsync(walletData);
+        //     entity.State = EntityState.Modified;
+        //     try
+        //     {
+        //         await ctx.SaveChangesAsync();
+        //     }
+        //     catch (DbUpdateException) // Does not exists
+        //     {
+        //         entity.State = EntityState.Added;
+        //         try
+        //         {
+        //             await ctx.SaveChangesAsync();
+        //         }
+        //         catch (DbUpdateException) // the Wallet does not exists in the DB
+        //         {
+        //             await SetWalletInfo(walletId, new WalletBlobInfo());
+        //             await ctx.SaveChangesAsync();
+        //         }
+        //     }
+        // }
+
+        public async Task UpdateTransactionComment(WalletId walletId, string txId, string requestComment)
         {
             ArgumentNullException.ThrowIfNull(walletId);
-            ArgumentNullException.ThrowIfNull(transactionId);
-            using var ctx = _ContextFactory.CreateContext();
-            var walletData = new WalletTransactionData() { WalletDataId = walletId.ToString(), TransactionId = transactionId };
-            walletData.SetBlobInfo(walletTransactionInfo);
-            var entity = await ctx.WalletTransactions.AddAsync(walletData);
-            entity.State = EntityState.Modified;
-            try
+            await using var ctx = _ContextFactory.CreateContext();
+            var existing =
+                await ctx.WalletTransactions.FindAsync(new {WalletDataId = walletId.ToString(), TransactionId = txId});
+            if (existing is null)
             {
-                await ctx.SaveChangesAsync();
+                existing = new() {WalletDataId = walletId.ToString(), TransactionId = txId};
+                await ctx.WalletTransactions.AddAsync(existing);
             }
-            catch (DbUpdateException) // Does not exists
-            {
-                entity.State = EntityState.Added;
-                try
-                {
-                    await ctx.SaveChangesAsync();
-                }
-                catch (DbUpdateException) // the Wallet does not exists in the DB
-                {
-                    await SetWalletInfo(walletId, new WalletBlobInfo());
-                    await ctx.SaveChangesAsync();
-                }
-            }
+            var blob = existing.GetBlobInfo();
+            blob.Comment = requestComment;
+            existing.SetBlobInfo(blob);
+            await ctx.SaveChangesAsync();
         }
+        
+        public async Task RemoveLabel(WalletId walletId, string[] id,string[] scripts, string[] txs )
+        {
+            ArgumentNullException.ThrowIfNull(walletId);
+            await using var ctx = _ContextFactory.CreateContext();
+            var existing =
+                await ctx.WalletLabels
+                    .Include(data => data.WalletTransactions)
+                    .Include(data => data.WalletScripts)
+                    .Where(data => data.WalletDataId ==  walletId.ToString() &&  id.Contains(data.Label)).ToListAsync();
+            if (existing.Any())
+            {
+                foreach (WalletLabelData data in existing)
+                {
+                    if (scripts?.Any() is true)
+                    {
+                        var removedScripts = 
+                            data.WalletScripts.Where(data => scripts.Contains(data.Script));
+                    
+                        ctx.RemoveRange(removedScripts);
+                        data.WalletScripts.RemoveAll(data => scripts.Contains(data.Script));
+                    }
+                    if (txs?.Any() is true)
+                    {
+                        var removedTxs = 
+                            data.WalletTransactions.Where(data => txs.Contains(data.TransactionId));
+                    
+                        ctx.RemoveRange(removedTxs);
+                        data.WalletTransactions.RemoveAll(data => txs.Contains(data.TransactionId));
+                    }
+
+                    if (!data.WalletScripts.Any() && !data.WalletTransactions.Any())
+                    {
+                    
+                        ctx.WalletLabels.Remove(data);
+                    }
+                }
+                
+            }
+            await ctx.SaveChangesAsync();
+        }
+        
+        
+        
+        public static  Dictionary<string, string[]> GetLabelFilter(IEnumerable<TransactionHistoryLine> transactionHistoryLines)
+        {
+            var result = new Dictionary<string, string[]>();
+            foreach (var transactionHistoryLine in transactionHistoryLines)
+            {
+                var scripts =
+                    transactionHistoryLine.Transaction is null
+                        ? Array.Empty<string>()
+                        : transactionHistoryLine.Transaction.Inputs
+                            .Select(txIn => txIn.GetSigner().ScriptPubKey.ToString())
+                            .Concat(transactionHistoryLine.Transaction.Outputs.Select(txOut =>
+                                txOut.ScriptPubKey.ToString())).Distinct().ToArray();
+                
+                result.Add(transactionHistoryLine.TransactionId.ToString(),  scripts);
+            }
+            return result;
+        }
+
+
+        public static List<TransactionHistoryLine> Filter(List<TransactionHistoryLine> txs,
+            Dictionary<string, List<WalletLabelData>> labels, TransactionStatus[] statusFilter = null, string labelFilter = null)
+        {
+            var result = new List<TransactionHistoryLine>();
+
+            foreach (TransactionHistoryLine t in txs)
+            {
+
+                if (!string.IsNullOrWhiteSpace(labelFilter))
+                {
+                    labels.TryGetValue(t.TransactionId.ToString(),
+                        out var txLabels);
+
+                    if (txLabels?.Any(data =>
+                        {
+                            var l = data.GetLabel();
+                            return labelFilter == l.Type || labelFilter == l.Text;
+                        }) is true)
+                        result.Add(t);
+                }
+
+                if (statusFilter?.Any() is true)
+                {
+                    if (statusFilter.Contains(TransactionStatus.Confirmed) && t.Confirmations != 0)
+                        result.Add(t);
+                    else if (statusFilter.Contains(TransactionStatus.Unconfirmed) && t.Confirmations == 0)
+                        result.Add(t);
+                }
+
+            }
+
+            return result;
+
+        }
+
     }
 }

--- a/BTCPayServer/Services/Wallets/BTCPayWallet.cs
+++ b/BTCPayServer/Services/Wallets/BTCPayWallet.cs
@@ -203,7 +203,7 @@ namespace BTCPayServer.Services.Wallets
         }
         bool? get_wallets_recentBugFixed = null;
         List<TransactionInformation> dummy = new List<TransactionInformation>();
-        public async Task<IList<TransactionHistoryLine>> FetchTransactionHistory(DerivationStrategyBase derivationStrategyBase, int? skip = null, int? count = null, TimeSpan? interval = null)
+        public async Task<List<TransactionHistoryLine>> FetchTransactionHistory(DerivationStrategyBase derivationStrategyBase, int? skip = null, int? count = null, TimeSpan? interval = null)
         {
             // This is two paths:
             // * Sometimes we can ask the DB to do the filtering of rows: If that's the case, we should try to filter at the DB level directly as it is the most efficient.
@@ -282,7 +282,8 @@ namespace BTCPayServer.Services.Wallets
                 Confirmations = t.Confirmations,
                 Height = t.Height,
                 SeenAt = t.Timestamp,
-                TransactionId = t.TransactionId
+                TransactionId = t.TransactionId,
+                Transaction = t.Transaction
             };
         }
 
@@ -371,5 +372,6 @@ namespace BTCPayServer.Services.Wallets
         public uint256 TransactionId { get; set; }
         public uint256 BlockHash { get; set; }
         public IMoney BalanceChange { get; set; }
+        public Transaction Transaction { get; set; }
     }
 }

--- a/BTCPayServer/Services/Wallets/Export/TransactionsExport.cs
+++ b/BTCPayServer/Services/Wallets/Export/TransactionsExport.cs
@@ -18,9 +18,9 @@ namespace BTCPayServer.Services.Wallets.Export
     public class TransactionsExport
     {
         private readonly BTCPayWallet _wallet;
-        private readonly Dictionary<string, WalletTransactionInfo> _walletTransactionsInfo;
+        private readonly WalletRepository.WalletTransactionListDataResult _walletTransactionsInfo;
 
-        public TransactionsExport(BTCPayWallet wallet, Dictionary<string, WalletTransactionInfo> walletTransactionsInfo)
+        public TransactionsExport(BTCPayWallet wallet, WalletRepository.WalletTransactionListDataResult walletTransactionsInfo)
         {
             _wallet = wallet;
             _walletTransactionsInfo = walletTransactionsInfo;
@@ -39,10 +39,13 @@ namespace BTCPayServer.Services.Wallets.Export
                     IsConfirmed = tx.Confirmations != 0
                 };
                 
-                if (_walletTransactionsInfo.TryGetValue(tx.TransactionId.ToString(), out var transactionInfo))
+                if (_walletTransactionsInfo.TransactionLabels.TryGetValue(tx.TransactionId.ToString(), out var labels))
                 {
-                    model.Labels = transactionInfo.Labels?.Select(l => l.Value.Text).ToList();
-                    model.Comment = transactionInfo.Comment;
+                    model.Labels = labels.Select(data => data.GetLabel().Text).ToList();
+                }
+                if (_walletTransactionsInfo.TransactionComments.TryGetValue(tx.TransactionId.ToString(), out var comment))
+                {
+                    model.Comment = comment;
                 }
 
                 return model;

--- a/BTCPayServer/Services/Wallets/WalletReceiveService.cs
+++ b/BTCPayServer/Services/Wallets/WalletReceiveService.cs
@@ -6,6 +6,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using BTCPayServer.Client.Models;
 using BTCPayServer.Events;
+using BTCPayServer.HostedServices;
 using BTCPayServer.Services.Labels;
 using BTCPayServer.Services.Stores;
 using Microsoft.Extensions.Hosting;
@@ -76,7 +77,7 @@ namespace BTCPayServer.Services.Wallets
             }
 
             var reserve = (await wallet.ReserveAddressAsync(derivationScheme.AccountDerivation));
-            await _walletRepository.AddLabels(walletId, new[] {new RawLabel("receive")},
+            await _walletRepository.AddLabels(walletId, new[] { UpdateTransactionLabel.ReceiveWalletLabel()},
                 new[] {reserve.ScriptPubKey.ToString()}, null);
             Set(walletId, reserve);
             return reserve;


### PR DESCRIPTION
Currently, we can only place labels on transactions, resulting in an inferior coin selection system.  This PR aims to re-implement so that labels can be placed on both transactions AND on scripts (addresses).

This means that when you generate an address, you can label it with who you shared it with, and when you send out money, you can also label their address. 

DESCRIPTION NOT COMPLETE. STILL WIP