### PR TITLE
Wallet Transactions Export: Add BIP-329 support

### DIFF
--- a/BTCPayServer.Tests/SeleniumTests.cs
+++ b/BTCPayServer.Tests/SeleniumTests.cs
@@ -1570,9 +1570,20 @@ namespace BTCPayServer.Tests
             Assert.Contains("\"Amount\": \"3.00000000\"", s.Driver.PageSource);
             s.Driver.SwitchTo().Window(s.Driver.WindowHandles.First());
 
+            // BIP-329 export
+            s.Driver.FindElement(By.Id("ExportDropdownToggle")).Click();
+            s.Driver.FindElement(By.Id("ExportBIP329")).Click();
+            Thread.Sleep(1000);
+            s.Driver.SwitchTo().Window(s.Driver.WindowHandles.Last());
+            Assert.Contains(s.WalletId.ToString(), s.Driver.Url);
+            Assert.EndsWith("export?format=bip329", s.Driver.Url);
+            Assert.Contains("{\"type\":\"tx\",\"ref\":\"", s.Driver.PageSource);
+            s.Driver.SwitchTo().Window(s.Driver.WindowHandles.First());
+
             // CSV export
             s.Driver.FindElement(By.Id("ExportDropdownToggle")).Click();
             s.Driver.FindElement(By.Id("ExportCSV")).Click();
+            s.Driver.SwitchTo().Window(s.Driver.WindowHandles.First());
         }
 
         [Fact(Timeout = TestTimeout)]

--- a/BTCPayServer.Tests/UtilitiesTests.cs
+++ b/BTCPayServer.Tests/UtilitiesTests.cs
@@ -14,6 +14,7 @@ using BTCPayServer.Client.Models;
 using BTCPayServer.Controllers;
 using ExchangeSharp;
 using NBitcoin;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using OpenQA.Selenium;
 using OpenQA.Selenium.Chrome;
@@ -250,7 +251,6 @@ retry:
         {
             // 1. Generate an API Token on https://www.transifex.com/user/settings/api/
             // 2. Run "dotnet user-secrets set TransifexAPIToken <youapitoken>"
-
             await PullTransifexTranslationsCore(TranslationFolder.CheckoutV1);
             await PullTransifexTranslationsCore(TranslationFolder.CheckoutV2);
 

--- a/BTCPayServer/Controllers/UIWalletsController.cs
+++ b/BTCPayServer/Controllers/UIWalletsController.cs
@@ -1306,22 +1306,34 @@ namespace BTCPayServer.Controllers
 
             var wallet = _walletProvider.GetWallet(paymentMethod.Network);
             var walletTransactionsInfoAsync = WalletRepository.GetWalletTransactionsInfo(walletId, (string[]?)null);
-            var input = await wallet.FetchTransactionHistory(paymentMethod.AccountDerivation, null, null);
+            var input = await wallet.FetchTransactionHistory(paymentMethod.AccountDerivation);
             var walletTransactionsInfo = await walletTransactionsInfoAsync;
             var export = new TransactionsExport(wallet, walletTransactionsInfo);
             var res = export.Process(input, format);
-
+            var fileType = format switch
+            {
+                "csv" => "csv",
+                "json" => "json",
+                "bip329" => "jsonl",
+                _ => throw new ArgumentOutOfRangeException(nameof(format), format, null)
+            };
+            var mimeType = format switch
+            {
+                "csv" => "text/csv",
+                "json" => "application/json",
+                "bip329" => "text/jsonl", // https://stackoverflow.com/questions/59938644/what-is-the-mime-type-of-jsonl-files
+                _ => throw new ArgumentOutOfRangeException(nameof(format), format, null)
+            };
             var cd = new ContentDisposition
             {
-                FileName = $"btcpay-{walletId}-{DateTime.UtcNow.ToString("yyyyMMdd-HHmmss", CultureInfo.InvariantCulture)}.{format}",
+                FileName = $"btcpay-{walletId}-{DateTime.UtcNow.ToString("yyyyMMdd-HHmmss", CultureInfo.InvariantCulture)}.{fileType}",
                 Inline = true
             };
             Response.Headers.Add("Content-Disposition", cd.ToString());
             Response.Headers.Add("X-Content-Type-Options", "nosniff");
-            return Content(res, "application/" + format);
+            return Content(res, mimeType);
         }
-
-
+        
         public class UpdateLabelsRequest
         {
             public string? Address { get; set; }

--- a/BTCPayServer/Services/Wallets/Export/TransactionsExport.cs
+++ b/BTCPayServer/Services/Wallets/Export/TransactionsExport.cs
@@ -64,10 +64,10 @@ namespace BTCPayServer.Services.Wallets.Export
             {
                 if (tx.Labels is { Count: > 0 })
                 {
-                    tx.Labels.ForEach(label =>
-                        res.Add(JsonConvert.SerializeObject(
-                            new { Type = "label", Ref = tx.TransactionId, Label = label }, Formatting.None,
-                            serializerSett)));
+                    var label = string.Join(", ", tx.Labels);
+                    var obj = new { Type = "tx", Ref = tx.TransactionId, Label = label };
+                    var json = JsonConvert.SerializeObject(obj, Formatting.None, serializerSett);
+                    res.Add(json);
                 }
                 return res;
             });

