### PR TITLE
Fix: If PoS item code contains a /, LNUrl would not work (fix #4601)

### DIFF
--- a/BTCPayServer/Controllers/UILNURLController.cs
+++ b/BTCPayServer/Controllers/UILNURLController.cs
@@ -265,8 +265,11 @@ namespace BTCPayServer
                     break;
             }
 
+            var escapedItemId = Extensions.UnescapeBackSlashUriString(itemCode);
             var item = items.FirstOrDefault(item1 =>
-                item1.Id.Equals(itemCode, StringComparison.InvariantCultureIgnoreCase));
+                item1.Id.Equals(itemCode, StringComparison.InvariantCultureIgnoreCase) ||
+                item1.Id.Equals(escapedItemId, StringComparison.InvariantCultureIgnoreCase));
+
             if (item is null ||
                 item.Inventory <= 0 ||
                 (item.PaymentMethods?.Any() is true &&

--- a/BTCPayServer/Extensions.cs
+++ b/BTCPayServer/Extensions.cs
@@ -36,6 +36,20 @@ namespace BTCPayServer
 {
     public static class Extensions
     {
+        /// <summary>
+        /// Unescape Uri string for %2F
+        /// See details at: https://github.com/dotnet/aspnetcore/issues/14170#issuecomment-533342396
+        /// </summary>
+        /// <param name="uriString">The Uri string.</param>
+        /// <returns>Unescaped back slash Uri string.</returns>
+        public static string UnescapeBackSlashUriString(string uriString)
+        {
+            if (uriString == null)
+            {
+                return null;
+            }
+            return uriString.Replace("%2f", "%2F").Replace("%2F", "/");
+        }
         public static bool IsValidEmail(this string email)
         {
             if (string.IsNullOrEmpty(email))


### PR DESCRIPTION
This is caused by a weird buggy behavior from ASP.NET Core concerning path value decoding. (More information on
https://github.com/dotnet/aspnetcore/issues/14170#issuecomment-533342396)

This hasn't been fixed for a while (now 7 years), and the dotnet team keeps reporting it over and over.

Fix #4601