### PR TITLE
BIP21: Uppercase addresses only in QR, not in payment URL

### DIFF
--- a/BTCPayServer.Tests/Checkoutv2Tests.cs
+++ b/BTCPayServer.Tests/Checkoutv2Tests.cs
@@ -152,7 +152,7 @@ namespace BTCPayServer.Tests
             Assert.Empty(s.Driver.FindElements(By.CssSelector(".payment-method")));
             payUrl = s.Driver.FindElement(By.CssSelector(".btn-primary")).GetAttribute("href");
             Assert.StartsWith("bitcoin:", payUrl);
-            Assert.Contains("&LIGHTNING=", payUrl);
+            Assert.Contains("&lightning=", payUrl);
 
             // BIP21 with LN as default payment method
             s.GoToHome();
@@ -161,7 +161,7 @@ namespace BTCPayServer.Tests
             Assert.Empty(s.Driver.FindElements(By.CssSelector(".payment-method")));
             payUrl = s.Driver.FindElement(By.CssSelector(".btn-primary")).GetAttribute("href");
             Assert.StartsWith("bitcoin:", payUrl);
-            Assert.Contains("&LIGHTNING=", payUrl);
+            Assert.Contains("&lightning=", payUrl);
 
             // BIP21 with topup invoice (which is only available with Bitcoin onchain)
             s.GoToHome();
@@ -170,7 +170,7 @@ namespace BTCPayServer.Tests
             Assert.Empty(s.Driver.FindElements(By.CssSelector(".payment-method")));
             payUrl = s.Driver.FindElement(By.CssSelector(".btn-primary")).GetAttribute("href");
             Assert.StartsWith("bitcoin:", payUrl);
-            Assert.DoesNotContain("&LIGHTNING=", payUrl);
+            Assert.DoesNotContain("&lightning=", payUrl);
 
             // Expiry message should not show amount for topup invoice
             expirySeconds = s.Driver.FindElement(By.Id("ExpirySeconds"));

--- a/BTCPayServer.Tests/UnitTest1.cs
+++ b/BTCPayServer.Tests/UnitTest1.cs
@@ -1618,6 +1618,10 @@ namespace BTCPayServer.Tests
             Assert.Contains("&lightning=", paymentMethodUnified.InvoiceBitcoinUrl);
             Assert.Contains("&lightning=", paymentMethodUnified.InvoiceBitcoinUrlQR);
 
+            // Check correct casing: Addresses in payment URI need to be …
+            // - lowercase in link version
+            // - uppercase in QR version
+            
             // Standard for all uppercase characters in QR codes is still not implemented in all wallets
             // But we're proceeding with BECH32 being uppercase
             Assert.Equal($"bitcoin:{paymentMethodUnified.BtcAddress}", paymentMethodUnified.InvoiceBitcoinUrl.Split('?')[0]);

--- a/BTCPayServer.Tests/UnitTest1.cs
+++ b/BTCPayServer.Tests/UnitTest1.cs
@@ -1610,20 +1610,24 @@ namespace BTCPayServer.Tests
 
             // validate that QR code now has both onchain and offchain payment urls
             res = await user.GetController<UIInvoiceController>().Checkout(invoice.Id);
-            var paymentMethodSecond = Assert.IsType<PaymentModel>(
+            var paymentMethodUnified = Assert.IsType<PaymentModel>(
                 Assert.IsType<ViewResult>(res).Model
             );
-            Assert.Contains("&lightning=", paymentMethodSecond.InvoiceBitcoinUrlQR);
-            Assert.StartsWith("bitcoin:", paymentMethodSecond.InvoiceBitcoinUrlQR);
-            var split = paymentMethodSecond.InvoiceBitcoinUrlQR.Split('?')[0];
+            Assert.StartsWith("bitcoin:", paymentMethodUnified.InvoiceBitcoinUrl);
+            Assert.StartsWith("bitcoin:", paymentMethodUnified.InvoiceBitcoinUrlQR);
+            Assert.Contains("&lightning=", paymentMethodUnified.InvoiceBitcoinUrl);
+            Assert.Contains("&lightning=", paymentMethodUnified.InvoiceBitcoinUrlQR);
 
             // Standard for all uppercase characters in QR codes is still not implemented in all wallets
             // But we're proceeding with BECH32 being uppercase
-            Assert.True($"bitcoin:{paymentMethodSecond.BtcAddress.ToUpperInvariant()}" == split);
+            Assert.Equal($"bitcoin:{paymentMethodUnified.BtcAddress}", paymentMethodUnified.InvoiceBitcoinUrl.Split('?')[0]);
+            Assert.Equal($"bitcoin:{paymentMethodUnified.BtcAddress.ToUpperInvariant()}", paymentMethodUnified.InvoiceBitcoinUrlQR.Split('?')[0]);
 
-            // Fallback lightning invoice should be uppercase inside the QR code.
-            var lightningFallback = paymentMethodSecond.InvoiceBitcoinUrlQR.Split(new[] { "&lightning=" }, StringSplitOptions.None)[1];
-            Assert.True(lightningFallback.ToUpperInvariant() == lightningFallback);
+            // Fallback lightning invoice should be uppercase inside the QR code, lowercase in payment URI
+            var lightningFallback = paymentMethodUnified.InvoiceBitcoinUrl.Split(new[] { "&lightning=" }, StringSplitOptions.None)[1];
+            Assert.NotNull(lightningFallback);
+            Assert.Contains($"&lightning={lightningFallback}", paymentMethodUnified.InvoiceBitcoinUrl);
+            Assert.Contains($"&lightning={lightningFallback.ToUpperInvariant()}", paymentMethodUnified.InvoiceBitcoinUrlQR);
         }
 
         [Fact(Timeout = 60 * 2 * 1000)]

