### PR TITLE
Generate unique order IDs for PoS and Crowdfund sales

### DIFF
--- a/BTCPayServer/Components/AppTopItems/AppTopItems.cs
+++ b/BTCPayServer/Components/AppTopItems/AppTopItems.cs
@@ -24,7 +24,7 @@ public class AppTopItems : ViewComponent
     public async Task<IViewComponentResult> InvokeAsync(string appId, string appType)
     {
         var type = _appService.GetAppType(appType);
-        if (type is not IHasItemStatsAppType salesAppType || type is not AppBaseType appBaseType)
+        if (type is not (IHasItemStatsAppType and AppBaseType appBaseType))
             return new HtmlContentViewComponentResult(new StringHtmlContent(string.Empty));
 
         var vm = new AppTopItemsViewModel

--- a/BTCPayServer/Components/TruncateCenter/Default.cshtml
+++ b/BTCPayServer/Components/TruncateCenter/Default.cshtml
@@ -1,6 +1,7 @@
 @model BTCPayServer.Components.TruncateCenter.TruncateCenterViewModel
 @{
     var classes = string.IsNullOrEmpty(Model.Classes) ? string.Empty : Model.Classes.Trim();
+    var isTruncated = !string.IsNullOrEmpty(Model.Start) && !string.IsNullOrEmpty(Model.End);
     @if (Model.Copy) classes += " truncate-center--copy";
     @if (Model.Elastic) classes += " truncate-center--elastic";
 }
@@ -15,9 +16,12 @@
     }
     else
     {
-        <span class="truncate-center-truncated" @(!string.IsNullOrEmpty(Model.Start) ? $"data-bs-toggle=tooltip title={Model.Text}" : "")>
-            <span class="truncate-center-start">@(Model.Elastic ? Model.Text : $"{Model.Start}…")</span>
-            <span class="truncate-center-end">@Model.End</span>
+        <span class="truncate-center-truncated" @(isTruncated ? $"data-bs-toggle=tooltip title={Model.Text}" : "")>
+            <span class="truncate-center-start">@(Model.Elastic || !isTruncated ? Model.Text : $"{Model.Start}…")</span>
+            @if (isTruncated)
+            {
+                <span class="truncate-center-end">@Model.End</span>
+            }
         </span>
         <span class="truncate-center-text">@Model.Text</span>
     }

--- a/BTCPayServer/Controllers/UIInvoiceController.UI.cs
+++ b/BTCPayServer/Controllers/UIInvoiceController.UI.cs
@@ -1142,6 +1142,7 @@ namespace BTCPayServer.Controllers
                 StoreId = fs.GetFilterArray("storeid"),
                 ItemCode = fs.GetFilterArray("itemcode"),
                 OrderId = fs.GetFilterArray("orderid"),
+                AdditionalSearchTerms = fs.GetFilterArray("plugin"),
                 StartDate = fs.GetFilterDate("startdate", timezoneOffset),
                 EndDate = fs.GetFilterDate("enddate", timezoneOffset)
             };

--- a/BTCPayServer/Controllers/UIInvoiceController.UI.cs
+++ b/BTCPayServer/Controllers/UIInvoiceController.UI.cs
@@ -1100,10 +1100,9 @@ namespace BTCPayServer.Controllers
 
             // Apps
             var apps = await _appService.GetAllApps(GetUserId(), false, storeId);
-            var appIds = fs.GetFilterArray("appid");
-            if (appIds is { Length: > 0 })
+            var appTags = fs.GetFilterArray("appid")?.Select(AppService.GetAppInternalTag);
+            if (appTags != null)
             {
-                var appTags = appIds.Select(AppService.GetAppInternalTag);
                 list = list.Where(inv => inv.Version < InvoiceEntity.InternalTagSupport_Version ||
                                 inv.InternalTags.Any(it => appTags.Contains(it))).ToArray();
             }

