### PR TITLE
Pull Payment: Support LNURL Withdraw with SATS denomination

### DIFF
--- a/BTCPayServer.Tests/GreenfieldAPITests.cs
+++ b/BTCPayServer.Tests/GreenfieldAPITests.cs
@@ -1074,6 +1074,22 @@ namespace BTCPayServer.Tests
             var lnrURLs = await unauthenticated.GetPullPaymentLNURL(test4.Id);
             Assert.IsType<string>(lnrURLs.LNURLBech32);
             Assert.IsType<string>(lnrURLs.LNURLUri);
+            Assert.Equal(12.303228134m, test4.Amount);
+            Assert.Equal("BTC", test4.Currency);
+            
+            // Test with SATS denomination values
+            var testSats = await client.CreatePullPayment(storeId, new Client.Models.CreatePullPaymentRequest()
+            {
+                Name = "Test SATS",
+                Amount = 21000,
+                Currency = "SATS",
+                PaymentMethods = new[] { "BTC", "BTC-LightningNetwork", "BTC_LightningLike" }
+            });
+            lnrURLs = await unauthenticated.GetPullPaymentLNURL(testSats.Id);
+            Assert.IsType<string>(lnrURLs.LNURLBech32);
+            Assert.IsType<string>(lnrURLs.LNURLUri);
+            Assert.Equal(21000, testSats.Amount);
+            Assert.Equal("SATS", testSats.Currency);
 
             //permission test around auto approved pps and payouts
             var nonApproved = await acc.CreateClient(Policies.CanCreateNonApprovedPullPayments);

--- a/BTCPayServer/Controllers/GreenField/GreenfieldPullPaymentController.cs
+++ b/BTCPayServer/Controllers/GreenField/GreenfieldPullPaymentController.cs
@@ -255,16 +255,15 @@ namespace BTCPayServer.Controllers.Greenfield
                 return PullPaymentNotFound();
 
             var blob = pp.GetBlob();
