### PR TITLE
Use better default than coingecko when creating a new store

### DIFF
--- a/BTCPayServer.Tests/SeleniumTester.cs
+++ b/BTCPayServer.Tests/SeleniumTester.cs
@@ -176,6 +176,7 @@ namespace BTCPayServer.Tests
             var name = "Store" + RandomUtils.GetUInt64();
             TestLogs.LogInformation($"Created store {name}");
             Driver.WaitForElement(By.Id("Name")).SendKeys(name);
+            new SelectElement(Driver.FindElement(By.Id("PreferredExchange"))).SelectByText("CoinGecko");
             Driver.WaitForElement(By.Id("Create")).Click();
             Driver.FindElement(By.Id("StoreNav-StoreSettings")).Click();
             Driver.FindElement(By.Id($"SectionNav-{StoreNavPages.General.ToString()}")).Click();

--- a/BTCPayServer.Tests/TestAccount.cs
+++ b/BTCPayServer.Tests/TestAccount.cs
@@ -174,7 +174,7 @@ namespace BTCPayServer.Tests
                 await RegisterAsync();
             }
             var store = GetController<UIUserStoresController>();
-            await store.CreateStore(new CreateStoreViewModel { Name = "Test Store" });
+            await store.CreateStore(new CreateStoreViewModel { Name = "Test Store", PreferredExchange = "coingecko" });
             StoreId = store.CreatedStoreId;
             parent.Stores.Add(StoreId);
         }

--- a/BTCPayServer/Controllers/UIStoresController.cs
+++ b/BTCPayServer/Controllers/UIStoresController.cs
@@ -201,7 +201,7 @@ namespace BTCPayServer.Controllers
             var exchanges = GetSupportedExchanges();
             var storeBlob = CurrentStore.GetStoreBlob();
             var vm = new RatesViewModel();
-            vm.SetExchangeRates(exchanges, storeBlob.PreferredExchange ?? CoinGeckoRateProvider.CoinGeckoName);
+            vm.SetExchangeRates(exchanges, storeBlob.PreferredExchange ?? storeBlob.GetRecommendedExchange());
             vm.Spread = (double)(storeBlob.Spread * 100m);
             vm.StoreId = CurrentStore.Id;
             vm.Script = storeBlob.GetRateRules(_NetworkProvider).ToString();
@@ -225,7 +225,7 @@ namespace BTCPayServer.Controllers
             }
 
             var exchanges = GetSupportedExchanges();
-            model.SetExchangeRates(exchanges, model.PreferredExchange);
+            model.SetExchangeRates(exchanges, model.PreferredExchange ?? this.HttpContext.GetStoreData().GetStoreBlob().GetRecommendedExchange());
             model.StoreId = storeId ?? model.StoreId;
             CurrencyPair[]? currencyPairs = null;
             try

--- a/BTCPayServer/Controllers/UIUserStoresController.cs
+++ b/BTCPayServer/Controllers/UIUserStoresController.cs
@@ -44,7 +44,7 @@ namespace BTCPayServer.Controllers
             var vm = new CreateStoreViewModel
             {
                 DefaultCurrency = StoreBlob.StandardDefaultCurrency,
-                Exchanges = GetExchangesSelectList(CoinGeckoRateProvider.CoinGeckoName)
+                Exchanges = GetExchangesSelectList(null)
             };
 
             return View(vm);
@@ -99,7 +99,9 @@ namespace BTCPayServer.Controllers
             var exchanges = _rateFactory.RateProviderFactory
                 .GetSupportedExchanges()
                 .Where(r => !string.IsNullOrWhiteSpace(r.Name))
-                .OrderBy(s => s.Id, StringComparer.OrdinalIgnoreCase);
+                .OrderBy(s => s.Id, StringComparer.OrdinalIgnoreCase)
+                .ToList();
+            exchanges.Insert(0, new AvailableRateProvider(null, "Recommended", ""));
             var chosen = exchanges.FirstOrDefault(f => f.Id == selected) ?? exchanges.First();
             return new SelectList(exchanges, nameof(chosen.Id), nameof(chosen.Name), chosen.Id);
         }

