### PR TITLE
Add currency code to payment request table

### DIFF
--- a/BTCPayServer/Controllers/UIPaymentRequestController.cs
+++ b/BTCPayServer/Controllers/UIPaymentRequestController.cs
@@ -89,7 +89,7 @@ namespace BTCPayServer.Controllers
                 var blob = data.GetBlob();
                 return new ViewPaymentRequestViewModel(data)
                 {
-                    AmountFormatted = _Currencies.FormatCurrency(blob.Amount, blob.Currency)
+                    AmountFormatted = _Currencies.DisplayFormatCurrency(blob.Amount, blob.Currency)
                 };
             }).ToList();
 


### PR DESCRIPTION
https://github.com/btcpayserver/btcpayserver/discussions/4619

Some currencies have exactly the same formatting even though their values are different. Showing them with exactly the same formatting can be misleading even though it's technically correct for each of these currencies.

Not sure what the best way of dealing with this is but adding a column with the currency code seems like the most straightforward way to deal with this even though the currency code display can be redundant in many cases.

|Before|After|
|---|---|
|![before](https://user-images.githubusercontent.com/1934678/221487230-5b6fc946-6636-4796-ad91-6c96510f14b6.PNG)|![Capture](https://user-images.githubusercontent.com/1934678/221487260-4d29414a-6a63-4036-9bc0-341d3f17a517.PNG)|
