### PR TITLE
App domain redirect

### DIFF
--- a/BTCPayServer.Tests/SeleniumTests.cs
+++ b/BTCPayServer.Tests/SeleniumTests.cs
@@ -839,10 +839,7 @@ namespace BTCPayServer.Tests
             s.Driver.FindElement(By.Id("SaveButton")).Click();
             s.Driver.ScrollTo(By.Id("RootAppId"));
             s.Driver.FindElement(By.Id("AddDomainButton")).Click();
-
-            var uri = new Uri(s.Driver.Url, UriKind.Absolute);
-            var domain = uri.AbsoluteUri.Replace(uri.AbsolutePath, "");
-            s.Driver.FindElement(By.Id("DomainToAppMapping_0__Domain")).SendKeys(domain);
+            s.Driver.FindElement(By.Id("DomainToAppMapping_0__Domain")).SendKeys(new Uri(s.Driver.Url, UriKind.Absolute).DnsSafeHost);
             select = new SelectElement(s.Driver.FindElement(By.Id("DomainToAppMapping_0__AppId")));
             select.SelectByText("Point of", true);
             s.Driver.FindElement(By.Id("SaveButton")).Click();

--- a/BTCPayServer.Tests/SeleniumTests.cs
+++ b/BTCPayServer.Tests/SeleniumTests.cs
@@ -839,10 +839,14 @@ namespace BTCPayServer.Tests
             s.Driver.FindElement(By.Id("SaveButton")).Click();
             s.Driver.ScrollTo(By.Id("RootAppId"));
             s.Driver.FindElement(By.Id("AddDomainButton")).Click();
-            s.Driver.FindElement(By.Id("DomainToAppMapping_0__Domain")).SendKeys(new Uri(s.Driver.Url, UriKind.Absolute).DnsSafeHost);
+
+            var uri = new Uri(s.Driver.Url, UriKind.Absolute);
+            var domain = uri.AbsoluteUri.Replace(uri.AbsolutePath, "");
+            s.Driver.FindElement(By.Id("DomainToAppMapping_0__Domain")).SendKeys(domain);
             select = new SelectElement(s.Driver.FindElement(By.Id("DomainToAppMapping_0__AppId")));
             select.SelectByText("Point of", true);
             s.Driver.FindElement(By.Id("SaveButton")).Click();
+            Assert.Contains("Policies updated successfully", s.FindAlertMessage().Text);
 
             s.Logout();
             s.LogIn(userId);

--- a/BTCPayServer/Controllers/UIAccountController.cs
+++ b/BTCPayServer/Controllers/UIAccountController.cs
@@ -758,27 +758,21 @@ namespace BTCPayServer.Controllers
             {
                 return Redirect(returnUrl);
             }
-            
+
             // After login, if there is an app on "/", we should redirect to BTCPay explicit home route, and not to the app.
             if (PoliciesSettings.RootAppId is not null && PoliciesSettings.RootAppType is not null)
                 return RedirectToAction(nameof(UIHomeController.Home), "UIHome");
 
-            if (PoliciesSettings.DomainToAppMapping is not { } mapping)
-                return RedirectToAction(nameof(UIHomeController.Index), "UIHome");
-            
-            var matchedDomainMapping = mapping.FirstOrDefault(item =>
+            if (PoliciesSettings.DomainToAppMapping is { } mapping)
             {
-                Uri.TryCreate(item.Domain, UriKind.Absolute, out var uri);
-                var host = HttpContext.Request.Host.Value;
-                var domain = uri?.Authority ?? item.Domain;
-                return domain!.Equals(host, StringComparison.InvariantCultureIgnoreCase);
-            });
-
-            return RedirectToAction(matchedDomainMapping is not null
-                ? nameof(UIHomeController.Home)
-                : nameof(UIHomeController.Index), "UIHome");
+                var matchedDomainMapping = mapping.FirstOrDefault(item =>
+                    item.Domain.Equals(HttpContext.Request.Host.Host, StringComparison.InvariantCultureIgnoreCase));
+                if (matchedDomainMapping is not null)
+                    return RedirectToAction(nameof(UIHomeController.Home), "UIHome");
+            }
+            
+            return RedirectToAction(nameof(UIHomeController.Index), "UIHome");
         }
