### PR TITLE
Fix several HTML injections

### DIFF
--- a/BTCPayServer/Controllers/UIAppsController.cs
+++ b/BTCPayServer/Controllers/UIAppsController.cs
@@ -13,6 +13,7 @@ using BTCPayServer.Services.Stores;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Rendering;
 
 namespace BTCPayServer.Controllers
 {
@@ -23,11 +24,13 @@ namespace BTCPayServer.Controllers
         public UIAppsController(
             UserManager<ApplicationUser> userManager,
             StoreRepository storeRepository,
-            AppService appService)
+            AppService appService,
+            IHtmlHelper html)
         {
             _userManager = userManager;
             _storeRepository = storeRepository;
             _appService = appService;
+            Html = html;
         }
 
         private readonly UserManager<ApplicationUser> _userManager;
@@ -35,6 +38,7 @@ namespace BTCPayServer.Controllers
         private readonly AppService _appService;
 
         public string CreatedAppId { get; set; }
+        public IHtmlHelper Html { get; }
 
         public class AppUpdated
         {
@@ -175,7 +179,7 @@ namespace BTCPayServer.Controllers
             if (app == null)
                 return NotFound();
 
-            return View("Confirm", new ConfirmModel("Delete app", $"The app <strong>{app.Name}</strong> and its settings will be permanently deleted. Are you sure?", "Delete"));
+            return View("Confirm", new ConfirmModel("Delete app", $"The app <strong>{Html.Encode(app.Name)}</strong> and its settings will be permanently deleted. Are you sure?", "Delete"));
         }
 
         [Authorize(Policy = Policies.CanModifyStoreSettings, AuthenticationSchemes = AuthenticationSchemes.Cookie)]

--- a/BTCPayServer/Controllers/UIManageController.APIKeys.cs
+++ b/BTCPayServer/Controllers/UIManageController.APIKeys.cs
@@ -2,9 +2,11 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using System.Text.Encodings.Web;
 using System.Threading.Tasks;
 using BTCPayServer.Abstractions.Extensions;
 using BTCPayServer.Abstractions.Models;
+using BTCPayServer.Abstractions.Services;
 using BTCPayServer.Client;
 using BTCPayServer.Data;
 using BTCPayServer.Models;
@@ -41,7 +43,7 @@ namespace BTCPayServer.Controllers
             return View("Confirm", new ConfirmModel
             {
                 Title = "Delete API key",
-                Description = $"Any application using the API key <strong>{key.Label ?? key.Id}<strong> will immediately lose access.",
+                Description = $"Any application using the API key <strong>{Html.Encode(key.Label ?? key.Id)}<strong> will immediately lose access.",
                 Action = "Delete",
                 ActionName = nameof(DeleteAPIKeyPost)
             });

--- a/BTCPayServer/Controllers/UIManageController.cs
+++ b/BTCPayServer/Controllers/UIManageController.cs
@@ -16,6 +16,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Rendering;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.Logging;
 using MimeKit;
@@ -38,6 +39,7 @@ namespace BTCPayServer.Controllers
         private readonly Fido2Service _fido2Service;
         private readonly LinkGenerator _linkGenerator;
         private readonly UserLoginCodeService _userLoginCodeService;
+        private readonly IHtmlHelper Html;
         private readonly UserService _userService;
         readonly StoreRepository _StoreRepository;
 
@@ -54,7 +56,8 @@ namespace BTCPayServer.Controllers
           Fido2Service fido2Service,
           LinkGenerator linkGenerator,
           UserService userService,
-          UserLoginCodeService userLoginCodeService
+          UserLoginCodeService userLoginCodeService,
+          IHtmlHelper htmlHelper
           )
         {
             _userManager = userManager;
@@ -68,6 +71,7 @@ namespace BTCPayServer.Controllers
             _fido2Service = fido2Service;
             _linkGenerator = linkGenerator;
             _userLoginCodeService = userLoginCodeService;
+            Html = htmlHelper;
             _userService = userService;
             _StoreRepository = storeRepository;
         }

