### PR TITLE
Make sure end date is after start date in Crowdfund app

### DIFF
--- a/BTCPayServer.Tests/SeleniumTests.cs
+++ b/BTCPayServer.Tests/SeleniumTests.cs
@@ -800,6 +800,16 @@ namespace BTCPayServer.Tests
             s.Driver.FindElement(By.Id("TargetCurrency")).Clear();
             s.Driver.FindElement(By.Id("TargetCurrency")).SendKeys("JPY");
             s.Driver.FindElement(By.Id("TargetAmount")).SendKeys("700");
+            
+            // test wrong dates
+            s.Driver.ExecuteJavaScript("const now = new Date();document.getElementById('StartDate').value = now.toISOString();" +
+                "const yst = new Date(now.setDate(now.getDate() -1));document.getElementById('EndDate').value = yst.toISOString()");
+            s.Driver.FindElement(By.Id("SaveSettings")).Click();
+            Assert.Contains("End date cannot be before start date", s.Driver.PageSource);
+            Assert.DoesNotContain("App updated", s.Driver.PageSource);
+            
+            // unset end date
+            s.Driver.ExecuteJavaScript("document.getElementById('EndDate').value = ''");
             s.Driver.FindElement(By.Id("SaveSettings")).Click();
             Assert.Contains("App updated", s.FindAlertMessage().Text);
 

--- a/BTCPayServer/Plugins/Crowdfund/Controllers/UICrowdfundController.cs
+++ b/BTCPayServer/Plugins/Crowdfund/Controllers/UICrowdfundController.cs
@@ -126,7 +126,7 @@ namespace BTCPayServer.Plugins.Crowdfund.Controllers
             if (!string.IsNullOrEmpty(request.ChoiceKey))
             {
                 var choices = _appService.GetPOSItems(settings.PerksTemplate, settings.TargetCurrency);
-                choice = choices.FirstOrDefault(c => c.Id == request.ChoiceKey);
+                choice = choices?.FirstOrDefault(c => c.Id == request.ChoiceKey);
                 if (choice == null)
                     return NotFound("Incorrect option provided");
                 title = choice.Title;
@@ -379,7 +379,13 @@ namespace BTCPayServer.Plugins.Crowdfund.Controllers
         {
             if (string.IsNullOrWhiteSpace(currency))
             {
-                currency = (await _storeRepository.FindStore(storeId)).GetStoreBlob().DefaultCurrency;
+                var store = await _storeRepository.FindStore(storeId);
+                if (store == null)
+                {
+                    throw new Exception($"Could not find store with id {storeId}");
+                }
+
+                currency = store.GetStoreBlob().DefaultCurrency;
             }
             return currency.Trim().ToUpperInvariant();
         }

--- a/BTCPayServer/Plugins/Crowdfund/Controllers/UICrowdfundController.cs
+++ b/BTCPayServer/Plugins/Crowdfund/Controllers/UICrowdfundController.cs
@@ -287,12 +287,17 @@ namespace BTCPayServer.Plugins.Crowdfund.Controllers
 
             if (Enum.Parse<CrowdfundResetEvery>(vm.ResetEvery) != CrowdfundResetEvery.Never && !vm.StartDate.HasValue)
             {
-                ModelState.AddModelError(nameof(vm.StartDate), "A start date is needed when the goal resets every X amount of time.");
+                ModelState.AddModelError(nameof(vm.StartDate), "A start date is needed when the goal resets every X amount of time");
             }
 
             if (Enum.Parse<CrowdfundResetEvery>(vm.ResetEvery) != CrowdfundResetEvery.Never && vm.ResetEveryAmount <= 0)
             {
-                ModelState.AddModelError(nameof(vm.ResetEveryAmount), "You must reset the goal at a minimum of 1 ");
+                ModelState.AddModelError(nameof(vm.ResetEveryAmount), "You must reset the goal at a minimum of 1");
+            }
+
+            if (vm.StartDate != null && vm.EndDate != null && DateTime.Compare((DateTime)vm.StartDate, (DateTime)vm.EndDate) > 0)
+            {
+                ModelState.AddModelError(nameof(vm.EndDate), "End date cannot be before start date");
             }
 
             if (vm.DisplayPerksRanking)

--- a/BTCPayServer/Views/Shared/Crowdfund/UpdateCrowdfund.cshtml
+++ b/BTCPayServer/Views/Shared/Crowdfund/UpdateCrowdfund.cshtml
@@ -108,7 +108,6 @@
                             <vc:icon symbol="close"/>
                         </button>
                     </div>
-                    <span asp-validation-for="StartDate" class="text-danger"></span>
                 </div>
                 <div class="form-group mb-0 w-250px">
                     <label asp-for="EndDate" class="form-label"></label>
@@ -121,8 +120,9 @@
                             <vc:icon symbol="close"/>
                         </button>
                     </div>
-                    <span asp-validation-for="EndDate" class="text-danger"></span>
                 </div>
+                <span asp-validation-for="StartDate" class="text-danger"></span>
+                <span asp-validation-for="EndDate" class="text-danger"></span>
             </div>
             
             <div class="form-group mt-4" id="ResetRow" hidden="@(Model.StartDate == null)">


### PR DESCRIPTION
I noticed we don't validate that end date is after start date in the crowdfund app. We should probably check for this. This PR adds this check.

![Capture](https://user-images.githubusercontent.com/1934678/187060966-a802f0a2-916e-4d19-b903-00a14d42c844.PNG)
