### PR TITLE
show all plugins regardless of version

### DIFF
--- a/BTCPayServer/Plugins/PluginBuilderClient.cs
+++ b/BTCPayServer/Plugins/PluginBuilderClient.cs
@@ -55,10 +55,13 @@ namespace BTCPayServer.Plugins
         {
             this.httpClient = httpClient;
         }
-        static JsonSerializerSettings serializerSettings = new JsonSerializerSettings() { ContractResolver = new Newtonsoft.Json.Serialization.CamelCasePropertyNamesContractResolver() };
+        static JsonSerializerSettings serializerSettings = new() { ContractResolver = new Newtonsoft.Json.Serialization.CamelCasePropertyNamesContractResolver() };
         public async Task<PublishedVersion[]> GetPublishedVersions(string btcpayVersion, bool includePreRelease)
         {
-            var result = await httpClient.GetStringAsync($"api/v1/plugins?btcpayVersion={btcpayVersion}&includePreRelease={includePreRelease}");
+            var queryString = $"?includePreRelease={includePreRelease}";
+            if(btcpayVersion is not null)
+                queryString += $"&btcpayVersion={btcpayVersion}&";
+            var result = await httpClient.GetStringAsync($"api/v1/plugins{queryString}");
             return JsonConvert.DeserializeObject<PublishedVersion[]>(result, serializerSettings) ?? throw new InvalidOperationException();
         }
     }

--- a/BTCPayServer/Plugins/PluginService.cs
+++ b/BTCPayServer/Plugins/PluginService.cs
@@ -50,7 +50,7 @@ namespace BTCPayServer.Plugins
 
         public async Task<AvailablePlugin[]> GetRemotePlugins()
         {
-            var versions = await _pluginBuilderClient.GetPublishedVersions(Env.Version, _policiesSettings.PluginPreReleases);
+            var versions = await _pluginBuilderClient.GetPublishedVersions(null, _policiesSettings.PluginPreReleases);
             return versions.Select(v =>
             {
                 var p = v.ManifestInfo.ToObject<AvailablePlugin>();


### PR DESCRIPTION
We used to show all plugins available even if your btcpay did not support it, allowing users to discover plugins and also incentivizing them to update their BTCpay (they were not able to install unless criteria was met).