--- a/BTCPayServer/Controllers/UIServerController.Users.cs
+++ b/BTCPayServer/Controllers/UIServerController.Users.cs
@@ -225,15 +225,15 @@ namespace BTCPayServer.Controllers
                 {
                     // return
                     return View("Confirm", new ConfirmModel("Delete admin",
-                        $"Unable to proceed: As the user <strong>{user.Email}</strong> is the last enabled admin, it cannot be removed."));
+                        $"Unable to proceed: As the user <strong>{Html.Encode(user.Email)}</strong> is the last enabled admin, it cannot be removed."));
                 }
 
                 return View("Confirm", new ConfirmModel("Delete admin",
-                    $"The admin <strong>{user.Email}</strong> will be permanently deleted. This action will also delete all accounts, users and data associated with the server account. Are you sure?",
+                    $"The admin <strong>{Html.Encode(user.Email)}</strong> will be permanently deleted. This action will also delete all accounts, users and data associated with the server account. Are you sure?",
                     "Delete"));
             }
 
-            return View("Confirm", new ConfirmModel("Delete user", $"The user <strong>{user.Email}</strong> will be permanently deleted. Are you sure?", "Delete"));
+            return View("Confirm", new ConfirmModel("Delete user", $"The user <strong>{Html.Encode(user.Email)}</strong> will be permanently deleted. Are you sure?", "Delete"));
         }
 
         [HttpPost("server/users/{userId}/delete")]
@@ -259,9 +259,9 @@ namespace BTCPayServer.Controllers
             if (!enable && await _userService.IsUserTheOnlyOneAdmin(user))
             {
                 return View("Confirm", new ConfirmModel("Disable admin",
-                    $"Unable to proceed: As the user <strong>{user.Email}</strong> is the last enabled admin, it cannot be disabled."));
+                    $"Unable to proceed: As the user <strong>{Html.Encode(user.Email)}</strong> is the last enabled admin, it cannot be disabled."));
             }
-            return View("Confirm", new ConfirmModel($"{(enable ? "Enable" : "Disable")} user", $"The user <strong>{user.Email}</strong> will be {(enable ? "enabled" : "disabled")}. Are you sure?", (enable ? "Enable" : "Disable")));
+            return View("Confirm", new ConfirmModel($"{(enable ? "Enable" : "Disable")} user", $"The user <strong>{Html.Encode(user.Email)}</strong> will be {(enable ? "enabled" : "disabled")}. Are you sure?", (enable ? "Enable" : "Disable")));
         }
 
         [HttpPost("server/users/{userId}/toggle")]
@@ -288,7 +288,7 @@ namespace BTCPayServer.Controllers
             if (user == null)
                 return NotFound();
 
-            return View("Confirm", new ConfirmModel("Send verification email", $"This will send a verification email to <strong>{user.Email}</strong>.", "Send"));
+            return View("Confirm", new ConfirmModel("Send verification email", $"This will send a verification email to <strong>{Html.Encode(user.Email)}</strong>.", "Send"));
         }
 
         [HttpPost("server/users/{userId}/verification-email")]

--- a/BTCPayServer/Controllers/UIServerController.cs
+++ b/BTCPayServer/Controllers/UIServerController.cs
@@ -89,7 +89,8 @@ namespace BTCPayServer.Controllers
             Logs logs,
             LinkGenerator linkGenerator,
             EmailSenderFactory emailSenderFactory,
-            IHostApplicationLifetime applicationLifetime
+            IHostApplicationLifetime applicationLifetime,
+            IHtmlHelper html
         )
         {
             _policiesSettings = policiesSettings;
@@ -113,6 +114,7 @@ namespace BTCPayServer.Controllers
             _linkGenerator = linkGenerator;
             _emailSenderFactory = emailSenderFactory;
             ApplicationLifetime = applicationLifetime;
+            Html = html;
         }
 
         [Route("server/maintenance")]
@@ -296,6 +298,7 @@ namespace BTCPayServer.Controllers
 
         public IHttpClientFactory HttpClientFactory { get; }
         public IHostApplicationLifetime ApplicationLifetime { get; }
+        public IHtmlHelper Html { get; }
 
         [Route("server/policies")]
         public async Task<IActionResult> Policies()
