### PR TITLE
Adapt cookie auth to work with same API permission system

### DIFF
--- a/BTCPayServer.Client/Permissions.cs
+++ b/BTCPayServer.Client/Permissions.cs
@@ -103,13 +103,40 @@ namespace BTCPayServer.Client
             return policy.StartsWith("btcpay.user", StringComparison.OrdinalIgnoreCase);
         }
     }
+
+    public class PermissionSet
+    {
+        public PermissionSet() : this(Array.Empty<Permission>())
+        {
+
+        }
+        public PermissionSet(Permission[] permissions)
+        {
+            Permissions = permissions;
+        }
+
+        public Permission[] Permissions { get; }
+
+        public bool Contains(Permission requestedPermission)
+        {
+            return Permissions.Any(p => p.Contains(requestedPermission));
+        }
+        public bool Contains(string permission, string store)
+        {
+            if (permission is null)
+                throw new ArgumentNullException(nameof(permission));
+            if (store is null)
+                throw new ArgumentNullException(nameof(store));
+            return Contains(Permission.Create(permission, store));
+        }
+    }
     public class Permission
     {
         static Permission()
         {
             Init();
         }
-        
+
         public static Permission Create(string policy, string scope = null)
         {
             if (TryCreatePermission(policy, scope, out var r))
@@ -203,7 +230,8 @@ namespace BTCPayServer.Client
                 return true;
             if (policy == subpolicy)
                 return true;
-            if (!PolicyMap.TryGetValue(policy, out var subPolicies)) return false;
+            if (!PolicyMap.TryGetValue(policy, out var subPolicies))
+                return false;
             return subPolicies.Contains(subpolicy) || subPolicies.Any(s => ContainsPolicy(s, subpolicy));
         }
 
@@ -217,23 +245,23 @@ namespace BTCPayServer.Client
                 Policies.CanModifyInvoices,
                 Policies.CanViewStoreSettings,
                 Policies.CanModifyStoreWebhooks,
-                Policies.CanModifyPaymentRequests, 
+                Policies.CanModifyPaymentRequests,
                 Policies.CanUseLightningNodeInStore);
 
             PolicyHasChild(Policies.CanManageUsers, Policies.CanCreateUser);
-            PolicyHasChild(Policies.CanManagePullPayments, Policies.CanCreatePullPayments );
-            PolicyHasChild(Policies.CanCreatePullPayments, Policies.CanCreateNonApprovedPullPayments );
-            PolicyHasChild(Policies.CanModifyPaymentRequests, Policies.CanViewPaymentRequests );
-            PolicyHasChild(Policies.CanModifyProfile, Policies.CanViewProfile );
-            PolicyHasChild(Policies.CanUseLightningNodeInStore, Policies.CanViewLightningInvoiceInStore, Policies.CanCreateLightningInvoiceInStore );
-            PolicyHasChild(Policies.CanManageNotificationsForUser, Policies.CanViewNotificationsForUser );
+            PolicyHasChild(Policies.CanManagePullPayments, Policies.CanCreatePullPayments);
+            PolicyHasChild(Policies.CanCreatePullPayments, Policies.CanCreateNonApprovedPullPayments);
+            PolicyHasChild(Policies.CanModifyPaymentRequests, Policies.CanViewPaymentRequests);
+            PolicyHasChild(Policies.CanModifyProfile, Policies.CanViewProfile);
+            PolicyHasChild(Policies.CanUseLightningNodeInStore, Policies.CanViewLightningInvoiceInStore, Policies.CanCreateLightningInvoiceInStore);
+            PolicyHasChild(Policies.CanManageNotificationsForUser, Policies.CanViewNotificationsForUser);
             PolicyHasChild(Policies.CanModifyServerSettings,
                 Policies.CanUseInternalLightningNode,
                 Policies.CanManageUsers);
-            PolicyHasChild(Policies.CanUseInternalLightningNode, Policies.CanCreateLightningInvoiceInternalNode,Policies.CanViewLightningInvoiceInternalNode );
-            PolicyHasChild(Policies.CanManageCustodianAccounts, Policies.CanViewCustodianAccounts );
-            PolicyHasChild(Policies.CanModifyInvoices, Policies.CanViewInvoices, Policies.CanCreateInvoice );
-            PolicyHasChild(Policies.CanViewStoreSettings, Policies.CanViewInvoices, Policies.CanViewPaymentRequests  );
+            PolicyHasChild(Policies.CanUseInternalLightningNode, Policies.CanCreateLightningInvoiceInternalNode, Policies.CanViewLightningInvoiceInternalNode);
+            PolicyHasChild(Policies.CanManageCustodianAccounts, Policies.CanViewCustodianAccounts);
+            PolicyHasChild(Policies.CanModifyInvoices, Policies.CanViewInvoices, Policies.CanCreateInvoice, Policies.CanCreateLightningInvoiceInStore);
+            PolicyHasChild(Policies.CanViewStoreSettings, Policies.CanViewInvoices, Policies.CanViewPaymentRequests);
         }
 
         private static void PolicyHasChild(string policy, params string[] subPolicies)