--- a/BTCPayServer/Controllers/UIInvoiceController.cs
+++ b/BTCPayServer/Controllers/UIInvoiceController.cs
@@ -110,15 +110,15 @@ namespace BTCPayServer.Controllers
 
 
         internal async Task<DataWrapper<InvoiceResponse>> CreateInvoiceCore(BitpayCreateInvoiceRequest invoice,
-            StoreData store, string serverUrl, List<string>? additionalTags = null, string[]? additionalSearchTerms = null, 
+            StoreData store, string serverUrl, List<string>? additionalTags = null,
             CancellationToken cancellationToken = default, Action<InvoiceEntity>? entityManipulator = null)
         {
-            var entity = await CreateInvoiceCoreRaw(invoice, store, serverUrl, additionalTags, additionalSearchTerms, cancellationToken, entityManipulator);
+            var entity = await CreateInvoiceCoreRaw(invoice, store, serverUrl, additionalTags, cancellationToken, entityManipulator);
             var resp = entity.EntityToDTO();
             return new DataWrapper<InvoiceResponse>(resp) { Facade = "pos/invoice" };
         }
 
-        internal async Task<InvoiceEntity> CreateInvoiceCoreRaw(BitpayCreateInvoiceRequest invoice, StoreData store, string serverUrl, List<string>? additionalTags = null, string[]? additionalSearchTerms = null, CancellationToken cancellationToken = default, Action<InvoiceEntity>? entityManipulator = null)
+        internal async Task<InvoiceEntity> CreateInvoiceCoreRaw(BitpayCreateInvoiceRequest invoice, StoreData store, string serverUrl, List<string>? additionalTags = null, CancellationToken cancellationToken = default, Action<InvoiceEntity>? entityManipulator = null)
         {
             var storeBlob = store.GetStoreBlob();
             var entity = _InvoiceRepository.CreateNewInvoice();
@@ -197,7 +197,7 @@ namespace BTCPayServer.Controllers
             entity.DefaultPaymentMethod = invoice.DefaultPaymentMethod;
             entity.RequiresRefundEmail = invoice.RequiresRefundEmail;
 
-            return await CreateInvoiceCoreRaw(entity, store, excludeFilter, additionalSearchTerms, cancellationToken, entityManipulator);
+            return await CreateInvoiceCoreRaw(entity, store, excludeFilter, null, cancellationToken, entityManipulator);
         }
 
         internal async Task<InvoiceEntity> CreatePaymentRequestInvoice(Data.PaymentRequestData prData, decimal? amount, decimal amountDue, StoreData storeData, HttpRequest request, CancellationToken cancellationToken)

--- a/BTCPayServer/Controllers/UIInvoiceController.cs
+++ b/BTCPayServer/Controllers/UIInvoiceController.cs
@@ -110,15 +110,15 @@ namespace BTCPayServer.Controllers
 
 
         internal async Task<DataWrapper<InvoiceResponse>> CreateInvoiceCore(BitpayCreateInvoiceRequest invoice,
-            StoreData store, string serverUrl, List<string>? additionalTags = null,
+            StoreData store, string serverUrl, List<string>? additionalTags = null, string[]? additionalSearchTerms = null, 
             CancellationToken cancellationToken = default, Action<InvoiceEntity>? entityManipulator = null)
         {
-            var entity = await CreateInvoiceCoreRaw(invoice, store, serverUrl, additionalTags, cancellationToken, entityManipulator);
+            var entity = await CreateInvoiceCoreRaw(invoice, store, serverUrl, additionalTags, additionalSearchTerms, cancellationToken, entityManipulator);
             var resp = entity.EntityToDTO();
             return new DataWrapper<InvoiceResponse>(resp) { Facade = "pos/invoice" };
         }
 
-        internal async Task<InvoiceEntity> CreateInvoiceCoreRaw(BitpayCreateInvoiceRequest invoice, StoreData store, string serverUrl, List<string>? additionalTags = null, CancellationToken cancellationToken = default, Action<InvoiceEntity>? entityManipulator = null)
+        internal async Task<InvoiceEntity> CreateInvoiceCoreRaw(BitpayCreateInvoiceRequest invoice, StoreData store, string serverUrl, List<string>? additionalTags = null, string[]? additionalSearchTerms = null, CancellationToken cancellationToken = default, Action<InvoiceEntity>? entityManipulator = null)
         {
             var storeBlob = store.GetStoreBlob();
             var entity = _InvoiceRepository.CreateNewInvoice();
@@ -197,7 +197,7 @@ namespace BTCPayServer.Controllers
             entity.DefaultPaymentMethod = invoice.DefaultPaymentMethod;
             entity.RequiresRefundEmail = invoice.RequiresRefundEmail;
 
-            return await CreateInvoiceCoreRaw(entity, store, excludeFilter, null, cancellationToken, entityManipulator);
+            return await CreateInvoiceCoreRaw(entity, store, excludeFilter, additionalSearchTerms, cancellationToken, entityManipulator);
         }
 
         internal async Task<InvoiceEntity> CreatePaymentRequestInvoice(Data.PaymentRequestData prData, decimal? amount, decimal amountDue, StoreData storeData, HttpRequest request, CancellationToken cancellationToken)

