### PR TITLE
Checkout v2: Configure countdown timer

### DIFF
--- a/BTCPayServer.Client/Models/StoreBaseData.cs
+++ b/BTCPayServer.Client/Models/StoreBaseData.cs
@@ -22,7 +22,7 @@ namespace BTCPayServer.Client.Models
 
         [JsonConverter(typeof(TimeSpanJsonConverter.Seconds))]
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-        public TimeSpan TimerExpiration { get; set; } = TimeSpan.FromMinutes(5);
+        public TimeSpan DisplayExpirationTimer { get; set; } = TimeSpan.FromMinutes(5);
 
         [JsonConverter(typeof(TimeSpanJsonConverter.Seconds))]
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]

--- a/BTCPayServer.Client/Models/StoreBaseData.cs
+++ b/BTCPayServer.Client/Models/StoreBaseData.cs
@@ -22,6 +22,10 @@ namespace BTCPayServer.Client.Models
 
         [JsonConverter(typeof(TimeSpanJsonConverter.Seconds))]
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public TimeSpan TimerExpiration { get; set; } = TimeSpan.FromMinutes(5);
+
+        [JsonConverter(typeof(TimeSpanJsonConverter.Seconds))]
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public TimeSpan MonitoringExpiration { get; set; } = TimeSpan.FromMinutes(60);
 
         [JsonConverter(typeof(StringEnumConverter))]

--- a/BTCPayServer.Tests/Checkoutv2Tests.cs
+++ b/BTCPayServer.Tests/Checkoutv2Tests.cs
@@ -188,10 +188,10 @@ namespace BTCPayServer.Tests
             invoiceId = s.CreateInvoice();
             s.GoToHome();
             s.GoToStore(StoreNavPages.CheckoutAppearance);
-            var timerExpiration = s.Driver.FindElement(By.Id("TimerExpiration"));
-            Assert.Equal("5", timerExpiration.GetAttribute("value"));
-            timerExpiration.Clear();
-            timerExpiration.SendKeys("10");
+            var displayExpirationTimer = s.Driver.FindElement(By.Id("DisplayExpirationTimer"));
+            Assert.Equal("5", displayExpirationTimer.GetAttribute("value"));
+            displayExpirationTimer.Clear();
+            displayExpirationTimer.SendKeys("10");
             s.Driver.FindElement(By.Id("Save")).Click();
             Assert.Contains("Store successfully updated", s.FindAlertMessage().Text);
             

--- a/BTCPayServer.Tests/Checkoutv2Tests.cs
+++ b/BTCPayServer.Tests/Checkoutv2Tests.cs
@@ -180,7 +180,35 @@ namespace BTCPayServer.Tests
 
             paymentInfo = s.Driver.WaitForElement(By.Id("PaymentInfo"));
             Assert.Contains("This invoice will expire in", paymentInfo.Text);
+            Assert.Contains("00:0", paymentInfo.Text);
             Assert.DoesNotContain("Please send", paymentInfo.Text);
+            
+            // Configure countdown timer
+            s.GoToHome();
+            invoiceId = s.CreateInvoice();
+            s.GoToHome();
+            s.GoToStore(StoreNavPages.CheckoutAppearance);
+            var timerExpiration = s.Driver.FindElement(By.Id("TimerExpiration"));
+            Assert.Equal("5", timerExpiration.GetAttribute("value"));
+            timerExpiration.Clear();
+            timerExpiration.SendKeys("10");
+            s.Driver.FindElement(By.Id("Save")).Click();
+            Assert.Contains("Store successfully updated", s.FindAlertMessage().Text);
+            
+            s.GoToInvoiceCheckout(invoiceId);
+            paymentInfo = s.Driver.FindElement(By.Id("PaymentInfo"));
+            Assert.False(paymentInfo.Displayed);
+            Assert.DoesNotContain("This invoice will expire in", paymentInfo.Text);
+            
+            expirySeconds = s.Driver.FindElement(By.Id("ExpirySeconds"));
+            expirySeconds.Clear();
+            expirySeconds.SendKeys("599");
+            s.Driver.FindElement(By.Id("Expire")).Click();
+
+            paymentInfo = s.Driver.WaitForElement(By.Id("PaymentInfo"));
+            Assert.True(paymentInfo.Displayed);
+            Assert.Contains("This invoice will expire in", paymentInfo.Text);
+            Assert.Contains("09:5", paymentInfo.Text);
         }
 
         [Fact(Timeout = TestTimeout)]

