### PR TITLE
Fix XSS: Stenghten CSP rules on static file uploads

### DIFF
--- a/BTCPayServer/Storage/StorageExtensions.cs
+++ b/BTCPayServer/Storage/StorageExtensions.cs
@@ -75,7 +75,7 @@ namespace BTCPayServer.Storage
                 {
                     context.Context.Response.Headers["Content-Disposition"] = "attachment";
                 }
-                context.Context.Response.Headers["Content-Security-Policy"] = "script-src 'self'";
+                context.Context.Response.Headers["Content-Security-Policy"] = "script-src ;";
             };
         }
     }


### PR DESCRIPTION
Credit to @d47sec

XSS on static files that we fixed on https://github.com/btcpayserver/btcpayserver/pull/4567 isn't enough!

It is possible to just upload a js file, then upload a html file referencing it.
This will bypass our CSP because we use `self` rule.

This fix is still brittle to be honest. If there is a HTML injection somewhere, it can be leveraged to a script injection by referencing a malicious js file uploaded.
Will need more stuff.