### PR TITLE
Pluginify on chain wallet setup

### DIFF
--- a/BTCPayServer.Client/BTCPayServer.Client.csproj
+++ b/BTCPayServer.Client/BTCPayServer.Client.csproj
@@ -12,6 +12,8 @@
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <RepositoryUrl>https://github.com/btcpayserver/btcpayserver</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
+        <Configurations>Debug;Release;Altcoins-Debug;Altcoins-Release</Configurations>
+        <Platforms>AnyCPU</Platforms>
     </PropertyGroup>
   <PropertyGroup>
     <Version Condition=" '$(Version)' == '' ">1.7.2</Version>

--- a/BTCPayServer/Controllers/UIStoresController.Onchain.cs
+++ b/BTCPayServer/Controllers/UIStoresController.Onchain.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.ObjectModel;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -250,7 +251,7 @@ namespace BTCPayServer.Controllers
                 CryptoCode = cryptoCode,
                 Method = method,
                 SetupRequest = request,
-                Confirmation = string.IsNullOrEmpty(request.ExistingMnemonic),
+                Confirmation = !isImport,
                 Network = network,
                 Source = isImport ? "SeedImported" : "NBXplorerGenerated",
                 IsHotWallet = isImport ? request.SavePrivateKeys : method == WalletSetupMethod.HotWallet,
@@ -270,6 +271,8 @@ namespace BTCPayServer.Controllers
             GenerateWalletResponse response;
             try
             {
+                if(request.AdditionalOptions is not null)
+                    ((GenerateWalletRequest)request).AdditionalOptions = new ReadOnlyDictionary<string, string>(request.AdditionalOptions);
                 response = await client.GenerateWalletAsync(request);
                 if (response == null)
                 {
@@ -311,7 +314,7 @@ namespace BTCPayServer.Controllers
 
             var result = await UpdateWallet(vm);
 
-            if (!ModelState.IsValid || !(result is RedirectToActionResult))
+            if (!ModelState.IsValid || result is not RedirectToActionResult)
                 return result;
 
             if (!isImport)

--- a/BTCPayServer/Models/StoreViewModels/WalletSetupRequest.cs
+++ b/BTCPayServer/Models/StoreViewModels/WalletSetupRequest.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using NBXplorer.Models;
 
 namespace BTCPayServer.Models.StoreViewModels
@@ -6,5 +7,7 @@ namespace BTCPayServer.Models.StoreViewModels
     {
         public bool PayJoinEnabled { get; set; }
         public bool CanUsePayJoin { get; set; }
+        
+        public new Dictionary<string, string> AdditionalOptions { get; set; }
     }
 }

--- a/BTCPayServer/Views/UIStores/_GenerateWalletForm.cshtml
+++ b/BTCPayServer/Views/UIStores/_GenerateWalletForm.cshtml
@@ -140,7 +140,13 @@
             </div>
         </div>
     </div>
-
+    @if (Model.AdditionalOptions is not null)
+    {
+        @foreach (var dictKeys in Model.AdditionalOptions)
+        {
+            <input type="hidden" asp-for="AdditionalOptions[dictKeys.Key]" />
+        }
+    }
     <button type="submit" class="btn btn-primary" id="Continue">@(isImport ? "Continue" : "Create")</button>
 </form>
 

--- a/BTCPayServer/Views/UIStores/_LayoutWalletSetup.cshtml
+++ b/BTCPayServer/Views/UIStores/_LayoutWalletSetup.cshtml
@@ -19,3 +19,5 @@
 }
 
 @RenderBody()
+
+<vc:ui-extension-point location="onchain-wallet-setup-post-body" model="@Model"/>


### PR DESCRIPTION
This PR fixes a few logical points in the wallet setup flow to allow more extensive plugin flexibility; It also fixes an issue when building plugins that requires an Altcoin config profile. Here is an example showcasing the Liquid+ plugin using this to enforce that it is a hot wallet (a requirement it has) and that import to RPC is always set, and a new option that is used to configure the wallet further https://i.imgur.com/pDPQ73v.gif