### PR TITLE
Remove payment requirement for marking expired invoices

### DIFF
--- a/BTCPayServer/Services/Invoices/InvoiceEntity.cs
+++ b/BTCPayServer/Services/Invoices/InvoiceEntity.cs
@@ -836,8 +836,8 @@ namespace BTCPayServer.Services.Invoices
         {
             return (Status == InvoiceStatusLegacy.Paid) ||
                    (Status == InvoiceStatusLegacy.New) ||
-                   ((Status == InvoiceStatusLegacy.New || Status == InvoiceStatusLegacy.Expired) && ExceptionStatus == InvoiceExceptionStatus.PaidPartial) ||
-                   ((Status == InvoiceStatusLegacy.New || Status == InvoiceStatusLegacy.Expired) && ExceptionStatus == InvoiceExceptionStatus.PaidLate) ||
+                   ((Status == InvoiceStatusLegacy.New || Status == InvoiceStatusLegacy.Expired)) ||
+                   ((Status == InvoiceStatusLegacy.New || Status == InvoiceStatusLegacy.Expired)) ||
                    (Status != InvoiceStatusLegacy.Complete && ExceptionStatus == InvoiceExceptionStatus.Marked) ||
                    (Status == InvoiceStatusLegacy.Invalid);
         }
@@ -846,8 +846,8 @@ namespace BTCPayServer.Services.Invoices
         {
             return (Status == InvoiceStatusLegacy.Paid) ||
                    (Status == InvoiceStatusLegacy.New) ||
-                   ((Status == InvoiceStatusLegacy.New || Status == InvoiceStatusLegacy.Expired) && ExceptionStatus == InvoiceExceptionStatus.PaidPartial) ||
-                   ((Status == InvoiceStatusLegacy.New || Status == InvoiceStatusLegacy.Expired) && ExceptionStatus == InvoiceExceptionStatus.PaidLate) ||
+                   ((Status == InvoiceStatusLegacy.New || Status == InvoiceStatusLegacy.Expired)) ||
+                   ((Status == InvoiceStatusLegacy.New || Status == InvoiceStatusLegacy.Expired)) ||
                    (Status != InvoiceStatusLegacy.Invalid && ExceptionStatus == InvoiceExceptionStatus.Marked);
         }
 

--- a/BTCPayServer/Services/Invoices/InvoiceEntity.cs
+++ b/BTCPayServer/Services/Invoices/InvoiceEntity.cs
@@ -834,20 +834,13 @@ namespace BTCPayServer.Services.Invoices
 
         public bool CanMarkComplete()
         {
-            return (Status == InvoiceStatusLegacy.Paid) ||
-                   (Status == InvoiceStatusLegacy.New) ||
-                   ((Status == InvoiceStatusLegacy.New || Status == InvoiceStatusLegacy.Expired)) ||
-                   ((Status == InvoiceStatusLegacy.New || Status == InvoiceStatusLegacy.Expired)) ||
-                   (Status != InvoiceStatusLegacy.Complete && ExceptionStatus == InvoiceExceptionStatus.Marked) ||
-                   (Status == InvoiceStatusLegacy.Invalid);
+            return Status is InvoiceStatusLegacy.New or InvoiceStatusLegacy.Paid or InvoiceStatusLegacy.Expired or InvoiceStatusLegacy.Invalid ||
+                   (Status != InvoiceStatusLegacy.Complete && ExceptionStatus == InvoiceExceptionStatus.Marked);
         }
 
         public bool CanMarkInvalid()
         {
-            return (Status == InvoiceStatusLegacy.Paid) ||
-                   (Status == InvoiceStatusLegacy.New) ||
-                   ((Status == InvoiceStatusLegacy.New || Status == InvoiceStatusLegacy.Expired)) ||
-                   ((Status == InvoiceStatusLegacy.New || Status == InvoiceStatusLegacy.Expired)) ||
+            return Status is InvoiceStatusLegacy.New or InvoiceStatusLegacy.Paid or InvoiceStatusLegacy.Expired ||
                    (Status != InvoiceStatusLegacy.Invalid && ExceptionStatus == InvoiceExceptionStatus.Marked);
         }
 


### PR DESCRIPTION
Allows to manually mark expired invoices, regardless of registered payments. See dennisreimann/btcpayserver-plugin-lnbank#34 for context, in which BTCPay Server sometimes did not register payments that were received to a LNbank wallet (this got fixed in btcpayserver/BTCPayServer.Lightning#129)