@@ -247,7 +275,7 @@ namespace BTCPayServer.Client
             }
             else
             {
-                PolicyMap.Add(policy,subPolicies.ToHashSet());
+                PolicyMap.Add(policy, subPolicies.ToHashSet());
             }
         }
 

--- a/BTCPayServer.Client/Permissions.cs
+++ b/BTCPayServer.Client/Permissions.cs
@@ -79,9 +79,7 @@ namespace BTCPayServer.Client
         }
         public static bool IsValidPolicy(string policy)
         {
-            return AllPolicies.Any(p => 
-                p.Equals(policy, StringComparison.OrdinalIgnoreCase)) ||
-                policy.Equals(CanModifyStoreSettingsUnscoped);
+            return AllPolicies.Any(p => p.Equals(policy, StringComparison.OrdinalIgnoreCase));
         }
 
         public static bool IsStorePolicy(string policy)

--- a/BTCPayServer.Client/Permissions.cs
+++ b/BTCPayServer.Client/Permissions.cs
@@ -98,6 +98,10 @@ namespace BTCPayServer.Client
         {
             return policy.StartsWith("btcpay.plugin", StringComparison.OrdinalIgnoreCase);
         }
+        public static bool IsUserPolicy(string policy)
+        {
+            return policy.StartsWith("btcpay.user", StringComparison.OrdinalIgnoreCase);
+        }
     }
     public class Permission
     {
@@ -213,7 +217,8 @@ namespace BTCPayServer.Client
                 Policies.CanModifyInvoices,
                 Policies.CanViewStoreSettings,
                 Policies.CanModifyStoreWebhooks,
-                Policies.CanModifyPaymentRequests);
+                Policies.CanModifyPaymentRequests, 
+                Policies.CanUseLightningNodeInStore);
 
             PolicyHasChild(Policies.CanManageUsers, Policies.CanCreateUser);
             PolicyHasChild(Policies.CanManagePullPayments, Policies.CanCreatePullPayments );

--- a/BTCPayServer.Data/Data/StoreData.cs
+++ b/BTCPayServer.Data/Data/StoreData.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations.Schema;
 using System.Text;
+using BTCPayServer.Client;
 using BTCPayServer.Client.Models;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;

--- a/BTCPayServer.Tests/TestAccount.cs
+++ b/BTCPayServer.Tests/TestAccount.cs
@@ -220,8 +220,8 @@ namespace BTCPayServer.Tests
             RegisterDetails = new RegisterViewModel()
             {
                 Email = Utils.GenerateEmail(),
-                ConfirmPassword = "Kitten0@",
-                Password = "Kitten0@",
+                ConfirmPassword = Password,
+                Password = Password,
                 IsAdmin = isAdmin
             };
             await account.Register(RegisterDetails);
@@ -240,6 +240,7 @@ namespace BTCPayServer.Tests
             Email = RegisterDetails.Email;
             IsAdmin = account.RegisteredAdmin;
         }
+        public string Password { get; set; } = "Kitten0@";
 
         public RegisterViewModel RegisterDetails { get; set; }
 

--- a/BTCPayServer/BTCPayServer.csproj
+++ b/BTCPayServer/BTCPayServer.csproj
@@ -139,6 +139,7 @@
 
 	<ItemGroup>
     <Watch Include="Views\**\*.*"></Watch>
+    <Watch Remove="Views\UIAccount\CheatPermissions.cshtml" />
     <Content Update="Views\UIApps\_ViewImports.cshtml">
       <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
       <Pack>$(IncludeRazorContentInPack)</Pack>

--- a/BTCPayServer/Controllers/UIHomeController.cs
+++ b/BTCPayServer/Controllers/UIHomeController.cs
@@ -222,7 +222,7 @@ namespace BTCPayServer.Controllers
 
         public RedirectToActionResult RedirectToStore(StoreData store)
         {
-            return store.Role == StoreRoles.Owner
+            return store.HasPermission(Policies.CanModifyStoreSettings)
                 ? RedirectToAction("Dashboard", "UIStores", new { storeId = store.Id })
                 : RedirectToAction("ListInvoices", "UIInvoice", new { storeId = store.Id });
         }

