### PR TITLE
Fix: Poll of Lightning Invoice status might fail on LND if LNURL is used

### DIFF
--- a/BTCPayServer/BTCPayServer.csproj
+++ b/BTCPayServer/BTCPayServer.csproj
@@ -47,7 +47,7 @@
   <ItemGroup>
     <PackageReference Include="BIP78.Sender" Version="0.2.2" />
     <PackageReference Include="BTCPayServer.Hwi" Version="2.0.2" />
-    <PackageReference Include="BTCPayServer.Lightning.All" Version="1.4.22" />
+    <PackageReference Include="BTCPayServer.Lightning.All" Version="1.4.23" />
     <PackageReference Include="CsvHelper" Version="15.0.5" />
     <PackageReference Include="Dapper" Version="2.0.123" />
     <PackageReference Include="Fido2" Version="2.0.2" />

--- a/BTCPayServer/Payments/Lightning/LightningListener.cs
+++ b/BTCPayServer/Payments/Lightning/LightningListener.cs
@@ -221,7 +221,7 @@ namespace BTCPayServer.Payments.Lightning
             }));
             leases.Add(_Aggregator.Subscribe<Events.InvoiceNewPaymentDetailsEvent>(inv =>
             {
-                if (inv.PaymentMethodId.PaymentType == LNURLPayPaymentType.Instance)
+                if (inv.PaymentMethodId.PaymentType == LNURLPayPaymentType.Instance && !string.IsNullOrEmpty(inv.InvoiceId))
                 {
                     _memoryCache.Remove(GetCacheKey(inv.InvoiceId));
                     _CheckInvoices.Writer.TryWrite(inv.InvoiceId);

--- a/btcpayserver.sln
+++ b/btcpayserver.sln
@@ -245,8 +245,6 @@ Global
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
-	GlobalSection(NestedProjects) = preSolution
-	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {203A3162-BE45-4721-937D-6804E0E1AFF8}
 	EndGlobalSection


### PR DESCRIPTION
Reported on mattermost:

```
2023-04-20 18:49:35.396 [DBG] INVC: Added 1 invoices to the expiry watcher
2023-04-20 18:49:35.743 [ERR] RPCS: [/lnrpc.Lightning/LookupInvoice]: error parsing payment hash: invalid hash length of 0, want 32
2023-04-20 18:49:35.788 [ERR] RPCS: [/lnrpc.Lightning/LookupInvoice]: error parsing payment hash: invalid hash length of 0, want 32
2023-04-20 18:49:35.792 [INF] INVC: New invoice subscription client: id=16
2023-04-20 18:49:35.794 [INF] INVC: Cancelling invoice subscription for client=16
```

```
fail: PayServer:      BTC (Lightning): Error while contacting https://ln.laisee.org:8080/
HTTP Response: 

{"code":2, "message":"error parsing payment hash: invalid hash length of 0, want 32", "details":[]}

BTCPayServer.Lightning.LND.SwaggerException: The HTTP status code of the response was not expected (500).
   at BTCPayServer.Lightning.LND.LndSwaggerClient.LookupInvoiceAsync(String r_hash_str, Byte[] r_hash, CancellationToken cancellationToken)
   at BTCPayServer.Lightning.LND.LndClient.GetInvoice(String invoiceId, CancellationToken cancellation)
   at BTCPayServer.Lightning.LND.LndClient.BTCPayServer.Lightning.ILightningClient.GetInvoice(String invoiceId, CancellationToken cancellation)
   at BTCPayServer.Payments.Lightning.LightningInstanceListener.PollPayment(ListenedInvoice listenedInvoice, CancellationToken cancellation) in /source/BTCPayServer/Payments/Lightning/LightningListener.cs:line 471
   at BTCPayServer.Payments.Lightning.LightningInstanceListener.PollAllListenedInvoices(CancellationToken cancellation) in /source/BTCPayServer/Payments/Lightning/LightningListener.cs:line 551
   at BTCPayServer.Payments.Lightning.LightningInstanceListener.Listen(CancellationToken cancellation) in /source/BTCPayServer/Payments/Lightning/LightningListener.cs:line 502
```

It is unclear if this was the source of the issue, but at least this will stop sending exception during invoice poll.