--- a/BTCPayServer/Controllers/GreenField/GreenfieldStoresController.cs
+++ b/BTCPayServer/Controllers/GreenField/GreenfieldStoresController.cs
@@ -140,6 +140,7 @@ namespace BTCPayServer.Controllers.Greenfield
                 DefaultLang = storeBlob.DefaultLang,
                 MonitoringExpiration = storeBlob.MonitoringExpiration,
                 InvoiceExpiration = storeBlob.InvoiceExpiration,
+                TimerExpiration = storeBlob.TimerExpiration,
                 CustomLogo = storeBlob.CustomLogo,
                 CustomCSS = storeBlob.CustomCSS,
                 HtmlTitle = storeBlob.HtmlTitle,
@@ -179,6 +180,7 @@ namespace BTCPayServer.Controllers.Greenfield
             blob.DefaultLang = restModel.DefaultLang;
             blob.MonitoringExpiration = restModel.MonitoringExpiration;
             blob.InvoiceExpiration = restModel.InvoiceExpiration;
+            blob.TimerExpiration = restModel.TimerExpiration;
             blob.CustomLogo = restModel.CustomLogo;
             blob.CustomCSS = restModel.CustomCSS;
             blob.HtmlTitle = restModel.HtmlTitle;
@@ -213,8 +215,10 @@ namespace BTCPayServer.Controllers.Greenfield
             }
             if (request.InvoiceExpiration < TimeSpan.FromMinutes(1) && request.InvoiceExpiration > TimeSpan.FromMinutes(60 * 24 * 24))
                 ModelState.AddModelError(nameof(request.InvoiceExpiration), "InvoiceExpiration can only be between 1 and 34560 mins");
+            if (request.TimerExpiration < TimeSpan.FromMinutes(1) && request.TimerExpiration > TimeSpan.FromMinutes(60 * 24 * 24))
+                ModelState.AddModelError(nameof(request.TimerExpiration), "TimerExpiration can only be between 1 and 34560 mins");
             if (request.MonitoringExpiration < TimeSpan.FromMinutes(10) && request.MonitoringExpiration > TimeSpan.FromMinutes(60 * 24 * 24))
-                ModelState.AddModelError(nameof(request.MonitoringExpiration), "InvoiceExpiration can only be between 10 and 34560 mins");
+                ModelState.AddModelError(nameof(request.MonitoringExpiration), "MonitoringExpiration can only be between 10 and 34560 mins");
             if (request.PaymentTolerance < 0 && request.PaymentTolerance > 100)
                 ModelState.AddModelError(nameof(request.PaymentTolerance), "PaymentTolerance can only be between 0 and 100 percent");
 

--- a/BTCPayServer/Controllers/GreenField/GreenfieldStoresController.cs
+++ b/BTCPayServer/Controllers/GreenField/GreenfieldStoresController.cs
@@ -140,7 +140,7 @@ namespace BTCPayServer.Controllers.Greenfield
                 DefaultLang = storeBlob.DefaultLang,
                 MonitoringExpiration = storeBlob.MonitoringExpiration,
                 InvoiceExpiration = storeBlob.InvoiceExpiration,
-                TimerExpiration = storeBlob.TimerExpiration,
+                DisplayExpirationTimer = storeBlob.DisplayExpirationTimer,
                 CustomLogo = storeBlob.CustomLogo,
                 CustomCSS = storeBlob.CustomCSS,
                 HtmlTitle = storeBlob.HtmlTitle,
