### PR TITLE
Fix Monero and Zcash nav extensions

### DIFF
--- a/BTCPayServer/Views/Shared/Monero/StoreNavMoneroExtension.cshtml
+++ b/BTCPayServer/Views/Shared/Monero/StoreNavMoneroExtension.cshtml
@@ -1,12 +1,16 @@
 @using BTCPayServer.Services.Altcoins.Monero.Configuration
 @using BTCPayServer.Services.Altcoins.Monero.UI
+@using Microsoft.AspNetCore.Mvc.TagHelpers
+@using BTCPayServer.Abstractions.Contracts
 @inject SignInManager<ApplicationUser> SignInManager;
 @inject MoneroLikeConfiguration MoneroLikeConfiguration;
+@inject IScopeProvider ScopeProvider
 @{
-    var controller = ViewContext.RouteData.Values["Controller"].ToString();
-    var isMonero = controller.Equals(nameof(UIMoneroLikeStoreController), StringComparison.InvariantCultureIgnoreCase);
+    var storeId = ScopeProvider.GetCurrentStoreId();
+    var isActive = !string.IsNullOrEmpty(storeId) && ViewContext.RouteData.Values.TryGetValue("Controller", out var controller) && controller is not null && 
+                   nameof(UIMoneroLikeStoreController).StartsWith(controller.ToString() ?? string.Empty, StringComparison.InvariantCultureIgnoreCase);
 }
 @if (SignInManager.IsSignedIn(User) && User.IsInRole(Roles.ServerAdmin) && MoneroLikeConfiguration.MoneroLikeConfigurationItems.Any())
 {
-    <a class="nav-link @(isMonero ? "active" : string.Empty)" asp-route-storeId="@this.Context.GetRouteValue("storeId")" asp-action="GetStoreMoneroLikePaymentMethods" asp-controller="UIMoneroLikeStore">Monero</a>
+    <a class="nav-link @(isActive ? "active" : string.Empty)" asp-route-storeId="@storeId" asp-action="GetStoreMoneroLikePaymentMethods" asp-controller="UIMoneroLikeStore">Monero</a>
 }

--- a/BTCPayServer/Views/Shared/Monero/StoreWalletsNavMoneroExtension.cshtml
+++ b/BTCPayServer/Views/Shared/Monero/StoreWalletsNavMoneroExtension.cshtml
@@ -3,18 +3,20 @@
 @using Microsoft.AspNetCore.Mvc.TagHelpers
 @using BTCPayServer.Client
 @using BTCPayServer.Abstractions.TagHelpers
+@using BTCPayServer.Abstractions.Contracts
 @inject MoneroLikeConfiguration MoneroLikeConfiguration;
+@inject IScopeProvider ScopeProvider
 @{
-    var controller = ViewContext.RouteData.Values["Controller"].ToString();
-    var isMonero = nameof(UIMoneroLikeStoreController).StartsWith(controller, StringComparison.InvariantCultureIgnoreCase);
+    var storeId = ScopeProvider.GetCurrentStoreId();
+    var isActive = !string.IsNullOrEmpty(storeId) && ViewContext.RouteData.Values.TryGetValue("Controller", out var controller) && controller is not null && 
+                   nameof(UIMoneroLikeStoreController).StartsWith(controller.ToString() ?? string.Empty, StringComparison.InvariantCultureIgnoreCase);
 }
 @if (MoneroLikeConfiguration.MoneroLikeConfigurationItems.Any())
 {
     <li class="nav-item" permission="@Policies.CanModifyStoreSettings">
-        <a asp-action="GetStoreMoneroLikePaymentMethods" asp-controller="UIMoneroLikeStore" asp-route-storeId="@Model.Store.Id" class="nav-link @(isMonero ? "active" : string.Empty)" id="@($"StoreNav-Monero")">
+        <a asp-action="GetStoreMoneroLikePaymentMethods" asp-controller="UIMoneroLikeStore" asp-route-storeId="@storeId" class="nav-link @(isActive ? "active" : string.Empty)" id="StoreNav-Monero">
             <span class="me-2 btcpay-status"></span>
             <span>Monero</span>
         </a>
-
     </li>
 }

--- a/BTCPayServer/Views/Shared/Zcash/StoreNavZcashExtension.cshtml
+++ b/BTCPayServer/Views/Shared/Zcash/StoreNavZcashExtension.cshtml
@@ -1,12 +1,16 @@
 @using BTCPayServer.Services.Altcoins.Zcash.Configuration
 @using BTCPayServer.Services.Altcoins.Zcash.UI
+@using Microsoft.AspNetCore.Mvc.TagHelpers
+@using BTCPayServer.Abstractions.Contracts
 @inject SignInManager<ApplicationUser> SignInManager;
 @inject ZcashLikeConfiguration ZcashLikeConfiguration;
+@inject IScopeProvider ScopeProvider
 @{
-    var controller = ViewContext.RouteData.Values["Controller"].ToString();
-    var isZcash = controller.Equals(nameof(UIZcashLikeStoreController), StringComparison.InvariantCultureIgnoreCase);
+    var storeId = ScopeProvider.GetCurrentStoreId();
+    var isActive = !string.IsNullOrEmpty(storeId) && ViewContext.RouteData.Values.TryGetValue("Controller", out var controller) && controller is not null && 
+                   nameof(UIZcashLikeStoreController).StartsWith(controller.ToString() ?? string.Empty, StringComparison.InvariantCultureIgnoreCase);
 }
 @if (SignInManager.IsSignedIn(User) && User.IsInRole(Roles.ServerAdmin) && ZcashLikeConfiguration.ZcashLikeConfigurationItems.Any())
 {
-    <a class="nav-link @(isZcash ? "active" : string.Empty)" asp-route-storeId="@this.Context.GetRouteValue("storeId")" asp-action="GetStoreZcashLikePaymentMethods" asp-controller="UIZcashLikeStore">Zcash</a>
+    <a class="nav-link @(isActive ? "active" : string.Empty)" asp-route-storeId="@storeId" asp-action="GetStoreZcashLikePaymentMethods" asp-controller="UIZcashLikeStore">Zcash</a>
 }


### PR DESCRIPTION
They failed with an `System.NullReferenceException: Object reference not set to an instance of an object.` when navigating to a LNbank page, because LNbank uses Razor Pages and the controller part wan't defined. Brought up [on Mattermost](https://chat.btcpayserver.org/btcpayserver/pl/x3iohhct97nateyq4y1c4hp9mw).