@@ -836,7 +839,7 @@ namespace BTCPayServer.Controllers
                 return NotFound();
             return View("Confirm",
                 new ConfirmModel("Delete dynamic DNS service",
-                    $"Deleting the dynamic DNS service for <strong>{hostname}</strong> means your BTCPay Server will stop updating the associated DNS record periodically.", "Delete"));
+                    $"Deleting the dynamic DNS service for <strong>{Html.Encode(hostname)}</strong> means your BTCPay Server will stop updating the associated DNS record periodically.", "Delete"));
         }
 
         [HttpPost("server/services/dynamic-dns/{hostname}/delete")]

--- a/BTCPayServer/Controllers/UIStoresController.Onchain.cs
+++ b/BTCPayServer/Controllers/UIStoresController.Onchain.cs
@@ -800,9 +800,9 @@ namespace BTCPayServer.Controllers
                 ? ""
                 : " or imported it into an external wallet. If you no longer have access to your private key (recovery seed), immediately replace the wallet";
             return
-                $"<p class=\"text-danger fw-bold\">Please note that this is a <strong>{walletType} wallet</strong>!</p>" +
-                $"<p class=\"text-danger fw-bold\">Do not proceed if you have not backed up the wallet{additionalText}.</p>" +
-                $"<p class=\"text-start mb-0\">This action will erase the current wallet data from the server. {info}</p>";
+                $"<p class=\"text-danger fw-bold\">Please note that this is a <strong>{Html.Encode(walletType)} wallet</strong>!</p>" +
+                $"<p class=\"text-danger fw-bold\">Do not proceed if you have not backed up the wallet{Html.Encode(additionalText)}.</p>" +
+                $"<p class=\"text-start mb-0\">This action will erase the current wallet data from the server. {Html.Encode(info)}</p>";
         }
 
         private string WalletReplaceWarning(bool isHotWallet)

--- a/BTCPayServer/Controllers/UIStoresController.cs
+++ b/BTCPayServer/Controllers/UIStoresController.cs
@@ -65,7 +65,8 @@ namespace BTCPayServer.Controllers
             WebhookSender webhookNotificationManager,
             IDataProtectionProvider dataProtector,
             IOptions<LightningNetworkOptions> lightningNetworkOptions,
-            IOptions<ExternalServicesOptions> externalServiceOptions)
+            IOptions<ExternalServicesOptions> externalServiceOptions,
+            IHtmlHelper html)
         {
             _RateFactory = rateFactory;
             _Repo = repo;
@@ -89,6 +90,7 @@ namespace BTCPayServer.Controllers
             _BtcpayServerOptions = btcpayServerOptions;
             _BTCPayEnv = btcpayEnv;
             _externalServiceOptions = externalServiceOptions;
+            Html = html;
         }
 
         readonly BTCPayServerOptions _BtcpayServerOptions;
@@ -113,6 +115,7 @@ namespace BTCPayServer.Controllers
 
         public string? GeneratedPairingCode { get; set; }
         public WebhookSender WebhookNotificationManager { get; }
+        public IHtmlHelper Html { get; }
         public LightningNetworkOptions LightningNetworkOptions { get; }
         public IDataProtector DataProtector { get; }
 
@@ -180,7 +183,7 @@ namespace BTCPayServer.Controllers
             var user = await _UserManager.FindByIdAsync(userId);
             if (user == null)
                 return NotFound();
-            return View("Confirm", new ConfirmModel("Remove store user", $"This action will prevent <strong>{user.Email}</strong> from accessing this store and its settings. Are you sure?", "Remove"));
+            return View("Confirm", new ConfirmModel("Remove store user", $"This action will prevent <strong>{Html.Encode(user.Email)}</strong> from accessing this store and its settings. Are you sure?", "Remove"));
         }
 
         [HttpPost("{storeId}/users/{userId}/delete")]
@@ -776,7 +779,7 @@ namespace BTCPayServer.Controllers
             var token = await _TokenRepository.GetToken(tokenId);
             if (token == null || token.StoreId != CurrentStore.Id)
                 return NotFound();
-            return View("Confirm", new ConfirmModel("Revoke the token", $"The access token with the label <strong>{token.Label}</strong> will be revoked. Do you wish to continue?", "Revoke"));
+            return View("Confirm", new ConfirmModel("Revoke the token", $"The access token with the label <strong>{Html.Encode(token.Label)}</strong> will be revoked. Do you wish to continue?", "Revoke"));
         }
 
         [HttpPost("{storeId}/tokens/{tokenId}/revoke")]

