### PR TITLE
Rename walletobjects Parent/Child to A/B

### DIFF
--- a/BTCPayServer.Data/Data/WalletObjectData.cs
+++ b/BTCPayServer.Data/Data/WalletObjectData.cs
@@ -27,36 +27,36 @@ namespace BTCPayServer.Data
         public string Id { get; set; }
         public string Data { get; set; }
 
-        public List<WalletObjectLinkData> ChildLinks { get; set; }
-        public List<WalletObjectLinkData> ParentLinks { get; set; }
+        public List<WalletObjectLinkData> Bs { get; set; }
+        public List<WalletObjectLinkData> As { get; set; }
 
         public IEnumerable<(string type, string id, string linkdata, string objectdata)> GetLinks()
         {
-            if (ChildLinks is not null)
-                foreach (var c in ChildLinks)
+            if (Bs is not null)
+                foreach (var c in Bs)
                 {
-                    yield return (c.ChildType, c.ChildId, c.Data, c.Child?.Data);
+                    yield return (c.BType, c.BId, c.Data, c.B?.Data);
                 }
-            if (ParentLinks is not null)
-                foreach (var c in ParentLinks)
+            if (As is not null)
+                foreach (var c in As)
                 {
-                    yield return (c.ParentType, c.ParentId, c.Data, c.Parent?.Data);
+                    yield return (c.AType, c.AId, c.Data, c.A?.Data);
                 }
         }
 
         public IEnumerable<WalletObjectData> GetNeighbours()
         {
-            if (ChildLinks != null)
-                foreach (var c in ChildLinks)
+            if (Bs != null)
+                foreach (var c in Bs)
                 {
-                    if (c.Child != null)
-                        yield return c.Child;
+                    if (c.B != null)
+                        yield return c.B;
                 }
-            if (ParentLinks != null)
-                foreach (var c in ParentLinks)
+            if (As != null)
+                foreach (var c in As)
                 {
-                    if (c.Parent != null)
-                        yield return c.Parent;
+                    if (c.A != null)
+                        yield return c.A;
                 }
         }
 

