### PR TITLE
Fix wrong data mapping to store data instead of store user data.

### DIFF
--- a/BTCPayServer/wwwroot/swagger/v1/swagger.template.stores-users.json
+++ b/BTCPayServer/wwwroot/swagger/v1/swagger.template.stores-users.json
@@ -189,7 +189,7 @@
             "StoreUserDataList": {
                 "type": "array",
                 "items": {
-                    "$ref": "#/components/schemas/StoreData"
+                    "$ref": "#/components/schemas/StoreUserData"
                 }
             },
             "StoreUserData": {


### PR DESCRIPTION
On the "[Get store users](https://docs.btcpayserver.org/API/Greenfield/v1/#tag/Stores-(Users))" endpoint the response example contains the whole store settings but not the expected store users. 