### PR TITLE
Payment Request: Fix invoice creation

### DIFF
--- a/BTCPayServer.Tests/SeleniumTests.cs
+++ b/BTCPayServer.Tests/SeleniumTests.cs
@@ -871,9 +871,8 @@ namespace BTCPayServer.Tests
             var viewUrl = s.Driver.Url;
             
             Assert.Equal("Amount due", s.Driver.FindElement(By.CssSelector("[data-test='amount-due-title']")).Text);
-            Assert.Equal("Pay Invoice",
-                s.Driver.FindElement(By.CssSelector("[data-test='pay-button']")).Text.Trim());
-
+            Assert.Equal("Pay Invoice", s.Driver.FindElement(By.CssSelector("[data-test='pay-button']")).Text.Trim());
+            
             // expire
             s.GoToUrl(editUrl);
             s.Driver.ExecuteJavaScript("document.getElementById('ExpiryDate').value = '2021-01-21T21:00:00.000Z'");
@@ -891,8 +890,13 @@ namespace BTCPayServer.Tests
             
             s.GoToUrl(viewUrl);
             s.Driver.AssertElementNotFound(By.CssSelector("[data-test='status']"));
-            Assert.Equal("Pay Invoice",
-                s.Driver.FindElement(By.CssSelector("[data-test='pay-button']")).Text.Trim());
+            Assert.Equal("Pay Invoice", s.Driver.FindElement(By.CssSelector("[data-test='pay-button']")).Text.Trim());
+            
+            // test invoice creation, click with JS, because the button is inside a sticky header
+            s.Driver.ExecuteJavaScript("document.querySelector('[data-test=\"pay-button\"]').click()");
+            // checkout v1
+            s.Driver.WaitForElement(By.CssSelector("invoice"));
+            Assert.Contains("Awaiting Payment", s.Driver.PageSource);
             
             // archive (from details page)
             s.GoToUrl(editUrl);

--- a/BTCPayServer/Controllers/UIPaymentRequestController.cs
+++ b/BTCPayServer/Controllers/UIPaymentRequestController.cs
@@ -35,6 +35,7 @@ namespace BTCPayServer.Controllers
         private readonly EventAggregator _EventAggregator;
         private readonly CurrencyNameTable _Currencies;
         private readonly InvoiceRepository _InvoiceRepository;
+        private readonly StoreRepository _storeRepository;
 
         public UIPaymentRequestController(
             UIInvoiceController invoiceController,
@@ -43,6 +44,7 @@ namespace BTCPayServer.Controllers
             PaymentRequestService paymentRequestService,
             EventAggregator eventAggregator,
             CurrencyNameTable currencies,
+            StoreRepository storeRepository,
             InvoiceRepository invoiceRepository)
         {
             _InvoiceController = invoiceController;
@@ -51,6 +53,7 @@ namespace BTCPayServer.Controllers
             _PaymentRequestService = paymentRequestService;
             _EventAggregator = eventAggregator;
             _Currencies = currencies;
+            _storeRepository = storeRepository;
             _InvoiceRepository = invoiceRepository;
         }
 
@@ -223,7 +226,8 @@ namespace BTCPayServer.Controllers
 
             try
             {
-                var newInvoice = await _InvoiceController.CreatePaymentRequestInvoice(result, amount, this.GetCurrentStore(), Request, cancellationToken);
+                var store = await _storeRepository.FindStore(result.StoreId);
+                var newInvoice = await _InvoiceController.CreatePaymentRequestInvoice(result, amount, store, Request, cancellationToken);
                 if (redirectToInvoice)
                 {
                     return RedirectToAction("Checkout", "UIInvoice", new { invoiceId = newInvoice.Id });


### PR DESCRIPTION
Fix and test for a regression introduced with #4243: As the `PayPaymentRequest` action allows anonymous access, the `CookieAuthorizationHandler` isn't run and hence the `GetCurrentStore` returns `null`.

This leads to an exception when creating the invoice. Store needs to be fetched seperately - like [before](https://github.com/btcpayserver/btcpayserver/commit/4bbc7d966280b5affd51bfd2a8c58b318fd3a3a6#diff-bdc264670a171e862d09fdf1a1c9f3ca14b41982a3c4c8e66d4f780cdde9f21dL241).