### PR TITLE
Make CanUsePullPaymentsViaUI more robust

### DIFF
--- a/BTCPayServer.Tests/SeleniumTests.cs
+++ b/BTCPayServer.Tests/SeleniumTests.cs
@@ -1619,7 +1619,10 @@ namespace BTCPayServer.Tests
                 s.Driver.Navigate().Refresh();
                 Assert.Contains("transaction-label", s.Driver.PageSource);
             });
-            Assert.Equal("payout", s.Driver.FindElement(By.ClassName("transaction-label")).Text);
+            var labels = s.Driver.FindElements(By.CssSelector("#WalletTransactionsList tr:first-child div.transaction-label"));
+            Assert.Equal(2, labels.Count);
+            Assert.Contains(labels, element => element.Text == "payout");
+            Assert.Contains(labels, element => element.Text == "pull-payment");
 
             s.GoToStore(s.StoreId, StoreNavPages.Payouts);
             s.Driver.FindElement(By.Id($"{PayoutState.InProgress}-view")).Click();


### PR DESCRIPTION
Fixes this nasty flaky test failure:

```
Failed CanUsePullPaymentsViaUI [17 s]
  Error Message:
   Assert.Equal() Failure
           ↓ (pos 1)
Expected: payout
Actual:   pull-payment
           ↑ (pos 1)
  Stack Trace:
     at BTCPayServer.Tests.ChromeTests.CanUsePullPaymentsViaUI() in /source/BTCPayServer.Tests/SeleniumTests.cs:line 1622
```

Because there are actually two labels, the previous selector was dependent on the correct ordern, because it always chose the first one …

![grafik](https://user-images.githubusercontent.com/886/224362817-15a32776-5c84-4982-a68d-35af67eb3e52.png)
