### PR TITLE
Remove redundant exception status from invoice state label

### DIFF
--- a/BTCPayServer/Views/UIInvoice/Invoice.cshtml
+++ b/BTCPayServer/Views/UIInvoice/Invoice.cshtml
@@ -202,11 +202,6 @@
                 else
                 {
                     @Model.State
-                    @if (Model.StatusException != InvoiceExceptionStatus.None)
-                    {
-                        @String.Format(" ({0})", Model.StatusException.ToString())
-                        ;
-                    }
                 }
             </td>
         </tr>


### PR DESCRIPTION
We are showing exception status of the invoice twice on the invoice details page if the status is one of those that can't be changed by the user. This is redundant because the main status string will also always contain the exception status.

|Before|After|
|---|---|
|![Capture](https://user-images.githubusercontent.com/1934678/191656700-eda9e167-c146-4807-97ae-a3bda8b2440b.PNG)|![after](https://user-images.githubusercontent.com/1934678/191656698-5cd3c242-486d-4faa-b2af-43087da86211.PNG)|