### PR TITLE
Fix warnings in Form builder

### DIFF
--- a/BTCPayServer/Controllers/UIInvoiceController.UI.cs
+++ b/BTCPayServer/Controllers/UIInvoiceController.UI.cs
@@ -274,7 +274,7 @@ namespace BTCPayServer.Controllers
                     else
                     {
                         TempData["formId"] = formId;
-                        TempData["redirectUrl"] = Request.GetCurrentUrl();;
+                        TempData["redirectUrl"] = Request.GetCurrentUrl();
                         
                         return RedirectToAction("ViewStepForm", "UIForms");
                     }

--- a/BTCPayServer/Controllers/UIInvoiceController.UI.cs
+++ b/BTCPayServer/Controllers/UIInvoiceController.UI.cs
@@ -258,7 +258,6 @@ namespace BTCPayServer.Controllers
 
             var formId = i.CheckoutFormId;
 
-            JObject formResponse = null;
             switch (formId)
             {
                 case { } frid when string.IsNullOrEmpty(frid) || frid == GenericFormOption.None.ToString():

--- a/BTCPayServer/Controllers/UIPaymentRequestController.cs
+++ b/BTCPayServer/Controllers/UIPaymentRequestController.cs
@@ -205,7 +205,6 @@ namespace BTCPayServer.Controllers
                 formId = storeBlob.CheckoutFormId;
             }
 
-            JObject formResponse = null;
             switch (formId)
             {
                 case { } frid when string.IsNullOrEmpty(frid) || frid == GenericFormOption.None.ToString():

--- a/BTCPayServer/Forms/UIFormsController.cs
+++ b/BTCPayServer/Forms/UIFormsController.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#nullable enable
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;

--- a/BTCPayServer/Forms/UIFormsController.cs
+++ b/BTCPayServer/Forms/UIFormsController.cs
@@ -214,7 +214,7 @@ public class UIFormsController : Controller
     [HttpPost("~/forms/{id?}")]
     public async Task<IActionResult> SubmitForm(
         string? id,
-        [FromServices]StoreRepository storeRepository,  
+        [FromServices] StoreRepository storeRepository,  
         [FromServices] UIInvoiceController invoiceController)
     {
         if (TempData.TryGetValue("formId", out var formId) )


### PR DESCRIPTION
Two formResponses variables are not used.
For the string? I followed other controllers and added #nullable enable

However, you might probably change to just string

Also cleanup a superfluous semicolon and a missing space