### PR TITLE
Prevent people from starting with --sqlitefile or --mysql

### DIFF
--- a/BTCPayServer/Configuration/BTCPayServerOptions.cs
+++ b/BTCPayServer/Configuration/BTCPayServerOptions.cs
@@ -67,11 +67,21 @@ namespace BTCPayServer.Configuration
 
             if (conf.GetOrDefault<string>("POSTGRES", null) == null)
             {
-
-                if (conf.GetOrDefault<string>("SQLITEFILE", null) != null)
-                    Logs.Configuration.LogWarning("SQLITE backend support is out of support. Please migrate to Postgres by following the following instructions https://github.com/btcpayserver/btcpayserver/blob/master/docs/db-migration.md");
-                if (conf.GetOrDefault<string>("MYSQL", null) != null)
-                    Logs.Configuration.LogWarning("MYSQL backend support is out of support. Please migrate to Postgres by following the following instructions (https://github.com/btcpayserver/btcpayserver/blob/master/docs/db-migration.md)");
+                var allowDeprecated = conf.GetOrDefault<bool>("DEPRECATED", false);
+                if (allowDeprecated)
+                {
+                    if (conf.GetOrDefault<string>("SQLITEFILE", null) != null)
+                        Logs.Configuration.LogWarning("SQLITE backend support is out of support. Please migrate to Postgres by following the following instructions https://github.com/btcpayserver/btcpayserver/blob/master/docs/db-migration.md");
+                    if (conf.GetOrDefault<string>("MYSQL", null) != null)
+                        Logs.Configuration.LogWarning("MYSQL backend support is out of support. Please migrate to Postgres by following the following instructions (https://github.com/btcpayserver/btcpayserver/blob/master/docs/db-migration.md)");
+                }
+                else
+                {
+                    if (conf.GetOrDefault<string>("SQLITEFILE", null) != null)
+                        throw new ConfigException("SQLITE backend support is out of support. Please migrate to Postgres by following the following instructions (https://github.com/btcpayserver/btcpayserver/blob/master/docs/db-migration.md). If you don't want to update, you can try to start this instance by using the command line argument --deprecated");
+                    if (conf.GetOrDefault<string>("MYSQL", null) != null)
+                        throw new ConfigException("MYSQL backend support is out of support. Please migrate to Postgres by following the following instructions (https://github.com/btcpayserver/btcpayserver/blob/master/docs/db-migration.md). If you don't want to update, you can try to start this instance by using the command line argument --deprecated");
+                }
             }
             DockerDeployment = conf.GetOrDefault<bool>("dockerdeployment", true);
             TorrcFile = conf.GetOrDefault<string>("torrcfile", null);

--- a/BTCPayServer/Configuration/DefaultConfiguration.cs
+++ b/BTCPayServer/Configuration/DefaultConfiguration.cs
@@ -30,6 +30,7 @@ namespace BTCPayServer.Configuration
             app.Option("--mysql", $"DEPRECATED: Connection string to a MySQL database", CommandOptionType.SingleValue);
             app.Option("--nocsp", $"Disable CSP (default false)", CommandOptionType.BoolValue);
             app.Option("--sqlitefile", $"DEPRECATED: File name to an SQLite database file inside the data directory", CommandOptionType.SingleValue);
+            app.Option("--deprecated", $"Allow deprecated settings (default:false)", CommandOptionType.BoolValue);
             app.Option("--externalservices", $"Links added to external services inside Server Settings / Services under the format service1:path2;service2:path2.(default: empty)", CommandOptionType.SingleValue);
             app.Option("--rootpath", "The root path in the URL to access BTCPay (default: /)", CommandOptionType.SingleValue);
             app.Option("--sshconnection", "SSH server to manage BTCPay under the form user@server:port (default: root@externalhost or empty)", CommandOptionType.SingleValue);


### PR DESCRIPTION
If `--sqlitefile` or `--mysql` is without `--postgres` (ie, not in a migration), then BTCPay will fail starting.

`--deprecated` can be used to bypass this error, in case somebody doesn't want to update and just want to kick the can for a while.