### PR TITLE
Fix LNURL-Withdraw payments

### DIFF
--- a/BTCPayServer.Tests/Checkoutv2Tests.cs
+++ b/BTCPayServer.Tests/Checkoutv2Tests.cs
@@ -231,7 +231,7 @@ namespace BTCPayServer.Tests
             Assert.True(s.Driver.FindElement(By.Id("LNURLEnabled")).Selected);
             Assert.True(s.Driver.FindElement(By.Id("LNURLStandardInvoiceEnabled")).Selected);
             
-            // BIP21 with topup invoice
+            // BIP21 with top-up invoice
             invoiceId = s.CreateInvoice(amount: null);
             s.GoToInvoiceCheckout(invoiceId);
             s.Driver.WaitUntilAvailable(By.Id("Checkout-v2"));
@@ -250,7 +250,7 @@ namespace BTCPayServer.Tests
             Assert.StartsWith($"bitcoin:{address.ToUpperInvariant()}?lightning=LNURL", qrValue);
             s.Driver.FindElement(By.Id("PayByLNURL"));
 
-            // Expiry message should not show amount for topup invoice
+            // Expiry message should not show amount for top-up invoice
             expirySeconds = s.Driver.FindElement(By.Id("ExpirySeconds"));
             expirySeconds.Clear();
             expirySeconds.SendKeys("5");

--- a/BTCPayServer/Data/Payouts/LightningLike/LightningLikePayoutHandler.cs
+++ b/BTCPayServer/Data/Payouts/LightningLike/LightningLikePayoutHandler.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using BTCPayServer.Abstractions.Models;
@@ -15,8 +14,6 @@ using LNURL;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using NBitcoin;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 
 namespace BTCPayServer.Data.Payouts.LightningLike
 {

--- a/BTCPayServer/Data/Payouts/PayoutExtensions.cs
+++ b/BTCPayServer/Data/Payouts/PayoutExtensions.cs
@@ -77,7 +77,6 @@ namespace BTCPayServer.Data
             this IEnumerable<IPayoutHandler> payoutHandlers, StoreData storeData)
         {
             return (await Task.WhenAll(payoutHandlers.Select(handler => handler.GetSupportedPaymentMethods(storeData)))).SelectMany(ids => ids).ToList();
-
         }
     }
 }

--- a/BTCPayServer/Plugins/NFC/NFCController.cs
+++ b/BTCPayServer/Plugins/NFC/NFCController.cs
@@ -58,7 +58,7 @@ namespace BTCPayServer.Plugins.NFC
             if (!methods.TryGetValue(new PaymentMethodId("BTC", PaymentTypes.LNURLPay), out var lnurlPaymentMethod) &&
                 !methods.TryGetValue(new PaymentMethodId("BTC", PaymentTypes.LightningLike), out lnPaymentMethod))
             {
-                return BadRequest("destination for lnurlw was not specified");
+                return BadRequest("Destination for lnurlw was not specified");
             }
 
             Uri uri;
@@ -68,7 +68,7 @@ namespace BTCPayServer.Plugins.NFC
                 uri = LNURL.LNURL.Parse(request.Lnurl, out tag);
                 if (uri is null)
                 {
-                    return BadRequest("lnurl was malformed");
+                    return BadRequest("LNURL was malformed");
                 }
             }
             catch (Exception e)
@@ -76,10 +76,9 @@ namespace BTCPayServer.Plugins.NFC
                 return BadRequest(e.Message);
             }
 