@@ -180,7 +180,7 @@ namespace BTCPayServer.Controllers.Greenfield
             blob.DefaultLang = restModel.DefaultLang;
             blob.MonitoringExpiration = restModel.MonitoringExpiration;
             blob.InvoiceExpiration = restModel.InvoiceExpiration;
-            blob.TimerExpiration = restModel.TimerExpiration;
+            blob.DisplayExpirationTimer = restModel.DisplayExpirationTimer;
             blob.CustomLogo = restModel.CustomLogo;
             blob.CustomCSS = restModel.CustomCSS;
             blob.HtmlTitle = restModel.HtmlTitle;
@@ -215,8 +215,8 @@ namespace BTCPayServer.Controllers.Greenfield
             }
             if (request.InvoiceExpiration < TimeSpan.FromMinutes(1) && request.InvoiceExpiration > TimeSpan.FromMinutes(60 * 24 * 24))
                 ModelState.AddModelError(nameof(request.InvoiceExpiration), "InvoiceExpiration can only be between 1 and 34560 mins");
-            if (request.TimerExpiration < TimeSpan.FromMinutes(1) && request.TimerExpiration > TimeSpan.FromMinutes(60 * 24 * 24))
-                ModelState.AddModelError(nameof(request.TimerExpiration), "TimerExpiration can only be between 1 and 34560 mins");
+            if (request.DisplayExpirationTimer < TimeSpan.FromMinutes(1) && request.DisplayExpirationTimer > TimeSpan.FromMinutes(60 * 24 * 24))
+                ModelState.AddModelError(nameof(request.DisplayExpirationTimer), "DisplayExpirationTimer can only be between 1 and 34560 mins");
             if (request.MonitoringExpiration < TimeSpan.FromMinutes(10) && request.MonitoringExpiration > TimeSpan.FromMinutes(60 * 24 * 24))
                 ModelState.AddModelError(nameof(request.MonitoringExpiration), "MonitoringExpiration can only be between 10 and 34560 mins");
             if (request.PaymentTolerance < 0 && request.PaymentTolerance > 100)

--- a/BTCPayServer/Controllers/UIInvoiceController.UI.cs
+++ b/BTCPayServer/Controllers/UIInvoiceController.UI.cs
@@ -774,6 +774,7 @@ namespace BTCPayServer.Controllers
                 CustomerEmail = invoice.RefundMail,
                 RequiresRefundEmail = invoice.RequiresRefundEmail ?? storeBlob.RequiresRefundEmail,
                 ExpirationSeconds = Math.Max(0, (int)(invoice.ExpirationTime - DateTimeOffset.UtcNow).TotalSeconds),
+                TimerExpirationSeconds = (int)storeBlob.TimerExpiration.TotalSeconds,
                 MaxTimeSeconds = (int)(invoice.ExpirationTime - invoice.InvoiceTime).TotalSeconds,
                 MaxTimeMinutes = (int)(invoice.ExpirationTime - invoice.InvoiceTime).TotalMinutes,
                 ItemDesc = invoice.Metadata.ItemDesc,

--- a/BTCPayServer/Controllers/UIInvoiceController.UI.cs
+++ b/BTCPayServer/Controllers/UIInvoiceController.UI.cs
@@ -774,7 +774,7 @@ namespace BTCPayServer.Controllers
                 CustomerEmail = invoice.RefundMail,
                 RequiresRefundEmail = invoice.RequiresRefundEmail ?? storeBlob.RequiresRefundEmail,
                 ExpirationSeconds = Math.Max(0, (int)(invoice.ExpirationTime - DateTimeOffset.UtcNow).TotalSeconds),
-                TimerExpirationSeconds = (int)storeBlob.TimerExpiration.TotalSeconds,
+                DisplayExpirationTimer = (int)storeBlob.DisplayExpirationTimer.TotalSeconds,
                 MaxTimeSeconds = (int)(invoice.ExpirationTime - invoice.InvoiceTime).TotalSeconds,
                 MaxTimeMinutes = (int)(invoice.ExpirationTime - invoice.InvoiceTime).TotalMinutes,
                 ItemDesc = invoice.Metadata.ItemDesc,

