### PR TITLE
Refactor: Dot not make LNURLPaymentMethodDetails depends on BTCPayInvoiceId

### DIFF
--- a/BTCPayServer.Tests/SeleniumTester.cs
+++ b/BTCPayServer.Tests/SeleniumTester.cs
@@ -1,4 +1,5 @@
 using System;
+using System.ComponentModel;
 using System.Globalization;
 using System.IO;
 using System.Linq;
@@ -64,7 +65,6 @@ namespace BTCPayServer.Tests
                 var containerIp = File.ReadAllText("/etc/hosts").Split('\n', StringSplitOptions.RemoveEmptyEntries).Last()
                     .Split('\t', StringSplitOptions.RemoveEmptyEntries)[0].Trim();
                 TestLogs.LogInformation($"Selenium: Container's IP {containerIp}");
-                ServerUri = Server.PayTester.ServerUri;
             }
             else
             {
@@ -76,8 +76,8 @@ namespace BTCPayServer.Tests
                 Driver = new ChromeDriver(cds, options,
                     // A bit less than test timeout
                     TimeSpan.FromSeconds(50));
-                ServerUri = Server.PayTester.ServerUri;
             }
+            ServerUri = Server.PayTester.ServerUri;
             Driver.Manage().Window.Maximize();
 
             TestLogs.LogInformation($"Selenium: Using {Driver.GetType()}");

--- a/BTCPayServer.Tests/SeleniumTester.cs
+++ b/BTCPayServer.Tests/SeleniumTester.cs
@@ -64,7 +64,7 @@ namespace BTCPayServer.Tests
                 var containerIp = File.ReadAllText("/etc/hosts").Split('\n', StringSplitOptions.RemoveEmptyEntries).Last()
                     .Split('\t', StringSplitOptions.RemoveEmptyEntries)[0].Trim();
                 TestLogs.LogInformation($"Selenium: Container's IP {containerIp}");
