### PR TITLE
Bumping LND to 0.16.0-beta

### DIFF
--- a/BTCPayServer.Tests/docker-compose.altcoins.yml
+++ b/BTCPayServer.Tests/docker-compose.altcoins.yml
@@ -243,7 +243,7 @@ services:
       - "5432"
 
   merchant_lnd:
-    image: btcpayserver/lnd:v0.15.4-beta-1
+    image: btcpayserver/lnd:v0.16.0-beta
     restart: unless-stopped
     environment:
       LND_CHAIN: "btc"
@@ -278,7 +278,7 @@ services:
       - bitcoind
 
   customer_lnd:
-    image: btcpayserver/lnd:v0.15.4-beta-1
+    image: btcpayserver/lnd:v0.16.0-beta
     restart: unless-stopped
     environment:
       LND_CHAIN: "btc"

--- a/BTCPayServer.Tests/docker-compose.yml
+++ b/BTCPayServer.Tests/docker-compose.yml
@@ -230,7 +230,7 @@ services:
       - "5432"
 
   merchant_lnd:
-    image: btcpayserver/lnd:v0.15.4-beta-1
+    image: btcpayserver/lnd:v0.16.0-beta
     restart: unless-stopped
     environment:
       LND_CHAIN: "btc"
@@ -267,7 +267,7 @@ services:
       - bitcoind
 
   customer_lnd:
-    image: btcpayserver/lnd:v0.15.4-beta-1
+    image: btcpayserver/lnd:v0.16.0-beta
     restart: unless-stopped
     environment:
       LND_CHAIN: "btc"


### PR DESCRIPTION
Updating our devenv to use LND 0.16.0; Docker image available on https://hub.docker.com/layers/btcpayserver/lnd/v0.16.0-beta/images/sha256-ddc2dea59306e45957ea9a4bdd8b0d39662bf1996f89b6bc193922a33b07951d?context=repo

Used it in BTCPayServer.Lightning library and it's good to go:
https://github.com/btcpayserver/BTCPayServer.Lightning/pull/125