### PR TITLE
Fix: If reverse proxy wasn't well configured, an error message should have been displayed

### DIFF
--- a/BTCPayServer/Components/MainNav/Default.cshtml
+++ b/BTCPayServer/Components/MainNav/Default.cshtml
@@ -9,6 +9,7 @@
 @using BTCPayServer.Client
 @using BTCPayServer.Services
 @using BTCPayServer.Views.CustodianAccounts
+@inject Microsoft.AspNetCore.Http.IHttpContextAccessor HttpContext;
 @inject BTCPayServerEnvironment Env
 @inject SignInManager<ApplicationUser> SignInManager
 @inject PoliciesSettings PoliciesSettings
@@ -227,7 +228,7 @@
                 })()
             </script>
         }
-        else if (Env.IsSecure)
+        else if (Env.IsSecure(HttpContext.HttpContext))
         {
             <ul class="navbar-nav">
                 @if (!PoliciesSettings.LockSubscription)

--- a/BTCPayServer/Controllers/UIAccountController.cs
+++ b/BTCPayServer/Controllers/UIAccountController.cs
@@ -227,7 +227,7 @@ namespace BTCPayServer.Controllers
 
         private async Task<LoginWithFido2ViewModel> BuildFido2ViewModel(bool rememberMe, ApplicationUser user)
         {
-            if (_btcPayServerEnvironment.IsSecure)
+            if (_btcPayServerEnvironment.IsSecure(HttpContext))
             {
                 var r = await _fido2Service.RequestLogin(user.Id);
                 if (r is null)
@@ -247,7 +247,7 @@ namespace BTCPayServer.Controllers
 
         private async Task<LoginWithLNURLAuthViewModel> BuildLNURLAuthViewModel(bool rememberMe, ApplicationUser user)
         {
-            if (_btcPayServerEnvironment.IsSecure)
+            if (_btcPayServerEnvironment.IsSecure(HttpContext))
             {
                 var r = await _lnurlAuthService.RequestLogin(user.Id);
                 if (r is null)
@@ -777,7 +777,7 @@ namespace BTCPayServer.Controllers
 
         private bool CanLoginOrRegister()
         {
-            return _btcPayServerEnvironment.IsDeveloping || _btcPayServerEnvironment.IsSecure;
+            return _btcPayServerEnvironment.IsDeveloping || _btcPayServerEnvironment.IsSecure(HttpContext);
         }
 
         private void SetInsecureFlags()

--- a/BTCPayServer/Controllers/UIManageController.APIKeys.cs
+++ b/BTCPayServer/Controllers/UIManageController.APIKeys.cs
@@ -67,7 +67,7 @@ namespace BTCPayServer.Controllers
         [HttpGet]
         public async Task<IActionResult> AddApiKey()
         {
-            if (!_btcPayServerEnvironment.IsSecure)
+            if (!_btcPayServerEnvironment.IsSecure(HttpContext))
             {
                 TempData.SetStatusMessageModel(new StatusMessageModel()
                 {
@@ -84,7 +84,7 @@ namespace BTCPayServer.Controllers
         public async Task<IActionResult> AuthorizeAPIKey(string[] permissions, string applicationName = null, Uri redirect = null,
             bool strict = true, bool selectiveStores = false, string applicationIdentifier = null)
         {
-            if (!_btcPayServerEnvironment.IsSecure)
+            if (!_btcPayServerEnvironment.IsSecure(HttpContext))
             {
                 TempData.SetStatusMessageModel(new StatusMessageModel
                 {

--- a/BTCPayServer/Views/Shared/_Layout.cshtml
+++ b/BTCPayServer/Views/Shared/_Layout.cshtml
@@ -1,6 +1,7 @@
 @using BTCPayServer.Abstractions.Extensions
 @using BTCPayServer.Components.StoreSelector
 @using BTCPayServer.Components.MainNav
+@inject Microsoft.AspNetCore.Http.IHttpContextAccessor _context;
 @inject BTCPayServer.Services.BTCPayServerEnvironment _env
 @inject SignInManager<ApplicationUser> _signInManager
 @inject UserManager<ApplicationUser> _userManager
@@ -15,6 +16,8 @@
         var user = await _userManager.GetUserAsync(User);
         notificationDisabled = user?.DisabledNotifications == "all";
     }
+	var expectedScheme = _context.HttpContext.Request.Scheme;
+	var expectedHost = _context.HttpContext.Request.Host.ToString();
 }
 
 <!DOCTYPE html>
@@ -37,21 +40,20 @@
     </div>
     <vc:main-nav />
 </header>
+<template id="badUrl">
+	<div class="alert alert-danger alert-dismissible m-3" role="alert">
+        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close">
+            <vc:icon symbol="close"/>
+        </button>
+        <span>
+            BTCPay is expecting you to access this website from <strong>@(expectedScheme)://@(expectedHost)/</strong>.
+            If you use a reverse proxy, please set the <strong>X-Forwarded-Proto</strong> header to <strong id="browserScheme">@(expectedScheme)</strong>
+            (<a href="https://docs.btcpayserver.org/FAQ/Deployment/#cause-3-btcpay-is-expecting-you-to-access-this-website-from" target="_blank" class="alert-link" rel="noreferrer noopener">More information</a>)
+        </span>
+    </div>
+</template>
 <main id="mainContent">
-    @if (_env.Context.Request.Host.ToString() != _env.ExpectedHost || _env.Context.Request.Scheme != _env.ExpectedProtocol)
-    {
-        <div id="badUrl" class="alert alert-danger alert-dismissible m-3" role="alert">
-            <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close">
-                <vc:icon symbol="close"/>
-            </button>
-            <span>
-                BTCPay is expecting you to access this website from <strong>@(_env.ExpectedProtocol)://@(_env.ExpectedHost)/</strong>.
-                If you use a reverse proxy, please set the <strong>X-Forwarded-Proto</strong> header to <strong id="browserScheme">@(_env.ExpectedProtocol)</strong>
-                (<a href="https://docs.btcpayserver.org/FAQ/Deployment/#cause-3-btcpay-is-expecting-you-to-access-this-website-from" target="_blank" class="alert-link" rel="noreferrer noopener">More information</a>)
-            </span>
-        </div>
-    }
-    @if (!_env.IsSecure)
+    @if (!_env.IsSecure(_context.HttpContext))
     {
         <div id="insecureEnv" class="alert alert-danger alert-dismissible" style="position:absolute; top:75px;" role="alert">
             <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close">
@@ -76,6 +78,12 @@
     @if (!notificationDisabled)
     {
         <script>
+			var mainContent = document.getElementById("mainContent");
+			if (window.location.protocol != "@(expectedScheme):" || window.location.host != "@expectedHost")
+			{
+				var tmpl = document.getElementById("badUrl");
+				mainContent.prepend(tmpl.content.cloneNode(true));
+			}
             if ('WebSocket' in window && window.WebSocket.CLOSING === 2) {
                 const { host, protocol } = window.location;
                 var wsUri = "@_linkGenerator.GetPathByAction("SubscribeUpdates", "UINotifications", pathBase: Context.Request.PathBase)";


### PR DESCRIPTION
We were using a singleton `BTCPayEnvironment` with a reference to the `IHttpContextAccessor`.

This is an undefined behavior, as `IHttpContextAccessor `is in the context of a single request, while `BTCPayEnvironment` is in the context of the application lifetime.

On top of this, even if the `BTCPayEnvironment` was magically using the right `HttpContext` (I don't see how it could have) of the current request, the server side check was entirely meaningless, as it was checking `ExpectedHost/Protocol` against itself.

Instead, the message should displayed by javascript which compare the URL of the browser with what is expected server side.