### PR TITLE
Improve create first store case

### DIFF
--- a/BTCPayServer.Tests/SeleniumTester.cs
+++ b/BTCPayServer.Tests/SeleniumTester.cs
@@ -180,7 +180,7 @@ namespace BTCPayServer.Tests
             {
                 Driver.FindElement(By.Id("StoreSelectorToggle")).Click();
             }
-            Driver.WaitForElement(By.Id("StoreSelectorCreate")).Click();
+            GoToUrl("/stores/create");
             var name = "Store" + RandomUtils.GetUInt64();
             TestLogs.LogInformation($"Created store {name}");
             Driver.WaitForElement(By.Id("Name")).SendKeys(name);

--- a/BTCPayServer/Components/StoreSelector/Default.cshtml
+++ b/BTCPayServer/Components/StoreSelector/Default.cshtml
@@ -37,10 +37,9 @@ else
 {
     <a asp-controller="UIInvoice" asp-action="ListInvoices" asp-route-storeId="@Model.CurrentStoreId" id="StoreSelectorHome" class="navbar-brand py-2">@{await LogoContent();}</a>
 }
-
-<div id="StoreSelector">
-    @if (Model.Options.Any())
-    {
+@if (Model.Options.Any())
+{
+    <div id="StoreSelector">
         <div id="StoreSelectorDropdown" class="dropdown only-for-js">
             <button id="StoreSelectorToggle" class="btn btn-secondary dropdown-toggle rounded-pill px-3 @(Model.CurrentStoreId == null ? "empty-state" : "")" type="button" data-bs-toggle="dropdown" aria-expanded="false">
                 @if (!string.IsNullOrEmpty(Model.CurrentStoreLogoFileId))
@@ -72,9 +71,5 @@ else
                 <li><a asp-controller="UIUserStores" asp-action="CreateStore" class="dropdown-item" id="StoreSelectorCreate">Create Store</a></li>
             </ul>
         </div>
-    }
-    else if (SignInManager.IsSignedIn(User))
-    {
-        <a asp-controller="UIUserStores" asp-action="CreateStore" class="btn btn-primary w-100 rounded-pill text-nowrap" id="StoreSelectorCreate">Create Store</a>
-    }
-</div>
+    </div>
+}

--- a/BTCPayServer/Controllers/UIHomeController.cs
+++ b/BTCPayServer/Controllers/UIHomeController.cs
@@ -97,18 +97,9 @@ namespace BTCPayServer.Controllers
                 }
 
                 var stores = await _storeRepository.GetStoresByUserId(userId);
-                if (stores.Any())
-                {
-                    // redirect to first store
-                    return RedirectToStore(stores.First());
-                }
-
-                var vm = new HomeViewModel
-                {
-                    HasStore = stores.Any()
-                };
-
-                return View("Home", vm);
+                return stores.Any()
+                    ? RedirectToStore(stores.First())
+                    : RedirectToAction(nameof(UIUserStoresController.CreateStore), "UIUserStores");
             }
 
             return Challenge();

--- a/BTCPayServer/Controllers/UIUserStoresController.cs
+++ b/BTCPayServer/Controllers/UIUserStoresController.cs
@@ -39,10 +39,12 @@ namespace BTCPayServer.Controllers
 
         [HttpGet("create")]
         [Authorize(AuthenticationSchemes = AuthenticationSchemes.Cookie, Policy = Policies.CanModifyStoreSettingsUnscoped)]
-        public IActionResult CreateStore()
+        public async Task<IActionResult> CreateStore()
         {
+            var stores = await _repo.GetStoresByUserId(GetUserId());
             var vm = new CreateStoreViewModel
             {
+                IsFirstStore = !stores.Any(),
                 DefaultCurrency = StoreBlob.StandardDefaultCurrency,
                 Exchanges = GetExchangesSelectList(null)
             };
@@ -56,6 +58,8 @@ namespace BTCPayServer.Controllers
         {
             if (!ModelState.IsValid)
             {
+                var stores = await _repo.GetStoresByUserId(GetUserId());
+                vm.IsFirstStore = !stores.Any();
                 vm.Exchanges = GetExchangesSelectList(vm.PreferredExchange);
                 return View(vm);
             }

--- a/BTCPayServer/Models/StoreViewModels/CreateStoreViewModel.cs
+++ b/BTCPayServer/Models/StoreViewModels/CreateStoreViewModel.cs
@@ -5,6 +5,8 @@ namespace BTCPayServer.Models.StoreViewModels
 {
     public class CreateStoreViewModel
     {
+        public bool IsFirstStore { get; set; }
+        
         [Required]
         [MaxLength(50)]
         [MinLength(1)]

--- a/BTCPayServer/Views/UIUserStores/CreateStore.cshtml
+++ b/BTCPayServer/Views/UIUserStores/CreateStore.cshtml
@@ -1,6 +1,6 @@
 ﻿@model BTCPayServer.Models.StoreViewModels.CreateStoreViewModel
 @{
-    ViewData.SetActivePage(StoreNavPages.Create, "Create a new store");
+    ViewData.SetActivePage(StoreNavPages.Create, Model.IsFirstStore ? "Create your first store" : "Create a new store");
 }
 
 @section PageFootContent {
@@ -20,7 +20,15 @@
 
 <partial name="_StatusMessage" />
 
-<h2 class="mt-1 mb-4">@ViewData["Title"]</h2>
+@if (Model.IsFirstStore)
+{
+    <h2>@ViewData["Title"]</h2>
+    <p class="lead text-secondary">To start accepting payments, set up a store.</p>
+}
+else
+{
+    <h2 class="mt-1 mb-4">@ViewData["Title"]</h2>
+}
 <div class="row">
     <div class="col-xl-8 col-xxl-constrain">
         <form asp-action="CreateStore">


### PR DESCRIPTION
As discussed in the design meeting:

- Home redirects to the Create Store page if there are no stores yet
- Enhances the copy on that page for the first store case
- Removes the  redundant Create Store CTA button in the sidebar

Closes #3900.

![grafik](https://user-images.githubusercontent.com/886/236305034-0c603a02-244c-46ad-8728-69b6e736ea05.png)