-                ServerUri = new Uri(Server.PayTester.ServerUri.AbsoluteUri.Replace($"http://{Server.PayTester.HostName}", $"http://{containerIp}", StringComparison.OrdinalIgnoreCase), UriKind.Absolute);
+                ServerUri = Server.PayTester.ServerUri;
             }
             else
             {

--- a/BTCPayServer.Tests/SeleniumTests.cs
+++ b/BTCPayServer.Tests/SeleniumTests.cs
@@ -2306,7 +2306,6 @@ namespace BTCPayServer.Tests
             var invoices = await repo.GetInvoices(new InvoiceQuery() { StoreId = new[] { s.StoreId } });
             Assert.Equal(2, invoices.Length);
             var emailSuffix = $"@{s.Server.PayTester.HostName}:{s.Server.PayTester.Port}";
-
             foreach (var i in invoices)
             {
                 var lightningPaymentMethod = i.GetPaymentMethod(new PaymentMethodId("BTC", PaymentTypes.LNURLPay));
@@ -2323,6 +2322,8 @@ namespace BTCPayServer.Tests
             }
 
             var lnUsername = lnaddress1.Split('@')[0];
+
+
             LNURLPayRequest req;
             using (var resp = await s.Server.PayTester.HttpClient.GetAsync($"/.well-known/lnurlp/{lnUsername}"))
             {

--- a/BTCPayServer.Tests/docker-compose.altcoins.yml
+++ b/BTCPayServer.Tests/docker-compose.altcoins.yml
@@ -38,6 +38,10 @@ services:
       - selenium
     extra_hosts:
       - "tests:127.0.0.1"
+    networks:
+      default:
+      custom:
+        ipv4_address: 172.23.0.18
     volumes:
       - "sshd_datadir:/root/.ssh"
       - "customer_lightningd_datadir:/etc/customer_lightningd_datadir"
@@ -89,6 +93,8 @@ services:
     image: selenium/standalone-chrome:101.0
     expose:
       - "4444"
+    extra_hosts:
+      - "tests:172.18.0.18"
   nbxplorer:
     image: nicolasdorier/nbxplorer:2.3.58
     restart: unless-stopped
@@ -404,3 +410,12 @@ volumes:
     torrcdir:
     tor_servicesdir:
     monero_data:
+
+networks:
+  default:
+    driver: bridge
+  custom:
+    driver: bridge
+    ipam:
+      config:
+        - subnet: 172.23.0.0/16

--- a/BTCPayServer.Tests/docker-compose.yml
+++ b/BTCPayServer.Tests/docker-compose.yml
@@ -36,6 +36,10 @@ services:
       - selenium
     extra_hosts:
       - "tests:127.0.0.1"
+    networks:
+      default:
+      custom:
+        ipv4_address: 172.23.0.18
     volumes:
       - "sshd_datadir:/root/.ssh"
       - "customer_lightningd_datadir:/etc/customer_lightningd_datadir"
@@ -84,6 +88,8 @@ services:
       - merchant_lnd
   selenium:
     image: selenium/standalone-chrome:101.0
+    extra_hosts:
+      - "tests:172.18.0.18"
     expose:
       - "4444"
   nbxplorer:
@@ -109,7 +115,6 @@ services:
       NBXPLORER_NOAUTH: 1
     depends_on:
       - bitcoind
-
 
   bitcoind:
     restart: unless-stopped
@@ -323,3 +328,12 @@ volumes:
     tor_datadir:
     torrcdir:
     tor_servicesdir:
+
+networks:
+  default:
+    driver: bridge
+  custom:
+    driver: bridge
+    ipam:
+      config:
+        - subnet: 172.23.0.0/16

--- a/BTCPayServer/Controllers/GreenField/GreenfieldInvoiceController.cs
+++ b/BTCPayServer/Controllers/GreenField/GreenfieldInvoiceController.cs
@@ -547,7 +547,7 @@ namespace BTCPayServer.Controllers.Greenfield
                         Amount = accounting.TotalDue.ToDecimal(MoneyUnit.BTC),
                         NetworkFee = accounting.NetworkFee.ToDecimal(MoneyUnit.BTC),
                         PaymentLink =
-                            method.GetId().PaymentType.GetPaymentLink(method.Network, details, accounting.Due,
+                            method.GetId().PaymentType.GetPaymentLink(method.Network, entity, details, accounting.Due,
                                 Request.GetAbsoluteRoot()),
                         Payments = payments.Select(paymentEntity => ToPaymentModel(entity, paymentEntity)).ToList(),
                         AdditionalData = details.GetAdditionalData()

--- a/BTCPayServer/Controllers/UIInvoiceController.UI.cs
+++ b/BTCPayServer/Controllers/UIInvoiceController.UI.cs
@@ -238,7 +238,7 @@ namespace BTCPayServer.Controllers
                         Link = link,
                         Id = txId,
                         Destination = paymentData.GetDestination(),
-                        PaymentProof = GetPaymentProof(paymentData),
+                        PaymentProof = paymentData.GetPaymentProof(),
                         PaymentType = paymentData.GetPaymentType()
                     };
                 })
@@ -250,16 +250,6 @@ namespace BTCPayServer.Controllers
             vm.AdditionalData = PosDataParser.ParsePosData(receiptData);
 
             return View(vm);
-        }
-
-        private string? GetPaymentProof(CryptoPaymentData paymentData)
-        {
-            return paymentData switch
-            {
-                BitcoinLikePaymentData b => b.Outpoint.ToString(),
-                LightningLikePaymentData l => l.Preimage?.ToString(),
-                _ => null
-            };
         }
 
         private string? GetTransactionLink(PaymentMethodId paymentMethodId, string txId)

--- a/BTCPayServer/Payments/Bitcoin/BitcoinLikePaymentData.cs
+++ b/BTCPayServer/Payments/Bitcoin/BitcoinLikePaymentData.cs
@@ -106,6 +106,11 @@ namespace BTCPayServer.Payments.Bitcoin
         {
             return GetDestination().ToString();
         }
+
+        string CryptoPaymentData.GetPaymentProof()
+        {
+            return Outpoint?.ToString();
+        }
     }
 
 

--- a/BTCPayServer/Payments/LNURLPay/LNURLPayPaymentHandler.cs
+++ b/BTCPayServer/Payments/LNURLPay/LNURLPayPaymentHandler.cs
@@ -99,7 +99,6 @@ namespace BTCPayServer.Payments.Lightning
             {
                 Activated = true,
                 LightningSupportedPaymentMethod = lnLightningSupportedPaymentMethod,
-                BTCPayInvoiceId = paymentMethod.ParentEntity.Id,
                 Bech32Mode = supportedPaymentMethod.UseBech32Scheme,
                 NodeInfo = nodeInfo?.ToString()
             };

