### PR TITLE
Allow DI access to host

### DIFF
--- a/BTCPayServer/HostAccessor.cs
+++ b/BTCPayServer/HostAccessor.cs
@@ -1,0 +1,22 @@
+﻿using System.Threading.Tasks;
+using Microsoft.AspNetCore.Hosting;
+
+public class HostAccessor
+{
+    private IWebHost _host;
+    private TaskCompletionSource<IWebHost> _taskCompletionSource = new();
+    public IWebHost Host
+    {
+        set
+        {
+            _host = value;
+            _taskCompletionSource.SetResult(_host);
+        }
+    }
+
+    public Task<IWebHost> GetHost()
+    {
+        return _taskCompletionSource.Task;
+
+    }
+}


### PR DESCRIPTION
Currently, there is no way to view correctly what btcpay is bound to internally.  There is access to `IServer` which has a similar structure and data, but it only provides the bound addresses of the internal Kestrel server, while the `IWebHost` takes precedence.  This is needed to be able to reliably generate loopback calls in case we need to call local endpoints from plugins (beyond greenfield calls)