### PR TITLE
[Bug] If a altcoins is disabled from BTCPay and payout processor is used, it would crash at restart

### DIFF
--- a/BTCPayServer/PayoutProcessors/PayoutProcessorService.cs
+++ b/BTCPayServer/PayoutProcessors/PayoutProcessorService.cs
@@ -136,7 +136,16 @@ public class PayoutProcessorService : EventHostedServiceBase
         if (matchedProcessor is not null)
         {
             await StopProcessor(data.Id, cancellationToken);
-            var processor = await matchedProcessor.ConstructProcessor(data);
+            IHostedService processor = null;
+            try
+            {
+                processor = await matchedProcessor.ConstructProcessor(data);
+            }
+            catch(Exception ex)
+            {
+                Logs.PayServer.LogWarning(ex, $"Payout processor ({data.PaymentMethod}) failed to start. Skipping...");
+                return;
+            }
             await processor.StartAsync(cancellationToken);
             Services.TryAdd(data.Id, processor);
         }


### PR DESCRIPTION
@astupidmoose reported that his btcpay was failing to start after disabling Dash with this exception.

```
Unhandled exception. System.ArgumentNullException: Value cannot be null. (Parameter 'network')
   at System.ArgumentNullException.Throw(String paramName)
   at System.ArgumentNullException.ThrowIfNull(Object argument, String paramName)
   at BTCPayServer.ExplorerClientProvider.GetExplorerClient(BTCPayNetworkBase network) in /source/BTCPayServer/ExplorerClientProvider.cs:line 86
   at BTCPayServer.Services.Fees.NBXplorerFeeProviderFactory.CreateFeeProvider(BTCPayNetworkBase network) in /source/BTCPayServer/Services/Fees/NBxplorerFeeProvider.cs:line 22
   at BTCPayServer.PayoutProcessors.OnChain.OnChainAutomatedPayoutProcessor..ctor(ApplicationDbContextFactory applicationDbContextFactory, ExplorerClientProvider explorerClientProvider, BTCPayWalletProvider btcPayWalletProvider, BTCPayNetworkJsonSerializerSettings btcPayNetworkJsonSerializerSettings, ILoggerFactory logger, BitcoinLikePayoutHandler bitcoinLikePayoutHandler, EventAggregator eventAggregator, WalletRepository walletRepository, StoreRepository storeRepository, PayoutProcessorData payoutProcesserSettings, PullPaymentHostedService pullPaymentHostedService, BTCPayNetworkProvider btcPayNetworkProvider, IPluginHookService pluginHookService, IFeeProviderFactory feeProviderFactory) in /source/BTCPayServer/PayoutProcessors/OnChain/OnChainAutomatedPayoutProcessor.cs:line 57
   at System.RuntimeMethodHandle.InvokeMethod(Object target, Span1& arguments, Signature sig, Boolean constructor, Boolean wrapExceptions)
   at System.Reflection.RuntimeConstructorInfo.Invoke(BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
   at Microsoft.Extensions.DependencyInjection.ActivatorUtilities.ConstructorMatcher.CreateInstance(IServiceProvider provider)
   at Microsoft.Extensions.DependencyInjection.ActivatorUtilities.CreateInstance(IServiceProvider provider, Type instanceType, Object[] parameters)
   at Microsoft.Extensions.DependencyInjection.ActivatorUtilities.CreateInstance[T](IServiceProvider provider, Object[] parameters)
   at BTCPayServer.PayoutProcessors.OnChain.OnChainAutomatedPayoutSenderFactory.ConstructProcessor(PayoutProcessorData settings) in /source/BTCPayServer/PayoutProcessors/OnChain/OnChainAutomatedPayoutSenderFactory.cs:line 61
   at BTCPayServer.PayoutProcessors.PayoutProcessorService.StartOrUpdateProcessor(PayoutProcessorData data, CancellationToken cancellationToken) in /source/BTCPayServer/PayoutProcessors/PayoutProcessorService.cs:line 139
   at BTCPayServer.PayoutProcessors.PayoutProcessorService.StartAsync(CancellationToken cancellationToken) in /source/BTCPayServer/PayoutProcessors/PayoutProcessorService.cs:line 119
   at Microsoft.AspNetCore.Hosting.HostedServiceExecutor.ExecuteAsync(Func2 callback, Boolean throwOnFirstFailure)
   at Microsoft.AspNetCore.Hosting.WebHost.StartAsync(CancellationToken cancellationToken)
   at Microsoft.AspNetCore.Hosting.WebHostExtensions.StartWithTasksAsync(IWebHost webHost, CancellationToken cancellationToken) in /source/BTCPayServer/Extensions/WebHostExtensions.cs:line 23
   at BTCPayServer.Program.Main(String[] args) in /source/BTCPayServer/Program.cs:line 76
```

This PR catch errors in the constructors of payouts and just skip them.