### PR TITLE
CheckoutV2: When WebSocket disconnects, we should continue polling via XHR

### DIFF
--- a/BTCPayServer/wwwroot/checkout-v2/checkout.js
+++ b/BTCPayServer/wwwroot/checkout-v2/checkout.js
@@ -278,8 +278,10 @@ function initApp() {
                             if (e.data !== 'ping') await updateFn();
                         };
                         socket.onerror = function (e) {
-                            self.pollUpdates(2000, socket)
                             console.error('Error while connecting to websocket for invoice notifications (callback):', e);
+                        };
+                        socket.onclose = function () {
+                            self.pollUpdates(2000, socket);
                         };
                     }
                     catch (e) {

--- a/BTCPayServer/wwwroot/checkout-v2/checkout.js
+++ b/BTCPayServer/wwwroot/checkout-v2/checkout.js
@@ -265,6 +265,7 @@ function initApp() {
                 }
             },
             listenIn () {
+                const self = this;
                 let socket = null;
                 const updateFn = this.fetchData;
                 const supportsWebSockets = 'WebSocket' in window && window.WebSocket.CLOSING === 2;
@@ -277,6 +278,7 @@ function initApp() {
                             if (e.data !== 'ping') await updateFn();
                         };
                         socket.onerror = function (e) {
+                            self.pollUpdates(2000, socket)
                             console.error('Error while connecting to websocket for invoice notifications (callback):', e);
                         };
                     }


### PR DESCRIPTION
This fixes #5164