### PR TITLE
Language selector: Ensure correct font-size

### DIFF
--- a/BTCPayServer/wwwroot/checkout-v2/checkout.css
+++ b/BTCPayServer/wwwroot/checkout-v2/checkout.css
@@ -183,6 +183,7 @@ section dl > div dd {
     box-shadow: none;
     border: none;
     cursor: pointer;
+    font-size: var(--btcpay-body-font-size);
 }
 #DefaultLang:hover {
     color: var(--btcpay-body-text-hover);

--- a/BTCPayServer/wwwroot/checkout-v2/checkout.css
+++ b/BTCPayServer/wwwroot/checkout-v2/checkout.css
@@ -179,7 +179,7 @@ section dl > div dd {
 #DefaultLang {
     width: calc(var(--text-width, 110px) + 3rem);
     color: var(--btcpay-body-text-muted);
-    background-color: transparent;
+    background-color: var(--btcpay-body-bg);
     box-shadow: none;
     border: none;
     cursor: pointer;


### PR DESCRIPTION
Fixes the cut-off text on iOS, because somehow iOS uses a larger font-size by default.

![grafik](https://user-images.githubusercontent.com/886/224353379-f31b4537-2a87-41b2-b53f-4bac75044cca.png)
