### PR TITLE
Disable internal node options if no internal node configured

### DIFF
--- a/BTCPayServer.Common/BTCPayNetwork.cs
+++ b/BTCPayServer.Common/BTCPayNetwork.cs
@@ -137,6 +137,7 @@ namespace BTCPayServer
 
         public string CryptoImagePath { get; set; }
         public string[] DefaultRateRules { get; set; } = Array.Empty<string>();
+
         public override string ToString()
         {
             return CryptoCode;

--- a/BTCPayServer/Controllers/UIStoresController.LightningLike.cs
+++ b/BTCPayServer/Controllers/UIStoresController.LightningLike.cs
@@ -108,7 +108,7 @@ namespace BTCPayServer.Controllers
             if (store == null)
                 return NotFound();
 
-            vm.CanUseInternalNode = CanUseInternalLightning();
+            vm.CanUseInternalNode = CanUseInternalLightning(vm.CryptoCode);
 
             if (vm.CryptoCode == null)
             {
@@ -122,7 +122,7 @@ namespace BTCPayServer.Controllers
             LightningSupportedPaymentMethod? paymentMethod = null;
             if (vm.LightningNodeType == LightningNodeType.Internal)
             {
-                if (!CanUseInternalLightning())
+                if (!CanUseInternalLightning(network.CryptoCode))
                 {
                     ModelState.AddModelError(nameof(vm.ConnectionString), "You are not authorized to use the internal lightning node");
                     return View(vm);
@@ -364,14 +364,14 @@ namespace BTCPayServer.Controllers
             return RedirectToAction(nameof(LightningSettings), new { storeId, cryptoCode });
         }
 
-        private bool CanUseInternalLightning()
+        private bool CanUseInternalLightning(string cryptoCode)
         {
-            return User.IsInRole(Roles.ServerAdmin) || _policiesSettings.AllowLightningInternalNodeForAll;
+            return LightningNetworkOptions.InternalLightningByCryptoCode.ContainsKey(cryptoCode.ToUpperInvariant()) && (User.IsInRole(Roles.ServerAdmin) || _policiesSettings.AllowLightningInternalNodeForAll);
         }
 
         private void SetExistingValues(StoreData store, LightningNodeViewModel vm)
         {
-            vm.CanUseInternalNode = CanUseInternalLightning();
+            vm.CanUseInternalNode = CanUseInternalLightning(vm.CryptoCode);
             var lightning = GetExistingLightningSupportedPaymentMethod(vm.CryptoCode, store);
 
             if (lightning != null)

--- a/BTCPayServer/Controllers/UIStoresController.cs
+++ b/BTCPayServer/Controllers/UIStoresController.cs
@@ -64,6 +64,7 @@ namespace BTCPayServer.Controllers
             IFileService fileService,
             WebhookSender webhookNotificationManager,
             IDataProtectionProvider dataProtector,
+            IOptions<LightningNetworkOptions> lightningNetworkOptions,
             IOptions<ExternalServicesOptions> externalServiceOptions)
         {
             _RateFactory = rateFactory;
@@ -80,6 +81,7 @@ namespace BTCPayServer.Controllers
             _fileService = fileService;
             DataProtector = dataProtector.CreateProtector("ConfigProtector");
             WebhookNotificationManager = webhookNotificationManager;
+            LightningNetworkOptions = lightningNetworkOptions.Value;
             _EventAggregator = eventAggregator;
             _NetworkProvider = networkProvider;
             _ExplorerProvider = explorerProvider;
@@ -111,6 +113,7 @@ namespace BTCPayServer.Controllers
 
         public string? GeneratedPairingCode { get; set; }
         public WebhookSender WebhookNotificationManager { get; }
+        public LightningNetworkOptions LightningNetworkOptions { get; }
         public IDataProtector DataProtector { get; }
 
         [TempData]


### PR DESCRIPTION
If `BTCPAY_BTCLIGHTNING` isn't configured, then the internal node on

![image](https://user-images.githubusercontent.com/3020646/202846217-d29893da-4cfd-49b2-a691-bc569a86693c.png)

Should be disabled. It wasn't the case before.