### PR TITLE
Revert "Refactor custodian"

### DIFF
--- a/BTCPayServer.Abstractions/Custodians/ICustodian.cs
+++ b/BTCPayServer.Abstractions/Custodians/ICustodian.cs
@@ -20,6 +20,9 @@ public interface ICustodian
      */
     Task<Dictionary<string, decimal>> GetAssetBalancesAsync(JObject config, CancellationToken cancellationToken);
 
-    public Task<Form.Form> GetConfigForm(CancellationToken cancellationToken = default);
+    public Task<Form.Form> GetConfigForm(JObject config, string locale,
+        CancellationToken cancellationToken = default);
+
+    public JObject cleanupConfigBeforeSave(JObject config);
 
 }

--- a/BTCPayServer.Abstractions/Extensions/JObjectExtensions.cs
+++ b/BTCPayServer.Abstractions/Extensions/JObjectExtensions.cs
@@ -1,0 +1,78 @@
+using System;
+using System.Linq;
+using System.Reflection;
+using NBitcoin.RPC;
+using Newtonsoft.Json.Linq;
+
+namespace BTCPayServer.Abstractions.Extensions;
+
+public static class JObjectExtensions
+{
+    public static string GetValueByPath(this JObject json, string path)
+    {
+        string[] pathParts = path.Split('.');
+
+        JObject loopedJObject = json;
+        var last = pathParts.Last();
+        string r = null;
+        
+        foreach (string pathPart in pathParts)
+        {
+            var isLast = pathPart.Equals(last);
+
+            var childNode = loopedJObject.GetValue(pathPart);
+            if (isLast)
+            {
+                // Set the value now we're reached the final node
+                r = loopedJObject.GetValue(pathPart)?.ToString();
+            }
+            else if (childNode == null)
+            {
+                r = null;
+            }
+            else if (childNode is JObject childNodeJObject)
+            {
+                loopedJObject = childNodeJObject;
+            }
+            else
+            {
+                throw new Exception("Cannot move into key '" + path + "' in JObject " + json);
+            }
+        }
+
+        return r?.ToString();
+    }
+
+    public static void SetValueByPath(this JObject json, string path, string value)
+    {
+        string[] pathParts = path.Split('.');
+
+        JObject loopedJObject = json;
+        var last = pathParts.Last();
+        foreach (string pathPart in pathParts)
+        {
+            var isLast = pathPart.Equals(last);
+
+            var childNode = loopedJObject.GetValue(pathPart);
+            if (isLast)
+            {
+                // Set the value now we're reached the final node
+                loopedJObject.Add(pathPart, value);
+            }
+            else if (childNode == null)
+            {
+                var childNodeJObj = new JObject();
+                loopedJObject.Add(pathPart, childNodeJObj);
+                loopedJObject = childNodeJObj;
+            }
+            else if (childNode is JObject childNodeJObject)
+            {
+                loopedJObject = childNodeJObject;
+            }
+            else
+            {
+                throw new Exception("Cannot move into key '" + path + "' in JObject " + json);
+            }
+        }
+    }
+}

--- a/BTCPayServer.Tests/MockCustodian/MockCustodian.cs
+++ b/BTCPayServer.Tests/MockCustodian/MockCustodian.cs
@@ -56,10 +56,16 @@ public class MockCustodian : ICustodian, ICanDeposit, ICanTrade, ICanWithdraw
         return Task.FromResult(r);
     }
 
-    public Task<Form> GetConfigForm(CancellationToken cancellationToken = default)
+    public Task<Form> GetConfigForm(JObject config, string locale, CancellationToken cancellationToken = default)
     {
         return null;
     }
+
+    public JObject cleanupConfigBeforeSave(JObject config)
+    {
+        return config;
+    }
+
 
     public Task<DepositAddressData> GetDepositAddressAsync(string paymentMethod, JObject config, CancellationToken cancellationToken)
     {

--- a/Plugins/BTCPayServer.Plugins.Custodians.FakeCustodian/FakeCustodian.cs
+++ b/Plugins/BTCPayServer.Plugins.Custodians.FakeCustodian/FakeCustodian.cs
@@ -29,20 +29,21 @@ public class FakeCustodian : ICustodian
         return Task.FromResult(r);
     }
 
