### PR TITLE
Checkout v2: Option to display amount in Sats in BIP21 case

### DIFF
--- a/BTCPayServer.Rating/Currencies.json
+++ b/BTCPayServer.Rating/Currencies.json
@@ -1305,7 +1305,7 @@
       "name":"Satoshis",
       "code":"SATS",
       "divisibility":0,
-      "symbol":"Sats",
+      "symbol":"sats",
       "crypto":true
    },
    {

--- a/BTCPayServer.Tests/CheckoutUITests.cs
+++ b/BTCPayServer.Tests/CheckoutUITests.cs
@@ -182,7 +182,7 @@ namespace BTCPayServer.Tests
 
             var invoiceId = s.CreateInvoice(10, "USD", "a@g.com");
             s.GoToInvoiceCheckout(invoiceId);
-            Assert.Contains("Sats", s.Driver.FindElement(By.ClassName("payment__currencies_noborder")).Text);
+            Assert.Contains("sats", s.Driver.FindElement(By.ClassName("payment__currencies_noborder")).Text);
         }
 
         [Fact(Timeout = TestTimeout)]

--- a/BTCPayServer.Tests/Checkoutv2Tests.cs
+++ b/BTCPayServer.Tests/Checkoutv2Tests.cs
@@ -193,6 +193,7 @@ namespace BTCPayServer.Tests
             s.GoToHome();
             s.GoToStore(StoreNavPages.CheckoutAppearance);
             s.Driver.SetCheckbox(By.Id("OnChainWithLnInvoiceFallback"), true);
+            s.Driver.SetCheckbox(By.Id("LightningAmountInSatoshi"), false);
             s.Driver.FindElement(By.Id("Save")).Click();
             Assert.Contains("Store successfully updated", s.FindAlertMessage().Text);
 
@@ -200,6 +201,7 @@ namespace BTCPayServer.Tests
             s.GoToInvoiceCheckout(invoiceId);
             s.Driver.WaitUntilAvailable(By.Id("Checkout-v2"));
             Assert.Empty(s.Driver.FindElements(By.CssSelector(".payment-method")));
+            Assert.Contains("BTC", s.Driver.FindElement(By.Id("AmountDue")).Text);
             qrValue = s.Driver.FindElement(By.CssSelector(".qr-container")).GetAttribute("data-qr-value");
             address = s.Driver.FindElement(By.CssSelector(".qr-container")).GetAttribute("data-clipboard");
             payUrl = s.Driver.FindElement(By.Id("PayInWallet")).GetAttribute("href");
@@ -214,6 +216,16 @@ namespace BTCPayServer.Tests
             Assert.StartsWith($"bitcoin:{address.ToUpperInvariant()}?amount=", qrValue);
             Assert.Contains("&lightning=LNBCRT", qrValue);
             s.Driver.FindElement(By.Id("PayByLNURL"));
+            
+            // Switch to amount displayed in Sats
+            s.GoToHome();
+            s.GoToStore(StoreNavPages.CheckoutAppearance);
+            s.Driver.SetCheckbox(By.Id("LightningAmountInSatoshi"), true);
+            s.Driver.FindElement(By.Id("Save")).Click();
+            Assert.Contains("Store successfully updated", s.FindAlertMessage().Text);
+            s.GoToInvoiceCheckout(invoiceId);
+            s.Driver.WaitUntilAvailable(By.Id("Checkout-v2"));
+            Assert.Contains("Sats", s.Driver.FindElement(By.Id("AmountDue")).Text);
 
             // BIP21 with LN as default payment method
             s.GoToHome();

--- a/BTCPayServer.Tests/Checkoutv2Tests.cs
+++ b/BTCPayServer.Tests/Checkoutv2Tests.cs
@@ -102,7 +102,7 @@ namespace BTCPayServer.Tests
             s.Driver.ElementDoesNotExist(By.Id("Address_BTC"));
             s.Driver.FindElement(By.Id("PayByLNURL"));
 
