### PR TITLE
Summernote: Allow Twitter embeds

### DIFF
--- a/BTCPayServer/wwwroot/main/site.js
+++ b/BTCPayServer/wwwroot/main/site.js
@@ -86,7 +86,8 @@ document.addEventListener("DOMContentLoaded", () => {
                 row: 10
             },
             codeviewFilter: true,
-            codeviewFilterRegex: new RegExp($.summernote.options.codeviewFilterRegex.source + '|<.*?( on\\w+?=.*?)>', 'gi')
+            codeviewFilterRegex: new RegExp($.summernote.options.codeviewFilterRegex.source + '|<.*?( on\\w+?=.*?)>', 'gi'),
+            codeviewIframeWhitelistSrc: ['twitter.com', 'syndication.twitter.com']
         });
     }
 


### PR DESCRIPTION
Bitcoin Ekasi is planning a crowdfund and they want to embed their Twitter timeline into the page. This adds the necessary domains to the SUmmernote iframe whitelist.