--- a/BTCPayServer/Controllers/UIInvoiceController.cs
+++ b/BTCPayServer/Controllers/UIInvoiceController.cs
@@ -24,6 +24,7 @@ using BTCPayServer.Services.PaymentRequests;
 using BTCPayServer.Services.Rates;
 using BTCPayServer.Services.Stores;
 using BTCPayServer.Validation;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
@@ -56,6 +57,7 @@ namespace BTCPayServer.Controllers
         private readonly UIWalletsController _walletsController;
         private readonly InvoiceActivator _invoiceActivator;
         private readonly LinkGenerator _linkGenerator;
+        private readonly IAuthorizationService _authorizationService;
 
         public WebhookSender WebhookNotificationManager { get; }
 
@@ -78,7 +80,8 @@ namespace BTCPayServer.Controllers
             ExplorerClientProvider explorerClients,
             UIWalletsController walletsController,
             InvoiceActivator invoiceActivator,
-            LinkGenerator linkGenerator)
+            LinkGenerator linkGenerator,
+            IAuthorizationService authorizationService)
         {
             _displayFormatter = displayFormatter;
             _CurrencyNameTable = currencyNameTable ?? throw new ArgumentNullException(nameof(currencyNameTable));
@@ -98,6 +101,7 @@ namespace BTCPayServer.Controllers
             _walletsController = walletsController;
             _invoiceActivator = invoiceActivator;
             _linkGenerator = linkGenerator;
+            _authorizationService = authorizationService;
         }
 
 

--- a/BTCPayServer/Data/StoreDataExtensions.cs
+++ b/BTCPayServer/Data/StoreDataExtensions.cs
@@ -1,8 +1,10 @@
 #nullable enable
 using System;
 using System.Collections.Generic;
+using System.Data;
 using System.Linq;
 using System.Text;
+using BTCPayServer.Client;
 using BTCPayServer.Payments;
 using BTCPayServer.Payments.Lightning;
 using BTCPayServer.Services.Rates;
