### PR TITLE
Do not crash when an invoice have an amount that is too big

### DIFF
--- a/BTCPayServer.Tests/UnitTest1.cs
+++ b/BTCPayServer.Tests/UnitTest1.cs
@@ -39,6 +39,7 @@ using BTCPayServer.Plugins.PayButton;
 using BTCPayServer.Plugins.PointOfSale;
 using BTCPayServer.Plugins.PointOfSale.Controllers;
 using BTCPayServer.Security.Bitpay;
+using BTCPayServer.Security.Greenfield;
 using BTCPayServer.Services;
 using BTCPayServer.Services.Apps;
 using BTCPayServer.Services.Invoices;
@@ -1984,6 +1985,7 @@ namespace BTCPayServer.Tests
             var user = tester.NewAccount();
             user.GrantAccess(true);
             user.RegisterDerivationScheme("BTC");
+            var btcpayClient = await user.CreateClient();
 
             DateTimeOffset expiration = DateTimeOffset.UtcNow + TimeSpan.FromMinutes(21);
 
@@ -2064,6 +2066,20 @@ namespace BTCPayServer.Tests
 
             var zeroInvoicePM = await greenfield.GetInvoicePaymentMethods(user.StoreId, zeroInvoice.Id);
             Assert.Empty(zeroInvoicePM);
+
+            var invoice6 = await btcpayClient.CreateInvoice(user.StoreId,
+                new CreateInvoiceRequest()
+                {
+                    Amount = GreenfieldConstants.MaxAmount,
+                    Currency = "USD"
+                });
+            var repo = tester.PayTester.GetService<InvoiceRepository>();
+            var entity = (await repo.GetInvoice(invoice6.Id));
+            Assert.Equal((decimal)ulong.MaxValue, entity.Price);
+            entity.GetPaymentMethods().First().Calculate();
+            // Shouldn't be possible as we clamp the value, but existing invoice may have that
+            entity.Price = decimal.MaxValue;
+            entity.GetPaymentMethods().First().Calculate();
         }
 
         [Fact(Timeout = LongRunningTestTimeout)]

--- a/BTCPayServer/Controllers/GreenField/GreenfieldInvoiceController.cs
+++ b/BTCPayServer/Controllers/GreenField/GreenfieldInvoiceController.cs
@@ -12,6 +12,7 @@ using BTCPayServer.Data;
 using BTCPayServer.HostedServices;
 using BTCPayServer.Payments;
 using BTCPayServer.Rating;
+using BTCPayServer.Security.Greenfield;
 using BTCPayServer.Services;
 using BTCPayServer.Services.Invoices;
 using BTCPayServer.Services.Rates;
@@ -182,6 +183,10 @@ namespace BTCPayServer.Controllers.Greenfield
             if (request.Amount < 0.0m)
             {
                 ModelState.AddModelError(nameof(request.Amount), "The amount should be 0 or more.");
+            }
+            if (request.Amount > GreenfieldConstants.MaxAmount)
+            {
+                ModelState.AddModelError(nameof(request.Amount), $"The amount should less than {GreenfieldConstants.MaxAmount}.");
             }
             request.Checkout ??= new CreateInvoiceRequest.CheckoutOptions();
             if (request.Checkout.PaymentMethods?.Any() is true)

--- a/BTCPayServer/Controllers/UIInvoiceController.cs
+++ b/BTCPayServer/Controllers/UIInvoiceController.cs
@@ -17,6 +17,7 @@ using BTCPayServer.Payments;
 using BTCPayServer.Payments.Bitcoin;
 using BTCPayServer.Rating;
 using BTCPayServer.Security;
+using BTCPayServer.Security.Greenfield;
 using BTCPayServer.Services;
 using BTCPayServer.Services.Apps;
 using BTCPayServer.Services.Invoices;
