### PR TITLE
Fix flaky test

### DIFF
--- a/BTCPayServer/BTCPayServer.csproj
+++ b/BTCPayServer/BTCPayServer.csproj
@@ -1,4 +1,4 @@
- <Project Sdk="Microsoft.NET.Sdk.Web">
+﻿ <Project Sdk="Microsoft.NET.Sdk.Web">
   <Import Project="../Build/Version.csproj" Condition="Exists('../Build/Version.csproj')" />
   <Import Project="../Build/Common.csproj" />
 
@@ -51,7 +51,7 @@
     <PackageReference Include="Fido2" Version="2.0.2" />
     <PackageReference Include="Fido2.AspNet" Version="2.0.2" />
     <PackageReference Include="HtmlSanitizer" Version="5.0.372" />
-    <PackageReference Include="LNURL" Version="0.0.24" />
+    <PackageReference Include="LNURL" Version="0.0.26" />
     <PackageReference Include="MailKit" Version="3.3.0" />
     <PackageReference Include="McMaster.NETCore.Plugins.Mvc" Version="1.4.0" />
     <PackageReference Include="QRCoder" Version="1.4.3" />

--- a/BTCPayServer/Controllers/GreenField/GreenfieldPullPaymentController.cs
+++ b/BTCPayServer/Controllers/GreenField/GreenfieldPullPaymentController.cs
@@ -250,7 +250,7 @@ namespace BTCPayServer.Controllers.Greenfield
 
         [HttpPost("~/api/v1/pull-payments/{pullPaymentId}/payouts")]
         [AllowAnonymous]