--- a/BTCPayServer/Views/Shared/Crowdfund/UpdateCrowdfund.cshtml
+++ b/BTCPayServer/Views/Shared/Crowdfund/UpdateCrowdfund.cshtml
@@ -334,7 +334,7 @@
 
 <div class="d-flex gap-3 mt-3">
     <a class="btn btn-secondary" asp-action="ListInvoices" asp-controller="UIInvoice" asp-route-storeId="@Model.StoreId" asp-route-searchterm="@Model.SearchTerm">Invoices</a>
-    <a id="DeleteApp" class="btn btn-outline-danger" asp-controller="UIApps" asp-action="DeleteApp" asp-route-appId="@Model.AppId" data-bs-toggle="modal" data-bs-target="#ConfirmModal" data-description="The app <strong>@Model.AppName</strong> and its settings will be permanently deleted." data-confirm-input="DELETE">Delete this app</a>
+    <a id="DeleteApp" class="btn btn-outline-danger" asp-controller="UIApps" asp-action="DeleteApp" asp-route-appId="@Model.AppId" data-bs-toggle="modal" data-bs-target="#ConfirmModal" data-description="The app <strong>@Html.Encode(Model.AppName)</strong> and its settings will be permanently deleted." data-confirm-input="DELETE">Delete this app</a>
 </div>
 
 <partial name="_Confirm" model="@(new ConfirmModel("Delete app", "This app will be removed from this store.", "Delete"))" />

--- a/BTCPayServer/Views/Shared/PointOfSale/UpdatePointOfSale.cshtml
+++ b/BTCPayServer/Views/Shared/PointOfSale/UpdatePointOfSale.cshtml
@@ -265,7 +265,7 @@
 
 <div class="d-flex gap-3 mt-3">
     <a class="btn btn-secondary" asp-action="ListInvoices" asp-controller="UIInvoice" asp-route-storeId="@Model.StoreId" asp-route-searchterm="@Model.SearchTerm">Invoices</a>
-    <a id="DeleteApp" class="btn btn-outline-danger" asp-controller="UIApps" asp-action="DeleteApp" asp-route-appId="@Model.Id" data-bs-toggle="modal" data-bs-target="#ConfirmModal" data-description="The app <strong>@Model.AppName</strong> and its settings will be permanently deleted." data-confirm-input="DELETE">Delete this app</a>
+  <a id="DeleteApp" class="btn btn-outline-danger" asp-controller="UIApps" asp-action="DeleteApp" asp-route-appId="@Model.Id" data-bs-toggle="modal" data-bs-target="#ConfirmModal" data-description="The app <strong>@Html.Encode(Model.AppName)</strong> and its settings will be permanently deleted." data-confirm-input="DELETE">Delete this app</a>
 </div>
 
 <partial name="_Confirm" model="@(new ConfirmModel("Delete app", "This app will be removed from this store.", "Delete"))" />

--- a/BTCPayServer/Views/UIApps/ListApps.cshtml
+++ b/BTCPayServer/Views/UIApps/ListApps.cshtml
@@ -1,4 +1,4 @@
-﻿@using BTCPayServer.Services.Apps
+@using BTCPayServer.Services.Apps
 @using BTCPayServer.Abstractions.Models
 @model ListAppsViewModel
 @{
@@ -103,7 +103,7 @@
                                 <a asp-action="@app.UpdateAction" asp-controller="UIApps" asp-route-appId="@app.Id" asp-route-storeId="@app.StoreId">Settings</a>
                                 <span> - </span>
                             }
-                            <a asp-action="DeleteApp" asp-route-appId="@app.Id" data-bs-toggle="modal" data-bs-target="#ConfirmModal" data-description="The app <strong>@app.AppName</strong> and its settings will be permanently deleted from your store <strong>@app.StoreName</strong>." data-confirm-input="DELETE">Delete</a>
+					<a asp-action="DeleteApp" asp-route-appId="@app.Id" data-bs-toggle="modal" data-bs-target="#ConfirmModal" data-description="The app <strong>@Html.Encode(app.AppName)</strong> and its settings will be permanently deleted from your store <strong>@Html.Encode(app.StoreName)</strong>." data-confirm-input="DELETE">Delete</a>
                         </td>
                     </tr>
                 }

