### PR TITLE
Fix cart receipt + fix pos email form forwarding

### DIFF
--- a/BTCPayServer/Components/MainNav/Default.cshtml
+++ b/BTCPayServer/Components/MainNav/Default.cshtml
@@ -145,7 +145,10 @@
                                         </a>
                                     </li>
                                     <li class="nav-item" permission="@Policies.CanModifyStoreSettings">
-                                        <a asp-area="" asp-controller="UIStorePullPayments" asp-action="Payouts" asp-route-storeId="@Model.Store.Id" class="nav-link @ViewData.IsActivePage(StoreNavPages.Payouts)" id="StoreNav-Payouts">
+                                        <a asp-area="" 
+                                           asp-controller="UIStorePullPayments" asp-action="Payouts" 
+                                           asp-route-pullPaymentId=""
+                                           asp-route-storeId="@Model.Store.Id" class="nav-link @ViewData.IsActivePage(StoreNavPages.Payouts)" id="StoreNav-Payouts">
                                             <vc:icon symbol="payouts"/>
                                             <span>Payouts</span>
                                         </a>

--- a/BTCPayServer/Controllers/UIInvoiceController.UI.cs
+++ b/BTCPayServer/Controllers/UIInvoiceController.UI.cs
@@ -184,8 +184,14 @@ namespace BTCPayServer.Controllers
             var receipt = InvoiceDataBase.ReceiptOptions.Merge(store.GetStoreBlob().ReceiptOptions, i.ReceiptOptions);
 
             if (receipt.Enabled is not true)
+            {
+                if (i.RedirectURL is not null)
+                {
+                    return Redirect(i.RedirectURL.ToString());
+                }   
                 return NotFound();
 
+            }
             var storeBlob = store.GetStoreBlob();
             var vm = new InvoiceReceiptViewModel
             {

--- a/BTCPayServer/Controllers/UIPaymentRequestController.cs
+++ b/BTCPayServer/Controllers/UIPaymentRequestController.cs
@@ -235,6 +235,14 @@ namespace BTCPayServer.Controllers
             }
 
             var form = Form.Parse(formData.Config);
+            if (!string.IsNullOrEmpty(prBlob.Email))
+            {
+                var emailField = form.GetFieldByFullName("buyerEmail");
+                if (emailField is not null)
+                {
+                    emailField.Value = prBlob.Email;
+                }
+            }
             if (Request.Method == "POST" && Request.HasFormContentType)
             {
                 form.ApplyValuesFromForm(Request.Form);

--- a/BTCPayServer/Plugins/PointOfSale/Controllers/UIPointOfSaleController.cs
+++ b/BTCPayServer/Plugins/PointOfSale/Controllers/UIPointOfSaleController.cs
@@ -253,15 +253,15 @@ namespace BTCPayServer.Plugins.PointOfSale.Controllers
                     {
                         var vm = new PostRedirectViewModel
                         {
-                            AspAction = nameof(POSForm),
-                            AspController = "UIPointOfSale",
-                            RouteParameters = new Dictionary<string, string> { { "appId", appId } },
-                            FormParameters = new MultiValueDictionary<string, string>(Request.Form.Select(pair => new KeyValuePair<string, IReadOnlyCollection<string>>(pair.Key, pair.Value)))
+                            FormUrl = Url.Action(nameof(POSForm), "UIPointOfSale", new {appId, buyerEmail = email}),
+                            FormParameters = new MultiValueDictionary<string, string>(Request.Form.Select(pair =>
+                                new KeyValuePair<string, IReadOnlyCollection<string>>(pair.Key, pair.Value)))
                         };
                         if (viewType.HasValue)
                         {
                             vm.RouteParameters.Add("viewType", viewType.Value.ToString());
                         }
+
                         return View("PostRedirect", vm);
                     }
 
@@ -405,6 +405,7 @@ namespace BTCPayServer.Plugins.PointOfSale.Controllers
             var store = await _appService.GetStore(app);
             var storeBlob = store.GetStoreBlob();
             var form = Form.Parse(formData.Config);
+            form.ApplyValuesFromForm(Request.Query);
             var vm = new FormViewModel
             {
                 StoreName = store.StoreName,

--- a/BTCPayServer/Views/Shared/PosData.cshtml
+++ b/BTCPayServer/Views/Shared/PosData.cshtml
@@ -30,34 +30,16 @@
                     }
                 </td>
             }
