### PR TITLE
Fix secondary order XSS: Harden file type inputs

### DIFF
--- a/BTCPayServer.Tests/FastTests.cs
+++ b/BTCPayServer.Tests/FastTests.cs
@@ -582,6 +582,22 @@ namespace BTCPayServer.Tests
         }
 
         [Fact]
+        public void CanDetectImage()
+        {
+            Assert.True(FileTypeDetector.IsPicture(new byte[] { 0x42, 0x4D }, "test.bmp"));
+            Assert.False(FileTypeDetector.IsPicture(new byte[] { 0x42, 0x4D }, ".bmp"));
+            Assert.False(FileTypeDetector.IsPicture(new byte[] { 0x42, 0x4D }, "test.svg"));
+            Assert.True(FileTypeDetector.IsPicture(new byte[] { 0xFF, 0xD8, 0xFF, 0xD9 }, "test.jpg"));
+            Assert.True(FileTypeDetector.IsPicture(new byte[] { 0xFF, 0xD8, 0xFF, 0xD9 }, "test.jpeg"));
+            Assert.False(FileTypeDetector.IsPicture(new byte[] { 0xFF, 0xD8, 0xFF, 0xDA }, "test.jpg"));
+            Assert.False(FileTypeDetector.IsPicture(new byte[] { 0xFF, 0xD8, 0xFF }, "test.jpg"));
+            Assert.True(FileTypeDetector.IsPicture(new byte[] { 0x3C, 0x73, 0x76, 0x67 }, "test.svg"));
+            Assert.False(FileTypeDetector.IsPicture(new byte[] { 0x3C, 0x73, 0x76, 0x67 }, "test.jpg"));
+            Assert.False(FileTypeDetector.IsPicture(new byte[] { 0xFF }, "e.jpg"));
+            Assert.False(FileTypeDetector.IsPicture(new byte[] { }, "empty.jpg"));
+        }
+
+        [Fact]
         public void RoundupCurrenciesCorrectly()
         {
             foreach (var test in new[]

--- a/BTCPayServer/BufferizedFormFile.cs
+++ b/BTCPayServer/BufferizedFormFile.cs
@@ -1,0 +1,62 @@
+using Microsoft.AspNetCore.Http;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace BTCPayServer
+{
+    public class BufferizedFormFile : IFormFile
+    {
+        private IFormFile _formFile;
+        private MemoryStream _content;
+        public byte[] Buffer { get; }
+        BufferizedFormFile(IFormFile formFile, byte[] content)
+        {
+            _formFile = formFile;
+            Buffer = content;
+            _content = new MemoryStream(content);
+        }
+
+        public string ContentType => _formFile.ContentType;
+
+        public string ContentDisposition => _formFile.ContentDisposition;
+
+        public IHeaderDictionary Headers => _formFile.Headers;
+
+        public long Length => _formFile.Length;
+
+        public string Name => _formFile.Name;
+
+        public string FileName => _formFile.FileName;
+
+        public static async Task<BufferizedFormFile> Bufferize(IFormFile formFile)
+        {
+            if (formFile is BufferizedFormFile b)
+                return b;
+            var content = new byte[formFile.Length];
+            using var fs = formFile.OpenReadStream();
+            await fs.ReadAsync(content, 0, content.Length);
+            return new BufferizedFormFile(formFile, content);
+        }
+
+        public void CopyTo(Stream target)
+        {
+            _content.CopyTo(target);
+        }
+
+        public Task CopyToAsync(Stream target, CancellationToken cancellationToken = default)
+        {
+            return _content.CopyToAsync(target, cancellationToken);
+        }
+
+        public Stream OpenReadStream()
+        {
+            return _content;
+        }
+
+        public void Rewind()
+        {
+            _content.Seek(0, SeekOrigin.Begin);
+        }
+    }
+}

--- a/BTCPayServer/Extensions.cs
+++ b/BTCPayServer/Extensions.cs
@@ -36,6 +36,10 @@ namespace BTCPayServer
 {
     public static class Extensions
     {
+        public static Task<BufferizedFormFile> Bufferize(this IFormFile formFile)
+        {
+            return BufferizedFormFile.Bufferize(formFile);
+        }
         /// <summary>
         /// Unescape Uri string for %2F
         /// See details at: https://github.com/dotnet/aspnetcore/issues/14170#issuecomment-533342396

--- a/BTCPayServer/FileTypeDetector.cs
+++ b/BTCPayServer/FileTypeDetector.cs
@@ -1,0 +1,92 @@
+#nullable enable
+using System;
+using System.Linq;
+using Microsoft.EntityFrameworkCore;
+using NBitcoin.DataEncoders;
+
+namespace BTCPayServer
+{
+    public class FileTypeDetector
+    {
+        // Thanks to https://www.garykessler.net/software/FileSigs_20220731.zip
+
+        const string pictureSigs =
+            "JPEG2000 image files,00 00 00 0C 6A 50 20 20,JP2,Picture,0,(null)\n" +
+            "Bitmap image,42 4D,BMP|DIB,Picture,0,(null)\n" +
+            "GIF file,47 49 46 38,GIF,Picture,0,00 3B\n" +
+            "PNG image,89 50 4E 47 0D 0A 1A 0A,PNG|APNG,Picture,0,49 45 4E 44 AE 42 60 82\n" +
+            "Generic JPEGimage fil,FF D8,JPE|JPEG|JPG,Picture,0,FF D9\n" +
+            "JPEG-EXIF-SPIFF images,FF D8 FF,JFIF|JPE|JPEG|JPG,Picture,0,FF D9\n" +
+            "SVG images, 3C 73 76 67,SVG,Picture,0,(null)\n" +
+            "Google WebP image file, 52 49 46 46 XX XX XX XX 57 45 42 50,WEBP,Picture,0,(null)\n" +
+            "AVIF image file, XX XX XX XX 66 74 79 70,AVIF,Picture,0,(null)\n";
+
+        readonly static (int[] Header, int[]? Trailer, string[] Extensions)[] headerTrailers;
+        static FileTypeDetector()
+        {
+            var lines = pictureSigs.Split('\n', StringSplitOptions.RemoveEmptyEntries);
+            headerTrailers = new (int[] Header, int[]? Trailer, string[] Extensions)[lines.Length];
+            for (int i = 0; i < lines.Length; i++)
+            {
+                var cells = lines[i].Split(',');
+                headerTrailers[i] = (
+                    DecodeData(cells[1]),
+                    cells[^1] == "(null)" ? null : DecodeData(cells[^1]),
+                    cells[2].Split('|').Select(p => $".{p}").ToArray()
+                    );
+            }
+        }
+
+        private static int[] DecodeData(string pattern)
+        {
+            pattern = pattern.Replace(" ", "");
+            int[] res = new int[pattern.Length / 2];
+            for (int i = 0; i < pattern.Length; i+=2)
+            {
+                var b = pattern[i..(i + 2)];
+                if (b == "XX")
+                    res[i/2] = -1;
+                else
+                    res[i/2] = byte.Parse(b, System.Globalization.NumberStyles.HexNumber);
+            }
+            return res;
+        }
+
+        public static bool IsPicture(byte[] bytes, string? filename)
+        {
+            for (int i = 0; i < headerTrailers.Length; i++)
+            {
+                if (headerTrailers[i].Header is int[] header)
+                {
+                    if (header.Length > bytes.Length)
+                        goto next;
+                    for (int x = 0; x < header.Length; x++)
+                    {
+                        if (bytes[x] != header[x] && header[x] != -1)
+                            goto next;
+                    }
+                }
+                if (headerTrailers[i].Trailer is int[] trailer)
+                {
+                    if (trailer.Length > bytes.Length)
+                        goto next;
+                    for (int x = 0; x < trailer.Length; x++)
+                    {
+                        if (bytes[^(trailer.Length - x)] != trailer[x] && trailer[x] != -1)
+                            goto next;
+                    }
+                }
+
+                if (filename is not null)
+                {
+                    if (!headerTrailers[i].Extensions.Any(ext => filename.Length > ext.Length && filename.EndsWith(ext, StringComparison.OrdinalIgnoreCase)))
+                        return false;
+                }
+                return true;
+next:
+                ;
+            }
+            return false;
+        }
+    }
+}

--- a/BTCPayServer/Storage/StorageExtensions.cs
+++ b/BTCPayServer/Storage/StorageExtensions.cs
@@ -76,6 +76,7 @@ namespace BTCPayServer.Storage
                     context.Context.Response.Headers["Content-Disposition"] = "attachment";
                 }
                 context.Context.Response.Headers["Content-Security-Policy"] = "script-src ;";
+                context.Context.Response.Headers["X-Content-Type-Options"] = "nosniff";
             };
         }
     }


### PR DESCRIPTION
I was thinking we could avoid validating file upload.
But nope... @nayefhmoodh has shown me a secondary order XSS which can even avoid the strictest CSP by crafting a rogue PDF file...

Credit to @nayefhmoodh

https://huntr.dev/bounties/9464e3c6-961d-4e23-8b3d-07cbb31de541/