--- a/BTCPayServer/Controllers/UIStoresController.cs
+++ b/BTCPayServer/Controllers/UIStoresController.cs
@@ -390,6 +390,7 @@ namespace BTCPayServer.Controllers
             vm.CustomCSS = storeBlob.CustomCSS;
             vm.CustomLogo = storeBlob.CustomLogo;
             vm.HtmlTitle = storeBlob.HtmlTitle;
+            vm.TimerExpiration = (int)storeBlob.TimerExpiration.TotalMinutes;
             vm.ReceiptOptions = CheckoutAppearanceViewModel.ReceiptOptionsViewModel.Create(storeBlob.ReceiptOptions);
             vm.AutoDetectLanguage = storeBlob.AutoDetectLanguage;
             vm.SetLanguages(_LangService, storeBlob.DefaultLang);
@@ -436,8 +437,7 @@ namespace BTCPayServer.Controllers
             return defaultChoice is null ? null : choices.FirstOrDefault(c => defaultChoice.ToString().Equals(c.Value, StringComparison.OrdinalIgnoreCase));
         }
 
-        [HttpPost]
-        [Route("{storeId}/checkout")]
+        [HttpPost("{storeId}/checkout")]
         public async Task<IActionResult> CheckoutAppearance(CheckoutAppearanceViewModel model)
         {
             bool needUpdate = false;
@@ -513,6 +513,7 @@ namespace BTCPayServer.Controllers
             blob.CustomLogo = model.CustomLogo;
             blob.CustomCSS = model.CustomCSS;
             blob.HtmlTitle = string.IsNullOrWhiteSpace(model.HtmlTitle) ? null : model.HtmlTitle;
+            blob.TimerExpiration = TimeSpan.FromMinutes(model.TimerExpiration);
             blob.AutoDetectLanguage = model.AutoDetectLanguage;
             blob.DefaultLang = model.DefaultLang;
             blob.NormalizeToRelativeLinks(Request);

--- a/BTCPayServer/Controllers/UIStoresController.cs
+++ b/BTCPayServer/Controllers/UIStoresController.cs
@@ -390,7 +390,7 @@ namespace BTCPayServer.Controllers
             vm.CustomCSS = storeBlob.CustomCSS;
             vm.CustomLogo = storeBlob.CustomLogo;
             vm.HtmlTitle = storeBlob.HtmlTitle;
-            vm.TimerExpiration = (int)storeBlob.TimerExpiration.TotalMinutes;
+            vm.DisplayExpirationTimer = (int)storeBlob.DisplayExpirationTimer.TotalMinutes;
             vm.ReceiptOptions = CheckoutAppearanceViewModel.ReceiptOptionsViewModel.Create(storeBlob.ReceiptOptions);
             vm.AutoDetectLanguage = storeBlob.AutoDetectLanguage;
             vm.SetLanguages(_LangService, storeBlob.DefaultLang);
@@ -513,7 +513,7 @@ namespace BTCPayServer.Controllers
             blob.CustomLogo = model.CustomLogo;
             blob.CustomCSS = model.CustomCSS;
             blob.HtmlTitle = string.IsNullOrWhiteSpace(model.HtmlTitle) ? null : model.HtmlTitle;
-            blob.TimerExpiration = TimeSpan.FromMinutes(model.TimerExpiration);
+            blob.DisplayExpirationTimer = TimeSpan.FromMinutes(model.DisplayExpirationTimer);
             blob.AutoDetectLanguage = model.AutoDetectLanguage;
             blob.DefaultLang = model.DefaultLang;
             blob.NormalizeToRelativeLinks(Request);

--- a/BTCPayServer/Data/StoreBlob.cs
+++ b/BTCPayServer/Data/StoreBlob.cs
@@ -25,6 +25,7 @@ namespace BTCPayServer.Data
         public StoreBlob()
         {
             InvoiceExpiration = TimeSpan.FromMinutes(15);
+            TimerExpiration = TimeSpan.FromMinutes(5);
             RefundBOLT11Expiration = TimeSpan.FromDays(30);
             MonitoringExpiration = TimeSpan.FromDays(1);
             PaymentTolerance = 0;
@@ -95,6 +96,11 @@ namespace BTCPayServer.Data
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.Populate)]
         [JsonConverter(typeof(TimeSpanJsonConverter.Minutes))]
         public TimeSpan InvoiceExpiration { get; set; }
