### PR TITLE
Fix: The current preimage of a invoice's lightning payment method should be available via API

### DIFF
--- a/BTCPayServer.Tests/GreenfieldAPITests.cs
+++ b/BTCPayServer.Tests/GreenfieldAPITests.cs
@@ -2631,7 +2631,7 @@ namespace BTCPayServer.Tests
             for (int i = 0; i < invoices.Length; i++)
             {
                 pm[i] = Assert.Single(await client.GetInvoicePaymentMethods(user.StoreId, (await invoices[i]).Id));
-                Assert.False(pm[i].AdditionalData.HasValues);
+                Assert.True(pm[i].AdditionalData.HasValues);
             }
 
             // Pay them all at once

--- a/BTCPayServer/Payments/Lightning/LightningLikePaymentMethodDetails.cs
+++ b/BTCPayServer/Payments/Lightning/LightningLikePaymentMethodDetails.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using BTCPayServer.Lightning;
 using BTCPayServer.Services.Invoices;
 using NBitcoin;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
 namespace BTCPayServer.Payments.Lightning
@@ -10,7 +11,9 @@ namespace BTCPayServer.Payments.Lightning
     public class LightningLikePaymentMethodDetails : IPaymentMethodDetails
     {
         public string BOLT11 { get; set; }
+        [JsonConverter(typeof(NBitcoin.JsonConverters.UInt256JsonConverter))]
         public uint256 PaymentHash { get; set; }
+        [JsonConverter(typeof(NBitcoin.JsonConverters.UInt256JsonConverter))]
         public uint256 Preimage { get; set; }
         public string InvoiceId { get; set; }
         public string NodeInfo { get; set; }

--- a/BTCPayServer/Services/Invoices/InvoiceEntity.cs
+++ b/BTCPayServer/Services/Invoices/InvoiceEntity.cs
@@ -1007,6 +1007,11 @@ namespace BTCPayServer.Services.Invoices
                 };
             }
 
+            // A bug in previous version of BTCPay Server wasn't properly serializing those fields
+            if (PaymentMethodDetails["PaymentHash"] is JObject)
+                PaymentMethodDetails["PaymentHash"] = null;
+            if (PaymentMethodDetails["Preimage"] is JObject)
+                PaymentMethodDetails["Preimage"] = null;
             IPaymentMethodDetails details = GetId().PaymentType.DeserializePaymentMethodDetails(Network, PaymentMethodDetails.ToString());
             switch (details)
             {


### PR DESCRIPTION
We are serializing payment method details in two places: Payments blob and inside the Invoices blob.

Sadly, we aren't using the NBitcoin's serializer for the payment method detail in the Invoices blob. resulting in the unuseful

```json
{
  "PaymentHash": { "Size": 32 }
}
```

Being saved in the database. Notice the casing is wrong.

We will really need to refactor everything concerning payment methods and payment methods details very soon.