### PR TITLE
Fix: PayjoinController could throw HTTP 500 of a few corner cases

### DIFF
--- a/BTCPayServer/Payments/PayJoin/PayjoinReceiverContext.cs
+++ b/BTCPayServer/Payments/PayJoin/PayjoinReceiverContext.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
@@ -23,10 +24,10 @@ namespace BTCPayServer.Payments.PayJoin
             _explorerClient = explorerClient;
             _utxoLocker = utxoLocker;
         }
-        public Invoice Invoice { get; set; }
-        public NBitcoin.Transaction OriginalTransaction { get; set; }
+        public InvoiceEntity? Invoice { get; set; }
+        public NBitcoin.Transaction? OriginalTransaction { get; set; }
         public InvoiceLogs Logs { get; } = new InvoiceLogs();
-        public OutPoint[] LockedUTXOs { get; set; }
+        public OutPoint[]? LockedUTXOs { get; set; }
         public async Task DisposeAsync()
         {
             List<Task> disposing = new List<Task>();


### PR DESCRIPTION
I activated nullable on `PayJoinEndpointController`, finding it was hard to review correctness during another refactoring, and I found that a few corner cases were not properly handled, and might throw error 500.

I am unsure if those corner cases could be used though, but it was too difficult to analyze, so I just fixed the warnings with nullable just in case.

On top of this `PayjoinReceiverContext.Invoice` was never set, which mean we weren't saving some of the logs happening for the invoice during a payjoin.