--- a/BTCPayServer/Data/StoreBlob.cs
+++ b/BTCPayServer/Data/StoreBlob.cs
@@ -178,20 +178,19 @@ namespace BTCPayServer.Data
             return rules;
         }
 
-        public string GetRecommendedExchange()
+        public static JObject RecommendedExchanges = new ()
         {
-            return DefaultCurrency switch
-            {
-                "EUR" => "kraken",
-                "USD" => "kraken",
-                "GBP" => "kraken",
-                "CHF" => "kraken",
-                "GTQ" => "bitpay",
-                "COP" => "yadio",
-                "JPY" => "bitbank",
-                _ => "coingecko"
-            };
-        }
+            { "EUR", "kraken" },
+            { "USD", "kraken" },
+            { "GBP", "kraken" },
+            { "CHF", "kraken" },
+            { "GTQ", "yadio" },
+            { "COP", "kraken" },
+            { "JPY", "bitbank" }
+        };
+
+        public string GetRecommendedExchange() =>
+            RecommendedExchanges.Property(DefaultCurrency)?.Value.ToString() ?? "coingecko";
 
         [Obsolete("Use GetExcludedPaymentMethods instead")]
         public string[] ExcludedPaymentMethods { get; set; }

--- a/BTCPayServer/Data/StoreBlob.cs
+++ b/BTCPayServer/Data/StoreBlob.cs
@@ -170,12 +170,27 @@ namespace BTCPayServer.Data
                 }
             }
 
-            var preferredExchange = string.IsNullOrEmpty(PreferredExchange) ? CoinGeckoRateProvider.CoinGeckoName : PreferredExchange;
+            var preferredExchange = string.IsNullOrEmpty(PreferredExchange) ? GetRecommendedExchange() : PreferredExchange;
             builder.AppendLine(CultureInfo.InvariantCulture, $"X_X = {preferredExchange}(X_X);");
 
             BTCPayServer.Rating.RateRules.TryParse(builder.ToString(), out var rules);
             rules.Spread = Spread;
             return rules;
+        }
+
+        public string GetRecommendedExchange()
+        {
+            return DefaultCurrency switch
+            {
+                "EUR" => "kraken",
+                "USD" => "kraken",
+                "GBP" => "kraken",
+                "CHF" => "kraken",
+                "GTQ" => "bitpay",
+                "COP" => "yadio",
+                "JPY" => "bitbank",
+                _ => "coingecko"
+            };
         }
 
         [Obsolete("Use GetExcludedPaymentMethods instead")]

--- a/BTCPayServer/Data/StoreBlob.cs
+++ b/BTCPayServer/Data/StoreBlob.cs
@@ -186,7 +186,8 @@ namespace BTCPayServer.Data
             { "CHF", "kraken" },
             { "GTQ", "yadio" },
             { "COP", "kraken" },
-            { "JPY", "bitbank" }
+            { "JPY", "bitbank" },
+            { "TRY", "btcturk" }
         };
 
         public string GetRecommendedExchange() =>

--- a/BTCPayServer/Data/StoreBlob.cs
+++ b/BTCPayServer/Data/StoreBlob.cs
@@ -184,8 +184,8 @@ namespace BTCPayServer.Data
             { "USD", "kraken" },
             { "GBP", "kraken" },
             { "CHF", "kraken" },
-            { "GTQ", "yadio" },
-            { "COP", "kraken" },
+            { "GTQ", "bitpay" },
+            { "COP", "yadio" },
             { "JPY", "bitbank" },
             { "TRY", "btcturk" }
         };

