### PR TITLE
Revert "Fix: Setting the password of a new created user via API shouldn't be required (Close #4534)"

### DIFF
--- a/BTCPayServer/wwwroot/swagger/v1/swagger.template.users.json
+++ b/BTCPayServer/wwwroot/swagger/v1/swagger.template.users.json
@@ -108,8 +108,7 @@
                                     },
                                     "password": {
                                         "type": "string",
-                                        "description": "The password of the new user (if no password is set, an email will be sent to the user requiring him to set the password)",
-                                        "nullable": true
+                                        "description": "The password of the new user"
                                     },
                                     "isAdministrator": {
                                         "type": "boolean",


### PR DESCRIPTION
Reverts btcpayserver/btcpayserver#4645