### PR TITLE
Bumping LND to 0.15.4-beta-1

### DIFF
--- a/BTCPayServer.Tests/docker-compose.altcoins.yml
+++ b/BTCPayServer.Tests/docker-compose.altcoins.yml
@@ -237,7 +237,7 @@ services:
       - "5432"
 
   merchant_lnd:
-    image: btcpayserver/lnd:v0.15.2-beta
+    image: btcpayserver/lnd:v0.15.4-beta-1
     restart: unless-stopped
     environment:
       LND_CHAIN: "btc"
@@ -272,7 +272,7 @@ services:
       - bitcoind
 
   customer_lnd:
-    image: btcpayserver/lnd:v0.15.2-beta
+    image: btcpayserver/lnd:v0.15.4-beta-1
     restart: unless-stopped
     environment:
       LND_CHAIN: "btc"

--- a/BTCPayServer.Tests/docker-compose.yml
+++ b/BTCPayServer.Tests/docker-compose.yml
@@ -225,7 +225,7 @@ services:
       - "5432"
 
   merchant_lnd:
-    image: btcpayserver/lnd:v0.15.2-beta
+    image: btcpayserver/lnd:v0.15.4-beta-1
     restart: unless-stopped
     environment:
       LND_CHAIN: "btc"
@@ -262,7 +262,7 @@ services:
       - bitcoind
 
   customer_lnd:
-    image: btcpayserver/lnd:v0.15.2-beta
+    image: btcpayserver/lnd:v0.15.4-beta-1
     restart: unless-stopped
     environment:
       LND_CHAIN: "btc"


### PR DESCRIPTION
Updating our devenv to use LND 0.15.4; Docker image available on https://hub.docker.com/layers/btcpayserver/lnd/v0.15.4-beta-1/images/sha256-cadbbff93cf36146e24fa4f32170b4b9d278a2e1acfdc50470790a94506ee9c3?context=explore

Used it in BTCPayServer.Lightning library and it's good to go:
https://github.com/btcpayserver/BTCPayServer.Lightning/pull/107