### PR TITLE
Show the git commit of the current build of BTCPay

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,9 +41,10 @@ jobs:
       - run:
           command: |
             LATEST_TAG=${CIRCLE_TAG:1} #trim v from tag
+            GIT_COMMIT=$(git rev-parse HEAD)
             #
-            sudo docker build --pull -t $DOCKERHUB_REPO:$LATEST_TAG-amd64 -f amd64.Dockerfile .
-            sudo docker build --pull --build-arg CONFIGURATION_NAME=Altcoins-Release -t $DOCKERHUB_REPO:$LATEST_TAG-altcoins-amd64 -f amd64.Dockerfile .
+            sudo docker build --build-arg GIT_COMMIT=${GIT_COMMIT} --pull -t $DOCKERHUB_REPO:$LATEST_TAG-amd64 -f amd64.Dockerfile .
+            sudo docker build --build-arg GIT_COMMIT=${GIT_COMMIT} --pull --build-arg CONFIGURATION_NAME=Altcoins-Release -t $DOCKERHUB_REPO:$LATEST_TAG-altcoins-amd64 -f amd64.Dockerfile .
             sudo docker login --username=$DOCKERHUB_USER --password=$DOCKERHUB_PASS
             sudo docker push $DOCKERHUB_REPO:$LATEST_TAG-amd64
             sudo docker push $DOCKERHUB_REPO:$LATEST_TAG-altcoins-amd64
@@ -57,9 +58,10 @@ jobs:
           command: |
             sudo docker run --rm --privileged multiarch/qemu-user-static:register --reset
             LATEST_TAG=${CIRCLE_TAG:1} #trim v from tag
+            GIT_COMMIT=$(git rev-parse HEAD)
             #
-            sudo docker build --pull -t $DOCKERHUB_REPO:$LATEST_TAG-arm32v7 -f arm32v7.Dockerfile .
-            sudo docker build --pull --build-arg CONFIGURATION_NAME=Altcoins-Release -t $DOCKERHUB_REPO:$LATEST_TAG-altcoins-arm32v7 -f arm32v7.Dockerfile .
+            sudo docker build --build-arg GIT_COMMIT=${GIT_COMMIT} --pull -t $DOCKERHUB_REPO:$LATEST_TAG-arm32v7 -f arm32v7.Dockerfile .
+            sudo docker build --build-arg GIT_COMMIT=${GIT_COMMIT} --pull --build-arg CONFIGURATION_NAME=Altcoins-Release -t $DOCKERHUB_REPO:$LATEST_TAG-altcoins-arm32v7 -f arm32v7.Dockerfile .
             sudo docker login --username=$DOCKERHUB_USER --password=$DOCKERHUB_PASS
             sudo docker push $DOCKERHUB_REPO:$LATEST_TAG-arm32v7
             sudo docker push $DOCKERHUB_REPO:$LATEST_TAG-altcoins-arm32v7
@@ -73,9 +75,10 @@ jobs:
           command: |
             sudo docker run --rm --privileged multiarch/qemu-user-static:register --reset
             LATEST_TAG=${CIRCLE_TAG:1} #trim v from tag
+            GIT_COMMIT=$(git rev-parse HEAD)
             #
-            sudo docker build --pull -t $DOCKERHUB_REPO:$LATEST_TAG-arm64v8 -f arm64v8.Dockerfile .
-            sudo docker build --build-arg CONFIGURATION_NAME=Altcoins-Release --pull -t $DOCKERHUB_REPO:$LATEST_TAG-altcoins-arm64v8 -f arm64v8.Dockerfile .
+            sudo docker build --build-arg GIT_COMMIT=${GIT_COMMIT} --pull -t $DOCKERHUB_REPO:$LATEST_TAG-arm64v8 -f arm64v8.Dockerfile .
+            sudo docker build --build-arg GIT_COMMIT=${GIT_COMMIT} --build-arg CONFIGURATION_NAME=Altcoins-Release --pull -t $DOCKERHUB_REPO:$LATEST_TAG-altcoins-arm64v8 -f arm64v8.Dockerfile .
             sudo docker login --username=$DOCKERHUB_USER --password=$DOCKERHUB_PASS
             sudo docker push $DOCKERHUB_REPO:$LATEST_TAG-arm64v8
             sudo docker push $DOCKERHUB_REPO:$LATEST_TAG-altcoins-arm64v8

--- a/BTCPayServer/BTCPayServer.csproj
+++ b/BTCPayServer/BTCPayServer.csproj
@@ -1,16 +1,18 @@
- <Project Sdk="Microsoft.NET.Sdk.Web">
+﻿ <Project Sdk="Microsoft.NET.Sdk.Web">
   <Import Project="../Build/Version.csproj" Condition="Exists('../Build/Version.csproj')" />
   <Import Project="../Build/Common.csproj" />
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-
     <PreserveCompilationContext>true</PreserveCompilationContext>
-
     <RunAnalyzersDuringLiveAnalysis>False</RunAnalyzersDuringLiveAnalysis>
-
     <RunAnalyzersDuringBuild>False</RunAnalyzersDuringBuild>
   </PropertyGroup>
+   <ItemGroup>
+     <AssemblyAttribute  Condition="'$(GitCommit)' != ''" Include="BTCPayServer.GitCommitAttribute">
+       <_Parameter1>$(GitCommit)</_Parameter1>
+     </AssemblyAttribute>
+   </ItemGroup>
   <ItemGroup>
     <Compile Remove="Build\**" />
     <Compile Remove="wwwroot\vendor\jquery-nice-select\**" />

