### PR TITLE
Do not show Vue components when there is no JavaScript enabled

### DIFF
--- a/BTCPayServer/Views/Shared/LayoutHead.cshtml
+++ b/BTCPayServer/Views/Shared/LayoutHead.cshtml
@@ -19,7 +19,7 @@
 @* Non-JS *@
 <noscript>
     <style>
-        .hide-when-js, [v-cloak] { display: block !important; }
+        .hide-when-js { display: block !important; }
         .only-for-js { display: none !important; }
     </style>
 </noscript>


### PR DESCRIPTION
Small fix, came across this while testing the noscript checkout version.