### PR TITLE
Fix error HTTP 500 happening on Point of Sale (Fix: #4355)

### DIFF
--- a/BTCPayServer/Controllers/UIPaymentRequestController.cs
+++ b/BTCPayServer/Controllers/UIPaymentRequestController.cs
@@ -194,17 +194,17 @@ namespace BTCPayServer.Controllers
 
             var prBlob = result.GetBlob();
             var prFormId = prBlob.FormId;
-            switch (prFormId)
+            var formConfig = prFormId is null ? null : Forms.UIFormsController.GetFormData(prFormId)?.Config;
+            switch (formConfig)
             {
                 case null:
-                case { } when string.IsNullOrEmpty(prFormId):
-                case { } when Request.Method == "GET" && prBlob.FormResponse is not null:
+                case { } when !this.Request.HasFormContentType && prBlob.FormResponse is not null:
                     return RedirectToAction("ViewPaymentRequest", new { payReqId });
-                case { } when Request.Method == "GET" && prBlob.FormResponse is null:
-                        break;
+                case { } when !this.Request.HasFormContentType && prBlob.FormResponse is null:
+                    break;
                 default:
                     // POST case: Handle form submit
-                    var formData = Form.Parse(UIFormsController.GetFormData(prFormId).Config);
+                    var formData = Form.Parse(formConfig);
                     formData.ApplyValuesFromForm(Request.Form);
                     if (FormProviders.Validate(formData, ModelState))
                     {

--- a/BTCPayServer/Forms/UIFormsController.cs
+++ b/BTCPayServer/Forms/UIFormsController.cs
@@ -57,7 +57,7 @@ public class UIFormsController : Controller
         if (formData?.Config is null)
             return NotFound();
         
-        if (command is not "Submit")
+        if (!Request.HasFormContentType)
             return GetFormView(formData, redirectUrl);
 
         var conf = Form.Parse(formData.Config);

--- a/BTCPayServer/Plugins/PointOfSale/Controllers/UIPointOfSaleController.cs
+++ b/BTCPayServer/Plugins/PointOfSale/Controllers/UIPointOfSaleController.cs
@@ -225,16 +225,16 @@ namespace BTCPayServer.Plugins.PointOfSale.Controllers
 
             var store = await _appService.GetStore(app);
             var posFormId = settings.FormId;
+
+            var formConfig = posFormId is null ? null : Forms.UIFormsController.GetFormData(posFormId)?.Config;
             JObject formResponse = null;
-            switch (posFormId)
+            switch (formConfig)
             {
                 case null:
-                case { } when string.IsNullOrEmpty(posFormId):
+                case { } when !this.Request.HasFormContentType:
                     break;
-                
                 default:
-                    // POST case: Handle form submit
-                    var formData = Form.Parse(Forms.UIFormsController.GetFormData(posFormId).Config);
+                    var formData = Form.Parse(formConfig);
                     formData.ApplyValuesFromForm(this.Request.Form);
 
                     if (FormProviders.Validate(formData, ModelState))

--- a/BTCPayServer/Services/Stores/CheckoutFormSelectList.cs
+++ b/BTCPayServer/Services/Stores/CheckoutFormSelectList.cs
@@ -36,5 +36,5 @@ public static class CheckoutFormSelectList
         typeof(GenericFormOption).DisplayName(opt.ToString());
 
     private static SelectListItem GenericOptionItem(GenericFormOption opt) =>
-        new() { Text = DisplayName(opt), Value = opt.ToString() };
+        new() { Text = DisplayName(opt), Value = opt == GenericFormOption.None ? null : opt.ToString() };
 }


### PR DESCRIPTION
If the user doesn't select any form, the form id would have the value `"None"` , which didn't exist.
I refactored the code to not only fix this bug, but also make sure that any invalid value wouldn't result in a crash.