### PR TITLE
Bumping LND to 0.16.3-beta

### DIFF
--- a/BTCPayServer.Tests/docker-compose.altcoins.yml
+++ b/BTCPayServer.Tests/docker-compose.altcoins.yml
@@ -224,7 +224,7 @@ services:
       - "5432"
 
   merchant_lnd:
-    image: btcpayserver/lnd:v0.16.2-beta
+    image: btcpayserver/lnd:v0.16.3-beta
     restart: unless-stopped
     environment:
       LND_CHAIN: "btc"
@@ -259,7 +259,7 @@ services:
       - bitcoind
 
   customer_lnd:
-    image: btcpayserver/lnd:v0.16.2-beta
+    image: btcpayserver/lnd:v0.16.3-beta
     restart: unless-stopped
     environment:
       LND_CHAIN: "btc"

--- a/BTCPayServer.Tests/docker-compose.yml
+++ b/BTCPayServer.Tests/docker-compose.yml
@@ -211,7 +211,7 @@ services:
       - "5432"
 
   merchant_lnd:
-    image: btcpayserver/lnd:v0.16.2-beta
+    image: btcpayserver/lnd:v0.16.3-beta
     restart: unless-stopped
     environment:
       LND_CHAIN: "btc"
@@ -248,7 +248,7 @@ services:
       - bitcoind
 
   customer_lnd:
-    image: btcpayserver/lnd:v0.16.2-beta
+    image: btcpayserver/lnd:v0.16.3-beta
     restart: unless-stopped
     environment:
       LND_CHAIN: "btc"


### PR DESCRIPTION
Updating our devenv to use LND 0.16.3; Docker image available on https://hub.docker.com/layers/btcpayserver/lnd/v0.16.3-beta/images/sha256-9ff34769378cfca18664c7d1da3747e7ad7fb7f38a9a7b82a3d4f85e5bfef7bf?context=explore

Used it in BTCPayServer.Lightning library and it's good to go:
https://github.com/btcpayserver/BTCPayServer.Lightning/pull/134