### PR TITLE
Pay Button: Fix circular reference when serializing JSON

### DIFF
--- a/BTCPayServer/Plugins/PayButton/Controllers/UIPayButtonController.cs
+++ b/BTCPayServer/Plugins/PayButton/Controllers/UIPayButtonController.cs
@@ -60,6 +60,11 @@ namespace BTCPayServer.Plugins.PayButton.Controllers
             }
 
             var apps = await _appService.GetAllApps(_userManager.GetUserId(User), false, store.Id);
+            // unset app store data, because we don't need it and inclusion leads to circular references when serializing to JSON
+            foreach (var app in apps)
+            {
+                app.App.StoreData = null;
+            }
             var appUrl = HttpContext.Request.GetAbsoluteRoot().WithTrailingSlash();
             var model = new PayButtonViewModel
             {


### PR DESCRIPTION
When apps were set, the `GetAllApps` included the store data, which led to a circular reference when serializing the JSON. That data isn't necessary here, so we can just drop it before rendering.

Fixes #5038.