### PR TITLE
Use PluginLoader in the Plugin packer to prevent conflicts

### DIFF
--- a/BTCPayServer.PluginPacker/BTCPayServer.PluginPacker.csproj
+++ b/BTCPayServer.PluginPacker/BTCPayServer.PluginPacker.csproj
@@ -26,6 +26,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+      <PackageReference Include="McMaster.NETCore.Plugins.Mvc" Version="1.4.0" />
       <ProjectReference Include="..\BTCPayServer.Abstractions\BTCPayServer.Abstractions.csproj" />
       <None Include="icon.png" Pack="true" PackagePath="\" />
   </ItemGroup>

--- a/BTCPayServer.PluginPacker/Program.cs
+++ b/BTCPayServer.PluginPacker/Program.cs
@@ -8,6 +8,7 @@ using System.Text;
 using System.Text.Json;
 using System.Threading.Tasks;
 using BTCPayServer.Abstractions.Contracts;
+using McMaster.NETCore.Plugins;
 using NBitcoin.Crypto;
 using NBitcoin.DataEncoders;
 using NBitcoin.Secp256k1;
@@ -33,7 +34,8 @@ namespace BTCPayServer.PluginPacker
                 throw new Exception($"{rootDLLPath} could not be found");
             }
 
-            var assembly = Assembly.LoadFrom(rootDLLPath);
+            var plugin = PluginLoader.CreateFromAssemblyFile(rootDLLPath, false, new[] { typeof(IBTCPayServerPlugin) });
+            var assembly = plugin.LoadAssembly(name);
             var extension = GetAllExtensionTypesFromAssembly(assembly).FirstOrDefault();
             if (extension is null)
             {


### PR DESCRIPTION
I was having strange errors trying to pack @dennisreimann LNBank.

```
Could not load file or assembly 'BTCPayServer.Lightning.Common, Version=1.3.15.0, Culture=neutral, PublicKeyToken=null'. Could not find or load a specific file. (0x80131621)
Could not load file or assembly 'BTCPayServer.Lightning.Common, Version=1.3.15.0, Culture=neutral, PublicKeyToken=null'. Could not find or load a specific file. (0x80131621)
Could not load file or assembly 'BTCPayServer.Lightning.Common, Version=1.3.15.0, Culture=neutral, PublicKeyToken=null'. Could not find or load a specific file. (0x80131621)
Could not load file or assembly 'BTCPayServer.Lightning.Common, Version=1.3.15.0, Culture=neutral, PublicKeyToken=null'. Could not find or load a specific file. (0x80131621)
Could not load file or assembly 'BTCPayServer.Lightning.Common, Version=1.3.15.0, Culture=neutral, PublicKeyToken=null'. Could not find or load a specific file. (0x80131621)
Could not load file or assembly 'BTCPayServer.Lightning.Common, Version=1.3.15.0, Culture=neutral, PublicKeyToken=null'. Could not find or load a specific file. (0x80131621)
   at System.Reflection.RuntimeModule.GetTypes(RuntimeModule module)
   at System.Reflection.Assembly.GetTypes()
   at BTCPayServer.PluginPacker.Program.GetAllExtensionTypesFromAssembly(Assembly assembly) in /build-tools/btcpayserver/BTCPayServer.PluginPacker/Program.cs:line 110
   at BTCPayServer.PluginPacker.Program.Main(String[] args) in /build-tools/btcpayserver/BTCPayServer.PluginPacker/Program.cs:line 36
   at BTCPayServer.PluginPacker.Program.<Main>(String[] args)
```

The weirdest was that it was not happening locally on my windows, only inside a docker container.
The publish folder had the missing assemblies.

I decided to just use the `PluginLoader` we already use in BTCPayServer to load the assembly, as it takes care of fixing those kind of conflicts. And it indeed just worked.

Ping @Kukks 