-        public async Task<IActionResult> CreatePayout(string pullPaymentId, CreatePayoutRequest request)
+        public async Task<IActionResult> CreatePayout(string pullPaymentId, CreatePayoutRequest request, CancellationToken cancellationToken)
         {
             if (!PaymentMethodId.TryParse(request?.PaymentMethod, out var paymentMethodId))
             {
@@ -270,7 +270,7 @@ namespace BTCPayServer.Controllers.Greenfield
             if (pp is null)
                 return PullPaymentNotFound();
             var ppBlob = pp.GetBlob();
-            var destination = await payoutHandler.ParseAndValidateClaimDestination(paymentMethodId, request!.Destination, ppBlob);
+            var destination = await payoutHandler.ParseAndValidateClaimDestination(paymentMethodId, request!.Destination, ppBlob, cancellationToken);
             if (destination.destination is null)
             {
                 ModelState.AddModelError(nameof(request.Destination), destination.error ?? "The destination is invalid for the payment specified");
@@ -332,7 +332,7 @@ namespace BTCPayServer.Controllers.Greenfield
                     return PullPaymentNotFound();
                 ppBlob = pp.GetBlob();
             }
-            var destination = await payoutHandler.ParseAndValidateClaimDestination(paymentMethodId, request!.Destination, ppBlob);
+            var destination = await payoutHandler.ParseAndValidateClaimDestination(paymentMethodId, request!.Destination, ppBlob, default);
             if (destination.destination is null)
             {
                 ModelState.AddModelError(nameof(request.Destination), destination.error ?? "The destination is invalid for the payment specified");

--- a/BTCPayServer/Controllers/GreenField/LocalBTCPayServerClient.cs
+++ b/BTCPayServer/Controllers/GreenField/LocalBTCPayServerClient.cs
@@ -357,7 +357,7 @@ namespace BTCPayServer.Controllers.Greenfield
             CancellationToken cancellationToken = default)
         {
             return GetFromActionResult<PayoutData>(
-                await GetController<GreenfieldPullPaymentController>().CreatePayout(pullPaymentId, payoutRequest));
+                await GetController<GreenfieldPullPaymentController>().CreatePayout(pullPaymentId, payoutRequest, cancellationToken));
         }
 
         public override async Task CancelPayout(string storeId, string payoutId,

--- a/BTCPayServer/Controllers/UIPullPaymentController.cs
+++ b/BTCPayServer/Controllers/UIPullPaymentController.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using BTCPayServer.Abstractions.Constants;
 using BTCPayServer.Abstractions.Extensions;
@@ -153,7 +154,7 @@ namespace BTCPayServer.Controllers
 
         [AllowAnonymous]
         [HttpPost("pull-payments/{pullPaymentId}/claim")]
-        public async Task<IActionResult> ClaimPullPayment(string pullPaymentId, ViewPullPaymentModel vm)
+        public async Task<IActionResult> ClaimPullPayment(string pullPaymentId, ViewPullPaymentModel vm, CancellationToken cancellationToken)
         {
             using var ctx = _dbContextFactory.CreateContext();
             var pp = await ctx.PullPayments.FindAsync(pullPaymentId);
@@ -172,7 +173,7 @@ namespace BTCPayServer.Controllers
                 ModelState.AddModelError(nameof(vm.SelectedPaymentMethod), "Invalid destination with selected payment method");
                 return await ViewPullPayment(pullPaymentId);
             }
-            var destination = await payoutHandler.ParseAndValidateClaimDestination(paymentMethodId, vm.Destination, ppBlob);
+            var destination = await payoutHandler.ParseAndValidateClaimDestination(paymentMethodId, vm.Destination, ppBlob, cancellationToken);
             if (destination.destination is null)
             {
                 ModelState.AddModelError(nameof(vm.Destination), destination.error ?? "Invalid destination with selected payment method");

--- a/BTCPayServer/Data/Payouts/BitcoinLike/BitcoinLikePayoutHandler.cs
+++ b/BTCPayServer/Data/Payouts/BitcoinLike/BitcoinLikePayoutHandler.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using BTCPayServer;
 using BTCPayServer.Abstractions.Models;
@@ -71,7 +72,7 @@ public class BitcoinLikePayoutHandler : IPayoutHandler
             await explorerClient.TrackAsync(TrackedSource.Create(bitcoinLikeClaimDestination.Address));
     }
 
-    public Task<(IClaimDestination destination, string error)> ParseClaimDestination(PaymentMethodId paymentMethodId, string destination)
+    public Task<(IClaimDestination destination, string error)> ParseClaimDestination(PaymentMethodId paymentMethodId, string destination, CancellationToken cancellationToken)
     {
         var network = _btcPayNetworkProvider.GetNetwork<BTCPayNetwork>(paymentMethodId.CryptoCode);
         destination = destination.Trim();
@@ -287,7 +288,7 @@ public class BitcoinLikePayoutHandler : IPayoutHandler
             var blob = payout.GetBlob(_jsonSerializerSettings);
             if (payout.GetPaymentMethodId() != paymentMethodId)
                 continue;
-            var claim = await ParseClaimDestination(paymentMethodId, blob.Destination);
+            var claim = await ParseClaimDestination(paymentMethodId, blob.Destination, default);
             switch (claim.destination)
             {
                 case UriClaimDestination uriClaimDestination:

--- a/BTCPayServer/Data/Payouts/IPayoutHandler.cs
+++ b/BTCPayServer/Data/Payouts/IPayoutHandler.cs
@@ -1,6 +1,7 @@
 #nullable enable
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using BTCPayServer.Abstractions.Models;
 using BTCPayServer.Client.Models;
@@ -15,11 +16,11 @@ public interface IPayoutHandler
     public bool CanHandle(PaymentMethodId paymentMethod);
     public Task TrackClaim(PaymentMethodId paymentMethodId, IClaimDestination claimDestination);
     //Allows payout handler to parse payout destinations on its own
-    public Task<(IClaimDestination destination, string error)> ParseClaimDestination(PaymentMethodId paymentMethodId, string destination);
+    public Task<(IClaimDestination destination, string error)> ParseClaimDestination(PaymentMethodId paymentMethodId, string destination, CancellationToken cancellationToken);
     public (bool valid, string? error) ValidateClaimDestination(IClaimDestination claimDestination, PullPaymentBlob? pullPaymentBlob);
-    public async Task<(IClaimDestination? destination, string? error)> ParseAndValidateClaimDestination(PaymentMethodId paymentMethodId, string destination, PullPaymentBlob? pullPaymentBlob)
+    public async Task<(IClaimDestination? destination, string? error)> ParseAndValidateClaimDestination(PaymentMethodId paymentMethodId, string destination, PullPaymentBlob? pullPaymentBlob, CancellationToken cancellationToken)
     {
-        var res = await ParseClaimDestination(paymentMethodId, destination);
+        var res = await ParseClaimDestination(paymentMethodId, destination, cancellationToken);
         if (res.destination is null)
             return res;
         var res2 = ValidateClaimDestination(res.destination, pullPaymentBlob);

--- a/BTCPayServer/Data/Payouts/LightningLike/LightningLikePayoutHandler.cs
+++ b/BTCPayServer/Data/Payouts/LightningLike/LightningLikePayoutHandler.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using BTCPayServer.Abstractions.Models;
 using BTCPayServer.Client.Models;
@@ -59,7 +60,7 @@ namespace BTCPayServer.Data.Payouts.LightningLike
                 : LightningLikePayoutHandlerClearnetNamedClient);
         }
 
-        public async Task<(IClaimDestination destination, string error)> ParseClaimDestination(PaymentMethodId paymentMethodId, string destination)
+        public async Task<(IClaimDestination destination, string error)> ParseClaimDestination(PaymentMethodId paymentMethodId, string destination, CancellationToken cancellationToken)
         {
             destination = destination.Trim();
             var network = _btcPayNetworkProvider.GetNetwork<BTCPayNetwork>(paymentMethodId.CryptoCode);
@@ -72,7 +73,9 @@ namespace BTCPayServer.Data.Payouts.LightningLike
 
                 if (lnurlTag is null)
                 {
-                    var info = (LNURLPayRequest)(await LNURL.LNURL.FetchInformation(lnurl, CreateClient(lnurl)));
+                    using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+                    using var t = CancellationTokenSource.CreateLinkedTokenSource(timeout.Token, cancellationToken);
+                    var info = (LNURLPayRequest)(await LNURL.LNURL.FetchInformation(lnurl, CreateClient(lnurl), t.Token));
                     lnurlTag = info.Tag;
                 }
 

--- a/BTCPayServer/HostedServices/PullPaymentHostedService.cs
+++ b/BTCPayServer/HostedServices/PullPaymentHostedService.cs
@@ -383,7 +383,7 @@ namespace BTCPayServer.HostedServices
                 var payoutHandler = _payoutHandlers.FindPayoutHandler(paymentMethod);
                 if (payoutHandler is null)
                     throw new InvalidOperationException($"No payout handler for {paymentMethod}");
-                var dest = await payoutHandler.ParseClaimDestination(paymentMethod, payoutBlob.Destination);
+                var dest = await payoutHandler.ParseClaimDestination(paymentMethod, payoutBlob.Destination, default);
                 decimal minimumCryptoAmount =
                     await payoutHandler.GetMinimumPayoutAmount(paymentMethod, dest.destination);
                 if (cryptoAmount < minimumCryptoAmount)

--- a/BTCPayServer/Hosting/MigrationStartupTask.cs
+++ b/BTCPayServer/Hosting/MigrationStartupTask.cs
@@ -423,7 +423,7 @@ WHERE cte.""Id""=p.""Id""
                 {
                     continue;
                 }
-                var claim = await handler?.ParseClaimDestination(pmi, payoutData.GetBlob(_btcPayNetworkJsonSerializerSettings).Destination);
+                var claim = await handler?.ParseClaimDestination(pmi, payoutData.GetBlob(_btcPayNetworkJsonSerializerSettings).Destination, default);
                 payoutData.Destination = claim.destination?.Id;
             }
             await ctx.SaveChangesAsync();

--- a/BTCPayServer/PayoutProcessors/BaseAutomatedPayoutProcessor.cs
+++ b/BTCPayServer/PayoutProcessors/BaseAutomatedPayoutProcessor.cs
@@ -75,7 +75,6 @@ public abstract class BaseAutomatedPayoutProcessor<T> : BaseAsyncService where T
                 await context.SaveChangesAsync();
             }
         }
-        Logs.PayServer.LogInformation($"WAITING {CancellationToken.IsCancellationRequested}");
         await Task.Delay(blob.Interval, CancellationToken);
     }
 