-            var pms = blob.SupportedPaymentMethods.FirstOrDefault(id => id.PaymentType == LightningPaymentType.Instance && _networkProvider.DefaultNetwork.CryptoCode == id.CryptoCode);
-            if (pms is not null && blob.Currency.Equals(pms.CryptoCode, StringComparison.InvariantCultureIgnoreCase))
+            if (_pullPaymentService.SupportsLNURL(blob))
             {
                 var lnurlEndpoint = new Uri(Url.Action("GetLNURLForPullPayment", "UILNURL", new
                 {
                     cryptoCode = _networkProvider.DefaultNetwork.CryptoCode,
-                    pullPaymentId = pullPaymentId
+                    pullPaymentId
                 }, Request.Scheme, Request.Host.ToString())!);
 
-                return base.Ok(new PullPaymentLNURL()
+                return base.Ok(new PullPaymentLNURL
                 {
                     LNURLBech32 = LNURL.LNURL.EncodeUri(lnurlEndpoint, "withdrawRequest", true).ToString(),
                     LNURLUri = LNURL.LNURL.EncodeUri(lnurlEndpoint, "withdrawRequest", false).ToString()

--- a/BTCPayServer/Controllers/UILNURLController.cs
+++ b/BTCPayServer/Controllers/UILNURLController.cs
@@ -108,9 +108,8 @@ namespace BTCPayServer
                 return NotFound();
             }
 
-            var lnurlSupportedCurrencies = new [] { "BTC", "SATS" };
             var blob = pp.GetBlob();
-            if (!lnurlSupportedCurrencies.Contains(blob.Currency))
+            if (!_pullPaymentHostedService.SupportsLNURL(blob))
             {
                 return NotFound();
             }

--- a/BTCPayServer/Controllers/UILNURLController.cs
+++ b/BTCPayServer/Controllers/UILNURLController.cs
@@ -108,25 +108,26 @@ namespace BTCPayServer
                 return NotFound();
             }
 
+            var lnurlSupportedCurrencies = new [] { "BTC", "SATS" };
             var blob = pp.GetBlob();
-            if (!blob.Currency.Equals(cryptoCode, StringComparison.InvariantCultureIgnoreCase))
+            if (!lnurlSupportedCurrencies.Contains(blob.Currency))
             {
                 return NotFound();
             }
 
+            var unit = blob.Currency == "SATS" ? LightMoneyUnit.Satoshi : LightMoneyUnit.BTC;
             var progress = _pullPaymentHostedService.CalculatePullPaymentProgress(pp, DateTimeOffset.UtcNow);
-
             var remaining = progress.Limit - progress.Completed - progress.Awaiting;
             var request = new LNURLWithdrawRequest
             {
-                MaxWithdrawable = LightMoney.FromUnit(remaining, LightMoneyUnit.BTC),
+                MaxWithdrawable = LightMoney.FromUnit(remaining, unit),
                 K1 = pullPaymentId,
                 BalanceCheck = new Uri(Request.GetCurrentUrl()),
-                CurrentBalance = LightMoney.FromUnit(remaining, LightMoneyUnit.BTC),
+                CurrentBalance = LightMoney.FromUnit(remaining, unit),
                 MinWithdrawable =
                     LightMoney.FromUnit(
                         Math.Min(await _lightningLikePayoutHandler.GetMinimumPayoutAmount(pmi, null), remaining),
-                        LightMoneyUnit.BTC),
+                        unit),
                 Tag = "withdrawRequest",
                 Callback = new Uri(Request.GetCurrentUrl()),
                 // It's not `pp.GetBlob().Description` because this would be HTML
@@ -154,13 +155,13 @@ namespace BTCPayServer
                 return NotFound();
             }
 
-            var claimResponse = await _pullPaymentHostedService.Claim(new ClaimRequest()
+            var claimResponse = await _pullPaymentHostedService.Claim(new ClaimRequest
             {
                 Destination = new BoltInvoiceClaimDestination(pr, result),
                 PaymentMethodId = pmi,
                 PullPaymentId = pullPaymentId,
                 StoreId = pp.StoreId,
-                Value = result.MinimumAmount.ToDecimal(LightMoneyUnit.BTC)
+                Value = result.MinimumAmount.ToDecimal(unit)
             });
 
             if (claimResponse.Result != ClaimRequest.ClaimResult.Ok)

--- a/BTCPayServer/HostedServices/PullPaymentHostedService.cs
+++ b/BTCPayServer/HostedServices/PullPaymentHostedService.cs
@@ -46,6 +46,8 @@ namespace BTCPayServer.HostedServices
 
     public class PullPaymentHostedService : BaseAsyncService
     {
+        private readonly string[] _lnurlSupportedCurrencies = { "BTC", "SATS" };
+        
         public class CancelRequest
         {
             public CancelRequest(string pullPaymentId)
@@ -335,6 +337,14 @@ namespace BTCPayServer.HostedServices
                     }
                 }
             }
+        }
+
+        public bool SupportsLNURL(PullPaymentBlob blob)
+        {
+            var pms = blob.SupportedPaymentMethods.FirstOrDefault(id => 
+                id.PaymentType == LightningPaymentType.Instance && 
+                _networkProvider.DefaultNetwork.CryptoCode == id.CryptoCode);
+            return pms is not null && _lnurlSupportedCurrencies.Contains(blob.Currency);
         }
 
         public Task<RateResult> GetRate(PayoutData payout, string explicitRateRule, CancellationToken cancellationToken)

--- a/BTCPayServer/Models/ViewPullPaymentModel.cs
+++ b/BTCPayServer/Models/ViewPullPaymentModel.cs
@@ -96,6 +96,7 @@ namespace BTCPayServer.Models
         public DateTimeOffset StartDate { get; set; }
         public DateTime LastRefreshed { get; set; }
         public CurrencyData CurrencyData { get; set; }
+        public Uri LnurlEndpoint { get; set; }
         public bool Archived { get; set; }
         public bool AutoApprove { get; set; }
 

--- a/BTCPayServer/Views/UIPullPayment/ViewPullPayment.cshtml
+++ b/BTCPayServer/Views/UIPullPayment/ViewPullPayment.cshtml
@@ -26,12 +26,12 @@
         }
     }
     
-    
     string lnurl = null;
     string lnurlUri = null;
-
+    var lnurlSupportedCurrencies = new [] { "BTC", "SATS" };
+    
     var pms = Model.PaymentMethods.FirstOrDefault(id => id.PaymentType == LightningPaymentType.Instance && BtcPayNetworkProvider.DefaultNetwork.CryptoCode == id.CryptoCode);