@@ -14,6 +16,33 @@ namespace BTCPayServer.Data
 {
     public static class StoreDataExtensions
     {
+        public static PermissionSet GetPermissionSet(this StoreData store)
+        {
+            ArgumentNullException.ThrowIfNull(store);
+            if (store.Role is null)
+                return new PermissionSet();
+            return new PermissionSet(store.Role == StoreRoles.Owner
+                        ? new[]
+                        {
+                        Permission.Create(Policies.CanModifyStoreSettings, store.Id),
+                        Permission.Create(Policies.CanTradeCustodianAccount, store.Id),
+                        Permission.Create(Policies.CanWithdrawFromCustodianAccounts, store.Id),
+                        Permission.Create(Policies.CanDepositToCustodianAccounts, store.Id)
+                        }
+                        : new[]
+                        {
+                        Permission.Create(Policies.CanViewStoreSettings, store.Id),
+                        Permission.Create(Policies.CanModifyInvoices, store.Id),
+                        Permission.Create(Policies.CanViewCustodianAccounts, store.Id),
+                        Permission.Create(Policies.CanDepositToCustodianAccounts, store.Id)
+                        });
+        }
+        public static bool HasPermission(this StoreData store, string permission)
+        {
+            ArgumentNullException.ThrowIfNull(store);
+            return store.GetPermissionSet().Contains(permission, store.Id);
+        }
+
 #pragma warning disable CS0618
         public static PaymentMethodId? GetDefaultPaymentId(this StoreData storeData)
         {

--- a/BTCPayServer/Models/AccountViewModels/CheatPermissionsViewModel.cs
+++ b/BTCPayServer/Models/AccountViewModels/CheatPermissionsViewModel.cs
@@ -1,0 +1,10 @@
+using Microsoft.AspNetCore.Authorization;
+
+namespace BTCPayServer.Models.AccountViewModels
+{
+    public class CheatPermissionsViewModel
+    {
+        public string StoreId { get; internal set; }
+        public (string, AuthorizationResult Result)[] Permissions { get; set; }
+    }
+}

--- a/BTCPayServer/Security/CookieAuthorizationHandler.cs
+++ b/BTCPayServer/Security/CookieAuthorizationHandler.cs
@@ -141,18 +141,7 @@ namespace BTCPayServer.Security
             {
                 if (store is not null)
                 {
-                    var requestedPermission = Permission.Create(policy, store.Id);
-                    var givenPermissions = store.Role == StoreRoles.Owner
-                        ? new[]
-                        {
-                        Permission.Create(Policies.CanModifyStoreSettings, store.Id)
-                        }
-                        : new[]
-                        {
-                        Permission.Create(Policies.CanViewStoreSettings, store.Id),
-                        Permission.Create(Policies.CanModifyInvoices, store.Id)
-                        };
-                    if (givenPermissions.Any(p => p.Contains(requestedPermission)))
+                    if (store.HasPermission(policy))
                     {
                         success = true;
                     }

--- a/BTCPayServer/Security/CookieAuthorizationHandler.cs
+++ b/BTCPayServer/Security/CookieAuthorizationHandler.cs
@@ -116,9 +116,11 @@ namespace BTCPayServer.Security
             storeId ??= _httpContext.GetUserPrefsCookie()?.CurrentStoreId;
 
             var policy = requirement.Policy;
+            bool requiredUnscoped = false;
             if (policy.EndsWith(':'))
             {
                 policy = policy.Substring(0, policy.Length - 1);
+                requiredUnscoped = true;
                 storeId = null;
             }
 
@@ -155,7 +157,7 @@ namespace BTCPayServer.Security
                         success = true;
                     }
                 }
-                else if (userId is not null)
+                else if (requiredUnscoped)
                 {
                     success = true;
                 }

--- a/BTCPayServer/Security/GreenField/APIKeyExtensions.cs
+++ b/BTCPayServer/Security/GreenField/APIKeyExtensions.cs
@@ -49,17 +49,11 @@ namespace BTCPayServer.Security.Greenfield
         }
         public static bool HasPermission(this AuthorizationHandlerContext context, Permission permission)
         {
-            return HasPermission(context, permission, false);
-        }
-        public static bool HasPermission(this AuthorizationHandlerContext context, Permission permission, bool requireUnscoped)
-        {
             foreach (var claim in context.User.Claims.Where(c =>
                 c.Type.Equals(GreenfieldConstants.ClaimTypes.Permission, StringComparison.InvariantCultureIgnoreCase)))
             {
                 if (Permission.TryParse(claim.Value, out var claimPermission))
                 {
-                    if (requireUnscoped && claimPermission.Scope is not null)
-                        continue;
                     if (claimPermission.Contains(permission))
                     {
                         return true;

--- a/BTCPayServer/Views/UIAccount/CheatPermissions.cshtml
+++ b/BTCPayServer/Views/UIAccount/CheatPermissions.cshtml
@@ -1,0 +1,22 @@
+@model CheatPermissionsViewModel
+
+@{
+	ViewData["Title"] = "Permissions";
+	Layout = "_LayoutSignedOut";
+}
+
+@if (Model.StoreId is not null)
+{
+	<h1>Store: @Model.StoreId</h1>
+}
+else
+{
+	<h1>No scope</h1>
+}
+
+<ul>
+@foreach (var p in Model.Permissions.Where(o => o.Result.Succeeded))
+{
+	<li>@p.Item1</li>
+}
+</ul>

--- a/BTCPayServer/Views/UIInvoice/Invoice.cshtml
+++ b/BTCPayServer/Views/UIInvoice/Invoice.cshtml
@@ -1,3 +1,7 @@
+@using BTCPayServer.Client.Models
+@using Microsoft.AspNetCore.Mvc.TagHelpers
+@using BTCPayServer.Client
+@using BTCPayServer.Abstractions.TagHelpers
 @model InvoiceDetailsModel
 @{
     ViewData["Title"] = $"Invoice {Model.Id}";
@@ -102,7 +106,7 @@
         }
         @if (Model.CanRefund)
         {
-            <a asp-action="Refund" asp-route-invoiceId="@Model.Id" id="IssueRefund" class="btn btn-primary text-nowrap" data-bs-toggle="modal" data-bs-target="#RefundModal">Issue Refund</a>
+            <a asp-action="Refund" asp-route-invoiceId="@Model.Id" id="IssueRefund" class="btn btn-primary text-nowrap" data-bs-toggle="modal" data-bs-target="#RefundModal" permission="@Policies.CanCreateNonApprovedPullPayments">Issue Refund</a>
         }
         else
         {


### PR DESCRIPTION
fixes #3512 

This PR merges the approach of permissions used in greenfield with the cookie auth used on the website. This will allow us to build a similar experience of fine-grained permissions for users on a server and store level through custom roles and custom  store roles.