+
+        [DefaultValue(typeof(TimeSpan), "00:05:00")]
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Populate)]
+        [JsonConverter(typeof(TimeSpanJsonConverter.Minutes))]
+        public TimeSpan TimerExpiration { get; set; }
 
         public decimal Spread { get; set; } = 0.0m;
 

--- a/BTCPayServer/Data/StoreBlob.cs
+++ b/BTCPayServer/Data/StoreBlob.cs
@@ -25,7 +25,7 @@ namespace BTCPayServer.Data
         public StoreBlob()
         {
             InvoiceExpiration = TimeSpan.FromMinutes(15);
-            TimerExpiration = TimeSpan.FromMinutes(5);
+            DisplayExpirationTimer = TimeSpan.FromMinutes(5);
             RefundBOLT11Expiration = TimeSpan.FromDays(30);
             MonitoringExpiration = TimeSpan.FromDays(1);
             PaymentTolerance = 0;
@@ -100,7 +100,7 @@ namespace BTCPayServer.Data
         [DefaultValue(typeof(TimeSpan), "00:05:00")]
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.Populate)]
         [JsonConverter(typeof(TimeSpanJsonConverter.Minutes))]
-        public TimeSpan TimerExpiration { get; set; }
+        public TimeSpan DisplayExpirationTimer { get; set; }
 
         public decimal Spread { get; set; } = 0.0m;
 

--- a/BTCPayServer/Models/InvoicingModels/PaymentModel.cs
+++ b/BTCPayServer/Models/InvoicingModels/PaymentModel.cs
@@ -40,11 +40,10 @@ namespace BTCPayServer.Models.InvoicingModels
         public bool ShowRecommendedFee { get; set; }
         public decimal FeeRate { get; set; }
         public int ExpirationSeconds { get; set; }
-        public int TimerExpirationSeconds { get; set; }
+        public int DisplayExpirationTimer { get; set; }
         public string Status { get; set; }
         public string MerchantRefLink { get; set; }
         public int MaxTimeSeconds { get; set; }
-
         public string StoreName { get; set; }
         public string ItemDesc { get; set; }
         public string TimeLeft { get; set; }

--- a/BTCPayServer/Models/InvoicingModels/PaymentModel.cs
+++ b/BTCPayServer/Models/InvoicingModels/PaymentModel.cs
@@ -40,6 +40,7 @@ namespace BTCPayServer.Models.InvoicingModels
         public bool ShowRecommendedFee { get; set; }
         public decimal FeeRate { get; set; }
         public int ExpirationSeconds { get; set; }
+        public int TimerExpirationSeconds { get; set; }
         public string Status { get; set; }
         public string MerchantRefLink { get; set; }
         public int MaxTimeSeconds { get; set; }

--- a/BTCPayServer/Models/StoreViewModels/CheckoutAppearanceViewModel.cs
+++ b/BTCPayServer/Models/StoreViewModels/CheckoutAppearanceViewModel.cs
@@ -55,9 +55,9 @@ namespace BTCPayServer.Models.StoreViewModels
         [Display(Name = "Custom HTML title to display on Checkout page")]
         public string HtmlTitle { get; set; }
 
-        [Display(Name = "Show expiration timer once … minutes are left")]
+        [Display(Name = "Show a timer … seconds before invoice expiration")]
         [Range(1, 60 * 24 * 24)]
