### PR TITLE
Fix XSS on uploaded files to the file storage

### DIFF
--- a/BTCPayServer/Storage/StorageExtensions.cs
+++ b/BTCPayServer/Storage/StorageExtensions.cs
@@ -75,6 +75,7 @@ namespace BTCPayServer.Storage
                 {
                     context.Context.Response.Headers["Content-Disposition"] = "attachment";
                 }
+                context.Context.Response.Headers["Content-Security-Policy"] = "script-src 'self'";
             };
         }
     }


### PR DESCRIPTION
I tweet that a few day ago

![image](https://user-images.githubusercontent.com/3020646/214806551-25ceb3a9-fa32-4d66-b32f-7f3e17108776.png)

Didn't age well... or did it? turns out @ctflearner found a script injection, in the one single fucking place there isn't CSP!

@dennisreimann @Kukks good to keep in mind if you have any other project anywhere: If you use the default dotnet Static File middleware and expose files controlled by users, you are by default exposed to XSS!

A user can upload a `.php` file with a `<script>` inside. When browsing the file on the direct link, the browser happily execute the JS.

It's not severe as it require the victim to actively browse a specific link, but it's not good.

https://huntr.dev/bounties/7830b9b4-af2e-44ef-8b00-ee2491d4e7ff/