### PR TITLE
Fix receipts for Lightning Address invoices

### DIFF
--- a/BTCPayServer/Controllers/UIInvoiceController.UI.cs
+++ b/BTCPayServer/Controllers/UIInvoiceController.UI.cs
@@ -176,7 +176,7 @@ namespace BTCPayServer.Controllers
                 });
             }
             JToken? receiptData = null;
-            i.Metadata?.AdditionalData.TryGetValue("receiptData", out receiptData);
+            i.Metadata?.AdditionalData?.TryGetValue("receiptData", out receiptData);
                 
             return View(new InvoiceReceiptViewModel
             {


### PR DESCRIPTION
`AdditionalData` needs to be null-checked, because it isn't set for invoices generated via Lightning Address. 

Fixes #4169.