-        public int TimerExpiration { get; set; }
+        public int DisplayExpirationTimer { get; set; }
 
         public class ReceiptOptionsViewModel
         {

--- a/BTCPayServer/Models/StoreViewModels/CheckoutAppearanceViewModel.cs
+++ b/BTCPayServer/Models/StoreViewModels/CheckoutAppearanceViewModel.cs
@@ -55,6 +55,10 @@ namespace BTCPayServer.Models.StoreViewModels
         [Display(Name = "Custom HTML title to display on Checkout page")]
         public string HtmlTitle { get; set; }
 
+        [Display(Name = "Show expiration timer once … minutes are left")]
+        [Range(1, 60 * 24 * 24)]
+        public int TimerExpiration { get; set; }
+
         public class ReceiptOptionsViewModel
         {
             public static ReceiptOptionsViewModel Create(Client.Models.InvoiceDataBase.ReceiptOptions opts)

--- a/BTCPayServer/Models/StoreViewModels/CheckoutAppearanceViewModel.cs
+++ b/BTCPayServer/Models/StoreViewModels/CheckoutAppearanceViewModel.cs
@@ -55,7 +55,7 @@ namespace BTCPayServer.Models.StoreViewModels
         [Display(Name = "Custom HTML title to display on Checkout page")]
         public string HtmlTitle { get; set; }
 
-        [Display(Name = "Show a timer … seconds before invoice expiration")]
+        [Display(Name = "Show a timer … minutes before invoice expiration")]
         [Range(1, 60 * 24 * 24)]
         public int DisplayExpirationTimer { get; set; }
 

--- a/BTCPayServer/Views/UIStores/CheckoutAppearance.cshtml
+++ b/BTCPayServer/Views/UIStores/CheckoutAppearance.cshtml
@@ -86,12 +86,12 @@
                     </a>
                 </div>
                 <div class="form-group">
-                    <label asp-for="TimerExpiration" class="form-label"></label>
+                    <label asp-for="DisplayExpirationTimer" class="form-label"></label>
                     <div class="input-group">
-                        <input inputmode="numeric" asp-for="TimerExpiration" class="form-control" style="max-width:10ch;"/>
+                        <input inputmode="numeric" asp-for="DisplayExpirationTimer" class="form-control" style="max-width:10ch;"/>
                         <span class="input-group-text">minutes</span>
                     </div>
-                    <span asp-validation-for="TimerExpiration" class="text-danger"></span>
+                    <span asp-validation-for="DisplayExpirationTimer" class="text-danger"></span>
                 </div>
             </div>
                             

--- a/BTCPayServer/Views/UIStores/CheckoutAppearance.cshtml
+++ b/BTCPayServer/Views/UIStores/CheckoutAppearance.cshtml
@@ -85,6 +85,14 @@
                         <span class="fa fa-question-circle-o text-secondary" title="More information..."></span>
                     </a>
                 </div>
+                <div class="form-group">
+                    <label asp-for="TimerExpiration" class="form-label"></label>
+                    <div class="input-group">
+                        <input inputmode="numeric" asp-for="TimerExpiration" class="form-control" style="max-width:10ch;"/>
+                        <span class="input-group-text">minutes</span>
+                    </div>
+                    <span asp-validation-for="TimerExpiration" class="text-danger"></span>
+                </div>
             </div>
                             
             <div class="checkout-settings collapse @(Model.UseNewCheckout ? "" : "show")" id="OldCheckoutSettings">

--- a/BTCPayServer/wwwroot/checkout-v2/checkout.js
+++ b/BTCPayServer/wwwroot/checkout-v2/checkout.js
@@ -113,7 +113,8 @@ function initApp() {
                 return this.showTimer || this.showPaymentDueInfo;
             },
             showTimer () {
-                return this.isActive && (this.expirationPercentage >= 75 || this.minutesLeft < 5);
+                return this.isActive && (this.expirationPercentage >= 75 ||
+                    this.remainingSeconds < this.srvModel.timerExpirationSeconds);
             },
             showPaymentDueInfo () {
                 return this.btcPaid > 0 && this.btcDue > 0;

--- a/BTCPayServer/wwwroot/checkout-v2/checkout.js
+++ b/BTCPayServer/wwwroot/checkout-v2/checkout.js
@@ -114,7 +114,7 @@ function initApp() {
             },
             showTimer () {
                 return this.isActive && (this.expirationPercentage >= 75 ||
-                    this.remainingSeconds < this.srvModel.timerExpirationSeconds);
+                    this.remainingSeconds < this.srvModel.displayExpirationTimer);
             },
             showPaymentDueInfo () {
                 return this.btcPaid > 0 && this.btcDue > 0;

--- a/BTCPayServer/wwwroot/checkout-v2/checkout.js
+++ b/BTCPayServer/wwwroot/checkout-v2/checkout.js
@@ -90,7 +90,6 @@ function initApp() {
                 srvModel,
                 displayPaymentDetails: false,
                 remainingSeconds: srvModel.expirationSeconds,
-                expirationPercentage: 0,
                 emailAddressInput: "",
                 emailAddressInputDirty: false,
                 emailAddressInputInvalid: false,
@@ -113,8 +112,7 @@ function initApp() {
                 return this.showTimer || this.showPaymentDueInfo;
             },
             showTimer () {
-                return this.isActive && (this.expirationPercentage >= 75 ||
-                    this.remainingSeconds < this.srvModel.displayExpirationTimer);
+                return this.isActive && this.remainingSeconds < this.srvModel.displayExpirationTimer;
             },
             showPaymentDueInfo () {
                 return this.btcPaid > 0 && this.btcDue > 0;
@@ -191,7 +189,6 @@ function initApp() {
             },
             updateTimer () {
                 this.remainingSeconds = Math.floor((this.endDate.getTime() - new Date().getTime())/1000);
-                this.expirationPercentage = 100 - Math.floor((this.remainingSeconds / this.srvModel.maxTimeSeconds) * 100);
                 if (this.isActive) {
                     setTimeout(this.updateTimer, 500);
                 }

--- a/BTCPayServer/wwwroot/swagger/v1/swagger.template.stores.json
+++ b/BTCPayServer/wwwroot/swagger/v1/swagger.template.stores.json
@@ -308,6 +308,13 @@
                         "description": "The time after which an invoice is considered expired if not paid. The value will be rounded down to a minute.",
                         "allOf": [ { "$ref": "#/components/schemas/TimeSpanSeconds" } ]
                     },
+                    "timerExpiration": {
+                        "default": 300,
+                        "minimum": 60,
+                        "maximum": 2073600,
+                        "description": "The time left that will trigger the countdown timer on the checkout page to be shown. The value will be rounded down to a minute.",
+                        "allOf": [ { "$ref": "#/components/schemas/TimeSpanSeconds" } ]
+                    },
                     "monitoringExpiration": {
                         "default": 3600,
                         "minimum": 600,

--- a/BTCPayServer/wwwroot/swagger/v1/swagger.template.stores.json
+++ b/BTCPayServer/wwwroot/swagger/v1/swagger.template.stores.json
@@ -308,7 +308,7 @@
                         "description": "The time after which an invoice is considered expired if not paid. The value will be rounded down to a minute.",
                         "allOf": [ { "$ref": "#/components/schemas/TimeSpanSeconds" } ]
                     },
-                    "timerExpiration": {
+                    "displayExpirationTimer": {
                         "default": 300,
                         "minimum": 60,
                         "maximum": 2073600,


### PR DESCRIPTION
This addresses feedback by @astupidmoose left [here](https://github.com/btcpayserver/btcpayserver/discussions/4308#discussioncomment-4438926): Make the countdown timer configurable with a minutes setting. This way the merchant has full control over when to display the timer. They could even set it to equal the invoice expiry, so that it is shown right from the beginning.

![grafik](https://user-images.githubusercontent.com/886/209227784-d36becbb-c287-4646-b2fa-0c1d81971396.png)
