### PR TITLE
Greenfield: Show detailed Lightning routing error

### DIFF
--- a/BTCPayServer/Controllers/GreenField/GreenfieldLightningNodeApiController.cs
+++ b/BTCPayServer/Controllers/GreenField/GreenfieldLightningNodeApiController.cs
@@ -256,7 +256,7 @@ namespace BTCPayServer.Controllers.Greenfield
 
             return result.Result switch
             {
-                PayResult.CouldNotFindRoute => this.CreateAPIError("could-not-find-route", "Impossible to find a route to the peer"),
+                PayResult.CouldNotFindRoute => this.CreateAPIError("could-not-find-route", result.ErrorDetail ?? "Impossible to find a route to the peer"),
                 PayResult.Error => this.CreateAPIError("generic-error", result.ErrorDetail),
                 PayResult.Unknown => Accepted(new LightningPaymentData
                 {


### PR DESCRIPTION
The implementations have more detailed messages for LN routing errors, which e.g. allow me to detect self-payemnts in LNbank. We pass those from the LN lib, so if we have it, we should display it to provide a better insight on what's going on when a rout cannot be found.