### PR TITLE
Swap crypto amount for fiat amount in checkout v2 header

### DIFF
--- a/BTCPayServer.Tests/Checkoutv2Tests.cs
+++ b/BTCPayServer.Tests/Checkoutv2Tests.cs
@@ -115,6 +115,7 @@ namespace BTCPayServer.Tests
             Assert.Contains("BTC Lightning settings successfully updated", s.FindAlertMessage().Text);
             s.GoToInvoiceCheckout(invoiceId);
             s.Driver.WaitUntilAvailable(By.Id("Checkout-v2"));
+            s.Driver.ToggleCollapse("PaymentDetails");
             Assert.Contains("sats", s.Driver.FindElement(By.Id("PaymentDetails-TotalPrice")).Text);
 
             // Details should not show exchange rate

--- a/BTCPayServer.Tests/Checkoutv2Tests.cs
+++ b/BTCPayServer.Tests/Checkoutv2Tests.cs
@@ -264,7 +264,7 @@ namespace BTCPayServer.Tests
             s.GoToInvoiceCheckout(invoiceId);
             s.Driver.WaitUntilAvailable(By.Id("Checkout-v2"));
             Assert.Empty(s.Driver.FindElements(By.CssSelector(".payment-method")));
-            Assert.Contains("BTC", s.Driver.FindElement(By.Id("AmountDue")).Text);
+            Assert.Contains("$", s.Driver.FindElement(By.Id("AmountDue")).Text);
             qrValue = s.Driver.FindElement(By.CssSelector(".qr-container")).GetAttribute("data-qr-value");
             address = s.Driver.FindElement(By.CssSelector(".qr-container")).GetAttribute("data-clipboard");
             payUrl = s.Driver.FindElement(By.Id("PayInWallet")).GetAttribute("href");
@@ -295,7 +295,7 @@ namespace BTCPayServer.Tests
             Assert.Contains("Store successfully updated", s.FindAlertMessage().Text);
             s.GoToInvoiceCheckout(invoiceId);
             s.Driver.WaitUntilAvailable(By.Id("Checkout-v2"));
-            Assert.Contains("sats", s.Driver.FindElement(By.Id("AmountDue")).Text);
+            Assert.Contains("$", s.Driver.FindElement(By.Id("AmountDue")).Text);
 
             // Check details
             s.Driver.ToggleCollapse("PaymentDetails");

--- a/BTCPayServer.Tests/Checkoutv2Tests.cs
+++ b/BTCPayServer.Tests/Checkoutv2Tests.cs
@@ -106,7 +106,8 @@ namespace BTCPayServer.Tests
             s.Driver.ElementDoesNotExist(By.Id("Address_BTC"));
 
             // Lightning amount in sats
-            Assert.Contains("BTC", s.Driver.FindElement(By.Id("AmountDue")).Text);
+            s.Driver.ToggleCollapse("PaymentDetails");
+            Assert.Contains("BTC", s.Driver.FindElement(By.Id("PaymentDetails-TotalPrice")).Text);
             s.GoToHome();
             s.GoToLightningSettings();
             s.Driver.SetCheckbox(By.Id("LightningAmountInSatoshi"), true);
@@ -114,10 +115,9 @@ namespace BTCPayServer.Tests
             Assert.Contains("BTC Lightning settings successfully updated", s.FindAlertMessage().Text);
             s.GoToInvoiceCheckout(invoiceId);
             s.Driver.WaitUntilAvailable(By.Id("Checkout-v2"));
-            Assert.Contains("sats", s.Driver.FindElement(By.Id("AmountDue")).Text);
+            Assert.Contains("sats", s.Driver.FindElement(By.Id("PaymentDetails-TotalPrice")).Text);
 
             // Details should not show exchange rate
-            s.Driver.ToggleCollapse("PaymentDetails");
             s.Driver.ElementDoesNotExist(By.Id("PaymentDetails-ExchangeRate"));
             s.Driver.ElementDoesNotExist(By.Id("PaymentDetails-TotalFiat"));
             s.Driver.ElementDoesNotExist(By.Id("PaymentDetails-RecommendedFee"));

--- a/BTCPayServer/Views/UIInvoice/CheckoutV2.cshtml
+++ b/BTCPayServer/Views/UIInvoice/CheckoutV2.cshtml
@@ -48,7 +48,7 @@
                     }
                     else
                     {
-                        <h2 id="AmountDue" v-text="`${srvModel.btcDue} ${srvModel.cryptoCode}`" :data-clipboard="srvModel.btcDue" data-clipboard-hover :data-amount-due="srvModel.btcDue">@Model.BtcDue @Model.CryptoCode</h2>
+                        <h2 id="AmountDue" v-text="`${srvModel.orderAmountFiat}`" :data-clipboard="srvModel.orderAmountFiat" data-clipboard-hover :data-amount-due="srvModel.btcDue">@Model.OrderAmountFiat</h2>
                     }
                 </div>
                 <div id="PaymentInfo" class="info mt-3 mb-2" v-collapsible="showInfo">


### PR DESCRIPTION
The #1 piece of user feedback we've received about the point of sale checkout flow was to display the fiat amount prominently. Normies don't care about the sat amount due, they care about the fiat amount due. This change shows the fiat amount above the fold, and interested users can click View Details to view the sat amount due.