### PR TITLE
Lowercase the `lightning` param in unified Bitcoin payment links due to apps not detecting Lightning payments otherwise

### DIFF
--- a/BTCPayServer.Tests/Checkoutv2Tests.cs
+++ b/BTCPayServer.Tests/Checkoutv2Tests.cs
@@ -152,7 +152,7 @@ namespace BTCPayServer.Tests
             Assert.Empty(s.Driver.FindElements(By.CssSelector(".payment-method")));
             payUrl = s.Driver.FindElement(By.CssSelector(".btn-primary")).GetAttribute("href");
             Assert.StartsWith("bitcoin:", payUrl);
-            Assert.Contains("&LIGHTNING=", payUrl);
+            Assert.Contains("&lightning=", payUrl);
 
             // BIP21 with LN as default payment method
             s.GoToHome();
@@ -161,7 +161,7 @@ namespace BTCPayServer.Tests
             Assert.Empty(s.Driver.FindElements(By.CssSelector(".payment-method")));
             payUrl = s.Driver.FindElement(By.CssSelector(".btn-primary")).GetAttribute("href");
             Assert.StartsWith("bitcoin:", payUrl);
-            Assert.Contains("&LIGHTNING=", payUrl);
+            Assert.Contains("&lightning=", payUrl);
 
             // BIP21 with topup invoice (which is only available with Bitcoin onchain)
             s.GoToHome();
@@ -170,7 +170,7 @@ namespace BTCPayServer.Tests
             Assert.Empty(s.Driver.FindElements(By.CssSelector(".payment-method")));
             payUrl = s.Driver.FindElement(By.CssSelector(".btn-primary")).GetAttribute("href");
             Assert.StartsWith("bitcoin:", payUrl);
-            Assert.DoesNotContain("&LIGHTNING=", payUrl);
+            Assert.DoesNotContain("&lightning=", payUrl);
 
             // Expiry message should not show amount for topup invoice
             expirySeconds = s.Driver.FindElement(By.Id("ExpirySeconds"));

--- a/BTCPayServer/Payments/Bitcoin/BitcoinLikePaymentHandler.cs
+++ b/BTCPayServer/Payments/Bitcoin/BitcoinLikePaymentHandler.cs
@@ -76,7 +76,8 @@ namespace BTCPayServer.Payments.Bitcoin
 
             if (model.Activated)
             {
-                model.InvoiceBitcoinUrl = (cryptoInfo.PaymentUrls?.BIP21 ?? "") + lightningFallback;
+                model.InvoiceBitcoinUrl = (cryptoInfo.PaymentUrls?.BIP21 ?? "") + lightningFallback
+                    .Replace("LIGHTNING=", "lightning=", StringComparison.OrdinalIgnoreCase);
                 model.InvoiceBitcoinUrlQR = (cryptoInfo.PaymentUrls?.BIP21 ?? "") + lightningFallback
                     .Replace("LIGHTNING=", "lightning=", StringComparison.OrdinalIgnoreCase);
 

--- a/BTCPayServer/Views/Shared/Bitcoin/BitcoinLikeMethodCheckout-v2.cshtml
+++ b/BTCPayServer/Views/Shared/Bitcoin/BitcoinLikeMethodCheckout-v2.cshtml
@@ -46,7 +46,7 @@
                 return this.model.invoiceBitcoinUrl.indexOf('@PayjoinClient.BIP21EndpointKey=') !== -1;
             },
             BOLT11 () {
-                const match = this.model.invoiceBitcoinUrl.match(/&LIGHTNING=(.*)&?/i);
+                const match = this.model.invoiceBitcoinUrl.match(/&lightning=(.*)&?/i);
                 return match ? match[1].toLowerCase() : null;
             }
         }


### PR DESCRIPTION
This PR changes the `lightning` query param in unified BIP21 URLs to lowercase as popular wallet apps (confirmed on CashApp, Muun) do not detect the Lightning address otherwise.

I've confirmed that CashApp and Muun (as of Jan 2023) do not detect the Lightning component of the unified BIP21 URL if the `lightning` parameter is capitalised.

I initially ran into the issue where it was odd that scanning the QR worked fine, but the "Open in Wallet" / "Pay in Wallet" button in both old and new checkouts didn't work. A bit of digging and investigation that both CashApp and Muun appear to only expect lowercase `lightning`.

I don't have a working .NET environment but this appears to be the changes that need to be made.
