### PR TITLE
Swagger doc fix: store website nullable

### DIFF
--- a/BTCPayServer/wwwroot/swagger/v1/swagger.template.stores.json
+++ b/BTCPayServer/wwwroot/swagger/v1/swagger.template.stores.json
@@ -292,6 +292,7 @@
                     },
                     "website": {
                         "type": "string",
+                        "nullable": true,
                         "description": "The absolute url of the store",
                         "format": "url"
                     },


### PR DESCRIPTION
I tested the API and the `website` field on store creation can be null it seems. Updated the swagger file accordingly.