### PR TITLE
[Greenfield]: Add DescriptionHashOnly to include a description hash in the BOLT11

### DIFF
--- a/BTCPayServer.Client/BTCPayServer.Client.csproj
+++ b/BTCPayServer.Client/BTCPayServer.Client.csproj
@@ -28,7 +28,7 @@
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
   </ItemGroup>
     <ItemGroup>
-      <PackageReference Include="BTCPayServer.Lightning.Common" Version="1.3.16" />
+      <PackageReference Include="BTCPayServer.Lightning.Common" Version="1.3.17" />
       <PackageReference Include="NBitcoin" Version="7.0.20" />
       <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     </ItemGroup>

--- a/BTCPayServer.Client/Models/CreateLightningInvoiceRequest.cs
+++ b/BTCPayServer.Client/Models/CreateLightningInvoiceRequest.cs
@@ -22,8 +22,7 @@ namespace BTCPayServer.Client.Models
         [JsonConverter(typeof(JsonConverters.LightMoneyJsonConverter))]
         public LightMoney Amount { get; set; }
         public string Description { get; set; }
-        [JsonConverter(typeof(NBitcoin.JsonConverters.UInt256JsonConverter))]
-        public uint256 DescriptionHash { get; set; }
+        public bool DescriptionHashOnly { get; set; }
         [JsonConverter(typeof(JsonConverters.TimeSpanJsonConverter.Seconds))]
         public TimeSpan Expiry { get; set; }
         public bool PrivateRouteHints { get; set; }

--- a/BTCPayServer/Controllers/UILNURLController.cs
+++ b/BTCPayServer/Controllers/UILNURLController.cs
@@ -565,14 +565,14 @@ namespace BTCPayServer
                         }
                     }
 
-                    var descriptionHash = new uint256(Hashes.SHA256(Encoding.UTF8.GetBytes(metadata)), false);
                     LightningInvoice invoice;
                     try
                     {
                         var expiry = i.ExpirationTime.ToUniversalTime() - DateTimeOffset.UtcNow;
-                        var param = new CreateInvoiceParams(amount.Value, descriptionHash, expiry)
+                        var param = new CreateInvoiceParams(amount.Value, metadata, expiry)
                         {
-                            PrivateRouteHints = blob.LightningPrivateRouteHints
+                            PrivateRouteHints = blob.LightningPrivateRouteHints,
+                            DescriptionHashOnly = true
                         };
                         invoice = await client.CreateInvoice(param);
                         if (!BOLT11PaymentRequest.Parse(invoice.BOLT11, network.NBitcoinNetwork)

--- a/BTCPayServer/wwwroot/swagger/v1/swagger.template.lightning.common.json
+++ b/BTCPayServer/wwwroot/swagger/v1/swagger.template.lightning.common.json
@@ -25,12 +25,12 @@
                         "nullable": true,
                         "description": "Description of the invoice in the BOLT11"
                     },
-                  "descriptionHashOnly": {
-                    "type": "boolean",
-                    "nullable": true,
-                    "default": false,
-                    "description": "If `deschashonly` is `true` (default false), then the bolt11 returned contains a hash of the `description`, rather than the `description`, itself: this allows much longer descriptions, but they must be communicated via some other mechanism."
-                  },
+                    "descriptionHashOnly": {
+                        "type": "boolean",
+                        "nullable": true,
+                        "default": false,
+                        "description": "If `descriptionHashOnly` is `true` (default is `false`), then the BOLT11 returned contains a hash of the `description`, rather than the `description`, itself. This allows for much longer descriptions, but they must be communicated via some other mechanism."
+                    },
                     "expiry": {
                         "description": "Expiration time in seconds",
                         "allOf": [ {"$ref": "#/components/schemas/TimeSpanSeconds"}]

--- a/BTCPayServer/wwwroot/swagger/v1/swagger.template.lightning.common.json
+++ b/BTCPayServer/wwwroot/swagger/v1/swagger.template.lightning.common.json
@@ -25,12 +25,12 @@
                         "nullable": true,
                         "description": "Description of the invoice in the BOLT11"
                     },
-                    "descriptionHash": {
-                        "type": "string",
-                        "format": "hex",
-                        "nullable": true,
-                        "description": "Description hash of the invoice in the BOLT11"
-                    },
+                  "descriptionHashOnly": {
+                    "type": "boolean",
+                    "nullable": true,
+                    "default": false,
+                    "description": "If `deschashonly` is `true` (default false), then the bolt11 returned contains a hash of the `description`, rather than the `description`, itself: this allows much longer descriptions, but they must be communicated via some other mechanism."
+                  },
                     "expiry": {
                         "description": "Expiration time in seconds",
                         "allOf": [ {"$ref": "#/components/schemas/TimeSpanSeconds"}]


### PR DESCRIPTION
Update dependency to core lightning library (See https://github.com/btcpayserver/BTCPayServer.Lightning/pull/110)

People running clightning 22.11 will not need the plugin `invoicewithdescriptionhash` anymore.

There is also a breaking change in the Greenfield API.
Routes to create new lightning invoices were previously accepting a parameter `descriptionHash` in order to create a BOLT11 with the description hash inside.
This property has been removed, instead we have a boolean `descriptionHashOnly`. Users who wants the same functionality as before need to set `description` and turn the `descriptionHashOnly` to true.

I tried to maintain backward compatibility, but this was a bit too complicated, and the the previous API was fundamentally flawed and untested. I guess it is almost unused, so this should be OK.