--- a/BTCPayServer/Payments/LNURLPay/LNURLPayPaymentMethodDetails.cs
+++ b/BTCPayServer/Payments/LNURLPay/LNURLPayPaymentMethodDetails.cs
@@ -14,8 +14,6 @@ namespace BTCPayServer.Payments
 
         [JsonConverter(typeof(LightMoneyJsonConverter))]
         public LightMoney GeneratedBoltAmount { get; set; }
-
-        public string BTCPayInvoiceId { get; set; }
         public bool Bech32Mode { get; set; }
 
         public string ProvidedComment { get; set; }

--- a/BTCPayServer/Payments/LNURLPay/PaymentTypes.LNURL.cs
+++ b/BTCPayServer/Payments/LNURLPay/PaymentTypes.LNURL.cs
@@ -27,7 +27,7 @@ namespace BTCPayServer.Payments
             return JsonConvert.DeserializeObject<LNURLPaySupportedPaymentMethod>(value.ToString());
         }
 
-        public override string GetPaymentLink(BTCPayNetworkBase network, IPaymentMethodDetails paymentMethodDetails,
+        public override string GetPaymentLink(BTCPayNetworkBase network, InvoiceEntity invoice, IPaymentMethodDetails paymentMethodDetails,
             Money cryptoInfoDue, string serverUri)
         {
             if (!paymentMethodDetails.Activated)
@@ -36,7 +36,7 @@ namespace BTCPayServer.Payments
             }
             var lnurlPaymentMethodDetails = (LNURLPayPaymentMethodDetails)paymentMethodDetails;
             var uri = new Uri(
-                $"{serverUri.WithTrailingSlash()}{network.CryptoCode}/lnurl/pay/i/{lnurlPaymentMethodDetails.BTCPayInvoiceId}");
+                $"{serverUri.WithTrailingSlash()}{network.CryptoCode}/UILNURL/pay/i/{invoice.Id}");
             return LNURL.LNURL.EncodeUri(uri, "payRequest", lnurlPaymentMethodDetails.Bech32Mode).ToString();
         }
 
@@ -58,13 +58,13 @@ namespace BTCPayServer.Payments
             return IsPaymentTypeBase(paymentType);
         }
 
-        public override void PopulateCryptoInfo(PaymentMethod details, InvoiceCryptoInfo invoiceCryptoInfo, string serverUrl)
+        public override void PopulateCryptoInfo(InvoiceEntity invoice, PaymentMethod details, InvoiceCryptoInfo invoiceCryptoInfo, string serverUrl)
         {
             invoiceCryptoInfo.PaymentUrls = new InvoiceCryptoInfo.InvoicePaymentUrls()
             {
                 AdditionalData = new Dictionary<string, JToken>()
                 {
-                    {"LNURLP", JToken.FromObject(GetPaymentLink(details.Network, details.GetPaymentMethodDetails(), invoiceCryptoInfo.Due,
+                    {"LNURLP", JToken.FromObject(GetPaymentLink(details.Network, invoice, details.GetPaymentMethodDetails(), invoiceCryptoInfo.Due,
                         serverUrl))}
                 }
             };

--- a/BTCPayServer/Payments/Lightning/LightningLikePaymentData.cs
+++ b/BTCPayServer/Payments/Lightning/LightningLikePaymentData.cs
@@ -63,5 +63,10 @@ namespace BTCPayServer.Payments.Lightning
         {
             return true;
         }
+
+        public string GetPaymentProof()
+        {
+            return Preimage.ToString();
+        }
     }
 }

--- a/BTCPayServer/Payments/Lightning/LightningListener.cs
+++ b/BTCPayServer/Payments/Lightning/LightningListener.cs
@@ -271,8 +271,7 @@ namespace BTCPayServer.Payments.Lightning
                                 NodeInfo = lnurlPayPaymentMethodDetails.NodeInfo,
                                 GeneratedBoltAmount = null,
                                 BOLT11 = null,
-                                LightningSupportedPaymentMethod = lnurlPayPaymentMethodDetails.LightningSupportedPaymentMethod,
-                                BTCPayInvoiceId = lnurlPayPaymentMethodDetails.BTCPayInvoiceId
+                                LightningSupportedPaymentMethod = lnurlPayPaymentMethodDetails.LightningSupportedPaymentMethod
                             };
                             await _InvoiceRepository.NewPaymentDetails(invoice.Id, lnurlPayPaymentMethodDetails,
                                 paymentMethod.Network);

--- a/BTCPayServer/Payments/PaymentTypes.Bitcoin.cs
+++ b/BTCPayServer/Payments/PaymentTypes.Bitcoin.cs
@@ -66,7 +66,7 @@ namespace BTCPayServer.Payments
             return string.Format(CultureInfo.InvariantCulture, network.BlockExplorerLink, txId);
         }
 
