### PR TITLE
Refund updates

### DIFF
--- a/BTCPayServer.Client/Models/RefundInvoiceRequest.cs
+++ b/BTCPayServer.Client/Models/RefundInvoiceRequest.cs
@@ -9,6 +9,7 @@ namespace BTCPayServer.Client.Models
     {
         RateThen,
         CurrentRate,
+        MinusPercentage,
         Fiat,
         Custom
     }
@@ -18,8 +19,13 @@ namespace BTCPayServer.Client.Models
         public string? Name { get; set; } = null;
         public string? PaymentMethod { get; set; }
         public string? Description { get; set; } = null;
+        
         [JsonConverter(typeof(StringEnumConverter))]
         public RefundVariant? RefundVariant { get; set; }
+        
+        [JsonConverter(typeof(NumericStringJsonConverter))]
+        public decimal? CustomPercentage { get; set; }
+        
         [JsonConverter(typeof(NumericStringJsonConverter))]
         public decimal? CustomAmount { get; set; }
         public string? CustomCurrency { get; set; }

--- a/BTCPayServer.Client/Models/RefundInvoiceRequest.cs
+++ b/BTCPayServer.Client/Models/RefundInvoiceRequest.cs
@@ -10,6 +10,7 @@ namespace BTCPayServer.Client.Models
         RateThen,
         CurrentRate,
         MinusPercentage,
+        OverpaidAmount,
         Fiat,
         Custom
     }

--- a/BTCPayServer.Client/Models/RefundInvoiceRequest.cs
+++ b/BTCPayServer.Client/Models/RefundInvoiceRequest.cs
@@ -9,7 +9,6 @@ namespace BTCPayServer.Client.Models
     {
         RateThen,
         CurrentRate,
-        MinusPercentage,
         OverpaidAmount,
         Fiat,
         Custom
@@ -25,7 +24,7 @@ namespace BTCPayServer.Client.Models
         public RefundVariant? RefundVariant { get; set; }
         
         [JsonConverter(typeof(NumericStringJsonConverter))]
-        public decimal? CustomPercentage { get; set; }
+        public decimal SubtractPercentage { get; set; }
         
         [JsonConverter(typeof(NumericStringJsonConverter))]
         public decimal? CustomAmount { get; set; }

--- a/BTCPayServer.Tests/GreenfieldAPITests.cs
+++ b/BTCPayServer.Tests/GreenfieldAPITests.cs
@@ -1950,6 +1950,28 @@ namespace BTCPayServer.Tests
                 CustomCurrency = "BTC"
             });
             Assert.True(pp.AutoApproveClaims);
+            
+            // test RefundVariant.MinusPercentage
+            validationError = await AssertValidationError(new[] { "CustomPercentage" }, async () =>
+            {
+                await client.RefundInvoice(user.StoreId, invoice.Id, new RefundInvoiceRequest
+                {
+                    PaymentMethod = method.PaymentMethod,
+                    RefundVariant = RefundVariant.MinusPercentage,
+                });
+            });
+            Assert.Contains("CustomPercentage: Percentage must be a numeric value between 0 and 100", validationError.Message);
+
+            // should auto-approve
+            pp = await client.RefundInvoice(user.StoreId, invoice.Id, new RefundInvoiceRequest
+            {
+                PaymentMethod = method.PaymentMethod,
+                RefundVariant = RefundVariant.MinusPercentage,
+                CustomPercentage = 6.15m
+            });
+            Assert.Equal("BTC", pp.Currency);
+            Assert.True(pp.AutoApproveClaims);
+            Assert.Equal(0.9385m, pp.Amount);
         }
 
         [Fact(Timeout = TestTimeout)]

--- a/BTCPayServer/Controllers/UIInvoiceController.UI.cs
+++ b/BTCPayServer/Controllers/UIInvoiceController.UI.cs
@@ -383,6 +383,8 @@ namespace BTCPayServer.Controllers
                         model.CurrentRateText = _displayFormatter.Currency(model.CryptoAmountNow, paymentMethodId.CryptoCode);
                         model.FiatAmount = paidCurrency;
                     }