-            else if (value is Dictionary<string, object>subItems)
+            else if (value is Dictionary<string, object> {Count: > 0 } subItems)
             {
-                @* This is the array case *@
-                if (subItems.Count == 1 && subItems.First().Value is string str2)
-                {
-                    <th class="w-150px">@key</th>
-                    <td>
-                        @if (IsValidURL(str2))
-                        {
-                            <a href="@str2" target="_blank" rel="noreferrer noopener">@str2</a>
-                        }
-                        else
-                        {
-                            @subItems.First().Value?.ToString()
-                        }
-					</td>
-				}
-				else if (subItems.Count > 0)
-				{
-					<td colspan="2" >
-						@{
-							Write(Html.Raw($"<h{Model.Level + 3} class=\"mt-4 mb-3\">"));
-							Write(key);
-							Write(Html.Raw($"</h{Model.Level + 3}>"));
-						}
-                        <partial name="PosData" model="(subItems, Model.Level + 1)"/>
-                    </td>
-                }
+                <td colspan="2" >
+                    @{
+                        Write(Html.Raw($"<h{Model.Level + 3} class=\"mt-4 mb-3\">"));
+                        Write(key);
+                        Write(Html.Raw($"</h{Model.Level + 3}>"));
+                    } 
+                    <partial name="PosData" model="@((subItems, Model.Level + 1))"/>
+                </td>
             }
         </tr>
     }

--- a/BTCPayServer/Views/UIPaymentRequest/EditPaymentRequest.cshtml
+++ b/BTCPayServer/Views/UIPaymentRequest/EditPaymentRequest.cshtml
@@ -86,7 +86,7 @@
                 <label asp-for="Email" class="form-label"></label>
                 <input type="email" asp-for="Email" placeholder="Firstname Lastname <email@example.com>" class="form-control" />
                 <span asp-validation-for="Email" class="text-danger"></span>
-                <div id="PaymentRequestEmailHelpBlock" class="form-text">Receive updates for this payment request.</div>
+                <div id="PaymentRequestEmailHelpBlock" class="form-text">The receipent's email, in case you configure <a asp-action="StoreEmails" asp-controller="UIStores" asp-route-storeId="@Model.StoreId">email rules</a> or want the payments linked in the export.</div>
             </div>
             <div class="form-group">
                 <label asp-for="FormId" class="form-label"></label>

--- a/BTCPayServer/Views/UIPaymentRequest/EditPaymentRequest.cshtml
+++ b/BTCPayServer/Views/UIPaymentRequest/EditPaymentRequest.cshtml
@@ -86,7 +86,7 @@
                 <label asp-for="Email" class="form-label"></label>
                 <input type="email" asp-for="Email" placeholder="Firstname Lastname <email@example.com>" class="form-control" />
                 <span asp-validation-for="Email" class="text-danger"></span>
-                <div id="PaymentRequestEmailHelpBlock" class="form-text">The receipent's email, in case you configure <a asp-action="StoreEmails" asp-controller="UIStores" asp-route-storeId="@Model.StoreId">email rules</a> or want the payments linked in the export.</div>
++                <div id="PaymentRequestEmailHelpBlock" class="form-text">The recipient's email. This will send notification mails to the recipient, as configured by the <a asp-action="StoreEmails" asp-controller="UIStores" asp-route-storeId="@Model.StoreId">email rules</a>, and include the email in the invoice export data.</div>
             </div>
             <div class="form-group">
                 <label asp-for="FormId" class="form-label"></label>


### PR DESCRIPTION
fixes #4890 fixes #4810 fixes #4895 fixes #4788

* If there is only one cart item, show it as usual. (#4890)
* If an email is supplied to the pos purchase endpoint, pass it along to the form ( #4810)
* If the invoice's receipt is disabled, and there is an invoice redirect URL, redirect to it. ( #4895)
* Fix the payouts nav link doing unnecessary filtering (#4788)
