### PR TITLE
Greenfield: Allow marking payout status and payment proofs

### DIFF
--- a/BTCPayServer.Client/BTCPayServerClient.PullPayments.cs
+++ b/BTCPayServer.Client/BTCPayServerClient.PullPayments.cs
@@ -53,6 +53,16 @@ namespace BTCPayServer.Client
             var response = await _httpClient.SendAsync(CreateHttpRequest($"api/v1/pull-payments/{HttpUtility.UrlEncode(pullPaymentId)}/payouts", bodyPayload: payoutRequest, method: HttpMethod.Post), cancellationToken);
             return await HandleResponse<PayoutData>(response);
         } 
+        public virtual async Task<PayoutData> GetPullPaymentPayout(string pullPaymentId, string payoutId, CancellationToken cancellationToken = default)
+        {
+            var response = await _httpClient.SendAsync(CreateHttpRequest($"api/v1/pull-payments/{HttpUtility.UrlEncode(pullPaymentId)}/payouts/{payoutId}", method: HttpMethod.Get), cancellationToken);
+            return await HandleResponse<PayoutData>(response);
+        } 
+        public virtual async Task<PayoutData> GetStorePayout(string storeId, string payoutId, CancellationToken cancellationToken = default)
+        {
+            var response = await _httpClient.SendAsync(CreateHttpRequest($"api/v1/stores/{storeId}/payouts/{payoutId}", method: HttpMethod.Get), cancellationToken);
+            return await HandleResponse<PayoutData>(response);
+        } 
         public virtual async Task<PayoutData> CreatePayout(string storeId, CreatePayoutThroughStoreRequest payoutRequest, CancellationToken cancellationToken = default)
         {
             var response = await _httpClient.SendAsync(CreateHttpRequest($"api/v1/stores/{storeId}/payouts", bodyPayload: payoutRequest, method: HttpMethod.Post), cancellationToken);
@@ -69,13 +79,22 @@ namespace BTCPayServer.Client
             return await HandleResponse<PayoutData>(response);
         }
 
-        public async Task MarkPayoutPaid(string storeId, string payoutId,
+        public virtual async Task MarkPayoutPaid(string storeId, string payoutId,
             CancellationToken cancellationToken = default)
         {
             var response = await _httpClient.SendAsync(
                 CreateHttpRequest(
                     $"api/v1/stores/{HttpUtility.UrlEncode(storeId)}/payouts/{HttpUtility.UrlEncode(payoutId)}/mark-paid",
                     method: HttpMethod.Post), cancellationToken);
+            await HandleResponse(response);
+        }
+        public virtual async Task MarkPayout(string storeId, string payoutId, MarkPayoutRequest request,
+            CancellationToken cancellationToken = default)
+        {
+            var response = await _httpClient.SendAsync(
+                CreateHttpRequest(
+                    $"api/v1/stores/{HttpUtility.UrlEncode(storeId)}/payouts/{HttpUtility.UrlEncode(payoutId)}/mark",
+                    method: HttpMethod.Post, bodyPayload: request), cancellationToken);
             await HandleResponse(response);
         }
     }

--- a/BTCPayServer.Client/Models/MarkPayoutRequest.cs
+++ b/BTCPayServer.Client/Models/MarkPayoutRequest.cs
@@ -1,0 +1,13 @@
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+using Newtonsoft.Json.Linq;
+
+namespace BTCPayServer.Client.Models;
+
+public class MarkPayoutRequest
+{
+    [JsonConverter(typeof(StringEnumConverter))]
+    public PayoutState State { get; set; } = PayoutState.Completed;
+
+    public JObject? PaymentProof { get; set; }
+}

--- a/BTCPayServer.Client/Models/PayoutData.cs
+++ b/BTCPayServer.Client/Models/PayoutData.cs
@@ -2,6 +2,7 @@ using System;
 using BTCPayServer.JsonConverters;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
+using Newtonsoft.Json.Linq;
 
 namespace BTCPayServer.Client.Models
 {
@@ -29,5 +30,6 @@ namespace BTCPayServer.Client.Models
         [JsonConverter(typeof(StringEnumConverter))]
         public PayoutState State { get; set; }
         public int Revision { get; set; }
+        public JObject PaymentProof { get; set; }
     }
 }

--- a/BTCPayServer.Tests/GreenfieldAPITests.cs
+++ b/BTCPayServer.Tests/GreenfieldAPITests.cs
@@ -796,6 +796,100 @@ namespace BTCPayServer.Tests
             await AssertAPIError("invalid-state", async () => await client.MarkPayoutPaid(storeId, payout.Id));
         }
 