+                    model.CryptoCode = paymentMethodId.CryptoCode;
+                    model.InvoiceCurrency = invoice.Currency;
                     model.CustomAmount = model.FiatAmount;
                     model.CustomCurrency = invoice.Currency;
                     model.FiatText = _displayFormatter.Currency(model.FiatAmount, invoice.Currency);

--- a/BTCPayServer/Models/InvoicingModels/RefundModel.cs
+++ b/BTCPayServer/Models/InvoicingModels/RefundModel.cs
@@ -24,11 +24,15 @@ namespace BTCPayServer.Models.InvoicingModels
         public string RateThenText { get; set; }
         public string FiatText { get; set; }
         public decimal FiatAmount { get; set; }
+        
+        [Display(Name = "Specify the percentage by which to reduce the refund")]
+        public decimal CustomPercentage { get; set; }
 
         [Display(Name = "Specify the amount and currency for the refund")]
         public decimal CustomAmount { get; set; }
         public string CustomCurrency { get; set; }
         public string InvoiceCurrency { get; set; }
         public string CryptoCode { get; set; }
+        public int CryptoDivisibility { get; set; }
     }
 }

--- a/BTCPayServer/Models/InvoicingModels/RefundModel.cs
+++ b/BTCPayServer/Models/InvoicingModels/RefundModel.cs
@@ -26,9 +26,7 @@ namespace BTCPayServer.Models.InvoicingModels
         public decimal FiatAmount { get; set; }
         public decimal? OverpaidAmount { get; set; }
         public string OverpaidAmountText { get; set; }
-        
-        [Display(Name = "Specify the percentage by which to reduce the refund")]
-        public decimal CustomPercentage { get; set; }
+        public decimal SubtractPercentage { get; set; }
 
         [Display(Name = "Specify the amount and currency for the refund")]
         public decimal CustomAmount { get; set; }
@@ -36,5 +34,6 @@ namespace BTCPayServer.Models.InvoicingModels
         public string InvoiceCurrency { get; set; }
         public string CryptoCode { get; set; }
         public int CryptoDivisibility { get; set; }
+        public int InvoiceDivisibility { get; set; }
     }
 }

--- a/BTCPayServer/Models/InvoicingModels/RefundModel.cs
+++ b/BTCPayServer/Models/InvoicingModels/RefundModel.cs
@@ -28,5 +28,7 @@ namespace BTCPayServer.Models.InvoicingModels
         [Display(Name = "Specify the amount and currency for the refund")]
         public decimal CustomAmount { get; set; }
         public string CustomCurrency { get; set; }
+        public string InvoiceCurrency { get; set; }
+        public string CryptoCode { get; set; }
     }
 }

--- a/BTCPayServer/Models/InvoicingModels/RefundModel.cs
+++ b/BTCPayServer/Models/InvoicingModels/RefundModel.cs
@@ -24,6 +24,8 @@ namespace BTCPayServer.Models.InvoicingModels
         public string RateThenText { get; set; }
         public string FiatText { get; set; }
         public decimal FiatAmount { get; set; }
+        public decimal? OverpaidAmount { get; set; }
+        public string OverpaidAmountText { get; set; }
         
         [Display(Name = "Specify the percentage by which to reduce the refund")]
         public decimal CustomPercentage { get; set; }

--- a/BTCPayServer/Views/UIInvoice/Invoice.cshtml
+++ b/BTCPayServer/Views/UIInvoice/Invoice.cshtml
@@ -438,7 +438,7 @@
         <section class="mt-4 d-print-none">
             <h3 class="mb-3">Webhooks</h3>
             <div class="table-responsive-xl">
-                <table class="table table-hover table-responsive-md mb-5">
+                <table class="table table-hover mb-5">
                     <thead>
                     <tr>
                         <th>Status</th>
