### PR TITLE
Bugfix: Cannot create new Fake Custodian

### DIFF
--- a/BTCPayServer.Abstractions/Custodians/ICustodian.cs
+++ b/BTCPayServer.Abstractions/Custodians/ICustodian.cs
@@ -21,6 +21,6 @@ public interface ICustodian
      */
     Task<Dictionary<string, decimal>> GetAssetBalancesAsync(JObject config, CancellationToken cancellationToken);
 
-    public Task<Form.Form> GetConfigForm(JObject config, CancellationToken cancellationToken = default);
+    public Task<Form.Form> GetConfigForm(JObject config, bool isNew, CancellationToken cancellationToken = default);
 
 }

--- a/BTCPayServer.Tests/MockCustodian/MockCustodian.cs
+++ b/BTCPayServer.Tests/MockCustodian/MockCustodian.cs
@@ -56,7 +56,7 @@ public class MockCustodian : ICustodian, ICanDeposit, ICanTrade, ICanWithdraw
         return Task.FromResult(r);
     }
 
-    public Task<Form> GetConfigForm(JObject config, CancellationToken cancellationToken = default)
+    public Task<Form> GetConfigForm(JObject config, bool isNew, CancellationToken cancellationToken = default)
     {
         return null;
     }

--- a/BTCPayServer/Plugins/FakeCustodian/FakeCustodian.cs
+++ b/BTCPayServer/Plugins/FakeCustodian/FakeCustodian.cs
@@ -54,16 +54,20 @@ public class FakeCustodian : ICustodian, ICanDeposit, ICanWithdraw, ICanTrade
         return Task.FromResult(r);
     }
 
-    public Task<Form> GetConfigForm(JObject config, CancellationToken cancellationToken = default)
+    public Task<Form> GetConfigForm(JObject config, bool isNew, CancellationToken cancellationToken = default)
     {
         var form = new Form();
 
         var generalFieldset = Field.CreateFieldset();
         generalFieldset.Label = "General";
-        // TODO we cannot validate the custodian account ID because we have no access to the correct value. This is fine given this is a development tool and won't be needed by actual custodians.
-        var accountIdField = Field.Create("Custodian Account ID", "CustodianAccountId", null, true,
-            "Enter the ID of this custodian account. This is needed as a workaround which only applies to the Fake Custodian.");
-        generalFieldset.Fields.Add(accountIdField);
+        
+        if (!isNew)
+        {
+            // TODO we cannot validate the custodian account ID because we have no access to the correct value. This is fine given this is a development tool and won't be needed by actual custodians.
+            var accountIdField = Field.Create("Custodian Account ID", "CustodianAccountId", null, true,
+                "Enter the ID of this custodian account. This is needed as a workaround which only applies to the Fake Custodian.");
+            generalFieldset.Fields.Add(accountIdField);
+        }
 
         // TODO we cannot validate the store ID because we have no access to the correct value. This is fine given this is a development tool and won't be needed by actual custodians.
         var storeIdField = Field.Create("Store ID", "StoreId", null, true,


### PR DESCRIPTION
Minor bugfix that fixes the issue where you can't create a new Fake Custodian because you can't fill out the form due to a required field you cannot answer.

Expanded the interface with a bool `isNew` so it knows the config form is for a new custodian (and not an update/edit). Tried several alternatives, but there was simply no other, reliable way of detecting create vs edit.