-
             if (!string.IsNullOrEmpty(tag) && !tag.Equals("withdrawRequest"))
             {
-                return BadRequest("lnurl was not lnurl-withdraw");
+                return BadRequest("LNURL was not LNURL-Withdraw");
             }
 
             var httpClient = _httpClientFactory.CreateClient(uri.IsOnion()
@@ -98,7 +97,7 @@ namespace BTCPayServer.Plugins.NFC
             
             if (info?.Callback is null)
             {
-                return BadRequest("Could not fetch info from lnurl-withdraw ");
+                return BadRequest("Could not fetch info from LNURL-Withdraw");
             }
 
             httpClient = _httpClientFactory.CreateClient(info.Callback.IsOnion()
@@ -106,7 +105,6 @@ namespace BTCPayServer.Plugins.NFC
                 : LightningLikePayoutHandler.LightningLikePayoutHandlerClearnetNamedClient);
 
             string bolt11 = null;
-
             if (lnPaymentMethod is not null)
             {
                 if (lnPaymentMethod.GetPaymentMethodDetails() is LightningLikePaymentMethodDetails { Activated: false } lnPMD)
@@ -120,17 +118,19 @@ namespace BTCPayServer.Plugins.NFC
                 if (invoice.Type == InvoiceType.TopUp && request.Amount is not null)
                 {
                     due = new LightMoney(request.Amount.Value, LightMoneyUnit.Satoshi);
-                }else if (invoice.Type == InvoiceType.TopUp)
+                }
+                else if (invoice.Type == InvoiceType.TopUp)
                 {
-                    return BadRequest("This is a topup invoice and you need to provide the amount in sats to pay.");
+                    return BadRequest("This is a top-up invoice and you need to provide the amount in sats to pay.");
                 }
                 else
                 {
-                    due =  new LightMoney(lnPaymentMethod.Calculate().Due);
+                    due = new LightMoney(lnPaymentMethod.Calculate().Due);
                 }
+                
                 if (info.MinWithdrawable > due || due > info.MaxWithdrawable)
                 {
-                    return BadRequest("invoice amount is not payable with the lnurl allowed amounts.");
+                    return BadRequest("Invoice amount is not payable with the LNURL allowed amounts.");
                 }
 
                 if (lnPMD?.Activated is true)
@@ -145,13 +145,14 @@ namespace BTCPayServer.Plugins.NFC
                 if (invoice.Type == InvoiceType.TopUp && request.Amount is not null)
                 {
                     due = new Money(request.Amount.Value, MoneyUnit.Satoshi);
-                }else if (invoice.Type == InvoiceType.TopUp)
+                }
+                else if (invoice.Type == InvoiceType.TopUp)
                 {
-                    return BadRequest("This is a topup invoice and you need to provide the amount in sats to pay.");
+                    return BadRequest("This is a top-up invoice and you need to provide the amount in sats to pay.");
                 }
                 else
                 {
-                    due =  lnurlPaymentMethod.Calculate().Due;
+                    due = lnurlPaymentMethod.Calculate().Due;
                 }
 
                 var amount = LightMoney.Satoshis(due.Satoshi);

--- a/BTCPayServer/Views/Shared/NFC/CheckoutEnd.cshtml
+++ b/BTCPayServer/Views/Shared/NFC/CheckoutEnd.cshtml
@@ -2,19 +2,23 @@
 @using BTCPayServer.Abstractions.TagHelpers
 <template id="lnurl-withdraw-template">
     <template v-if="display">
-        <button v-if="isV2" class="btn btn-secondary rounded-pill w-100 mt-4" type="button"
-            :disabled="scanning || submitting" v-on:click="startScan" :id="btnId"
-            :class="{ 'loading': scanning || submitting, 'text-secondary': !supported }">{{btnText}}</button>
-        <bp-loading-button v-else>
-            <button  class="action-button" style="margin: 0 45px;width:calc(100% - 90px) !important"
-                    :disabled="scanning || submitting" v-on:click="startScan" :id="btnId"
-                    :class="{ 'loading': scanning || submitting, 'action-button': supported, 'btn btn-text w-100': !supported  }">
-                <span class="button-text">{{btnText}}</span>
-                <div class="loader-wrapper">
-                    @await Html.PartialAsync("~/Views/UIInvoice/Checkout-Spinner.cshtml")
-                </div>
-            </button>
-        </bp-loading-button>
+        <div class="mt-4">
+            <p id="CheatSuccessMessage" class="alert alert-success text-break" v-if="successMessage" v-text="successMessage"></p>
+            <p id="CheatErrorMessage" class="alert alert-danger text-break" v-if="errorMessage" v-text="errorMessage"></p>
+            <button v-if="isV2" class="btn btn-secondary rounded-pill w-100" type="button"
+                :disabled="scanning || submitting" v-on:click="startScan" :id="btnId"
+                :class="{ 'loading': scanning || submitting, 'text-secondary': !supported }">{{btnText}}</button>
+            <bp-loading-button v-else>
+                <button class="action-button" style="margin: 0 45px;width:calc(100% - 90px) !important"
+                        :disabled="scanning || submitting" v-on:click="startScan" :id="btnId"
+                        :class="{ 'loading': scanning || submitting, 'action-button': supported, 'btn btn-text w-100': !supported  }">
+                    <span class="button-text">{{btnText}}</span>
+                    <div class="loader-wrapper">
+                        @await Html.PartialAsync("~/Views/UIInvoice/Checkout-Spinner.cshtml")
+                    </div>
+                </button>
+            </bp-loading-button>
+        </div>
     </template>
 </template>
 <script type="text/javascript">
