### PR TITLE
Wallet object scripts

### DIFF
--- a/BTCPayServer.Data/Data/WalletObjectData.cs
+++ b/BTCPayServer.Data/Data/WalletObjectData.cs
@@ -21,6 +21,8 @@ namespace BTCPayServer.Data
             public const string PayjoinExposed = "pj-exposed";
             public const string Payout = "payout";
             public const string PullPayment = "pull-payment";
+            public const string Script = "script";
+            public const string Utxo = "utxo";
         }
         public string WalletId { get; set; }
         public string Type { get; set; }

--- a/BTCPayServer.Tests/GreenfieldAPITests.cs
+++ b/BTCPayServer.Tests/GreenfieldAPITests.cs
@@ -3194,7 +3194,7 @@ namespace BTCPayServer.Tests
                 // Only the node `test` `test` is connected to `test1`
                 var wid = new WalletId(admin.StoreId, "BTC");
                 var repo = tester.PayTester.GetService<WalletRepository>();
-                var allObjects = await repo.GetWalletObjects((new(wid, null) { UseInefficientPath = useInefficient }));
+                var allObjects = await repo.GetWalletObjects(new(wid) { UseInefficientPath = useInefficient });
                 var allObjectsNoWallet = await repo.GetWalletObjects((new() { UseInefficientPath = useInefficient }));
                 var allObjectsNoWalletAndType = await repo.GetWalletObjects((new() { Type = "test", UseInefficientPath = useInefficient }));
                 var allTests = await repo.GetWalletObjects((new(wid, "test") { UseInefficientPath = useInefficient }));

--- a/BTCPayServer/Controllers/GreenField/GreenfieldStoreOnChainWalletsController.cs
+++ b/BTCPayServer/Controllers/GreenField/GreenfieldStoreOnChainWalletsController.cs
@@ -189,7 +189,7 @@ namespace BTCPayServer.Controllers.Greenfield
 
             var wallet = _btcPayWalletProvider.GetWallet(network);
             var walletId = new WalletId(storeId, cryptoCode);
-            var walletTransactionsInfoAsync = await _walletRepository.GetWalletTransactionsInfo(walletId);
+            var walletTransactionsInfoAsync = await _walletRepository.GetWalletTransactionsInfo(walletId, (string[] ) null);
 
             var preFiltering = true;
             if (statusFilter?.Any() is true || !string.IsNullOrWhiteSpace(labelFilter))

--- a/BTCPayServer/Controllers/UIWalletsController.cs
+++ b/BTCPayServer/Controllers/UIWalletsController.cs
@@ -578,17 +578,24 @@ namespace BTCPayServer.Controllers
                 var utxos = await _walletProvider.GetWallet(network)
                     .GetUnspentCoins(schemeSettings.AccountDerivation, false, cancellation);
 
-                var walletTransactionsInfoAsync = await this.WalletRepository.GetWalletTransactionsInfo(walletId, utxos.Select(u => u.OutPoint.Hash.ToString()).Distinct().ToArray());
+                var walletTransactionsInfoAsync = await this.WalletRepository.GetWalletTransactionsInfo(walletId, 
+                    utxos.SelectMany(u => GetWalletObjectsQuery.Get(u)).Distinct().ToArray());
                 vm.InputsAvailable = utxos.Select(coin =>
                 {
                     walletTransactionsInfoAsync.TryGetValue(coin.OutPoint.Hash.ToString(), out var info);
-                    var labels = CreateTransactionTagModels(info).ToList();
+                    walletTransactionsInfoAsync.TryGetValue(coin.ScriptPubKey.ToHex(), out var info2);
+                    
+                    if (info is not null && info2 is not null)
+                    {
+                        info.Merge(info2);
+                    }
+                    info ??= info2;
                     return new WalletSendModel.InputSelectionOption()
                     {
                         Outpoint = coin.OutPoint.ToString(),
                         Amount = coin.Value.GetValue(network),
                         Comment = info?.Comment,
-                        Labels = labels,
+                        Labels = CreateTransactionTagModels(info),
                         Link = string.Format(CultureInfo.InvariantCulture, network.BlockExplorerLink,
                             coin.OutPoint.Hash.ToString()),
                         Confirmations = coin.Confirmations
@@ -1291,7 +1298,7 @@ namespace BTCPayServer.Controllers
                 return NotFound();
             
             var wallet = _walletProvider.GetWallet(paymentMethod.Network);
-            var walletTransactionsInfoAsync = WalletRepository.GetWalletTransactionsInfo(walletId);
+            var walletTransactionsInfoAsync = WalletRepository.GetWalletTransactionsInfo(walletId, (string[] ) null);
             var input = await wallet.FetchTransactionHistory(paymentMethod.AccountDerivation, null, null);
             var walletTransactionsInfo = await walletTransactionsInfoAsync;
             var export = new TransactionsExport(wallet, walletTransactionsInfo);

--- a/BTCPayServer/Data/WalletTransactionInfo.cs
+++ b/BTCPayServer/Data/WalletTransactionInfo.cs
@@ -7,7 +7,6 @@ using BTCPayServer.Services;
 using BTCPayServer.Services.Labels;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
-using Newtonsoft.Json.Serialization;
 
 namespace BTCPayServer.Data
 {
@@ -83,5 +82,23 @@ namespace BTCPayServer.Data
             }
         }
 
+        public string Type { get; set; }
+
+        public void Merge(WalletTransactionInfo? value)
+        {
+            if (value is null)
+                return;
+
+            foreach (var valueLabelColor in value.LabelColors)
+            {
+                LabelColors.TryAdd(valueLabelColor.Key, valueLabelColor.Value);
+            }
+            
+            foreach (var valueAttachment in value.Attachments.Where(valueAttachment => !Attachments.Any(attachment =>
+                         attachment.Id == valueAttachment.Id && attachment.Type == valueAttachment.Type)))
+            {
+                Attachments.Add(valueAttachment);
+            }
+        }
     }
 }