--- a/BTCPayServer/Views/UICustodianAccounts/EditCustodianAccount.cshtml
+++ b/BTCPayServer/Views/UICustodianAccounts/EditCustodianAccount.cshtml
@@ -1,4 +1,4 @@
-﻿@using BTCPayServer.Views.Apps
+@using BTCPayServer.Views.Apps
 @using BTCPayServer.Abstractions.Extensions
 @using BTCPayServer.Abstractions.Models
 @model BTCPayServer.Models.CustodianAccountViewModels.EditCustodianAccountViewModel
@@ -35,7 +35,7 @@
                 <input type="submit" value="Continue" class="btn btn-primary" id="Save"/>
             </div>
         </form>
-        <a asp-action="DeleteCustodianAccount" asp-route-storeId="@Model.CustodianAccount.StoreId" asp-route-accountId="@Model.CustodianAccount.Id" class="btn btn-outline-danger" role="button" id="DeleteCustodianAccountConfig" data-bs-toggle="modal" data-bs-target="#ConfirmModal" data-description="The custodian account <strong>@Model.CustodianAccount.Name</strong> will be permanently deleted." data-confirm-input="DELETE">
+        <a asp-action="DeleteCustodianAccount" asp-route-storeId="@Model.CustodianAccount.StoreId" asp-route-accountId="@Model.CustodianAccount.Id" class="btn btn-outline-danger" role="button" id="DeleteCustodianAccountConfig" data-bs-toggle="modal" data-bs-target="#ConfirmModal" data-description="The custodian account <strong>@Html.Encode(Model.CustodianAccount.Name)</strong> will be permanently deleted." data-confirm-input="DELETE">
             <span class="fa fa-trash"></span> Delete this custodian account
         </a>
     </div>

--- a/BTCPayServer/Views/UILNURL/EditLightningAddress.cshtml
+++ b/BTCPayServer/Views/UILNURL/EditLightningAddress.cshtml
@@ -1,4 +1,4 @@
-﻿@using BTCPayServer.Views.Stores
+@using BTCPayServer.Views.Stores
 @using BTCPayServer.Abstractions.Extensions
 @using BTCPayServer.Abstractions.Models
 @model UILNURLController.EditLightningAddressVM
@@ -139,7 +139,7 @@
                             </td>
                             <td class="text-end">
                                 <button type="submit" title="Remove" name="command" value="@($"remove:{Model.Items[index].Username}")"
-                                        class="btn btn-link px-0 remove" data-bs-toggle="modal" data-bs-target="#ConfirmModal" data-description="The Lightning Address <strong>@address</strong> will be removed." data-confirm-input="REMOVE">
+				class="btn btn-link px-0 remove" data-bs-toggle="modal" data-bs-target="#ConfirmModal" data-description="The Lightning Address <strong>@Html.Encode(address)</strong> will be removed." data-confirm-input="REMOVE">
                                     Remove
                                 </button>
                             </td>

--- a/BTCPayServer/Views/UIManage/APIKeys.cshtml
+++ b/BTCPayServer/Views/UIManage/APIKeys.cshtml
@@ -70,7 +70,7 @@
                                 }
                             </td>
                             <td class="text-end">
-                                <a asp-action="DeleteAPIKey" asp-route-id="@keyData.Id" asp-controller="UIManage" data-bs-toggle="modal" data-bs-target="#ConfirmModal" data-description="Any application using the API key <strong>@(keyData.Label ?? keyData.Id)<strong> will immediately lose access." data-confirm-input="DELETE">Delete</a>
+								<a asp-action="DeleteAPIKey" asp-route-id="@keyData.Id" asp-controller="UIManage" data-bs-toggle="modal" data-bs-target="#ConfirmModal" data-description="Any application using the API key <strong>@Html.Encode(keyData.Label ?? keyData.Id)</strong> will immediately lose access." data-confirm-input="DELETE">Delete</a>
                                 <span>-</span>
                                 <button type="button" class="btn btn-link only-for-js p-0" data-qr="@index">Show QR</button>
                             </td>