@@ -515,7 +515,7 @@
         <section class="mt-4">
             <h3 class="mb-3">Refunds</h3>
             <div class="table-responsive-xl">
-                <table class="table table-hover table-responsive-md mb-5">
+                <table class="table table-hover mb-5">
                     <thead>
                     <tr>
                         <th>Pull Payment</th>

--- a/BTCPayServer/Views/UIInvoice/Invoice.cshtml
+++ b/BTCPayServer/Views/UIInvoice/Invoice.cshtml
@@ -1,4 +1,3 @@
-@using BTCPayServer.Client.Models
 @using Microsoft.AspNetCore.Mvc.TagHelpers
 @using BTCPayServer.Client
 @using BTCPayServer.Abstractions.TagHelpers
@@ -89,6 +88,23 @@
         }
         delegate('change', '#CustomAmount', checkCustomAmount);
         delegate('change', '#CustomCurrency', checkCustomAmount);
+        
+        function updateCustomPercentageResult() {
+            const $refundForm = document.getElementById('RefundForm');
+            const $result = document.getElementById('CustomPercentageResult');
+            const cryptoCode = $refundForm.querySelector('#CryptoCode').value;
+            const cryptoAmountThen = parseFloat($refundForm.querySelector('#CryptoAmountThen').value);
+            const percentage = parseFloat($refundForm.querySelector('#CustomPercentage').value);
+            const divisibility = parseInt($refundForm.querySelector('#CryptoDivisibility').value);
+            const isInvalid = isNaN(percentage);
+            $result.hidden = isInvalid;
+            if (!isInvalid) {
+                const reduceByAmount = (cryptoAmountThen * (percentage / 100));
+                const refundAmount = (cryptoAmountThen - reduceByAmount).toFixed(divisibility);
+                $result.innerText = `= ${refundAmount} ${cryptoCode} refund`;
+            }
+        }
+        delegate('change', '#CustomPercentage', updateCustomPercentageResult);
     </script>
 }
 

--- a/BTCPayServer/Views/UIInvoice/Invoice.cshtml
+++ b/BTCPayServer/Views/UIInvoice/Invoice.cshtml
@@ -68,6 +68,27 @@
             const response = await fetch(url, { method, body })
             await handleRefundResponse(response)
         })
+        
+        function checkCustomAmount() {
+            const $refundForm = document.getElementById('RefundForm');
+            const currency = $refundForm.querySelector('#CustomCurrency').value;
+            const cryptoCode = $refundForm.querySelector('#CryptoCode').value;
+            const invoiceCurrency = $refundForm.querySelector('#InvoiceCurrency').value;
+            const amount = parseFloat($refundForm.querySelector('#CustomAmount').value);
+            const fiatAmount = parseFloat($refundForm.querySelector('#FiatAmount').value);
+            const cryptoAmountNow = parseFloat($refundForm.querySelector('#CryptoAmountNow').value);
+            const cryptoAmountThen = parseFloat($refundForm.querySelector('#CryptoAmountThen').value);
+            
+            let isOverpaying = false;
+            if (currency === cryptoCode) {
+                isOverpaying = amount > Math.max(cryptoAmountNow, cryptoAmountThen);
+            } else if (currency === invoiceCurrency) {
+                isOverpaying = amount > fiatAmount;
+            }
+            document.getElementById('CustomAmountWarning').hidden = !isOverpaying;
+        }
+        delegate('change', '#CustomAmount', checkCustomAmount);
+        delegate('change', '#CustomCurrency', checkCustomAmount);
     </script>
 }
 

--- a/BTCPayServer/Views/UIInvoice/Invoice.cshtml
+++ b/BTCPayServer/Views/UIInvoice/Invoice.cshtml
@@ -89,22 +89,69 @@
         delegate('change', '#CustomAmount', checkCustomAmount);
         delegate('change', '#CustomCurrency', checkCustomAmount);
         