-            // Lightning amount in Sats
+            // Lightning amount in sats
             Assert.Contains("BTC", s.Driver.FindElement(By.Id("AmountDue")).Text);
             s.GoToHome();
             s.GoToLightningSettings();
@@ -111,7 +111,7 @@ namespace BTCPayServer.Tests
             Assert.Contains("BTC Lightning settings successfully updated", s.FindAlertMessage().Text);
             s.GoToInvoiceCheckout(invoiceId);
             s.Driver.WaitUntilAvailable(By.Id("Checkout-v2"));
-            Assert.Contains("Sats", s.Driver.FindElement(By.Id("AmountDue")).Text);
+            Assert.Contains("sats", s.Driver.FindElement(By.Id("AmountDue")).Text);
 
             // Expire
             var expirySeconds = s.Driver.FindElement(By.Id("ExpirySeconds"));
@@ -217,7 +217,7 @@ namespace BTCPayServer.Tests
             Assert.Contains("&lightning=LNBCRT", qrValue);
             s.Driver.FindElement(By.Id("PayByLNURL"));
             
-            // Switch to amount displayed in Sats
+            // Switch to amount displayed in sats
             s.GoToHome();
             s.GoToStore(StoreNavPages.CheckoutAppearance);
             s.Driver.SetCheckbox(By.Id("LightningAmountInSatoshi"), true);
@@ -225,7 +225,7 @@ namespace BTCPayServer.Tests
             Assert.Contains("Store successfully updated", s.FindAlertMessage().Text);
             s.GoToInvoiceCheckout(invoiceId);
             s.Driver.WaitUntilAvailable(By.Id("Checkout-v2"));
-            Assert.Contains("Sats", s.Driver.FindElement(By.Id("AmountDue")).Text);
+            Assert.Contains("sats", s.Driver.FindElement(By.Id("AmountDue")).Text);
 
             // BIP21 with LN as default payment method
             s.GoToHome();

--- a/BTCPayServer.Tests/FastTests.cs
+++ b/BTCPayServer.Tests/FastTests.cs
@@ -1466,14 +1466,14 @@ namespace BTCPayServer.Tests
             Assert.Equal(1m / 0.000061m, rule2.BidAsk.Bid);
 
             // testing rounding 
-            rule2 = rules.GetRuleFor(CurrencyPair.Parse("Sats_EUR"));
+            rule2 = rules.GetRuleFor(CurrencyPair.Parse("SATS_EUR"));
             rule2.ExchangeRates.SetRate("coinbase", CurrencyPair.Parse("BTC_EUR"), new BidAsk(1.23m, 2.34m));
             Assert.True(rule2.Reevaluate());
             Assert.Equal("0.00000001 * (1.23, 2.34)", rule2.ToString(true));
             Assert.Equal(0.0000000234m, rule2.BidAsk.Ask);
             Assert.Equal(0.0000000123m, rule2.BidAsk.Bid);
 
-            rule2 = rules.GetRuleFor(CurrencyPair.Parse("EUR_Sats"));
+            rule2 = rules.GetRuleFor(CurrencyPair.Parse("EUR_SATS"));
             rule2.ExchangeRates.SetRate("coinbase", CurrencyPair.Parse("BTC_EUR"), new BidAsk(1.23m, 2.34m));
             Assert.True(rule2.Reevaluate());
             Assert.Equal("1 / (0.00000001 * (1.23, 2.34))", rule2.ToString(true));

--- a/BTCPayServer.Tests/FastTests.cs
+++ b/BTCPayServer.Tests/FastTests.cs
@@ -326,7 +326,7 @@ namespace BTCPayServer.Tests
             var networkProvider = new BTCPayNetworkProvider(ChainName.Regtest);
             var paymentMethodHandlerDictionary = new PaymentMethodHandlerDictionary(new IPaymentMethodHandler[]
             {
-                new BitcoinLikePaymentHandler(null, networkProvider, null, null, null),
+                new BitcoinLikePaymentHandler(null, networkProvider, null, null, null, null),
                 new LightningLikePaymentHandler(null, null, networkProvider, null, null, null),
             });
             var entity = new InvoiceEntity();