--- a/BTCPayServer.Data/Data/WalletObjectLinkData.cs
+++ b/BTCPayServer.Data/Data/WalletObjectLinkData.cs
@@ -11,14 +11,14 @@ namespace BTCPayServer.Data
     public class WalletObjectLinkData
     {
         public string WalletId { get; set; }
-        public string ParentType { get; set; }
-        public string ParentId { get; set; }
-        public string ChildType { get; set; }
-        public string ChildId { get; set; }
+        public string AType { get; set; }
+        public string AId { get; set; }
+        public string BType { get; set; }
+        public string BId { get; set; }
         public string Data { get; set; }
 
-        public WalletObjectData Parent { get; set; }
-        public WalletObjectData Child { get; set; }
+        public WalletObjectData A { get; set; }
+        public WalletObjectData B { get; set; }
 
         internal static void OnModelCreating(ModelBuilder builder, DatabaseFacade databaseFacade)
         {
@@ -26,28 +26,28 @@ namespace BTCPayServer.Data
             new
             {
                 o.WalletId,
-                o.ParentType,
-                o.ParentId,
-                o.ChildType,
-                o.ChildId,
+                o.AType,
+                o.AId,
+                o.BType,
+                o.BId,
             });
             builder.Entity<WalletObjectLinkData>().HasIndex(o => new
             {
                 o.WalletId,
-                o.ChildType,
-                o.ChildId,
+                o.BType,
+                o.BId,
             });
 
             builder.Entity<WalletObjectLinkData>()
-                .HasOne(o => o.Parent)
-                .WithMany(o => o.ChildLinks)
-                .HasForeignKey(o => new { o.WalletId, o.ParentType, o.ParentId })
+                .HasOne(o => o.A)
+                .WithMany(o => o.Bs)
+                .HasForeignKey(o => new { o.WalletId, o.AType, o.AId })
                 .OnDelete(DeleteBehavior.Cascade);
 
             builder.Entity<WalletObjectLinkData>()
-                .HasOne(o => o.Child)
-                .WithMany(o => o.ParentLinks)
-                .HasForeignKey(o => new { o.WalletId, o.ChildType, o.ChildId })
+                .HasOne(o => o.B)
+                .WithMany(o => o.As)
+                .HasForeignKey(o => new { o.WalletId, o.BType, o.BId })
                 .OnDelete(DeleteBehavior.Cascade);
 
             if (databaseFacade.IsNpgsql())

--- a/BTCPayServer.Data/Migrations/20220929132704_label.cs
+++ b/BTCPayServer.Data/Migrations/20220929132704_label.cs
@@ -40,33 +40,33 @@ namespace BTCPayServer.Migrations
                 columns: table => new
                 {
                     WalletId = table.Column<string>(type: "TEXT", nullable: false),
-                    ParentType = table.Column<string>(type: "TEXT", nullable: false),
-                    ParentId = table.Column<string>(type: "TEXT", nullable: false),
-                    ChildType = table.Column<string>(type: "TEXT", nullable: false),
-                    ChildId = table.Column<string>(type: "TEXT", nullable: false),
+                    AType = table.Column<string>(type: "TEXT", nullable: false),
+                    AId = table.Column<string>(type: "TEXT", nullable: false),
+                    BType = table.Column<string>(type: "TEXT", nullable: false),
+                    BId = table.Column<string>(type: "TEXT", nullable: false),
                     Data = table.Column<string>(type: migrationBuilder.IsNpgsql() ? "JSONB" : "TEXT", nullable: true)
                 },
                 constraints: table =>
                 {
-                    table.PrimaryKey("PK_WalletObjectLinks", x => new { x.WalletId, x.ParentType, x.ParentId, x.ChildType, x.ChildId });
+                    table.PrimaryKey("PK_WalletObjectLinks", x => new { x.WalletId, x.AType, x.AId, x.BType, x.BId });
                     table.ForeignKey(
-                        name: "FK_WalletObjectLinks_WalletObjects_WalletId_ChildType_ChildId",
-                        columns: x => new { x.WalletId, x.ChildType, x.ChildId },
+                        name: "FK_WalletObjectLinks_WalletObjects_WalletId_BType_BId",
+                        columns: x => new { x.WalletId, x.BType, x.BId },
                         principalTable: "WalletObjects",
                         principalColumns: new[] { "WalletId", "Type", "Id" },
                         onDelete: ReferentialAction.Cascade);
                     table.ForeignKey(
-                        name: "FK_WalletObjectLinks_WalletObjects_WalletId_ParentType_ParentId",
-                        columns: x => new { x.WalletId, x.ParentType, x.ParentId },
+                        name: "FK_WalletObjectLinks_WalletObjects_WalletId_AType_AId",
+                        columns: x => new { x.WalletId, x.AType, x.AId },
                         principalTable: "WalletObjects",
                         principalColumns: new[] { "WalletId", "Type", "Id" },
                         onDelete: ReferentialAction.Cascade);
                 });
 
             migrationBuilder.CreateIndex(
-                name: "IX_WalletObjectLinks_WalletId_ChildType_ChildId",
+                name: "IX_WalletObjectLinks_WalletId_BType_BId",
                 table: "WalletObjectLinks",
-                columns: new[] { "WalletId", "ChildType", "ChildId" });
+                columns: new[] { "WalletId", "BType", "BId" });
         }
 
         protected override void Down(MigrationBuilder migrationBuilder)

--- a/BTCPayServer.Data/Migrations/ApplicationDbContextModelSnapshot.cs
+++ b/BTCPayServer.Data/Migrations/ApplicationDbContextModelSnapshot.cs
@@ -872,24 +872,24 @@ namespace BTCPayServer.Migrations
                     b.Property<string>("WalletId")
                         .HasColumnType("TEXT");
 
-                    b.Property<string>("ParentType")
+                    b.Property<string>("AType")
                         .HasColumnType("TEXT");
 
-                    b.Property<string>("ParentId")
+                    b.Property<string>("AId")
                         .HasColumnType("TEXT");
 
-                    b.Property<string>("ChildType")
+                    b.Property<string>("BType")
                         .HasColumnType("TEXT");
 
-                    b.Property<string>("ChildId")
+                    b.Property<string>("BId")
                         .HasColumnType("TEXT");
 
                     b.Property<string>("Data")
                         .HasColumnType("TEXT");
 