-        function updateCustomPercentageResult() {
+        function updateSubtractPercentageResult() {
             const $refundForm = document.getElementById('RefundForm');
-            const $result = document.getElementById('CustomPercentageResult');
-            const cryptoCode = $refundForm.querySelector('#CryptoCode').value;
-            const cryptoAmountThen = parseFloat($refundForm.querySelector('#CryptoAmountThen').value);
-            const percentage = parseFloat($refundForm.querySelector('#CustomPercentage').value);
-            const divisibility = parseInt($refundForm.querySelector('#CryptoDivisibility').value);
-            const isInvalid = isNaN(percentage);
-            $result.hidden = isInvalid;
-            if (!isInvalid) {
-                const reduceByAmount = (cryptoAmountThen * (percentage / 100));
-                const refundAmount = (cryptoAmountThen - reduceByAmount).toFixed(divisibility);
-                $result.innerText = `= ${refundAmount} ${cryptoCode} refund`;
+            const $result = document.getElementById('SubtractPercentageResult');
+            const $selectedRefundOption = $refundForm.querySelector('[name="SelectedRefundOption"]:checked');
+            if (!$selectedRefundOption) {
+                $result.hidden = true;
+                return;
             }
+            
+            const refundOption = $selectedRefundOption.value;
+            const cryptoCode = $refundForm.querySelector('#CryptoCode').value;
+            const customCurrency = $refundForm.querySelector('#CustomCurrency').value;
+            const invoiceCurrency = $refundForm.querySelector('#InvoiceCurrency').value;
+            const customAmount = parseFloat($refundForm.querySelector('#CustomAmount').value);
+            const fiatAmount = parseFloat($refundForm.querySelector('#FiatAmount').value);
+            const overpaidAmount = parseFloat($refundForm.querySelector('#OverpaidAmount').value);
+            const cryptoAmountNow = parseFloat($refundForm.querySelector('#CryptoAmountNow').value);
+            const cryptoAmountThen = parseFloat($refundForm.querySelector('#CryptoAmountThen').value);
+            const cryptoDivisibility = parseInt($refundForm.querySelector('#CryptoDivisibility').value);
+            const invoiceDivisibility = parseInt($refundForm.querySelector('#InvoiceDivisibility').value);
+            const percentage = parseFloat($refundForm.querySelector('#SubtractPercentage').value);
+            const isInvalid = isNaN(percentage);
+            
+            let amount = null;
+            let currency = cryptoCode;
+            let divisibility = cryptoDivisibility;
+            switch (refundOption) {
+                case 'RateThen':
+                    amount = cryptoAmountThen;
+                    break;
+                case 'CurrentRate':
+                    amount = cryptoAmountNow;
+                    break;
+                case 'OverpaidAmount':
+                    amount = overpaidAmount;
+                    break;
+                case 'Fiat':
+                    amount = fiatAmount;
+                    currency = invoiceCurrency;
+                    divisibility = invoiceDivisibility;
+                    break;
+                case 'Custom':
+                    amount = customAmount;
+                    currency = customCurrency;
+                    divisibility = customCurrency === invoiceCurrency ? invoiceDivisibility : cryptoDivisibility;
+                    break;
+            }
+            
+            if (amount == null || isInvalid) {
+                $result.hidden = true;
+                return;
+            }
+            
+            console.log({ refundOption, isInvalid, amount, currency })
+            const reduceByAmount = (amount * (percentage / 100));
+            const refundAmount = (amount - reduceByAmount).toFixed(divisibility);
+            $result.innerText = `= ${refundAmount} ${currency} refund`;
+            $result.hidden = false;
         }
-        delegate('change', '#CustomPercentage', updateCustomPercentageResult);
+        delegate('change', '[name="SelectedRefundOption"]', updateSubtractPercentageResult);
+        delegate('change', '#SubtractPercentage', updateSubtractPercentageResult);
+        delegate('change', '#CustomCurrency', updateSubtractPercentageResult);
+        delegate('change', '#CustomAmount', updateSubtractPercentageResult);
     </script>
 }
 

--- a/BTCPayServer/Views/UIInvoice/_RefundModal.cshtml
+++ b/BTCPayServer/Views/UIInvoice/_RefundModal.cshtml
@@ -31,24 +31,26 @@
                     <span asp-validation-for="SelectedPaymentMethod" class="text-danger"></span>
                 </div>
             
-                <div class="form-group">
-                    <button id="ok" type="submit" class="btn btn-primary w-100">Next</button>
-                </div>
+                <button id="ok" type="submit" class="btn btn-primary w-100">Next</button>
             }
             break;
             
         case RefundSteps.SelectRate:
             <input type="hidden" asp-for="SelectedPaymentMethod"/>
             <input type="hidden" asp-for="CryptoAmountThen"/>
