### PR TITLE
UI: Remove highlight for valid fields

### DIFF
--- a/BTCPayServer/Views/Shared/_ValidationScriptsPartial.cshtml
+++ b/BTCPayServer/Views/Shared/_ValidationScriptsPartial.cshtml
@@ -9,7 +9,7 @@
             $(element.form).find(`[data-valmsg-for="${element.id}"]`).addClass('invalid-feedback');
         },
         unhighlight: function (element) {
-            $(element).addClass("is-valid").removeClass("is-invalid");
+            $(element).removeClass("is-invalid");
             $(element.form).find(`[data-valmsg-for="${element.id}"]`).removeClass('invalid-feedback');
         }
     });


### PR DESCRIPTION
I recently updated the validation defaults to use the Bootstrap 5 classes. This removes the highlight for validated fields, because imho it's too much to explicitely highlight fields with correct input and it also made these fields flash green on form submit, when the validation is done.