### PR TITLE
Do not through missing-permission error when no store on /api/v1/stores (Close #4735)

### DIFF
--- a/BTCPayServer.Tests/ApiKeysTests.cs
+++ b/BTCPayServer.Tests/ApiKeysTests.cs
@@ -286,7 +286,7 @@ namespace BTCPayServer.Tests
             if (permissions.Contains(canModifyAllStores) || storePermissions.Any())
             {
                 var resultStores =
-                    await TestApiAgainstAccessToken<StoreData[]>(accessToken, $"{TestApiPath}/me/stores",
+                    await TestApiAgainstAccessToken<Client.Models.StoreData[]>(accessToken, $"{TestApiPath}/me/stores",
                         tester.PayTester.HttpClient);
 
                 foreach (var selectiveStorePermission in storePermissions)

--- a/BTCPayServer.Tests/ServerTester.cs
+++ b/BTCPayServer.Tests/ServerTester.cs
@@ -246,15 +246,18 @@ namespace BTCPayServer.Tests
         }
 
         public List<string> Stores { get; internal set; } = new List<string>();
-
+        public bool DeleteStore { get; set; } = true;
         public void Dispose()
         {
             foreach (var r in this.Resources)
                 r.Dispose();
             TestLogs.LogInformation("Disposing the BTCPayTester...");
-            foreach (var store in Stores)
+            if (DeleteStore)
             {
-                Xunit.Assert.True(PayTester.StoreRepository.DeleteStore(store).GetAwaiter().GetResult());
+                foreach (var store in Stores)
+                {
+                    Xunit.Assert.True(PayTester.StoreRepository.DeleteStore(store).GetAwaiter().GetResult());
+                }
             }
             if (PayTester != null)
                 PayTester.Dispose();

--- a/BTCPayServer/Controllers/GreenField/GreenfieldStoresController.cs
+++ b/BTCPayServer/Controllers/GreenField/GreenfieldStoresController.cs
@@ -112,7 +112,7 @@ namespace BTCPayServer.Controllers.Greenfield
             return Ok(FromModel(store));
         }
 
-        private Client.Models.StoreData FromModel(Data.StoreData data)
+        internal static Client.Models.StoreData FromModel(Data.StoreData data)
         {
             var storeBlob = data.GetStoreBlob();
             return new Client.Models.StoreData()

--- a/BTCPayServer/Controllers/GreenField/GreenfieldTestApiKeyController.cs
+++ b/BTCPayServer/Controllers/GreenField/GreenfieldTestApiKeyController.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using System.Threading.Tasks;
 using BTCPayServer.Abstractions.Constants;
 using BTCPayServer.Client;
@@ -52,9 +53,9 @@ namespace BTCPayServer.Controllers.Greenfield
 
         [HttpGet("me/stores")]
         [Authorize(Policy = Policies.CanViewStoreSettings, AuthenticationSchemes = AuthenticationSchemes.Greenfield)]
-        public StoreData[] GetCurrentUserStores()
+        public BTCPayServer.Client.Models.StoreData[] GetCurrentUserStores()
         {
-            return this.HttpContext.GetStoresData();
+            return this.HttpContext.GetStoresData().Select(Greenfield.GreenfieldStoresController.FromModel).ToArray();
         }
 
         [HttpGet("me/stores/{storeId}/can-view")]

--- a/BTCPayServer/Security/GreenField/GreenFieldAuthorizationHandler.cs
+++ b/BTCPayServer/Security/GreenField/GreenFieldAuthorizationHandler.cs
@@ -118,8 +118,6 @@ namespace BTCPayServer.Security.Greenfield
                             if (context.HasPermission(Permission.Create(policy, store.Id), requiredUnscoped))
                                 permissionedStores.Add(store);
                         }
-                        if (!requiredUnscoped && permissionedStores.Count is 0)
-                            break;
                         _httpContext.SetStoresData(permissionedStores.ToArray());
                         success = true;
                     }


### PR DESCRIPTION
The rational for returning `missing-permission` when no store is found was: If the API token doesn't have the CanViewStores permissions, it should send `missing-permission`.

However, we aren't able to make the difference between not having any CanViewStores and having one but then store exists.

The current situation is counter intuitive (as #4735 show). Better we return an empty array.

Close #4735