### PR TITLE
Improve Labeling further

### DIFF
--- a/BTCPayServer/Controllers/UIWalletsController.PSBT.cs
+++ b/BTCPayServer/Controllers/UIWalletsController.PSBT.cs
@@ -459,14 +459,17 @@ namespace BTCPayServer.Controllers
                     }
                 }
                 if (ix is null) continue;
+                
+                var labels = _labelService.CreateTransactionTagModels(ix, Request);
                 var input = vm.Inputs.First(model => model.Index == inputToObject.Key);
-                input.Labels = ix.LabelColors;
+                input.Labels = labels;
             }
             foreach (var outputToObject in outputToObjects)
             {
                 if (!labelInfo.TryGetValue(outputToObject.Value.Id, out var ix)) continue;
+                var labels = _labelService.CreateTransactionTagModels(ix, Request);
                 var destination = vm.Destinations.First(model => model.Destination == outputToObject.Key);
-                destination.Labels = ix.LabelColors;
+                destination.Labels = labels;
             }
             
         }

--- a/BTCPayServer/Data/Payouts/IPayoutHandler.cs
+++ b/BTCPayServer/Data/Payouts/IPayoutHandler.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using BTCPayServer.Abstractions.Models;
 using BTCPayServer.Client.Models;
 using BTCPayServer.Data;
+using BTCPayServer.HostedServices;
 using BTCPayServer.Payments;
 using Microsoft.AspNetCore.Mvc;
 using PayoutData = BTCPayServer.Data.PayoutData;
@@ -14,7 +15,7 @@ using StoreData = BTCPayServer.Data.StoreData;
 public interface IPayoutHandler
 {
     public bool CanHandle(PaymentMethodId paymentMethod);
-    public Task TrackClaim(PaymentMethodId paymentMethodId, IClaimDestination claimDestination);
+    public Task TrackClaim(ClaimRequest claimRequest, PayoutData payoutData);
     //Allows payout handler to parse payout destinations on its own
     public Task<(IClaimDestination destination, string error)> ParseClaimDestination(PaymentMethodId paymentMethodId, string destination, CancellationToken cancellationToken);
     public (bool valid, string? error) ValidateClaimDestination(IClaimDestination claimDestination, PullPaymentBlob? pullPaymentBlob);

--- a/BTCPayServer/Data/Payouts/LightningLike/LightningLikePayoutHandler.cs
+++ b/BTCPayServer/Data/Payouts/LightningLike/LightningLikePayoutHandler.cs
@@ -6,6 +6,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using BTCPayServer.Abstractions.Models;
 using BTCPayServer.Client.Models;
+using BTCPayServer.HostedServices;
 using BTCPayServer.Lightning;
 using BTCPayServer.Payments;
 using BTCPayServer.Payments.Lightning;
@@ -45,7 +46,7 @@ namespace BTCPayServer.Data.Payouts.LightningLike
                    _btcPayNetworkProvider.GetNetwork<BTCPayNetwork>(paymentMethod.CryptoCode)?.SupportLightning is true;
         }
 
-        public Task TrackClaim(PaymentMethodId paymentMethodId, IClaimDestination claimDestination)
+        public Task TrackClaim(ClaimRequest claimRequest, PayoutData payoutData)
         {
             return Task.CompletedTask;
         }

--- a/BTCPayServer/HostedServices/PullPaymentHostedService.cs
+++ b/BTCPayServer/HostedServices/PullPaymentHostedService.cs
@@ -591,7 +591,7 @@ namespace BTCPayServer.HostedServices
                 await ctx.Payouts.AddAsync(payout);
                 try
                 {
-                    await payoutHandler.TrackClaim(req.ClaimRequest.PaymentMethodId, req.ClaimRequest.Destination);
+                    await payoutHandler.TrackClaim(req.ClaimRequest, payout);
                     await ctx.SaveChangesAsync();
                     if (req.ClaimRequest.PreApprove.GetValueOrDefault(ppBlob?.AutoApproveClaims is true))
                     {

--- a/BTCPayServer/Models/WalletViewModels/WalletPSBTReadyViewModel.cs
+++ b/BTCPayServer/Models/WalletViewModels/WalletPSBTReadyViewModel.cs
@@ -16,7 +16,7 @@ namespace BTCPayServer.Models.WalletViewModels
             public bool Positive { get; set; }
             public string Destination { get; set; }
             public string Balance { get; set; }
-            public Dictionary<string, string> Labels { get; set; } = new();
+            public IEnumerable<TransactionTagModel> Labels { get; set; } = new List<TransactionTagModel>();
         }
 
         public class InputViewModel
@@ -25,7 +25,7 @@ namespace BTCPayServer.Models.WalletViewModels
             public string Error { get; set; }
             public bool Positive { get; set; }
             public string BalanceChange { get; set; }
-            public Dictionary<string, string> Labels { get; set; } = new();
+            public IEnumerable<TransactionTagModel> Labels { get; set; } = new List<TransactionTagModel>();
         }
         public bool HasErrors => Inputs.Count == 0 || Inputs.Any(i => !string.IsNullOrEmpty(i.Error));
         public string BalanceChange { get; set; }

