### PR TITLE
Plugins built with newer version of BTCPay couldn't run on older version

### DIFF
--- a/BTCPayServer.PluginPacker/BTCPayServer.PluginPacker.csproj
+++ b/BTCPayServer.PluginPacker/BTCPayServer.PluginPacker.csproj
@@ -26,7 +26,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-      <PackageReference Include="McMaster.NETCore.Plugins.Mvc" Version="1.4.0" />
+      <PackageReference Include="BTCPayServer.NETCore.Plugins.Mvc" Version="1.4.4" />
       <ProjectReference Include="..\BTCPayServer.Abstractions\BTCPayServer.Abstractions.csproj" />
       <None Include="icon.png" Pack="true" PackagePath="\" />
   </ItemGroup>

--- a/BTCPayServer/BTCPayServer.csproj
+++ b/BTCPayServer/BTCPayServer.csproj
@@ -1,4 +1,4 @@
-﻿ <Project Sdk="Microsoft.NET.Sdk.Web">
+ <Project Sdk="Microsoft.NET.Sdk.Web">
   <Import Project="../Build/Version.csproj" Condition="Exists('../Build/Version.csproj')" />
   <Import Project="../Build/Common.csproj" />
 
@@ -55,7 +55,7 @@
     <PackageReference Include="HtmlSanitizer" Version="5.0.372" />
     <PackageReference Include="LNURL" Version="0.0.26" />
     <PackageReference Include="MailKit" Version="3.3.0" />
-    <PackageReference Include="McMaster.NETCore.Plugins.Mvc" Version="1.4.0" />
+    <PackageReference Include="BTCPayServer.NETCore.Plugins.Mvc" Version="1.4.4" />
     <PackageReference Include="QRCoder" Version="1.4.3" />
     <PackageReference Include="System.IO.Pipelines" Version="6.0.3" />
     <PackageReference Include="NBitpayClient" Version="1.0.0.39" />


### PR DESCRIPTION
When @Kukks attempted to build a new version of the NFC plugin, he noticed that the build was failing with this error:
![image](https://user-images.githubusercontent.com/3020646/207779624-80604467-8915-48e8-9087-207bbf59bcba.png)

After digging, I figured out that the plugin was relying on BTCPayServer.Abstractions 1.7.1 while the plugin packer was using BTCPayServer.Abstractions 1.7.0.

In this case, dotnet core plugin project wouldn't share types, and two assemblies would be loaded (1.7.1 and 1.7.0).

I found this was indeed an issue on https://github.com/natemcmaster/DotNetCorePlugins/issues/242

I submitted a PR to the project on https://github.com/natemcmaster/DotNetCorePlugins/pull/268.
However, this project hasn't been touch for one year and a half, so instead of waiting for a new released, I created a fork with our fix https://github.com/btcpayserver/DotNetCorePlugins and published the nuget packages on https://www.nuget.org/packages/BTCPayServer.NETCore.Plugins