### PR TITLE
Checkout: Fix modal iframe clipboard permissions

### DIFF
--- a/BTCPayServer/wwwroot/js/copy-to-clipboard.js
+++ b/BTCPayServer/wwwroot/js/copy-to-clipboard.js
@@ -18,15 +18,16 @@ window.copyToClipboard = async function (e, data) {
     const message = confirm.getAttribute('data-clipboard-confirm') || 'Copied';
     // Check compatibility and permissions:
     // https://web.dev/async-clipboard/#security-and-permissions
-    let hasPermission = false;
-    try {
-        const permissionStatus = await navigator.permissions.query({ name: 'clipboard-write', allowWithoutGesture: false });
-        hasPermission = permissionStatus.state === 'granted';
-    } catch (err) {}
+    let hasPermission = true;
+    if (navigator.clipboard && navigator.permissions) {
+        try {
+            const permissionStatus = await navigator.permissions.query({ name: 'clipboard-write', allowWithoutGesture: false });
+            hasPermission = permissionStatus.state === 'granted';
+        } catch (err) {}
+    }
     if (navigator.clipboard && hasPermission) {
-        navigator.clipboard.writeText(data).then(function () {
-            confirmCopy(confirm, message);
-        });
+        await navigator.clipboard.writeText(data);
+        confirmCopy(confirm, message);
     } else {
         const copyEl = document.createElement('textarea');
         copyEl.style.position = 'absolute';

--- a/BTCPayServer/wwwroot/js/copy-to-clipboard.js
+++ b/BTCPayServer/wwwroot/js/copy-to-clipboard.js
@@ -9,14 +9,21 @@ function confirmCopy(el, message) {
     }, 2500);
 }
 
-window.copyToClipboard = function (e, data) {
+window.copyToClipboard = async function (e, data) {
     e.preventDefault();
     const item = e.target.closest('[data-clipboard]') || e.target.closest('[data-clipboard-target]') || e.target;
     const confirm = item.dataset.clipboardConfirmElement
         ? document.getElementById(item.dataset.clipboardConfirmElement) || item
         : item.querySelector('[data-clipboard-confirm]') || item;
     const message = confirm.getAttribute('data-clipboard-confirm') || 'Copied';
-    if (navigator.clipboard) {
+    // Check compatibility and permissions:
+    // https://web.dev/async-clipboard/#security-and-permissions
+    let hasPermission = false;
+    try {
+        const permissionStatus = await navigator.permissions.query({ name: 'clipboard-write', allowWithoutGesture: false });
+        hasPermission = permissionStatus.state === 'granted';
+    } catch (err) {}
+    if (navigator.clipboard && hasPermission) {
         navigator.clipboard.writeText(data).then(function () {
             confirmCopy(confirm, message);
         });

--- a/BTCPayServer/wwwroot/modal/btcpay.js
+++ b/BTCPayServer/wwwroot/modal/btcpay.js
@@ -40,6 +40,9 @@
     iframe.style.zIndex = '2000';
     // Removed, see https://github.com/btcpayserver/btcpayserver/issues/2139#issuecomment-768223263
     // iframe.setAttribute('allowtransparency', 'true');
+    
+    // https://web.dev/async-clipboard/#permissions-policy-integration
+    iframe.setAttribute('allow', 'clipboard-read; clipboard-write')
 
     var origin = 'http://chat.btcpayserver.org join us there, and initialize this with your origin url through setApiUrlPrefix';
     var scriptMatch = thisScript.match(scriptSrcRegex)


### PR DESCRIPTION
WebKit-based browser require a [permissions policy](https://web.dev/async-clipboard/#permissions-policy-integration) to be set on the iframe element. See the discussions [here](https://github.com/btcpayserver/btcpayserver/discussions/4308#discussioncomment-4399342) and [on Mattermost](https://chat.btcpayserver.org/btcpayserver/pl/z7kdgidcjtnd8f5zs5648t1dhe).