--- a/BTCPayServer/Controllers/UILNURLController.cs
+++ b/BTCPayServer/Controllers/UILNURLController.cs
@@ -316,7 +316,6 @@ namespace BTCPayServer
                 invoiceMetadata.ItemDesc = item.Description;
             }
             createInvoice.Metadata = invoiceMetadata.ToJObject();
-            createInvoice.AdditionalSearchTerms = new [] { AppService.GetAppOrderId(app) };
 
             return await GetLNURLRequest(
                 cryptoCode,

--- a/BTCPayServer/Controllers/UILNURLController.cs
+++ b/BTCPayServer/Controllers/UILNURLController.cs
@@ -296,7 +296,7 @@ namespace BTCPayServer
 
             var createInvoice = new CreateInvoiceRequest()
             {
-                Amount = item?.Price.Value,
+                Amount = item?.Price,
                 Currency = currencyCode,
                 Checkout = new InvoiceDataBase.CheckoutOptions()
                 {
@@ -306,7 +306,8 @@ namespace BTCPayServer
                                                        HttpContext.Request.GetAbsoluteUri($"/apps/{app.Id}/pos"),
                         _ => null
                     }
-                }
+                },
+                AdditionalSearchTerms = new[] { AppService.GetAppSearchTerm(app) }
             };
 
             var invoiceMetadata = new InvoiceMetadata { OrderId = AppService.GetRandomOrderId() };

--- a/BTCPayServer/Controllers/UILNURLController.cs
+++ b/BTCPayServer/Controllers/UILNURLController.cs
@@ -309,15 +309,14 @@ namespace BTCPayServer
                 }
             };
 
-            var invoiceMetadata = new InvoiceMetadata();
-            invoiceMetadata.OrderId = AppService.GetAppOrderId(app);
+            var invoiceMetadata = new InvoiceMetadata { OrderId = AppService.GetRandomOrderId() };
             if (item != null)
             {
                 invoiceMetadata.ItemCode = item.Id;
                 invoiceMetadata.ItemDesc = item.Description;
             }
             createInvoice.Metadata = invoiceMetadata.ToJObject();
-
+            createInvoice.AdditionalSearchTerms = new [] { AppService.GetAppOrderId(app) };
 
             return await GetLNURLRequest(
                 cryptoCode,

--- a/BTCPayServer/Models/InvoicingModels/InvoicesModel.cs
+++ b/BTCPayServer/Models/InvoicingModels/InvoicesModel.cs
@@ -41,6 +41,5 @@ namespace BTCPayServer.Models.InvoicingModels
         public string Id { get; set; }
         public string AppName { get; set; }
         public string AppType { get; set; }
-        public string AppOrderId { get; set; }
     }
 }

--- a/BTCPayServer/Plugins/Crowdfund/Controllers/UICrowdfundController.cs
+++ b/BTCPayServer/Plugins/Crowdfund/Controllers/UICrowdfundController.cs
@@ -190,7 +190,6 @@ namespace BTCPayServer.Plugins.Crowdfund.Controllers
                     RedirectURL = request.RedirectUrl ?? appUrl,
                 }, store, HttpContext.Request.GetAbsoluteRoot(),
                     new List<string> { AppService.GetAppInternalTag(appId) },
