### PR TITLE
Greenfield: Fix missing payment data

### DIFF
--- a/BTCPayServer.Client/BTCPayServerClient.Lightning.Store.cs
+++ b/BTCPayServer.Client/BTCPayServerClient.Lightning.Store.cs
@@ -65,7 +65,7 @@ namespace BTCPayServer.Client
             return await HandleResponse<string>(response);
         }
 
-        public virtual async Task PayLightningInvoice(string storeId, string cryptoCode, PayLightningInvoiceRequest request,
+        public virtual async Task<LightningPaymentData> PayLightningInvoice(string storeId, string cryptoCode, PayLightningInvoiceRequest request,
             CancellationToken token = default)
         {
             if (request == null)
@@ -73,7 +73,7 @@ namespace BTCPayServer.Client
             var response = await _httpClient.SendAsync(
                 CreateHttpRequest($"api/v1/stores/{storeId}/lightning/{cryptoCode}/invoices/pay", bodyPayload: request,
                     method: HttpMethod.Post), token);
-            await HandleResponse(response);
+            return await HandleResponse<LightningPaymentData>(response);
         }
 
         public virtual async Task<LightningPaymentData> GetLightningPayment(string storeId, string cryptoCode,

--- a/BTCPayServer.Tests/GreenfieldAPITests.cs
+++ b/BTCPayServer.Tests/GreenfieldAPITests.cs
@@ -1719,10 +1719,17 @@ namespace BTCPayServer.Tests
             Assert.NotEmpty(merchantPendingInvoices);
             Assert.Contains(merchantPendingInvoices, i => i.Id == merchantInvoice.Id);
             
-            await client.PayLightningInvoice(user.StoreId, "BTC", new PayLightningInvoiceRequest()
+            var payResponse = await client.PayLightningInvoice(user.StoreId, "BTC", new PayLightningInvoiceRequest
             {
                 BOLT11 = merchantInvoice.BOLT11
             });
+            Assert.Equal(merchantInvoice.BOLT11, payResponse.BOLT11);
+            Assert.Equal(LightningPaymentStatus.Complete, payResponse.Status);
+            Assert.NotNull(payResponse.Preimage);
+            Assert.NotNull(payResponse.FeeAmount);
+            Assert.NotNull(payResponse.TotalAmount);
+            Assert.NotNull(payResponse.PaymentHash);
+            
             await Assert.ThrowsAsync<GreenfieldValidationException>(async () => await client.PayLightningInvoice(user.StoreId, "BTC", new PayLightningInvoiceRequest()
             {
                 BOLT11 = "lol"

--- a/BTCPayServer/Controllers/GreenField/LocalBTCPayServerClient.cs
+++ b/BTCPayServer/Controllers/GreenField/LocalBTCPayServerClient.cs
@@ -381,10 +381,11 @@ namespace BTCPayServer.Controllers.Greenfield
                 await GetController<GreenfieldStoreLightningNodeApiController>().GetDepositAddress(cryptoCode, token));
         }
 
-        public override async Task PayLightningInvoice(string storeId, string cryptoCode,
+        public override async Task<LightningPaymentData> PayLightningInvoice(string storeId, string cryptoCode,
             PayLightningInvoiceRequest request, CancellationToken token = default)
         {
-            HandleActionResult(await GetController<GreenfieldStoreLightningNodeApiController>().PayInvoice(cryptoCode, request, token));
+            return GetFromActionResult<LightningPaymentData>(
+                await GetController<GreenfieldStoreLightningNodeApiController>().PayInvoice(cryptoCode, request, token));
         }
 
         public override async Task<LightningInvoiceData> GetLightningInvoice(string storeId, string cryptoCode,


### PR DESCRIPTION
Fetches the detailed payment info once a payment has been made. Fixes #4229.

In this case the `ID` field is null, because the c-lightning invoice didn't have a label, which acts as the ID.

![grafik](https://user-images.githubusercontent.com/886/197575063-74c81874-8f02-422f-aa40-99f8993fe6f7.png)
