### PR TITLE
Compare domains in lowercase

### DIFF
--- a/BTCPayServer/Views/Shared/_Layout.cshtml
+++ b/BTCPayServer/Views/Shared/_Layout.cshtml
@@ -17,7 +17,7 @@
         notificationDisabled = user?.DisabledNotifications == "all";
     }
 	var expectedScheme = _context.HttpContext.Request.Scheme;
-	var expectedHost = _context.HttpContext.Request.Host.ToString();
+	var expectedHost = _context.HttpContext.Request.Host.ToString().ToLower();
 }
 
 <!DOCTYPE html>
@@ -79,7 +79,7 @@
     {
         <script>
 			var mainContent = document.getElementById("mainContent");
-			if (window.location.protocol != "@(expectedScheme):" || window.location.host != "@expectedHost")
+			if (window.location.protocol != "@(expectedScheme):" || window.location.host.toLowerCase() != "@expectedHost")
 			{
 				var tmpl = document.getElementById("badUrl");
 				mainContent.prepend(tmpl.content.cloneNode(true));


### PR DESCRIPTION
Domains are case-insensitive, so this comparison should be too.

I encountered this issue with a Citadel user who accidentally named their domain an uppercase name (Pay.example.com), but browsers automatically converted it to pay.example.com. They got the ` BTCPay is expecting you to access this website from ...` message in this case.