--- a/BTCPayServer/PayoutProcessors/BaseAutomatedPayoutProcessor.cs
+++ b/BTCPayServer/PayoutProcessors/BaseAutomatedPayoutProcessor.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -75,6 +75,7 @@ public abstract class BaseAutomatedPayoutProcessor<T> : BaseAsyncService where T
                 await context.SaveChangesAsync();
             }
         }
+        Logs.PayServer.LogInformation($"WAITING {CancellationToken.IsCancellationRequested}");
         await Task.Delay(blob.Interval, CancellationToken);
     }
 

--- a/BTCPayServer/PayoutProcessors/OnChain/OnChainAutomatedPayoutProcessor.cs
+++ b/BTCPayServer/PayoutProcessors/OnChain/OnChainAutomatedPayoutProcessor.cs
@@ -107,7 +107,7 @@ namespace BTCPayServer.PayoutProcessors.OnChain
                 }
 
                 var claimDestination =
-                    await _bitcoinLikePayoutHandler.ParseClaimDestination(paymentMethodId, blob.Destination);
+                    await _bitcoinLikePayoutHandler.ParseClaimDestination(paymentMethodId, blob.Destination, CancellationToken);
                 if (!string.IsNullOrEmpty(claimDestination.error))
                 {
                     continue;


### PR DESCRIPTION
`CanUseLNPayoutProcessor` is flaky, and I noticed it was because the hosted service `LightningAutomatedPayoutProcessor` is blocked waiting for the `Process` to finish.

Tracked it down to a couple of call to LNURL. Passing down the cancellation token should propagate the `LightningAutomatedPayoutProcessor` closure, and thus stop the flakyness.