### PR TITLE
Add missing param, fix response code.

### DIFF
--- a/BTCPayServer/wwwroot/swagger/v1/swagger.template.stores-email.json
+++ b/BTCPayServer/wwwroot/swagger/v1/swagger.template.stores-email.json
@@ -143,7 +143,7 @@
                     "x-position": 1
                 },
                 "responses": {
-                    "201": {
+                    "200": {
                         "description": "The email was sent (scheduled) successfully"
                     },
                     "400": {
@@ -215,6 +215,11 @@
                     "fromDisplay": {
                         "type": "string",
                         "description": "The name of the sender"
+                    },
+                    "disableCertificateCheck": {
+                        "type": "boolean",
+                        "default": false,
+                        "description": "Disable TLS certificate security checks"
                     }
                 }
             }


### PR DESCRIPTION
- The parameter `disableCertificateCheck` exists but was not documented
- When sending mail through API the response code is 200 and not as documented 201

Open questions:
1) the field `fromDisplay` seems to have no effect whatsover (it is not set as from display name on the actual email), was this a mistake? On the UI you also only have one field where you can enter mail and display name together?

2) I tried to add new lines (in PHP you add `\n` to the body text but they were not shown in the email, the text was sent as everything in one line. Not sure if this should have worked or not. 