### PR TITLE
Allow plugins to do something before and after automatic payouts

### DIFF
--- a/BTCPayServer/PayoutProcessors/AfterPayoutFilterData.cs
+++ b/BTCPayServer/PayoutProcessors/AfterPayoutFilterData.cs
@@ -1,0 +1,19 @@
+using System.Collections.Generic;
+using BTCPayServer.Data;
+using BTCPayServer.Payments;
+
+namespace BTCPayServer.PayoutProcessors;
+
+public class AfterPayoutFilterData
+{
+    private readonly StoreData _store;
+    private readonly ISupportedPaymentMethod _paymentMethod;
+    private readonly List<PayoutData> _payoutDatas;
+
+    public AfterPayoutFilterData(StoreData store, ISupportedPaymentMethod paymentMethod, List<PayoutData> payoutDatas)
+    {
+        _store = store;
+        _paymentMethod = paymentMethod;
+        _payoutDatas = payoutDatas;
+    }
+}

--- a/BTCPayServer/PayoutProcessors/BeforePayoutFilterData.cs
+++ b/BTCPayServer/PayoutProcessors/BeforePayoutFilterData.cs
@@ -1,0 +1,16 @@
+using BTCPayServer.Data;
+using BTCPayServer.Payments;
+
+namespace BTCPayServer.PayoutProcessors;
+
+public class BeforePayoutFilterData
+{
+    private readonly StoreData _store;
+    private readonly ISupportedPaymentMethod _paymentMethod;
+
+    public BeforePayoutFilterData(StoreData store, ISupportedPaymentMethod paymentMethod)
+    {
+        _store = store;
+        _paymentMethod = paymentMethod;
+    }
+}

--- a/BTCPayServer/PayoutProcessors/Lightning/LightningAutomatedPayoutProcessor.cs
+++ b/BTCPayServer/PayoutProcessors/Lightning/LightningAutomatedPayoutProcessor.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using BTCPayServer.Abstractions.Contracts;
 using BTCPayServer.Client.Models;
 using BTCPayServer.Configuration;
 using BTCPayServer.Data;
@@ -37,9 +38,10 @@ public class LightningAutomatedPayoutProcessor : BaseAutomatedPayoutProcessor<Au
         UserService userService,
         ILoggerFactory logger, IOptions<LightningNetworkOptions> options,
         StoreRepository storeRepository, PayoutProcessorData payoutProcesserSettings,
-        ApplicationDbContextFactory applicationDbContextFactory, PullPaymentHostedService pullPaymentHostedService, BTCPayNetworkProvider btcPayNetworkProvider) :
+        ApplicationDbContextFactory applicationDbContextFactory, PullPaymentHostedService pullPaymentHostedService, BTCPayNetworkProvider btcPayNetworkProvider,
+        IPluginHookService pluginHookService) :
         base(logger, storeRepository, payoutProcesserSettings, applicationDbContextFactory, pullPaymentHostedService,
-            btcPayNetworkProvider)
+            btcPayNetworkProvider, pluginHookService)
     {
         _btcPayNetworkJsonSerializerSettings = btcPayNetworkJsonSerializerSettings;
         _lightningClientFactoryService = lightningClientFactoryService;

--- a/BTCPayServer/PayoutProcessors/OnChain/OnChainAutomatedPayoutProcessor.cs
+++ b/BTCPayServer/PayoutProcessors/OnChain/OnChainAutomatedPayoutProcessor.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using BTCPayServer.Abstractions.Contracts;
 using BTCPayServer.Client.Models;
 using BTCPayServer.Data;
 using BTCPayServer.Events;
@@ -41,9 +42,10 @@ namespace BTCPayServer.PayoutProcessors.OnChain
             StoreRepository storeRepository,
             PayoutProcessorData payoutProcesserSettings,
             PullPaymentHostedService pullPaymentHostedService,
-            BTCPayNetworkProvider btcPayNetworkProvider) :
+            BTCPayNetworkProvider btcPayNetworkProvider,
+            IPluginHookService pluginHookService) :
             base(logger, storeRepository, payoutProcesserSettings, applicationDbContextFactory, pullPaymentHostedService,
-                btcPayNetworkProvider)
+                btcPayNetworkProvider, pluginHookService)
         {
             _explorerClientProvider = explorerClientProvider;
             _btcPayWalletProvider = btcPayWalletProvider;


### PR DESCRIPTION
This PR adds 2 new hooks for plugins so they can do something:
- Right before automatic payouts occur
- After automatic payouts occurred

I need this for a plugin where I want to quickly auto-approve or reject a previous approval before the payout executes.