### PR TITLE
Ensure redirecturl is local for form builder

### DIFF
--- a/BTCPayServer/Forms/UIFormsController.cs
+++ b/BTCPayServer/Forms/UIFormsController.cs
@@ -26,11 +26,19 @@ namespace BTCPayServer.Forms;
 [Authorize(Policy = Policies.CanModifyStoreSettings, AuthenticationSchemes = AuthenticationSchemes.Cookie)]
 public class UIFormsController : Controller
 {
+    private bool IsValidRedirectUri(string? redirectUrl) =>
+        !string.IsNullOrEmpty(redirectUrl) && Uri.TryCreate(redirectUrl, UriKind.RelativeOrAbsolute, out var uri) &&
+        (Url.IsLocalUrl(redirectUrl) || uri.Host.Equals(Request.Host.ToString()));
+
     [AllowAnonymous]
     [HttpGet("~/forms/{formId}")]
     [HttpPost("~/forms")]
     public IActionResult ViewPublicForm(string? formId, string? redirectUrl)
     {
+        if (!IsValidRedirectUri(redirectUrl))
+        {
+            return BadRequest();
+        }
         FormData? formData = string.IsNullOrEmpty(formId) ? null : GetFormData(formId);
         if (formData == null)
         {
@@ -49,6 +57,10 @@ public class UIFormsController : Controller
         [FromServices] StoreRepository storeRepository,  
         [FromServices] UIInvoiceController invoiceController)
     {
+        if (!IsValidRedirectUri(redirectUrl))
+        {
+            return BadRequest();
+        }
         var formData = GetFormData(formId);
         if (formData?.Config is null)
         {


### PR DESCRIPTION
After Tempdata was replaced with query strings for formbuilder, the endpoint opened up some attack vectors as anyone could control the links instead of being set internally by the form entrypoint.

Attack vector example:
https://localhost:14142/forms/Email?redirectUrl=http://bitcoinsv.com