### PR TITLE
Provide sensible default to BaseBTCPayServerPlugin

### DIFF
--- a/BTCPayServer.Abstractions/Models/BaseBTCPayServerPlugin.cs
+++ b/BTCPayServer.Abstractions/Models/BaseBTCPayServerPlugin.cs
@@ -8,18 +8,52 @@ namespace BTCPayServer.Abstractions.Models
 {
     public abstract class BaseBTCPayServerPlugin : IBTCPayServerPlugin
     {
-        public abstract string Identifier { get; }
-        public abstract string Name { get; }
+        public virtual string Identifier
+        {
+            get
+            {
+                return GetType().GetTypeInfo().Assembly.GetName().Name;
+            }
+        }
+        public virtual string Name
+        {
+            get
+            {
+                return GetType().GetTypeInfo().Assembly
+                        .GetCustomAttribute<AssemblyTitleAttribute>()?
+                        .Title ?? string.Empty;
+            }
+        }
 
         public virtual Version Version
         {
             get
             {
-                return Assembly.GetAssembly(GetType())?.GetName().Version ?? new Version(1, 0, 0, 0);
+                return GetVersion(GetType().GetTypeInfo().Assembly
+                        .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?
+                        .InformationalVersion) ??
+                        Assembly.GetAssembly(GetType())?.GetName()?.Version ??
+                        new Version(1, 0, 0, 0);
             }
         }
 
-        public abstract string Description { get; }
+        private static Version GetVersion(string informationalVersion)
+        {
+            if (informationalVersion is null)
+                return null;
+            Version.TryParse(informationalVersion, out var r);
+            return r;
+        }
+
+        public virtual string Description
+        {
+            get
+            {
+                return GetType().GetTypeInfo().Assembly
+                        .GetCustomAttribute<AssemblyDescriptionAttribute>()?
+                        .Description ?? string.Empty;
+            }
+        }
         public bool SystemPlugin { get; set; }
         public virtual IBTCPayServerPlugin.PluginDependency[] Dependencies { get; } = Array.Empty<IBTCPayServerPlugin.PluginDependency>();
 


### PR DESCRIPTION
With this PR you can set `Name`, `Version`, and `Description` of a plugin inside it's csproj, so you will not need to override the properties of `BaseBTCpayServerPlugin`.

For `Identifier`, we must use the assembly name. This is actually an assumption that a plugin dll has a single plugin, as such both should match. Failure to do so result in some undefined behaviors.

```xml
<PropertyGroup>
  <Title>My Awesome plugin</Title>
  <Description>My description</Description>
  <Version>1.4.6</Version>
</PropertyGroup>
```

This is a non breaking change.