### PR TITLE
BIP21 + LNURL fix

### DIFF
--- a/BTCPayServer.Tests/UnitTest1.cs
+++ b/BTCPayServer.Tests/UnitTest1.cs
@@ -1613,10 +1613,10 @@ namespace BTCPayServer.Tests
             var paymentMethodUnified = Assert.IsType<PaymentModel>(
                 Assert.IsType<ViewResult>(res).Model
             );
-            Assert.StartsWith("bitcoin:", paymentMethodUnified.InvoiceBitcoinUrl);
-            Assert.StartsWith("bitcoin:", paymentMethodUnified.InvoiceBitcoinUrlQR);
-            Assert.Contains("&lightning=", paymentMethodUnified.InvoiceBitcoinUrl);
-            Assert.Contains("&lightning=", paymentMethodUnified.InvoiceBitcoinUrlQR);
+            Assert.StartsWith("bitcoin:bcrt", paymentMethodUnified.InvoiceBitcoinUrl);
+            Assert.StartsWith("bitcoin:BCRT", paymentMethodUnified.InvoiceBitcoinUrlQR);
+            Assert.Contains("&lightning=lnbcrt", paymentMethodUnified.InvoiceBitcoinUrl);
+            Assert.Contains("&lightning=LNBCRT", paymentMethodUnified.InvoiceBitcoinUrlQR);
 
             // Check correct casing: Addresses in payment URI need to be …
             // - lowercase in link version

--- a/BTCPayServer/Controllers/UIInvoiceController.UI.cs
+++ b/BTCPayServer/Controllers/UIInvoiceController.UI.cs
@@ -655,7 +655,7 @@ namespace BTCPayServer.Controllers
                 var enabledPaymentIds = store.GetEnabledPaymentIds(_NetworkProvider)
                     .Where(pmId => storeBlob.CheckoutType == CheckoutType.V1 ||
                         // Exclude LNURL for Checkout v2 + non-top up invoices
-                        (pmId.PaymentType is not LNURLPayPaymentType || invoice.IsUnsetTopUp()))
+                        pmId != lnurlId || invoice.IsUnsetTopUp())
                     .ToArray();
 
                 // Exclude Lightning if OnChainWithLnInvoiceFallback is active and we have both payment methods
@@ -805,7 +805,7 @@ namespace BTCPayServer.Controllers
                 AvailableCryptos = invoice.GetPaymentMethods()
                                           .Where(i => i.Network != null && storeBlob.CheckoutType == CheckoutType.V1 ||
                                               // Exclude LNURL for Checkout v2 + non-top up invoices
-                                              i.GetId().PaymentType is not LNURLPayPaymentType || invoice.IsUnsetTopUp())
+                                              i.GetId() != lnurlId || invoice.IsUnsetTopUp())
                                           .Select(kv =>
                                           {
                                               var availableCryptoPaymentMethodId = kv.GetId();

--- a/BTCPayServer/Views/Shared/Bitcoin/BitcoinLikeMethodCheckout-v2.cshtml
+++ b/BTCPayServer/Views/Shared/Bitcoin/BitcoinLikeMethodCheckout-v2.cshtml
@@ -4,7 +4,7 @@
 <template id="bitcoin-method-checkout-template">
     @await Component.InvokeAsync("UiExtensionPoint", new {location = "checkout-v2-bitcoin-pre-content", model = Model})
     <div class="payment-box">
-        <div v-if="model.invoiceBitcoinUrlQR" class="qr-container" :data-clipboard="model.btcAddress" data-clipboard-confirm-element="QR_Text_@Model.PaymentMethodId">
+        <div v-if="model.invoiceBitcoinUrlQR" class="qr-container" :data-qr-value="model.invoiceBitcoinUrlQR" :data-clipboard="model.btcAddress" data-clipboard-confirm-element="QR_Text_@Model.PaymentMethodId">
             <div>
                 <qrcode :value="model.invoiceBitcoinUrlQR" tag="div" :options="qrOptions" />
             </div>

--- a/BTCPayServer/Views/Shared/Lightning/LightningLikeMethodCheckout-v2.cshtml
+++ b/BTCPayServer/Views/Shared/Lightning/LightningLikeMethodCheckout-v2.cshtml
@@ -3,7 +3,7 @@
 <template id="lightning-method-checkout-template">
     <div class="payment-box">
         @await Component.InvokeAsync("UiExtensionPoint" ,  new { location="checkout-v2-lightning-pre-content", model = Model})
-        <div v-if="model.invoiceBitcoinUrlQR" class="qr-container" :data-clipboard="model.btcAddress" data-clipboard-confirm-element="QR_Text_@Model.PaymentMethodId">
+        <div v-if="model.invoiceBitcoinUrlQR" class="qr-container" :data-qr-value="model.invoiceBitcoinUrlQR" :data-clipboard="model.btcAddress" data-clipboard-confirm-element="QR_Text_@Model.PaymentMethodId">
             <div>
                 <qrcode :value="model.invoiceBitcoinUrlQR" tag="div" :options="qrOptions" />
             </div>
@@ -12,10 +12,10 @@
         </div>
         <div v-if="model.btcAddress" class="input-group mt-3">
             <div class="form-floating">
-                <input id="Address_@Model.PaymentMethodId" class="form-control-plaintext" readonly="readonly" :value="model.btcAddress">
-                <label for="Address_@Model.PaymentMethodId" v-t="'lightning'"></label>
+                <input id="Lightning_@Model.PaymentMethodId" class="form-control-plaintext" readonly="readonly" :value="model.btcAddress">
+                <label for="Lightning_@Model.PaymentMethodId" v-t="'lightning'"></label>
             </div>
-            <button type="button" class="btn btn-link" data-clipboard-target="#Address_@Model.PaymentMethodId" :data-clipboard-confirm="$t('copy_confirm')" v-t="'copy'"></button>
+            <button type="button" class="btn btn-link" data-clipboard-target="#Lightning_@Model.PaymentMethodId" :data-clipboard-confirm="$t('copy_confirm')" v-t="'copy'"></button>
         </div>
         <a v-if="model.invoiceBitcoinUrl" class="btn btn-primary rounded-pill w-100 mt-4" target="_top"
            :href="model.invoiceBitcoinUrl" v-t="'pay_in_wallet'"></a>


### PR DESCRIPTION
In case of the unified invoice, the LNURL wasn't correct — with this change we are simply reusing th one that was issued on invoice creation instead of generating it anew on the fly.

Also fixes missing uppercasing for the QR code in case of non-unified QR. And removes the `lightning:` scheme from the LNURL that's displayed to the user (unifies it with what we do for Onchain and Lightning)

Fixes #4609.