### PR TITLE
POS: Fix choiceKey case

### DIFF
--- a/BTCPayServer/Views/Shared/PointOfSale/Public/Static.cshtml
+++ b/BTCPayServer/Views/Shared/PointOfSale/Public/Static.cshtml
@@ -32,7 +32,7 @@
                             @if (item.Price.Type != ViewPointOfSaleViewModel.Item.ItemPrice.ItemPriceType.Topup)
                             {
                                 <form method="post" asp-action="ViewPointOfSale" asp-route-appId="@Model.AppId" asp-antiforgery="false" data-buy>
-                                    <input type="hidden" name="choicekey" value="@item.Id" />
+                                    <input type="hidden" name="choiceKey" value="@item.Id" />
                                     @{PayFormInputContent(item.BuyButtonText ?? Model.CustomButtonText, item.Price.Type, item.Price.Value, item.Price.Value);}
                                 </form>
                             }
@@ -95,8 +95,8 @@
     {
         if (itemPriceType == ViewPointOfSaleViewModel.Item.ItemPrice.ItemPriceType.Fixed && priceValue == 0)
         {
-            <div class="input-group  ">
-                <input class="form-control" type="text" readonly  value="Free"/>
+            <div class="input-group">
+                <input class="form-control" type="text" readonly value="Free"/>
                 <button class="btn btn-primary text-nowrap" type="submit">@buttonText</button>
             </div>
         }


### PR DESCRIPTION
I came across this while debugging #4889. This does not actually fix it, but it fixes an inconsistence in the casing of the parameter name.

However, I think the original issue is a caching problem in the browser. I was able to reproduce it on first load, after reloading the page once more it works as intended. The weird thing is: even though the values are correct on first load (verified via debugger), the `choiceKey` for the first item is set incorrectly to an integer value.