@@ -61,7 +65,9 @@ Vue.component("lnurl-withdraw-checkout", {
             scanning: false,
             submitting: false,
             readerAbortController: null,
-            amount: 0
+            amount: 0,
+            successMessage: null,
+            errorMessage: null
         }
     },
     methods: {
@@ -72,13 +78,13 @@ Vue.component("lnurl-withdraw-checkout", {
                 }
                 if (this.model.isUnsetTopUp) {
                     const amountStr = prompt("How many sats do you want to pay?")
-                    if (amountStr){
+                    if (amountStr) {
                         try {
                             this.amount = parseInt(amountStr)
                         } catch {
                             alert("Please provide a valid number amount in sats");
                         }
-                    }else{
+                    } else {
                         return;    
                     }
                 }
@@ -87,9 +93,9 @@ Vue.component("lnurl-withdraw-checkout", {
                 self.submitting = false;
                 self.scanning = true;
                 if (!this.supported) {
-                    const result = prompt("Enter LNURL withdraw");
+                    const result = prompt("Enter LNURL-Withdraw");
                     if (result) {
-                        self.sendData.bind(self)(result);
+                        await self.sendData.bind(self)(result);
                         return;
                     }
                     self.scanning = false;
@@ -103,7 +109,7 @@ Vue.component("lnurl-withdraw-checkout", {
                     self.readerAbortController.abort()
                 })
 
-                ndef.addEventListener('reading', ({message, serialNumber}) => {
+                ndef.addEventListener('reading', async ({message, serialNumber}) => {
                     //Decode NDEF data from tag
                     const record = message.records[0]
                     const textDecoder = new TextDecoder('utf-8')
@@ -111,38 +117,38 @@ Vue.component("lnurl-withdraw-checkout", {
 
                     //User feedback, show loader icon
                     self.scanning = false;
-                    self.sendData.bind(self)(lnurl);
-
+                    await self.sendData.bind(self)(lnurl);
                 })
-            } catch(e) {
+            } catch (e) {
                 self.scanning = false;
                 self.submitting = false;
             }
         },
-        sendData: function (lnurl) {
+        sendData: async function (lnurl) {
             this.submitting = true;
-            //Post LNURLW data to server
-            var xhr = new XMLHttpRequest()
-            xhr.open('POST', this.url, true)
-            xhr.setRequestHeader('Content-Type', 'application/json')
-            xhr.send(JSON.stringify({lnurl, invoiceId: this.model.invoiceId, amount: this.amount}))
-            const self = this;
-            //User feedback, reset on failure
-            xhr.onload = function () {
-                if (xhr.readyState === xhr.DONE) {
-                    console.log(xhr.response);
-                    console.log(xhr.responseText);
-                    self.scanning = false;
-                    self.submitting = false;
-
-                    if(self.readerAbortController) {
-                        self.readerAbortController.abort()
-                    }
-
-                    if(xhr.response){
-                        alert(xhr.response)
-                    }
+            this.successMessage = null;
+            this.errorMessage = null;
+            
+            // Post LNURL-Withdraw data to server
+            const body = JSON.stringify({ lnurl, invoiceId: this.model.invoiceId, amount: this.amount })
+            const opts = { method: 'POST', headers: { 'Content-Type': 'application/json' }, body }
+            const response = await fetch(this.url, opts)
+            
+            // Handle response
+            try {
+                const result = await response.text()
+                if (response.ok) {
+                    this.successMessage = result;
+                } else {
+                    this.errorMessage = result;
                 }
+            } catch (error) {
+                this.errorMessage = error;
+            }
+            this.scanning = false;
+            this.submitting = false;
+            if (this.readerAbortController) {
+                this.readerAbortController.abort()
             }
         }
     }

--- a/BTCPayServer/Views/Shared/ShowQR.cshtml
+++ b/BTCPayServer/Views/Shared/ShowQR.cshtml
@@ -14,7 +14,7 @@
                             <qrcode :value="currentFragment" :options="qrOptions"></qrcode>
                         </component>
                     </div>
-                    <ul class="nav justify-content-center mt-4 mb-3" v-if="modes && Object.keys(modes).length > 1">
+                    <ul class="nav btcpay-pills justify-content-center mt-4 mb-3" v-if="modes && Object.keys(modes).length > 1">
                         <li class="nav-item" v-for="(item, key) in modes">
                             <a class="btcpay-pill" :class="{ 'active': key === mode }" href="#" v-on:click="mode = key">{{item.title}}</a>
                         </li>

--- a/BTCPayServer/wwwroot/swagger/v1/swagger.template.stores-payment-methods.lnurl.json
+++ b/BTCPayServer/wwwroot/swagger/v1/swagger.template.stores-payment-methods.lnurl.json
@@ -305,7 +305,7 @@
                     },
                     "enableForStandardInvoices": {
                         "type": "boolean",
-                        "description": "Whether to allow this payment method to also be used for standard invoices and not just topup invoices."
+                        "description": "Whether to allow this payment method to also be used for standard invoices and not just top-up invoices."
                     },
                     "lud12Enabled": {
                         "type": "boolean",


### PR DESCRIPTION
Fixes:
- Missing request data when called directly via `_uilnurlController.GetLNURLForInvoice`
- Comparisons of `long` and `LightMoney`, which did not work, because the `amount` provided was in sats and Lightmoney compares to millisats.

Closes #4663.