-    public Task<Form> GetConfigForm(CancellationToken cancellationToken = default)
+    public Task<Form> GetConfigForm(JObject config, string locale, CancellationToken cancellationToken = default)
     {
-        
+        var fakeConfig = ParseConfig(config);
+
         var form = new Form();
         var fieldset = Field.CreateFieldset();
 
         // Maybe a decimal type field would be better?
-        var fakeBTCBalance = Field.Create("BTC Balance", "BTCBalance", null, true,
+        var fakeBTCBalance = Field.Create("BTC Balance", "BTCBalance", fakeConfig?.BTCBalance.ToString(), true,
             "Enter the amount of BTC you want to have.");
-        var fakeLTCBalance = Field.Create("LTC Balance", "LTCBalance", null, true,
+        var fakeLTCBalance = Field.Create("LTC Balance", "LTCBalance", fakeConfig?.LTCBalance.ToString(), true,
             "Enter the amount of LTC you want to have.");
-        var fakeEURBalance = Field.Create("EUR Balance", "EURBalance", null, true,
+        var fakeEURBalance = Field.Create("EUR Balance", "EURBalance", fakeConfig?.EURBalance.ToString(), true,
             "Enter the amount of EUR you want to have.");
-        var fakeUSDBalance = Field.Create("USD Balance", "USDBalance", null, true,
+        var fakeUSDBalance = Field.Create("USD Balance", "USDBalance", fakeConfig?.USDBalance.ToString(), true,
             "Enter the amount of USD you want to have.");
 
         fieldset.Label = "Your fake balances";
@@ -53,6 +54,11 @@ public class FakeCustodian : ICustodian
         form.Fields.Add(fieldset);
 
         return Task.FromResult(form);
+    }
+
+    public JObject cleanupConfigBeforeSave(JObject config)
+    {
+        return config;
     }
 
     private FakeCustodianConfig ParseConfig(JObject config)


### PR DESCRIPTION
@NicolasDorier I need to have this commit reverted. It's a breaking change that cannot be handled the way it way I intended it.

My implementation for `GetConfigForm` from the Kraken plugin is this:

```
public async Task<Form>? GetConfigForm(JObject config, string locale,
        CancellationToken cancellationToken)
    {
        // TODO "locale" is not used yet, but keeping it here so it's clear translation should be done here.

        var krakenConfig = ParseConfig(config);

        var form = new Form();
        var fieldset = Field.CreateFieldset();
        fieldset.Label = "Connection details";

        var apiKeyField = Field.Create("API Key", "ApiKey", krakenConfig.ApiKey, true,
            "Enter your Kraken API Key. Your API Key should have <a href=\"/Resources/img/kraken-api-permissions.png\" target=\"_blank\" rel=\"noreferrer noopener\">at least these permissions</a>.", "password");
        var privateKeyField = Field.Create("Private Key", "PrivateKey", krakenConfig.PrivateKey,
            true, "Enter your Kraken Private Key", "password");

        form.Fields.Add(fieldset);
        fieldset.Fields.Add(apiKeyField);
        fieldset.Fields.Add(privateKeyField);

        // TODO: Instead of showing all, maybe show the withdrawal destinations for all assets that:
        // 1. we have an existing config value for,
        // 2. all assets stored with the custodian and
        // 3. all assets our store supports
        var withdrawalFieldset = Field.CreateFieldset();
        withdrawalFieldset.Label = "Withdrawal settings";
        form.Fields.Add(withdrawalFieldset);

        var paymentMethods = GetWithdrawablePaymentMethods();

        foreach (var paymentMethod in paymentMethods)
        {
            var fieldName = "WithdrawToStoreWalletAddressLabels." + paymentMethod;
            string value = config.GetValueByPath(fieldName);
            withdrawalFieldset.Fields.Add(Field.Create(
                $"Withdrawal \"address description\" pointing to your store's {paymentMethod} wallet",
                fieldName,
                value,
                false,
                "The exact name of the withdrawal destination as stored in your Kraken account for your store's " +
                paymentMethod +
                " wallet. <a target=\"_blank\" rel=\"noreferrer noopener\" href=\"https://support.kraken.com/hc/en-us/articles/360000672863\">Learn how to setup a withdrawal destination</a>. Example value: \"Mum's Bitcoin Savings\"", "text"));
        }

        try
        {
            await GetAssetBalancesAsync(config, cancellationToken);
        }
        catch (BadConfigException e)
        {
            foreach (var badConfigKey in e.BadConfigKeys)
            {
                var field = form.GetFieldByFullName(badConfigKey);
                field.ValidationErrors.Add("Invalid " + field.Label);
            }

            form.TopMessages.Add(new AlertMessage(AlertMessage.AlertMessageType.Danger,
                "Cannot connect to Kraken. Please check your API and private keys."));
        }

        return form;
    }
```