### PR TITLE
Add Greenfield invoice refund endpoint

### DIFF
--- a/BTCPayServer.Client/BTCPayServerClient.Invoices.cs
+++ b/BTCPayServer.Client/BTCPayServerClient.Invoices.cs
@@ -128,5 +128,19 @@ namespace BTCPayServer.Client
                     method: HttpMethod.Post), token);
             await HandleResponse(response);
         }
+
+        public virtual async Task<PullPaymentData> RefundInvoice(
+            string storeId,
+            string invoiceId,
+            string paymentMethod,
+            RefundInvoiceRequest request,
+            CancellationToken token = default
+        )
+        {
+            var response = await _httpClient.SendAsync(
+                CreateHttpRequest($"api/v1/stores/{storeId}/invoices/{invoiceId}/payment-methods/{paymentMethod}/refund", bodyPayload: request,
+                    method: HttpMethod.Post), token);
+            return await HandleResponse<PullPaymentData>(response);
+        }
     }
 }

--- a/BTCPayServer.Client/Models/RefundInvoiceRequest.cs
+++ b/BTCPayServer.Client/Models/RefundInvoiceRequest.cs
@@ -1,0 +1,25 @@
+#nullable enable
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
+namespace BTCPayServer.Client.Models
+{
+    public enum RefundVariant
+    {
+        RateThen,
+        CurrentRate,
+        Fiat,
+        Custom,
+        NotSet
+    }
+
+    public class RefundInvoiceRequest
+    {
+        public string? Name { get; set; } = null;
+        public string? Description { get; set; } = null;
+        [JsonConverter(typeof(StringEnumConverter))]
+        public RefundVariant RefundVariant { get; set; } = RefundVariant.NotSet;
+        public decimal CustomAmount { get; set; } = 0;
+        public string? CustomCurrency { get; set; } = null;
+    }
+}

--- a/BTCPayServer/Controllers/UIInvoiceController.UI.cs
+++ b/BTCPayServer/Controllers/UIInvoiceController.UI.cs
@@ -134,7 +134,7 @@ namespace BTCPayServer.Controllers
                 Events = invoice.Events,
                 PosData = PosDataParser.ParsePosData(invoice.Metadata.PosData),
                 Archived = invoice.Archived,
-                CanRefund = CanRefund(invoiceState),
+                CanRefund = invoiceState.CanRefund(),
                 Refunds = invoice.Refunds,
                 ShowCheckout = invoice.Status == InvoiceStatusLegacy.New,
                 ShowReceipt = invoice.Status.ToModernStatus() == InvoiceStatus.Settled && (invoice.ReceiptOptions?.Enabled ?? receipt.Enabled is true),
@@ -240,16 +240,6 @@ namespace BTCPayServer.Controllers
             var network = _NetworkProvider.GetNetwork(paymentMethodId.CryptoCode);
             return network == null ? null : paymentMethodId.PaymentType.GetTransactionLink(network, txId);
         }
-        bool CanRefund(InvoiceState invoiceState)
-        {
-            return invoiceState.Status == InvoiceStatusLegacy.Confirmed ||
-                invoiceState.Status == InvoiceStatusLegacy.Complete ||
-                (invoiceState.Status == InvoiceStatusLegacy.Expired &&
-                (invoiceState.ExceptionStatus == InvoiceExceptionStatus.PaidLate ||
-                invoiceState.ExceptionStatus == InvoiceExceptionStatus.PaidOver ||
-                invoiceState.ExceptionStatus == InvoiceExceptionStatus.PaidPartial)) ||
-                invoiceState.Status == InvoiceStatusLegacy.Invalid;
-        }
 
         [HttpGet("invoices/{invoiceId}/refund")]
         [Authorize(Policy = Policies.CanModifyStoreSettings, AuthenticationSchemes = AuthenticationSchemes.Cookie)]
@@ -268,7 +258,7 @@ namespace BTCPayServer.Controllers
                 return NotFound();
             if (invoice.CurrentRefund?.PullPaymentDataId is null && GetUserId() is null)
                 return NotFound();
-            if (!CanRefund(invoice.GetInvoiceState()))
+            if (!invoice.GetInvoiceState().CanRefund())
                 return NotFound();
             if (invoice.CurrentRefund?.PullPaymentDataId is string ppId && !invoice.CurrentRefund.PullPaymentData.Archived)
             {
@@ -324,7 +314,7 @@ namespace BTCPayServer.Controllers
             if (invoice == null)
                 return NotFound();
 
-            if (!CanRefund(invoice.GetInvoiceState()))
+            if (!invoice.GetInvoiceState().CanRefund())
                 return NotFound();
 
             var store = GetCurrentStore();

--- a/BTCPayServer/Services/Invoices/InvoiceEntity.cs
+++ b/BTCPayServer/Services/Invoices/InvoiceEntity.cs
@@ -835,6 +835,17 @@ namespace BTCPayServer.Services.Invoices
                    (Status != InvoiceStatusLegacy.Invalid && ExceptionStatus == InvoiceExceptionStatus.Marked);
         }
 
+        public bool CanRefund()
+        {
+            return Status == InvoiceStatusLegacy.Confirmed ||
+                Status == InvoiceStatusLegacy.Complete ||
+                (Status == InvoiceStatusLegacy.Expired &&
+                (ExceptionStatus == InvoiceExceptionStatus.PaidLate ||
+                ExceptionStatus == InvoiceExceptionStatus.PaidOver ||
+                ExceptionStatus == InvoiceExceptionStatus.PaidPartial)) ||
+                Status == InvoiceStatusLegacy.Invalid;
+        }
+
         public override int GetHashCode()
         {
             return HashCode.Combine(Status, ExceptionStatus);

--- a/BTCPayServer/wwwroot/swagger/v1/swagger.template.invoices.json
+++ b/BTCPayServer/wwwroot/swagger/v1/swagger.template.invoices.json
@@ -649,6 +649,79 @@
                     }
                 ]
             }
+        },
+        "/api/v1/stores/{storeId}/invoices/{invoiceId}/payment-methods/{paymentMethod}/refund": {
+            "post": {
+                "tags": [
+                    "Invoices",
+                    "Refund"
+                ],
+                "summary": "Refund invoice",
+                "parameters": [
+                    {
+                        "name": "storeId",
+                        "in": "path",
+                        "required": true,
+                        "description": "The store to query",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "invoiceId",
+                        "in": "path",
+                        "required": true,
+                        "description": "The invoice to refund",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "paymentMethod",
+                        "in": "path",
+                        "required": true,
+                        "description": "The payment method to refund with",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "description": "Refund invoice",
+                "operationId": "Invoices_Refund",
+                "responses": {
+                    "200": {
+                        "description": "Pull payment for refunding the invoice",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/PullPaymentData"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "A list of errors that occurred when refunding the invoice",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ValidationProblemDetails"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "If you are authenticated but forbidden to refund the invoice"
+                    }
+                },
+                "security": [
+                    {
+                        "API_Key": [
+                            "btcpay.store.canmodifystoresettings"
+                        ],
+                        "Basic": []
+                    }
+                ]
+            }
         }
     },
     "components": {


### PR DESCRIPTION
This PR adds an ability to refund an invoice through Greenfield API by POSTing to `/api/v1/stores/{storeId}/invoices/{invoiceId}/payment-methods/{paymentMethod}/refund`.

See discussion here: https://github.com/btcpayserver/btcpayserver/discussions/4181