### PR TITLE
Make sure string is valid URL before rendering it as such in invoice details POS data section

### DIFF
--- a/BTCPayServer/Views/UIInvoice/PosData.cshtml
+++ b/BTCPayServer/Views/UIInvoice/PosData.cshtml
@@ -1,6 +1,15 @@
 @model (Dictionary<string, object> Items, int Level)
 
-<table class="table table-hover my-0">
+@functions{
+    public bool IsValidURL(string source)
+    {
+        Uri uriResult;
+        return Uri.TryCreate(source, UriKind.Absolute, out uriResult) && 
+            (uriResult.Scheme == Uri.UriSchemeHttp || uriResult.Scheme == Uri.UriSchemeHttps);
+    }
+}
+
+<table class="table my-0">
     @foreach (var (key, value) in Model.Items)
     {
         <tr>
@@ -11,7 +20,7 @@
                     <th class="w-150px">@Safe.Raw(key)</th>
                 }
                 <td>
-                    @if (Uri.IsWellFormedUriString(str, UriKind.RelativeOrAbsolute))
+                    @if (IsValidURL(str))
                     {
                         <a href="@Safe.Raw(str)" target="_blank" rel="noreferrer noopener">@Safe.Raw(str)</a>
                     }
@@ -28,7 +37,7 @@
                 {
                     <th class="w-150px">@Safe.Raw(key)</th>
                     <td>
-                        @if (Uri.IsWellFormedUriString(str2, UriKind.RelativeOrAbsolute))
+                        @if (IsValidURL(str2))
                         {
                             <a href="@Safe.Raw(str2)" target="_blank" rel="noreferrer noopener">@Safe.Raw(str2)</a>
                         }


### PR DESCRIPTION
I noticed that we output anything that sort of looks like a URL as if it was actually a URL in the POS data section of invoice details. However, since the method we use doesn't actually make sure that something is a valid URL, random stuff ends up being rendered as a URL. This PR fixes it by making sure that something is a valid URL before outputting it on the page.

|Before|After|
|---|---|
|![before](https://user-images.githubusercontent.com/1934678/194220093-014e5de0-7e2c-478f-b797-4cfb6667f2b9.PNG)|![after](https://user-images.githubusercontent.com/1934678/194220108-d0c5b20e-fa4f-4ea0-814b-07cd67e0cd65.PNG)|