### PR TITLE
Fix sync modal z-index

### DIFF
--- a/BTCPayServer/Views/Shared/LayoutPartials/SyncModal.cshtml
+++ b/BTCPayServer/Views/Shared/LayoutPartials/SyncModal.cshtml
@@ -27,13 +27,13 @@
         </div>
     </div>
 
-    <style >
+    <style>
             #syncModal {
                 position: fixed;
                 bottom: 40px;
                 right: 10px;
                 margin: 0;
-                z-index: 1000;
+                z-index: 1040;
                 width: 500px;
                 max-width: 100%;
             }


### PR DESCRIPTION
This way it stays above the header and secondary nav.

Reported by @Kukks [on Mattermost](https://chat.btcpayserver.org/btcpayserver/pl/r9oofh5jsfbg7y17dwdbjekp7o).

![grafik](https://user-images.githubusercontent.com/886/196514396-64a37971-05c4-4566-a696-68974610c2ab.png)