--- a/BTCPayServer/Payments/Bitcoin/BitcoinLikePaymentHandler.cs
+++ b/BTCPayServer/Payments/Bitcoin/BitcoinLikePaymentHandler.cs
@@ -88,7 +88,6 @@ namespace BTCPayServer.Payments.Bitcoin
                 //
                 // The keys (e.g. "bitcoin:" or "lightning=" should be lowercase!
 
-
                 // cryptoInfo.PaymentUrls?.BIP21: bitcoin:bcrt1qxp2qa5?amount=0.00044007
                 model.InvoiceBitcoinUrl = model.InvoiceBitcoinUrlQR = cryptoInfo.PaymentUrls?.BIP21 ?? "";
                 // model.InvoiceBitcoinUrl: bitcoin:bcrt1qxp2qa5?amount=0.00044007
@@ -96,15 +95,17 @@ namespace BTCPayServer.Payments.Bitcoin
 
                 if (!string.IsNullOrEmpty(lightningFallback))
                 {
-                    model.InvoiceBitcoinUrl += $"&{lightningFallback}";
+                    var delimiterUrl = model.InvoiceBitcoinUrl.Contains("?") ? "&" : "?";
+                    model.InvoiceBitcoinUrl += $"{delimiterUrl}{lightningFallback}";
                     // model.InvoiceBitcoinUrl: bitcoin:bcrt1qxp2qa5dhn7?amount=0.00044007&lightning=lnbcrt440070n1...
-                    model.InvoiceBitcoinUrlQR += $"&{lightningFallback.ToUpperInvariant().Replace("LIGHTNING=", "lightning=", StringComparison.OrdinalIgnoreCase)}";
-                    // model.InvoiceBitcoinUrlQR: bitcoin:bcrt1qxp2qa5dhn7?amount=0.00044007&LIGHTNING=LNBCRT4400...
+                    
+                    var delimiterUrlQR = model.InvoiceBitcoinUrlQR.Contains("?") ? "&" : "?";
+                    model.InvoiceBitcoinUrlQR += $"{delimiterUrlQR}{lightningFallback.ToUpperInvariant().Replace("LIGHTNING=", "lightning=", StringComparison.OrdinalIgnoreCase)}";
+                    // model.InvoiceBitcoinUrlQR: bitcoin:bcrt1qxp2qa5dhn7?amount=0.00044007&lightning=LNBCRT4400...
                 }
 
                 if (network.CryptoCode.Equals("BTC", StringComparison.InvariantCultureIgnoreCase) && _bech32Prefix.TryGetValue(model.CryptoCode, out var prefix) && model.BtcAddress.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
                 {
-                    
                     model.InvoiceBitcoinUrlQR = model.InvoiceBitcoinUrlQR.Replace(
                         $"{network.NBitcoinNetwork.UriScheme}:{model.BtcAddress}", $"{network.NBitcoinNetwork.UriScheme}:{model.BtcAddress.ToUpperInvariant()}",
                         StringComparison.OrdinalIgnoreCase);

--- a/BTCPayServer/Views/Shared/Bitcoin/BitcoinLikeMethodCheckout-v2.cshtml
+++ b/BTCPayServer/Views/Shared/Bitcoin/BitcoinLikeMethodCheckout-v2.cshtml
@@ -46,7 +46,7 @@
                 return this.model.invoiceBitcoinUrl.indexOf('@PayjoinClient.BIP21EndpointKey=') !== -1;
             },
             BOLT11 () {
-                const match = this.model.invoiceBitcoinUrl.match(/&LIGHTNING=(.*)&?/i);
+                const match = this.model.invoiceBitcoinUrl.match(/&lightning=(.*)&?/i);
                 return match ? match[1].toLowerCase() : null;
             }
         }


### PR DESCRIPTION
The uppercased address/BOLT11 should only be used for the QR code, the payment URI for the link should stay as it is.

Previously we had the BOLT11 uppercased in both URL versions in the BIP21 case, but this leads to  [wallet incompatibility](https://chat.btcpayserver.org/btcpayserver/pl/d9b6w3mo47rezefcjq66bb7owh).

References:

- #2110
- https://bitcoinqr.dev/