### PR TITLE
Fix pagination of wallet's transactions

### DIFF
--- a/BTCPayServer/Controllers/UIWalletsController.cs
+++ b/BTCPayServer/Controllers/UIWalletsController.cs
@@ -317,8 +317,12 @@ namespace BTCPayServer.Controllers
                 }
 
                 model.Total = preFiltering ? null : model.Transactions.Count;
-                model.Transactions = model.Transactions.Skip(skip).Take(count)
-                    .ToList();
+                // if we couldn't filter at the db level, we need to apply skip and count
+                if (!preFiltering)
+                {
+                    model.Transactions = model.Transactions.Skip(skip).Take(count)
+                        .ToList();
+                }
             }
 
             model.CryptoCode = walletId.CryptoCode;


### PR DESCRIPTION
Only the first page of the wallet's transaction was returning the expected result.
There was two bugs, one at BTCPay Server level, and one at NBX.
Since we can't guarantee NBX version, I apply a workaround for old version.

This a bug fixed from #4074 by @dennisreimann and @HamroRamro 