-        public override string GetPaymentLink(BTCPayNetworkBase network, IPaymentMethodDetails paymentMethodDetails,
+        public override string GetPaymentLink(BTCPayNetworkBase network, InvoiceEntity invoice, IPaymentMethodDetails paymentMethodDetails,
             Money cryptoInfoDue, string serverUri)
         {
             if (!paymentMethodDetails.Activated)
@@ -100,12 +100,12 @@ namespace BTCPayServer.Payments
             return string.IsNullOrEmpty(paymentType) || base.IsPaymentType(paymentType);
         }
 
-        public override void PopulateCryptoInfo(PaymentMethod details, InvoiceCryptoInfo cryptoInfo,
+        public override void PopulateCryptoInfo(InvoiceEntity invoice, PaymentMethod details, InvoiceCryptoInfo cryptoInfo,
             string serverUrl)
         {
             cryptoInfo.PaymentUrls = new InvoiceCryptoInfo.InvoicePaymentUrls()
             {
-                BIP21 = GetPaymentLink(details.Network, details.GetPaymentMethodDetails(), cryptoInfo.Due, serverUrl),
+                BIP21 = GetPaymentLink(details.Network, invoice, details.GetPaymentMethodDetails(), cryptoInfo.Due, serverUrl),
             };
         }
     }

--- a/BTCPayServer/Payments/PaymentTypes.Lightning.cs
+++ b/BTCPayServer/Payments/PaymentTypes.Lightning.cs
@@ -51,7 +51,7 @@ namespace BTCPayServer.Payments
             return null;
         }
 
-        public override string GetPaymentLink(BTCPayNetworkBase network, IPaymentMethodDetails paymentMethodDetails,
+        public override string GetPaymentLink(BTCPayNetworkBase network, InvoiceEntity invoice, IPaymentMethodDetails paymentMethodDetails,
             Money cryptoInfoDue, string serverUri)
         {
             if (!paymentMethodDetails.Activated)
@@ -88,11 +88,11 @@ namespace BTCPayServer.Payments
             return paymentType?.Equals("offchain", StringComparison.InvariantCultureIgnoreCase) is true || base.IsPaymentType(paymentType);
         }
 
-        public override void PopulateCryptoInfo(PaymentMethod details, InvoiceCryptoInfo invoiceCryptoInfo, string serverUrl)
+        public override void PopulateCryptoInfo(InvoiceEntity invoice, PaymentMethod details, InvoiceCryptoInfo invoiceCryptoInfo, string serverUrl)
         {
             invoiceCryptoInfo.PaymentUrls = new InvoiceCryptoInfo.InvoicePaymentUrls()
             {
-                BOLT11 = GetPaymentLink(details.Network, details.GetPaymentMethodDetails(), invoiceCryptoInfo.Due,
+                BOLT11 = GetPaymentLink(details.Network, invoice, details.GetPaymentMethodDetails(), invoiceCryptoInfo.Due,
                     serverUrl)
             };
         }

--- a/BTCPayServer/Payments/PaymentTypes.cs
+++ b/BTCPayServer/Payments/PaymentTypes.cs
@@ -84,7 +84,7 @@ namespace BTCPayServer.Payments
         public abstract string SerializePaymentMethodDetails(BTCPayNetworkBase network, IPaymentMethodDetails details);
         public abstract ISupportedPaymentMethod DeserializeSupportedPaymentMethod(BTCPayNetworkBase network, JToken value);
         public abstract string GetTransactionLink(BTCPayNetworkBase network, string txId);
-        public abstract string GetPaymentLink(BTCPayNetworkBase network, IPaymentMethodDetails paymentMethodDetails,
+        public abstract string GetPaymentLink(BTCPayNetworkBase network, InvoiceEntity invoice, IPaymentMethodDetails paymentMethodDetails,
             Money cryptoInfoDue, string serverUri);
         public abstract string InvoiceViewPaymentPartialName { get; }
 
@@ -107,7 +107,7 @@ namespace BTCPayServer.Payments
                 StringComparer.InvariantCultureIgnoreCase);
         }
 
-        public abstract void PopulateCryptoInfo(PaymentMethod details, Services.Invoices.InvoiceCryptoInfo invoiceCryptoInfo,
+        public abstract void PopulateCryptoInfo(InvoiceEntity invoice, PaymentMethod details, Services.Invoices.InvoiceCryptoInfo invoiceCryptoInfo,
             string serverUrl);
     }
 }

