### PR TITLE
Add warnings in btcpay vault page for safari and brave (Fix https://github.com/btcpayserver/BTCPayServer.Vault/issues/54)

### DIFF
--- a/BTCPayServer/Views/UIWallets/WalletSendVault.cshtml
+++ b/BTCPayServer/Views/UIWallets/WalletSendVault.cshtml
@@ -82,13 +82,13 @@
 		var isSafari = window.safari !== undefined;
 		if (isSafari)
 		{
-			alertMsg.innerHTML = "Safari doesn't support BTCPay Server Vault. Please use a different browser. (<a href=\"https://bugs.webkit.org/show_bug.cgi?id=171934\" target=\"_blank\" rel=\"noreferrer noopener\">More information</a>)";
+			alertMsg.innerHTML = "Safari doesn't support BTCPay Server Vault. Please use a different browser. (<a class=\"alert-link\" href=\"https://bugs.webkit.org/show_bug.cgi?id=171934\" target=\"_blank\" rel=\"noreferrer noopener\">More information</a>)";
 			walletAlert.style.display = null;
 		}
 		var isBrave = navigator.brave !== undefined;
 		if (isBrave)
 		{
-			alertMsg.innerHTML = "Brave supports BTCPay Server Vault, but you need to disable Brave Shields. (<a href=\"https://www.updateland.com/how-to-turn-off-brave-shields/\" target=\"_blank\" rel=\"noreferrer noopener\">More information</a>)";
+			alertMsg.innerHTML = "Brave supports BTCPay Server Vault, but you need to disable Brave Shields. (<a class=\"alert-link\" href=\"https://www.updateland.com/how-to-turn-off-brave-shields/\" target=\"_blank\" rel=\"noreferrer noopener\">More information</a>)";
 			walletAlert.style.display = null;
 		}
     </script>

--- a/BTCPayServer/Views/UIWallets/WalletSendVault.cshtml
+++ b/BTCPayServer/Views/UIWallets/WalletSendVault.cshtml
@@ -25,7 +25,7 @@
     <p class="lead text-secondary mt-3">Using BTCPay Server Vault</p>
 </header>
 
-<div id="walletAlert" class="alert alert-danger alert-dismissible my-4" style="display:none;" role="alert">
+<div id="walletAlert" class="alert alert-warning alert-dismissible my-4" style="display:none;" role="alert">
     <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close">
         <vc:icon symbol="close" />
     </button>
@@ -77,5 +77,19 @@
         document.addEventListener("DOMContentLoaded", function () {
             askSign();
         });
+		var alertMsg = document.getElementById("alertMessage");
+		var walletAlert = document.getElementById("walletAlert");
+		var isSafari = window.safari !== undefined;
+		if (isSafari)
+		{
+			alertMsg.innerHTML = "Safari doesn't support BTCPay Server Vault. Please use a different browser. (<a href=\"https://bugs.webkit.org/show_bug.cgi?id=171934\" target=\"_blank\" rel=\"noreferrer noopener\">More information</a>)";
+			walletAlert.style.display = null;
+		}
+		var isBrave = navigator.brave !== undefined;
+		if (isBrave)
+		{
+			alertMsg.innerHTML = "Brave supports BTCPay Server Vault, but you need to disable Brave Shields. (<a href=\"https://www.updateland.com/how-to-turn-off-brave-shields/\" target=\"_blank\" rel=\"noreferrer noopener\">More information</a>)";
+			walletAlert.style.display = null;
+		}
     </script>
 }


### PR DESCRIPTION
BTCPay Server Vault isn't supported by Safari due to a bug of safari reported on https://github.com/btcpayserver/BTCPayServer.Vault/issues/54 .

If you use safari, you will see this banner with a link to https://bugs.webkit.org/show_bug.cgi?id=171934

![image](https://user-images.githubusercontent.com/3020646/197114409-16d89b04-e2f8-4931-9e36-d71b113dc90e.png)


If you run brave, the warning will ask to disable shields. (with a link to https://www.updateland.com/how-to-turn-off-brave-shields/)
![image](https://user-images.githubusercontent.com/3020646/197114300-586a2dd1-7b56-47ca-9f58-c6d4a109d25d.png)
