### PR TITLE
Show iframe when showing invoice in Shopify plugin

### DIFF
--- a/BTCPayServer/Views/Shared/PayButton/PayButton.cshtml
+++ b/BTCPayServer/Views/Shared/PayButton/PayButton.cshtml
@@ -32,7 +32,7 @@
         var xhttp = new XMLHttpRequest();
         xhttp.onreadystatechange = function() {
             if (this.readyState == 4 && this.status == 200 && this.responseText) {
-                window.btcpay.showInvoice(JSON.parse(this.responseText).invoiceId);
+                window.btcpay.appendInvoiceFrame(JSON.parse(this.responseText).invoiceId);
             }
         };
         xhttp.open('POST', event.target.getAttribute('action'), true);

--- a/BTCPayServer/Views/UIInvoice/ListInvoices.cshtml
+++ b/BTCPayServer/Views/UIInvoice/ListInvoices.cshtml
@@ -51,7 +51,7 @@
         delegate('click', '.showInvoice', e => {
             e.preventDefault();
             const { invoiceId } = e.target.dataset;
-            btcpay.showInvoice(invoiceId);
+            btcpay.appendInvoiceFrame(invoiceId);
         })
 
         $('#btnCustomRangeDate').on('click', function (sender) {

--- a/BTCPayServer/wwwroot/crowdfund/app.js
+++ b/BTCPayServer/wwwroot/crowdfund/app.js
@@ -219,8 +219,7 @@ document.addEventListener("DOMContentLoaded",function (ev) {
             this.sound = this.srvModel.soundsEnabled;
             this.animation = this.srvModel.animationsEnabled;
             eventAggregator.$on("invoice-created", function (invoiceId) {
-                btcpay.showInvoice(invoiceId);
-                btcpay.showFrame();
+                btcpay.appendAndShowInvoiceFrame(invoiceId);
 
                 self.contributeModalOpen = false;
                 self.setLoading(false);

--- a/BTCPayServer/wwwroot/modal/btcpay.js
+++ b/BTCPayServer/wwwroot/modal/btcpay.js
@@ -105,7 +105,7 @@
         onModalReceiveMessageMethod(event);
     }
 
-    function showInvoice(invoiceId, params) {
+    function appendInvoiceFrame(invoiceId, params) {
         showingInvoice = true;
         window.document.body.appendChild(iframe);
         var invoiceUrl = origin + '/invoice?id=' + invoiceId + '&view=modal';
@@ -113,6 +113,11 @@
             invoiceUrl += '&animateEntrance=false';
         }
         iframe.src = invoiceUrl;
+    }
+
+    function appendAndShowInvoiceFrame(invoiceId, params) {
+        appendInvoiceFrame(invoiceId, params);
+        showFrame();
     }
 
     function setButtonListeners() {
@@ -133,7 +138,9 @@
     window.btcpay = {
         showFrame: showFrame,
         hideFrame: hideFrame,
-        showInvoice: showInvoice,
+        showInvoice: appendInvoiceFrame,
+        appendInvoiceFrame: appendInvoiceFrame,
+        appendAndShowInvoiceFrame: appendAndShowInvoiceFrame,
         onModalWillEnter: onModalWillEnter,
         onModalWillLeave: onModalWillLeave,
         setApiUrlPrefix: setApiUrlPrefix,

--- a/BTCPayServer/wwwroot/payment-request/app.js
+++ b/BTCPayServer/wwwroot/payment-request/app.js
@@ -128,8 +128,7 @@ document.addEventListener("DOMContentLoaded",function (ev) {
 
             eventAggregator.$on("invoice-created", function (invoiceId) {
                 self.setLoading(false);
-                btcpay.showInvoice(invoiceId);
-                btcpay.showFrame();
+                btcpay.appendAndShowInvoiceFrame(invoiceId);
             });
             eventAggregator.$on("invoice-cancelled", function (){
                 self.setLoading(false);

--- a/BTCPayServer/wwwroot/shopify/btcpay-shopify.js
+++ b/BTCPayServer/wwwroot/shopify/btcpay-shopify.js
@@ -133,6 +133,7 @@ window.BTCPayShopifyIntegrationModule = function () {
                 });
             });
             window.btcpay.showInvoice(currentInvoiceData.invoiceId);
+            window.btcpay.showFrame();
         }
     }
 

--- a/BTCPayServer/wwwroot/shopify/btcpay-shopify.js
+++ b/BTCPayServer/wwwroot/shopify/btcpay-shopify.js
@@ -132,8 +132,7 @@ window.BTCPayShopifyIntegrationModule = function () {
                     handleInvoiceData(d, {backgroundCheck: true})
                 });
             });
-            window.btcpay.showInvoice(currentInvoiceData.invoiceId);
-            window.btcpay.showFrame();
+            btcpay.appendAndShowInvoiceFrame(currentInvoiceData.invoiceId);
         }
     }
 

--- a/BTCPayServer/wwwroot/tests/index.html
+++ b/BTCPayServer/wwwroot/tests/index.html
@@ -8,7 +8,7 @@
         window.onload = function(){
             const urlParams = new URLSearchParams(window.location.search);
             const myParam = urlParams.get('invoice');            
-            btcpay.showInvoice(myParam);
+            btcpay.appendInvoiceFrame(myParam);
         }
     </script>
 </head>


### PR DESCRIPTION
For whatever reason we do not call `btcpay.showFrame` after `btcpay.showInvoice` in the Shopify plugin even though we do it in other places. This results in the iframe being added to the document but not shown.

See here and here:

https://github.com/btcpayserver/btcpayserver/blob/5bbaa48b492556df32aaa8cd81b7e7ac9ea33794/BTCPayServer/wwwroot/payment-request/app.js#L131-L132

https://github.com/btcpayserver/btcpayserver/blob/4d0f76f9e8cf85c4104f248d5877d15dbc844a39/BTCPayServer/wwwroot/crowdfund/app.js#L222-L223




Close #4105