### PR TITLE
Have address wallet objects rather than script objects

### DIFF
--- a/BTCPayServer.Common/BTCPayServer.Common.csproj
+++ b/BTCPayServer.Common/BTCPayServer.Common.csproj
@@ -4,7 +4,7 @@
 
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="NBXplorer.Client" Version="4.2.1" />
+    <PackageReference Include="NBXplorer.Client" Version="4.2.2" />
     <PackageReference Include="NicolasDorier.StandardConfiguration" Version="1.0.0.18" />
   </ItemGroup>
   <ItemGroup Condition="'$(Altcoins)' != 'true'">

--- a/BTCPayServer.Data/Data/WalletObjectData.cs
+++ b/BTCPayServer.Data/Data/WalletObjectData.cs
@@ -21,7 +21,7 @@ namespace BTCPayServer.Data
             public const string PayjoinExposed = "pj-exposed";
             public const string Payout = "payout";
             public const string PullPayment = "pull-payment";
-            public const string Script = "script";
+            public const string Address = "address";
             public const string Utxo = "utxo";
         }
         public string WalletId { get; set; }

--- a/BTCPayServer.Tests/FastTests.cs
+++ b/BTCPayServer.Tests/FastTests.cs
@@ -678,7 +678,7 @@ namespace BTCPayServer.Tests
             parser = new DerivationSchemeParser(networkProvider.BTC);
             var od = "wpkh([8bafd160/49h/0h/0h]xpub661MyMwAqRbcGVBsTGeNZN6QGVHmMHLdSA4FteGsRrEriu4pnVZMZWnruFFFXkMnyoBjyHndD3Qwcfz4MPzBUxjSevweNFQx7SAYZATtcDw/0/*)#9x4vkw48";
             (strategyBase, rootedKeyPath) = parser.ParseOutputDescriptor(od);
-            Assert.Equal(1, rootedKeyPath.Length);
+            Assert.Single(rootedKeyPath);
             Assert.IsType<DirectDerivationStrategy>(strategyBase);
             Assert.True(((DirectDerivationStrategy)strategyBase).Segwit);
             

--- a/BTCPayServer.Tests/GreenfieldAPITests.cs
+++ b/BTCPayServer.Tests/GreenfieldAPITests.cs
@@ -1936,7 +1936,7 @@ namespace BTCPayServer.Tests
                     }
                 });
             var invoiceObject = await client.GetOnChainWalletObject(user.StoreId, "BTC", new OnChainWalletObjectId("invoice", newInvoice.Id), false);
-            Assert.Contains(invoiceObject.Links.Select(l => l.Type), t => t == "script");
+            Assert.Contains(invoiceObject.Links.Select(l => l.Type), t => t == "address");
 
             Assert.EndsWith($"/i/{newInvoice.Id}", newInvoice.CheckoutLink);
             var controller = tester.PayTester.GetController<UIInvoiceController>(user.UserId, user.StoreId);
@@ -1972,7 +1972,7 @@ namespace BTCPayServer.Tests
 
             invoice = await client.CreateInvoice(user.StoreId, new CreateInvoiceRequest() { Amount = 1, Currency = "USD" });
             invoiceObject = await client.GetOnChainWalletObject(user.StoreId, "BTC", new OnChainWalletObjectId("invoice", invoice.Id), false);
-            Assert.DoesNotContain(invoiceObject.Links.Select(l => l.Type), t => t == "script");
+            Assert.DoesNotContain(invoiceObject.Links.Select(l => l.Type), t => t == "address");
 
 
             paymentMethods = await client.GetInvoicePaymentMethods(store.Id, invoice.Id);
@@ -1981,7 +1981,7 @@ namespace BTCPayServer.Tests
             await client.ActivateInvoicePaymentMethod(user.StoreId, invoice.Id,
                 paymentMethods.First().PaymentMethod);
             invoiceObject = await client.GetOnChainWalletObject(user.StoreId, "BTC", new OnChainWalletObjectId("invoice", invoice.Id), false);
-            Assert.Contains(invoiceObject.Links.Select(l => l.Type), t => t == "script");
+            Assert.Contains(invoiceObject.Links.Select(l => l.Type), t => t == "address");
 
             paymentMethods = await client.GetInvoicePaymentMethods(store.Id, invoice.Id);
             Assert.Single(paymentMethods);
@@ -2046,10 +2046,10 @@ namespace BTCPayServer.Tests
                 var pm = Assert.Single(await client.GetInvoicePaymentMethods(user.StoreId, invoice.Id));
                 Assert.Single(pm.Payments);
                 Assert.Equal(-0.0001m, pm.Due);
-            });
 
-            invoiceObject = await client.GetOnChainWalletObject(user.StoreId, "BTC", new OnChainWalletObjectId("invoice", invoice.Id), false);
-            Assert.Contains(invoiceObject.Links.Select(l => l.Type), t => t == "tx");
+                invoiceObject = await client.GetOnChainWalletObject(user.StoreId, "BTC", new OnChainWalletObjectId("invoice", invoice.Id), false);
+                Assert.Contains(invoiceObject.Links.Select(l => l.Type), t => t == "tx");
+            });
         }
 
         [Fact(Timeout = 60 * 20 * 1000)]

--- a/BTCPayServer.Tests/docker-compose.altcoins.yml
+++ b/BTCPayServer.Tests/docker-compose.altcoins.yml
@@ -90,7 +90,7 @@ services:
     expose:
       - "4444"
   nbxplorer:
-    image: nicolasdorier/nbxplorer:2.3.40
+    image: nicolasdorier/nbxplorer:2.3.54
     restart: unless-stopped
     ports:
       - "32838:32838"

