### PR TITLE
Remove LNURLStandardInvoiceEnabled

### DIFF
--- a/BTCPayServer.Client/Models/InvoiceData.cs
+++ b/BTCPayServer.Client/Models/InvoiceData.cs
@@ -86,6 +86,7 @@ namespace BTCPayServer.Client.Models
             public bool? RequiresRefundEmail { get; set; } = null;
             public string DefaultLanguage { get; set; }
             public CheckoutType? CheckoutType { get; set; }
+            public bool? LazyPaymentMethods { get; set; }
         }
     }
     public class InvoiceData : InvoiceDataBase

--- a/BTCPayServer.Client/Models/LNURLPayPaymentMethodBaseData.cs
+++ b/BTCPayServer.Client/Models/LNURLPayPaymentMethodBaseData.cs
@@ -3,7 +3,6 @@ namespace BTCPayServer.Client.Models
     public class LNURLPayPaymentMethodBaseData
     {
         public bool UseBech32Scheme { get; set; }
-        public bool EnableForStandardInvoices { get; set; }
         public bool LUD12Enabled { get; set; }
 
         public LNURLPayPaymentMethodBaseData()

--- a/BTCPayServer.Client/Models/LNURLPayPaymentMethodData.cs
+++ b/BTCPayServer.Client/Models/LNURLPayPaymentMethodData.cs
@@ -16,12 +16,11 @@ namespace BTCPayServer.Client.Models
         {
         }
 
-        public LNURLPayPaymentMethodData(string cryptoCode, bool enabled, bool useBech32Scheme, bool enableForStandardInvoices)
+        public LNURLPayPaymentMethodData(string cryptoCode, bool enabled, bool useBech32Scheme)
         {
             Enabled = enabled;
             CryptoCode = cryptoCode;
             UseBech32Scheme = useBech32Scheme;
-            EnableForStandardInvoices = enableForStandardInvoices;
         }
     }
 }

--- a/BTCPayServer.Client/Models/LightningNetworkPaymentMethodBaseData.cs
+++ b/BTCPayServer.Client/Models/LightningNetworkPaymentMethodBaseData.cs
@@ -4,7 +4,6 @@ namespace BTCPayServer.Client.Models
     {
 
         public string ConnectionString { get; set; }
-        public bool DisableBOLT11PaymentOption { get; set; }
         public LightningNetworkPaymentMethodBaseData()
         {
 

--- a/BTCPayServer.Client/Models/LightningNetworkPaymentMethodData.cs
+++ b/BTCPayServer.Client/Models/LightningNetworkPaymentMethodData.cs
@@ -16,13 +16,12 @@ namespace BTCPayServer.Client.Models
         {
         }
 
-        public LightningNetworkPaymentMethodData(string cryptoCode, string connectionString, bool enabled, string paymentMethod, bool disableBOLT11PaymentOption)
+        public LightningNetworkPaymentMethodData(string cryptoCode, string connectionString, bool enabled, string paymentMethod)
         {
             Enabled = enabled;
             CryptoCode = cryptoCode;
             ConnectionString = connectionString;
             PaymentMethod = paymentMethod;
-            DisableBOLT11PaymentOption = disableBOLT11PaymentOption;
         }
 
         public string PaymentMethod { get; set; }

--- a/BTCPayServer.Tests/AltcoinTests/AltcoinTests.cs
+++ b/BTCPayServer.Tests/AltcoinTests/AltcoinTests.cs
@@ -51,6 +51,7 @@ namespace BTCPayServer.Tests
                 user.RegisterDerivationScheme(cryptoCode);
                 user.RegisterDerivationScheme("LTC");
                 user.RegisterLightningNode(cryptoCode, LightningConnectionType.CLightning);
+                user.SetLNUrl("BTC", false);
                 var btcNetwork = tester.PayTester.Networks.GetNetwork<BTCPayNetwork>(cryptoCode);
                 var invoice = await user.BitPay.CreateInvoiceAsync(
                     new Invoice

--- a/BTCPayServer.Tests/CheckoutUITests.cs
+++ b/BTCPayServer.Tests/CheckoutUITests.cs
@@ -164,7 +164,7 @@ namespace BTCPayServer.Tests
 
             var invoiceId = s.CreateInvoice(defaultPaymentMethod: "BTC_LightningLike");
             s.GoToInvoiceCheckout(invoiceId);
-            Assert.Equal("Bitcoin (Lightning) (BTC)", s.Driver.FindElement(By.ClassName("payment__currencies")).Text);
+            Assert.Equal("Bitcoin (Lightning)", s.Driver.FindElement(By.ClassName("payment__currencies")).Text);
             s.Driver.Quit();
         }
 
@@ -187,7 +187,7 @@ namespace BTCPayServer.Tests
 
             var invoiceId = s.CreateInvoice(10, "USD", "a@g.com");
             s.GoToInvoiceCheckout(invoiceId);
-            Assert.Contains("sats", s.Driver.FindElement(By.ClassName("payment__currencies_noborder")).Text);
+            Assert.Contains("sats", s.Driver.FindElement(By.ClassName("buyerTotalLine")).Text);
         }
 
         [Fact(Timeout = TestTimeout)]

--- a/BTCPayServer.Tests/Checkoutv2Tests.cs
+++ b/BTCPayServer.Tests/Checkoutv2Tests.cs
@@ -49,7 +49,6 @@ namespace BTCPayServer.Tests
             s.GoToHome();
             s.GoToLightningSettings();
             s.Driver.SetCheckbox(By.Id("LNURLEnabled"), true);
-            s.Driver.SetCheckbox(By.Id("LNURLStandardInvoiceEnabled"), true);
             s.Driver.FindElement(By.Id("save")).Click();
             Assert.Contains("BTC Lightning settings successfully updated", s.FindAlertMessage().Text);
 
@@ -296,7 +295,6 @@ namespace BTCPayServer.Tests
             s.GoToHome();
             s.GoToLightningSettings();
             Assert.True(s.Driver.FindElement(By.Id("LNURLEnabled")).Selected);
-            Assert.True(s.Driver.FindElement(By.Id("LNURLStandardInvoiceEnabled")).Selected);
 
             // BIP21 with top-up invoice
             invoiceId = s.CreateInvoice(amount: null);

--- a/BTCPayServer.Tests/Checkoutv2Tests.cs
+++ b/BTCPayServer.Tests/Checkoutv2Tests.cs
@@ -45,13 +45,6 @@ namespace BTCPayServer.Tests
             s.Driver.FindElement(By.Id("Save")).Click();
             Assert.Contains("Store successfully updated", s.FindAlertMessage().Text);
 
-            // Enable LNURL, which we will need for (non-)presence checks throughout this test
-            s.GoToHome();
-            s.GoToLightningSettings();
-            s.Driver.SetCheckbox(By.Id("LNURLEnabled"), true);
-            s.Driver.FindElement(By.Id("save")).Click();
-            Assert.Contains("BTC Lightning settings successfully updated", s.FindAlertMessage().Text);
-
             s.GoToStore(StoreNavPages.CheckoutAppearance);
             s.Driver.WaitForAndClick(By.Id("Presets"));
             s.Driver.WaitForAndClick(By.Id("Presets_InStore"));

--- a/BTCPayServer.Tests/SeleniumTests.cs
+++ b/BTCPayServer.Tests/SeleniumTests.cs
@@ -2146,13 +2146,7 @@ namespace BTCPayServer.Tests
 
             // Ensure the toggles are set correctly
             s.GoToLightningSettings();
-
             Assert.False(s.Driver.FindElement(By.Id("LNURLBech32Mode")).Selected);
-
-            //even though we set DisableBolt11PaymentMethod to true, logic when saving it turns it back off as otherwise no lightning option is available at all!
-            Assert.False(s.Driver.FindElement(By.Id("DisableBolt11PaymentMethod")).Selected);
-            // Invoice creation should fail, because it is a standard invoice with amount, but DisableBolt11PaymentMethod  = true
-            s.CreateInvoice(storeId, 0.0000001m, cryptoCode, "", null, expectedSeverity: StatusMessageModel.StatusSeverity.Success);
 
             i = s.CreateInvoice(storeId, null, cryptoCode);
             s.GoToInvoiceCheckout(i);
@@ -2168,14 +2162,13 @@ namespace BTCPayServer.Tests
             s.AddLightningNode(LightningConnectionType.LndREST, false);
             s.GoToLightningSettings();
             s.Driver.SetCheckbox(By.Id("LNURLEnabled"), true);
-            s.Driver.SetCheckbox(By.Id("DisableBolt11PaymentMethod"), true);
             s.Driver.FindElement(By.Id("save")).Click();
             Assert.Contains($"{cryptoCode} Lightning settings successfully updated", s.FindAlertMessage().Text);
-            var invForPP = s.CreateInvoice(0.0000001m, cryptoCode);
+            var invForPP = s.CreateInvoice(null, cryptoCode);
             s.GoToInvoiceCheckout(invForPP);
             s.Driver.FindElement(By.Id("copy-tab")).Click();
             lnurl = s.Driver.FindElement(By.CssSelector("input.checkoutTextbox")).GetAttribute("value");
-            parsed = LNURL.LNURL.Parse(lnurl, out tag);
+            LNURL.LNURL.Parse(lnurl, out tag);
 
             // Check that pull payment has lightning option
             s.GoToStore(s.StoreId, StoreNavPages.PullPayments);

--- a/BTCPayServer.Tests/SeleniumTests.cs
+++ b/BTCPayServer.Tests/SeleniumTests.cs
@@ -11,8 +11,10 @@ using System.Threading.Tasks;
 using BTCPayServer.Abstractions.Models;
 using BTCPayServer.Client;
 using BTCPayServer.Client.Models;
+using BTCPayServer.Controllers;
 using BTCPayServer.Data;
 using BTCPayServer.Lightning;
+using BTCPayServer.Models.InvoicingModels;
 using BTCPayServer.Payments;
 using BTCPayServer.Services;
 using BTCPayServer.Services.Invoices;
@@ -2088,21 +2090,22 @@ namespace BTCPayServer.Tests
             });
             // Standard invoice test
             s.GoToStore(storeId);