-                    b.HasKey("WalletId", "ParentType", "ParentId", "ChildType", "ChildId");
+                    b.HasKey("WalletId", "AType", "AId", "BType", "BId");
 
-                    b.HasIndex("WalletId", "ChildType", "ChildId");
+                    b.HasIndex("WalletId", "BType", "BId");
 
                     b.ToTable("WalletObjectLinks");
                 });
@@ -1384,21 +1384,21 @@ namespace BTCPayServer.Migrations
 
             modelBuilder.Entity("BTCPayServer.Data.WalletObjectLinkData", b =>
                 {
-                    b.HasOne("BTCPayServer.Data.WalletObjectData", "Child")
-                        .WithMany("ParentLinks")
-                        .HasForeignKey("WalletId", "ChildType", "ChildId")
+                    b.HasOne("BTCPayServer.Data.WalletObjectData", "A")
+                        .WithMany("Bs")
+                        .HasForeignKey("WalletId", "AType", "AId")
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
 
-                    b.HasOne("BTCPayServer.Data.WalletObjectData", "Parent")
-                        .WithMany("ChildLinks")
-                        .HasForeignKey("WalletId", "ParentType", "ParentId")
+                    b.HasOne("BTCPayServer.Data.WalletObjectData", "B")
+                        .WithMany("As")
+                        .HasForeignKey("WalletId", "BType", "BId")
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
 
-                    b.Navigation("Child");
+                    b.Navigation("A");
 
-                    b.Navigation("Parent");
+                    b.Navigation("B");
                 });
 
             modelBuilder.Entity("BTCPayServer.Data.WalletTransactionData", b =>
@@ -1545,9 +1545,9 @@ namespace BTCPayServer.Migrations
 
             modelBuilder.Entity("BTCPayServer.Data.WalletObjectData", b =>
                 {
-                    b.Navigation("ChildLinks");
+                    b.Navigation("As");
 
-                    b.Navigation("ParentLinks");
+                    b.Navigation("Bs");
                 });
 
             modelBuilder.Entity("BTCPayServer.Data.WebhookData", b =>

--- a/BTCPayServer/HostedServices/DbMigrationsHostedService.cs
+++ b/BTCPayServer/HostedServices/DbMigrationsHostedService.cs
@@ -173,10 +173,10 @@ next:
                             db.WalletObjectLinks.Add(new WalletObjectLinkData()
                             {
                                 WalletId = tx.WalletDataId,
-                                ChildType = Data.WalletObjectData.Types.Tx,
-                                ChildId = tx.TransactionId,
-                                ParentType = Data.WalletObjectData.Types.Label,
-                                ParentId = labelId
+                                BType = Data.WalletObjectData.Types.Tx,
+                                BId = tx.TransactionId,
+                                AType = Data.WalletObjectData.Types.Label,
+                                AId = labelId
                             });
 
                         if (label.Value is ReferenceLabel reflabel)
@@ -195,10 +195,10 @@ next:
                                     db.WalletObjectLinks.Add(new WalletObjectLinkData()
                                     {
                                         WalletId = tx.WalletDataId,
-                                        ChildType = Data.WalletObjectData.Types.Tx,
-                                        ChildId = tx.TransactionId,
-                                        ParentType = reflabel.Type,
-                                        ParentId = reflabel.Reference ?? String.Empty
+                                        BType = Data.WalletObjectData.Types.Tx,
+                                        BId = tx.TransactionId,
+                                        AType = reflabel.Type,
+                                        AId = reflabel.Reference ?? String.Empty
                                     });
                             }
                         }
@@ -224,10 +224,10 @@ next:
                                         db.WalletObjectLinks.Add(new WalletObjectLinkData()
                                         {
                                             WalletId = tx.WalletDataId,
-                                            ChildType = Data.WalletObjectData.Types.Tx,
-                                            ChildId = tx.TransactionId,
-                                            ParentType = "payout",
-                                            ParentId = payout
+                                            BType = Data.WalletObjectData.Types.Tx,
+                                            BId = tx.TransactionId,
+                                            AType = "payout",
+                                            AId = payout
                                         });
                                 }
                             }


### PR DESCRIPTION
The wallet object graph was directed before. It has been refactored already to be an undirected graph, as such we need to rename Parent/Child to just A/B.