-
 
         private bool CanLoginOrRegister()
         {

--- a/BTCPayServer/Filters/DomainMappingConstraintAttribute.cs
+++ b/BTCPayServer/Filters/DomainMappingConstraintAttribute.cs
@@ -35,29 +35,20 @@ namespace BTCPayServer.Filters
                 var matchedDomainMapping = mapping.FirstOrDefault(item => item.AppId == appId);
                 
                 // App is accessed via path, redirect to canonical domain
-                if (matchedDomainMapping != null && matchedDomainMapping.Domain.StartsWith("http"))
+                if (matchedDomainMapping != null)
                 {
-                    context.RouteContext.HttpContext.Response.Redirect(matchedDomainMapping.Domain);
+                    var req = context.RouteContext.HttpContext.Request;
+                    var url = new UriBuilder(req.Scheme, matchedDomainMapping.Domain).ToString();
+                    context.RouteContext.HttpContext.Response.Redirect(url);
                     return true;
                 }
             }
             
             if (hasDomainMapping)
             {
-                var matchedDomainMapping = mapping.FirstOrDefault(item =>
-                {
-                    if (Uri.CheckHostName(item.Domain) != UriHostNameType.Unknown)
-                    {
-                        return item.Domain.Equals(context.RouteContext.HttpContext.Request.Host.Value,
-                            StringComparison.InvariantCultureIgnoreCase);
-                    }
-                    if (Uri.TryCreate(item.Domain, UriKind.Absolute, out var uri))
-                    {
-                        return uri.Authority.Equals(context.RouteContext.HttpContext.Request.Host.Value,
-                            StringComparison.InvariantCultureIgnoreCase);
-                    }
-                    return false;
-                });
+                var matchedDomainMapping = mapping.FirstOrDefault(item => 
+                    item.Domain.Equals(context.RouteContext.HttpContext.Request.Host.Host,
+                        StringComparison.InvariantCultureIgnoreCase));
                 if (matchedDomainMapping != null)
                 {
                     if (AppType is not { } appType)

--- a/BTCPayServer/Filters/DomainMappingConstraintAttribute.cs
+++ b/BTCPayServer/Filters/DomainMappingConstraintAttribute.cs
@@ -1,11 +1,8 @@
 using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Threading.Tasks;
-using BTCPayServer.Abstractions.Contracts;
-using BTCPayServer.HostedServices;
 using BTCPayServer.Services;
 using BTCPayServer.Services.Apps;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.ActionConstraints;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -15,45 +12,71 @@ namespace BTCPayServer.Filters
     {
         public DomainMappingConstraintAttribute()
         {
-
         }
+        
         public DomainMappingConstraintAttribute(AppType appType)
         {
             AppType = appType;
         }
+        
         public int Order => 100;
-        public AppType? AppType { get; set; }
+        private AppType? AppType { get; }
 
         public bool Accept(ActionConstraintContext context)
         {
-            if (context.RouteContext.RouteData.Values.ContainsKey("appId"))
-                return true;
+            var hasAppId = context.RouteContext.RouteData.Values.ContainsKey("appId");
             var policies = context.RouteContext.HttpContext.RequestServices.GetService<PoliciesSettings>();
-            if (policies?.DomainToAppMapping is { } mapping)
+            var mapping = policies?.DomainToAppMapping;
+            var hasDomainMapping = mapping is { Count: > 0 };
+
+            if (hasAppId && hasDomainMapping)
+            {
+                var appId = (string)context.RouteContext.RouteData.Values["appId"];
+                var matchedDomainMapping = mapping.FirstOrDefault(item => item.AppId == appId);
+                
+                // App is accessed via path, redirect to canonical domain
+                if (matchedDomainMapping != null && matchedDomainMapping.Domain.StartsWith("http"))
+                {
+                    context.RouteContext.HttpContext.Response.Redirect(matchedDomainMapping.Domain);
+                    return true;
+                }
+            }
+            
+            if (hasDomainMapping)
             {
                 var matchedDomainMapping = mapping.FirstOrDefault(item =>
-                item.Domain.Equals(context.RouteContext.HttpContext.Request.Host.Host, StringComparison.InvariantCultureIgnoreCase));
+                {
+                    if (Uri.CheckHostName(item.Domain) != UriHostNameType.Unknown)
+                    {
+                        return item.Domain.Equals(context.RouteContext.HttpContext.Request.Host.Value,
+                            StringComparison.InvariantCultureIgnoreCase);
+                    }
+                    if (Uri.TryCreate(item.Domain, UriKind.Absolute, out var uri))
+                    {
+                        return uri.Authority.Equals(context.RouteContext.HttpContext.Request.Host.Value,
+                            StringComparison.InvariantCultureIgnoreCase);
+                    }
+                    return false;
+                });
                 if (matchedDomainMapping != null)
                 {
-                    if (!(AppType is { } appType))
+                    if (AppType is not { } appType)
                         return false;
                     if (appType != matchedDomainMapping.AppType)
                         return false;
                     context.RouteContext.RouteData.Values.Add("appId", matchedDomainMapping.AppId);
                     return true;
                 }
-
-                if (AppType == policies.RootAppType)
-                {
-                    context.RouteContext.RouteData.Values.Add("appId", policies.RootAppId);
-
-                    return true;
-                }
-
-                return AppType is null;
             }
 
-            return AppType is null;
+            if (AppType == policies.RootAppType)
+            {
+                context.RouteContext.RouteData.Values.Add("appId", policies.RootAppId);
+
+                return true;
+            }
+
+            return hasAppId || AppType is null;
         }
     }
 }