+        [Fact]
+        [Trait("Integration", "Integration")]
+        public async Task CanProcessPayoutsExternally()
+        {
+            using var tester = CreateServerTester();
+            await tester.StartAsync();
+            var acc = tester.NewAccount();
+            acc.Register();
+            await acc.CreateStoreAsync();
+            var storeId = (await acc.RegisterDerivationSchemeAsync("BTC", importKeysToNBX: true)).StoreId;
+            var client = await acc.CreateClient();
+            var address = await tester.ExplorerNode.GetNewAddressAsync();
+            var payout = await client.CreatePayout(storeId, new CreatePayoutThroughStoreRequest()
+            {
+                 Approved = false,
+                 PaymentMethod = "BTC",
+                 Amount = 0.0001m,
+                 Destination = address.ToString()
+            });
+            await AssertAPIError("invalid-state", async () =>
+            {
+                await client.MarkPayout(storeId, payout.Id, new MarkPayoutRequest() {State = PayoutState.Completed});
+
+            });
+
+            await client.ApprovePayout(storeId, payout.Id, new ApprovePayoutRequest());
+            
+            await client.MarkPayout(storeId, payout.Id, new MarkPayoutRequest() {State = PayoutState.Completed});
+            Assert.Equal(PayoutState.Completed,(await client.GetStorePayouts(storeId,false)).Single(data => data.Id == payout.Id ).State );
+            Assert.Null((await client.GetStorePayouts(storeId,false)).Single(data => data.Id == payout.Id ).PaymentProof );
+
+            foreach (var state in new []{ PayoutState.AwaitingApproval, PayoutState.Cancelled, PayoutState.Completed, PayoutState.AwaitingApproval, PayoutState.InProgress})
+            {
+                await AssertAPIError("invalid-state", async () =>
+                {
+                    await client.MarkPayout(storeId, payout.Id, new MarkPayoutRequest() {State = state});
+                });
+            }
+            payout = await client.CreatePayout(storeId, new CreatePayoutThroughStoreRequest()
+            {
+                Approved = true,
+                PaymentMethod = "BTC",
+                Amount = 0.0001m,
+                Destination = address.ToString()
+            });
+
+            payout = await client.GetStorePayout(storeId, payout.Id);
+            Assert.NotNull(payout);
+            Assert.Equal(PayoutState.AwaitingPayment, payout.State);
+            await AssertValidationError(new []{"PaymentProof"}, async () =>
+            {
+                await client.MarkPayout(storeId, payout.Id, new MarkPayoutRequest() {State = PayoutState.Completed, PaymentProof = JObject.FromObject(new
+                {
+                    test = "zyx"
+                })});
+            });
+            await client.MarkPayout(storeId, payout.Id, new MarkPayoutRequest() {State = PayoutState.InProgress, PaymentProof = JObject.FromObject(new
+            {
+                proofType = "external-proof"
+            })});
+            payout = await client.GetStorePayout(storeId, payout.Id);
+            Assert.NotNull(payout);
+            Assert.Equal(PayoutState.InProgress, payout.State);
+            Assert.True(payout.PaymentProof.TryGetValue("proofType", out var savedType));
+            Assert.Equal("external-proof",savedType);
+            
+            await client.MarkPayout(storeId, payout.Id, new MarkPayoutRequest() {State = PayoutState.AwaitingPayment, PaymentProof = JObject.FromObject(new
+            {
+                proofType = "external-proof",
+                id="finality proof",
+                link="proof.com"
+            })});
+            payout = await client.GetStorePayout(storeId, payout.Id);
+            Assert.NotNull(payout);
+            Assert.Null(payout.PaymentProof);
+            Assert.Equal(PayoutState.AwaitingPayment, payout.State);
+            
+            await client.MarkPayout(storeId, payout.Id, new MarkPayoutRequest() {State = PayoutState.Completed, PaymentProof = JObject.FromObject(new
+            {
+                proofType = "external-proof",
+                id="finality proof",
+                link="proof.com"
+            })});
+            payout = await client.GetStorePayout(storeId, payout.Id);
+            Assert.NotNull(payout);
+            Assert.Equal(PayoutState.Completed, payout.State);
+            Assert.True(payout.PaymentProof.TryGetValue("proofType", out savedType));
+            Assert.True(payout.PaymentProof.TryGetValue("link", out var savedLink));
+            Assert.True(payout.PaymentProof.TryGetValue("id", out var savedId));
+            Assert.Equal("external-proof",savedType);
+            Assert.Equal("finality proof",savedId);
+            Assert.Equal("proof.com",savedLink);
+        }
+
         private DateTimeOffset RoundSeconds(DateTimeOffset dateTimeOffset)
         {
             return new DateTimeOffset(dateTimeOffset.Year, dateTimeOffset.Month, dateTimeOffset.Day, dateTimeOffset.Hour, dateTimeOffset.Minute, dateTimeOffset.Second, dateTimeOffset.Offset);

--- a/BTCPayServer/Controllers/GreenField/LocalBTCPayServerClient.cs
+++ b/BTCPayServer/Controllers/GreenField/LocalBTCPayServerClient.cs
@@ -1162,5 +1162,26 @@ namespace BTCPayServer.Controllers.Greenfield
             return GetFromActionResult<StoreRateConfiguration>(await GetController<GreenfieldStoreRateConfigurationController>().UpdateStoreRateConfiguration(request));
         }
         
