### PR TITLE
Lightning: Relax GetInfo constraint for LNDhub connections

### DIFF
--- a/BTCPayServer/BTCPayServer.csproj
+++ b/BTCPayServer/BTCPayServer.csproj
@@ -48,7 +48,7 @@
     <PackageReference Include="YamlDotNet" Version="8.0.0" />
     <PackageReference Include="BIP78.Sender" Version="0.2.2" />
     <PackageReference Include="BTCPayServer.Hwi" Version="2.0.2" />
-    <PackageReference Include="BTCPayServer.Lightning.All" Version="1.4.26" />
+    <PackageReference Include="BTCPayServer.Lightning.All" Version="1.4.27" />
     <PackageReference Include="CsvHelper" Version="15.0.5" />
     <PackageReference Include="Dapper" Version="2.0.123" />
     <PackageReference Include="Fido2" Version="2.0.2" />

--- a/BTCPayServer/Payments/Lightning/LightningLikePaymentHandler.cs
+++ b/BTCPayServer/Payments/Lightning/LightningLikePaymentHandler.cs
@@ -123,11 +123,16 @@ namespace BTCPayServer.Payments.Lightning
         {
             if (!_Dashboard.IsFullySynched(network.CryptoCode, out var summary))
                 throw new PaymentMethodUnavailableException("Full node not available");
-
+            
             try
             {
                 using var cts = new CancellationTokenSource(LightningTimeout);
                 var client = CreateLightningClient(supportedPaymentMethod, network);
+
+                // LNDhub-compatible implementations might not offer all of GetInfo data.
+                // Skip checks in those cases, see https://github.com/lnbits/lnbits/issues/1182
+                var isLndHub = client is LndHubLightningClient;
+                
                 LightningNodeInformation info;
                 try
                 {
@@ -137,8 +142,8 @@ namespace BTCPayServer.Payments.Lightning
                 {
                     throw new PaymentMethodUnavailableException("The lightning node did not reply in a timely manner");
                 }
-                catch (NullReferenceException) when (client is LndHubLightningClient)
-                {   // LNDhub-compatible implementation by LNbits does not support GetInfo, see https://github.com/lnbits/lnbits/issues/1182
+                catch (NotSupportedException) when (isLndHub)
+                {
                     return new NodeInfo[] {};
                 }
                 catch (Exception ex)
@@ -151,9 +156,9 @@ namespace BTCPayServer.Payments.Lightning
                 var nodeInfo = preferOnion != null && info.NodeInfoList.Any(i => i.IsTor == preferOnion)
                     ? info.NodeInfoList.Where(i => i.IsTor == preferOnion.Value).ToArray()
                     : info.NodeInfoList.Select(i => i).ToArray();
-
+                
                 var blocksGap = summary.Status.ChainHeight - info.BlockHeight;
-                if (blocksGap > 10)
+                if (blocksGap > 10 && !(isLndHub && info.BlockHeight == 0))
                 {
                     throw new PaymentMethodUnavailableException($"The lightning node is not synched ({blocksGap} blocks left)");
                 }

--- a/BTCPayServer/Payments/Lightning/LightningLikePaymentHandler.cs
+++ b/BTCPayServer/Payments/Lightning/LightningLikePaymentHandler.cs
@@ -9,6 +9,7 @@ using BTCPayServer.Configuration;
 using BTCPayServer.Data;
 using BTCPayServer.HostedServices;
 using BTCPayServer.Lightning;
+using BTCPayServer.Lightning.LndHub;
 using BTCPayServer.Logging;
 using BTCPayServer.Models;
 using BTCPayServer.Models.InvoicingModels;
@@ -135,6 +136,10 @@ namespace BTCPayServer.Payments.Lightning
                 catch (OperationCanceledException) when (cts.IsCancellationRequested)
                 {
                     throw new PaymentMethodUnavailableException("The lightning node did not reply in a timely manner");
+                }
+                catch (NullReferenceException) when (client is LndHubLightningClient)
+                {   // LNDhub-compatible implementation by LNbits does not support GetInfo, see https://github.com/lnbits/lnbits/issues/1182
+                    return new NodeInfo[] {};
                 }
                 catch (Exception ex)
                 {


### PR DESCRIPTION
The LNDhub-compatible implementation by LNbits does not support the `GetInfo` call for all their funding sources — see lnbits/lnbits#1182. By catching that exception in combination with the `LndHubLightningClient`, we give people the ability to still use their LNbits-based LNDhub as a Lightning node.

Talked about this with @Kukks and @callebtc at BTCPrague, because people keep asking for a workaround. Fixes #4482.