-            <input type="hidden" asp-for="FiatAmount"/>
+            <input type="hidden" asp-for="FiatAmount"/>        
+            <input type="hidden" asp-for="OverpaidAmount"/>
             <input type="hidden" asp-for="CryptoAmountNow"/>            
             <input type="hidden" asp-for="CryptoDivisibility"/>
             <input type="hidden" asp-for="CryptoCode"/>
             <input type="hidden" asp-for="InvoiceCurrency"/>
+            <input type="hidden" asp-for="InvoiceDivisibility"/>
             <style>
                 .additional-options { display: none; }
                 [name="SelectedRefundOption"]:checked ~ .additional-options { display: block; }
             </style>
+                           
+            <span asp-validation-for="SelectedRefundOption" class="text-danger w-100"></span>
             <div class="form-group">
                 <div class="form-check">
                     <input id="RateThenOption" asp-for="SelectedRefundOption" type="radio" value="RateThen" class="form-check-input"/>
@@ -63,13 +65,6 @@
                     <div class="form-text">The crypto currency price, at the current rate.</div>
                 </div>
             </div>
-            <div class="form-group">
-                <div class="form-check">
-                    <input id="FiatOption" asp-for="SelectedRefundOption" type="radio" value="Fiat" class="form-check-input"/>
-                    <label for="FiatOption" class="form-check-label">@Model.FiatText</label>
-                    <div class="form-text">The invoice currency, at the rate when the refund will be sent.</div>
-                </div>
-            </div>
             @if (Model.OverpaidAmount is not null)
             {
                 <div class="form-group">
@@ -82,18 +77,9 @@
             }
             <div class="form-group">
                 <div class="form-check">
-                    <input id="MinusPercentageOption" asp-for="SelectedRefundOption" type="radio" value="MinusPercentage" class="form-check-input"/>
-                    <label for="MinusPercentageOption" class="form-check-label">@Model.RateThenText, minus x%</label>
-                    <div class="form-text">The crypto currency amount received, less a specified percentage as processing fee.</div>
-                    <div class="form-group pt-2 additional-options">
-                        <label asp-for="CustomPercentage" class="form-label"></label>
-                        <div class="input-group">
-                            <input asp-for="CustomPercentage" type="number" step=".01" min="0" class="form-control" style="flex: 0 0 10ch;" />
-                            <span class="input-group-text">%</span>
-                            <span class="input-group-text" id="CustomPercentageResult" hidden></span>
-                        </div>
-                        <span asp-validation-for="CustomPercentage" class="text-danger w-100"></span>
-                    </div>
+                    <input id="FiatOption" asp-for="SelectedRefundOption" type="radio" value="Fiat" class="form-check-input"/>
+                    <label for="FiatOption" class="form-check-label">@Model.FiatText</label>
+                    <div class="form-text">The invoice currency, at the rate when the refund will be sent.</div>
                 </div>
             </div>
             <div class="form-group">
@@ -115,14 +101,20 @@
                     </div>
                 </div>
             </div>
