### PR TITLE
Greenfield: Currency rate should be strings

### DIFF
--- a/BTCPayServer.Client/Models/StoreRateResult.cs
+++ b/BTCPayServer.Client/Models/StoreRateResult.cs
@@ -1,10 +1,13 @@
 using System.Collections.Generic;
+using BTCPayServer.JsonConverters;
+using Newtonsoft.Json;
 
 namespace BTCPayServer.Client.Models;
 
 public class StoreRateResult
 {
     public string CurrencyPair { get; set; }
+    [JsonConverter(typeof(NumericStringJsonConverter))]
     public decimal? Rate { get; set; }
     public List<string> Errors { get; set; }
 }

--- a/BTCPayServer/wwwroot/swagger/v1/swagger.template.invoices.json
+++ b/BTCPayServer/wwwroot/swagger/v1/swagger.template.invoices.json
@@ -1260,6 +1260,7 @@
                     "rate": {
                         "type": "string",
                         "format": "decimal",
+                        "example": "64392.23",
                         "description": "The rate between this payment method's currency and the invoice currency"
                     },
                     "paymentMethodPaid": {

--- a/BTCPayServer/wwwroot/swagger/v1/swagger.template.stores-rates-config.json
+++ b/BTCPayServer/wwwroot/swagger/v1/swagger.template.stores-rates-config.json
@@ -238,8 +238,9 @@
                         "description": "Errors relating to this currency pair fetching based on your config"
                     },
                     "rate": {
-                        "type": "number",
-                        "example": 24520.23,
+                        "type": "string",
+                        "format": "decimal",
+                        "example": "64392.23",
                         "description": "the rate fetched based on the currency pair"
                     }
                 }


### PR DESCRIPTION
Breaking change on  /api/v1/stores/{storeId}/rates/configuration/preview

That said, the swagger was documenting a string when it was a decimal anyway...