### PR TITLE
Crowdfund: Fix JS errors in empty state

### DIFF
--- a/BTCPayServer/Views/Shared/Crowdfund/Public/ViewCrowdfund.cshtml
+++ b/BTCPayServer/Views/Shared/Crowdfund/Public/ViewCrowdfund.cshtml
@@ -277,7 +277,7 @@
 <template id="perks-template">
     <div class="perks-container">
         <perk v-if="!perks || perks.length === 0"
-              :perk="{title: 'Donate Custom Amount', price: { type: 0, value: null }}"
+              :perk="{title: 'Donate Custom Amount', priceType: 'Topup', price: { type: 'Topup' } }"
               :target-currency="targetCurrency"
               :active="active"
               :loading="loading"


### PR DESCRIPTION
An empty crowdfund with the default perk had JS errors.