--- a/BTCPayServer/Services/WalletRepository.cs
+++ b/BTCPayServer/Services/WalletRepository.cs
@@ -318,10 +318,10 @@ namespace BTCPayServer.Services
         
         public async Task<(string Label, string Color)[]> GetWalletLabels(WalletObjectId objectId)
         {
-            return await GetWalletLabels(w => 
-                w.WalletId == objectId.WalletId.ToString() &&
-                w.Type == objectId.Type &&
-                w.Id == objectId.Id);
+            
+            await using var ctx = _ContextFactory.CreateContext();
+            var obj = await GetWalletObject(objectId, true);
+            return obj is null ? Array.Empty<(string Label, string Color)>() : obj.GetNeighbours().Where(data => data.Type == WalletObjectData.Types.Label).Select(FormatToLabel).ToArray();
         }
         
         private async Task<(string Label, string Color)[]> GetWalletLabels(Expression<Func<WalletObjectData, bool>> predicate)

--- a/BTCPayServer/Views/UIWallets/_PSBTInfo.cshtml
+++ b/BTCPayServer/Views/UIWallets/_PSBTInfo.cshtml
@@ -35,10 +35,25 @@
                 {
                     <td>@input.Index</td>
                 }<td>
-                    @foreach (var label in input.Labels)
-                    {
-                        <div class="transaction-label" style="--label-bg:@label.Value;--label-fg:@ColorPalette.Default.TextColor(label.Value)">@label.Key</div>
-                    }
+                    @if (input.Labels.Any())
+                                           {
+                                               <div class="d-flex flex-wrap gap-2 align-items-center">
+                                                   @foreach (var label in input.Labels)
+                                                   {
+                                                       <div class="transaction-label" style="--label-bg:@label.Color;--label-fg:@label.TextColor">
+                                                           <span>@label.Text</span>
+                                                           @if (!string.IsNullOrEmpty(label.Link))
+                                                           {
+                                                               <a class="transaction-label-info transaction-details-icon" href="@label.Link"
+                                                                  target="_blank" rel="noreferrer noopener" title="@label.Tooltip" data-bs-html="true"
+                                                                  data-bs-toggle="tooltip" data-bs-custom-class="transaction-label-tooltip">
+                                                                   <vc:icon symbol="info" />
+                                                               </a>
+                                                           }
+                                                       </div>
+                                                   }
+                                               </div>
+                                           }
                 </td>
                 <td class="text-end text-@(input.Positive ? "success" : "danger")">@input.BalanceChange</td>
                 
@@ -64,11 +79,25 @@
             <tr>
                 <td class="text-break">@destination.Destination</td>
                 <td>
-                
-                    @foreach (var label in destination.Labels)
-                    {
-                        <div class="transaction-label" style="--label-bg:@label.Value;--label-fg:@ColorPalette.Default.TextColor(label.Value)">@label.Key</div>
-                    }
+                  @if (destination.Labels.Any())
+                                        {
+                                            <div class="d-flex flex-wrap gap-2 align-items-center">
+                                                @foreach (var label in destination.Labels)
+                                                {
+                                                    <div class="transaction-label" style="--label-bg:@label.Color;--label-fg:@label.TextColor">
+                                                        <span>@label.Text</span>
+                                                        @if (!string.IsNullOrEmpty(label.Link))
+                                                        {
+                                                            <a class="transaction-label-info transaction-details-icon" href="@label.Link"
+                                                               target="_blank" rel="noreferrer noopener" title="@label.Tooltip" data-bs-html="true"
+                                                               data-bs-toggle="tooltip" data-bs-custom-class="transaction-label-tooltip">
+                                                                <vc:icon symbol="info" />
+                                                            </a>
+                                                        }
+                                                    </div>
+                                                }
+                                            </div>
+                                        }
                 </td>
                 <td class="text-end text-@(destination.Positive ? "success" : "danger")">@destination.Balance</td>
 


### PR DESCRIPTION
* If loading addresses into the send wallet page using bip21 or address,  (or clicking on "Send selected payouts"  from the payotus page), existing labels will be pre-populated.
*  Add the payout label to the address when the payoutis created instead of to the transaction when it is paid.
*  Add the label attachments when adding labels from an address to the transaction.