### PR TITLE
Improve detection of plugin bricking an install on startup

### DIFF
--- a/BTCPayServer/Program.cs
+++ b/BTCPayServer/Program.cs
@@ -85,11 +85,11 @@ namespace BTCPayServer
                 if (!string.IsNullOrEmpty(ex.Message))
                     logs.Configuration.LogError(ex.Message);
             }
-            catch (Exception e) when (PluginManager.IsExceptionByPlugin(e))
+            catch (Exception e) when (PluginManager.IsExceptionByPlugin(e, out var pluginName))
             {
-                logs.Configuration.LogError(e, $"Disabling plugin {e.Source} as it crashed on startup");
+                logs.Configuration.LogError(e, $"Disabling plugin {pluginName} as it crashed on startup");
                 var pluginDir = new DataDirectories().Configure(conf).PluginDir;
-                PluginManager.DisablePlugin(pluginDir, e.Source);
+                PluginManager.DisablePlugin(pluginDir, pluginName);
             }
             finally
             {


### PR DESCRIPTION
After some downgrade of my server, the server started crashing with this error:

```
Unhandled exception. System.Reflection.ReflectionTypeLoadException: Unable to load one or more of the requested types.
Method 'get_Identifier' in type 'BTCPayServer.Plugins.LNbank.LNbankPlugin' from assembly 'BTCPayServer.Plugins.LNbank, Version=1.3.9.0, Culture=neutral, PublicKeyToken=null' does not have an implementation.
   at System.Reflection.RuntimeModule.GetTypes(RuntimeModule module)
   at System.Reflection.RuntimeAssembly.get_DefinedTypes()
   at Microsoft.AspNetCore.Mvc.ApplicationParts.AssemblyPart.get_Types()
   at Microsoft.AspNetCore.Mvc.Controllers.ControllerFeatureProvider.PopulateFeature(IEnumerable`1 parts, ControllerFeature feature)
   at Microsoft.AspNetCore.Mvc.ApplicationParts.ApplicationPartManager.PopulateFeature[TFeature](TFeature feature)
   at Microsoft.Extensions.DependencyInjection.MvcCoreMvcBuilderExtensions.AddControllersAsServices(IMvcBuilder builder)
   at BTCPayServer.Hosting.Startup.ConfigureServices(IServiceCollection services) in /source/BTCPayServer/Hosting/Startup.cs:line 118
   at System.RuntimeMethodHandle.InvokeMethod(Object target, Span`1& arguments, Signature sig, Boolean constructor, Boolean wrapExceptions)
   at System.Reflection.RuntimeMethodInfo.Invoke(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
   at Microsoft.AspNetCore.Hosting.ConfigureServicesBuilder.InvokeCore(Object instance, IServiceCollection services)
   at Microsoft.AspNetCore.Hosting.ConfigureServicesBuilder.<>c__DisplayClass9_0.<Invoke>g__Startup|0(IServiceCollection serviceCollection)
   at Microsoft.AspNetCore.Hosting.StartupLoader.ConfigureServicesDelegateBuilder`1.<>c__DisplayClass15_0.<BuildStartupServicesFilterPipeline>g__RunPipeline|0(IServiceCollection services)
```

The `IsExceptionByPlugin` wasn't catching properly that this was caused by `LNbankPlugin`, and so my server wouldn't come back online.

To fix this, I am also checking for the any plugin name in the exception message.

Note that since we are enforcing the fact that a plugin's identifier is the same as the assembly name, this work fine.