### PR TITLE
Fix: Version numbers in UI appeared with a suffix zero x.x.x.0 instead of x.x.x

### DIFF
--- a/BTCPayServer/Services/BTCPayServerEnvironment.cs
+++ b/BTCPayServer/Services/BTCPayServerEnvironment.cs
@@ -17,7 +17,7 @@ namespace BTCPayServer.Services
         readonly TorServices torServices;
         public BTCPayServerEnvironment(IWebHostEnvironment env, BTCPayNetworkProvider provider, TorServices torServices, BTCPayServerOptions opts)
         {
-            Version = typeof(BTCPayServerEnvironment).GetTypeInfo().Assembly.GetCustomAttribute<AssemblyFileVersionAttribute>().Version;
+            Version = typeof(BTCPayServerEnvironment).GetTypeInfo().Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion;
             Commit = typeof(BTCPayServerEnvironment).GetTypeInfo().Assembly.GetCustomAttribute<GitCommitAttribute>()?.ShortSHA;
 #if DEBUG
             Build = "Debug";


### PR DESCRIPTION
Saving trees

Before:
![image](https://user-images.githubusercontent.com/3020646/211714151-942938cf-8a37-4bd7-98cd-c4091e6217dd.png)

After:
![image](https://user-images.githubusercontent.com/3020646/211714090-78ff06d7-a484-42e1-8603-0fb6c0a1edca.png)