@@ -126,6 +127,14 @@ namespace BTCPayServer.Controllers
             if (entity.ExpirationTime - TimeSpan.FromSeconds(30.0) < entity.InvoiceTime)
             {
                 throw new BitpayHttpException(400, "The expirationTime is set too soon");
+            }
+            if (entity.Price < 0.0m)
+            {
+                throw new BitpayHttpException(400, "The price should be 0 or more.");
+            }
+            if (entity.Price > GreenfieldConstants.MaxAmount)
+            {
+                throw new BitpayHttpException(400, $"The price should less than {GreenfieldConstants.MaxAmount}.");
             }
             entity.Metadata.OrderId = invoice.OrderId;
             entity.Metadata.PosDataLegacy = invoice.PosData;
@@ -278,6 +287,7 @@ namespace BTCPayServer.Controllers
             if (string.IsNullOrEmpty(entity.Currency))
                 entity.Currency = storeBlob.DefaultCurrency;
             entity.Currency = entity.Currency.Trim().ToUpperInvariant();
+            entity.Price = Math.Min(GreenfieldConstants.MaxAmount, entity.Price);
             entity.Price = Math.Max(0.0m, entity.Price);
             var currencyInfo = _CurrencyNameTable.GetNumberFormatInfo(entity.Currency, false);
             if (currencyInfo != null)

--- a/BTCPayServer/Extensions.cs
+++ b/BTCPayServer/Extensions.cs
@@ -105,16 +105,23 @@ namespace BTCPayServer
 
         public static decimal RoundUp(decimal value, int precision)
         {
-            for (int i = 0; i < precision; i++)
+            try
             {
-                value = value * 10m;
+                for (int i = 0; i < precision; i++)
+                {
+                    value = value * 10m;
+                }
+                value = Math.Ceiling(value);
+                for (int i = 0; i < precision; i++)
+                {
+                    value = value / 10m;
+                }
+                return value;
             }
-            value = Math.Ceiling(value);
-            for (int i = 0; i < precision; i++)
+            catch (OverflowException)
             {
-                value = value / 10m;
+                return value;
             }
-            return value;
         }
 
         public static IServiceCollection AddScheduledTask<T>(this IServiceCollection services, TimeSpan every)

--- a/BTCPayServer/Security/GreenField/GreenFieldConstants.cs
+++ b/BTCPayServer/Security/GreenField/GreenFieldConstants.cs
@@ -2,6 +2,7 @@ namespace BTCPayServer.Security.Greenfield
 {
     public static class GreenfieldConstants
     {
+        public const decimal MaxAmount = ulong.MaxValue;
         public const string AuthenticationType = "Greenfield";
 
         public static class ClaimTypes


### PR DESCRIPTION
User reported

```
fail: PayServer:      Unhandled error on watching invoice CUvkPDYMaxJUeEi8eG7dN8
System.OverflowException: Value was either too large or too small for an Int64.
   at System.Decimal.ToInt64(Decimal d)
   at NBitcoin.Money.Coins(Decimal coins)
   at BTCPayServer.Services.Invoices.PaymentMethod.Calculate(Func`2 paymentPredicate)
   at BTCPayServer.HostedServices.InvoiceWatcher.GetNearestClearedPayment(PaymentMethodDictionary allPaymentMethods, PaymentMethodAccounting& accounting) in /source/BTCPayServer/HostedServices/InvoiceWatcher.cs:line 213
   at BTCPayServer.HostedServices.InvoiceWatcher.UpdateInvoice(UpdateInvoiceContext context)
   at BTCPayServer.HostedServices.InvoiceWatcher.StartLoop(CancellationToken cancellation) in /source/BTCPayServer/HostedServices/InvoiceWatcher.cs:line 320
```

I can reproduce.

My fix is just to catch such exception and return max values so it doesn't crash. (Calls to `Calculate` aren't expecting exceptions)
Those exception only happen if a too high amount is set on the invoice, as such I think it is safe to just return garbage which doesn't throw in this case.

I also prevent a value that is too big in Greenfield. If we call `CreateInvoiceRaw` without validating and the value is too big, I just clamp the value to the max amount `ulong.Max`.