### PR TITLE
Do not generate new address when a new payment is detected

### DIFF
--- a/BTCPayServer.Tests/UnitTest1.cs
+++ b/BTCPayServer.Tests/UnitTest1.cs
@@ -2154,6 +2154,7 @@ namespace BTCPayServer.Tests
                 txFee = localInvoice.BtcDue - invoice.BtcDue;
                 Assert.Equal("paidPartial", localInvoice.ExceptionStatus.ToString());
                 Assert.Equal(1, localInvoice.CryptoInfo[0].TxCount);
+                Assert.Equal(localInvoice.BitcoinAddress, invoice.BitcoinAddress); //Same address
                 Assert.True(IsMapped(invoice, ctx));
                 Assert.True(IsMapped(localInvoice, ctx));
 

--- a/BTCPayServer.Tests/UnitTest1.cs
+++ b/BTCPayServer.Tests/UnitTest1.cs
@@ -2154,7 +2154,6 @@ namespace BTCPayServer.Tests
                 txFee = localInvoice.BtcDue - invoice.BtcDue;
                 Assert.Equal("paidPartial", localInvoice.ExceptionStatus.ToString());
                 Assert.Equal(1, localInvoice.CryptoInfo[0].TxCount);
-                Assert.NotEqual(localInvoice.BitcoinAddress, invoice.BitcoinAddress); //New address
                 Assert.True(IsMapped(invoice, ctx));
                 Assert.True(IsMapped(localInvoice, ctx));
 

--- a/BTCPayServer/Payments/Bitcoin/NBXplorerListener.cs
+++ b/BTCPayServer/Payments/Bitcoin/NBXplorerListener.cs
@@ -414,20 +414,6 @@ namespace BTCPayServer.Payments.Bitcoin
             if (invoice == null)
                 return null;
             var paymentMethod = invoice.GetPaymentMethod(wallet.Network, PaymentTypes.BTCLike);
-            if (paymentMethod != null &&
-                paymentMethod.GetPaymentMethodDetails() is BitcoinLikeOnChainPaymentMethod btc &&
-                btc.Activated &&
-                btc.GetDepositAddress(wallet.Network.NBitcoinNetwork).ScriptPubKey == paymentData.ScriptPubKey &&
-                paymentMethod.Calculate().Due > Money.Zero)
-            {
-                var address = await wallet.ReserveAddressAsync(invoice.StoreId, strategy, "invoice");
-                btc.DepositAddress = address.Address.ToString();
-                btc.KeyPath = address.KeyPath;
-                await _InvoiceRepository.NewPaymentDetails(invoice.Id, btc, wallet.Network);
-                _Aggregator.Publish(new InvoiceNewPaymentDetailsEvent(invoice.Id, btc, paymentMethod.GetId()));
-                paymentMethod.SetPaymentMethodDetails(btc);
-                invoice.SetPaymentMethod(paymentMethod);
-            }
             wallet.InvalidateCache(strategy);
             _Aggregator.Publish(new InvoiceEvent(invoice, InvoiceEvent.ReceivedPayment) { Payment = payment });
             return invoice;


### PR DESCRIPTION
When a bitcoin address is used for a payment, it was being switched with a new address.

We got feedback of customers and merchants very confused about it, and thinking they got scammed.
I believe we should just reuse addresses. This isn't good for privacy, but this is a corner case that almost never happen. It isn't really worth bothering support with this.

Fix https://github.com/btcpayserver/btcpayserver/issues/4980