### PR TITLE
Checkout Appearance: Move language settings into the general section

### DIFF
--- a/BTCPayServer/Views/UIStores/CheckoutAppearance.cshtml
+++ b/BTCPayServer/Views/UIStores/CheckoutAppearance.cshtml
@@ -108,17 +108,6 @@
                     <label asp-for="RequiresRefundEmail" class="form-check-label"></label>
                 </div>
                 <div class="form-group">
-                    <div class="form-check">
-                        <input asp-for="AutoDetectLanguage" type="checkbox" class="form-check-input" />
-                        <label asp-for="AutoDetectLanguage" class="form-check-label"></label>
-                        <div class="form-text">Detects the language of the customer's browser with 99.9% accuracy.</div>
-                    </div>
-                </div>
-                <div class="form-group">
-                    <label asp-for="DefaultLang" class="form-label"></label>
-                    <select asp-for="DefaultLang" asp-items="Model.Languages" class="form-select w-auto"></select>
-                </div>
-                <div class="form-group">
                     <label asp-for="CustomLogo" class="form-label"></label>
                     <a href="https://docs.btcpayserver.org/Development/Theme/#checkout-page-themes" target="_blank" rel="noreferrer noopener">
                         <vc:icon symbol="info" />
@@ -142,7 +131,17 @@
                     @await Component.InvokeAsync("UiExtensionPoint", new {location = "invoice-checkout-theme-options", model = Model})
                 </div>
             </div>
-
+            <div class="form-group">
+                <div class="form-check">
+                    <input asp-for="AutoDetectLanguage" type="checkbox" class="form-check-input" />
+                    <label asp-for="AutoDetectLanguage" class="form-check-label"></label>
+                    <div class="form-text">Detects the language of the customer's browser with 99.9% accuracy.</div>
+                </div>
+            </div>
+            <div class="form-group">
+                <label asp-for="DefaultLang" class="form-label"></label>
+                <select asp-for="DefaultLang" asp-items="Model.Languages" class="form-select w-auto"></select>
+            </div>
             <div class="form-group">
                 <label asp-for="HtmlTitle" class="form-label"></label>
                 <input asp-for="HtmlTitle" class="form-control" />


### PR DESCRIPTION
The language settings work for both versions of the checkout, so let's make them available for both. Request by @petzsch.