@@ -512,7 +512,7 @@ namespace BTCPayServer.Tests
             var networkProvider = new BTCPayNetworkProvider(ChainName.Regtest);
             var paymentMethodHandlerDictionary = new PaymentMethodHandlerDictionary(new IPaymentMethodHandler[]
             {
-                new BitcoinLikePaymentHandler(null, networkProvider, null, null, null),
+                new BitcoinLikePaymentHandler(null, networkProvider, null, null, null, null),
                 new LightningLikePaymentHandler(null, null, networkProvider, null, null, null),
             });
             var entity = new InvoiceEntity();
@@ -1715,7 +1715,7 @@ namespace BTCPayServer.Tests
             var networkProvider = new BTCPayNetworkProvider(ChainName.Regtest);
             var paymentMethodHandlerDictionary = new PaymentMethodHandlerDictionary(new IPaymentMethodHandler[]
             {
-                new BitcoinLikePaymentHandler(null, networkProvider, null, null, null),
+                new BitcoinLikePaymentHandler(null, networkProvider, null, null, null, null),
                 new LightningLikePaymentHandler(null, null, networkProvider, null, null, null),
             });
             var networkBTC = networkProvider.GetNetwork("BTC");

--- a/BTCPayServer.Tests/PayJoinTests.cs
+++ b/BTCPayServer.Tests/PayJoinTests.cs
@@ -221,7 +221,7 @@ namespace BTCPayServer.Tests
                     var receiverCoin = await receiverUser.ReceiveUTXO(Money.Satoshis(810), network);
 
                     string errorCode = receiverAddressType == senderAddressType ? null : "unavailable|any UTXO available";