+        public override async Task MarkPayoutPaid(string storeId, string payoutId, CancellationToken cancellationToken = default)
+        {
+            HandleActionResult(await GetController<GreenfieldPullPaymentController>().MarkPayoutPaid(storeId, payoutId, cancellationToken));
+        }
+
+        public override async Task MarkPayout(string storeId, string payoutId, MarkPayoutRequest request,
+            CancellationToken cancellationToken = default)
+        {
+            HandleActionResult(await GetController<GreenfieldPullPaymentController>().MarkPayout(storeId, payoutId, request));
+        }
+
+        public override async Task<PayoutData> GetPullPaymentPayout(string pullPaymentId, string payoutId, CancellationToken cancellationToken = default)
+        {
+            return GetFromActionResult<PayoutData>(await GetController<GreenfieldPullPaymentController>().GetPayout(pullPaymentId, payoutId));
+        }
+
+        public override async Task<PayoutData> GetStorePayout(string storeId, string payoutId,
+            CancellationToken cancellationToken = default)
+        {
+            return GetFromActionResult<PayoutData>(await GetController<GreenfieldPullPaymentController>().GetStorePayout(storeId, payoutId));
+        }
     }
 }

--- a/BTCPayServer/Controllers/UILNURLController.cs
+++ b/BTCPayServer/Controllers/UILNURLController.cs
@@ -31,6 +31,7 @@ using Microsoft.AspNetCore.Routing;
 using NBitcoin;
 using NBitcoin.Crypto;
 using Newtonsoft.Json;
