### PR TITLE
Update default value for "showCustomAmount" in Swagger docs

### DIFF
--- a/BTCPayServer/wwwroot/swagger/v1/swagger.template.apps.json
+++ b/BTCPayServer/wwwroot/swagger/v1/swagger.template.apps.json
@@ -296,7 +296,7 @@
                     "showCustomAmount": {
                         "type": "boolean",
                         "description": "Whether to include a special item in the store which allows user to input a custom payment amount",
-                        "default": true,
+                        "default": false,
                         "nullable": true
                     },
                     "showDiscount": {


### PR DESCRIPTION
`showCustomAmount` was updated to default to `false` in code some time ago but Swagger docs for Greenfield API were not updated accordingly.