### PR TITLE
UI: Store selector link distinguishes between owner and user

### DIFF
--- a/BTCPayServer/Components/StoreSelector/Default.cshtml
+++ b/BTCPayServer/Components/StoreSelector/Default.cshtml
@@ -3,7 +3,6 @@
 @using BTCPayServer.Abstractions.Contracts
 @using BTCPayServer.Client
 @using BTCPayServer.Services
-@inject SignInManager<ApplicationUser> SignInManager
 @inject BTCPayServerEnvironment Env
 @inject IFileService FileService
 @model BTCPayServer.Components.StoreSelector.StoreSelectorViewModel
@@ -33,8 +32,7 @@
 else
 {
     <a asp-controller="UIStores" asp-action="Dashboard" permission="@Policies.CanModifyStoreSettings" asp-route-storeId="@Model.CurrentStoreId" id="StoreSelectorHome" class="navbar-brand py-2">@{await LogoContent();}</a>
-
-    <a asp-controller="UIInvoice" asp-action="ListInvoices" not-permission="@Policies.CanModifyStoreSettings"  asp-route-storeId="@Model.CurrentStoreId" id="StoreSelectorHome" class="navbar-brand py-2">@{await LogoContent();}</a>
+    <a asp-controller="UIInvoice" asp-action="ListInvoices" not-permission="@Policies.CanModifyStoreSettings" asp-route-storeId="@Model.CurrentStoreId" id="StoreSelectorHome" class="navbar-brand py-2">@{await LogoContent();}</a>
 }
 @if (Model.Options.Any())
 {

--- a/BTCPayServer/Components/StoreSelector/StoreSelector.cs
+++ b/BTCPayServer/Components/StoreSelector/StoreSelector.cs
@@ -1,5 +1,6 @@
 using System.Linq;
 using System.Threading.Tasks;
+using BTCPayServer.Client;
 using BTCPayServer.Data;
 using BTCPayServer.Services.Stores;
 using Microsoft.AspNetCore.Identity;
@@ -38,12 +39,14 @@ namespace BTCPayServer.Components.StoreSelector
                         .FirstOrDefault()?
                         .Network.CryptoCode;
                     var walletId = cryptoCode != null ? new WalletId(store.Id, cryptoCode) : null;
+                    var role = store.GetStoreRoleOfUser(userId);
                     return new StoreSelectorOption
                     {
                         Text = store.StoreName,
                         Value = store.Id,
                         Selected = store.Id == currentStore?.Id,
-                        WalletId = walletId
+                        WalletId = walletId,
+                        IsOwner = role != null && role.Permissions.Contains(Policies.CanModifyStoreSettings)
                     };
                 })
                 .OrderBy(s => s.Text)


### PR DESCRIPTION
The `IsOwner` property went missing with #4940, so everyone landed on the invoices list when switching stores. This brings back the original behaviour of linking to the Dashboard, if the user has the permission to access it.

Fixes #5015.