### PR TITLE
Fix: Lightning wallet such as Alby should be able to access LND config

### DIFF
--- a/BTCPayServer/Controllers/UIServerController.cs
+++ b/BTCPayServer/Controllers/UIServerController.cs
@@ -29,6 +29,7 @@ using BTCPayServer.Storage.Services;
 using BTCPayServer.Storage.Services.Providers;
 using BTCPayServer.Validation;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Cors;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Rendering;
@@ -664,6 +665,8 @@ namespace BTCPayServer.Controllers
 
         [Route("lnd-config/{configKey}/lnd.config")]
         [AllowAnonymous]
+        [EnableCors(CorsPolicies.All)]
+        [IgnoreAntiforgeryToken]
         public IActionResult GetLNDConfig(ulong configKey)
         {
             var conf = _LnConfigProvider.GetConfig(configKey);


### PR DESCRIPTION
Trying to setup Alby on my node, I have the following error.
This PR enable CORS so it should then work.

![image](https://github.com/btcpayserver/btcpayserver/assets/3020646/b56fab24-66ad-4f64-92af-9f388f8952fb)