+using MarkPayoutRequest = BTCPayServer.HostedServices.MarkPayoutRequest;
 
 namespace BTCPayServer
 {
@@ -167,9 +168,9 @@ namespace BTCPayServer
                     switch (payResult.Result)
                     {
                         case PayResult.Ok:
-                            await _pullPaymentHostedService.MarkPaid(new PayoutPaidRequest()
+                            await _pullPaymentHostedService.MarkPaid(new MarkPayoutRequest()
                             {
-                                PayoutId = claimResponse.PayoutData.Id, Proof = new ManualPayoutProof { }
+                                PayoutId = claimResponse.PayoutData.Id, State = PayoutState.Completed
                             });
 
                             return Ok(new LNUrlStatusResponse {Status = "OK"});
@@ -178,7 +179,7 @@ namespace BTCPayServer
                                 new PullPaymentHostedService.CancelRequest(new string[]
                                 {
                                     claimResponse.PayoutData.Id
-                                }));
+                                }, null));
 
                             return Ok(new LNUrlStatusResponse
                             {

--- a/BTCPayServer/Controllers/UIStorePullPaymentsController.PullPayments.cs
+++ b/BTCPayServer/Controllers/UIStorePullPaymentsController.PullPayments.cs
@@ -20,6 +20,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Rendering;
 using Microsoft.EntityFrameworkCore;
+using MarkPayoutRequest = BTCPayServer.HostedServices.MarkPayoutRequest;
 using PayoutData = BTCPayServer.Data.PayoutData;
 using PullPaymentData = BTCPayServer.Data.PullPaymentData;
 using StoreData = BTCPayServer.Data.StoreData;
@@ -391,12 +392,12 @@ namespace BTCPayServer.Controllers
                             continue;
 
                         var result =
-                            await _pullPaymentService.MarkPaid(new PayoutPaidRequest() { PayoutId = payout.Id });
-                        if (result != PayoutPaidRequest.PayoutPaidResult.Ok)
+                            await _pullPaymentService.MarkPaid(new MarkPayoutRequest() { PayoutId = payout.Id });
+                        if (result != MarkPayoutRequest.PayoutPaidResult.Ok)
                         {
                             TempData.SetStatusMessageModel(new StatusMessageModel()
                             {
-                                Message = PayoutPaidRequest.GetErrorMessage(result),
+                                Message = MarkPayoutRequest.GetErrorMessage(result),
                                 Severity = StatusMessageModel.StatusSeverity.Error
                             });
                             return RedirectToAction(nameof(Payouts),
@@ -418,7 +419,7 @@ namespace BTCPayServer.Controllers
 
                 case "cancel":
                     await _pullPaymentService.Cancel(
-                        new PullPaymentHostedService.CancelRequest(payoutIds));
+                        new PullPaymentHostedService.CancelRequest(payoutIds, new[] {storeId}));
                     TempData.SetStatusMessageModel(new StatusMessageModel()
                     {
                         Message = "Payouts archived", Severity = StatusMessageModel.StatusSeverity.Success

--- a/BTCPayServer/Data/Payouts/BitcoinLike/PayoutTransactionOnChainBlob.cs
+++ b/BTCPayServer/Data/Payouts/BitcoinLike/PayoutTransactionOnChainBlob.cs
@@ -13,7 +13,8 @@ namespace BTCPayServer.Data
         public HashSet<uint256> Candidates { get; set; } = new HashSet<uint256>();
 
         [JsonIgnore] public string LinkTemplate { get; set; }
-        public string ProofType { get; } = "PayoutTransactionOnChainBlob";
+        public string ProofType { get; } = Type;
+        public const string Type  = "PayoutTransactionOnChainBlob";
 
         [JsonIgnore]
         public string Link

--- a/BTCPayServer/Data/Payouts/LightningLike/LightningLikePayoutHandler.cs
+++ b/BTCPayServer/Data/Payouts/LightningLike/LightningLikePayoutHandler.cs
@@ -125,12 +125,12 @@ namespace BTCPayServer.Data.Payouts.LightningLike
             {
                 return null;
             }
-            if (proofType == ManualPayoutProof.Type)
+            if (proofType == PayoutLightningBlob.PayoutLightningBlobProofType)
             {
-                return raw.ToObject<ManualPayoutProof>();
+                return raw.ToObject<PayoutLightningBlob>();
             }
 
-            return raw.ToObject<PayoutLightningBlob>();
+            return raw.ToObject<ManualPayoutProof>();
         }
 
         public void StartBackgroundCheck(Action<Type[]> subscribe)

--- a/BTCPayServer/Data/Payouts/LightningLike/PayoutLightningBlob.cs
+++ b/BTCPayServer/Data/Payouts/LightningLike/PayoutLightningBlob.cs
@@ -4,7 +4,8 @@ namespace BTCPayServer.Data.Payouts.LightningLike
     {
         public string PaymentHash { get; set; }
 
-        public string ProofType { get; } = "PayoutLightningBlob";
+        public static string PayoutLightningBlobProofType  = "PayoutLightningBlob";
+        public string ProofType { get; } = PayoutLightningBlobProofType;
         public string Link { get; } = null;
         public string Id => PaymentHash;
         public string Preimage { get; set; }

--- a/BTCPayServer/Data/Payouts/ManualPayoutProof.cs
+++ b/BTCPayServer/Data/Payouts/ManualPayoutProof.cs
@@ -1,3 +1,7 @@
+using System.Collections.Generic;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
 namespace BTCPayServer.Data
 {
     public class ManualPayoutProof : IPayoutProof
@@ -6,5 +10,7 @@ namespace BTCPayServer.Data
         public string ProofType { get; } = Type;
         public string Link { get; set; }
         public string Id { get; set; }
+        
+        [JsonExtensionData] public Dictionary<string, JToken> AdditionalData { get; set; }
     }
 }

--- a/BTCPayServer/wwwroot/swagger/v1/swagger.template.pull-payments.json
+++ b/BTCPayServer/wwwroot/swagger/v1/swagger.template.pull-payments.json
@@ -534,6 +534,37 @@
                     }
                 }
             ],
+            "get": {
+                "summary": "Get Payout",
+                "operationId": "GetStorePayout",
+                "description": "Get payout",
+                "responses": {
+                    "200": {
+                        "description": "A specific payout of a store",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/PayoutData"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Payout not found"
+                    }
+                },
+                "tags": [
+                    "Stores (Payouts)"
+                ],
+                "security": [
+                    {
+                        "API_Key": [
+                            "btcpay.store.canmanagepullpayments"
+                        ],
+                        "Basic": []
+                    }
+                ]
+            },
             "post": {
                 "summary": "Approve Payout",
                 "operationId": "PullPayments_ApprovePayout",
@@ -696,6 +727,89 @@
                     }
                 ]
             }
