### PR TITLE
Remove system plugins from the plugin list

### DIFF
--- a/BTCPayServer/Plugins/PluginManager.cs
+++ b/BTCPayServer/Plugins/PluginManager.cs
@@ -123,8 +123,12 @@ namespace BTCPayServer.Plugins
                     _plugins.Add(plugin);
                     var fileProvider = CreateEmbeddedFileProviderForAssembly(pluginAssembly);
                     loadedPlugins.Add((plugin, pluginAssembly, fileProvider));
-                    plugins.AddRange(GetAllPluginTypesFromAssembly(pluginAssembly)
-                        .Select(GetPluginInstanceFromType));
+                    foreach (var p in GetAllPluginTypesFromAssembly(pluginAssembly)
+                        .Select(GetPluginInstanceFromType))
+                    {
+                        p.SystemPlugin = false;
+                        plugins.Add(p);
+                    }
 
                 }
                 catch (Exception e)

--- a/BTCPayServer/Plugins/PluginService.cs
+++ b/BTCPayServer/Plugins/PluginService.cs
@@ -52,6 +52,7 @@ namespace BTCPayServer.Plugins
             {
                 var p = v.ManifestInfo.ToObject<AvailablePlugin>();
                 p.Documentation = v.Documentation;
+                p.SystemPlugin = false;
                 return p;
             }).ToArray();
         }

--- a/BTCPayServer/Views/UIServer/ListPlugins.cshtml
+++ b/BTCPayServer/Views/UIServer/ListPlugins.cshtml
@@ -132,11 +132,11 @@
 {
     <h3 class="mb-4">Installed Plugins</h3>
     <div class="row mb-4">
-        @foreach (var plugin in Model.Installed)
+        @foreach (var plugin in Model.Installed.Where(i => !i.SystemPlugin))
         {
             var matchedAvailable = Model.Available.Where(availablePlugin => availablePlugin.Identifier == plugin.Identifier && availablePlugin.Version > plugin.Version).OrderByDescending(availablePlugin => availablePlugin.Version).ToArray();
             var x = matchedAvailable.FirstOrDefault(availablePlugin => DependenciesMet(availablePlugin.Dependencies)) ?? matchedAvailable.FirstOrDefault();
-            var updateAvailable = !plugin.SystemPlugin && matchedAvailable.Any();
+            var updateAvailable = matchedAvailable.Any();
             var tabId = plugin.Identifier.ToLowerInvariant().Replace(".", "_");
             <div class="col col-12 col-md-6 col-lg-12 col-xl-6 col-xxl-4 mb-4">
                 <div class="card h-100" id="@plugin.Identifier">
@@ -151,11 +151,7 @@
                         <div class="d-flex flex-wrap align-items-center mb-2">
                             <h5 class="text-muted d-flex align-items-center mt-1 gap-3">
                                 @plugin.Version
-                                @if (plugin.SystemPlugin)
-                                {
-                                    <div class="badge bg-light">System plugin</div>
-                                }
-                                else if (updateAvailable && x != null)
+                                @if (updateAvailable && x != null)
                                 {
                                     <div class="badge bg-info">
                                         @x.Version available
@@ -219,7 +215,7 @@
                     @{
                         var pendingAction = Model.Commands.Any(tuple => tuple.plugin.Equals(plugin.Identifier, StringComparison.InvariantCultureIgnoreCase));
                     }
-                    @if (!plugin.SystemPlugin && (pendingAction || (updateAvailable && x != null && DependenciesMet(x.Dependencies)) || !DependentOn(plugin.Identifier)))
+                    @if (pendingAction || (updateAvailable && x != null && DependenciesMet(x.Dependencies)) || !DependentOn(plugin.Identifier))
                     {
                         <div class="card-footer border-0 pb-3 d-flex">
                             @if (pendingAction)


### PR DESCRIPTION
I believe we should remove "System plugin section" there is nothing a user can do with it.
It just means that the plugin is in the core code.... so what? it's kind of useless information for users, they can do nothing with it.

Before:
![image](https://user-images.githubusercontent.com/3020646/207271568-d31dfc30-06d4-47b3-a01e-bae837ac1fad.png)


After:
![image](https://user-images.githubusercontent.com/3020646/207271008-09215ca5-952e-4626-978b-060263cf2bf4.png)