--- a/BTCPayServer/HostedServices/TransactionLabelMarkerHostedService.cs
+++ b/BTCPayServer/HostedServices/TransactionLabelMarkerHostedService.cs
@@ -40,6 +40,9 @@ namespace BTCPayServer.HostedServices
         {
             switch (evt)
             {
+                // For each new transaction that we detect, we check if we can find
+                // any utxo or script object matching it.
+                // If we find, then we create a link between them and the tx object.
                 case NewOnChainTransactionEvent transactionEvent:
                 {
                     var txHash = transactionEvent.NewTransactionEvent.TransactionData.TransactionHash.ToString();
@@ -55,8 +58,7 @@ namespace BTCPayServer.HostedServices
                             new ObjectTypeId(WalletObjectData.Types.Utxo,txOut.ToCoin().Outpoint.ToString())
                             
                             } )).Distinct().ToArray();
-                    
-                    // we are intentionally excluding wallet id filter so that we reduce db trips
+
                     var objs = await _walletRepository.GetWalletObjects(new GetWalletObjectsQuery(){TypesIds = matchedObjects});
 
                     foreach (var walletObjectDatas in objs.GroupBy(data => data.Key.WalletId))

--- a/BTCPayServer/HostedServices/TransactionLabelMarkerHostedService.cs
+++ b/BTCPayServer/HostedServices/TransactionLabelMarkerHostedService.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using BTCPayServer.Client.Models;
 using BTCPayServer.Data;
 using BTCPayServer.Events;
 using BTCPayServer.Logging;
