### PR TITLE
PoS UI fix: scale-down item image

### DIFF
--- a/BTCPayServer/Views/Shared/PointOfSale/Public/Cart.cshtml
+++ b/BTCPayServer/Views/Shared/PointOfSale/Public/Cart.cshtml
@@ -27,7 +27,7 @@
 </script>
 
 <script id="template-cart-item-image" type="text/template">
-    <img src="{image}" width="50" alt="">
+    <img class="cart-item-image" src="{image}" alt="">
 </script>
 
 <script id="template-cart-custom-amount" type="text/template">

--- a/BTCPayServer/wwwroot/cart/css/style.css
+++ b/BTCPayServer/wwwroot/cart/css/style.css
@@ -20,6 +20,12 @@
     object-fit: scale-down;
 }
 
+.cart-item-image {
+    width: 50px;
+    height: 50px;
+    object-fit: scale-down;
+}
+
 .js-cart-added {
     background-color: rgba(0, 0, 0, 0.7);
     border-radius: 0.25rem;

--- a/BTCPayServer/wwwroot/cart/css/style.css
+++ b/BTCPayServer/wwwroot/cart/css/style.css
@@ -17,7 +17,7 @@
 .card-img-top {
     width: 100%;
     max-height: 180px;
-    object-fit: cover;
+    object-fit: scale-down;
 }
 
 .js-cart-added {


### PR DESCRIPTION
before:

<img width="307" alt="Screenshot 2022-08-24 at 17 23 04" src="https://user-images.githubusercontent.com/42201/186458572-24cca74f-1741-4c64-91c4-2e6f61e64b2b.png">

after:

<img width="307" alt="Screenshot 2022-08-24 at 17 23 14" src="https://user-images.githubusercontent.com/42201/186458613-06ae072e-11c3-4675-80b6-a4cb9ad513a2.png">

image source: https://cdn.rohlik.cz/images/grocery/products/762961/762961-1646145765627.jpg