-    if (pms is not null && Model.Currency.Equals(pms.CryptoCode, StringComparison.InvariantCultureIgnoreCase))
+    if (pms is not null && lnurlSupportedCurrencies.Contains(Model.Currency))
     {
         var lnurlEndpoint = new Uri(Url.Action("GetLNURLForPullPayment", "UILNURL", new
         {

--- a/BTCPayServer/Views/UIPullPayment/ViewPullPayment.cshtml
+++ b/BTCPayServer/Views/UIPullPayment/ViewPullPayment.cshtml
@@ -1,11 +1,9 @@
 @using BTCPayServer.Client
-@using BTCPayServer.Payments
 @using BTCPayServer.Services
 @using Microsoft.AspNetCore.Mvc.TagHelpers
 @using BTCPayServer.Abstractions.TagHelpers
 @inject BTCPayServer.Security.ContentSecurityPolicies Csp
 @inject BTCPayServerEnvironment Env
-@inject BTCPayNetworkProvider BtcPayNetworkProvider
 @inject DisplayFormatter DisplayFormatter
 @model BTCPayServer.Models.ViewPullPaymentModel
 @{
@@ -24,22 +22,6 @@
             default:
                 return "bg-warning";
         }
-    }
-    
-    string lnurl = null;
-    string lnurlUri = null;
-    var lnurlSupportedCurrencies = new [] { "BTC", "SATS" };
-    
-    var pms = Model.PaymentMethods.FirstOrDefault(id => id.PaymentType == LightningPaymentType.Instance && BtcPayNetworkProvider.DefaultNetwork.CryptoCode == id.CryptoCode);
-    if (pms is not null && lnurlSupportedCurrencies.Contains(Model.Currency))
-    {
-        var lnurlEndpoint = new Uri(Url.Action("GetLNURLForPullPayment", "UILNURL", new
-        {
-            cryptoCode = pms.CryptoCode,
-            pullPaymentId = Model.Id
-        }, Context.Request.Scheme, Context.Request.Host.ToString()));
-        lnurl = LNURL.LNURL.EncodeUri(lnurlEndpoint, "withdrawRequest", true).ToString();
-        lnurlUri = LNURL.LNURL.EncodeUri(lnurlEndpoint, "withdrawRequest", false).ToString();
     }
 }
 <!DOCTYPE html>
@@ -62,7 +44,7 @@
                         <div class="row align-items-center" style="width:calc(100% + 30px)">
                             <div class="col-12 mb-3 col-lg-6 mb-lg-0">
                                 <div class="input-group">
-                                    @if (lnurl is not null)
+                                    @if (Model.LnurlEndpoint is not null)
                                     {
                                         <button type="button" class="input-group-prepend btn btn-outline-secondary" id="lnurlwithdraw-button" data-bs-toggle="modal" data-bs-target="#scan-qr-modal">
                                             <span class="fa fa-qrcode  fa-2x" title="LNURL-Withdraw"></span>
@@ -223,8 +205,10 @@
         </footer>
     </div>
     <partial name="LayoutFoot" />
-  @if (lnurl is not null)
+  @if (Model.LnurlEndpoint is not null)
   {
+      var lnurlUri = LNURL.LNURL.EncodeUri(Model.LnurlEndpoint, "withdrawRequest", false).ToString();
+      var lnurlBech32 = LNURL.LNURL.EncodeUri(Model.LnurlEndpoint, "withdrawRequest", true).ToString();
       var note = "You can scan or open this link with a <a href='https://github.com/fiatjaf/lnurl-rfc#lnurl-documents' target='_blank' rel='noreferrer noopener'>LNURL-Withdraw</a> enabled wallet.";
       if (!Model.AutoApprove)
       {
@@ -237,7 +221,7 @@
         document.addEventListener("DOMContentLoaded", () => {
             const modes = {
                 uri: { title: "URI", fragments: [@Safe.Json(lnurlUri)], showData: true, href: @Safe.Json(lnurlUri) },
-                bech32: { title: "Bech32", fragments: [@Safe.Json(lnurl)], showData: true, href: @Safe.Json(lnurl) }
+                bech32: { title: "Bech32", fragments: [@Safe.Json(lnurlBech32)], showData: true, href: @Safe.Json(lnurlBech32) }
             };
             initQRShow({ title: "LNURL Withdraw", note: @Safe.Json(note), modes })
     });


### PR DESCRIPTION
Currently the LNURL Withdraw feature is only active for pull payments denominated in BTC. This PR extends it to the SATS denomination as well.

![sats-denominated](https://github.com/btcpayserver/btcpayserver/assets/886/9720cc5a-495c-435c-a74d-ade82511e4e3)