-                    var invoice = receiverUser.BitPay.CreateInvoice(new Invoice() { Price = 50000, Currency = "sats", FullNotifications = true });
+                    var invoice = receiverUser.BitPay.CreateInvoice(new Invoice() { Price = 50000, Currency = "SATS", FullNotifications = true });
                     if (unsupportedFormats.Contains(receiverAddressType))
                     {
                         Assert.Null(TestAccount.GetPayjoinBitcoinUrl(invoice, cashCow.Network));

--- a/BTCPayServer/Controllers/UIStoresController.cs
+++ b/BTCPayServer/Controllers/UIStoresController.cs
@@ -27,7 +27,6 @@ using BTCPayServer.Services.Stores;
 using BTCPayServer.Services.Wallets;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.DataProtection;
-using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Rendering;
@@ -388,6 +387,7 @@ namespace BTCPayServer.Controllers
 
             vm.UseNewCheckout = storeBlob.CheckoutType == Client.Models.CheckoutType.V2;
             vm.OnChainWithLnInvoiceFallback = storeBlob.OnChainWithLnInvoiceFallback;
+            vm.LightningAmountInSatoshi = storeBlob.LightningAmountInSatoshi;
             vm.RequiresRefundEmail = storeBlob.RequiresRefundEmail;
             vm.LazyPaymentMethods = storeBlob.LazyPaymentMethods;
             vm.RedirectAutomatically = storeBlob.RedirectAutomatically;
@@ -507,6 +507,7 @@ namespace BTCPayServer.Controllers
             blob.CheckoutType = model.UseNewCheckout ? Client.Models.CheckoutType.V2 : Client.Models.CheckoutType.V1;
 
             blob.OnChainWithLnInvoiceFallback = model.OnChainWithLnInvoiceFallback;
+            blob.LightningAmountInSatoshi = model.LightningAmountInSatoshi;
             blob.RequiresRefundEmail = model.RequiresRefundEmail;
             blob.LazyPaymentMethods = model.LazyPaymentMethods;
             blob.RedirectAutomatically = model.RedirectAutomatically;

--- a/BTCPayServer/Models/StoreViewModels/CheckoutAppearanceViewModel.cs
+++ b/BTCPayServer/Models/StoreViewModels/CheckoutAppearanceViewModel.cs
@@ -26,6 +26,9 @@ namespace BTCPayServer.Models.StoreViewModels
         [Display(Name = "Unify on-chain and lightning payment URL/QR code")]
         public bool OnChainWithLnInvoiceFallback { get; set; }
 
+        [Display(Name = "Display Lightning payment amounts in Satoshis")]
+        public bool LightningAmountInSatoshi { get; set; }
+
         [Display(Name = "Default payment method on checkout")]
         public string DefaultPaymentMethod { get; set; }
 

--- a/BTCPayServer/Payments/IPaymentMethodHandler.cs
+++ b/BTCPayServer/Payments/IPaymentMethodHandler.cs
@@ -106,7 +106,7 @@ namespace BTCPayServer.Payments
             { 
                 NumberFormat = { NumberGroupSeparator = " " }
             };
-            model.CryptoCode = "Sats";
+            model.CryptoCode = "sats";
             model.BtcDue = Money.Parse(model.BtcDue).ToUnit(MoneyUnit.Satoshi).ToString("N0", satoshiCulture);
             model.BtcPaid = Money.Parse(model.BtcPaid).ToUnit(MoneyUnit.Satoshi).ToString("N0", satoshiCulture);
             model.OrderAmount = Money.Parse(model.OrderAmount).ToUnit(MoneyUnit.Satoshi).ToString("N0", satoshiCulture);

--- a/BTCPayServer/Payments/IPaymentMethodHandler.cs
+++ b/BTCPayServer/Payments/IPaymentMethodHandler.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Threading.Tasks;
 using BTCPayServer.Data;
 using BTCPayServer.Logging;
@@ -97,6 +98,20 @@ namespace BTCPayServer.Payments
             BTCPayNetworkBase network)
         {
             return null;
+        }
+        
+        public virtual void PreparePaymentModelForAmountInSats(PaymentModel model, IPaymentMethod paymentMethod, CurrencyNameTable currencyNameTable)
+        {
+            var satoshiCulture = new CultureInfo(CultureInfo.InvariantCulture.Name)
+            { 
+                NumberFormat = { NumberGroupSeparator = " " }
+            };
+            model.CryptoCode = "Sats";
+            model.BtcDue = Money.Parse(model.BtcDue).ToUnit(MoneyUnit.Satoshi).ToString("N0", satoshiCulture);
+            model.BtcPaid = Money.Parse(model.BtcPaid).ToUnit(MoneyUnit.Satoshi).ToString("N0", satoshiCulture);
+            model.OrderAmount = Money.Parse(model.OrderAmount).ToUnit(MoneyUnit.Satoshi).ToString("N0", satoshiCulture);
+            model.NetworkFee = new Money(model.NetworkFee, MoneyUnit.BTC).ToUnit(MoneyUnit.Satoshi);
+            model.Rate = currencyNameTable.DisplayFormatCurrency(paymentMethod.Rate / 100_000_000, model.InvoiceCurrency);
         }
 
         public Task<IPaymentMethodDetails> CreatePaymentMethodDetails(InvoiceLogs logs,

--- a/BTCPayServer/Payments/LNURLPay/LNURLPayPaymentHandler.cs
+++ b/BTCPayServer/Payments/LNURLPay/LNURLPayPaymentHandler.cs
@@ -1,23 +1,17 @@
 #nullable enable
-using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.Linq;
-using System.Threading;
 using System.Threading.Tasks;
 using BTCPayServer.Client.Models;
 using BTCPayServer.Configuration;
 using BTCPayServer.Data;
-using BTCPayServer.HostedServices;
 using BTCPayServer.Lightning;
 using BTCPayServer.Logging;
 using BTCPayServer.Models;
 using BTCPayServer.Models.InvoicingModels;
-using BTCPayServer.Services;
 using BTCPayServer.Services.Invoices;
 using BTCPayServer.Services.Rates;
 using Microsoft.Extensions.Options;
-using NBitcoin;
 
 namespace BTCPayServer.Payments.Lightning
 {
@@ -112,23 +106,16 @@ namespace BTCPayServer.Payments.Lightning
             var network = _networkProvider.GetNetwork<BTCPayNetwork>(model.CryptoCode);
             var cryptoInfo = invoiceResponse.CryptoInfo.First(o => o.GetpaymentMethodId() == paymentMethodId);
             var lnurl = cryptoInfo.PaymentUrls?.AdditionalData["LNURLP"].ToObject<string>();
+            
             model.PaymentMethodName = GetPaymentMethodName(network);
             model.BtcAddress = lnurl?.Replace(UriScheme, "");
             model.InvoiceBitcoinUrl = lnurl;
             model.InvoiceBitcoinUrlQR = lnurl?.ToUpperInvariant().Replace(UriScheme.ToUpperInvariant(), UriScheme);
             model.PeerInfo = ((LNURLPayPaymentMethodDetails)paymentMethod.GetPaymentMethodDetails()).NodeInfo;
+            
             if (storeBlob.LightningAmountInSatoshi && model.CryptoCode == "BTC")
             {
-                var satoshiCulture = new CultureInfo(CultureInfo.InvariantCulture.Name);
-                satoshiCulture.NumberFormat.NumberGroupSeparator = " ";
-                model.CryptoCode = "Sats";
-                model.BtcDue = Money.Parse(model.BtcDue).ToUnit(MoneyUnit.Satoshi).ToString("N0", satoshiCulture);
-                model.BtcPaid = Money.Parse(model.BtcPaid).ToUnit(MoneyUnit.Satoshi).ToString("N0", satoshiCulture);
-                model.OrderAmount = Money.Parse(model.OrderAmount).ToUnit(MoneyUnit.Satoshi)
-                    .ToString("N0", satoshiCulture);
-                model.NetworkFee = new Money(model.NetworkFee, MoneyUnit.BTC).ToUnit(MoneyUnit.Satoshi);
-                model.Rate =
-                    _currencyNameTable.DisplayFormatCurrency(paymentMethod.Rate / 100_000_000, model.InvoiceCurrency);
+                base.PreparePaymentModelForAmountInSats(model, paymentMethod, _currencyNameTable);
             }
         }
 

--- a/BTCPayServer/Views/UIInvoice/Checkout-Body.cshtml
+++ b/BTCPayServer/Views/UIInvoice/Checkout-Body.cshtml
@@ -50,7 +50,7 @@
                 <div class="paywithRowRight cursorPointer" v-on:click="openPaymentMethodDialog">
                     <span class="payment__currencies " v-show="!changingCurrencies">
                         <img v-bind:src="srvModel.cryptoImage" />
-                        <span>{{srvModel.paymentMethodName}} ({{srvModel.cryptoCodeSrv}})</span>
+                        <span>{{srvModel.paymentMethodName}} ({{srvModel.cryptoCode}})</span>
                         <span v-show="srvModel.isLightning">&#9889;</span>
                         <span class="clickable_indicator fa fa-angle-right"></span>
                     </span>
@@ -75,7 +75,7 @@
             {
                 <div class="payment__currencies_noborder">
                     <img v-bind:src="srvModel.cryptoImage" />
-                    <span>{{srvModel.paymentMethodName}} ({{srvModel.cryptoCodeSrv}})</span>
+                    <span>{{srvModel.paymentMethodName}} ({{srvModel.cryptoCode}})</span>
                     <span v-show="srvModel.isLightning">&#9889;</span>
                 </div>
             }
@@ -102,8 +102,8 @@
                 <span>{{ srvModel.btcDue }} {{ srvModel.cryptoCode }}</span>
             </div>
             <div class="single-item-order__right__ex-rate" v-if="srvModel.orderAmountFiat && srvModel.cryptoCode">
-                <span v-if="srvModel.cryptoCodeSrv === 'Sats'">1 Sat = {{ srvModel.rate }}</span>
-                <span v-else>1 {{ srvModel.cryptoCodeSrv }} = {{ srvModel.rate }}</span>
+                <span v-if="srvModel.cryptoCode === 'sats'">1 sat = {{ srvModel.rate }}</span>
+                <span v-else>1 {{ srvModel.cryptoCode }} = {{ srvModel.rate }}</span>
             </div>
         </div>
         <span class="fa fa-angle-double-down" v-if="!srvModel.isUnsetTopUp"></span>

--- a/BTCPayServer/Views/UIInvoice/Checkout.cshtml
+++ b/BTCPayServer/Views/UIInvoice/Checkout.cshtml
@@ -358,8 +358,6 @@
                 if (jsonData.paymentMethodId === this.srvModel.paymentMethodId) {
                     this.changingCurrencies = false;
                 }
-                // displaying satoshis for lightning payments
-                jsonData.cryptoCodeSrv = jsonData.cryptoCode;
                 // expand line items to show details on amount due for multi-transaction payment
                 if (this.srvModel.txCount === 1 && jsonData.txCount > 1) {
                     this.onlyExpandLineItems();

--- a/BTCPayServer/Views/UIInvoice/CheckoutV2.cshtml
+++ b/BTCPayServer/Views/UIInvoice/CheckoutV2.cshtml
@@ -191,8 +191,8 @@
             <div v-if="srvModel.rate && srvModel.cryptoCode">
                 <dt v-t="'exchange_rate'"></dt>
                 <dd :data-clipboard="srvModel.rate" :data-clipboard-confirm="$t('copy_confirm')">
-                    <template v-if="srvModel.cryptoCodeSrv === 'Sats'">1 Sat = {{ srvModel.rate }}</template>
-                    <template v-else>1 {{ srvModel.cryptoCodeSrv }} = {{ srvModel.rate }}</template>
+                    <template v-if="srvModel.cryptoCode === 'sats'">1 sat = {{ srvModel.rate }}</template>
+                    <template v-else>1 {{ srvModel.cryptoCode }} = {{ srvModel.rate }}</template>
                 </dd>
             </div>
             <div v-if="srvModel.networkFee">

--- a/BTCPayServer/Views/UIStores/CheckoutAppearance.cshtml
+++ b/BTCPayServer/Views/UIStores/CheckoutAppearance.cshtml
@@ -94,6 +94,10 @@
                     <vc:icon symbol="info" />
                 </a>
             </div>
+            <div class="form-check">
+                <input asp-for="LightningAmountInSatoshi" type="checkbox" class="form-check-input" />
+                <label asp-for="LightningAmountInSatoshi" class="form-check-label"></label>
+            </div>
             <div class="checkout-settings collapse @(Model.UseNewCheckout ? "" : "show")" id="OldCheckoutSettings">
                 <div class="form-check">
                     <input asp-for="RequiresRefundEmail" type="checkbox" class="form-check-input" />

--- a/BTCPayServer/wwwroot/checkout-v2/checkout.js
+++ b/BTCPayServer/wwwroot/checkout-v2/checkout.js
@@ -260,10 +260,7 @@ function initApp() {
                     const { status } = data;
                     window.parent.postMessage({ invoiceId, status }, '*');
                 }
-    
-                // displaying satoshis for lightning payments
-                data.cryptoCodeSrv = data.cryptoCode;
-    
+                
                 const newEnd = new Date();
                 newEnd.setSeconds(newEnd.getSeconds() + data.expirationSeconds);
                 this.endDate = newEnd;


### PR DESCRIPTION
We have this option for Lightning invoices and it makes sense to reuse it in the BIP21 case as well. Addresses one of the points in #4364.

This PR also
- contains some refactoring to extract the part that does the model modifications
- mirrors the setting from the Lightning Settings on the Checkout Appearance page

![grafik](https://user-images.githubusercontent.com/886/222707156-b229309b-5d73-444f-b1a8-d8f9bb81a1b9.png)

![grafik](https://user-images.githubusercontent.com/886/222707255-5d8512c3-dc58-4749-aa43-a74588f8bf16.png)

