### PR TITLE
Dashboard: Limit "Top Items" to five

### DIFF
--- a/BTCPayServer/Components/AppTopItems/AppTopItems.cs
+++ b/BTCPayServer/Components/AppTopItems/AppTopItems.cs
@@ -40,7 +40,7 @@ public class AppTopItems : ViewComponent
         var app = HttpContext.GetAppData();
         var entries = await _appService.GetItemStats(app);
         vm.SalesCount = entries.Select(e => e.SalesCount).ToList();
-        vm.Entries = entries.ToList();
+        vm.Entries = entries.Take(5).ToList();
         vm.AppType = app.AppType;
         vm.AppUrl = await appBaseType.ConfigureLink(app);
         vm.Name = app.Name;


### PR DESCRIPTION
Feedback we got at BTCPrague (from @rolandschellhorn): Do not show more than five items in the top list, because otherwise the list can get very long if there's a POS with many items.