### PR TITLE
UI: Decrease content padding top on small screens

### DIFF
--- a/BTCPayServer/wwwroot/main/layout.css
+++ b/BTCPayServer/wwwroot/main/layout.css
@@ -676,6 +676,12 @@
     }
 }
 
+@media (min-width: 992px) and (max-height: 799px) {
+    :root {
+        --content-padding-top: 1.25rem;
+    }
+}
+
 @media (max-width: 449px) {
     #StoreSelector {
         max-width: 40vw;


### PR DESCRIPTION
If the viewport height is less than 800px, decrease the content padding top for breakpoints L and on.

### Before

![before](https://user-images.githubusercontent.com/886/223709664-984d89b1-d067-4d9e-89fb-1271737de69c.png)

### After


![after](https://user-images.githubusercontent.com/886/223709662-75df6ce0-f1d8-48d1-abda-42ac5a8a3bbf.png)