### PR TITLE
Use the plugin builder website instead of docker to fetch plugins

### DIFF
--- a/BTCPayServer/Configuration/BTCPayServerOptions.cs
+++ b/BTCPayServer/Configuration/BTCPayServerOptions.cs
@@ -140,14 +140,15 @@ namespace BTCPayServer.Configuration
             }
 
             DisableRegistration = conf.GetOrDefault<bool>("disable-registration", true);
-            PluginRemote = conf.GetOrDefault("plugin-remote", "btcpayserver/btcpayserver-plugins");
+            var pluginRemote = conf.GetOrDefault<string>("plugin-remote", null);
+            if (pluginRemote != null)
+                Logs.Configuration.LogWarning("plugin-remote is an obsolete configuration setting, please remove it from configuration");
             RecommendedPlugins = conf.GetOrDefault("recommended-plugins", "").ToLowerInvariant().Split('\r', '\n', '\t', ' ').Where(s => !string.IsNullOrEmpty(s)).Distinct().ToArray();
             CheatMode = conf.GetOrDefault("cheatmode", false);
             if (CheatMode && this.NetworkType == ChainName.Mainnet)
                 throw new ConfigException($"cheatmode can't be used on mainnet");
         }
 
-        public string PluginRemote { get; set; }
         public string[] RecommendedPlugins { get; set; }
         public bool CheatMode { get; set; }
 

--- a/BTCPayServer/Configuration/DefaultConfiguration.cs
+++ b/BTCPayServer/Configuration/DefaultConfiguration.cs
@@ -45,7 +45,7 @@ namespace BTCPayServer.Configuration
             app.Option("--debuglog", "A rolling log file for debug messages.", CommandOptionType.SingleValue);
             app.Option("--debugloglevel", "The severity you log (default:information)", CommandOptionType.SingleValue);
             app.Option("--disable-registration", "Disables new user registrations (default:true)", CommandOptionType.SingleValue);
-            app.Option("--plugin-remote", "Which github repository to fetch the available plugins list (default:btcpayserver/btcpayserver-plugins)", CommandOptionType.SingleValue);
+            app.Option("--plugin-remote", "Obsolete, do not use", CommandOptionType.SingleValue);
             app.Option("--recommended-plugins", "Plugins which would be marked as recommended to be installed. Separated by newline or space", CommandOptionType.MultipleValue);
             app.Option("--xforwardedproto", "If specified, set X-Forwarded-Proto to the specified value, this may be useful if your reverse proxy handle https but is not configured to add X-Forwarded-Proto (example: --xforwardedproto https)", CommandOptionType.SingleValue);
             app.Option("--cheatmode", "Add some helper UI to facilitate dev-time testing (Default false)", CommandOptionType.BoolValue);

--- a/BTCPayServer/Controllers/GreenField/GreenfieldStoreLightningNetworkPaymentMethodsController.cs
+++ b/BTCPayServer/Controllers/GreenField/GreenfieldStoreLightningNetworkPaymentMethodsController.cs
@@ -35,7 +35,6 @@ namespace BTCPayServer.Controllers.Greenfield
         private readonly StoreRepository _storeRepository;
         private readonly BTCPayNetworkProvider _btcPayNetworkProvider;
         private readonly IAuthorizationService _authorizationService;
-        private readonly ISettingsRepository _settingsRepository;
 
         public GreenfieldStoreLightningNetworkPaymentMethodsController(
             StoreRepository storeRepository,
@@ -47,7 +46,6 @@ namespace BTCPayServer.Controllers.Greenfield
             _storeRepository = storeRepository;
             _btcPayNetworkProvider = btcPayNetworkProvider;
             _authorizationService = authorizationService;
-            _settingsRepository = settingsRepository;
             PoliciesSettings = policiesSettings;
         }
 

