### PR TITLE
POS: Backwards-compatible price parsing

### DIFF
--- a/BTCPayServer.Tests/FastTests.cs
+++ b/BTCPayServer.Tests/FastTests.cs
@@ -1146,6 +1146,37 @@ namespace BTCPayServer.Tests
         }
 
         [Fact]
+        public void CanParseOldPosAppData()
+        {
+            var data = new JObject()
+            {
+                ["price"] = 1.64m
+            }.ToString();
+            Assert.Equal(1.64m, JsonConvert.DeserializeObject<PosAppCartItem>(data).Price);
+
+            data = new JObject()
+            {
+                ["price"] = new JObject()
+                {
+                    ["value"] = 1.65m
+                }
+            }.ToString();
+            Assert.Equal(1.65m, JsonConvert.DeserializeObject<PosAppCartItem>(data).Price);
+
+            data = new JObject()
+            {
+                ["price"] = new JObject()
+                {
+                    ["value"] = null
+                }
+            }.ToString();
+            Assert.Equal(0.0m, JsonConvert.DeserializeObject<PosAppCartItem>(data).Price);
+
+            var o = JObject.Parse(JsonConvert.SerializeObject(new PosAppCartItem() { Price = 1.356m }));
+            Assert.Equal(1.356m, o["price"].Value<decimal>());
+        }
+
+        [Fact]
         public void CanParseCurrencyValue()
         {
             Assert.True(CurrencyValue.TryParse("1.50USD", out var result));

--- a/BTCPayServer/Services/Invoices/PosAppData.cs
+++ b/BTCPayServer/Services/Invoices/PosAppData.cs
@@ -52,18 +52,6 @@ public class PosAppCartItem
     public string Image { get; set; }
 }
 
-public class PosAppCartItemPrice
-{
-    [JsonProperty(PropertyName = "formatted")]
-    public string Formatted { get; set; }
-
-    [JsonProperty(PropertyName = "value")]
-    public decimal Value { get; set; }
-
-    [JsonProperty(PropertyName = "type")]
-    public ViewPointOfSaleViewModel.ItemPriceType Type { get; set; }
-}
-
 public class PosAppCartItemPriceJsonConverter : JsonConverter
 {
     public override bool CanConvert(Type objectType)
@@ -89,7 +77,7 @@ public class PosAppCartItemPriceJsonConverter : JsonConverter
             case JTokenType.Null:
                 return null;
             case JTokenType.Object:
-                return token.ToObject<PosAppCartItemPrice>().Value;
+                return token.ToObject<JObject>()?["value"]?.Value<decimal?>();
             default:
                 throw new JsonSerializationException($"Unexpected token type: {token.Type}");
         }
@@ -103,9 +91,6 @@ public class PosAppCartItemPriceJsonConverter : JsonConverter
                 break;
             case decimal x:
                 writer.WriteValue(x.ToString(CultureInfo.InvariantCulture));
-                break;
-            case PosAppCartItemPrice x:
-                writer.WriteValue(x.Value.ToString(CultureInfo.InvariantCulture));
                 break;
         }
     }


### PR DESCRIPTION
Fixes #5159 and a regression introduced in bbff9710bf2f4a66bd6f4cd9e8ee55618d0ca5e0: The price in posData needs to be parsed in a backwards-compatible manner, as the old format of price as an object exists in the invoice metadata.