### PR TITLE
Lightning: Better handling for non-public nodes

### DIFF
--- a/BTCPayServer/Controllers/UIPublicLightningNodeInfoController.cs
+++ b/BTCPayServer/Controllers/UIPublicLightningNodeInfoController.cs
@@ -13,7 +13,6 @@ using Microsoft.AspNetCore.Mvc;
 
 namespace BTCPayServer.Controllers
 {
-
     [Route("embed/{storeId}/{cryptoCode}/ln")]
     [AllowAnonymous]
     public class UIPublicLightningNodeInfoController : Controller
@@ -43,11 +42,11 @@ namespace BTCPayServer.Controllers
                 var paymentMethodDetails = GetExistingLightningSupportedPaymentMethod(cryptoCode, store);
                 var network = _BtcPayNetworkProvider.GetNetwork<BTCPayNetwork>(cryptoCode);
                 var nodeInfo =
-                    await _LightningLikePaymentHandler.GetNodeInfo(paymentMethodDetails, network, new InvoiceLogs());
+                    await _LightningLikePaymentHandler.GetNodeInfo(paymentMethodDetails, network, new InvoiceLogs(), throws: true);
 
                 return View(new ShowLightningNodeInfoViewModel
                 {
-                    Available = nodeInfo.Any(),
+                    Available = true,
                     NodeInfo = nodeInfo.Select(n => new ShowLightningNodeInfoViewModel.NodeData(n)).ToArray(),
                     CryptoCode = cryptoCode,
                     CryptoImage = GetImage(paymentMethodDetails.PaymentId, network),

--- a/BTCPayServer/Payments/Lightning/LightningLikePaymentHandler.cs
+++ b/BTCPayServer/Payments/Lightning/LightningLikePaymentHandler.cs
@@ -147,15 +147,10 @@ namespace BTCPayServer.Payments.Lightning
                                                                 (!string.IsNullOrEmpty(ex.InnerException?.Message) ? $" ({ex.InnerException.Message})" : ""));
                 }
 
+                // Node info might be empty if there are no public URIs to announce. The UI also supports this.
                 var nodeInfo = preferOnion != null && info.NodeInfoList.Any(i => i.IsTor == preferOnion)
                     ? info.NodeInfoList.Where(i => i.IsTor == preferOnion.Value).ToArray()
                     : info.NodeInfoList.Select(i => i).ToArray();
-
-                // Maybe the user does not have an  easily accessible ln node. Node info should be optional. The UI also supports this.
-                // if (!nodeInfo.Any())
-                // {
-                //     throw new PaymentMethodUnavailableException("No lightning node public address has been configured");
-                // }
 
                 var blocksGap = summary.Status.ChainHeight - info.BlockHeight;
                 if (blocksGap > 10)

--- a/BTCPayServer/Views/UIPublicLightningNodeInfo/ShowLightningNodeInfo.cshtml
+++ b/BTCPayServer/Views/UIPublicLightningNodeInfo/ShowLightningNodeInfo.cshtml
@@ -28,34 +28,41 @@
                         </h4>
                         @if (Model.Available)
                         {
-                            @if (Model.NodeInfo.Length > 1)
+                            @if (Model.NodeInfo.Any())
                             {
-                                <ul class="nav nav-pills justify-content-center mt-4" id="nodeInfo-tab" role="tablist">
+                                @if (Model.NodeInfo.Length > 1)
+                                {
+                                    <ul class="nav nav-pills justify-content-center mt-4" id="nodeInfo-tab" role="tablist">
+                                        @for (var i = 0; i < Model.NodeInfo.Length; i++)
+                                        {
+                                            var nodeInfo = Model.NodeInfo[i];
+                                            <li class="nav-item" role="presentation">
+                                                <button class="nav-link w-100px @(i == 0 ? "active" : "")" id="nodeInfo-tab-@i" data-bs-toggle="pill" data-bs-target="#nodeInfo-@i" type="button" role="tab" aria-controls="nodeInfo-@i" aria-selected="true">@(nodeInfo.IsTor ? "Tor" : "Clearnet")</button>
+                                            </li>
+                                        }
+                                    </ul>
+                                }
+                                <div class="tab-content" id="nodeInfo-tabContent">
                                     @for (var i = 0; i < Model.NodeInfo.Length; i++)
                                     {
-                                        var nodeInfo = Model.NodeInfo[i];
-                                        <li class="nav-item" role="presentation">
-                                            <button class="nav-link w-100px @(i == 0 ? "active" : "")" id="nodeInfo-tab-@i" data-bs-toggle="pill" data-bs-target="#nodeInfo-@i" type="button" role="tab" aria-controls="nodeInfo-@i" aria-selected="true">@(nodeInfo.IsTor ? "Tor" : "Clearnet")</button>
-                                        </li>
+                                        var nodeInfo = Model.NodeInfo[i].ToString();
+                                        <div class="tab-pane fade @(i == 0 ? "show active" : "")" id="nodeInfo-@i" role="tabpanel" aria-labelledby="nodeInfo-tab-@i">
+                                            <div class="qr-container my-4 w-100">
+                                                <img alt="@Model.CryptoCode" class="qr-icon" src="@Model.CryptoImage"/>
+                                                <vc:qr-code data="@nodeInfo"/>
+                                            </div>
+                                            <div class="input-group" data-clipboard="@nodeInfo">
+                                                <input type="text" class="form-control" style="cursor:copy" readonly="readonly" value="@nodeInfo" id="nodeInfo-addr-@i"/>
+                                                <button type="button" class="btn btn-outline-secondary" data-clipboard-confirm>Copy</button>
+                                            </div>
+                                        </div>
                                     }
-                                </ul>
+                                </div>
                             }
-                            <div class="tab-content" id="nodeInfo-tabContent">
-                                @for (var i = 0; i < Model.NodeInfo.Length; i++)
-                                {
-                                    var nodeInfo = Model.NodeInfo[i].ToString();
-                                    <div class="tab-pane fade @(i == 0 ? "show active" : "")" id="nodeInfo-@i" role="tabpanel" aria-labelledby="nodeInfo-tab-@i">
-                                        <div class="qr-container my-4 w-100">
-                                            <img alt="@Model.CryptoCode" class="qr-icon" src="@Model.CryptoImage"/>
-                                            <vc:qr-code data="@nodeInfo"/>
-                                        </div>
-                                        <div class="input-group" data-clipboard="@nodeInfo">
-                                            <input type="text" class="form-control" style="cursor:copy" readonly="readonly" value="@nodeInfo" id="nodeInfo-addr-@i"/>
-                                            <button type="button" class="btn btn-outline-secondary" data-clipboard-confirm>Copy</button>
-                                        </div>
-                                    </div>
-                                }
-                            </div>
+                            else
+                            {
+                                <p class="text-center mt-4">No public address available.</p>
+                            }
                         }
                     </div>
                 </div>


### PR DESCRIPTION
`LightningLikePaymentHandler.GetNodeInfo` needed the `throws` argument to handle the cases as previously, otherwise the catch case in `ShowLightningNodeInfo` never occured.

State with this PR: A node can be available, but not have any public addresses. The latter will now be reported when testing the connection and on the public node info page.

Fixes #4246.