-            s.GoToLightningSettings();
-            s.Driver.SetCheckbox(By.Id("LNURLStandardInvoiceEnabled"), true);
-            SudoForceSaveLightningSettingsRightNowAndFast(s, cryptoCode);
             i = s.CreateInvoice(storeId, 0.0000001m, cryptoCode);
             s.GoToInvoiceCheckout(i);
-            s.Driver.FindElement(By.ClassName("payment__currencies")).Click();
-            // BOLT11 is also available for standard invoices
-            Assert.Equal(2, s.Driver.FindElements(By.CssSelector(".vex.vex-theme-btcpay .vex-content .vexmenu li.vexmenuitem")).Count);
-            s.Driver.FindElement(By.CssSelector(".vex.vex-theme-btcpay .vex-content .vexmenu li.vexmenuitem")).Click();
+            s.Driver.FindElement(By.ClassName("payment__currencies_noborder")).Click();
+            // BOLT11 is also displayed for standard invoice (not LNURL, even if it is available)
             s.Driver.FindElement(By.Id("copy-tab")).Click();
-            lnurl = s.Driver.FindElement(By.CssSelector("input.checkoutTextbox")).GetAttribute("value");
-            parsed = LNURL.LNURL.Parse(lnurl, out tag);
-            fetchedReuqest = Assert.IsType<LNURLPayRequest>(await LNURL.LNURL.FetchInformation(parsed, new HttpClient()));
+            var bolt11 = s.Driver.FindElement(By.CssSelector("input.checkoutTextbox")).GetAttribute("value");
+            var bolt11Parsed = Lightning.BOLT11PaymentRequest.Parse(bolt11, s.Server.ExplorerNode.Network);
+            var invoiceId = s.Driver.Url.Split('/').Last();
+            using (var resp = await s.Server.PayTester.HttpClient.GetAsync("BTC/lnurl/pay/i/" + invoiceId))
+            {
+                resp.EnsureSuccessStatusCode();
+                fetchedReuqest = JsonConvert.DeserializeObject<LNURLPayRequest>(await resp.Content.ReadAsStringAsync());
+            }
             Assert.Equal(0.0000001m, fetchedReuqest.MaxSendable.ToDecimal(LightMoneyUnit.BTC));
             Assert.Equal(0.0000001m, fetchedReuqest.MinSendable.ToDecimal(LightMoneyUnit.BTC));
