### PR TITLE
fix Custodian Swagger docs missing some path parameters

### DIFF
--- a/BTCPayServer/wwwroot/swagger/v1/swagger.template.custodians.json
+++ b/BTCPayServer/wwwroot/swagger/v1/swagger.template.custodians.json
@@ -85,6 +85,15 @@
                 ],
                 "summary": "Add a custodial account to a store.",
                 "description": "Add a custodial account to a store.",
+                "parameters": [
+                    {
+                        "name": "storeId",
+                        "in": "path",
+                        "required": true,
+                        "description": "The Store ID",
+                        "schema": { "type": "string" }
+                    }
+                ],
                 "requestBody": {
                     "x-name": "request",
                     "content": {
@@ -182,6 +191,26 @@
                 ],
                 "summary": "Update custodial account",
                 "description": "Update custodial account",
+                "parameters": [
+                    {
+                        "name": "storeId",
+                        "in": "path",
+                        "required": true,
+                        "description": "The Store ID",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "accountId",
+                        "in": "path",
+                        "required": true,
+                        "description": "The Custodian Account ID",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
                 "requestBody": {
                     "x-name": "request",
                     "content": {
@@ -225,6 +254,26 @@
                 ],
                 "summary": "Delete store custodian account",
                 "description": "Deletes a custodial account",
+                "parameters": [
+                    {
+                        "name": "storeId",
+                        "in": "path",
+                        "required": true,
+                        "description": "The Store ID",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "accountId",
+                        "in": "path",
+                        "required": true,
+                        "description": "The Custodian Account ID",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "Custodian account deleted"


### PR DESCRIPTION
* add `storeId` path parameter to [Add a custodial account to a store](https://docs.btcpayserver.org/API/Greenfield/v1/#operation/Custodians_AddStoreCustodianAccount)
* Add `storeId` and `accountId` path parameters to [Update custodial account](https://docs.btcpayserver.org/API/Greenfield/v1/#operation/Custodians_UpdateStoreCustodianAccount)
* Add `storeId` and `accountId` path parameters to [Delete store custodian account](https://docs.btcpayserver.org/API/Greenfield/v1/#operation/Custodians_DeleteStoreCustodianAccount)