--- a/BTCPayServer/Data/StoreDataExtensions.cs
+++ b/BTCPayServer/Data/StoreDataExtensions.cs
@@ -49,7 +49,7 @@ namespace BTCPayServer.Data
         {
             var result = storeData.StoreBlob == null ? new StoreBlob() : new Serializer(null).ToObject<StoreBlob>(storeData.StoreBlob);
             if (result.PreferredExchange == null)
-                result.PreferredExchange = CoinGeckoRateProvider.CoinGeckoName;
+                result.PreferredExchange = result.GetRecommendedExchange();
             if (result.PaymentMethodCriteria is null)
                 result.PaymentMethodCriteria = new List<PaymentMethodCriteria>();
             result.PaymentMethodCriteria.RemoveAll(criteria => criteria?.PaymentMethod is null);

--- a/BTCPayServer/Models/StoreViewModels/CreateStoreViewModel.cs
+++ b/BTCPayServer/Models/StoreViewModels/CreateStoreViewModel.cs
@@ -15,7 +15,6 @@ namespace BTCPayServer.Models.StoreViewModels
         [Display(Name = "Default currency")]
         public string DefaultCurrency { get; set; }
 
-        [Required]
         [Display(Name = "Preferred Price Source")]
         public string PreferredExchange { get; set; }
         

--- a/BTCPayServer/Models/StoreViewModels/RatesViewModel.cs
+++ b/BTCPayServer/Models/StoreViewModels/RatesViewModel.cs
@@ -19,9 +19,8 @@ namespace BTCPayServer.Models.StoreViewModels
         
         public void SetExchangeRates(IEnumerable<AvailableRateProvider> supportedList, string preferredExchange)
         {
-            var defaultStore = preferredExchange ?? CoinGeckoRateProvider.CoinGeckoName;
             supportedList = supportedList.Select(a => new AvailableRateProvider(a.Id, a.SourceId, a.DisplayName, a.Url, a.Source)).ToArray();
-            var chosen = supportedList.FirstOrDefault(f => f.Id == defaultStore) ?? supportedList.FirstOrDefault();
+            var chosen = supportedList.FirstOrDefault(f => f.Id == preferredExchange) ?? supportedList.FirstOrDefault();
             Exchanges = new SelectList(supportedList, nameof(chosen.Id), nameof(chosen.Name), chosen);
             PreferredExchange = chosen?.Id;
             RateSource = chosen?.Url;

--- a/BTCPayServer/Views/UIUserStores/CreateStore.cshtml
+++ b/BTCPayServer/Views/UIUserStores/CreateStore.cshtml
@@ -5,6 +5,17 @@
 
 @section PageFootContent {
     <partial name="_ValidationScriptsPartial"/>
+    <script>
+        const exchanges = @Safe.Json(StoreBlob.RecommendedExchanges);
+        const recommended = document.querySelector("#PreferredExchange option[value='']")
+        const updateRecommended = currency => {
+            const source = exchanges[currency] || 'coingecko'
+            const name = source.charAt(0).toUpperCase() + source.slice(1)
+            recommended.innerText = `Recommended (${name})`
+        }
+        updateRecommended(@Safe.Json(Model.DefaultCurrency))
+        delegate('change', '#DefaultCurrency', e => updateRecommended(e.target.value))
+    </script>
 }
 
 <partial name="_StatusMessage" />
@@ -27,6 +38,7 @@
             <div class="form-group">
                 <label asp-for="PreferredExchange" class="form-label" data-required></label>
                 <select asp-for="PreferredExchange" asp-items="Model.Exchanges" class="form-select w-300px"></select>
+                <div class="form-text mt-2 only-for-js">The recommended price source gets chosen based on the default currency.</div>
                 <span asp-validation-for="PreferredExchange" class="text-danger"></span>
             </div>
             <div class="form-group mt-4">


### PR DESCRIPTION
Many people do not pay attention to set the rate source when creating a store.
While coingecko is kind of the best guess if we had no information about the currency, it turns out we know the currency.

This PR attempt to select a better recommendation based on the default currency of the store at creation time.

```csharp
public string GetRecommendedExchange()
{
return DefaultCurrency switch
{
    "EUR" => "kraken",
    "USD" => "kraken",
    "GBP" => "kraken",
    "CHF" => "kraken",
    "GTQ" => "bitpay",
    "COP" => "yadio",
    "JPY" => "bitbank",
    _ => "coingecko"
};
}
```

![image](https://user-images.githubusercontent.com/3020646/206377171-2e6135e8-3602-459b-b3f1-344b3469d9e8.png)

Please give other recommendations on https://docs.google.com/forms/d/e/1FAIpQLSd_r7N9tKzmzKACh7vEqJzSjNIpQzrNK5he_wbUor5mnb1-lg/viewform?usp=sf_link or in response to this PR.