### PR TITLE
Update incorrect "monitoringTime" field for invoice API docs

### DIFF
--- a/BTCPayServer/wwwroot/swagger/v1/swagger.template.invoices.json
+++ b/BTCPayServer/wwwroot/swagger/v1/swagger.template.invoices.json
@@ -789,8 +789,8 @@
                                     }
                                 ]
                             },
-                            "monitoringTime": {
-                                "description": "The monitoring time of the invoice",
+                            "monitoringExpiration": {
+                                "description": "Expiration time for monitoring of the invoice for any changes",
                                 "allOf": [
                                     {
                                         "$ref": "#/components/schemas/UnixTimestamp"


### PR DESCRIPTION
`monitoringTime` in Swagger docs was initially introduced in https://github.com/btcpayserver/btcpayserver/pull/1760, however, this field never actually existed in the code. What existed was `monitoringExpiration` which wasn't documented.

Close #4248