-                    new [] { AppService.GetAppOrderId(app) },
                     cancellationToken, entity =>
                     {
                         entity.Metadata.OrderUrl = appUrl;
@@ -249,7 +248,7 @@ namespace BTCPayServer.Plugins.Crowdfund.Controllers
                 IsRecurring = resetEvery != nameof(CrowdfundResetEvery.Never),
                 UseAllStoreInvoices = app.TagAllInvoices,
                 AppId = appId,
-                SearchTerm = app.TagAllInvoices ? $"storeid:{app.StoreDataId}" : $"plugin:{AppService.GetAppOrderId(app)}",
+                SearchTerm = app.TagAllInvoices ? $"storeid:{app.StoreDataId}" : $"appid:{app.Id}",
                 DisplayPerksRanking = settings.DisplayPerksRanking,
                 DisplayPerksValue = settings.DisplayPerksValue,
                 SortPerksByPopularity = settings.SortPerksByPopularity,

--- a/BTCPayServer/Plugins/Crowdfund/Controllers/UICrowdfundController.cs
+++ b/BTCPayServer/Plugins/Crowdfund/Controllers/UICrowdfundController.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using BTCPayServer.Abstractions.Constants;
 using BTCPayServer.Abstractions.Extensions;
 using BTCPayServer.Client;
+using BTCPayServer.Client.Models;
 using BTCPayServer.Controllers;
 using BTCPayServer.Data;
 using BTCPayServer.Filters;
@@ -13,6 +14,7 @@ using BTCPayServer.Models;
 using BTCPayServer.Plugins.Crowdfund.Models;
 using BTCPayServer.Plugins.PointOfSale.Models;
 using BTCPayServer.Services.Apps;
+using BTCPayServer.Services.Invoices;
 using BTCPayServer.Services.Rates;
 using BTCPayServer.Services.Stores;
 using Microsoft.AspNetCore.Authorization;
@@ -21,6 +23,7 @@ using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using NBitpayClient;
 using NicolasDorier.RateLimits;
+using CrowdfundResetEvery = BTCPayServer.Services.Apps.CrowdfundResetEvery;
 
 namespace BTCPayServer.Plugins.Crowdfund.Controllers
 {
@@ -175,33 +178,41 @@ namespace BTCPayServer.Plugins.Crowdfund.Controllers
             {
                 var appPath = await _appService.ViewLink(app);
                 var appUrl = HttpContext.Request.GetAbsoluteUri(appPath);
-                var invoice = await _invoiceController.CreateInvoiceCore(new BitpayCreateInvoiceRequest
+                var invoice = await _invoiceController.CreateInvoiceCoreRaw(new CreateInvoiceRequest()
                 {
-                    OrderId = AppService.GetRandomOrderId(),
+                    Amount = price,
                     Currency = settings.TargetCurrency,
-                    ItemCode = request.ChoiceKey ?? string.Empty,
-                    ItemDesc = title,
-                    BuyerEmail = request.Email,
-                    Price = price,
-                    NotificationURL = settings.NotificationUrl,
-                    FullNotifications = true,
-                    ExtendedNotifications = true,
-                    SupportedTransactionCurrencies = paymentMethods,
-                    RedirectURL = request.RedirectUrl ?? appUrl,
+                    Metadata = new InvoiceMetadata()
+                    {
+                        OrderId = AppService.GetRandomOrderId(),
+                        ItemCode = request.ChoiceKey ?? string.Empty,
+                        ItemDesc = title,
+                        BuyerEmail = request.Email
+                    }.ToJObject(),
+                    Checkout = new InvoiceDataBase.CheckoutOptions()
+                    {
+                        RedirectURL = request.RedirectUrl ?? appUrl,
+                        PaymentMethods = paymentMethods?.Where(p => p.Value.Enabled)
+                                                    .Select(p => p.Key).ToArray()
+                    },
+                    AdditionalSearchTerms = new[] { AppService.GetAppSearchTerm(app) }
                 }, store, HttpContext.Request.GetAbsoluteRoot(),
                     new List<string> { AppService.GetAppInternalTag(appId) },
                     cancellationToken, entity =>
                     {
+                        entity.NotificationURLTemplate = settings.NotificationUrl;
+                        entity.FullNotifications = true;
+                        entity.ExtendedNotifications = true;
                         entity.Metadata.OrderUrl = appUrl;
                     });
 
                 if (request.RedirectToCheckout)
                 {
                     return RedirectToAction(nameof(UIInvoiceController.Checkout), "UIInvoice",
-                        new { invoiceId = invoice.Data.Id });
+                        new { invoiceId = invoice.Id });
                 }
 
-                return Ok(invoice.Data.Id);
+                return Ok(invoice.Id);
             }
             catch (BitpayHttpException e)
             {

--- a/BTCPayServer/Plugins/PointOfSale/Controllers/UIPointOfSaleController.cs
+++ b/BTCPayServer/Plugins/PointOfSale/Controllers/UIPointOfSaleController.cs
@@ -283,6 +283,7 @@ namespace BTCPayServer.Plugins.PointOfSale.Controllers
             }
             try
             {
+                var appOrderId = AppService.GetAppOrderId(app);
                 var invoice = await _invoiceController.CreateInvoiceCore(new BitpayCreateInvoiceRequest
                 {
                     ItemCode = choice?.Id,
@@ -290,7 +291,7 @@ namespace BTCPayServer.Plugins.PointOfSale.Controllers
                     Currency = settings.Currency,
                     Price = price,
                     BuyerEmail = email,
-                    OrderId = orderId ?? AppService.GetAppOrderId(app),
+                    OrderId = orderId ?? $"{appOrderId}-{Encoders.Base58.EncodeData(RandomUtils.GetBytes(16))}",
                     NotificationURL =
                             string.IsNullOrEmpty(notificationUrl) ? settings.NotificationUrl : notificationUrl,
                     RedirectURL = !string.IsNullOrEmpty(redirectUrl) ? redirectUrl
@@ -305,6 +306,7 @@ namespace BTCPayServer.Plugins.PointOfSale.Controllers
                         : requiresRefundEmail == RequiresRefundEmail.On,
                 }, store, HttpContext.Request.GetAbsoluteRoot(),
                     new List<string> { AppService.GetAppInternalTag(appId) },
+                    new [] { appOrderId },
                     cancellationToken, entity =>
                     {
                         entity.Metadata.OrderUrl = Request.GetDisplayUrl();

--- a/BTCPayServer/Plugins/PointOfSale/Controllers/UIPointOfSaleController.cs
+++ b/BTCPayServer/Plugins/PointOfSale/Controllers/UIPointOfSaleController.cs
@@ -283,7 +283,6 @@ namespace BTCPayServer.Plugins.PointOfSale.Controllers
             }
             try
             {
-                var appOrderId = AppService.GetAppOrderId(app);
                 var invoice = await _invoiceController.CreateInvoiceCore(new BitpayCreateInvoiceRequest
                 {
                     ItemCode = choice?.Id,
@@ -291,7 +290,7 @@ namespace BTCPayServer.Plugins.PointOfSale.Controllers
                     Currency = settings.Currency,
                     Price = price,
                     BuyerEmail = email,
-                    OrderId = orderId ?? $"{appOrderId}-{Encoders.Base58.EncodeData(RandomUtils.GetBytes(16))}",
+                    OrderId = orderId ?? AppService.GetRandomOrderId(),
                     NotificationURL =
                             string.IsNullOrEmpty(notificationUrl) ? settings.NotificationUrl : notificationUrl,
                     RedirectURL = !string.IsNullOrEmpty(redirectUrl) ? redirectUrl
@@ -306,7 +305,7 @@ namespace BTCPayServer.Plugins.PointOfSale.Controllers
                         : requiresRefundEmail == RequiresRefundEmail.On,
                 }, store, HttpContext.Request.GetAbsoluteRoot(),
                     new List<string> { AppService.GetAppInternalTag(appId) },
-                    new [] { appOrderId },
+                    new [] { AppService.GetAppOrderId(app) },
                     cancellationToken, entity =>
                     {
                         entity.Metadata.OrderUrl = Request.GetDisplayUrl();
@@ -518,7 +517,7 @@ namespace BTCPayServer.Plugins.PointOfSale.Controllers
                 Description = settings.Description,
                 NotificationUrl = settings.NotificationUrl,
                 RedirectUrl = settings.RedirectUrl,
-                SearchTerm = app.TagAllInvoices ? $"storeid:{app.StoreDataId}" : $"orderid:{AppService.GetAppOrderId(app)}",
+                SearchTerm = app.TagAllInvoices ? $"storeid:{app.StoreDataId}" : $"plugin:{AppService.GetAppOrderId(app)}",
                 RedirectAutomatically = settings.RedirectAutomatically.HasValue ? settings.RedirectAutomatically.Value ? "true" : "false" : "",
                 FormId = settings.FormId
             };

--- a/BTCPayServer/Plugins/PointOfSale/Controllers/UIPointOfSaleController.cs
+++ b/BTCPayServer/Plugins/PointOfSale/Controllers/UIPointOfSaleController.cs
@@ -305,7 +305,6 @@ namespace BTCPayServer.Plugins.PointOfSale.Controllers
                         : requiresRefundEmail == RequiresRefundEmail.On,
                 }, store, HttpContext.Request.GetAbsoluteRoot(),
                     new List<string> { AppService.GetAppInternalTag(appId) },
-                    new [] { AppService.GetAppOrderId(app) },
                     cancellationToken, entity =>
                     {
                         entity.Metadata.OrderUrl = Request.GetDisplayUrl();
@@ -517,7 +516,7 @@ namespace BTCPayServer.Plugins.PointOfSale.Controllers
                 Description = settings.Description,
                 NotificationUrl = settings.NotificationUrl,
                 RedirectUrl = settings.RedirectUrl,
-                SearchTerm = app.TagAllInvoices ? $"storeid:{app.StoreDataId}" : $"plugin:{AppService.GetAppOrderId(app)}",
+                SearchTerm = app.TagAllInvoices ? $"storeid:{app.StoreDataId}" : $"appid:{app.Id}",
                 RedirectAutomatically = settings.RedirectAutomatically.HasValue ? settings.RedirectAutomatically.Value ? "true" : "false" : "",
                 FormId = settings.FormId
             };

--- a/BTCPayServer/SearchString.cs
+++ b/BTCPayServer/SearchString.cs
@@ -2,8 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
-using System.Text.RegularExpressions;
-using ExchangeSharp;
 
 namespace BTCPayServer
 {

--- a/BTCPayServer/Services/Apps/AppService.cs
+++ b/BTCPayServer/Services/Apps/AppService.cs
@@ -202,8 +202,8 @@ namespace BTCPayServer.Services.Apps
             };
         }
 
-        public static string GetAppOrderId(AppData app) => GetAppOrderId(app.AppType, app.Id);
-        public static string GetAppOrderId(string appType, string appId) =>
+        public static string GetAppSearchTerm(AppData app) => GetAppSearchTerm(app.AppType, app.Id);
+        public static string GetAppSearchTerm(string appType, string appId) =>
             appType switch
             {
                 CrowdfundAppType.AppType => $"crowdfund-app_{appId}",
@@ -224,11 +224,10 @@ namespace BTCPayServer.Services.Apps
 
         public static async Task<InvoiceEntity[]> GetInvoicesForApp(InvoiceRepository invoiceRepository, AppData appData, DateTimeOffset? startDate = null, string[]? status = null)
         {
-            var searchCriteria = appData.TagAllInvoices ? null : new[] { GetAppOrderId(appData) };
             var invoices = await invoiceRepository.GetInvoices(new InvoiceQuery
             {
                 StoreId = new[] { appData.StoreDataId },
-                AdditionalSearchTerms = searchCriteria,
+                TextSearch = appData.TagAllInvoices ? null : GetAppSearchTerm(appData),
                 Status = status ?? new[]{
                     InvoiceState.ToString(InvoiceStatusLegacy.New),
                     InvoiceState.ToString(InvoiceStatusLegacy.Paid),

--- a/BTCPayServer/Services/Apps/AppService.cs
+++ b/BTCPayServer/Services/Apps/AppService.cs
@@ -216,13 +216,19 @@ namespace BTCPayServer.Services.Apps
         {
             return invoice.GetInternalTags("APP#");
         }
+        
+        public static string GetRandomOrderId(int length = 16)
+        {
+            return Encoders.Base58.EncodeData(RandomUtils.GetBytes(length));
+        }
 
         public static async Task<InvoiceEntity[]> GetInvoicesForApp(InvoiceRepository invoiceRepository, AppData appData, DateTimeOffset? startDate = null, string[]? status = null)
         {
+            var searchCriteria = appData.TagAllInvoices ? null : new[] { GetAppOrderId(appData) };
             var invoices = await invoiceRepository.GetInvoices(new InvoiceQuery
             {
                 StoreId = new[] { appData.StoreDataId },
-                OrderId = appData.TagAllInvoices ? null : new[] { GetAppOrderId(appData) },
+                AdditionalSearchTerms = searchCriteria,
                 Status = status ?? new[]{
                     InvoiceState.ToString(InvoiceStatusLegacy.New),
                     InvoiceState.ToString(InvoiceStatusLegacy.Paid),

--- a/BTCPayServer/Services/Invoices/InvoiceRepository.cs
+++ b/BTCPayServer/Services/Invoices/InvoiceRepository.cs
@@ -671,24 +671,28 @@ namespace BTCPayServer.Services.Invoices
 #pragma warning restore CA1310 // Specify StringComparison
             }
 
+            if (queryObject.AdditionalSearchTerms is { Length: > 0 })
+                query = query.Where(i => i.InvoiceSearchData.Any(data => 
+                    queryObject.AdditionalSearchTerms.Contains(data.Value)));
+
             if (queryObject.StartDate != null)
                 query = query.Where(i => queryObject.StartDate.Value <= i.Created);
 
             if (queryObject.EndDate != null)
                 query = query.Where(i => i.Created <= queryObject.EndDate.Value);
 
-            if (queryObject.OrderId != null && queryObject.OrderId.Length > 0)
+            if (queryObject.OrderId is { Length: > 0 })
             {
                 var statusSet = queryObject.OrderId.ToHashSet().ToArray();
                 query = query.Where(i => statusSet.Contains(i.OrderId));
             }
-            if (queryObject.ItemCode != null && queryObject.ItemCode.Length > 0)
+            if (queryObject.ItemCode is { Length: > 0 })
             {
                 var statusSet = queryObject.ItemCode.ToHashSet().ToArray();
                 query = query.Where(i => statusSet.Contains(i.ItemCode));
             }
 
-            if (queryObject.Status != null && queryObject.Status.Length > 0)
+            if (queryObject.Status is { Length: > 0 })
             {
                 var statusSet = queryObject.Status.ToHashSet();
                 // We make sure here that the old filters still work
@@ -907,6 +911,7 @@ namespace BTCPayServer.Services.Invoices
             get;
             set;
         }
+        public string[] AdditionalSearchTerms { get; set; }
         public bool IncludeAddresses { get; set; }
 
         public bool IncludeEvents { get; set; }

--- a/BTCPayServer/Services/Invoices/InvoiceRepository.cs
+++ b/BTCPayServer/Services/Invoices/InvoiceRepository.cs
@@ -668,10 +668,6 @@ namespace BTCPayServer.Services.Invoices
 #pragma warning restore CA1310 // Specify StringComparison
             }
 
-            if (queryObject.AdditionalSearchTerms is { Length: > 0 })
-                query = query.Where(i => i.InvoiceSearchData.Any(data => 
-                    queryObject.AdditionalSearchTerms.Contains(data.Value)));
-
             if (queryObject.StartDate != null)
                 query = query.Where(i => queryObject.StartDate.Value <= i.Created);
 
@@ -906,7 +902,6 @@ namespace BTCPayServer.Services.Invoices
             get;
             set;
         }
-        public string[] AdditionalSearchTerms { get; set; }
         public bool IncludeAddresses { get; set; }
 
         public bool IncludeEvents { get; set; }

--- a/BTCPayServer/Views/UIInvoice/ListInvoices.cshtml
+++ b/BTCPayServer/Views/UIInvoice/ListInvoices.cshtml
@@ -8,7 +8,7 @@
     ViewData.SetActivePage(InvoiceNavPages.Index, "Invoices");
     var statusFilterCount = CountArrayFilter("status") + CountArrayFilter("exceptionstatus") + (HasBooleanFilter("includearchived") ? 1 : 0) + (HasBooleanFilter("unusual") ? 1 : 0);
     var hasDateFilter = HasArrayFilter("startdate") || HasArrayFilter("enddate");
-    var appFilterCount = Model.Apps.Count(app => HasArrayFilter("plugin", app.AppOrderId));
+    var appFilterCount = Model.Apps.Count(app => HasArrayFilter("appid", app.Id));
 }
 
 @functions
@@ -279,7 +279,7 @@
             <div class="dropdown-menu" aria-labelledby="AppOptionsToggle">
                 @foreach (var app in Model.Apps)
                 {
-                    <a asp-action="ListInvoices" asp-route-storeId="@Model.StoreId" asp-route-count="@Model.Count" asp-route-searchTerm="@Model.Search.Toggle("plugin", app.AppOrderId)" class="dropdown-item @(HasArrayFilter("plugin", app.AppOrderId) ? "custom-active" : "")">@app.AppName</a>
+                    <a asp-action="ListInvoices" asp-route-storeId="@Model.StoreId" asp-route-count="@Model.Count" asp-route-searchTerm="@Model.Search.Toggle("appid", app.Id)" class="dropdown-item @(HasArrayFilter("appid", app.Id) ? "custom-active" : "")">@app.AppName</a>
                 }
             </div>
         </div> 

--- a/BTCPayServer/Views/UIInvoice/ListInvoices.cshtml
+++ b/BTCPayServer/Views/UIInvoice/ListInvoices.cshtml
@@ -8,7 +8,7 @@
     ViewData.SetActivePage(InvoiceNavPages.Index, "Invoices");
     var statusFilterCount = CountArrayFilter("status") + CountArrayFilter("exceptionstatus") + (HasBooleanFilter("includearchived") ? 1 : 0) + (HasBooleanFilter("unusual") ? 1 : 0);
     var hasDateFilter = HasArrayFilter("startdate") || HasArrayFilter("enddate");
-    var appFilterCount = Model.Apps.Count(app => HasArrayFilter("orderid", app.AppOrderId));
+    var appFilterCount = Model.Apps.Count(app => HasArrayFilter("plugin", app.AppOrderId));
 }
 
 @functions
@@ -140,7 +140,7 @@
                 })
                 .on("click", ".invoice-row", function (e) {
                     const $invoiceRow = $(e.currentTarget);
-                    if (!$(e.target).is("a,.badge,.selector")) {
+                    if ($(e.target).is("td")) {
                         $invoiceRow.find(".selector").trigger("click");
                     }
                 });
@@ -279,7 +279,7 @@
             <div class="dropdown-menu" aria-labelledby="AppOptionsToggle">
                 @foreach (var app in Model.Apps)
                 {
-                    <a asp-action="ListInvoices" asp-route-storeId="@Model.StoreId" asp-route-count="@Model.Count" asp-route-searchTerm="@Model.Search.Toggle("orderid", app.AppOrderId)" class="dropdown-item @(HasArrayFilter("orderid", app.AppOrderId) ? "custom-active" : "")">@app.AppName</a>
+                    <a asp-action="ListInvoices" asp-route-storeId="@Model.StoreId" asp-route-count="@Model.Count" asp-route-searchTerm="@Model.Search.Toggle("plugin", app.AppOrderId)" class="dropdown-item @(HasArrayFilter("plugin", app.AppOrderId) ? "custom-active" : "")">@app.AppName</a>
                 }
             </div>
         </div> 
@@ -379,16 +379,7 @@
                             </td>
                             <td>@invoice.Date.ToBrowserDate()</td>
                             <td>
-                                <div class="text-truncate" style="max-width:120px;" data-bs-toggle="tooltip" title="@invoice.OrderId">
-                                    @if (invoice.RedirectUrl != string.Empty)
-                                    {
-                                        <a href="@invoice.RedirectUrl" rel="noreferrer noopener">@invoice.OrderId</a>
-                                    }
-                                    else
-                                    {
-                                        @invoice.OrderId
-                                    }
-                                </div>
+                                <vc:truncate-center text="@invoice.OrderId" link="@invoice.RedirectUrl" classes="truncate-center-id" />
                             </td>
                             <td class="text-break">@invoice.InvoiceId</td>
                             <td>


### PR DESCRIPTION
Before, the order IDs for the apps weren't unique as they all shared the same app order ID, e.g. `pos-app_4BPMc3oqazLim9H67qc36JLvRmMt`. This appends a randomized value to make it a unique order ID, like `pos-app_4BPMc3oqazLim9H67qc36JLvRmMt-5NpZgWgYwE1QNQ9eT8rAhw`.

Also modifies the search to incorporate those changes.

Part of #5054.