### PR TITLE
Fix runtime error on ubuntu 22.04 in dev mode

### DIFF
--- a/BTCPayServer/BTCPayServer.csproj
+++ b/BTCPayServer/BTCPayServer.csproj
@@ -94,6 +94,11 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.7" />
   </ItemGroup>
 
+   <PropertyGroup>
+     <!--https://stackoverflow.com/questions/70236519/invalidoperationexception-cannot-find-compilation-library-location-for-package/70741481#70741481-->
+     <GenerateRuntimeConfigDevFile>true</GenerateRuntimeConfigDevFile>
+   </PropertyGroup>
+
 	<ItemGroup>
 	  <None Include="wwwroot\vendor\font-awesome\fonts\fontawesome-webfont.svg" />
 	  <None Include="wwwroot\vendor\font-awesome\fonts\fontawesome-webfont.woff2" />


### PR DESCRIPTION
User reported:

> Hi there! I’m in the process of setting up BTCPayserver on Ubuntu 22.04, followed all of the directions pretty carefully, including a fresh install of .NET 6.0 from the MS repos… I’m getting a weird error when trying to view served up web pages:  System.InvalidOperationException: Cannot find compilation library location for package ‘System.Security.Cryptography.Pkcs’  Anyone seen such an issue?

It seems to be a common issue, reported on 

https://stackoverflow.com/questions/70236519/invalidoperationexception-cannot-find-compilation-library-location-for-package/70741481#70741481

https://github.com/dotnet/sdk/issues/16818

https://github.com/toddams/RazorLight/issues/460

The workaround should fix the issue.