### PR TITLE
Fix: Form in Payment Requests was not setting its values to the invoices metadata

### DIFF
--- a/BTCPayServer.Tests/SeleniumTests.cs
+++ b/BTCPayServer.Tests/SeleniumTests.cs
@@ -116,8 +116,11 @@ namespace BTCPayServer.Tests
 
             s.Driver.FindElement(By.Name("buyerEmail")).SendKeys("aa@aa.com");
             s.Driver.FindElement(By.CssSelector("input[type='submit']")).Click();
+            invoiceId = s.Driver.Url.Split('/').Last();
             s.Driver.Navigate().GoToUrl(editUrl);
             Assert.Contains("aa@aa.com", s.Driver.PageSource);
+            var invoice = await s.Server.PayTester.GetService<InvoiceRepository>().GetInvoice(invoiceId);
+            Assert.Equal("aa@aa.com", invoice.Metadata.BuyerEmail);
 
             //Custom Forms
             s.GoToStore(StoreNavPages.Forms);

--- a/BTCPayServer/Controllers/GreenField/GreenfieldPaymentRequestsController.cs
+++ b/BTCPayServer/Controllers/GreenField/GreenfieldPaymentRequestsController.cs
@@ -124,7 +124,8 @@ namespace BTCPayServer.Controllers.Greenfield
 
             try
             {
-                var invoice = await _invoiceController.CreatePaymentRequestInvoice(pr, amount, this.StoreData, Request, cancellationToken);
+                var prData = await _paymentRequestRepository.FindPaymentRequest(pr.Id, null);
+                var invoice = await _invoiceController.CreatePaymentRequestInvoice(prData, amount, pr.AmountDue, this.StoreData, Request, cancellationToken);
                 return Ok(GreenfieldInvoiceController.ToModel(invoice, _linkGenerator, Request));
             }
             catch (BitpayHttpException e)

--- a/BTCPayServer/Controllers/UIPaymentRequestController.cs
+++ b/BTCPayServer/Controllers/UIPaymentRequestController.cs
@@ -277,7 +277,6 @@ namespace BTCPayServer.Controllers
 
                 return BadRequest("Payment Request cannot be paid as it has been archived");
             }
-
             if (!result.FormSubmitted && !string.IsNullOrEmpty(result.FormId))
             {
                 var formData = await FormDataService.GetForm(result.FormId);
@@ -322,7 +321,8 @@ namespace BTCPayServer.Controllers
             try
             {
                 var store = await _storeRepository.FindStore(result.StoreId);
-                var newInvoice = await _InvoiceController.CreatePaymentRequestInvoice(result, amount, store, Request, cancellationToken);
+                var prData = await _PaymentRequestRepository.FindPaymentRequest(result.Id, null);
+                var newInvoice = await _InvoiceController.CreatePaymentRequestInvoice(prData, amount, result.AmountDue, store, Request, cancellationToken);
                 if (redirectToInvoice)
                 {
                     return RedirectToAction("Checkout", "UIInvoice", new { invoiceId = newInvoice.Id });


### PR DESCRIPTION
When creating a new PR with a Form, we would save the form's metadata in the PR's metadata, but wouldn't set the invoice's metadata.