@@ -22,42 +23,77 @@ namespace BTCPayServer.HostedServices
 {
     public class TransactionLabelMarkerHostedService : EventHostedServiceBase
     {
-        private readonly EventAggregator _eventAggregator;
         private readonly WalletRepository _walletRepository;
 
         public TransactionLabelMarkerHostedService(EventAggregator eventAggregator, WalletRepository walletRepository, Logs logs) :
             base(eventAggregator, logs)
         {
-            _eventAggregator = eventAggregator;
             _walletRepository = walletRepository;
         }
 
         protected override void SubscribeToEvents()
         {
             Subscribe<InvoiceEvent>();
+            Subscribe<NewOnChainTransactionEvent>();
         }
         protected override async Task ProcessEvent(object evt, CancellationToken cancellationToken)
         {
-            if (evt is InvoiceEvent invoiceEvent && invoiceEvent.Name == InvoiceEvent.ReceivedPayment &&
-                invoiceEvent.Payment.GetPaymentMethodId()?.PaymentType == BitcoinPaymentType.Instance &&
-                invoiceEvent.Payment.GetCryptoPaymentData() is BitcoinLikePaymentData bitcoinLikePaymentData)
+            switch (evt)
             {
-                var walletId = new WalletId(invoiceEvent.Invoice.StoreId, invoiceEvent.Payment.GetCryptoCode());
-                var transactionId = bitcoinLikePaymentData.Outpoint.Hash;
-                var labels = new List<Attachment>
+                case NewOnChainTransactionEvent transactionEvent:
                 {
-                    Attachment.Invoice(invoiceEvent.Invoice.Id)
-                };
-                foreach (var paymentId in PaymentRequestRepository.GetPaymentIdsFromInternalTags(invoiceEvent.Invoice))
-                {
-                    labels.Add(Attachment.PaymentRequest(paymentId));
-                }
-                foreach (var appId in AppService.GetAppInternalTags(invoiceEvent.Invoice))
-                {
-                    labels.Add(Attachment.App(appId));
-                }
+                    var txHash = transactionEvent.NewTransactionEvent.TransactionData.TransactionHash.ToString();
+                    
+                    // find all wallet objects that fit this transaction
+                    // that means see if there are any utxo objects that match in/outs and scripts/addresses that match outs
+                    var matchedObjects = transactionEvent.NewTransactionEvent.TransactionData.Transaction.Inputs
+                        .Select(txIn => new ObjectTypeId(WalletObjectData.Types.Utxo, txIn.PrevOut.ToString()))
+                        .Concat(transactionEvent.NewTransactionEvent.TransactionData.Transaction.Outputs.AsIndexedOutputs().SelectMany(txOut =>
+                           
+                            new[]{
+                            new ObjectTypeId(WalletObjectData.Types.Script,txOut.TxOut.ScriptPubKey.ToHex()),
+                            new ObjectTypeId(WalletObjectData.Types.Utxo,txOut.ToCoin().Outpoint.ToString())
+                            
+                            } )).Distinct().ToArray();
+                    
+                    // we are intentionally excluding wallet id filter so that we reduce db trips
+                    var objs = await _walletRepository.GetWalletObjects(new GetWalletObjectsQuery(){TypesIds = matchedObjects});
 
-                await _walletRepository.AddWalletTransactionAttachment(walletId, transactionId, labels);
+                    foreach (var walletObjectDatas in objs.GroupBy(data => data.Key.WalletId))
+                    {
+                        var txWalletObject = new WalletObjectId(walletObjectDatas.Key,
+                            WalletObjectData.Types.Tx, txHash);
+                        await _walletRepository.EnsureWalletObject(txWalletObject);
+                        foreach (var walletObjectData in walletObjectDatas)
+                        {
+                            await _walletRepository.EnsureWalletObjectLink(txWalletObject, walletObjectData.Key);
+                        }
+                    }
+
+                    break;
+                }
+                case InvoiceEvent {Name: InvoiceEvent.ReceivedPayment} invoiceEvent when
+                    invoiceEvent.Payment.GetPaymentMethodId()?.PaymentType == BitcoinPaymentType.Instance &&
+                    invoiceEvent.Payment.GetCryptoPaymentData() is BitcoinLikePaymentData bitcoinLikePaymentData:
+                {
+                    var walletId = new WalletId(invoiceEvent.Invoice.StoreId, invoiceEvent.Payment.GetCryptoCode());
+                    var transactionId = bitcoinLikePaymentData.Outpoint.Hash;
+                    var labels = new List<Attachment>
+                    {
+                        Attachment.Invoice(invoiceEvent.Invoice.Id)
+                    };
+                    foreach (var paymentId in PaymentRequestRepository.GetPaymentIdsFromInternalTags(invoiceEvent.Invoice))
+                    {
+                        labels.Add(Attachment.PaymentRequest(paymentId));
+                    }
+                    foreach (var appId in AppService.GetAppInternalTags(invoiceEvent.Invoice))
+                    {
+                        labels.Add(Attachment.App(appId));
+                    }
+
+                    await _walletRepository.AddWalletTransactionAttachment(walletId, transactionId, labels);
+                    break;
+                }
             }
         }
     }


### PR DESCRIPTION
This PR starts introducing the concept of being able to label individual addresses and utxos with the new wallet objects system.

When a new tx is detected, we will look for objects where:
* the spent utxos 
* the tx output scripts/addresses
* the tx newly created utxos

Then, we will link these *existing* objects to the tx object (which will be created if it does not exist).

Currently, we do not transfer labels from these objects to the tx object. That will be the scope of a separate PR, "Wallet object link stickyness"

As an introduction, the wallet receive page will now tag the receiving address with a wallet object of type `receive`.

  