### PR TITLE
FileService: Null-check stored file before removal

### DIFF
--- a/BTCPayServer/Storage/Services/FileService.cs
+++ b/BTCPayServer/Storage/Services/FileService.cs
@@ -120,8 +120,8 @@ namespace BTCPayServer.Storage.Services
                 return;
             var provider = GetProvider(settings);
             var storedFile = await _fileRepository.GetFile(fileId);
-            if (string.IsNullOrEmpty(userId) ||
-                storedFile.ApplicationUserId.Equals(userId, StringComparison.InvariantCultureIgnoreCase))
+            if (storedFile != null && (string.IsNullOrEmpty(userId) ||
+                storedFile.ApplicationUserId.Equals(userId, StringComparison.InvariantCultureIgnoreCase)))
             {
                 await provider.RemoveFile(storedFile, settings);
                 await _fileRepository.RemoveFile(storedFile);


### PR DESCRIPTION
Might solve [this problem reported on Mattermost](https://chat.btcpayserver.org/btcpayserver/pl/5xuaf94wz3rqjg1b4b9hxes8jw).