--- a/BTCPayServer/GitCommitAttribute.cs
+++ b/BTCPayServer/GitCommitAttribute.cs
@@ -1,0 +1,18 @@
+using System;
+
+namespace BTCPayServer
+{
+    [AttributeUsage(AttributeTargets.Assembly, Inherited = false)]
+    public sealed class GitCommitAttribute : Attribute
+    {
+        public string SHA
+        {
+            get;
+        }
+        public string ShortSHA => SHA.Substring(0, 9);
+        public GitCommitAttribute(string sha)
+        {
+            SHA = sha;
+        }
+    }
+}

--- a/BTCPayServer/Services/BTCPayServerEnvironment.cs
+++ b/BTCPayServer/Services/BTCPayServerEnvironment.cs
@@ -72,7 +72,6 @@ namespace BTCPayServer.Services
         }
 
         public string Commit { get; set; }
-        public HttpContext Context => httpContext.HttpContext;
 
         public override string ToString()
         {

--- a/BTCPayServer/Services/BTCPayServerEnvironment.cs
+++ b/BTCPayServer/Services/BTCPayServerEnvironment.cs
@@ -20,6 +20,7 @@ namespace BTCPayServer.Services
         {
             this.httpContext = httpContext;
             Version = typeof(BTCPayServerEnvironment).GetTypeInfo().Assembly.GetCustomAttribute<AssemblyFileVersionAttribute>().Version;
+            Commit = typeof(BTCPayServerEnvironment).GetTypeInfo().Assembly.GetCustomAttribute<GitCommitAttribute>()?.ShortSHA;
 #if DEBUG
             Build = "Debug";
 #else
@@ -78,12 +79,15 @@ namespace BTCPayServer.Services
             }
         }
 
+        public string Commit { get; set; }
         public HttpContext Context => httpContext.HttpContext;
 
         public override string ToString()
         {
             StringBuilder txt = new StringBuilder();
             txt.Append(CultureInfo.InvariantCulture, $"© BTCPay Server v{Version}");
+            if (Commit != null)
+                txt.Append($"+{Commit}");
             if (AltcoinsVersion)
                 txt.Append(" (Altcoins)");
             if (!Environment.IsProduction() || !Build.Equals("Release", StringComparison.OrdinalIgnoreCase))

--- a/amd64.Dockerfile
+++ b/amd64.Dockerfile
@@ -18,7 +18,8 @@ COPY BTCPayServer.Abstractions/. BTCPayServer.Abstractions/.
 COPY BTCPayServer/. BTCPayServer/.
 COPY Build/Version.csproj Build/Version.csproj
 ARG CONFIGURATION_NAME=Release
-RUN cd BTCPayServer && dotnet publish --output /app/ --configuration ${CONFIGURATION_NAME}
+ARG GIT_COMMIT
+RUN cd BTCPayServer && dotnet publish -p:GitCommit=${GIT_COMMIT} --output /app/ --configuration ${CONFIGURATION_NAME}
 
 FROM mcr.microsoft.com/dotnet/aspnet:6.0.9-bullseye-slim
 

--- a/arm32v7.Dockerfile
+++ b/arm32v7.Dockerfile
@@ -22,7 +22,8 @@ COPY BTCPayServer.Abstractions/. BTCPayServer.Abstractions/.
 COPY BTCPayServer/. BTCPayServer/.
 COPY Build/Version.csproj Build/Version.csproj
 ARG CONFIGURATION_NAME=Release
-RUN cd BTCPayServer && dotnet publish --output /app/ --configuration ${CONFIGURATION_NAME}
+ARG GIT_COMMIT
+RUN cd BTCPayServer && dotnet publish -p:GitCommit=${GIT_COMMIT} --output /app/ --configuration ${CONFIGURATION_NAME}
 
 # Note that we are using buster rather than bullseye. Somehow, raspberry pi 4 doesn't like bullseye.
 FROM mcr.microsoft.com/dotnet/aspnet:6.0.9-bullseye-slim-arm32v7

--- a/arm64v8.Dockerfile
+++ b/arm64v8.Dockerfile
@@ -23,7 +23,8 @@ COPY BTCPayServer.Abstractions/. BTCPayServer.Abstractions/.
 COPY BTCPayServer/. BTCPayServer/.
 COPY Build/Version.csproj Build/Version.csproj
 ARG CONFIGURATION_NAME=Release
-RUN cd BTCPayServer && dotnet publish --output /app/ --configuration ${CONFIGURATION_NAME}
+ARG GIT_COMMIT
+RUN cd BTCPayServer && dotnet publish -p:GitCommit=${GIT_COMMIT} --output /app/ --configuration ${CONFIGURATION_NAME}
 
 # Force the builder machine to take make an arm runtime image. This is fine as long as the builder does not run any program
 FROM mcr.microsoft.com/dotnet/aspnet:6.0.9-bullseye-slim-arm64v8


### PR DESCRIPTION
As some people start forking BTCPay, it's better we know exactly the commit which is running.
Note that it won't show up on dev build, just for btcpay published docker images.

![image](https://user-images.githubusercontent.com/3020646/202963650-5083f78c-4bc7-4c4a-90d0-03048e2a0b85.png)

