### PR TITLE
POS: Fix escaped HTML entities in item title

### DIFF
--- a/BTCPayServer/Views/Shared/PointOfSale/Public/Cart.cshtml
+++ b/BTCPayServer/Views/Shared/PointOfSale/Public/Cart.cshtml
@@ -240,11 +240,11 @@
                     <div class="js-add-cart card px-0 card-wrapper" data-index="@index">
                         @if (!string.IsNullOrWhiteSpace(image))
                         {
-                            <img class="card-img-top" src="@image" alt="@item.Title" asp-append-version="true">
+                            <img class="card-img-top" src="@image" alt="@Safe.Raw(item.Title)" asp-append-version="true">
                         }
                         <div class="card-body p-3">
-                            <h6 class="card-title mb-0">@item.Title</h6>
-                            @if (!String.IsNullOrWhiteSpace(description))
+                            <h6 class="card-title mb-0">@Safe.Raw(item.Title)</h6>
+                            @if (!string.IsNullOrWhiteSpace(description))
                             {
                                 <p class="card-text">@Safe.Raw(description)</p>
                             }

--- a/BTCPayServer/Views/Shared/PointOfSale/Public/Print.cshtml
+++ b/BTCPayServer/Views/Shared/PointOfSale/Public/Print.cshtml
@@ -84,11 +84,10 @@ else
                 var item = Model.Items[x];
                 <div class="card" data-id="@x">
                     <div class="card-body my-auto">
-                        <h4 class="card-title text-center">@item.Title</h4>
+                        <h4 class="card-title text-center">@Safe.Raw(item.Title)</h4>
                         @if (!string.IsNullOrEmpty(item.Description))
                         {
-                            <p class="card-title text-center">@item.Description</p>
-                            
+                            <p class="card-title text-center">@Safe.Raw(item.Description)</p>
                         }
                         <div class="w-100 mb-3 fs-5 text-center">
                             @switch (item.Price.Type)

--- a/BTCPayServer/Views/Shared/PointOfSale/Public/Static.cshtml
+++ b/BTCPayServer/Views/Shared/PointOfSale/Public/Static.cshtml
@@ -23,7 +23,7 @@
                 <div class="card px-0" data-id="@x">
                     @if (!string.IsNullOrWhiteSpace(item.Image))
                     {
-                        <img class="card-img-top" src="@item.Image" alt="Card image cap" asp-append-version="true">
+                        <img class="card-img-top" src="@item.Image" alt="@Safe.Raw(item.Title)" asp-append-version="true">
                     }
                     @{CardBody(item.Title, item.Description);}
                     <div class="card-footer bg-transparent border-0 pb-3">
@@ -114,7 +114,7 @@
     private void CardBody(string title, string description)
     {
         <div class="card-body my-auto pb-0">
-            <h5 class="card-title">@title</h5>
+            <h5 class="card-title">@Safe.Raw(title)</h5>
             @if (!string.IsNullOrWhiteSpace(description))
             {
                 <p class="card-text">@Safe.Raw(description)</p>


### PR DESCRIPTION
Properly escapes and the sanitized values. Fixes #4794.