### PR TITLE
Dashboard: Fix SATS denomination display

### DIFF
--- a/BTCPayServer/Components/StoreWalletBalance/Default.cshtml
+++ b/BTCPayServer/Components/StoreWalletBalance/Default.cshtml
@@ -92,8 +92,7 @@
                 window.setTimeout(() => {
                     const yLabels = [...document.querySelectorAll('.ct-label.ct-vertical.ct-start')];
                     if (yLabels) {
-                        const factor = rate ? 6 : 8;
-                        const width = Math.max(...(yLabels.map(l => l.innerText.length * factor)));
+                        const width = Math.max(...(yLabels.map(l => l.innerText.length * 7.5)));
                         const opts = Object.assign({}, renderOpts, { 
                             axisY: Object.assign({}, renderOpts.axisY, { offset: width })
                         });

--- a/BTCPayServer/Views/UIStores/Dashboard.cshtml
+++ b/BTCPayServer/Views/UIStores/Dashboard.cshtml
@@ -7,7 +7,6 @@
 @using BTCPayServer.Components.AppSales
 @using BTCPayServer.Components.AppTopItems
 @using BTCPayServer.Services.Apps
-@inject AppService AppService
 @model StoreDashboardViewModel
 @{
     ViewData.SetActivePage(StoreNavPages.Dashboard, Model.StoreName, Model.StoreId);
@@ -63,8 +62,11 @@
             displayDefaultCurrency(amount, rate, currency, divisibility) {
                 const value = DashboardUtils.toDefaultCurrency(amount, rate);
                 const locale = currency === 'USD' ? 'en-US' : navigator.language;
+                const isSats = currency === 'SATS';
+                if (isSats) currency = 'BTC';
                 const opts = { currency, style: 'decimal', minimumFractionDigits: divisibility };
-                return new Intl.NumberFormat(locale, opts).format(value);
+                const val = new Intl.NumberFormat(locale, opts).format(value);
+                return isSats ? val.replace(/[\\.,]/g, ' ') : val;
             },
             async fetchRate(currencyPair) {
                 const storeId = @Safe.Json(Context.GetRouteValue("storeId"));


### PR DESCRIPTION
When the default currency of the store is SATS, the display was broken.

## Before 

![sats-before](https://github.com/btcpayserver/btcpayserver/assets/886/64a8c184-0f86-4119-81fa-bcc08780e983)

## After

![sats](https://github.com/btcpayserver/btcpayserver/assets/886/029984c8-3b91-4f1f-b8e1-a0559214cee5)