-            
-            <div class="form-group">
-                <span asp-validation-for="SelectedRefundOption" class="text-danger w-100"></span>
+            <hr class="border" />
+            <div class="form-group form-check">
+                <label asp-for="SubtractPercentage" class="form-label">
+                    Optional: Specify the percentage by which to reduce the refund, e.g. as processing charge or to compensate for the mining fee.
+                </label>
+                <div class="input-group">
+                    <input asp-for="SubtractPercentage" type="number" step=".01" min="0" class="form-control" style="flex: 0 0 10ch;" />
+                    <span class="input-group-text">%</span>
+                    <span class="input-group-text" id="SubtractPercentageResult" hidden></span>
+                </div>
+                <span asp-validation-for="SubtractPercentage" class="text-danger w-100"></span>
             </div>
             
-            <div class="form-group">
-                <button id="ok" type="submit" class="btn btn-primary w-100">Create refund</button>
-            </div>
+            <button id="ok" type="submit" class="btn btn-primary w-100">Create refund</button>
             break;
     }
 </form>

--- a/BTCPayServer/Views/UIInvoice/_RefundModal.cshtml
+++ b/BTCPayServer/Views/UIInvoice/_RefundModal.cshtml
@@ -51,6 +51,17 @@
             </style>
                            
             <span asp-validation-for="SelectedRefundOption" class="text-danger w-100"></span>
+            @if (Model.OverpaidAmount is not null)
+            {
+                <div class="form-group">
+                    <div class="form-check">
+                        <input id="OverpaidAmountOption" asp-for="SelectedRefundOption" type="radio" value="OverpaidAmount" class="form-check-input"/>
+                        <label for="OverpaidAmountOption" class="form-check-label d-flex align-items-center gap-2">@Model.OverpaidAmountText <span class="badge bg-info">Overpaid amount</span></label>
+                        <div class="form-text">The crypto currency amount that was overpaid.</div>
+                    </div>
+                </div>
+                <hr class="border" />
+            }
             <div class="form-group">
                 <div class="form-check">
                     <input id="RateThenOption" asp-for="SelectedRefundOption" type="radio" value="RateThen" class="form-check-input"/>
@@ -65,16 +76,6 @@
                     <div class="form-text">The crypto currency price, at the current rate.</div>
                 </div>
             </div>
-            @if (Model.OverpaidAmount is not null)
-            {
-                <div class="form-group">
-                    <div class="form-check">
-                        <input id="OverpaidAmountOption" asp-for="SelectedRefundOption" type="radio" value="OverpaidAmount" class="form-check-input"/>
-                        <label for="OverpaidAmountOption" class="form-check-label">@Model.OverpaidAmountText</label>
-                        <div class="form-text">The crypto currency amount that was overpaid.</div>
-                    </div>
-                </div>
-            }
             <div class="form-group">
                 <div class="form-check">
                     <input id="FiatOption" asp-for="SelectedRefundOption" type="radio" value="Fiat" class="form-check-input"/>

--- a/BTCPayServer/Views/UIInvoice/_RefundModal.cshtml
+++ b/BTCPayServer/Views/UIInvoice/_RefundModal.cshtml
@@ -41,12 +41,13 @@
             <input type="hidden" asp-for="SelectedPaymentMethod"/>
             <input type="hidden" asp-for="CryptoAmountThen"/>
             <input type="hidden" asp-for="FiatAmount"/>
-            <input type="hidden" asp-for="CryptoAmountNow"/>
+            <input type="hidden" asp-for="CryptoAmountNow"/>            
+            <input type="hidden" asp-for="CryptoDivisibility"/>
             <input type="hidden" asp-for="CryptoCode"/>
             <input type="hidden" asp-for="InvoiceCurrency"/>
             <style>
-                #CustomOption ~ .form-group { display: none; }
-                #CustomOption:checked ~ .form-group { display: block; }
+                .additional-options { display: none; }
+                [name="SelectedRefundOption"]:checked ~ .additional-options { display: block; }
             </style>
             <div class="form-group">
                 <div class="form-check">
@@ -69,13 +70,28 @@
                     <div class="form-text">The invoice currency, at the rate when the refund will be sent.</div>
                 </div>
             </div>
