### PR TITLE
Disable receipts for payment request invoices

### DIFF
--- a/BTCPayServer/Controllers/UIInvoiceController.cs
+++ b/BTCPayServer/Controllers/UIInvoiceController.cs
@@ -194,7 +194,8 @@ namespace BTCPayServer.Controllers
                     Metadata = invoiceMetadata.ToJObject(),
                     Currency = pr.Currency,
                     Amount = amount,
-                    Checkout = { RedirectURL = redirectUrl }
+                    Checkout = { RedirectURL = redirectUrl },
+                    Receipt = new InvoiceDataBase.ReceiptOptions { Enabled = false }
                 };
 
             var additionalTags = new List<string> { PaymentRequestRepository.GetInternalTag(pr.Id) };


### PR DESCRIPTION
Payment requests have a receipt-ish style by default. Receipts for each individual invoice of a payment request can be quite confusing as individually they do not prove the pay request was settled.