### PR TITLE
Allow any bolt11 invoice for pullpayments/payouts

### DIFF
--- a/BTCPayServer/Controllers/GreenField/GreenfieldPullPaymentController.cs
+++ b/BTCPayServer/Controllers/GreenField/GreenfieldPullPaymentController.cs
@@ -115,7 +115,7 @@ namespace BTCPayServer.Controllers.Greenfield
             {
                 ModelState.AddModelError(nameof(request.Period), $"The period should be positive");
             }
-            if (request.BOLT11Expiration <= TimeSpan.Zero)
+            if (request.BOLT11Expiration < TimeSpan.Zero)
             {
                 ModelState.AddModelError(nameof(request.BOLT11Expiration), $"The BOLT11 expiration should be positive");
             }
@@ -142,7 +142,7 @@ namespace BTCPayServer.Controllers.Greenfield
             }
             if (!ModelState.IsValid)
                 return this.CreateValidationError(ModelState);
-            var ppId = await _pullPaymentService.CreatePullPayment(new HostedServices.CreatePullPayment()
+            var ppId = await _pullPaymentService.CreatePullPayment(new CreatePullPayment()
             {
                 StartsAt = request.StartsAt,
                 ExpiresAt = request.ExpiresAt,

--- a/BTCPayServer/HostedServices/PullPaymentHostedService.cs
+++ b/BTCPayServer/HostedServices/PullPaymentHostedService.cs
@@ -120,6 +120,7 @@ namespace BTCPayServer.HostedServices
             o.Period = create.Period is TimeSpan period ? (long?)period.TotalSeconds : null;
             o.Id = Encoders.Base58.EncodeData(RandomUtils.GetBytes(20));
             o.StoreId = create.StoreId;
+            
             o.SetBlob(new PullPaymentBlob()
             {
                 Name = create.Name ?? string.Empty,

--- a/BTCPayServer/Models/StoreViewModels/GeneralSettingsViewModel.cs
+++ b/BTCPayServer/Models/StoreViewModels/GeneralSettingsViewModel.cs
@@ -54,7 +54,7 @@ namespace BTCPayServer.Models.StoreViewModels
         public string DefaultCurrency { get; set; }
 
         [Display(Name = "Minimum acceptable expiration time for BOLT11 for refunds")]
-        [Range(1, 365 * 10)]
+        [Range(0, 365 * 10)]
         public long BOLT11Expiration { get; set; }
     }
 }

--- a/BTCPayServer/Models/StoreViewModels/PaymentViewModel.cs
+++ b/BTCPayServer/Models/StoreViewModels/PaymentViewModel.cs
@@ -26,7 +26,7 @@ namespace BTCPayServer.Models.StoreViewModels
         public string DefaultCurrency { get; set; }
 
         [Display(Name = "Minimum acceptable expiration time for BOLT11 for refunds")]
-        [Range(1, 365 * 10)]
+        [Range(0, 365 * 10)]
         public long BOLT11Expiration { get; set; }
     }
 }

--- a/BTCPayServer/Models/WalletViewModels/PullPaymentsModel.cs
+++ b/BTCPayServer/Models/WalletViewModels/PullPaymentsModel.cs
@@ -66,7 +66,7 @@ namespace BTCPayServer.Models.WalletViewModels
         public IEnumerable<string> PaymentMethods { get; set; }
         public IEnumerable<SelectListItem> PaymentMethodItems { get; set; }
         [Display(Name = "Minimum acceptable expiration time for BOLT11 for refunds")]
-        [Range(1, 365 * 10)]
+        [Range(0, 365 * 10)]
         public long BOLT11Expiration { get; set; } = 30;
         [Display(Name = "Automatically approve claims")]
         public bool AutoApproveClaims { get; set; } = false;


### PR DESCRIPTION
closes #4830

If users want to deal with expired payout destinations, then they should be able to conifugre it that way. Some wallets simply do not allow customizing the bolt11 expiry and the defaults are much less than a day. I think we should merge #3857 if we introduce this as an automated payotu processor for lightning running every few minutes would work together with this and solve it.