### PR TITLE
Crowdfund: Fix null pointer exception for topup type (missing price)

### DIFF
--- a/BTCPayServer/Views/Shared/Crowdfund/Public/ContributeForm.cshtml
+++ b/BTCPayServer/Views/Shared/Crowdfund/Public/ContributeForm.cshtml
@@ -1,4 +1,3 @@
-@using BTCPayServer.Models.AppViewModels
 @using BTCPayServer.Plugins.PointOfSale.Models
 @model BTCPayServer.Plugins.Crowdfund.Models.ContributeToCrowdfund
 
@@ -28,7 +27,7 @@
                         @(string.IsNullOrEmpty(item.Title) ? item.Id : item.Title)
                     </label>
                     <span class="text-muted">
-                        @if (item.Price.Value > 0)
+                        @if (item.Price is > 0)
                         {
                             <span>@item.Price.Value</span>
                             <span>@vm.TargetCurrency</span>


### PR DESCRIPTION
Items with type topup have a price = null and hence not even the property set (ignored in JSON). This needs to be handled in the temlate, otherwise this exception occurs:

```
An unhandled exception was thrown by the application.
System.InvalidOperationException: Nullable object must have a value.
   at AspNetCoreGeneratedDocument.Views_Shared_Crowdfund_Public_ContributeForm.<>c__DisplayClass24_0.<<ExecuteAsync>b__0>d.MoveNext()
```