### PR TITLE
Checkout v2: Fix automatic redirect after paid

### DIFF
--- a/BTCPayServer/wwwroot/checkout-v2/checkout.js
+++ b/BTCPayServer/wwwroot/checkout-v2/checkout.js
@@ -252,12 +252,12 @@ function initApp() {
                 eventBus.$emit('data-fetched', this.srvModel);
     
                 const self = this;
-                if (this.isPaid && data.redirectAutomatically && data.merchantRefLink) {
+                if (self.isPaid && data.redirectAutomatically && self.storeLink) {
                     setTimeout(function () {
-                        if (self.isModal && window.top.location === data.merchantRefLink){
+                        if (self.isModal && window.top.location === self.storeLink){
                             self.close();
                         } else {
-                            window.top.location = data.merchantRefLink;
+                            window.top.location = self.storeLink;
                         }
                     }, 2000);
                 }


### PR DESCRIPTION
Should use captured `storeLink` property instead of the `merchantRefLink`.