### PR TITLE
Lightning Address: Fix availability check and refactor option view

### DIFF
--- a/BTCPayServer/Views/Shared/LNURL/LightningAddressNav.cshtml
+++ b/BTCPayServer/Views/Shared/LNURL/LightningAddressNav.cshtml
@@ -1,18 +1,14 @@
-@using BTCPayServer.Payments.Lightning
 @using BTCPayServer.Views.Stores
 @using BTCPayServer.Abstractions.Extensions
 @inject BTCPayNetworkProvider BTCPayNetworkProvider
 @{
+    const string cryptoCode = "BTC";
     var store = Context.GetStoreData();
-    var isLightningEnabled = store.IsLightningEnabled(BTCPayNetworkProvider);
-    var isLNUrlEnabled = store.IsLNUrlEnabled(BTCPayNetworkProvider);
-    var possible =
-        isLightningEnabled &&
-        isLNUrlEnabled &&
-        store.GetSupportedPaymentMethods(BTCPayNetworkProvider).OfType<LNURLPaySupportedPaymentMethod>().Any(type => type.CryptoCode == "BTC");
+    var isLightningEnabled = store.IsLightningEnabled(BTCPayNetworkProvider, cryptoCode);
+    var isLNUrlEnabled = store.IsLNUrlEnabled(BTCPayNetworkProvider, cryptoCode);
 }
 
-@if (possible)
+@if (isLightningEnabled && isLNUrlEnabled)
 {
     <li class="nav-item">
         <a asp-area="" asp-controller="UILNURL" asp-action="EditLightningAddress" asp-route-storeId="@store.Id" class="nav-link @ViewData.IsActivePage("LightningAddress", nameof(StoreNavPages))" id="StoreNav-LightningAddress">

--- a/BTCPayServer/Views/Shared/LNURL/LightningAddressOption.cshtml
+++ b/BTCPayServer/Views/Shared/LNURL/LightningAddressOption.cshtml
@@ -1,18 +1,11 @@
-@using BTCPayServer.Payments.Lightning
 @inject BTCPayNetworkProvider BTCPayNetworkProvider
 @{
+    const string cryptoCode = "BTC";
     var store = Context.GetStoreData();
-    var cryptoCode = "BTC";
-    var isLightningEnabled = store.IsLightningEnabled(BTCPayNetworkProvider);
-    var isLNUrlEnabled = store.IsLNUrlEnabled(BTCPayNetworkProvider);
-    var possible =
-        isLightningEnabled &&
-        isLNUrlEnabled &&
-        store.GetSupportedPaymentMethods(BTCPayNetworkProvider).OfType<LNURLPaySupportedPaymentMethod>().Any(type => type.CryptoCode == cryptoCode);
-    var network = BTCPayNetworkProvider.GetNetwork<BTCPayNetwork>(cryptoCode);
+    var isLightningEnabled = store.IsLightningEnabled(BTCPayNetworkProvider, cryptoCode);
+    var isLNUrlEnabled = store.IsLNUrlEnabled(BTCPayNetworkProvider, cryptoCode);
 }
 
-@if (network?.SupportLightning is true) {
 <li class="list-group-item bg-tile" id="lightning-address-option">
     <div class="d-flex align-items-center">
         <span class="d-flex flex-wrap flex-fill flex-column flex-sm-row">
@@ -24,32 +17,31 @@
             </strong>
         </span>
         <span class="d-flex align-items-center fw-semibold">
-            @if (possible)
+            @switch (isLightningEnabled)
             {
-                <a id="lightning-address-setup-link" class="btn btn-primary btn-sm ms-4 px-3 py-1 fw-semibold" asp-controller="UILNURL" asp-action="EditLightningAddress" asp-route-storeId="@Context.GetRouteValue("storeId")">
-                    Setup
-                </a>
-            }
-            else
-            {
-                if (!isLightningEnabled)
-                {
-                    <a asp-controller="UIStores" asp-action="SetupLightningNode" asp-route-cryptoCode="@cryptoCode" asp-route-storeId="@store.Id" class="btn btn-link p-0">
-                        You need to setup Lightning first
+                case true when isLNUrlEnabled:
+                    <a asp-controller="UILNURL" asp-action="EditLightningAddress" asp-route-storeId="@store.Id" id="lightning-address-setup-link" class="btn btn-primary btn-sm ms-4 px-3 py-1 fw-semibold">
+                        Setup
                     </a>
-                }
-                else
-                {
+                    break;
+                case false:
                     <span class="d-flex align-items-center text-danger">
                         <span class="me-2 btcpay-status btcpay-status--disabled"></span>
-                        <a asp-action="LightningSettings" asp-route-cryptoCode="BTC" asp-route-storeId="@store.Id" asp-fragment="ln-url">
+                        <a asp-controller="UIStores" asp-action="SetupLightningNode" asp-route-cryptoCode="@cryptoCode" asp-route-storeId="@store.Id" class="btn btn-link p-0">
+                            You need to setup Lightning first
+                        </a>
+                    </span>
+                    break;
+                default:
+                    <span class="d-flex align-items-center text-danger">
+                        <span class="me-2 btcpay-status btcpay-status--disabled"></span>
+                        <a asp-action="LightningSettings" asp-route-cryptoCode="BTC" asp-route-storeId="@store.Id" asp-fragment="ln-url" class="btn btn-link p-0">
                             You need LNURL configured first
                         </a>
                     </span>
-                }
+                    break;
             }
         </span>
     </div>
 </li>
-}
 


### PR DESCRIPTION
As @petzsch rightfully assumed in #4578, the check took only the last available LN payment method into account, which in this case was LN on LTC. We now pass the crypto code as well and I refactored the checks as well as the option view.

Fixes #4578.