### PR TITLE
Bumping LND to 0.15.2-beta

### DIFF
--- a/BTCPayServer.Tests/docker-compose.altcoins.yml
+++ b/BTCPayServer.Tests/docker-compose.altcoins.yml
@@ -237,7 +237,7 @@ services:
       - "5432"
 
   merchant_lnd:
-    image: btcpayserver/lnd:v0.15.0-beta
+    image: btcpayserver/lnd:v0.15.2-beta
     restart: unless-stopped
     environment:
       LND_CHAIN: "btc"
@@ -272,7 +272,7 @@ services:
       - bitcoind
 
   customer_lnd:
-    image: btcpayserver/lnd:v0.15.0-beta
+    image: btcpayserver/lnd:v0.15.2-beta
     restart: unless-stopped
     environment:
       LND_CHAIN: "btc"

--- a/BTCPayServer.Tests/docker-compose.yml
+++ b/BTCPayServer.Tests/docker-compose.yml
@@ -225,7 +225,7 @@ services:
       - "5432"
 
   merchant_lnd:
-    image: btcpayserver/lnd:v0.15.0-beta
+    image: btcpayserver/lnd:v0.15.2-beta
     restart: unless-stopped
     environment:
       LND_CHAIN: "btc"
@@ -262,7 +262,7 @@ services:
       - bitcoind
 
   customer_lnd:
-    image: btcpayserver/lnd:v0.15.0-beta
+    image: btcpayserver/lnd:v0.15.2-beta
     restart: unless-stopped
     environment:
       LND_CHAIN: "btc"


### PR DESCRIPTION
Updating our devenv to use LND 0.15.2; Docker image available on https://hub.docker.com/layers/btcpayserver/lnd/v0.15.2-beta/images/sha256-889a04d4955c86b1b1ba6ec25e04270343ddf08dc4e28bff3b6d56cdfa879f9d?context=explore

Used it in BTCPayServer.Lightning library and it's good to go:
https://github.com/btcpayserver/BTCPayServer.Lightning/pull/101
