### PR TITLE
Updates preferred price source copy label

### DIFF
--- a/BTCPayServer.Tests/SeleniumTester.cs
+++ b/BTCPayServer.Tests/SeleniumTester.cs
@@ -176,7 +176,9 @@ namespace BTCPayServer.Tests
             var name = "Store" + RandomUtils.GetUInt64();
             TestLogs.LogInformation($"Created store {name}");
             Driver.WaitForElement(By.Id("Name")).SendKeys(name);
-            new SelectElement(Driver.FindElement(By.Id("PreferredExchange"))).SelectByText("CoinGecko");
+            var rateSource = new SelectElement(Driver.FindElement(By.Id("PreferredExchange")));
+            Assert.Equal("Kraken (Recommended)", rateSource.SelectedOption.Text);
+            rateSource.SelectByText("CoinGecko");
             Driver.WaitForElement(By.Id("Create")).Click();
             Driver.FindElement(By.Id("StoreNav-StoreSettings")).Click();
             Driver.FindElement(By.Id($"SectionNav-{StoreNavPages.General.ToString()}")).Click();

--- a/BTCPayServer/Views/UIUserStores/CreateStore.cshtml
+++ b/BTCPayServer/Views/UIUserStores/CreateStore.cshtml
@@ -11,7 +11,7 @@
         const updateRecommended = currency => {
             const source = exchanges[currency] || 'coingecko'
             const name = source.charAt(0).toUpperCase() + source.slice(1)
-            recommended.innerText = `Recommended (${name})`
+            recommended.innerText = `${name} (Recommended)`
         }
         updateRecommended(@Safe.Json(Model.DefaultCurrency))
         delegate('change', '#DefaultCurrency', e => updateRecommended(e.target.value))


### PR DESCRIPTION
Minor update, but makes the label a little easier to read top to bottom.

Current:
<img width="389" alt="Screen Shot 2022-12-29 at 9 08 14 PM" src="https://user-images.githubusercontent.com/6250771/210123258-a7722ebd-c4b6-4896-8ffd-07d7a3b72e6a.png">

Proposed:
<img width="390" alt="Screen Shot 2022-12-29 at 9 17 11 PM" src="https://user-images.githubusercontent.com/6250771/210123259-fe4455c7-4241-4dbe-9812-edacfe42a69c.png">
