### PR TITLE
Fix: Incorrect rounding in the receipt of PoS invoice (fix #5071)

### DIFF
--- a/BTCPayServer.Rating/Extensions.cs
+++ b/BTCPayServer.Rating/Extensions.cs
@@ -15,7 +15,7 @@ namespace BTCPayServer.Rating
                 while (true)
                 {
                     var rounded = decimal.Round(value, divisibility, MidpointRounding.AwayFromZero);
-                    if ((Math.Abs(rounded - value) / value) < 0.001m)
+                    if ((Math.Abs(rounded - value) / value) < 0.01m)
                     {
                         value = rounded;
                         break;


### PR DESCRIPTION
Fix #5071 and fixes #5055.

The problem is that we would still show more decimal if the amount it was representing was more than 0.1% of the value we were rounding.

I changed it to 1%.