### PR TITLE
Fix bitbank and yadio rate providers

### DIFF
--- a/BTCPayServer.Rating/Providers/BitbankRateProvider.cs
+++ b/BTCPayServer.Rating/Providers/BitbankRateProvider.cs
@@ -28,6 +28,7 @@ namespace BTCPayServer.Services.Rates
                     $"BitBank Rates API Error: {errorCode}. See https://github.com/bitbankinc/bitbank-api-docs/blob/master/errors.md for more details.");
             }
             return ((data as JArray) ?? new JArray())
+                .Where(p => p["buy"].Type != JTokenType.Null && p["sell"].Type != JTokenType.Null)
                 .Select(item => new PairRate(CurrencyPair.Parse(item["pair"].ToString()), CreateBidAsk(item as JObject)))
                 .ToArray();
         }

--- a/BTCPayServer.Rating/Providers/YadioRateProvider.cs
+++ b/BTCPayServer.Rating/Providers/YadioRateProvider.cs
@@ -31,8 +31,7 @@ namespace BTCPayServer.Services.Rates
             {
 
                 string name = ((JProperty)item).Name;
-                int value = results[name].Value<int>();
-                
+                var value = results[name].Value<decimal>();
                 list.Add(new PairRate(new CurrencyPair("BTC", name), new BidAsk(value)));
             }
 


### PR DESCRIPTION
Bitbank and yadio were broken because some shitcoin either had too big value, or none.