### PR TITLE
Import xpub: Surface error details

### DIFF
--- a/BTCPayServer/Controllers/UIStoresController.Onchain.cs
+++ b/BTCPayServer/Controllers/UIStoresController.Onchain.cs
@@ -119,17 +119,16 @@ namespace BTCPayServer.Controllers
                             accountSettings.AccountKeyPath =
                                 vm.KeyPath == null ? null : KeyPath.Parse(vm.KeyPath);
                             accountSettings.RootFingerprint = string.IsNullOrEmpty(vm.RootFingerprint)
-                                ? (HDFingerprint?)null
-                                : new HDFingerprint(
-                                    NBitcoin.DataEncoders.Encoders.Hex.DecodeData(vm.RootFingerprint));
+                                ? null
+                                : new HDFingerprint(Encoders.Hex.DecodeData(vm.RootFingerprint));
                         }
                     }
                     vm.DerivationScheme = strategy.AccountDerivation.ToString();
                     ModelState.Remove(nameof(vm.DerivationScheme));
                 }
-                catch
+                catch (Exception ex)
                 {
-                    ModelState.AddModelError(nameof(vm.DerivationScheme), "Invalid wallet format");
+                    ModelState.AddModelError(nameof(vm.DerivationScheme), $"Invalid wallet format: {ex.Message}");
                     return View(vm.ViewName, vm);
                 }
             }

--- a/BTCPayServer/Controllers/UIStoresController.cs
+++ b/BTCPayServer/Controllers/UIStoresController.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using BTCPayServer.Abstractions.Constants;
@@ -672,10 +673,10 @@ namespace BTCPayServer.Controllers
         private DerivationSchemeSettings ParseDerivationStrategy(string derivationScheme, BTCPayNetwork network)
         {
             var parser = new DerivationSchemeParser(network);
-            try
+            var isOD = Regex.Match(derivationScheme, @"\(.*?\)");
+            if (isOD.Success)
             {
-                var derivationSchemeSettings = new DerivationSchemeSettings();
-                derivationSchemeSettings.Network = network;
+                var derivationSchemeSettings = new DerivationSchemeSettings { Network = network };
                 var result = parser.ParseOutputDescriptor(derivationScheme);
                 derivationSchemeSettings.AccountOriginal = derivationScheme.Trim();
                 derivationSchemeSettings.AccountDerivation = result.Item1;
@@ -687,12 +688,9 @@ namespace BTCPayServer.Controllers
                 }).ToArray() ?? new AccountKeySettings[result.Item1.GetExtPubKeys().Count()];
                 return derivationSchemeSettings;
             }
-            catch (Exception)
-            {
-                // ignored
-            }
-
-            return new DerivationSchemeSettings(parser.Parse(derivationScheme), network);
+            
+            var strategy = parser.Parse(derivationScheme);
+            return new DerivationSchemeSettings(strategy, network);
         }
 
         [HttpGet]


### PR DESCRIPTION
Checks if the input is an output descriptor and explicitely handles that case instead of catching any errors. This allows us to display more detailed information about why an import might fail.

## Example

![multisig-import-01](https://user-images.githubusercontent.com/886/194850451-1a869454-bfbc-4f06-acea-7e5e7e440354.png)
