### PR TITLE
Hide sensitive info

### DIFF
--- a/BTCPayServer/Components/AppTopItems/Default.cshtml
+++ b/BTCPayServer/Components/AppTopItems/Default.cshtml
@@ -48,7 +48,7 @@
                         <span class="app-item-point ct-point"></span>
                         @entry.Title
                     </span>
-                    <span class="app-item-value">
+                    <span class="app-item-value" data-sensitive>
                         <span class="text-muted">@entry.SalesCount @($"{label}{(entry.SalesCount == 1 ? "" : "s")}"),</span>
                         @entry.TotalFormatted
                     </span>

--- a/BTCPayServer/Components/MainNav/Default.cshtml
+++ b/BTCPayServer/Components/MainNav/Default.cshtml
@@ -1,6 +1,5 @@
 @using BTCPayServer.Views.Server
 @using BTCPayServer.Views.Stores
-@using BTCPayServer.Views.Apps
 @using BTCPayServer.Views.Invoice
 @using BTCPayServer.Views.Manage
 @using BTCPayServer.Views.PaymentRequest
@@ -239,7 +238,7 @@
                     <span>Account</span>
                 </a>   
                 <ul class="dropdown-menu py-0 w-100" aria-labelledby="Nav-Account">
-                    <li class="p-3">
+                    <li class="p-3 border-bottom">
                         <strong class="d-block text-truncate" style="max-width:195px">@User.Identity.Name</strong>
                         @if (User.IsInRole(Roles.ServerAdmin))
                         {
@@ -248,10 +247,19 @@
                     </li>
                     @if (!Theme.CustomTheme)
                     {
-                        <li class="border-top py-1 px-3">
-                            <vc:theme-switch css-class="nav-link"/>
+                        <li class="py-1 px-3">
+                            <vc:theme-switch css-class="nav-link pb-0"/>
                         </li>
                     }
+                    <li class="py-1 px-3">
+                        <label class="d-flex align-items-center justify-content-between gap-3 nav-link">
+                            <span class="fw-semibold">Hide Sensitive Info</span>
+                            <input id="HideSensitiveInfo" name="HideSensitiveInfo" type="checkbox" class="btcpay-toggle" />
+                        </label>
+                        <script>
+                            document.getElementById('HideSensitiveInfo').checked = window.localStorage.getItem('btcpay-hide-sensitive-info') === 'true';
+                        </script>
+                    </li>
                     <li class="border-top py-1 px-3">
                         <a asp-area="" asp-controller="UIManage" asp-action="Index" class="nav-link @ViewData.IsActiveCategory(typeof(ManageNavPages))" id="Nav-ManageAccount">
                             <span>Manage Account</span>

--- a/BTCPayServer/Components/StoreLightningBalance/Default.cshtml
+++ b/BTCPayServer/Components/StoreLightningBalance/Default.cshtml
@@ -23,7 +23,7 @@
             @if (Model.Balance.OffchainBalance != null)
             {
                 <div class="balance">
-                    <h3 class="d-inline-block me-1" data-balance="@Model.TotalOffchain">@Model.TotalOffchain</h3>
+                    <h3 class="d-inline-block me-1" data-balance="@Model.TotalOffchain" data-sensitive>@Model.TotalOffchain</h3>
                     <span class="text-secondary fw-semibold text-nowrap">
                         <span class="currency">@Model.CryptoCode</span> in channels
                     </span>
@@ -32,7 +32,7 @@
                         @if (Model.Balance.OffchainBalance.Opening != null)
                         {
                             <div class="mt-2">
-                                <span class="fw-semibold" data-balance="@Model.Balance.OffchainBalance.Opening">
+                                <span class="fw-semibold" data-balance="@Model.Balance.OffchainBalance.Opening" data-sensitive>
                                     @Model.Balance.OffchainBalance.Opening
                                 </span>
                                 <span class="text-secondary text-nowrap">
@@ -43,7 +43,7 @@
                         @if (Model.Balance.OffchainBalance.Local != null)
                         {
                             <div class="mt-2">
-                                <span class="fw-semibold" data-balance="@Model.Balance.OffchainBalance.Local">
+                                <span class="fw-semibold" data-balance="@Model.Balance.OffchainBalance.Local" data-sensitive>
                                     @Model.Balance.OffchainBalance.Local
                                 </span>
                                 <span class="text-secondary text-nowrap">
@@ -54,7 +54,7 @@
                         @if (Model.Balance.OffchainBalance.Remote != null)
                         {
                             <div class="mt-2">
-                                <span class="fw-semibold" data-balance="@Model.Balance.OffchainBalance.Remote">
+                                <span class="fw-semibold" data-balance="@Model.Balance.OffchainBalance.Remote" data-sensitive>
                                     @Model.Balance.OffchainBalance.Remote
                                 </span>
                                 <span class="text-secondary text-nowrap">
@@ -65,7 +65,7 @@
                         @if (Model.Balance.OffchainBalance.Closing != null)
                         {
                             <div class="mt-2">
-                                <span class="fw-semibold" data-balance="@Model.Balance.OffchainBalance.Closing">
+                                <span class="fw-semibold" data-balance="@Model.Balance.OffchainBalance.Closing" data-sensitive>
                                     @Model.Balance.OffchainBalance.Closing
                                 </span>
                                 <span class="text-secondary text-nowrap">
@@ -79,7 +79,7 @@
             @if (Model.Balance.OnchainBalance != null)
             {
                 <div class="balance">
-                    <h3 class="d-inline-block me-1" data-balance="@Model.TotalOnchain">@Model.TotalOnchain</h3>
+                    <h3 class="d-inline-block me-1" data-balance="@Model.TotalOnchain" data-sensitive>@Model.TotalOnchain</h3>
                     <span class="text-secondary fw-semibold text-nowrap">
                         <span class="currency">@Model.CryptoCode</span> on-chain
                     </span>
@@ -87,7 +87,7 @@
                         @if (Model.Balance.OnchainBalance.Confirmed != null)
                         {
                             <div class="mt-2">
-                                <span class="fw-semibold" data-balance="@Model.Balance.OnchainBalance.Confirmed">
+                                <span class="fw-semibold" data-balance="@Model.Balance.OnchainBalance.Confirmed" data-sensitive>
                                     @Model.Balance.OnchainBalance.Confirmed
                                 </span>
                                 <span class="text-secondary text-nowrap">
@@ -98,7 +98,7 @@
                         @if (Model.Balance.OnchainBalance.Unconfirmed != null)
                         {
                             <div class="mt-2">
-                                <span class="fw-semibold" data-balance="@Model.Balance.OnchainBalance.Unconfirmed">
+                                <span class="fw-semibold" data-balance="@Model.Balance.OnchainBalance.Unconfirmed" data-sensitive>
                                     @Model.Balance.OnchainBalance.Unconfirmed
                                 </span>
                                 <span class="text-secondary text-nowrap">
@@ -109,7 +109,7 @@
                         @if (Model.Balance.OnchainBalance.Reserved != null)
                         {
                             <div class="mt-2">
-                                <span class="fw-semibold" data-balance="@Model.Balance.OnchainBalance.Reserved">
+                                <span class="fw-semibold" data-balance="@Model.Balance.OnchainBalance.Reserved" data-sensitive>
                                     @Model.Balance.OnchainBalance.Reserved
                                 </span>
                                 <span class="text-secondary text-nowrap">

--- a/BTCPayServer/Components/StoreRecentInvoices/Default.cshtml
+++ b/BTCPayServer/Components/StoreRecentInvoices/Default.cshtml
@@ -65,7 +65,9 @@
                             </span>
                         }
                     </td>
-                    <td class="text-end">@DisplayFormatter.Currency(invoice.Amount, invoice.Currency)</td>
+                    <td class="text-end">
+                        <span data-sensitive>@DisplayFormatter.Currency(invoice.Amount, invoice.Currency)</span>
+                    </td>
                 </tr>
             }
             </tbody>

--- a/BTCPayServer/Components/StoreRecentTransactions/Default.cshtml
+++ b/BTCPayServer/Components/StoreRecentTransactions/Default.cshtml
@@ -72,11 +72,15 @@
                     </td>
                     @if (tx.Positive)
                     {
-                        <td class="text-end text-success">@DisplayFormatter.Currency(tx.Balance, tx.Currency)</td>
+                        <td class="text-end text-success">
+                            <span data-sensitive>@DisplayFormatter.Currency(tx.Balance, tx.Currency)</span>
+                        </td>
                     }
                     else
                     {
-                        <td class="text-end text-danger">@DisplayFormatter.Currency(tx.Balance, tx.Currency)</td>
+                        <td class="text-end text-danger">
+                            <span data-sensitive>@DisplayFormatter.Currency(tx.Balance, tx.Currency)</span>
+                        </td>
                     }
                 </tr>
             }

--- a/BTCPayServer/Components/StoreWalletBalance/Default.cshtml
+++ b/BTCPayServer/Components/StoreWalletBalance/Default.cshtml
@@ -18,7 +18,7 @@
         @if (Model.Balance != null)
         {
             <div class="balance">
-                <h3 class="d-inline-block me-1" data-balance="@Model.Balance">@Model.Balance</h3>
+                <h3 class="d-inline-block me-1" data-balance="@Model.Balance" data-sensitive>@Model.Balance</h3>
                 <span class="text-secondary fw-semibold currency">@Model.CryptoCode</span>
             </div>
         }

--- a/BTCPayServer/Components/WalletNav/Default.cshtml
+++ b/BTCPayServer/Components/WalletNav/Default.cshtml
@@ -8,7 +8,7 @@
 <div class="d-sm-flex align-items-center justify-content-between">
     <a asp-controller="UIWallets" asp-action="WalletTransactions" asp-route-walletId="@Model.WalletId" class="unobtrusive-link">
         <h2 class="mb-1">@Model.Label</h2>
-        <div class="text-muted fw-semibold">
+        <div class="text-muted fw-semibold" data-sensitive>
             @Model.Balance @Model.Network.CryptoCode
         </div>
     </a>

--- a/BTCPayServer/Views/Shared/Bitcoin/ViewBitcoinLikePaymentData.cshtml
+++ b/BTCPayServer/Views/Shared/Bitcoin/ViewBitcoinLikePaymentData.cshtml
@@ -96,7 +96,7 @@
                         }
                         <td class="text-end">@payment.Confirmations</td>
                         <td class="payment-value text-end text-nowrap">
-                            @DisplayFormatter.Currency(payment.CryptoPaymentData.GetValue(), payment.Crypto)
+                            <span data-sensitive>@DisplayFormatter.Currency(payment.CryptoPaymentData.GetValue(), payment.Crypto)</span>
                             @if (!string.IsNullOrEmpty(payment.AdditionalInformation))
                             {
                                 <div>(@payment.AdditionalInformation)</div>

--- a/BTCPayServer/Views/Shared/LayoutHeadTheme.cshtml
+++ b/BTCPayServer/Views/Shared/LayoutHeadTheme.cshtml
@@ -25,6 +25,7 @@ else
 {
     <link href="~/main/themes/default.css" asp-append-version="true" rel="stylesheet" />
     <link href="~/main/themes/default-dark.css" asp-append-version="true" rel="stylesheet" id="DarkThemeLinkTag" />
+    <script>if (window.localStorage.getItem('btcpay-hide-sensitive-info') === 'true') { document.documentElement.setAttribute('data-hide-sensitive-info', 'true')}</script>
     <script src="~/js/theme-switch.js" asp-append-version="true"></script>
     <noscript><style>.btcpay-theme-switch { display: none !important; }</style></noscript>
 }

--- a/BTCPayServer/Views/Shared/Lightning/ViewLightningLikePaymentData.cshtml
+++ b/BTCPayServer/Views/Shared/Lightning/ViewLightningLikePaymentData.cshtml
@@ -52,7 +52,7 @@
                                 <vc:truncate-center text="@payment.PaymentProof" classes="truncate-center-id" />
                             </td>
                             <td class="payment-value text-end text-nowrap">
-                                @payment.Amount
+                                <span data-sensitive>@payment.Amount</span>
                             </td>
                         </tr>
                     }

--- a/BTCPayServer/Views/UIInvoice/Invoice.cshtml
+++ b/BTCPayServer/Views/UIInvoice/Invoice.cshtml
@@ -227,7 +227,7 @@
                 </tr>
                 <tr>
                     <th class="fw-semibold">Total Fiat Due</th>
-                    <td>@Model.Fiat</td>
+                    <td><span data-sensitive>@Model.Fiat</span></td>
                 </tr>
                 @if (!string.IsNullOrEmpty(Model.RefundEmail))
                 {

--- a/BTCPayServer/Views/UIInvoice/ListInvoices.cshtml
+++ b/BTCPayServer/Views/UIInvoice/ListInvoices.cshtml
@@ -375,7 +375,9 @@
                                     <span class="badge bg-warning">Refund</span>
                                 }
                             </td>
-                            <td class="text-end text-nowrap">@DisplayFormatter.Currency(invoice.Amount, invoice.Currency)</td>
+                            <td class="text-end text-nowrap">
+                                <span data-sensitive>@DisplayFormatter.Currency(invoice.Amount, invoice.Currency)</span>
+                            </td>
                             <td class="text-end text-nowrap">
                                 @if (invoice.ShowCheckout)
                                 {

--- a/BTCPayServer/Views/UIInvoice/ListInvoicesPaymentsPartial.cshtml
+++ b/BTCPayServer/Views/UIInvoice/ListInvoicesPaymentsPartial.cshtml
@@ -35,12 +35,12 @@
                             <vc:truncate-center text="@payment.Address" classes="truncate-center-id" />
                         </td>
                     }
-                    <td class="text-nowrap text-end">@payment.Rate</td>
-                    <td class="text-nowrap text-end">@payment.Paid</td>
-                    <td class="text-nowrap text-end">@payment.Due</td>
+                    <td class="text-nowrap text-end"><span data-sensitive>@payment.Rate</span></td>
+                    <td class="text-nowrap text-end"><span data-sensitive>@payment.Paid</span></td>
+                    <td class="text-nowrap text-end"><span data-sensitive>@payment.Due</span></td>
                     @if (invoice.Overpaid)
                     {
-                        <td class="text-nowrap text-end">@payment.Overpaid</td>
+                        <td class="text-nowrap text-end"><span data-sensitive>@payment.Overpaid</span></td>
                     }
                 </tr>
                 var details = payment.PaymentMethodRaw.GetPaymentMethodDetails();

--- a/BTCPayServer/Views/UIPaymentRequest/GetPaymentRequests.cshtml
+++ b/BTCPayServer/Views/UIPaymentRequest/GetPaymentRequests.cshtml
@@ -93,7 +93,9 @@
                             <td>
                                 <span class="badge badge-@item.Status.ToLower()">@item.Status</span>
                             </td>
-                            <td class="text-end">@item.AmountFormatted</td>
+                            <td class="text-end">
+                                <span data-sensitive>@item.AmountFormatted</span>
+                            </td>
                             <td class="text-end">
                                 <a asp-controller="UIInvoice" asp-action="ListInvoices" asp-route-storeId="@item.StoreId" asp-route-searchterm="@($"orderid:{PaymentRequestRepository.GetOrderIdForPaymentRequest(item.Id)}")">Invoices</a>
                                 <span> - </span>

--- a/BTCPayServer/Views/UIStorePullPayments/Payouts.cshtml
+++ b/BTCPayServer/Views/UIStorePullPayments/Payouts.cshtml
@@ -197,7 +197,7 @@
                                 <span class="text-break">@pp.Destination</span>
                             </td>
                             <td class="text-end text-nowrap">
-                                <span>@pp.Amount</span>
+                                <span data-sensitive>@pp.Amount</span>
                             </td>
                             @if (Model.PayoutState != PayoutState.AwaitingApproval)
                             {

--- a/BTCPayServer/Views/UIWallets/_WalletTransactionsList.cshtml
+++ b/BTCPayServer/Views/UIWallets/_WalletTransactionsList.cshtml
@@ -29,11 +29,15 @@
         </td>
         @if (transaction.Positive)
         {
-            <td class="text-end text-success">@transaction.Balance</td>
+            <td class="text-end text-success">
+                <span data-sensitive>@transaction.Balance</span>
+            </td>
         }
         else
         {
-            <td class="text-end text-danger">@transaction.Balance</td>
+            <td class="text-end text-danger">
+                <span data-sensitive>@transaction.Balance</span>
+            </td>
         }
         <td class="text-end">
             <div class="dropstart d-inline-block">

--- a/BTCPayServer/wwwroot/main/site.css
+++ b/BTCPayServer/wwwroot/main/site.css
@@ -8,6 +8,26 @@
     --chart-series-e-rgb: 160, 98, 75;
 }
 
+/* Hide sensitive info */
+[data-hide-sensitive-info="true"] [data-sensitive] {
+    visibility: hidden;
+    position: relative;
+}
+
+[data-hide-sensitive-info="true"] [data-sensitive]:before {
+    content: '***';
+    visibility: visible;
+    position: absolute;
+}
+
+[data-hide-sensitive-info="true"] .text-end [data-sensitive]:before {
+    right: 0;
+}
+
+[data-hide-sensitive-info="true"] .store-wallet-balance .ct-label.ct-vertical.ct-start {
+    visibility: hidden;
+}
+
 /* General and site-wide Bootstrap modifications */
 p {
     margin-bottom: 1.5rem;

--- a/BTCPayServer/wwwroot/main/site.js
+++ b/BTCPayServer/wwwroot/main/site.js
@@ -279,6 +279,21 @@ document.addEventListener("DOMContentLoaded", () => {
         setColorMode(mode)
         e.target.closest('.btcpay-theme-switch').blur()
     })
+
+    // Sensitive Info
+    const SENSITIVE_INFO_STORE_KEY = 'btcpay-hide-sensitive-info';
+    const SENSITIVE_INFO_DATA_ATTR = 'data-hide-sensitive-info';
+    delegate('change', '#HideSensitiveInfo', e => {
+        e.preventDefault()
+        const isActive = window.localStorage.getItem(SENSITIVE_INFO_STORE_KEY) === 'true';
+        if (isActive) {
+            window.localStorage.removeItem(SENSITIVE_INFO_STORE_KEY);
+            document.documentElement.removeAttribute(SENSITIVE_INFO_DATA_ATTR);
+        } else {
+            window.localStorage.setItem(SENSITIVE_INFO_STORE_KEY, 'true');
+            document.documentElement.setAttribute(SENSITIVE_INFO_DATA_ATTR, 'true');
+        }
+    });
     
     // Currency Selection: Remove the current input value once the element is focused, so that the user gets to
     // see the available options. If no selection or change is made, reset it to the previous value on blur.


### PR DESCRIPTION
Adds the `data-sensitive` attribute, which replaces the content of that HTML tag with `***` when the "Hide Sensitive Data" mode is on. As this is a feature that only works on the frontend level, the mode is persistsed in the local storage, similar to the chosen color mode.

Closes #3779.

![hide-sensitive-info](https://user-images.githubusercontent.com/886/236824807-692c0a73-b892-43be-93b1-45f41dbba187.gif)