--- a/BTCPayServer/Views/UIManage/TwoFactorAuthentication.cshtml
+++ b/BTCPayServer/Views/UIManage/TwoFactorAuthentication.cshtml
@@ -119,11 +119,11 @@
 
                         @if (device.Type == Fido2Credential.CredentialType.FIDO2)
                         {
-                            <a asp-controller="UIFido2" asp-action="Remove" asp-route-id="@device.Id" class="btn btn-outline-danger" data-bs-toggle="modal" data-bs-target="#ConfirmModal" data-title="Remove security device" data-description="Your account will no longer have the security device <strong>@name</strong> as an option for two-factor authentication." data-confirm="Remove" data-confirm-input="REMOVE">Remove</a>
+                            <a asp-controller="UIFido2" asp-action="Remove" asp-route-id="@device.Id" class="btn btn-outline-danger" data-bs-toggle="modal" data-bs-target="#ConfirmModal" data-title="Remove security device" data-description="Your account will no longer have the security device <strong>@Html.Encode(name)</strong> as an option for two-factor authentication." data-confirm="Remove" data-confirm-input="REMOVE">Remove</a>
                         }
                         else if (device.Type == Fido2Credential.CredentialType.LNURLAuth)
                         {
-                            <a asp-controller="UILNURLAuth" asp-action="Remove" asp-route-id="@device.Id" class="btn btn-outline-danger" data-bs-toggle="modal" data-bs-target="#ConfirmModal" data-title="Remove Lightning security" data-description="Your account will no longer be linked to the lightning node <strong>@name</strong> as an option for two-factor authentication." data-confirm="Remove" data-confirm-input="REMOVE">Remove</a>
+                            <a asp-controller="UILNURLAuth" asp-action="Remove" asp-route-id="@device.Id" class="btn btn-outline-danger" data-bs-toggle="modal" data-bs-target="#ConfirmModal" data-title="Remove Lightning security" data-description="Your account will no longer be linked to the lightning node <strong>@Html.Encode(name)</strong> as an option for two-factor authentication." data-confirm="Remove" data-confirm-input="REMOVE">Remove</a>
                         }
                     </div>
                 }

--- a/BTCPayServer/Views/UIPayoutProcessors/ConfigureStorePayoutProcessors.cshtml
+++ b/BTCPayServer/Views/UIPayoutProcessors/ConfigureStorePayoutProcessors.cshtml
@@ -1,4 +1,4 @@
-﻿@using BTCPayServer.Views.Stores
+@using BTCPayServer.Views.Stores
 @using Microsoft.AspNetCore.Mvc.TagHelpers
 @using BTCPayServer.Abstractions.Extensions
 @using BTCPayServer.Abstractions.Models
@@ -44,7 +44,7 @@
                                 {
                                     <a href="@processorsView.Factory.ConfigureLink(storeId, conf.Key, Context.Request)">Modify</a>
                                     <span>-</span>
-                                    <a asp-action="Remove" asp-route-storeId="@storeId" asp-route-id="@conf.Value.Id" data-bs-toggle="modal" data-bs-target="#ConfirmModal" data-description="The @processorsView.Factory.FriendlyName for @conf.Key.CryptoCode will be removed from your store.">Remove</a>
+                                    <a asp-action="Remove" asp-route-storeId="@storeId" asp-route-id="@conf.Value.Id" data-bs-toggle="modal" data-bs-target="#ConfirmModal" data-description="The @Html.Encode(processorsView.Factory.FriendlyName) for @Html.Encode(conf.Key.CryptoCode) will be removed from your store.">Remove</a>
                                 }
                             </td>
                         </tr>

--- a/BTCPayServer/Views/UIServer/DynamicDnsServices.cshtml
+++ b/BTCPayServer/Views/UIServer/DynamicDnsServices.cshtml
@@ -1,4 +1,4 @@
-﻿@using BTCPayServer.Abstractions.Models
+@using BTCPayServer.Abstractions.Models
 @model BTCPayServer.Models.ServerViewModels.DynamicDnsViewModel[]
 @{
     ViewData.SetActivePage(ServerNavPages.Services, "Dynamic DNS Settings");
@@ -61,7 +61,7 @@
                         <td class="text-end">
                             <a asp-action="DynamicDnsService" asp-route-hostname="@service.Settings.Hostname">Edit</a>
                             <span> - </span>
-                            <a asp-action="DeleteDynamicDnsService" asp-route-hostname="@service.Settings.Hostname" data-bs-toggle="modal" data-bs-target="#ConfirmModal" data-description="Deleting the dynamic DNS service for <strong>@service.Settings.Hostname</strong> means your BTCPay Server will stop updating the associated DNS record periodically." data-confirm-input="DELETE">Delete</a>
+                            <a asp-action="DeleteDynamicDnsService" asp-route-hostname="@service.Settings.Hostname" data-bs-toggle="modal" data-bs-target="#ConfirmModal" data-description="Deleting the dynamic DNS service for <strong>@Html.Encode(service.Settings.Hostname)</strong> means your BTCPay Server will stop updating the associated DNS record periodically." data-confirm-input="DELETE">Delete</a>
                         </td>
                     </tr>
                 }