--- a/BTCPayServer/Controllers/UIServerController.Plugins.cs
+++ b/BTCPayServer/Controllers/UIServerController.Plugins.cs
@@ -83,11 +83,11 @@ namespace BTCPayServer.Controllers
 
         [HttpPost("server/plugins/install")]
         public async Task<IActionResult> InstallPlugin(
-            [FromServices] PluginService pluginService, string plugin, bool update = false, string path ="")
+            [FromServices] PluginService pluginService, string plugin, bool update = false, string version = null)
         {
             try
             {
-                await pluginService.DownloadRemotePlugin(plugin, path);
+                await pluginService.DownloadRemotePlugin(plugin, version);
                 if (update)
                 {
                     pluginService.UpdatePlugin(plugin);

--- a/BTCPayServer/Plugins/PluginBuilderClient.cs
+++ b/BTCPayServer/Plugins/PluginBuilderClient.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace BTCPayServer.Plugins
+{
+    public class PublishedVersion
+    {
+        public string ProjectSlug { get; set; }
+        public long BuildId { get; set; }
+        public JObject BuildInfo { get; set; }
+        public JObject ManifestInfo { get; set; }
+    }
+    public class PluginBuilderClient
+    {
+        HttpClient httpClient;
+        public HttpClient HttpClient => httpClient;
+        public PluginBuilderClient(HttpClient httpClient)
+        {
+            this.httpClient = httpClient;
+        }
+        static JsonSerializerSettings serializerSettings = new JsonSerializerSettings() { ContractResolver = new Newtonsoft.Json.Serialization.CamelCasePropertyNamesContractResolver() };
+        public async Task<PublishedVersion[]> GetPublishedVersions(string btcpayVersion, bool includePreRelease)
+        {
+            var result = await httpClient.GetStringAsync($"api/v1/plugins?btcpayVersion={btcpayVersion}&includePreRelease={includePreRelease}");
+            return JsonConvert.DeserializeObject<PublishedVersion[]>(result, serializerSettings) ?? throw new InvalidOperationException();
+        }
+    }
+}

--- a/BTCPayServer/Services/PoliciesSettings.cs
+++ b/BTCPayServer/Services/PoliciesSettings.cs
@@ -33,6 +33,13 @@ namespace BTCPayServer.Services
         [Display(Name = "Disable non-admins access to the user creation API endpoint")]
         public bool DisableNonAdminCreateUserApi { get; set; }
 
+        public const string DefaultPluginSource = "https://plugin-builder.btcpayserver.org";
+        [UriAttribute]
+        [Display(Name = "Plugin server")]
+        public string PluginSource { get; set; }
+        [Display(Name = "Show plugins in pre-release")]
+        public bool PluginPreReleases { get; set; }
+
         public bool DisableSSHService { get; set; }
 
         [Display(Name = "Display app on website root")]

--- a/BTCPayServer/Views/UIServer/ListPlugins.cshtml
+++ b/BTCPayServer/Views/UIServer/ListPlugins.cshtml
@@ -226,7 +226,7 @@
                             {
                                 @if (updateAvailable && DependenciesMet(x.Dependencies))
                                 {
-                                    <form asp-action="InstallPlugin" asp-route-plugin="@plugin.Identifier" asp-route-path="@x.Path" asp-route-update="true" class="me-3">
+                                    <form asp-action="InstallPlugin" asp-route-plugin="@plugin.Identifier" asp-route-version="@x.Version" asp-route-update="true" class="me-3">
                                         <button type="submit" class="btn btn-secondary">Update</button>
                                     </form>
                                 }
@@ -304,7 +304,7 @@
                             @* Don't show the "Install" button if plugin has been disabled *@
                             @if (!disabled)
                             {
-                                <form asp-action="InstallPlugin" asp-route-plugin="@plugin.Identifier" asp-route-path="@plugin.Path">
+                                <form asp-action="InstallPlugin" asp-route-plugin="@plugin.Identifier" asp-route-version="@plugin.Version">
                                     <button type="submit" class="btn btn-primary">Install</button>
                                 </form>
                             }

--- a/BTCPayServer/Views/UIServer/Policies.cshtml
+++ b/BTCPayServer/Views/UIServer/Policies.cshtml
@@ -118,6 +118,21 @@
         </div>
     </div>
 
+	<h4 class="mb-3">Plugins</h4>
+	<div class="row">
+		<div class="col-12 col-lg-8">
+			<div class="form-group">
+				<label asp-for="PluginSource" class="form-label"></label>
+				<input asp-for="PluginSource" placeholder="@PoliciesSettings.DefaultPluginSource" class="form-control"/>
+				<span asp-validation-for="PluginSource" class="text-danger"></span>
+			</div>
+			<div class="form-check my-3">
+				<input asp-for="PluginPreReleases" type="checkbox" class="form-check-input"/>
+				<label asp-for="PluginPreReleases" class="form-check-label"></label>
+			</div>
+		</div>
+	</div>
+
     <h4 class="mb-3">Customization Settings</h4>
 
     <div class="form-group">


### PR DESCRIPTION
Until now, we were fetching information of plugins directly from https://github.com/btcpayserver/btcpayserver-plugins
This worked fine as the number of plugins were manageable, but it is now growing. Some users reported the page couldn't even open as github were flooded with too many request (I think @petzsch reported that somewhere)

We are now using our own plugin build server on https://plugin-builder.btcpayserver.org/ (see [source code](https://github.com/btcpayserver/btcpayserver-plugin-builder/)) which exposes two endpoints: One to list plugins and the other to download them.

I removed the `--plugin-remote` which allowed to use a different github repository to fetch the plugins.

Instead, I added two server policies which allow the server administrator to use a different plugin-builder server.

![image](https://user-images.githubusercontent.com/3020646/201581360-4c95dbc4-19e9-47c2-bf6c-8bf8e2d7cd97.png)

I didn't removed `--plugin-remote` completely, it is just ignored, as passing a command line option which doesn't exist anymore will crash btcpayserver on startup. I think we can completely remove it in a few month.

Codewise, note that the `PluginService` is now transient and not a singleton. The reason is that it resolve the `PluginBuilderClient`, whose internal `HttpClient.BaseAddress` is set to the URL set in the server policies. If it was a singleton, the `BaseAddress` wouldn't be updated when the server policies are changing.

Ping @Kukks @dennisreimann 