+
 
             await Assert.ThrowsAsync<LNUrlException>(async () =>
             {
@@ -2125,13 +2128,6 @@ namespace BTCPayServer.Tests
             Assert.Equal(new LightMoney(0.0000001m, LightMoneyUnit.BTC),
                 lnurlResponse2.GetPaymentRequest(network).MinimumAmount);
             s.GoToHome();
-            s.GoToLightningSettings();
-            // LNURL is enabled and settings are expanded
-            Assert.True(s.Driver.FindElement(By.Id("LNURLEnabled")).Selected);
-            Assert.Contains("show", s.Driver.FindElement(By.Id("LNURLSettings")).GetAttribute("class"));
-            s.Driver.SetCheckbox(By.Id("LNURLStandardInvoiceEnabled"), false);
-            s.Driver.FindElement(By.Id("save")).Click();
-            Assert.Contains($"{cryptoCode} Lightning settings successfully updated", s.FindAlertMessage().Text);
 
             i = s.CreateInvoice(storeId, 0.000001m, cryptoCode);
             s.GoToInvoiceCheckout(i);
@@ -2145,22 +2141,17 @@ namespace BTCPayServer.Tests
             s.GoToHome();
             s.GoToLightningSettings();
             s.Driver.SetCheckbox(By.Id("LNURLBech32Mode"), false);
-            s.Driver.SetCheckbox(By.Id("LNURLStandardInvoiceEnabled"), false);
-            s.Driver.SetCheckbox(By.Id("DisableBolt11PaymentMethod"), true);
             s.Driver.FindElement(By.Id("save")).Click();
             Assert.Contains($"{cryptoCode} Lightning settings successfully updated", s.FindAlertMessage().Text);
 
             // Ensure the toggles are set correctly
             s.GoToLightningSettings();
 
-            //TODO: DisableBolt11PaymentMethod is actually disabled because LNURLStandardInvoiceEnabled is disabled
-            // checkboxes is not good choice here, in next release we should have multi choice instead
             Assert.False(s.Driver.FindElement(By.Id("LNURLBech32Mode")).Selected);
-            Assert.False(s.Driver.FindElement(By.Id("LNURLStandardInvoiceEnabled")).Selected);
 
             //even though we set DisableBolt11PaymentMethod to true, logic when saving it turns it back off as otherwise no lightning option is available at all!
             Assert.False(s.Driver.FindElement(By.Id("DisableBolt11PaymentMethod")).Selected);
-            // Invoice creation should fail, because it is a standard invoice with amount, but DisableBolt11PaymentMethod  = true and LNURLStandardInvoiceEnabled = false
+            // Invoice creation should fail, because it is a standard invoice with amount, but DisableBolt11PaymentMethod  = true
             s.CreateInvoice(storeId, 0.0000001m, cryptoCode, "", null, expectedSeverity: StatusMessageModel.StatusSeverity.Success);
 
             i = s.CreateInvoice(storeId, null, cryptoCode);
@@ -2178,7 +2169,6 @@ namespace BTCPayServer.Tests
             s.GoToLightningSettings();
             s.Driver.SetCheckbox(By.Id("LNURLEnabled"), true);
             s.Driver.SetCheckbox(By.Id("DisableBolt11PaymentMethod"), true);
-            s.Driver.SetCheckbox(By.Id("LNURLStandardInvoiceEnabled"), true);
             s.Driver.FindElement(By.Id("save")).Click();
             Assert.Contains($"{cryptoCode} Lightning settings successfully updated", s.FindAlertMessage().Text);
             var invForPP = s.CreateInvoice(0.0000001m, cryptoCode);

--- a/BTCPayServer.Tests/ServerTester.cs
+++ b/BTCPayServer.Tests/ServerTester.cs
@@ -177,7 +177,7 @@ namespace BTCPayServer.Tests
 
         public async Task<PayResponse> SendLightningPaymentAsync(Invoice invoice)
         {
-            var bolt11 = invoice.CryptoInfo.Where(o => o.PaymentUrls.BOLT11 != null).First().PaymentUrls.BOLT11;
+            var bolt11 = invoice.CryptoInfo.Where(o => o.PaymentUrls?.BOLT11 != null).First().PaymentUrls.BOLT11;
             bolt11 = bolt11.Replace("lightning:", "", StringComparison.OrdinalIgnoreCase);
             return await CustomerLightningD.Pay(bolt11);
         }

--- a/BTCPayServer.Tests/TestAccount.cs
+++ b/BTCPayServer.Tests/TestAccount.cs
@@ -214,6 +214,13 @@ namespace BTCPayServer.Tests
             get => GenerateWalletResponseV.DerivationScheme;
         }
 
+        public void SetLNUrl(string cryptoCode, bool activated)
+        {
+            var lnSettingsVm = GetController<UIStoresController>().LightningSettings(StoreId, cryptoCode).AssertViewModel<LightningSettingsViewModel>();
+            lnSettingsVm.LNURLEnabled = activated;
+            Assert.IsType<RedirectToActionResult>(GetController<UIStoresController>().LightningSettings(lnSettingsVm).Result);
+        }
+
         private async Task RegisterAsync(bool isAdmin = false)
         {
             var account = parent.PayTester.GetController<UIAccountController>();

--- a/BTCPayServer.Tests/UnitTest1.cs
+++ b/BTCPayServer.Tests/UnitTest1.cs
@@ -1657,7 +1657,6 @@ namespace BTCPayServer.Tests
             user.RegisterLightningNode(cryptoCode, LightningConnectionType.Charge);
             var lnSettingsVm = user.GetController<UIStoresController>().LightningSettings(user.StoreId, cryptoCode).AssertViewModel<LightningSettingsViewModel>();
             lnSettingsVm.LNURLEnabled = true;
-            lnSettingsVm.LNURLStandardInvoiceEnabled = true;
             Assert.IsType<RedirectToActionResult>(user.GetController<UIStoresController>().LightningSettings(lnSettingsVm).Result);
             vm = user.GetController<UIStoresController>().CheckoutAppearance().AssertViewModel<CheckoutAppearanceViewModel>();
             criteria = Assert.Single(vm.PaymentMethodCriteria);

--- a/BTCPayServer.Tests/UnitTest1.cs
+++ b/BTCPayServer.Tests/UnitTest1.cs
@@ -1635,6 +1635,7 @@ namespace BTCPayServer.Tests
             var cryptoCode = "BTC";
             user.GrantAccess(true);
             user.RegisterLightningNode(cryptoCode, LightningConnectionType.Charge);
+            user.SetLNUrl(cryptoCode, false);
             var vm = user.GetController<UIStoresController>().CheckoutAppearance().AssertViewModel<CheckoutAppearanceViewModel>();
             var criteria = Assert.Single(vm.PaymentMethodCriteria);
             Assert.Equal(new PaymentMethodId(cryptoCode, LightningPaymentType.Instance).ToString(), criteria.PaymentMethod);
@@ -1649,15 +1650,12 @@ namespace BTCPayServer.Tests
                     Price = 1.5m,
                     Currency = "USD"
                 }, Facade.Merchant);
-
             Assert.Single(invoice.CryptoInfo);
             Assert.Equal(PaymentTypes.LightningLike.ToString(), invoice.CryptoInfo[0].PaymentType);
 
             // Activating LNUrl, we should still have only 1 payment criteria that can be set.
             user.RegisterLightningNode(cryptoCode, LightningConnectionType.Charge);
-            var lnSettingsVm = user.GetController<UIStoresController>().LightningSettings(user.StoreId, cryptoCode).AssertViewModel<LightningSettingsViewModel>();
-            lnSettingsVm.LNURLEnabled = true;
-            Assert.IsType<RedirectToActionResult>(user.GetController<UIStoresController>().LightningSettings(lnSettingsVm).Result);
+            user.SetLNUrl(cryptoCode, true);
             vm = user.GetController<UIStoresController>().CheckoutAppearance().AssertViewModel<CheckoutAppearanceViewModel>();
             criteria = Assert.Single(vm.PaymentMethodCriteria);
             Assert.Equal(new PaymentMethodId(cryptoCode, LightningPaymentType.Instance).ToString(), criteria.PaymentMethod);

--- a/BTCPayServer/Controllers/GreenField/GreenfieldStoreLNURLPayPaymentMethodsController.cs
+++ b/BTCPayServer/Controllers/GreenField/GreenfieldStoreLNURLPayPaymentMethodsController.cs
@@ -54,7 +54,7 @@ namespace BTCPayServer.Controllers.Greenfield
                     new LNURLPayPaymentMethodData(
                         paymentMethod.PaymentId.CryptoCode,
                         !excludedPaymentMethods.Match(paymentMethod.PaymentId),
-                        paymentMethod.UseBech32Scheme, paymentMethod.EnableForStandardInvoices
+                        paymentMethod.UseBech32Scheme
                     )
                 )
                 .Where((result) => enabled is null || enabled == result.Enabled)
@@ -124,8 +124,7 @@ namespace BTCPayServer.Controllers.Greenfield
             LNURLPaySupportedPaymentMethod? paymentMethod = new LNURLPaySupportedPaymentMethod()
             {
                 CryptoCode = cryptoCode,
-                UseBech32Scheme = paymentMethodData.UseBech32Scheme,
-                EnableForStandardInvoices = paymentMethodData.EnableForStandardInvoices
+                UseBech32Scheme = paymentMethodData.UseBech32Scheme
             };
 
             var store = Store;
@@ -154,7 +153,7 @@ namespace BTCPayServer.Controllers.Greenfield
                 : new LNURLPayPaymentMethodData(
                     paymentMethod.PaymentId.CryptoCode,
                     !excluded,
-                    paymentMethod.UseBech32Scheme, paymentMethod.EnableForStandardInvoices
+                    paymentMethod.UseBech32Scheme
                 );
         }
         private void AssertCryptoCodeWallet(string cryptoCode, out BTCPayNetwork network)

--- a/BTCPayServer/Controllers/GreenField/GreenfieldStoreLightningNetworkPaymentMethodsController.cs
+++ b/BTCPayServer/Controllers/GreenField/GreenfieldStoreLightningNetworkPaymentMethodsController.cs
@@ -66,8 +66,7 @@ namespace BTCPayServer.Controllers.Greenfield
                         paymentMethod.GetExternalLightningUrl()?.ToString() ??
                         paymentMethod.GetDisplayableConnectionString(),
                         !excludedPaymentMethods.Match(paymentMethod.PaymentId),
-                        paymentMethod.PaymentId.ToStringNormalized(),
-                        paymentMethod.DisableBOLT11PaymentOption
+                        paymentMethod.PaymentId.ToStringNormalized()
                     )
                 )
                 .Where((result) => enabled is null || enabled == result.Enabled)
@@ -207,7 +206,7 @@ namespace BTCPayServer.Controllers.Greenfield
                 ? null
                 : new LightningNetworkPaymentMethodData(paymentMethod.PaymentId.CryptoCode,
                     paymentMethod.GetDisplayableConnectionString(), !excluded,
-                    paymentMethod.PaymentId.ToStringNormalized(), paymentMethod.DisableBOLT11PaymentOption);
+                    paymentMethod.PaymentId.ToStringNormalized());
         }
 
         private BTCPayNetwork AssertSupportLightning(string cryptoCode)