--- a/BTCPayServer/Services/Altcoins/Monero/Payments/MoneroLikePaymentData.cs
+++ b/BTCPayServer/Services/Altcoins/Monero/Payments/MoneroLikePaymentData.cs
@@ -71,6 +71,11 @@ namespace BTCPayServer.Services.Altcoins.Monero.Payments
         {
             return Address;
         }
+
+        public string GetPaymentProof()
+        {
+            return null;
+        }
     }
 }
 #endif

--- a/BTCPayServer/Services/Altcoins/Monero/Payments/MoneroLikePaymentMethodHandler.cs
+++ b/BTCPayServer/Services/Altcoins/Monero/Payments/MoneroLikePaymentMethodHandler.cs
@@ -92,7 +92,7 @@ namespace BTCPayServer.Services.Altcoins.Monero.Payments
             if (model.Activated)
             {
                 var cryptoInfo = invoiceResponse.CryptoInfo.First(o => o.GetpaymentMethodId() == paymentMethodId);
-                model.InvoiceBitcoinUrl = MoneroPaymentType.Instance.GetPaymentLink(network,
+                model.InvoiceBitcoinUrl = MoneroPaymentType.Instance.GetPaymentLink(network, null,
                     new MoneroLikeOnChainPaymentMethodDetails() {DepositAddress = cryptoInfo.Address}, cryptoInfo.Due,
                     null);
                 model.InvoiceBitcoinUrlQR = model.InvoiceBitcoinUrl;

--- a/BTCPayServer/Services/Altcoins/Monero/Payments/MoneroPaymentType.cs
+++ b/BTCPayServer/Services/Altcoins/Monero/Payments/MoneroPaymentType.cs
@@ -49,7 +49,7 @@ namespace BTCPayServer.Services.Altcoins.Monero.Payments
             return string.Format(CultureInfo.InvariantCulture, network.BlockExplorerLink, txId);
         }
 
-        public override string GetPaymentLink(BTCPayNetworkBase network, IPaymentMethodDetails paymentMethodDetails, Money cryptoInfoDue, string serverUri)
+        public override string GetPaymentLink(BTCPayNetworkBase network, InvoiceEntity invoice, IPaymentMethodDetails paymentMethodDetails, Money cryptoInfoDue, string serverUri)
         {
             return paymentMethodDetails.Activated
                 ? $"{(network as MoneroLikeSpecificBtcPayNetwork).UriScheme}:{paymentMethodDetails.GetPaymentDestination()}?tx_amount={cryptoInfoDue.ToDecimal(MoneyUnit.BTC)}"
@@ -70,7 +70,7 @@ namespace BTCPayServer.Services.Altcoins.Monero.Payments
             return null;
         }
 
-        public override void PopulateCryptoInfo(PaymentMethod details, InvoiceCryptoInfo invoiceCryptoInfo, string serverUrl)
+        public override void PopulateCryptoInfo(InvoiceEntity invoice, PaymentMethod details, InvoiceCryptoInfo invoiceCryptoInfo, string serverUrl)
         {
             
         }

--- a/BTCPayServer/Services/Altcoins/Zcash/Payments/ZcashLikePaymentData.cs
+++ b/BTCPayServer/Services/Altcoins/Zcash/Payments/ZcashLikePaymentData.cs
@@ -64,6 +64,11 @@ namespace BTCPayServer.Services.Altcoins.Zcash.Payments
         {
             return Address;
         }
+
+        public string GetPaymentProof()
+        {
+            return null;
+        }
     }
 }
 #endif