--- a/BTCPayServer/Services/Wallets/Export/TransactionsExport.cs
+++ b/BTCPayServer/Services/Wallets/Export/TransactionsExport.cs
@@ -108,18 +108,18 @@ namespace BTCPayServer.Services.Wallets.Export
             Map(m => m.Labels).ConvertUsing(row => row.Labels == null ? string.Empty : string.Join(", ", row.Labels));
         }
     }
-#nullable restore
+
     public class ExportTransaction
     {
         [Name("Transaction Id")]
-        public string TransactionId { get; set; }
+        public string TransactionId { get; set; } = string.Empty;
         public DateTimeOffset Timestamp { get; set; }
-        public string Amount { get; set; }
-        public string Currency { get; set; }
+        public string Amount { get; set; } = string.Empty;
+        public string Currency { get; set; } = string.Empty;
 
         [Name("Is Confirmed")]
         public bool IsConfirmed { get; set; }
-        public string Comment { get; set; }
-        public List<string> Labels { get; set; }
+        public string? Comment { get; set; }
+        public List<string>? Labels { get; set; }
     }
 }

--- a/BTCPayServer/Views/UIWallets/WalletTransactions.cshtml
+++ b/BTCPayServer/Views/UIWallets/WalletTransactions.cshtml
@@ -165,6 +165,7 @@
             <div class="dropdown-menu" aria-labelledby="ExportDropdownToggle">
                 <a asp-action="Export" asp-route-walletId="@walletId" asp-route-format="csv" asp-route-labelFilter="@labelFilter" class="dropdown-item export-link" target="_blank" id="ExportCSV">CSV</a>
                 <a asp-action="Export" asp-route-walletId="@walletId" asp-route-format="json" asp-route-labelFilter="@labelFilter" class="dropdown-item export-link" target="_blank" id="ExportJSON">JSON</a>
+                <a asp-action="Export" asp-route-walletId="@walletId" asp-route-format="bip329" asp-route-labelFilter="@labelFilter" class="dropdown-item export-link" target="_blank" id="ExportBIP329">JSON (BIP-329)</a>
             </div>
         </div>
     </div>

--- a/BTCPayServer/Views/UIWallets/WalletTransactions.cshtml
+++ b/BTCPayServer/Views/UIWallets/WalletTransactions.cshtml
@@ -165,7 +165,7 @@
             <div class="dropdown-menu" aria-labelledby="ExportDropdownToggle">
                 <a asp-action="Export" asp-route-walletId="@walletId" asp-route-format="csv" asp-route-labelFilter="@labelFilter" class="dropdown-item export-link" target="_blank" id="ExportCSV">CSV</a>
                 <a asp-action="Export" asp-route-walletId="@walletId" asp-route-format="json" asp-route-labelFilter="@labelFilter" class="dropdown-item export-link" target="_blank" id="ExportJSON">JSON</a>
-                <a asp-action="Export" asp-route-walletId="@walletId" asp-route-format="bip329" asp-route-labelFilter="@labelFilter" class="dropdown-item export-link" target="_blank" id="ExportBIP329">JSON (BIP-329)</a>
+                <a asp-action="Export" asp-route-walletId="@walletId" asp-route-format="bip329" asp-route-labelFilter="@labelFilter" class="dropdown-item export-link" target="_blank" id="ExportBIP329">Wallet Labels (BIP-329)</a>
             </div>
         </div>
     </div>


### PR DESCRIPTION
Adds support for the [BIP 329](https://github.com/bitcoin/bips/blob/master/bip-0329.mediawiki) export format.

Sample transactions export:

```jsonl
{"type":"tx","ref":"9eb4b1f69dc0aad88f2530fdd124c77021c1633500e14369d0896bf75a025596","label":"microtransaction"}
{"type":"tx","ref":"98ee2e20e45967eeda330b191d881584d1e02ea05e633e4cb7c48aea8980fc63","label":"test"}
{"type":"tx","ref":"84ce8b198d85e715588da114b7b441833cfc4892ba9aa1f7f3cfbfdcf2ca1235","label":"Mining Income, microtransaction, test"}
```

Currently only the transaction data is exported, but I think we can also leverage the new labeling system to export other types, like `addr` as well. @NicolasDorier 

Closes #4536.

![grafik](https://user-images.githubusercontent.com/886/226856288-2db46a12-d2f8-4fc8-85b7-e0fc5ec92436.png)