--- a/BTCPayServer.Tests/docker-compose.yml
+++ b/BTCPayServer.Tests/docker-compose.yml
@@ -87,7 +87,7 @@ services:
     expose:
       - "4444"
   nbxplorer:
-    image: nicolasdorier/nbxplorer:2.3.40
+    image: nicolasdorier/nbxplorer:2.3.54
     restart: unless-stopped
     ports:
       - "32838:32838"

--- a/BTCPayServer/Controllers/UIInvoiceController.cs
+++ b/BTCPayServer/Controllers/UIInvoiceController.cs
@@ -391,8 +391,8 @@ namespace BTCPayServer.Controllers
                             await _walletRepository.EnsureWalletObjectLink(
                             new WalletObjectId(
                                 walletId,
-                                WalletObjectData.Types.Script,
-                                address.ScriptPubKey.ToHex()),
+                                WalletObjectData.Types.Address,
+                                address.ToString()),
                             new WalletObjectId(
                                 walletId,
                                 WalletObjectData.Types.Invoice,

--- a/BTCPayServer/Services/InvoiceActivator.cs
+++ b/BTCPayServer/Services/InvoiceActivator.cs
@@ -66,8 +66,8 @@ namespace BTCPayServer.Services
                             await _walletRepository.EnsureWalletObjectLink(
                             new WalletObjectId(
                                 walletId,
-                                WalletObjectData.Types.Script,
-                                address.ScriptPubKey.ToHex()),
+                                WalletObjectData.Types.Address,
+                                address.ToString()),
                             new WalletObjectId(
                                 walletId,
                                 WalletObjectData.Types.Invoice,

--- a/BTCPayServer/Services/WalletRepository.cs
+++ b/BTCPayServer/Services/WalletRepository.cs
@@ -52,16 +52,11 @@ namespace BTCPayServer.Services
         public string[]? Ids { get; set; }
         public bool IncludeNeighbours { get; set; } = true;
         public bool UseInefficientPath { get; set; }
-        
-        public static ObjectTypeId Get(Script script)
-        {
-            return new ObjectTypeId(WalletObjectData.Types.Script, script.ToHex());
-        }
 
         public static IEnumerable<ObjectTypeId> Get(ReceivedCoin coin)
         {
             yield return new ObjectTypeId(WalletObjectData.Types.Tx, coin.OutPoint.Hash.ToString());
-            yield return Get(coin.ScriptPubKey);
+            yield return new ObjectTypeId(WalletObjectData.Types.Address, coin.Address.ToString());
             yield return new ObjectTypeId(WalletObjectData.Types.Utxo, coin.OutPoint.ToString());
         }
     }
@@ -250,7 +245,7 @@ namespace BTCPayServer.Services
         {
             var wos = await GetWalletObjects(
                 new GetWalletObjectsQuery(walletId, WalletObjectData.Types.Tx, transactionIds));
-            return await GetWalletTransactionsInfoCore(walletId, wos);
+            return GetWalletTransactionsInfoCore(walletId, wos);
         }
 
         public async Task<Dictionary<string, WalletTransactionInfo>> GetWalletTransactionsInfo(WalletId walletId,
@@ -259,10 +254,10 @@ namespace BTCPayServer.Services
             var wos = await GetWalletObjects(
                 new GetWalletObjectsQuery(walletId, transactionIds));
             
-            return await GetWalletTransactionsInfoCore(walletId, wos);
+            return GetWalletTransactionsInfoCore(walletId, wos);
         }
 
-        private async Task<Dictionary<string, WalletTransactionInfo>> GetWalletTransactionsInfoCore(WalletId walletId,
+        private Dictionary<string, WalletTransactionInfo> GetWalletTransactionsInfoCore(WalletId walletId,
             Dictionary<WalletObjectId, WalletObjectData> wos)
         {
        

--- a/BTCPayServer/Services/Wallets/BTCPayWallet.cs
+++ b/BTCPayServer/Services/Wallets/BTCPayWallet.cs
@@ -27,6 +27,7 @@ namespace BTCPayServer.Services.Wallets
         public IMoney Value { get; set; }
         public Coin Coin { get; set; }
         public long Confirmations { get; set; }
+        public BitcoinAddress Address { get; set; }
     }
     public class NetworkCoins
     {
@@ -91,7 +92,7 @@ namespace BTCPayServer.Services.Wallets
             if (storeId != null)
             {
                 await WalletRepository.EnsureWalletObject(
-                    new WalletObjectId(new WalletId(storeId, Network.CryptoCode), WalletObjectData.Types.Script, pathInfo.ScriptPubKey.ToHex()),
+                    new WalletObjectId(new WalletId(storeId, Network.CryptoCode), WalletObjectData.Types.Address, pathInfo.Address.ToString()),
                     new JObject() { ["generatedBy"] = generatedBy });
             }
             return pathInfo;
@@ -360,7 +361,9 @@ namespace BTCPayServer.Services.Wallets
                               OutPoint = c.Outpoint,
                               ScriptPubKey = c.ScriptPubKey,
                               Coin = c.AsCoin(derivationStrategy),
-                              Confirmations = c.Confirmations
+                              Confirmations = c.Confirmations,
+                              // Some old version of NBX doesn't have Address in this call
+                              Address = c.Address ?? c.ScriptPubKey.GetDestinationAddress(Network.NBitcoinNetwork)
                           }).ToArray();
         }
 


### PR DESCRIPTION
I was talking with @Kukks about it.

Currently we create `script` wallet objects, but the wallet objects is a tool aimed at being exposed to the user.
As such scripts are too low level, instead we should put addresses.

Sadly, NBXplorer doesn't return all the data we need for this right now.
So I updated NBXplorer to get the addresses, and if we don't have those, then we fallback to trying to guess the address from the scriptPubKey. This fallback would give unexpected result for liquid blinded addresses, but that's not too bad.