--- a/BTCPayServer/Services/Apps/AppService.cs
+++ b/BTCPayServer/Services/Apps/AppService.cs
@@ -443,7 +443,7 @@ namespace BTCPayServer.Services.Apps
                     (storeId == null || us.StoreDataId == storeId))
                 .Join(ctx.Apps, us => us.StoreDataId, app => app.StoreDataId,
                     (us, app) =>
-                        new ListAppsViewModel.ListAppViewModel()
+                        new ListAppsViewModel.ListAppViewModel
                         {
                             IsOwner = us.Role == StoreRoles.Owner,
                             StoreId = us.StoreDataId,
@@ -455,6 +455,12 @@ namespace BTCPayServer.Services.Apps
                         })
                 .OrderBy(b => b.Created)
                 .ToArrayAsync();
+            
+            // allowNoUser can lead to apps being included twice, unify them with distinct
+            if (allowNoUser)
+            {
+                listApps = listApps.DistinctBy(a => a.Id).ToArray();
+            }
 
             foreach (ListAppsViewModel.ListAppViewModel app in listApps)
             {

--- a/BTCPayServer/Services/PoliciesSettings.cs
+++ b/BTCPayServer/Services/PoliciesSettings.cs
@@ -2,7 +2,6 @@ using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using BTCPayServer.Services.Apps;
 using BTCPayServer.Validation;
-using Microsoft.AspNetCore.Routing;
 using Newtonsoft.Json;
 
 namespace BTCPayServer.Services
@@ -63,7 +62,7 @@ namespace BTCPayServer.Services
 
         public class DomainToAppMappingItem
         {
-            [Display(Name = "Domain")] [Required] [Uri] public string Domain { get; set; }
+            [Display(Name = "Domain")] [Required] [HostName] public string Domain { get; set; }
             [Display(Name = "App")] [Required] public string AppId { get; set; }
 
             public AppType AppType { get; set; }

--- a/BTCPayServer/Services/PoliciesSettings.cs
+++ b/BTCPayServer/Services/PoliciesSettings.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using BTCPayServer.Services.Apps;
 using BTCPayServer.Validation;
+using Microsoft.AspNetCore.Routing;
 using Newtonsoft.Json;
 
 namespace BTCPayServer.Services
@@ -62,7 +63,7 @@ namespace BTCPayServer.Services
 
         public class DomainToAppMappingItem
         {
-            [Display(Name = "Domain")] [Required] [HostName] public string Domain { get; set; }
+            [Display(Name = "Domain")] [Required] [Uri] public string Domain { get; set; }
             [Display(Name = "App")] [Required] public string AppId { get; set; }
 
             public AppType AppType { get; set; }


### PR DESCRIPTION
An experimental stab at #4384: If present, it uses the domain mapping of an app as canonical reference and redirects to it.

Marking this as experimental and inviting discussing, because the behaviour of the `DomainMappingConstraint` needed to change quite a bit: 

- Before it exited early if the `appId` is present (direct access to the POS path, not the domain mapping)
- To make the domain mapping canonical we now need to check if there's a mapping for the app
- If so, we redirect to the mapped domain if it starts with `http`

For the latter, the `DomainToAppMappingItem.Domain` also needed a change:

- Before it strictly validated this property to be a hostname (e.g. `mybtcpay.com`)
- Now it accepts a URI, so that it can also include the protocol (and port, which is nice for local testing, e.g. `https://localhost:14142`)
- Sidenote: imho this improves the UX a bit as I assume most users wouldn't discern between a URL and strict hostname when we ask them to enter a domain. (I was also wondering why the port isn't allowed — in production this wouldn't be used anyways, but it would help with local dev and testing)

The implementation works in a backwards compatible-manner and would require the "domain" part of the mapping to be defined as a URI to redirect and work as intended in #4384.

The fix in a73b893284d7c00bc640be8df05328f13644cff6 is something I found along the way of implementing this, because I saw that the app list in the ViewBag grew.
