### PR TITLE
fixes language dropdown cutoff on checkout page

### DIFF
--- a/BTCPayServer/Views/UIInvoice/Checkout.cshtml
+++ b/BTCPayServer/Views/UIInvoice/Checkout.cshtml
@@ -86,7 +86,7 @@
 
     <invoice>
         <div class="no-bounce" id="checkoutCtrl" v-cloak>
-            <div class="modal page">
+            <div style="height: 100vh" class="modal page">
                 <div class="modal-dialog open opened" role="document" v-bind:class="{ 'expired': invoiceUnpayable, 'paid': invoicePaid, 'enter-purchaser-email': showEmailForm}">
                     <div class="modal-content long">
                         <div class="content">

--- a/BTCPayServer/Views/UIInvoice/Checkout.cshtml
+++ b/BTCPayServer/Views/UIInvoice/Checkout.cshtml
@@ -86,7 +86,7 @@
 
     <invoice>
         <div class="no-bounce" id="checkoutCtrl" v-cloak>
-            <div style="height: 100vh" class="modal page">
+            <div class="modal page min-vh-100">
                 <div class="modal-dialog open opened" role="document" v-bind:class="{ 'expired': invoiceUnpayable, 'paid': invoicePaid, 'enter-purchaser-email': showEmailForm}">
                     <div class="modal-content long">
                         <div class="content">


### PR DESCRIPTION
This is a simple fix that prevents the language dropdown on the Checkout page from being cut off as per #4452. The dropdown was being cutoff because the enclosing modal div was initially sizing to the collapsed dropdown and didn't resize when the dropdown expanded (due to its absolute positioning). This PR assigns a height of 100vh to the enclosing modal div, so that the dropdown has room to expand properly. 