--- a/BTCPayServer/Views/UIServer/ListUsers.cshtml
+++ b/BTCPayServer/Views/UIServer/ListUsers.cshtml
@@ -1,4 +1,4 @@
-﻿@using BTCPayServer.Abstractions.Models
+@using BTCPayServer.Abstractions.Models
 @model UsersViewModel
 @{
     ViewData.SetActivePage(ServerNavPages.Users);
@@ -97,7 +97,7 @@
                 </td>
                 <td class="text-end">
                     @if (!user.Verified && !user.Disabled) {
-                        <a asp-action="SendVerificationEmail" asp-route-userId="@user.Id" data-bs-toggle="modal" data-bs-target="#ConfirmModal" data-description="This will send a verification email to <strong>@user.Email</strong>.">Resend verification email</a>
+                        <a asp-action="SendVerificationEmail" asp-route-userId="@user.Id" data-bs-toggle="modal" data-bs-target="#ConfirmModal" data-description="This will send a verification email to <strong>@Html.Encode(user.Email)</strong>.">Resend verification email</a>
                         <span>-</span>
                     }
                     <a asp-action="User" asp-route-userId="@user.Id">Edit</a> <span> - </span> <a asp-action="DeleteUser" asp-route-userId="@user.Id">Remove</a>

--- a/BTCPayServer/Views/UIStorePullPayments/PullPayments.cshtml
+++ b/BTCPayServer/Views/UIStorePullPayments/PullPayments.cshtml
@@ -1,4 +1,4 @@
-﻿@using BTCPayServer.Views.Stores
+@using BTCPayServer.Views.Stores
 @using BTCPayServer.Abstractions.Extensions
 @using BTCPayServer.Abstractions.Models
 @using BTCPayServer.Client
@@ -148,7 +148,7 @@
                            asp-route-pullPaymentId="@pp.Id"
                            data-bs-toggle="modal"
                            data-bs-target="#ConfirmModal"
-                           data-description="Do you really want to archive the pull payment <strong>@pp.Name</strong>?">
+                           data-description="Do you really want to archive the pull payment <strong>@Html.Encode(pp.Name)</strong>?">
                             Archive
                         </a>
                     }

--- a/BTCPayServer/Views/UIStores/GeneralSettings.cshtml
+++ b/BTCPayServer/Views/UIStores/GeneralSettings.cshtml
@@ -138,7 +138,7 @@
         {
             <h3 class="mt-5 mb-3">Additional Actions</h3>
             <div id="danger-zone">
-                <a id="DeleteStore" class="btn btn-outline-danger mb-5 mt-2" asp-action="DeleteStore" asp-route-storeId="@Model.Id" data-bs-toggle="modal" data-bs-target="#ConfirmModal" data-description="The store <strong>@Model.StoreName</strong> will be permanently deleted. This action will also delete all invoices, apps and data associated with the store." data-confirm-input="DELETE">Delete this store</a>
+                <a id="DeleteStore" class="btn btn-outline-danger mb-5 mt-2" asp-action="DeleteStore" asp-route-storeId="@Model.Id" data-bs-toggle="modal" data-bs-target="#ConfirmModal" data-description="The store <strong>@Html.Encode(Model.StoreName)</strong> will be permanently deleted. This action will also delete all invoices, apps and data associated with the store." data-confirm-input="DELETE">Delete this store</a>
             </div>
         }
     </div>

--- a/BTCPayServer/Views/UIStores/ListTokens.cshtml
+++ b/BTCPayServer/Views/UIStores/ListTokens.cshtml
@@ -48,7 +48,7 @@
                         <td>@token.Label</td>
                         <td class="text-end">
                             <a asp-action="ShowToken" asp-route-storeId="@Context.GetRouteValue("storeId")" asp-route-tokenId="@token.Id">See information</a> - 
