### PR TITLE
UI: Fix missing timezone in browser dates

### DIFF
--- a/BTCPayServer.Abstractions/Extensions/ViewsRazor.cs
+++ b/BTCPayServer.Abstractions/Extensions/ViewsRazor.cs
@@ -96,7 +96,7 @@ namespace BTCPayServer.Abstractions.Extensions
         {
             var relative = date.ToTimeAgo();
             var initial = format.ToString().ToLower();
-            var dateTime = date.ToString("s", CultureInfo.InvariantCulture);
+            var dateTime = date.ToString("o", CultureInfo.InvariantCulture);
             var displayDate = format == DateDisplayFormat.Relative ? relative : date.ToString("g", CultureInfo.InvariantCulture);
             return new HtmlString($"<time datetime=\"{dateTime}\" data-relative=\"{relative}\" data-initial=\"{initial}\">{displayDate}</time>");
         }
@@ -105,7 +105,7 @@ namespace BTCPayServer.Abstractions.Extensions
         {
             var relative = date.ToTimeAgo();
             var initial = format.ToString().ToLower();
-            var dateTime = date.ToString("s", CultureInfo.InvariantCulture);
+            var dateTime = date.ToString("o", CultureInfo.InvariantCulture);
             var displayDate = format == DateDisplayFormat.Relative ? relative : date.ToString("g", CultureInfo.InvariantCulture);
             return new HtmlString($"<time datetime=\"{dateTime}\" data-relative=\"{relative}\" data-initial=\"{initial}\">{displayDate}</time>");
         }


### PR DESCRIPTION
Fix for an issue brought up by @petzsch in todays dev meeting. I messed this up with the [changes](https://github.com/btcpayserver/btcpayserver/pull/4074/files#diff-004b2cf421442ed815d5a2f2ab7e95a01177fbdc42af9887856104795ccfd64d) I did in #4074.