### PR TITLE
Plugins: Add checkout-noscript-end UI extension point

### DIFF
--- a/BTCPayServer/Views/UIInvoice/CheckoutNoScript.cshtml
+++ b/BTCPayServer/Views/UIInvoice/CheckoutNoScript.cshtml
@@ -70,5 +70,6 @@
     <p>
         <a asp-action="Checkout" asp-route-invoiceId="@Model.InvoiceId">Go back to Javascript enabled invoice</a>
     </p>
+    @await Component.InvokeAsync("UiExtensionPoint", new { location = "checkout-noscript-end", model = Model })
 </body>
 </html>


### PR DESCRIPTION
An equivalent to the already existing `checkout-end` extension point on the checkout page. Closes #4531.