-                            <a asp-action="RevokeToken" asp-route-storeId="@Context.GetRouteValue("storeId")" asp-route-tokenId="@token.Id" data-bs-toggle="modal" data-bs-target="#ConfirmModal" data-description="The access token with the label <strong>@token.Label</strong> will be revoked." data-confirm-input="REVOKE">Revoke</a>
+                            <a asp-action="RevokeToken" asp-route-storeId="@Context.GetRouteValue("storeId")" asp-route-tokenId="@token.Id" data-bs-toggle="modal" data-bs-target="#ConfirmModal" data-description="The access token with the label <strong>@Html.Encode(token.Label)</strong> will be revoked." data-confirm-input="REVOKE">Revoke</a>
                         </td>
                     </tr>
                 }

--- a/BTCPayServer/Views/UIStores/StoreUsers.cshtml
+++ b/BTCPayServer/Views/UIStores/StoreUsers.cshtml
@@ -1,4 +1,4 @@
-﻿@using BTCPayServer.Abstractions.Models
+@using BTCPayServer.Abstractions.Models
 @model StoreUsersViewModel
 @{
     Layout = "../Shared/_NavLayout.cshtml";
@@ -51,7 +51,7 @@
                         <td>@user.Email</td>
                         <td>@user.Role</td>
                         <td style="text-align:right">
-                            <a asp-action="DeleteStoreUser" asp-route-storeId="@Model.StoreId" asp-route-userId="@user.Id" data-bs-toggle="modal" data-bs-target="#ConfirmModal" data-description="This action will prevent <strong>@user.Email</strong> from accessing this store and its settings." data-confirm-input="REMOVE">Remove</a>
+                            <a asp-action="DeleteStoreUser" asp-route-storeId="@Model.StoreId" asp-route-userId="@user.Id" data-bs-toggle="modal" data-bs-target="#ConfirmModal" data-description="This action will prevent <strong>@Html.Encode(user.Email)</strong> from accessing this store and its settings." data-confirm-input="REMOVE">Remove</a>
                         </td>
                     </tr>
                 }

--- a/BTCPayServer/Views/UIStores/WalletSettings.cshtml
+++ b/BTCPayServer/Views/UIStores/WalletSettings.cshtml
@@ -52,7 +52,7 @@
                            data-bs-toggle="modal"
                            data-bs-target="#ConfirmModal"
                            data-title="Replace @Model.CryptoCode wallet"
-                           data-description="@ViewData["ReplaceDescription"]"
+                           data-description="@Html.Encode(ViewData["ReplaceDescription"])"
                            data-confirm="Setup new wallet"
                            data-confirm-input="REPLACE">
                             Replace wallet
@@ -64,7 +64,7 @@
                                     data-bs-toggle="modal"
                                     data-bs-target="#ConfirmModal"
                                     data-title="Remove @Model.CryptoCode wallet"
-                                    data-description="@ViewData["RemoveDescription"]"
+                                    data-description="@Html.Encode(ViewData["RemoveDescription"])"
                                     data-confirm="Remove"
                                     data-confirm-input="REMOVE">Remove wallet</button>
                         </form>


### PR DESCRIPTION
Several HTML injections need to be patched.
I need additional pairs of eyes that I'm not missing anything.

@dennisreimann most of those injections come from `data-description` for modals where are raw HTML. As such anything coming from user's input need to be escaped with `Html.Encode`.

I don't believe this is a critical issue that require urgent release, as it isn't possible to make JS injection thanks to CSP which save our ass once again!

Credit to @thewhiteevil from https://huntr.dev/bounties/3a73b45c-6f3e-4536-a327-cdfdbc59896f/

Reproduce steps:

* Go to the website https://mainnet.demo.btcpayserver.org/account/apikeys
* Click account.
* Click manage account.
* Then move on to the api endpoint.
* That is https://mainnet.demo.btcpayserver.org/account/apikeys
* Here, create api key with the label as a html payload.
* Use the following HTML payload in the label field: `<a href="https://hackerbro.in">clickhere</a>`
* Generate the api key.
* Now, click delete.
* Check that deleting part rendered the html injection.
* That's the issue.