### PR TITLE
Bumping LND to 0.16.2-beta

### DIFF
--- a/BTCPayServer.Tests/docker-compose.altcoins.yml
+++ b/BTCPayServer.Tests/docker-compose.altcoins.yml
@@ -243,7 +243,7 @@ services:
       - "5432"
 
   merchant_lnd:
-    image: btcpayserver/lnd:v0.16.1-beta
+    image: btcpayserver/lnd:v0.16.2-beta
     restart: unless-stopped
     environment:
       LND_CHAIN: "btc"
@@ -278,7 +278,7 @@ services:
       - bitcoind
 
   customer_lnd:
-    image: btcpayserver/lnd:v0.16.1-beta
+    image: btcpayserver/lnd:v0.16.2-beta
     restart: unless-stopped
     environment:
       LND_CHAIN: "btc"

--- a/BTCPayServer.Tests/docker-compose.yml
+++ b/BTCPayServer.Tests/docker-compose.yml
@@ -230,7 +230,7 @@ services:
       - "5432"
 
   merchant_lnd:
-    image: btcpayserver/lnd:v0.16.1-beta
+    image: btcpayserver/lnd:v0.16.2-beta
     restart: unless-stopped
     environment:
       LND_CHAIN: "btc"
@@ -267,7 +267,7 @@ services:
       - bitcoind
 
   customer_lnd:
-    image: btcpayserver/lnd:v0.16.1-beta
+    image: btcpayserver/lnd:v0.16.2-beta
     restart: unless-stopped
     environment:
       LND_CHAIN: "btc"


### PR DESCRIPTION
Updating our devenv to use LND 0.16.2; Docker image available on https://hub.docker.com/layers/btcpayserver/lnd/v0.16.2-beta/images/sha256-ce3bf85e3380cd74d8e1ecdab6c0d45ad8364a4c3689be0de6cc23fca20d8c81?context=explore

Used it in BTCPayServer.Lightning library and it's good to go:
https://github.com/btcpayserver/BTCPayServer.Lightning/pull/128