--- a/BTCPayServer/Controllers/UIInvoiceController.UI.cs
+++ b/BTCPayServer/Controllers/UIInvoiceController.UI.cs
@@ -789,7 +789,7 @@ namespace BTCPayServer.Controllers
 
             var isAltcoinsBuild = false;
 #if ALTCOINS
-                isAltcoinsBuild = true,
+                isAltcoinsBuild = true;
 #endif
 
             var model = new PaymentModel

--- a/BTCPayServer/Controllers/UIInvoiceController.UI.cs
+++ b/BTCPayServer/Controllers/UIInvoiceController.UI.cs
@@ -686,7 +686,7 @@ namespace BTCPayServer.Controllers
             if (displayedPaymentMethods.Contains(lnId) && displayedPaymentMethods.Contains(lnurlId))
                 displayedPaymentMethods.Remove(lnurlId);
 
-            if (paymentMethodId is not null && displayedPaymentMethods.Contains(paymentMethodId))
+            if (paymentMethodId is not null && !displayedPaymentMethods.Contains(paymentMethodId))
                 paymentMethodId = null;
             if (paymentMethodId is null)
             {

--- a/BTCPayServer/Controllers/UIInvoiceController.cs
+++ b/BTCPayServer/Controllers/UIInvoiceController.cs
@@ -248,6 +248,7 @@ namespace BTCPayServer.Controllers
             entity.RedirectAutomatically = invoice.Checkout.RedirectAutomatically ?? storeBlob.RedirectAutomatically;
             entity.CheckoutType = invoice.Checkout.CheckoutType;
             entity.RequiresRefundEmail = invoice.Checkout.RequiresRefundEmail;
+            entity.LazyPaymentMethods = invoice.Checkout.LazyPaymentMethods ?? storeBlob.LazyPaymentMethods;
             IPaymentFilter? excludeFilter = null;
             if (invoice.Checkout.PaymentMethods != null)
             {
@@ -460,7 +461,7 @@ namespace BTCPayServer.Controllers
                 var storeBlob = store.GetStoreBlob();
 
                 // Checkout v2 does not show a payment method switch for Bitcoin-only + BIP21, so exclude that case
-                var preparePayment = storeBlob.LazyPaymentMethods && !storeBlob.OnChainWithLnInvoiceFallback
+                var preparePayment = entity.LazyPaymentMethods && !storeBlob.OnChainWithLnInvoiceFallback
                     ? null
                     : handler.PreparePayment(supportedPaymentMethod, store, network);
                 var rate = await fetchingByCurrencyPair[new CurrencyPair(network.CryptoCode, entity.Currency)];

--- a/BTCPayServer/Controllers/UILNURLController.cs
+++ b/BTCPayServer/Controllers/UILNURLController.cs
@@ -447,19 +447,9 @@ namespace BTCPayServer
             try
             {
                 createInvoice.Checkout ??= new InvoiceDataBase.CheckoutOptions();
+                createInvoice.Checkout.LazyPaymentMethods = false;
                 createInvoice.Checkout.PaymentMethods = new[] { pmi.ToStringNormalized() };
                 i = await _invoiceController.CreateInvoiceCoreRaw(createInvoice, store, Request.GetAbsoluteRoot(), additionalTags);
-                var pm = i.GetPaymentMethod(pmi);
-                if (pm is null)
-                    return NotFound("LNUrl is enabled, but the invoice couldn't use it. Check the invoice's events for more information.");
-                // If LNUrl isn't activated, make sure it is
-                var pmd = pm.GetPaymentMethodDetails();
-                if (!pmd.Activated)
-                {
-                    if (!await _invoiceActivator.ActivateInvoicePaymentMethod(pmi, i, store))
-                        return NotFound("Unable to activate LNURL. Check the invoice's events for more information.");
-                    i = await _invoiceRepository.GetInvoice(i.Id);
-                }
             }
             catch (Exception e)
             {

--- a/BTCPayServer/Controllers/UILNURLController.cs
+++ b/BTCPayServer/Controllers/UILNURLController.cs
@@ -59,6 +59,7 @@ namespace BTCPayServer
         private readonly PullPaymentHostedService _pullPaymentHostedService;
         private readonly BTCPayNetworkJsonSerializerSettings _btcPayNetworkJsonSerializerSettings;
         private readonly IPluginHookService _pluginHookService;
+        private readonly InvoiceActivator _invoiceActivator;
 
         public UILNURLController(InvoiceRepository invoiceRepository,
             EventAggregator eventAggregator,
@@ -72,7 +73,8 @@ namespace BTCPayServer
             LightningLikePayoutHandler lightningLikePayoutHandler,
             PullPaymentHostedService pullPaymentHostedService,
             BTCPayNetworkJsonSerializerSettings btcPayNetworkJsonSerializerSettings,
-            IPluginHookService pluginHookService)
+            IPluginHookService pluginHookService,
+            InvoiceActivator invoiceActivator)
         {
             _invoiceRepository = invoiceRepository;
             _eventAggregator = eventAggregator;
@@ -87,6 +89,7 @@ namespace BTCPayServer
             _pullPaymentHostedService = pullPaymentHostedService;
             _btcPayNetworkJsonSerializerSettings = btcPayNetworkJsonSerializerSettings;
             _pluginHookService = pluginHookService;
+            _invoiceActivator = invoiceActivator;
         }
 
         [HttpGet("withdraw/pp/{pullPaymentId}")]
@@ -436,13 +439,27 @@ namespace BTCPayServer
             List<string> additionalTags = null,
             bool allowOverpay = true)
         {
-            if (GetLNUrlPaymentMethodId(cryptoCode, store, out _) is null)
+            var pmi = GetLNUrlPaymentMethodId(cryptoCode, store, out _);
+            if (pmi is null)
                 return NotFound("LNUrl or LN is disabled");
 
             InvoiceEntity i;
             try
             {
+                createInvoice.Checkout ??= new InvoiceDataBase.CheckoutOptions();
+                createInvoice.Checkout.PaymentMethods = new[] { pmi.ToStringNormalized() };
                 i = await _invoiceController.CreateInvoiceCoreRaw(createInvoice, store, Request.GetAbsoluteRoot(), additionalTags);
+                var pm = i.GetPaymentMethod(pmi);
+                if (pm is null)
+                    return NotFound("LNUrl is enabled, but the invoice couldn't use it. Check the invoice's events for more information.");
+                // If LNUrl isn't activated, make sure it is
+                var pmd = pm.GetPaymentMethodDetails();
+                if (!pmd.Activated)
+                {
+                    if (!await _invoiceActivator.ActivateInvoicePaymentMethod(pmi, i, store))
+                        return NotFound("Unable to activate LNURL. Check the invoice's events for more information.");
+                    i = await _invoiceRepository.GetInvoice(i.Id);
+                }
             }
             catch (Exception e)
             {
@@ -572,6 +589,15 @@ namespace BTCPayServer
                 var lightningPaymentMethod = i.GetPaymentMethod(pmi);
                 var paymentMethodDetails =
                     lightningPaymentMethod?.GetPaymentMethodDetails() as LNURLPayPaymentMethodDetails;
+                if (paymentMethodDetails is not null && !paymentMethodDetails.Activated)
+                {
+                    if (!await _invoiceActivator.ActivateInvoicePaymentMethod(pmi, i, store))
+                        return NotFound();
+                    i = await _invoiceRepository.GetInvoice(invoiceId, true);
+                    lightningPaymentMethod = i.GetPaymentMethod(pmi);
+                    paymentMethodDetails = lightningPaymentMethod.GetPaymentMethodDetails() as LNURLPayPaymentMethodDetails;
+                }
+
                 if (paymentMethodDetails?.LightningSupportedPaymentMethod is null)
                     return NotFound();
 

--- a/BTCPayServer/Controllers/UIStoresController.LightningLike.cs
+++ b/BTCPayServer/Controllers/UIStoresController.LightningLike.cs
@@ -244,25 +244,12 @@ namespace BTCPayServer.Controllers
             };
             SetExistingValues(store, vm);
 
-            if (lightning != null)
-            {
-                vm.DisableBolt11PaymentMethod = lightning.DisableBOLT11PaymentOption;
-            }
-
             var lnurl = GetExistingLNURLSupportedPaymentMethod(vm.CryptoCode, store);
             if (lnurl != null)
             {
                 vm.LNURLEnabled = !store.GetStoreBlob().GetExcludedPaymentMethods().Match(lnurl.PaymentId);
                 vm.LNURLBech32Mode = lnurl.UseBech32Scheme;
                 vm.LUD12Enabled = lnurl.LUD12Enabled;
-                vm.DisableBolt11PaymentMethod =
-                    vm.LNURLEnabled && vm.DisableBolt11PaymentMethod;
-            }
-            else
-            {
-                //disable by default for now
-                //vm.LNURLEnabled = !lnSet;
-                vm.DisableBolt11PaymentMethod = false;
             }
 
             return View(vm);
@@ -288,18 +275,8 @@ namespace BTCPayServer.Controllers
             blob.LightningAmountInSatoshi = vm.LightningAmountInSatoshi;
             blob.LightningPrivateRouteHints = vm.LightningPrivateRouteHints;
             blob.OnChainWithLnInvoiceFallback = vm.OnChainWithLnInvoiceFallback;
-            var disableBolt11PaymentMethod =
-                vm.LNURLEnabled && vm.DisableBolt11PaymentMethod;
             var lnurlId = new PaymentMethodId(vm.CryptoCode, PaymentTypes.LNURLPay);
             blob.SetExcluded(lnurlId, !vm.LNURLEnabled);
-            var lightning = GetExistingLightningSupportedPaymentMethod(vm.CryptoCode, store);
-            // Going to mark "lightning" as non-null here assuming that if we are POSTing here it's because we have a Lightning Node set-up
-            if (lightning!.DisableBOLT11PaymentOption != disableBolt11PaymentMethod)
-            {
-                needUpdate = true;
-                lightning.DisableBOLT11PaymentOption = disableBolt11PaymentMethod;
-                store.SetSupportedPaymentMethod(lightning);
-            }
 
             var lnurl = GetExistingLNURLSupportedPaymentMethod(vm.CryptoCode, store);
             if (lnurl is null || (

--- a/BTCPayServer/Controllers/UIStoresController.LightningLike.cs
+++ b/BTCPayServer/Controllers/UIStoresController.LightningLike.cs
@@ -181,7 +181,6 @@ namespace BTCPayServer.Controllers
                     {
                         CryptoCode = vm.CryptoCode,
                         UseBech32Scheme = true,
-                        EnableForStandardInvoices = false,
                         LUD12Enabled = false
                     });
 
@@ -255,10 +254,9 @@ namespace BTCPayServer.Controllers
             {
                 vm.LNURLEnabled = !store.GetStoreBlob().GetExcludedPaymentMethods().Match(lnurl.PaymentId);
                 vm.LNURLBech32Mode = lnurl.UseBech32Scheme;
-                vm.LNURLStandardInvoiceEnabled = lnurl.EnableForStandardInvoices;
                 vm.LUD12Enabled = lnurl.LUD12Enabled;
                 vm.DisableBolt11PaymentMethod =
-                    vm.LNURLEnabled && vm.LNURLStandardInvoiceEnabled && vm.DisableBolt11PaymentMethod;
+                    vm.LNURLEnabled && vm.DisableBolt11PaymentMethod;
             }
             else
             {
@@ -291,7 +289,7 @@ namespace BTCPayServer.Controllers
             blob.LightningPrivateRouteHints = vm.LightningPrivateRouteHints;
             blob.OnChainWithLnInvoiceFallback = vm.OnChainWithLnInvoiceFallback;
             var disableBolt11PaymentMethod =
-                vm.LNURLEnabled && vm.LNURLStandardInvoiceEnabled && vm.DisableBolt11PaymentMethod;
+                vm.LNURLEnabled && vm.DisableBolt11PaymentMethod;
             var lnurlId = new PaymentMethodId(vm.CryptoCode, PaymentTypes.LNURLPay);
             blob.SetExcluded(lnurlId, !vm.LNURLEnabled);
             var lightning = GetExistingLightningSupportedPaymentMethod(vm.CryptoCode, store);
@@ -305,7 +303,6 @@ namespace BTCPayServer.Controllers
 
             var lnurl = GetExistingLNURLSupportedPaymentMethod(vm.CryptoCode, store);
             if (lnurl is null || (
-                lnurl.EnableForStandardInvoices != vm.LNURLStandardInvoiceEnabled ||
                 lnurl.UseBech32Scheme != vm.LNURLBech32Mode ||
                 lnurl.LUD12Enabled != vm.LUD12Enabled))
             {
@@ -315,7 +312,6 @@ namespace BTCPayServer.Controllers
             store.SetSupportedPaymentMethod(new LNURLPaySupportedPaymentMethod
             {
                 CryptoCode = vm.CryptoCode,
-                EnableForStandardInvoices = vm.LNURLStandardInvoiceEnabled,
                 UseBech32Scheme = vm.LNURLBech32Mode,
                 LUD12Enabled = vm.LUD12Enabled
             });

--- a/BTCPayServer/Models/InvoicingModels/PaymentModel.cs
+++ b/BTCPayServer/Models/InvoicingModels/PaymentModel.cs
@@ -78,7 +78,6 @@ namespace BTCPayServer.Models.InvoicingModels
         public bool Activated { get; set; }
         public string InvoiceCurrency { get; set; }
         public string ReceiptLink { get; set; }
-        public bool AltcoinsBuild { get; set; }
         public CheckoutType CheckoutType { get; set; }
         public int? RequiredConfirmations { get; set; }
         public long? ReceivedConfirmations { get; set; }

--- a/BTCPayServer/Models/InvoicingModels/PaymentModel.cs
+++ b/BTCPayServer/Models/InvoicingModels/PaymentModel.cs
@@ -21,6 +21,7 @@ namespace BTCPayServer.Models.InvoicingModels
             public string PaymentMethodName { get; set; }
             public bool IsLightning { get; set; }
             public string CryptoCode { get; set; }
+            public bool Displayed { get; set; }
         }
         public string CustomCSSLink { get; set; }
         public string CustomLogoLink { get; set; }

--- a/BTCPayServer/Models/StoreViewModels/LightningSettingsViewModel.cs
+++ b/BTCPayServer/Models/StoreViewModels/LightningSettingsViewModel.cs
@@ -24,9 +24,6 @@ namespace BTCPayServer.Models.StoreViewModels
         [Display(Name = "LNURL Classic Mode")]
         public bool LNURLBech32Mode { get; set; } = true;
 
-        [Display(Name = "LNURL enabled for standard invoices")]
-        public bool LNURLStandardInvoiceEnabled { get; set; } = true;
-
         [Display(Name = "Allow payee to pass a comment")]
         public bool LUD12Enabled { get; set; }
 

--- a/BTCPayServer/Models/StoreViewModels/LightningSettingsViewModel.cs
+++ b/BTCPayServer/Models/StoreViewModels/LightningSettingsViewModel.cs
@@ -26,8 +26,5 @@ namespace BTCPayServer.Models.StoreViewModels
 
         [Display(Name = "Allow payee to pass a comment")]
         public bool LUD12Enabled { get; set; }
-
-        [Display(Name = "Do not offer BOLT11 for standard invoices")]
-        public bool DisableBolt11PaymentMethod { get; set; }
     }
 }

--- a/BTCPayServer/Payments/LNURLPay/LNURLPayPaymentHandler.cs
+++ b/BTCPayServer/Payments/LNURLPay/LNURLPayPaymentHandler.cs
@@ -50,49 +50,21 @@ namespace BTCPayServer.Payments.Lightning
             BTCPayNetwork network, object preparePaymentObject, IEnumerable<PaymentMethodId> invoicePaymentMethods)
         {
             var lnPmi = new PaymentMethodId(supportedPaymentMethod.CryptoCode, PaymentTypes.LightningLike);
-            if (string.IsNullOrEmpty(paymentMethod.ParentEntity.Id))
+            var lnSupported = store.GetSupportedPaymentMethods(_networkProvider)
+                .OfType<LightningSupportedPaymentMethod>()
+                .SingleOrDefault(method => method.PaymentId == lnPmi);
+            if (lnSupported is null)
             {
-                var lnSupported = store.GetSupportedPaymentMethods(_networkProvider)
-                    .OfType<LightningSupportedPaymentMethod>().SingleOrDefault(method =>
-                        method.PaymentId.CryptoCode == supportedPaymentMethod.CryptoCode &&
-                        method.PaymentId.PaymentType == LightningPaymentType.Instance);
-
-                if (lnSupported is null)
-                {
-                    throw new PaymentMethodUnavailableException("LNURL requires a lightning node to be configured for the store.");
-                }
-                using var cts = new CancellationTokenSource(LightningLikePaymentHandler.LightningTimeout);
-                try
-                {
-                    var client = lnSupported.CreateLightningClient(network, Options.Value, _lightningClientFactoryService);
-                    await client.GetInfo(cts.Token);
-                }
-                catch (OperationCanceledException) when (cts.IsCancellationRequested)
-                {
-                    throw new PaymentMethodUnavailableException("The lightning node did not reply in a timely manner");
-                }
-
-                return new LNURLPayPaymentMethodDetails()
-                {
-                    Activated = false,
-                    LightningSupportedPaymentMethod = lnSupported
-                };
+                throw new PaymentMethodUnavailableException("LNURL requires a lightning node to be configured for the store.");
             }
 
+            var client = lnSupported.CreateLightningClient(network, Options.Value, _lightningClientFactoryService);
+            var nodeInfo = (await _lightningLikePaymentHandler.GetNodeInfo(lnSupported, _networkProvider.GetNetwork<BTCPayNetwork>(supportedPaymentMethod.CryptoCode), logs, paymentMethod.PreferOnion)).FirstOrDefault();
 
-            var lnLightningSupportedPaymentMethod =
-                ((LNURLPayPaymentMethodDetails)paymentMethod.GetPaymentMethodDetails()).LightningSupportedPaymentMethod;
-
-            NodeInfo? nodeInfo = null;
-            if (lnLightningSupportedPaymentMethod != null)
-            {
-                nodeInfo = (await _lightningLikePaymentHandler.GetNodeInfo(lnLightningSupportedPaymentMethod, _networkProvider.GetNetwork<BTCPayNetwork>(supportedPaymentMethod.CryptoCode), logs, paymentMethod.PreferOnion)).FirstOrDefault();
-            }
-
-            return new LNURLPayPaymentMethodDetails
+            return new LNURLPayPaymentMethodDetails()
             {
                 Activated = true,
-                LightningSupportedPaymentMethod = lnLightningSupportedPaymentMethod,
+                LightningSupportedPaymentMethod = lnSupported,
                 Bech32Mode = supportedPaymentMethod.UseBech32Scheme,
                 NodeInfo = nodeInfo?.ToString()
             };

--- a/BTCPayServer/Payments/LNURLPay/LNURLPayPaymentHandler.cs
+++ b/BTCPayServer/Payments/LNURLPay/LNURLPayPaymentHandler.cs
@@ -50,12 +50,6 @@ namespace BTCPayServer.Payments.Lightning
             BTCPayNetwork network, object preparePaymentObject, IEnumerable<PaymentMethodId> invoicePaymentMethods)
         {
             var lnPmi = new PaymentMethodId(supportedPaymentMethod.CryptoCode, PaymentTypes.LightningLike);
-            if (!supportedPaymentMethod.EnableForStandardInvoices &&
-                paymentMethod.ParentEntity.Type == InvoiceType.Standard &&
-                invoicePaymentMethods.Contains(lnPmi))
-            {
-                throw new PaymentMethodUnavailableException("LNURL is not enabled for standard invoices");
-            }
             if (string.IsNullOrEmpty(paymentMethod.ParentEntity.Id))
             {
                 var lnSupported = store.GetSupportedPaymentMethods(_networkProvider)

--- a/BTCPayServer/Payments/LNURLPay/LNURLPaySupportedPaymentMethod.cs
+++ b/BTCPayServer/Payments/LNURLPay/LNURLPaySupportedPaymentMethod.cs
@@ -14,8 +14,6 @@ namespace BTCPayServer.Payments.Lightning
 
         public bool UseBech32Scheme { get; set; }
 
-        public bool EnableForStandardInvoices { get; set; } = false;
-
         public bool LUD12Enabled { get; set; } = true;
 
     }

--- a/BTCPayServer/Payments/LNURLPay/PaymentTypes.LNURL.cs
+++ b/BTCPayServer/Payments/LNURLPay/PaymentTypes.LNURL.cs
@@ -47,7 +47,6 @@ namespace BTCPayServer.Payments
                 return new LNURLPayPaymentMethodBaseData()
                 {
                     UseBech32Scheme = lightningSupportedPaymentMethod.UseBech32Scheme,
-                    EnableForStandardInvoices = lightningSupportedPaymentMethod.EnableForStandardInvoices,
                     LUD12Enabled = lightningSupportedPaymentMethod.LUD12Enabled
                 };
             return null;

--- a/BTCPayServer/Payments/Lightning/LightningLikePaymentHandler.cs
+++ b/BTCPayServer/Payments/Lightning/LightningLikePaymentHandler.cs
@@ -53,10 +53,6 @@ namespace BTCPayServer.Payments.Lightning
             LightningSupportedPaymentMethod supportedPaymentMethod, PaymentMethod paymentMethod, Data.StoreData store,
             BTCPayNetwork network, object preparePaymentObject, IEnumerable<PaymentMethodId> invoicePaymentMethods)
         {
-            if (supportedPaymentMethod.DisableBOLT11PaymentOption)
-            {
-                throw new PaymentMethodUnavailableException("BOLT11 payment method is disabled");
-            }
             if (paymentMethod.ParentEntity.Type == InvoiceType.TopUp)
             {
                 throw new PaymentMethodUnavailableException("Lightning Network payment method is not available for top-up invoices");

--- a/BTCPayServer/Payments/Lightning/LightningSupportedPaymentMethod.cs
+++ b/BTCPayServer/Payments/Lightning/LightningSupportedPaymentMethod.cs
@@ -17,8 +17,6 @@ namespace BTCPayServer.Payments.Lightning
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
         public string? LightningConnectionString { get; set; }
 
-        public bool DisableBOLT11PaymentOption { get; set; } = false;
-
         public LightningConnectionString? GetExternalLightningUrl()
         {
 #pragma warning disable CS0618 // Type or member is obsolete

--- a/BTCPayServer/Payments/PaymentMethodId.cs
+++ b/BTCPayServer/Payments/PaymentMethodId.cs
@@ -1,5 +1,6 @@
 #nullable enable
 using System;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 
@@ -11,7 +12,7 @@ namespace BTCPayServer.Payments
     /// </summary>
     public class PaymentMethodId
     {
-        public PaymentMethodId? FindNearest(PaymentMethodId[] others)
+        public PaymentMethodId? FindNearest(IEnumerable<PaymentMethodId> others)
         {
             ArgumentNullException.ThrowIfNull(others);
             return others.FirstOrDefault(f => f == this) ??

--- a/BTCPayServer/Services/Invoices/InvoiceEntity.cs
+++ b/BTCPayServer/Services/Invoices/InvoiceEntity.cs
@@ -461,6 +461,7 @@ namespace BTCPayServer.Services.Invoices
 
         [JsonConverter(typeof(StringEnumConverter))]
         public CheckoutType? CheckoutType { get; set; }
+        public bool LazyPaymentMethods { get; set; }
 
         public bool IsExpired()
         {

--- a/BTCPayServer/Services/Invoices/InvoiceRepository.cs
+++ b/BTCPayServer/Services/Invoices/InvoiceRepository.cs
@@ -213,12 +213,18 @@ namespace BTCPayServer.Services.Invoices
                     }
                     var paymentDestination = details.GetPaymentDestination();
                     string address = GetDestination(paymentMethod);
-                    await context.AddressInvoices.AddAsync(new AddressInvoiceData()
+                    if (address != null)
                     {
-                        InvoiceDataId = invoice.Id,
-                        CreatedTime = DateTimeOffset.UtcNow,
-                    }.Set(address, paymentMethod.GetId()));
-                    textSearch.Add(paymentDestination);
+                        await context.AddressInvoices.AddAsync(new AddressInvoiceData()
+                        {
+                            InvoiceDataId = invoice.Id,
+                            CreatedTime = DateTimeOffset.UtcNow,
+                        }.Set(address, paymentMethod.GetId()));
+                    }
+                    if (paymentDestination != null)
+                    {
+                        textSearch.Add(paymentDestination);
+                    }
                     textSearch.Add(paymentMethod.Calculate().TotalDue.ToString());
                 }
                 await context.PendingInvoices.AddAsync(new PendingInvoiceData() { Id = invoice.Id });

--- a/BTCPayServer/Views/UIInvoice/Checkout-Body.cshtml
+++ b/BTCPayServer/Views/UIInvoice/Checkout-Body.cshtml
@@ -52,8 +52,7 @@
                 <div class="paywithRowRight cursorPointer" v-on:click="openPaymentMethodDialog">
                     <span class="payment__currencies " v-show="!changingCurrencies">
                         <img v-bind:src="srvModel.cryptoImage" />
-                        <span>{{srvModel.paymentMethodName}} ({{srvModel.cryptoCode}})</span>
-                        <span v-show="srvModel.isLightning">&#9889;</span>
+                        <span>{{srvModel.paymentMethodName}}</span>
                         <span class="clickable_indicator fa fa-angle-right"></span>
                     </span>
                 </div>
@@ -65,8 +64,6 @@
                                 <a href="@crypto.Link" class="payment-method" data-payment-method="@crypto.PaymentMethodId" rel="noreferrer noopener">
                                     <img alt="@crypto.PaymentMethodName" src="@crypto.CryptoImage" asp-append-version="true" />
                                     @crypto.PaymentMethodName
-                                    @(crypto.IsLightning ? Html.Raw("&#9889;") : null)
-                                    <span>@crypto.CryptoCode</span>
                                 </a>
                             </li>
                         }
@@ -77,7 +74,7 @@
             {
                 <div class="payment__currencies_noborder">
                     <img v-bind:src="srvModel.cryptoImage" />
-                    <span>{{srvModel.paymentMethodName}} ({{srvModel.cryptoCode}})</span>
+                    <span>{{srvModel.paymentMethodName}}</span>
                     <span v-show="srvModel.isLightning">&#9889;</span>
                 </div>
             }

--- a/BTCPayServer/Views/UIInvoice/Checkout-Body.cshtml
+++ b/BTCPayServer/Views/UIInvoice/Checkout-Body.cshtml
@@ -1,5 +1,7 @@
 @model PaymentModel
-
+@{
+	var displayedPaymentMethods = Model.AvailableCryptos.Where(a => a.Displayed).ToList();
+}
 <div class="top-header">
     <div class="header">
         @if (!string.IsNullOrEmpty(Model.CustomLogoLink))
@@ -45,7 +47,7 @@
             </div>
         </div>
         <div class="single-item-order__right">
-            @if (Model.AvailableCryptos.Count > 1)
+			@if (displayedPaymentMethods.Count > 1)
             {
                 <div class="paywithRowRight cursorPointer" v-on:click="openPaymentMethodDialog">
                     <span class="payment__currencies " v-show="!changingCurrencies">
@@ -57,7 +59,7 @@
                 </div>
                 <div id="vexPopupDialog">
                     <ul class="vexmenu">
-                        @foreach (var crypto in Model.AvailableCryptos)
+						@foreach (var crypto in displayedPaymentMethods)
                         {
                             <li class="vexmenuitem">
                                 <a href="@crypto.Link" class="payment-method" data-payment-method="@crypto.PaymentMethodId" rel="noreferrer noopener">

--- a/BTCPayServer/Views/UIInvoice/Checkout-Body.cshtml
+++ b/BTCPayServer/Views/UIInvoice/Checkout-Body.cshtml
@@ -1,6 +1,6 @@
 @model PaymentModel
 @{
-	var displayedPaymentMethods = Model.AvailableCryptos.Where(a => a.Displayed).ToList();
+    var displayedPaymentMethods = Model.AvailableCryptos.Where(a => a.Displayed).ToList();
 }
 <div class="top-header">
     <div class="header">
@@ -47,7 +47,7 @@
             </div>
         </div>
         <div class="single-item-order__right">
-			@if (displayedPaymentMethods.Count > 1)
+            @if (displayedPaymentMethods.Count > 1)
             {
                 <div class="paywithRowRight cursorPointer" v-on:click="openPaymentMethodDialog">
                     <span class="payment__currencies " v-show="!changingCurrencies">
@@ -58,7 +58,7 @@
                 </div>
                 <div id="vexPopupDialog">
                     <ul class="vexmenu">
-						@foreach (var crypto in displayedPaymentMethods)
+                        @foreach (var crypto in displayedPaymentMethods)
                         {
                             <li class="vexmenuitem">
                                 <a href="@crypto.Link" class="payment-method" data-payment-method="@crypto.PaymentMethodId" rel="noreferrer noopener">

--- a/BTCPayServer/Views/UIInvoice/CheckoutNoScript.cshtml
+++ b/BTCPayServer/Views/UIInvoice/CheckoutNoScript.cshtml
@@ -1,6 +1,7 @@
-﻿@model PaymentModel
+@model PaymentModel
 @{
     Layout = null;
+	var displayedPaymentMethods = Model.AvailableCryptos.Where(a => a.Displayed).ToList();
 }
 <!DOCTYPE html>
 <html>
@@ -24,13 +25,13 @@
         {
             <h1 class="text-danger">This payment method requires javascript.</h1>
         }
-        @if (Model.AvailableCryptos.Count > 1)
+		@if (displayedPaymentMethods.Count > 1)
         {
             <div>
                 <hr />
                 <h2>Pay with:</h2>
                 <ul style="list-style-type: none;padding-left: 5px;">
-                    @foreach (var crypto in Model.AvailableCryptos)
+					@foreach (var crypto in displayedPaymentMethods)
                     {
                         <li style="height: 32px; line-height: 32px;">
                             <a asp-action="CheckoutNoScript" asp-route-invoiceId="@Model.InvoiceId" asp-route-paymentMethodId="@crypto.PaymentMethodId">

--- a/BTCPayServer/Views/UIInvoice/CheckoutNoScript.cshtml
+++ b/BTCPayServer/Views/UIInvoice/CheckoutNoScript.cshtml
@@ -1,7 +1,7 @@
 @model PaymentModel
 @{
     Layout = null;
-	var displayedPaymentMethods = Model.AvailableCryptos.Where(a => a.Displayed).ToList();
+    var displayedPaymentMethods = Model.AvailableCryptos.Where(a => a.Displayed).ToList();
 }
 <!DOCTYPE html>
 <html>
@@ -25,13 +25,13 @@
         {
             <h1 class="text-danger">This payment method requires javascript.</h1>
         }
-		@if (displayedPaymentMethods.Count > 1)
+        @if (displayedPaymentMethods.Count > 1)
         {
             <div>
                 <hr />
                 <h2>Pay with:</h2>
                 <ul style="list-style-type: none;padding-left: 5px;">
-					@foreach (var crypto in displayedPaymentMethods)
+                    @foreach (var crypto in displayedPaymentMethods)
                     {
                         <li style="height: 32px; line-height: 32px;">
                             <a asp-action="CheckoutNoScript" asp-route-invoiceId="@Model.InvoiceId" asp-route-paymentMethodId="@crypto.PaymentMethodId">

--- a/BTCPayServer/Views/UIInvoice/CheckoutV2.cshtml
+++ b/BTCPayServer/Views/UIInvoice/CheckoutV2.cshtml
@@ -12,10 +12,7 @@
 	ViewData["Title"] = Model.HtmlTitle;
 	Csp.UnsafeEval();
 	var hasPaymentPlugins = UiExtensions.Any(extension => extension.Location == "checkout-payment-method");
-    // Show LNURL as selectable payment method only for top up invoices + non-BIP21 case
-    var displayedPaymentMethods = Model.IsUnsetTopUp && !Model.OnChainWithLnInvoiceFallback
-        ? Model.AvailableCryptos
-        : Model.AvailableCryptos.Where(c => c.PaymentMethodId != "BTC_LNURLPAY").ToList();
+	var displayedPaymentMethods = Model.AvailableCryptos.Where(c => c.Displayed).ToList();
 }
 @functions {
     private string PaymentMethodName(PaymentModel.AvailableCrypto pm)

--- a/BTCPayServer/Views/UIInvoice/CheckoutV2.cshtml
+++ b/BTCPayServer/Views/UIInvoice/CheckoutV2.cshtml
@@ -15,13 +15,6 @@
 	var displayedPaymentMethods = Model.AvailableCryptos.Where(c => c.Displayed).ToList();
 }
 @functions {
-    private string PaymentMethodName(PaymentModel.AvailableCrypto pm)
-    {
-        return Model.AltcoinsBuild
-            ? pm.PaymentMethodName
-            : pm.PaymentMethodName.Replace("Bitcoin (", "").Replace(")", "").Replace("Lightning ", "");
-    }
-
     private string ToJsValue(object value)
     {
         return Safe.Json(value).ToString()?.Replace("\"", "'");
@@ -96,7 +89,7 @@
                                    class="btcpay-pill m-0 payment-method"
                                    :class="{ active: pmId === @ToJsValue(crypto.PaymentMethodId) }"
                                    v-on:click.prevent="changePaymentMethod(@ToJsValue(crypto.PaymentMethodId))">
-                                    @PaymentMethodName(crypto)
+                                    @crypto.PaymentMethodName
                                 </a>
                             }
                             @await Component.InvokeAsync("UiExtensionPoint", new { location = "checkout-payment-method", model = Model })

--- a/BTCPayServer/Views/UIStores/LightningSettings.cshtml
+++ b/BTCPayServer/Views/UIStores/LightningSettings.cshtml
@@ -101,16 +101,6 @@
 
                         <div class="form-group">
                             <label class="form-group d-flex align-items-center">
-                                <input type="checkbox" asp-for="LNURLStandardInvoiceEnabled" class="btcpay-toggle me-3" />
-                                <div class="">
-                                    <label asp-for="LNURLStandardInvoiceEnabled" class="form-label mb-0 me-1"></label>
-                                    <div class="form-text">Required for Lightning Address, the pay button and apps.</div>
-                                </div>
-                            </label>
-                        </div>
-
-                        <div class="form-group">
-                            <label class="form-group d-flex align-items-center">
                                 <input type="checkbox" asp-for="DisableBolt11PaymentMethod" class="btcpay-toggle me-3" />
                                 <div class="">
                                     <label asp-for="DisableBolt11PaymentMethod" class="form-label mb-0 me-1"></label>

--- a/BTCPayServer/Views/UIStores/LightningSettings.cshtml
+++ b/BTCPayServer/Views/UIStores/LightningSettings.cshtml
@@ -98,17 +98,6 @@
                                 </div>
                             </label>
                         </div>
-
-                        <div class="form-group">
-                            <label class="form-group d-flex align-items-center">
-                                <input type="checkbox" asp-for="DisableBolt11PaymentMethod" class="btcpay-toggle me-3" />
-                                <div class="">
-                                    <label asp-for="DisableBolt11PaymentMethod" class="form-label mb-0 me-1"></label>
-                                    <div class="form-text">Performance: Turn it off if users should pay only via LNURL.</div>
-                                </div>
-                            </label>
-                        </div>
-
                         <div class="form-group mb-3">
                             <div class="d-flex align-items-center">
                                 <input type="checkbox" asp-for="LUD12Enabled" class="btcpay-toggle me-3" />

--- a/BTCPayServer/wwwroot/swagger/v1/swagger.template.invoices.json
+++ b/BTCPayServer/wwwroot/swagger/v1/swagger.template.invoices.json
@@ -1173,6 +1173,11 @@
                         "nullable": true,
                         "description": "Default payment type for the invoice (e.g., BTC, BTC-LightningNetwork). Default payment method set for the store is used if this parameter is not specified."
                     },
+                    "lazyPaymentMethods": {
+                        "type": "boolean",
+                        "nullable": true,
+                        "description": "If true, payment methods are enabled individually upon user interaction in the invoice. Default to store's settings'"
+                    },
                     "expirationMinutes": {
                         "nullable": true,
                         "description": "The number of minutes after which an invoice becomes expired. Defaults to the store's settings. (The default store settings is 15)",

--- a/BTCPayServer/wwwroot/swagger/v1/swagger.template.stores-payment-methods.lightning-network.json
+++ b/BTCPayServer/wwwroot/swagger/v1/swagger.template.stores-payment-methods.lightning-network.json
@@ -279,11 +279,6 @@
                         "type": "string",
                         "description": "The lightning connection string. Set to 'Internal Node' to use the internal node. (See [this doc](https://github.com/btcpayserver/BTCPayServer.Lightning/blob/master/README.md#examples) for some example)",
                         "example": "type=clightning;server=..."
-                    },
-                    "disableBOLT11PaymentOption": {
-
-                        "type": "boolean",
-                        "description": "Whether to disable generation of bolt11 invoices. Useful when wanting to only use LNURL Pay exclusively."
                     }
                 }
             },

--- a/BTCPayServer/wwwroot/swagger/v1/swagger.template.stores-payment-methods.lnurl.json
+++ b/BTCPayServer/wwwroot/swagger/v1/swagger.template.stores-payment-methods.lnurl.json
@@ -303,10 +303,6 @@
                         "type": "boolean",
                         "description": "Whether to use [LUD-01](https://github.com/fiatjaf/lnurl-rfc/blob/luds/01.md)'s bech32 format or to use [LUD-17](https://github.com/fiatjaf/lnurl-rfc/blob/luds/17.md) url formatting. "
                     },
-                    "enableForStandardInvoices": {
-                        "type": "boolean",
-                        "description": "Whether to allow this payment method to also be used for standard invoices and not just top-up invoices."
-                    },
                     "lud12Enabled": {
                         "type": "boolean",
                         "description": "Allow comments to be passed on via lnurl."


### PR DESCRIPTION
This PR removes the lightning setting `LNURL enabled for standard invoices`, which was set to `false` by default.

It also adds the ability to set `lazyPaymentMethod` at the invoice level through Greenfield (see notes for the reason it cannot be done in a separate PR).

## Current situation

The motivation for disabling LNURL by default for standard invoice was to avoid complicating the checkout page with both BOLT11 payment and LNURL options.

While BOLT11 can't be used on TopUp invoices, for standard invoices showing two usable QR code to pay on lightning to the user was confusing. LNURL would be a redundant, less supported QR Code.

Recent change made checkout v2 displays only BOLT11 QR code for lightning payment even if LNURL is also possible.
However, Checkout v1 was still showing both options.

## Motivation of this PR

The main issue is that LNURL is now useful for NFC/Print view for PoS.
If this obscure checkbox isn't checked, NFC and print view won't work, since LNURL is disabled for standard invoices.

This PR completely removes the option and updates Checkout v1 to not show the LNURL payment in the displayed payment methods if BOLT11 is available.
Now, in both checkout, LNURL QR code will not be displayed if BOLT11 is available, however it will still be supported by NFC.

Additionally, a number of bugs have been fixed where LNURL wouldn't work well with lazy payment methods, as it wasn't checking whether the payment method was activated.

## Notes

Support for setting `lazyPaymentMethod` at the invoice level has been added because it shouldn't be set when creating an invoice originating from an LNURL request (e.g., for a PoS app print view).