### PR TITLE
Fix: Setting the password of a new created user via API shouldn't be required (Close #4534)

### DIFF
--- a/BTCPayServer.Tests/GreenfieldAPITests.cs
+++ b/BTCPayServer.Tests/GreenfieldAPITests.cs
@@ -655,15 +655,8 @@ namespace BTCPayServer.Tests
             tester.PayTester.DisableRegistration = true;
             await tester.StartAsync();
             var unauthClient = new BTCPayServerClient(tester.PayTester.ServerUri);
-            await AssertValidationError(new[] { "Email", "Password" },
+            await AssertValidationError(new[] { "Email" },
                 async () => await unauthClient.CreateUser(new CreateApplicationUserRequest()));
-            await AssertValidationError(new[] { "Password" },
-                async () => await unauthClient.CreateUser(
-                    new CreateApplicationUserRequest() { Email = "test@gmail.com" }));
-            // Pass too simple
-            await AssertValidationError(new[] { "Password" },
-                async () => await unauthClient.CreateUser(
-                    new CreateApplicationUserRequest() { Email = "test3@gmail.com", Password = "a" }));
 
             // We have no admin, so it should work
             var user1 = await unauthClient.CreateUser(
@@ -1346,10 +1339,6 @@ namespace BTCPayServer.Tests
                     Email = $"{Guid.NewGuid()}",
                     Password = Guid.NewGuid().ToString()
                 }));
-
-            await AssertValidationError(new[] { "Password" }, async () =>
-                await clientServer.CreateUser(
-                    new CreateApplicationUserRequest() { Email = $"{Guid.NewGuid()}@g.com", }));
 
             await AssertValidationError(new[] { "Email" }, async () =>
                 await clientServer.CreateUser(

--- a/BTCPayServer/Controllers/GreenField/GreenfieldUsersController.cs
+++ b/BTCPayServer/Controllers/GreenField/GreenfieldUsersController.cs
@@ -124,8 +124,6 @@ namespace BTCPayServer.Controllers.Greenfield
             {
                 ModelState.AddModelError(nameof(request.Email), "Invalid email");
             }
-            if (request.Password is null)
-                ModelState.AddModelError(nameof(request.Password), "Password is missing");
             if (!ModelState.IsValid)
             {
                 return this.CreateValidationError(ModelState);

--- a/BTCPayServer/wwwroot/swagger/v1/swagger.template.users.json
+++ b/BTCPayServer/wwwroot/swagger/v1/swagger.template.users.json
@@ -108,7 +108,8 @@
                                     },
                                     "password": {
                                         "type": "string",
-                                        "description": "The password of the new user"
+                                        "description": "The password of the new user (if no password is set, an email will be sent to the user requiring him to set the password)",
+                                        "nullable": true
                                     },
                                     "isAdministrator": {
                                         "type": "boolean",


### PR DESCRIPTION
Close #4534