### PR TITLE
Allow config to set default block explorer link

### DIFF
--- a/BTCPayServer/Configuration/DefaultConfiguration.cs
+++ b/BTCPayServer/Configuration/DefaultConfiguration.cs
@@ -138,6 +138,7 @@ namespace BTCPayServer.Configuration
             {
                 builder.AppendLine(CultureInfo.InvariantCulture, $"#{n.CryptoCode}.explorer.url={n.NBXplorerNetwork.DefaultSettings.DefaultUrl}");
                 builder.AppendLine(CultureInfo.InvariantCulture, $"#{n.CryptoCode}.explorer.cookiefile={ n.NBXplorerNetwork.DefaultSettings.DefaultCookieFile}");
+                builder.AppendLine(CultureInfo.InvariantCulture, $"#{n.CryptoCode}.blockexplorerlink=https://mempool.space/tx/{{0}}");
                 if (n.SupportLightning)
                 {
                     builder.AppendLine(CultureInfo.InvariantCulture, $"#{n.CryptoCode}.lightning=/root/.lightning/lightning-rpc");

--- a/BTCPayServer/Hosting/BTCPayServerServices.cs
+++ b/BTCPayServer/Hosting/BTCPayServerServices.cs
@@ -189,6 +189,11 @@ namespace BTCPayServer.Hosting
                             };
                         options.NBXplorerConnectionSettings.Add(setting);
                         options.ConnectionString = configuration.GetOrDefault<string>("explorer.postgres", null);
+                        var blockExplorerLink = configuration.GetOrDefault<string>("blockexplorerlink", null);
+                        if (!string.IsNullOrEmpty(blockExplorerLink))
+                        {
+                            btcPayNetwork.BlockExplorerLink = blockExplorerLink;
+                        }
                     }
                 });
             services.AddOptions<LightningNetworkOptions>().Configure<BTCPayNetworkProvider>(


### PR DESCRIPTION
This logic can potentially be inside BlockExplorerLinkStartupTask instead but it's not a big deal imo