--- a/BTCPayServer/Services/Altcoins/Zcash/Payments/ZcashLikePaymentMethodHandler.cs
+++ b/BTCPayServer/Services/Altcoins/Zcash/Payments/ZcashLikePaymentMethodHandler.cs
@@ -92,7 +92,7 @@ namespace BTCPayServer.Services.Altcoins.Zcash.Payments
             if (model.Activated)
             {
                 var cryptoInfo = invoiceResponse.CryptoInfo.First(o => o.GetpaymentMethodId() == paymentMethodId);
-                model.InvoiceBitcoinUrl = ZcashPaymentType.Instance.GetPaymentLink(network,
+                model.InvoiceBitcoinUrl = ZcashPaymentType.Instance.GetPaymentLink(network, null,
                     new ZcashLikeOnChainPaymentMethodDetails() {DepositAddress = cryptoInfo.Address}, cryptoInfo.Due,
                     null);
                 model.InvoiceBitcoinUrlQR = model.InvoiceBitcoinUrl;

--- a/BTCPayServer/Services/Altcoins/Zcash/Payments/ZcashPaymentType.cs
+++ b/BTCPayServer/Services/Altcoins/Zcash/Payments/ZcashPaymentType.cs
@@ -49,7 +49,7 @@ namespace BTCPayServer.Services.Altcoins.Zcash.Payments
             return string.Format(CultureInfo.InvariantCulture, network.BlockExplorerLink, txId);
         }
 
-        public override string GetPaymentLink(BTCPayNetworkBase network, IPaymentMethodDetails paymentMethodDetails, Money cryptoInfoDue, string serverUri)
+        public override string GetPaymentLink(BTCPayNetworkBase network, InvoiceEntity invoice, IPaymentMethodDetails paymentMethodDetails, Money cryptoInfoDue, string serverUri)
         {
             return paymentMethodDetails.Activated
                 ? $"{(network as ZcashLikeSpecificBtcPayNetwork).UriScheme}:{paymentMethodDetails.GetPaymentDestination()}?amount={cryptoInfoDue.ToDecimal(MoneyUnit.BTC)}"
@@ -70,7 +70,7 @@ namespace BTCPayServer.Services.Altcoins.Zcash.Payments
             return null;
         }
 
-        public override void PopulateCryptoInfo(PaymentMethod details, InvoiceCryptoInfo invoiceCryptoInfo, string serverUrl)
+        public override void PopulateCryptoInfo(InvoiceEntity invoice, PaymentMethod details, InvoiceCryptoInfo invoiceCryptoInfo, string serverUrl)
         {
             
         }

--- a/BTCPayServer/Services/Invoices/InvoiceEntity.cs
+++ b/BTCPayServer/Services/Invoices/InvoiceEntity.cs
@@ -546,7 +546,7 @@ namespace BTCPayServer.Services.Invoices
                 if (details?.Activated is true)
                 {
 
-                    paymentId.PaymentType.PopulateCryptoInfo(info, cryptoInfo, ServerUrl);
+                    paymentId.PaymentType.PopulateCryptoInfo(this, info, cryptoInfo, ServerUrl);
                     if (paymentId.PaymentType == PaymentTypes.BTCLike)
                     {
                         var minerInfo = new MinerFeeInfo();

--- a/BTCPayServer/Services/Invoices/InvoiceEntity.cs
+++ b/BTCPayServer/Services/Invoices/InvoiceEntity.cs
@@ -1330,5 +1330,7 @@ namespace BTCPayServer.Services.Invoices
 
         PaymentType GetPaymentType();
         string GetDestination();
+
+        string GetPaymentProof();
     }
 }


### PR DESCRIPTION
Ping @Kukks

If LNURL was activated during the invoice creation with lazy payment, then we would end up with a LNURP which has an incorrect value because `BTCPayInvoiceId` wasn't set.

This PR fixes this by just passing the `InvoiceEntity` when rendering LNURP in AdditonalData, since we always have access to it.

This part of the code requires soon a big refactoring, but that's after 1.9.

Also abstracted `GetPaymentProof` as it doesn't make sense to have a hardcoded switch there.