### PR TITLE
Add missing CORS to ln address of BTCPay (Compatibility Beach Wallet)

### DIFF
--- a/BTCPayServer/Controllers/UILNURLController.cs
+++ b/BTCPayServer/Controllers/UILNURLController.cs
@@ -26,6 +26,7 @@ using BTCPayServer.Services.Rates;
 using BTCPayServer.Services.Stores;
 using LNURL;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Cors;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
 using NBitcoin;
@@ -320,6 +321,8 @@ namespace BTCPayServer
         }
 
         [HttpGet("~/.well-known/lnurlp/{username}")]
+        [EnableCors(CorsPolicies.All)]
+        [IgnoreAntiforgeryToken]
         public async Task<IActionResult> ResolveLightningAddress(string username)
         {
             var lightningAddressSettings = await _lightningAddressService.ResolveByAddress(username);


### PR DESCRIPTION
We forgot to add CORS to ln address, resulting in incompatibility with a few wallet such as Beach Wallet.
@openoms

https://twitter.com/openoms/status/1620815072208760834?s=20&t=uOeORe0X_o38ubWQ_r-iQg