-
+            <div class="form-group">
+                <div class="form-check">
+                    <input id="MinusPercentageOption" asp-for="SelectedRefundOption" type="radio" value="MinusPercentage" class="form-check-input"/>
+                    <label for="MinusPercentageOption" class="form-check-label">@Model.RateThenText, minus x%</label>
+                    <div class="form-text">The crypto currency amount received, less a specified percentage as processing fee.</div>
+                    <div class="form-group pt-2 additional-options">
+                        <label asp-for="CustomPercentage" class="form-label"></label>
+                        <div class="input-group">
+                            <input asp-for="CustomPercentage" type="number" step=".01" min="0" class="form-control" style="flex: 0 0 10ch;" />
+                            <span class="input-group-text">%</span>
+                            <span class="input-group-text" id="CustomPercentageResult" hidden></span>
+                        </div>
+                        <span asp-validation-for="CustomPercentage" class="text-danger w-100"></span>
+                    </div>
+                </div>
+            </div>
             <div class="form-group">
                 <div class="form-check">
                     <input id="CustomOption" asp-for="SelectedRefundOption" type="radio" value="Custom" class="form-check-input"/>
                     <label for="CustomOption" class="form-check-label">Custom amount</label>
                     <div class="form-text">The specified amount with the specified currency, at the rate when the refund will be sent.</div>
-                    <div class="form-group pt-2">
+                    <div class="form-group pt-2 additional-options">
                         <label asp-for="CustomAmount" class="form-label"></label>
                         <div class="input-group">
                             <input asp-for="CustomAmount" type="number" step="any" asp-format="{0}" class="form-control"/>

--- a/BTCPayServer/Views/UIInvoice/_RefundModal.cshtml
+++ b/BTCPayServer/Views/UIInvoice/_RefundModal.cshtml
@@ -70,6 +70,16 @@
                     <div class="form-text">The invoice currency, at the rate when the refund will be sent.</div>
                 </div>
             </div>
+            @if (Model.OverpaidAmount is not null)
+            {
+                <div class="form-group">
+                    <div class="form-check">
+                        <input id="OverpaidAmountOption" asp-for="SelectedRefundOption" type="radio" value="OverpaidAmount" class="form-check-input"/>
+                        <label for="OverpaidAmountOption" class="form-check-label">@Model.OverpaidAmountText</label>
+                        <div class="form-text">The crypto currency amount that was overpaid.</div>
+                    </div>
+                </div>
+            }
             <div class="form-group">
                 <div class="form-check">
                     <input id="MinusPercentageOption" asp-for="SelectedRefundOption" type="radio" value="MinusPercentage" class="form-check-input"/>

--- a/BTCPayServer/Views/UIInvoice/_RefundModal.cshtml
+++ b/BTCPayServer/Views/UIInvoice/_RefundModal.cshtml
@@ -42,6 +42,8 @@
             <input type="hidden" asp-for="CryptoAmountThen"/>
             <input type="hidden" asp-for="FiatAmount"/>
             <input type="hidden" asp-for="CryptoAmountNow"/>
+            <input type="hidden" asp-for="CryptoCode"/>
+            <input type="hidden" asp-for="InvoiceCurrency"/>
             <style>
                 #CustomOption ~ .form-group { display: none; }
                 #CustomOption:checked ~ .form-group { display: block; }
@@ -78,6 +80,9 @@
                         <div class="input-group">
                             <input asp-for="CustomAmount" type="number" step="any" asp-format="{0}" class="form-control"/>
                             <input asp-for="CustomCurrency" type="text" class="form-control w-auto" currency-selection />
+                        </div>
+                        <div class="alert alert-warning my-2" hidden id="CustomAmountWarning" role="alert">
+                            This is an overpayment of the initial amount.
                         </div>
                         <span asp-validation-for="CustomAmount" class="text-danger w-100"></span>
                         <span asp-validation-for="CustomCurrency" class="text-danger w-100"></span>