+        },
+        "/api/v1/stores/{storeId}/payouts/{payoutId}/mark": {
+            "parameters": [
+                {
+                    "name": "storeId",
+                    "in": "path",
+                    "required": true,
+                    "description": "The ID of the store",
+                    "schema": {
+                        "type": "string"
+                    }
+                },
+                {
+                    "name": "payoutId",
+                    "in": "path",
+                    "required": true,
+                    "description": "The ID of the payout",
+                    "schema": {
+                        "type": "string"
+                    }
+                }
+            ],
+            "post": {
+                "summary": "Mark Payout",
+                "operationId": "PullPayments_MarkPayout",
+                "description": "Mark a payout with a state",
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "state": {
+                                        "$ref": "#/components/schemas/PayoutState"
+                                    },
+                                    "paymentProof": {
+                                        "$ref": "#/components/schemas/PayoutPaymentProof"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "The payout has been set to the specified state"
+                    },
+                    "422": {
+                        "description": "Unable to validate the request",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ValidationProblemDetails"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Wellknown error codes are: `invalid-state`",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProblemDetails"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "The payout is not found"
+                    }
+                },
+                "tags": [
+                    "Stores (Payouts)"
+                ],
+                "security": [
+                    {
+                        "API_Key": [
+                            "btcpay.store.canmanagepullpayments"
+                        ],
+                        "Basic": []
+                    }
+                ]
+            }
         }
     },
     "components": {
@@ -753,6 +867,57 @@
                     }
                 ]
             },
+            "PayoutPaymentProof": {
+                "type": "object",
+                "additionalProperties": true,
+                "description": "Additional information around how the payout is being or has been paid out. The mentioned properties are all optional (except `proofType`) and you can introduce any json format you wish.",
+                "properties": {
+                    "proofType": {
+                        "type": "string",
+                        "description": "The type of payment proof it is."
+                    }
+                },
+                "anyOf": [
+                    {
+                        "properties": {
+                            "link": {
+                                "type": "string",
+                                "format": "url",
+                                "nullable": true,
+                                "description": "A link to the proof of payout payment."
+                            }
+                        }
+                    },
+                    {
+                        "properties": {
+                            "id": {
+                                "type": "string",
+                                "nullable": true,
+                                "description": "A unique identifier to the proof of payout payment."
+                            }
+                        }
+                    }
+                ]
+            },
+            "PayoutState": {
+                "type": "string",
+                "example": "AwaitingPayment",
+                "description": "The state of the payout (`AwaitingApproval`, `AwaitingPayment`, `InProgress`, `Completed`, `Cancelled`)",
+                "x-enumNames": [
+                    "AwaitingApproval",
+                    "AwaitingPayment",
+                    "InProgress",
+                    "Completed",
+                    "Cancelled"
+                ],
+                "enum": [
+                    "AwaitingApproval",
+                    "AwaitingPayment",
+                    "InProgress",
+                    "Completed",
+                    "Cancelled"
+                ]
+            },
             "PayoutData": {
                 "type": "object",
                 "properties": {
@@ -801,23 +966,10 @@
                         "description": "The amount of the payout in the currency of the payment method (eg. BTC). This is only available from the `AwaitingPayment` state."
                     },
                     "state": {
-                        "type": "string",
-                        "example": "AwaitingPayment",
-                        "description": "The state of the payout (`AwaitingApproval`, `AwaitingPayment`, `InProgress`, `Completed`, `Cancelled`)",
-                        "x-enumNames": [
-                            "AwaitingApproval",
-                            "AwaitingPayment",
-                            "InProgress",
-                            "Completed",
-                            "Cancelled"
-                        ],
-                        "enum": [
-                            "AwaitingApproval",
-                            "AwaitingPayment",
-                            "InProgress",
-                            "Completed",
-                            "Cancelled"
-                        ]
+                        "$ref": "#/components/schemas/PayoutState"
+                    },
+                    "paymentProof": {
+                        "$ref": "#/components/schemas/PayoutPaymentProof"
                     }
                 }
             },


### PR DESCRIPTION
This allows external services to integrate with the payouts system to process payouts. This is also  a step to allow plugins to provide payout processors.

* It provides the payment proof through the greenfield payouts api.
* It allows you to set the state of a payout outside of the usual flow:
  * When state is awaiting payment, allow setting to In progess or completed
  * When state is in progress, allow setting back to awaiting payment
* Adds a get payout endpoint based on stored instead of pull payment

![GuessWho'SBackAgain-AgainGIF](https://user-images.githubusercontent.com/1818366/198559787-02374b35-7167-497b-b0ed-e26abd984888.gif)
