### PR TITLE
Always show overpaid amount if invoice is overpaid

### DIFF
--- a/BTCPayServer/Models/InvoicingModels/InvoiceDetailsModel.cs
+++ b/BTCPayServer/Models/InvoicingModels/InvoiceDetailsModel.cs
@@ -134,5 +134,6 @@ namespace BTCPayServer.Models.InvoicingModels
         public bool CanMarkStatus => CanMarkSettled || CanMarkInvalid;
         public List<RefundData> Refunds { get; set; }
         public bool ShowReceipt { get; set; }
+        public bool Overpaid { get; set; } = false;
     }
 }

--- a/BTCPayServer/Views/UIInvoice/ListInvoicesPaymentsPartial.cshtml
+++ b/BTCPayServer/Views/UIInvoice/ListInvoicesPaymentsPartial.cshtml
@@ -1,4 +1,3 @@
-@using BTCPayServer.Client.Models
 @model (InvoiceDetailsModel Invoice, bool ShowAddress)
 @{ var invoice = Model.Invoice; }
 
@@ -14,7 +13,7 @@
                 <th class="text-end">Rate</th>
                 <th class="text-end">Paid</th>
                 <th class="text-end">Due</th>
-                @if (invoice.StatusException == InvoiceExceptionStatus.PaidOver)
+                @if (invoice.Overpaid)
                 {
                     <th class="text-end">Overpaid</th>
                 }
@@ -34,7 +33,7 @@
                     <td class="text-end">@payment.Rate</td>
                     <td class="text-end">@payment.Paid</td>
                     <td class="text-end">@payment.Due</td>
-                    @if (invoice.StatusException == InvoiceExceptionStatus.PaidOver)
+                    @if (invoice.Overpaid)
                     {
                         <td class="text-end">@payment.Overpaid</td>
                     }


### PR DESCRIPTION
The currently used method for determining whether we should show the "Overpaid" column on the invoice details page is unreliable because it relies on the invoice status. However, invoice may be overpaid but its status can be `PaidLate` or something else and in this case this column won't be shown even if invoice is actually overpaid.

This PR changes the behavior such that the "Overpaid" column is always shown if invoice is overpaid no matter its status.

close #4146