--- a/BTCPayServer/wwwroot/swagger/v1/swagger.template.invoices.json
+++ b/BTCPayServer/wwwroot/swagger/v1/swagger.template.invoices.json
@@ -702,7 +702,7 @@
                   },
                   "refundVariant": {
                     "type": "string",
-                    "description": "* `RateThen`: Refund the crypto currency price, at the rate the invoice got paid.\r\n* `CurrentRate`: Refund the crypto currency price, at the current rate.\r\n*`Fiat`: Refund the invoice currency, at the rate when the refund will be sent.\r\n*`MinusPercentage`: Specify the percentage by which to reduce the refund. (see `customPercentage`)\r\n*`Custom`: Specify the amount, currency, and rate of the refund. (see `customAmount` and `customCurrency`)",
+                    "description": "* `RateThen`: Refund the crypto currency price, at the rate the invoice got paid.\r\n* `CurrentRate`: Refund the crypto currency price, at the current rate.\r\n*`Fiat`: Refund the invoice currency, at the rate when the refund will be sent.\r\n*`OverpaidAmount`: Refund the crypto currency amount that was overpaid.\r\n*`Custom`: Specify the amount, currency, and rate of the refund. (see `customAmount` and `customCurrency`)",
                     "x-enumNames": [
                       "RateThen",
                       "CurrentRate",
@@ -712,15 +712,15 @@
                     "enum": [
                       "RateThen",
                       "CurrentRate",
+                      "OverpaidAmount",
                       "Fiat",
-                      "MinusPercentage",
                       "Custom"
                     ]
                   },
-                  "customPercentage": {
+                  "subtractPercentage": {
                     "type": "string",
                     "format": "decimal",
-                    "description": "The percentage by which to reduce the refund if the `refundVariant` is `MinusPercentage`.",
+                    "description": "Optional percentage by which to reduce the refund, e.g. as processing charge or to compensate for the mining fee.",
                     "example": "2.1"
                   },
                   "customAmount": {

--- a/BTCPayServer/wwwroot/swagger/v1/swagger.template.invoices.json
+++ b/BTCPayServer/wwwroot/swagger/v1/swagger.template.invoices.json
@@ -702,7 +702,7 @@
                   },
                   "refundVariant": {
                     "type": "string",
-                    "description": "* `RateThen`: Refund the crypto currency price, at the rate the invoice got paid.\r\n* `CurrentRate`: Refund the crypto currency price, at the current rate.\r\n*`Fiat`: Refund the invoice currency, at the rate when the refund will be sent.\r\n*`Custom`: Specify the amount, currency, and rate of the refund. (see `customAmount` and `customCurrency`)",
+                    "description": "* `RateThen`: Refund the crypto currency price, at the rate the invoice got paid.\r\n* `CurrentRate`: Refund the crypto currency price, at the current rate.\r\n*`Fiat`: Refund the invoice currency, at the rate when the refund will be sent.\r\n*`MinusPercentage`: Specify the percentage by which to reduce the refund. (see `customPercentage`)\r\n*`Custom`: Specify the amount, currency, and rate of the refund. (see `customAmount` and `customCurrency`)",
                     "x-enumNames": [
                       "RateThen",
                       "CurrentRate",
@@ -713,8 +713,15 @@
                       "RateThen",
                       "CurrentRate",
                       "Fiat",
+                      "MinusPercentage",
                       "Custom"
                     ]
+                  },
+                  "customPercentage": {
+                    "type": "string",
+                    "format": "decimal",
+                    "description": "The percentage by which to reduce the refund if the `refundVariant` is `MinusPercentage`.",
+                    "example": "2.1"
                   },
                   "customAmount": {
                     "type": "string",


### PR DESCRIPTION
Closes #3839. Closes #4812.

- [x]  Should alert the user if they're going over pay the refund amount when selecting the custom amount
- [x]  An option to also offer a refund LESS the costs involved in issuing the refund (for example onchain fee to send it out)
- [x] #4812
