### PR TITLE
Fix: If user get locked out, unlocking or deleting user fails (Fix #4641)

### DIFF
--- a/BTCPayServer/Controllers/UIServerController.Users.cs
+++ b/BTCPayServer/Controllers/UIServerController.Users.cs
@@ -86,7 +86,7 @@ namespace BTCPayServer.Controllers
                 Id = user.Id,
                 Email = user.Email,
                 Verified = user.EmailConfirmed || !user.RequiresEmailConfirmation,
-                IsAdmin = _userService.IsRoleAdmin(roles)
+                IsAdmin = Roles.HasServerAdmin(roles)
             };
             return View(userVM);
         }
@@ -101,7 +101,7 @@ namespace BTCPayServer.Controllers
 
             var admins = await _UserManager.GetUsersInRoleAsync(Roles.ServerAdmin);
             var roles = await _UserManager.GetRolesAsync(user);
-            var wasAdmin = _userService.IsRoleAdmin(roles);
+            var wasAdmin = Roles.HasServerAdmin(roles);
             if (!viewModel.IsAdmin && admins.Count == 1 && wasAdmin)
             {
                 TempData[WellKnownTempData.ErrorMessage] = "This is the only Admin, so their role can't be removed until another Admin is added.";
@@ -219,7 +219,7 @@ namespace BTCPayServer.Controllers
                 return NotFound();
 
             var roles = await _UserManager.GetRolesAsync(user);
-            if (_userService.IsRoleAdmin(roles))
+            if (Roles.HasServerAdmin(roles))
             {
                 if (await _userService.IsUserTheOnlyOneAdmin(user))
                 {

--- a/BTCPayServer/Roles.cs
+++ b/BTCPayServer/Roles.cs
@@ -1,7 +1,15 @@
+using System.Collections.Generic;
+using System;
+using System.Linq;
+
 namespace BTCPayServer
 {
     public class Roles
     {
         public const string ServerAdmin = "ServerAdmin";
+        public static bool HasServerAdmin(IList<string> roles)
+        {
+            return roles.Contains(Roles.ServerAdmin, StringComparer.Ordinal);
+        }
     }
 }


### PR DESCRIPTION
This is due to the fact our UserService is a singleton, and it had a reference on UserManager which is scoped.

UserManager is caching user entities at the scope level. UserService then ended up with a view completely unsynchronized with the database.

Fix #4641