### PR TITLE
API docs: Remove id from create webhook endpoint; fix consistency.

### DIFF
--- a/BTCPayServer/wwwroot/swagger/v1/swagger.template.webhooks.json
+++ b/BTCPayServer/wwwroot/swagger/v1/swagger.template.webhooks.json
@@ -68,7 +68,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/WebhookDataCreate"
+                                    "$ref": "#/components/schemas/WebhookDataCreateResult"
                                 }
                             }
                         }
@@ -527,9 +527,6 @@
             "WebhookData": {
                 "allOf": [
                     {
-                        "$ref": "#/components/schemas/WebhookDataBase"
-                    },
-                    {
                         "type": "object",
                         "properties": {
                             "id": {
@@ -538,10 +535,30 @@
                                 "nullable": false
                             }
                         }
+                    },
+                    {
+                        "$ref": "#/components/schemas/WebhookDataBase"
                     }
                 ]
             },
             "WebhookDataCreate": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/WebhookDataBase"
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "secret": {
+                                "type": "string",
+                                "description": "Must be used by the callback receiver to ensure the delivery comes from BTCPay Server. BTCPay Server includes the `BTCPay-Sig` HTTP header, whose format is `sha256=HMAC256(UTF8(webhook's secret), body)`. The pattern to authenticate the webhook is similar to [how to secure webhooks in Github](https://docs.github.com/webhooks/securing/). If left out, null, or empty, the secret will be auto-generated.",
+                                "nullable": true
+                            }
+                        }
+                    }
+                ]
+            },
+            "WebhookDataCreateResult": {
                 "allOf": [
                     {
                         "$ref": "#/components/schemas/WebhookData"
@@ -551,8 +568,8 @@
                         "properties": {
                             "secret": {
                                 "type": "string",
-                                "description": "Must be used by the callback receiver to ensure the delivery comes from BTCPay Server. BTCPay Server includes the `BTCPay-Sig` HTTP header, whose format is `sha256=HMAC256(UTF8(webhook's secret), body)`. The pattern to authenticate the webhook is similar to [how to secure webhooks in Github](https://docs.github.com/webhooks/securing/).",
-                                "nullable": false
+                                "description": "Must be used by the callback receiver to ensure the delivery comes from BTCPay Server. BTCPay Server includes the `BTCPay-Sig` HTTP header, whose format is `sha256=HMAC256(UTF8(webhook's secret), body)`. The pattern to authenticate the webhook is similar to [how to secure webhooks in Github](https://docs.github.com/webhooks/securing/). Value of the auto-generated or custom secret.",
+                                "nullable": true
                             }
                         }
                     }
@@ -579,11 +596,6 @@
                 "type": "object",
                 "additionalProperties": false,
                 "properties": {
-                    "id": {
-                        "type": "string",
-                        "description": "The id of the webhook",
-                        "nullable": false
-                    },
                     "enabled": {
                         "type": "boolean",
                         "description": "Whether this webhook is enabled or not",


### PR DESCRIPTION
This fixes ID beeing wrongly in the request body of the create webhook call, see https://chat.btcpayserver.org/btcpayserver/pl/ha1tuw335pdhtjzfo4qzgg9zdo

I needed to change the schema a bit but now it makes imo more sense, WebhookDataBase is now without ID and the WebhookData is with ID. 

Also the responses from the PUT and POST are different, while the POST (create webhook) does return the `secret` the PUT (update webhook) does not (tested the api calls to be sure). Not sure if this should stay this way or if we want to have the PUT same response as the POST, let me know.

2 Problems (see screenshot below):

1. on the PUT (update webhook) the `secret` was nullable which is correct but on the POST (create webhook) it was not marked nullable although it is - as the secret will get autocreated in that case. Problem is I left PUT same and changed it on POST but now both do not show up as nullable on my regtest env? (see also https://docs.btcpayserver.org/API/Greenfield/v1/#operation/Webhooks_UpdateWebhook)

2. Without changing any major structure or sorting the events are now shown above the endpoints for me, no idea why. 

![image](https://github.com/btcpayserver/btcpayserver/assets/1136761/a48a22e4-e4cb-48af-8473-29a54f0b90ac)
