### PR TITLE
Refactor logic for calculating due amount of invoices

### DIFF
--- a/BTCPayServer.Common/Altcoins/Liquid/ElementsLikeBtcPayNetwork.cs
+++ b/BTCPayServer.Common/Altcoins/Liquid/ElementsLikeBtcPayNetwork.cs
@@ -1,4 +1,5 @@
 #if ALTCOINS
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using BTCPayServer.Common;
@@ -39,7 +40,7 @@ namespace BTCPayServer
             //precision 0: 10 = 0.00000010
             //precision 2: 10 = 0.00001000
             //precision 8: 10 = 10
-            var money = cryptoInfoDue is null ? (decimal?)null : cryptoInfoDue.Value / decimal.Parse("1".PadRight(1 + 8 - Divisibility, '0'));
+            var money = cryptoInfoDue / (decimal)Math.Pow(10, 8 - Divisibility);
             var builder = base.GenerateBIP21(cryptoInfoAddress, money);
             builder.QueryParams.Add("assetid", AssetId.ToString());
             return builder;

--- a/BTCPayServer.Common/Altcoins/Liquid/ElementsLikeBtcPayNetwork.cs
+++ b/BTCPayServer.Common/Altcoins/Liquid/ElementsLikeBtcPayNetwork.cs
@@ -34,12 +34,12 @@ namespace BTCPayServer
                     output.Value is AssetMoney assetMoney && assetMoney.AssetId == AssetId));
         }
 
-        public override PaymentUrlBuilder GenerateBIP21(string cryptoInfoAddress, Money cryptoInfoDue)
+        public override PaymentUrlBuilder GenerateBIP21(string cryptoInfoAddress, decimal? cryptoInfoDue)
         {
             //precision 0: 10 = 0.00000010
             //precision 2: 10 = 0.00001000
             //precision 8: 10 = 10
-            var money = cryptoInfoDue is null ? null : new Money(cryptoInfoDue.ToDecimal(MoneyUnit.BTC) / decimal.Parse("1".PadRight(1 + 8 - Divisibility, '0')), MoneyUnit.BTC);
+            var money = cryptoInfoDue is null ? (decimal?)null : cryptoInfoDue.Value / decimal.Parse("1".PadRight(1 + 8 - Divisibility, '0'));
             var builder = base.GenerateBIP21(cryptoInfoAddress, money);
             builder.QueryParams.Add("assetid", AssetId.ToString());
             return builder;

--- a/BTCPayServer.Common/BTCPayNetwork.cs
+++ b/BTCPayServer.Common/BTCPayNetwork.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using BTCPayServer.Common;
@@ -87,13 +88,13 @@ namespace BTCPayServer
             });
         }
 
-        public virtual PaymentUrlBuilder GenerateBIP21(string cryptoInfoAddress, Money cryptoInfoDue)
+        public virtual PaymentUrlBuilder GenerateBIP21(string cryptoInfoAddress, decimal? cryptoInfoDue)
         {
             var builder = new PaymentUrlBuilder(this.NBitcoinNetwork.UriScheme);
             builder.Host = cryptoInfoAddress;
-            if (cryptoInfoDue != null && cryptoInfoDue != Money.Zero)
+            if (cryptoInfoDue is not null && cryptoInfoDue.Value != 0.0m)
             {
-                builder.QueryParams.Add("amount", cryptoInfoDue.ToString(false, true));
+                builder.QueryParams.Add("amount", cryptoInfoDue.Value.ToString(CultureInfo.InvariantCulture));
             }
             return builder;
         }

--- a/BTCPayServer.Tests/FastTests.cs
+++ b/BTCPayServer.Tests/FastTests.cs
@@ -365,7 +365,7 @@ namespace BTCPayServer.Tests
             Assert.Equal(0.11764706m, accounting.Due);
             entity.Payments.Add(new PaymentEntity()
             {
-                PaymentCurrency = "BTC",
+                Currency = "BTC",
                 Output = new TxOut(Money.Coins(0.11764706m), new Key()),
                 Accounted = true
             });
@@ -418,7 +418,7 @@ namespace BTCPayServer.Tests
 
             entity.Payments.Add(new PaymentEntity()
             {
-                PaymentCurrency = "BTC",
+                Currency = "BTC",
                 Output = new TxOut(Money.Coins(0.5m), new Key()),
                 Rate = 5000,
                 Accounted = true,
@@ -432,7 +432,7 @@ namespace BTCPayServer.Tests
 
             entity.Payments.Add(new PaymentEntity()
             {
-                PaymentCurrency = "BTC",
+                Currency = "BTC",
                 Output = new TxOut(Money.Coins(0.2m), new Key()),
                 Accounted = true,
                 NetworkFee = 0.1m
@@ -444,7 +444,7 @@ namespace BTCPayServer.Tests
 
             entity.Payments.Add(new PaymentEntity()
             {
-                PaymentCurrency = "BTC",
+                Currency = "BTC",
                 Output = new TxOut(Money.Coins(0.6m), new Key()),
                 Accounted = true,
                 NetworkFee = 0.1m
@@ -455,7 +455,7 @@ namespace BTCPayServer.Tests
             Assert.Equal(1.3m, accounting.TotalDue);
 
             entity.Payments.Add(
-                new PaymentEntity() { PaymentCurrency = "BTC", Output = new TxOut(Money.Coins(0.2m), new Key()), Accounted = true });
+                new PaymentEntity() { Currency = "BTC", Output = new TxOut(Money.Coins(0.2m), new Key()), Accounted = true });
             entity.UpdateTotals();
             accounting = paymentMethod.Calculate();
             Assert.Equal(0.0m, accounting.Due);
@@ -483,7 +483,7 @@ namespace BTCPayServer.Tests
 
             entity.Payments.Add(new PaymentEntity()
             {
-                PaymentCurrency = "BTC",
+                Currency = "BTC",
                 Output = new TxOut(Money.Coins(1.0m), new Key()),
                 Accounted = true,
                 NetworkFee = 0.1m
@@ -506,7 +506,7 @@ namespace BTCPayServer.Tests
 
             entity.Payments.Add(new PaymentEntity()
             {
-                PaymentCurrency = "LTC",
+                Currency = "LTC",
                 Output = new TxOut(Money.Coins(1.0m), new Key()),
                 Accounted = true,
                 NetworkFee = 0.01m
@@ -531,7 +531,7 @@ namespace BTCPayServer.Tests
             var remaining = Money.Coins(4.2m - 0.5m + 0.01m / 2.0m).ToDecimal(MoneyUnit.BTC);
             entity.Payments.Add(new PaymentEntity()
             {
-                PaymentCurrency = "BTC",
+                Currency = "BTC",
                 Output = new TxOut(Money.Coins(remaining), new Key()),
                 Accounted = true,
                 NetworkFee = 0.1m
@@ -1964,7 +1964,7 @@ namespace BTCPayServer.Tests
                 new PaymentEntity()
                 {
                     Accounted = true,
-                    PaymentCurrency = "BTC",
+                    Currency = "BTC",
                     NetworkFee = 0.00000100m,
                     Network = networkProvider.GetNetwork("BTC"),
                 }
@@ -1979,7 +1979,7 @@ namespace BTCPayServer.Tests
                 new PaymentEntity()
                 {
                     Accounted = true,
-                    PaymentCurrency = "BTC",
+                    Currency = "BTC",
                     NetworkFee = 0.00000100m,
                     Network = networkProvider.GetNetwork("BTC")
                 }

--- a/BTCPayServer.Tests/FastTests.cs
+++ b/BTCPayServer.Tests/FastTests.cs
@@ -355,7 +355,7 @@ namespace BTCPayServer.Tests
             entity.Payments = new System.Collections.Generic.List<PaymentEntity>();
             entity.SetPaymentMethod(new PaymentMethod()
             {
-                PaymentCurrency = "BTC",
+                Currency = "BTC",
                 Rate = 34_000m
             });
             entity.Price = 4000;
@@ -382,11 +382,11 @@ namespace BTCPayServer.Tests
             // However, Calculate() should just cap it to 0.0m
             entity.SetPaymentMethod(new PaymentMethod()
             {
-                PaymentCurrency = "LTC",
+                Currency = "LTC",
                 Rate = 3400m
             });
             entity.UpdateTotals();
-            var method = entity.GetPaymentMethods().First(p => p.PaymentCurrency == "LTC");
+            var method = entity.GetPaymentMethods().First(p => p.Currency == "LTC");
             accounting = method.Calculate();
             Assert.Equal(0.0m, accounting.DueUncapped);
 
@@ -403,7 +403,7 @@ namespace BTCPayServer.Tests
             entity.Payments = new System.Collections.Generic.List<PaymentEntity>();
             entity.SetPaymentMethod(new PaymentMethod()
             {
-                PaymentCurrency = "BTC",
+                Currency = "BTC",
                 Rate = 5000,
                 NextNetworkFee = Money.Coins(0.1m)
             });
@@ -466,9 +466,9 @@ namespace BTCPayServer.Tests
             entity.Price = 5000;
             PaymentMethodDictionary paymentMethods = new PaymentMethodDictionary();
             paymentMethods.Add(
-                new PaymentMethod() { PaymentCurrency = "BTC", Rate = 1000, NextNetworkFee = Money.Coins(0.1m) });
+                new PaymentMethod() { Currency = "BTC", Rate = 1000, NextNetworkFee = Money.Coins(0.1m) });
             paymentMethods.Add(
-                new PaymentMethod() { PaymentCurrency = "LTC", Rate = 500, NextNetworkFee = Money.Coins(0.01m) });
+                new PaymentMethod() { Currency = "LTC", Rate = 500, NextNetworkFee = Money.Coins(0.01m) });
             entity.SetPaymentMethods(paymentMethods);
             entity.Payments = new List<PaymentEntity>();
             entity.UpdateTotals();
@@ -596,7 +596,7 @@ namespace BTCPayServer.Tests
             entity.Payments = new List<PaymentEntity>();
             entity.SetPaymentMethod(new PaymentMethod()
             {
-                PaymentCurrency = "BTC",
+                Currency = "BTC",
                 Rate = 5000,
                 NextNetworkFee = Money.Coins(0.1m)
             });
@@ -1946,14 +1946,14 @@ namespace BTCPayServer.Tests
             invoiceEntity.Payments = new System.Collections.Generic.List<PaymentEntity>();
             invoiceEntity.Price = 100;
             PaymentMethodDictionary paymentMethods = new PaymentMethodDictionary();
-            paymentMethods.Add(new PaymentMethod() { Network = networkBTC, PaymentCurrency = "BTC", Rate = 10513.44m, }
+            paymentMethods.Add(new PaymentMethod() { Network = networkBTC, Currency = "BTC", Rate = 10513.44m, }
                 .SetPaymentMethodDetails(
                     new BTCPayServer.Payments.Bitcoin.BitcoinLikeOnChainPaymentMethod()
                     {
                         NextNetworkFee = Money.Coins(0.00000100m),
                         DepositAddress = dummy
                     }));
-            paymentMethods.Add(new PaymentMethod() { Network = networkLTC, PaymentCurrency = "LTC", Rate = 216.79m }
+            paymentMethods.Add(new PaymentMethod() { Network = networkLTC, Currency = "LTC", Rate = 216.79m }
                 .SetPaymentMethodDetails(
                     new BTCPayServer.Payments.Bitcoin.BitcoinLikeOnChainPaymentMethod()
                     {

--- a/BTCPayServer.Tests/FastTests.cs
+++ b/BTCPayServer.Tests/FastTests.cs
@@ -348,7 +348,8 @@ namespace BTCPayServer.Tests
         }
         [Fact]
         public void CanCalculateDust()
-        {;
+        {
+            ;
             var entity = new InvoiceEntity();
             entity.Networks = new BTCPayNetworkProvider(ChainName.Regtest);
 #pragma warning disable CS0618
@@ -362,7 +363,7 @@ namespace BTCPayServer.Tests
             entity.UpdateTotals();
             var accounting = entity.GetPaymentMethods().First().Calculate();
             // Exact price should be 0.117647059..., but the payment method round up to one sat
-            Assert.Equal(Money.Coins(0.11764706m), accounting.Due);
+            Assert.Equal(0.11764706m, accounting.Due);
             entity.Payments.Add(new PaymentEntity()
             {
                 PaymentCurrency = "BTC",
@@ -398,8 +399,9 @@ namespace BTCPayServer.Tests
 
             var paymentMethod = entity.GetPaymentMethods().TryGet("BTC", PaymentTypes.BTCLike);
             var accounting = paymentMethod.Calculate();
-            Assert.Equal(Money.Coins(1.1m), accounting.Due);
-            Assert.Equal(Money.Coins(1.1m), accounting.TotalDue);
+            Assert.Equal(1.0m, accounting.ToSmallestUnit(Money.Satoshis(1.0m).ToDecimal(MoneyUnit.BTC)));
+            Assert.Equal(1.1m, accounting.Due);
+            Assert.Equal(1.1m, accounting.TotalDue);
 
             entity.Payments.Add(new PaymentEntity()
             {
@@ -412,8 +414,8 @@ namespace BTCPayServer.Tests
             entity.UpdateTotals();
             accounting = paymentMethod.Calculate();
             //Since we need to spend one more txout, it should be 1.1 - 0,5 + 0.1
-            Assert.Equal(Money.Coins(0.7m), accounting.Due);
-            Assert.Equal(Money.Coins(1.2m), accounting.TotalDue);
+            Assert.Equal(0.7m, accounting.Due);
+            Assert.Equal(1.2m, accounting.TotalDue);
 
             entity.Payments.Add(new PaymentEntity()
             {
@@ -424,8 +426,8 @@ namespace BTCPayServer.Tests
             });
             entity.UpdateTotals();
             accounting = paymentMethod.Calculate();
-            Assert.Equal(Money.Coins(0.6m), accounting.Due);
-            Assert.Equal(Money.Coins(1.3m), accounting.TotalDue);
+            Assert.Equal(0.6m, accounting.Due);
+            Assert.Equal(1.3m, accounting.TotalDue);
 
             entity.Payments.Add(new PaymentEntity()
             {
@@ -436,15 +438,15 @@ namespace BTCPayServer.Tests
             });
             entity.UpdateTotals();
             accounting = paymentMethod.Calculate();
-            Assert.Equal(Money.Zero, accounting.Due);
-            Assert.Equal(Money.Coins(1.3m), accounting.TotalDue);
+            Assert.Equal(0.0m, accounting.Due);
+            Assert.Equal(1.3m, accounting.TotalDue);
 
             entity.Payments.Add(
                 new PaymentEntity() { PaymentCurrency = "BTC", Output = new TxOut(Money.Coins(0.2m), new Key()), Accounted = true });
             entity.UpdateTotals();
             accounting = paymentMethod.Calculate();
-            Assert.Equal(Money.Zero, accounting.Due);
-            Assert.Equal(Money.Coins(1.3m), accounting.TotalDue);
+            Assert.Equal(0.0m, accounting.Due);
+            Assert.Equal(1.3m, accounting.TotalDue);
 
             entity = new InvoiceEntity();
             entity.Networks = networkProvider;
@@ -459,12 +461,12 @@ namespace BTCPayServer.Tests
             entity.UpdateTotals();
             paymentMethod = entity.GetPaymentMethod(new PaymentMethodId("BTC", PaymentTypes.BTCLike));
             accounting = paymentMethod.Calculate();
-            Assert.Equal(Money.Coins(5.1m), accounting.Due);
+            Assert.Equal(5.1m, accounting.Due);
 
             paymentMethod = entity.GetPaymentMethod(new PaymentMethodId("LTC", PaymentTypes.BTCLike));
             accounting = paymentMethod.Calculate();
 
-            Assert.Equal(Money.Coins(10.01m), accounting.TotalDue);
+            Assert.Equal(10.01m, accounting.TotalDue);
 
             entity.Payments.Add(new PaymentEntity()
             {
@@ -476,18 +478,18 @@ namespace BTCPayServer.Tests
             entity.UpdateTotals();
             paymentMethod = entity.GetPaymentMethod(new PaymentMethodId("BTC", PaymentTypes.BTCLike));
             accounting = paymentMethod.Calculate();
-            Assert.Equal(Money.Coins(4.2m), accounting.Due);
-            Assert.Equal(Money.Coins(1.0m), accounting.CryptoPaid);
-            Assert.Equal(Money.Coins(1.0m), accounting.Paid);
-            Assert.Equal(Money.Coins(5.2m), accounting.TotalDue);
+            Assert.Equal(4.2m, accounting.Due);
+            Assert.Equal(1.0m, accounting.CryptoPaid);
+            Assert.Equal(1.0m, accounting.Paid);
+            Assert.Equal(5.2m, accounting.TotalDue);
             Assert.Equal(2, accounting.TxRequired);
 
             paymentMethod = entity.GetPaymentMethod(new PaymentMethodId("LTC", PaymentTypes.BTCLike));
             accounting = paymentMethod.Calculate();
-            Assert.Equal(Money.Coins(10.01m + 0.1m * 2 - 2.0m /* 8.21m */), accounting.Due);
-            Assert.Equal(Money.Coins(0.0m), accounting.CryptoPaid);
-            Assert.Equal(Money.Coins(2.0m), accounting.Paid);
-            Assert.Equal(Money.Coins(10.01m + 0.1m * 2), accounting.TotalDue);
+            Assert.Equal(10.01m + 0.1m * 2 - 2.0m /* 8.21m */, accounting.Due);
+            Assert.Equal(0.0m, accounting.CryptoPaid);
+            Assert.Equal(2.0m, accounting.Paid);
+            Assert.Equal(10.01m + 0.1m * 2, accounting.TotalDue);
 
             entity.Payments.Add(new PaymentEntity()
             {
@@ -499,45 +501,45 @@ namespace BTCPayServer.Tests
             entity.UpdateTotals();
             paymentMethod = entity.GetPaymentMethod(new PaymentMethodId("BTC", PaymentTypes.BTCLike));
             accounting = paymentMethod.Calculate();
-            Assert.Equal(Money.Coins(4.2m - 0.5m + 0.01m / 2), accounting.Due);
-            Assert.Equal(Money.Coins(1.0m), accounting.CryptoPaid);
-            Assert.Equal(Money.Coins(1.5m), accounting.Paid);
-            Assert.Equal(Money.Coins(5.2m + 0.01m / 2), accounting.TotalDue); // The fee for LTC added
+            Assert.Equal(4.2m - 0.5m + 0.01m / 2, accounting.Due);
+            Assert.Equal(1.0m, accounting.CryptoPaid);
+            Assert.Equal(1.5m, accounting.Paid);
+            Assert.Equal(5.2m + 0.01m / 2, accounting.TotalDue); // The fee for LTC added
             Assert.Equal(2, accounting.TxRequired);
 
             paymentMethod = entity.GetPaymentMethod(new PaymentMethodId("LTC", PaymentTypes.BTCLike));
             accounting = paymentMethod.Calculate();
-            Assert.Equal(Money.Coins(8.21m - 1.0m + 0.01m), accounting.Due);
-            Assert.Equal(Money.Coins(1.0m), accounting.CryptoPaid);
-            Assert.Equal(Money.Coins(3.0m), accounting.Paid);
-            Assert.Equal(Money.Coins(10.01m + 0.1m * 2 + 0.01m), accounting.TotalDue);
+            Assert.Equal(8.21m - 1.0m + 0.01m, accounting.Due);
+            Assert.Equal(1.0m, accounting.CryptoPaid);
+            Assert.Equal(3.0m, accounting.Paid);
+            Assert.Equal(10.01m + 0.1m * 2 + 0.01m, accounting.TotalDue);
             Assert.Equal(2, accounting.TxRequired);
 
-            var remaining = Money.Coins(4.2m - 0.5m + 0.01m / 2);
+            var remaining = Money.Coins(4.2m - 0.5m + 0.01m / 2.0m).ToDecimal(MoneyUnit.BTC);
             entity.Payments.Add(new PaymentEntity()
             {
                 PaymentCurrency = "BTC",
-                Output = new TxOut(remaining, new Key()),
+                Output = new TxOut(Money.Coins(remaining), new Key()),
                 Accounted = true,
                 NetworkFee = 0.1m
             });
             entity.UpdateTotals();
             paymentMethod = entity.GetPaymentMethod(new PaymentMethodId("BTC", PaymentTypes.BTCLike));
             accounting = paymentMethod.Calculate();
-            Assert.Equal(Money.Zero, accounting.Due);
-            Assert.Equal(Money.Coins(1.0m) + remaining, accounting.CryptoPaid);
-            Assert.Equal(Money.Coins(1.5m) + remaining, accounting.Paid);
-            Assert.Equal(Money.Coins(5.2m + 0.01m / 2), accounting.TotalDue);
+            Assert.Equal(0.0m, accounting.Due);
+            Assert.Equal(1.0m + remaining, accounting.CryptoPaid);
+            Assert.Equal(1.5m + remaining, accounting.Paid);
+            Assert.Equal(5.2m + 0.01m / 2, accounting.TotalDue);
             Assert.Equal(accounting.Paid, accounting.TotalDue);
             Assert.Equal(2, accounting.TxRequired);
 
             paymentMethod = entity.GetPaymentMethod(new PaymentMethodId("LTC", PaymentTypes.BTCLike));
             accounting = paymentMethod.Calculate();
-            Assert.Equal(Money.Zero, accounting.Due);
-            Assert.Equal(Money.Coins(1.0m), accounting.CryptoPaid);
-            Assert.Equal(Money.Coins(3.0m) + remaining * 2, accounting.Paid);
+            Assert.Equal(0.0m, accounting.Due);
+            Assert.Equal(1.0m, accounting.CryptoPaid);
+            Assert.Equal(3.0m + remaining * 2, accounting.Paid);
             // Paying 2 BTC fee, LTC fee removed because fully paid
-            Assert.Equal(Money.Coins(10.01m + 0.1m * 2 + 0.1m * 2 /* + 0.01m no need to pay this fee anymore */),
+            Assert.Equal(10.01m + 0.1m * 2 + 0.1m * 2 /* + 0.01m no need to pay this fee anymore */,
                 accounting.TotalDue);
             Assert.Equal(1, accounting.TxRequired);
             Assert.Equal(accounting.Paid, accounting.TotalDue);
@@ -591,19 +593,19 @@ namespace BTCPayServer.Tests
 
             var paymentMethod = entity.GetPaymentMethods().TryGet("BTC", PaymentTypes.BTCLike);
             var accounting = paymentMethod.Calculate();
-            Assert.Equal(Money.Coins(1.1m), accounting.Due);
-            Assert.Equal(Money.Coins(1.1m), accounting.TotalDue);
-            Assert.Equal(Money.Coins(1.1m), accounting.MinimumTotalDue);
+            Assert.Equal(1.1m, accounting.Due);
+            Assert.Equal(1.1m, accounting.TotalDue);
+            Assert.Equal(1.1m, accounting.MinimumTotalDue);
 
             entity.PaymentTolerance = 10;
             entity.UpdateTotals();
             accounting = paymentMethod.Calculate();
-            Assert.Equal(Money.Coins(0.99m), accounting.MinimumTotalDue);
+            Assert.Equal(0.99m, accounting.MinimumTotalDue);
 
             entity.PaymentTolerance = 100;
             entity.UpdateTotals();
             accounting = paymentMethod.Calculate();
-            Assert.Equal(Money.Satoshis(1), accounting.MinimumTotalDue);
+            Assert.Equal(0.0000_0001m, accounting.MinimumTotalDue);
         }
 
         [Fact]
@@ -1099,7 +1101,7 @@ namespace BTCPayServer.Tests
             search = new SearchString(filter);
             Assert.Equal("2019-04-25 01:00 AM", search.Filters["startdate"].First());
             Assert.Equal("hekki", search.TextSearch);
-            
+
             // modify search
             filter = $"status:settled,exceptionstatus:paidLate,unusual:true, fulltext searchterm, storeid:{storeId},startdate:2019-04-25 01:00:00";
             search = new SearchString(filter);
@@ -1109,33 +1111,33 @@ namespace BTCPayServer.Tests
             Assert.Single(search.Filters["status"], "settled");
             Assert.Single(search.Filters["exceptionstatus"], "paidLate");
             Assert.Single(search.Filters["unusual"], "true");
-            
+
             // toggle off bool with same value
             var modified = new SearchString(search.Toggle("unusual", "true"));
             Assert.Null(modified.GetFilterBool("unusual"));
-            
+
             // add to array
             modified = new SearchString(modified.Toggle("status", "processing"));
             var statusArray = modified.GetFilterArray("status");
             Assert.Equal(2, statusArray.Length);
             Assert.Contains("processing", statusArray);
             Assert.Contains("settled", statusArray);
-            
+
             // toggle off array with same value
             modified = new SearchString(modified.Toggle("status", "settled"));
             statusArray = modified.GetFilterArray("status");
             Assert.Single(statusArray, "processing");
-            
+
             // toggle off array with null value
             modified = new SearchString(modified.Toggle("status", null));
             Assert.Null(modified.GetFilterArray("status"));
-            
+
             // toggle off date with null value
             modified = new SearchString(modified.Toggle("startdate", "-7d"));
             Assert.Single(modified.GetFilterArray("startdate"), "-7d");
             modified = new SearchString(modified.Toggle("startdate", null));
             Assert.Null(modified.GetFilterArray("startdate"));
-            
+
             // toggle off date with same value
             modified = new SearchString(modified.Toggle("enddate", "-7d"));
             Assert.Single(modified.GetFilterArray("enddate"), "-7d");
@@ -1976,19 +1978,19 @@ namespace BTCPayServer.Tests
                     .SetCryptoPaymentData(new BitcoinLikePaymentData()
                     {
                         Network = networkProvider.GetNetwork("BTC"),
-                        Output = new TxOut() { Value = accounting.Due }
+                        Output = new TxOut() { Value = Money.Coins(accounting.Due) }
                     }));
             invoiceEntity.UpdateTotals();
             accounting = btc.Calculate();
-            Assert.Equal(Money.Zero, accounting.Due);
-            Assert.Equal(Money.Zero, accounting.DueUncapped);
+            Assert.Equal(0.0m, accounting.Due);
+            Assert.Equal(0.0m, accounting.DueUncapped);
 
             var ltc = invoiceEntity.GetPaymentMethod(new PaymentMethodId("LTC", PaymentTypes.BTCLike));
             accounting = ltc.Calculate();
 
-            Assert.Equal(Money.Zero, accounting.Due);
+            Assert.Equal(0.0m, accounting.Due);
             // LTC might have over paid due to BTC paying above what it should (round 1 satoshi up)
-            Assert.True(accounting.DueUncapped < Money.Zero);
+            Assert.True(accounting.DueUncapped < 0.0m);
         }
 
         [Fact]

--- a/BTCPayServer.Tests/FastTests.cs
+++ b/BTCPayServer.Tests/FastTests.cs
@@ -349,7 +349,7 @@ namespace BTCPayServer.Tests
         [Fact]
         public void CanCalculateDust()
         {
-            var entity = new InvoiceEntity();
+            var entity = new InvoiceEntity() { Currency = "USD" };
             entity.Networks = new BTCPayNetworkProvider(ChainName.Regtest);
 #pragma warning disable CS0618
             entity.Payments = new System.Collections.Generic.List<PaymentEntity>();
@@ -397,7 +397,7 @@ namespace BTCPayServer.Tests
         public void CanCalculateCryptoDue()
         {
             var networkProvider = new BTCPayNetworkProvider(ChainName.Regtest);
-            var entity = new InvoiceEntity();
+            var entity = new InvoiceEntity() { Currency = "USD" };
             entity.Networks = networkProvider;
 #pragma warning disable CS0618
             entity.Payments = new System.Collections.Generic.List<PaymentEntity>();

--- a/BTCPayServer.Tests/FastTests.cs
+++ b/BTCPayServer.Tests/FastTests.cs
@@ -349,7 +349,6 @@ namespace BTCPayServer.Tests
         [Fact]
         public void CanCalculateDust()
         {
-            ;
             var entity = new InvoiceEntity();
             entity.Networks = new BTCPayNetworkProvider(ChainName.Regtest);
 #pragma warning disable CS0618
@@ -377,6 +376,20 @@ namespace BTCPayServer.Tests
             Assert.True(Money.Satoshis(1.0m).ToDecimal(MoneyUnit.BTC) * entity.Rates["BTC"] > entity.Dust);
             Assert.True(!entity.IsOverPaid);
             Assert.True(!entity.IsUnderPaid);
+
+            // Now, imagine there is litecoin. It might seem from its
+            // perspecitve that there has been a slight over payment.
+            // However, Calculate() should just cap it to 0.0m
+            entity.SetPaymentMethod(new PaymentMethod()
+            {
+                PaymentCurrency = "LTC",
+                Rate = 3400m
+            });
+            entity.UpdateTotals();
+            var method = entity.GetPaymentMethods().First(p => p.PaymentCurrency == "LTC");
+            accounting = method.Calculate();
+            Assert.Equal(0.0m, accounting.DueUncapped);
+
 #pragma warning restore CS0618
         }
 #if ALTCOINS

--- a/BTCPayServer.Tests/FastTests.cs
+++ b/BTCPayServer.Tests/FastTests.cs
@@ -1934,11 +1934,6 @@ namespace BTCPayServer.Tests
 #pragma warning disable CS0618
             var dummy = new Key().PubKey.GetAddress(ScriptPubKeyType.Legacy, Network.RegTest).ToString();
             var networkProvider = new BTCPayNetworkProvider(ChainName.Regtest);
-            var paymentMethodHandlerDictionary = new PaymentMethodHandlerDictionary(new IPaymentMethodHandler[]
-            {
-                new BitcoinLikePaymentHandler(null, networkProvider, null, null, null, null),
-                new LightningLikePaymentHandler(null, null, networkProvider, null, null, null),
-            });
             var networkBTC = networkProvider.GetNetwork("BTC");
             var networkLTC = networkProvider.GetNetwork("LTC");
             InvoiceEntity invoiceEntity = new InvoiceEntity();
@@ -2002,8 +1997,9 @@ namespace BTCPayServer.Tests
             accounting = ltc.Calculate();
 
             Assert.Equal(0.0m, accounting.Due);
-            // LTC might have over paid due to BTC paying above what it should (round 1 satoshi up)
-            Assert.True(accounting.DueUncapped < 0.0m);
+            // LTC might should be over paid due to BTC paying above what it should (round 1 satoshi up), but we handle this case
+            // and set DueUncapped to zero.
+            Assert.Equal(0.0m, accounting.DueUncapped);
         }
 
         [Fact]

--- a/BTCPayServer.Tests/UnitTest1.cs
+++ b/BTCPayServer.Tests/UnitTest1.cs
@@ -1761,7 +1761,7 @@ namespace BTCPayServer.Tests
                 var parsedJson = await GetExport(user);
                 Assert.Equal(3, parsedJson.Length);
 
-                var invoiceDueAfterFirstPayment = (3 * networkFee).ToDecimal(MoneyUnit.BTC) * invoice.Rate;
+                var invoiceDueAfterFirstPayment = 3 * networkFee.ToDecimal(MoneyUnit.BTC) * invoice.Rate;
                 var pay1str = parsedJson[0].ToString();
                 Assert.Contains("\"InvoiceItemDesc\": \"Some \\\", description\"", pay1str);
                 Assert.Equal(invoiceDueAfterFirstPayment, GetFieldValue(pay1str, "InvoiceDue"));

--- a/BTCPayServer/Controllers/GreenField/GreenfieldInvoiceController.cs
+++ b/BTCPayServer/Controllers/GreenField/GreenfieldInvoiceController.cs
@@ -396,7 +396,7 @@ namespace BTCPayServer.Controllers.Greenfield
                 return this.CreateValidationError(ModelState);
 
             var accounting = invoicePaymentMethod.Calculate();
-            var cryptoPaid = accounting.Paid.ToDecimal(MoneyUnit.BTC);
+            var cryptoPaid = accounting.Paid;
             var cdCurrency = _currencyNameTable.GetCurrencyData(invoice.Currency, true);
             var paidCurrency = Math.Round(cryptoPaid * invoicePaymentMethod.Rate, cdCurrency.Divisibility);
             var rateResult = await _rateProvider.FetchRate(
@@ -464,7 +464,7 @@ namespace BTCPayServer.Controllers.Greenfield
                         return this.CreateValidationError(ModelState);
                     }
                     
-                    var dueAmount = accounting.TotalDue.ToDecimal(MoneyUnit.BTC);
+                    var dueAmount = accounting.TotalDue;
                     createPullPayment.Currency = cryptoCode;
                     createPullPayment.Amount = Math.Round(paidAmount - dueAmount, appliedDivisibility);
                     createPullPayment.AutoApproveClaims = true;
@@ -580,11 +580,11 @@ namespace BTCPayServer.Controllers.Greenfield
                         CryptoCode = method.GetId().CryptoCode,
                         Destination = details.GetPaymentDestination(),
                         Rate = method.Rate,
-                        Due = accounting.DueUncapped.ToDecimal(MoneyUnit.BTC),
-                        TotalPaid = accounting.Paid.ToDecimal(MoneyUnit.BTC),
-                        PaymentMethodPaid = accounting.CryptoPaid.ToDecimal(MoneyUnit.BTC),
-                        Amount = accounting.TotalDue.ToDecimal(MoneyUnit.BTC),
-                        NetworkFee = accounting.NetworkFee.ToDecimal(MoneyUnit.BTC),
+                        Due = accounting.DueUncapped,
+                        TotalPaid = accounting.Paid,
+                        PaymentMethodPaid = accounting.CryptoPaid,
+                        Amount = accounting.TotalDue,
+                        NetworkFee = accounting.NetworkFee,
                         PaymentLink =
                             method.GetId().PaymentType.GetPaymentLink(method.Network, entity, details, accounting.Due,
                                 Request.GetAbsoluteRoot()),

--- a/BTCPayServer/Controllers/UIInvoiceController.Testing.cs
+++ b/BTCPayServer/Controllers/UIInvoiceController.Testing.cs
@@ -55,7 +55,7 @@ namespace BTCPayServer.Controllers
                         return Ok(new
                         {
                             Txid = txid,
-                            AmountRemaining = (paymentMethod.Calculate().Due - amount).ToUnit(MoneyUnit.BTC),
+                            AmountRemaining = paymentMethod.Calculate().Due - amount.ToDecimal(MoneyUnit.BTC),
                             SuccessMessage = $"Created transaction {txid}"
                         });
 
@@ -70,11 +70,11 @@ namespace BTCPayServer.Controllers
                         {
                             var bolt11 = BOLT11PaymentRequest.Parse(destination, network);
                             var paymentHash = bolt11.PaymentHash?.ToString();
-                            var paid = new Money(response.Details.TotalAmount.ToUnit(LightMoneyUnit.Satoshi), MoneyUnit.Satoshi);
+                            var paid = response.Details.TotalAmount.ToDecimal(LightMoneyUnit.BTC);
                             return Ok(new
                             {
                                 Txid = paymentHash,
-                                AmountRemaining = (paymentMethod.Calculate().TotalDue - paid).ToUnit(MoneyUnit.BTC),
+                                AmountRemaining = paymentMethod.Calculate().TotalDue - paid,
                                 SuccessMessage = $"Sent payment {paymentHash}"
                             });
                         }

--- a/BTCPayServer/Controllers/UIInvoiceController.UI.cs
+++ b/BTCPayServer/Controllers/UIInvoiceController.UI.cs
@@ -228,18 +228,14 @@ namespace BTCPayServer.Controllers
 
                     string txId = paymentData.GetPaymentId();
                     string? link = GetTransactionLink(paymentMethodId, txId);
-                    var paymentMethod = i.GetPaymentMethod(paymentMethodId);
-                    var amount = paymentData.GetValue();
-                    var rate = paymentMethod.Rate;
-                    var paid = (amount - paymentEntity.NetworkFee) * rate;
-
+                    
                     return new ViewPaymentRequestViewModel.PaymentRequestInvoicePayment
                     {
-                        Amount = amount,
-                        Paid = paid,
+                        Amount = paymentEntity.PaidAmount.Gross,
+                        Paid = paymentEntity.PaidAmount.Net,
                         ReceivedDate = paymentEntity.ReceivedTime.DateTime,
-                        PaidFormatted = _displayFormatter.Currency(paid, i.Currency, DisplayFormatter.CurrencyFormat.Symbol),
-                        RateFormatted = _displayFormatter.Currency(rate, i.Currency, DisplayFormatter.CurrencyFormat.Symbol),
+                        PaidFormatted = _displayFormatter.Currency(paymentEntity.PaidAmount.Net, i.Currency, DisplayFormatter.CurrencyFormat.Symbol),
+                        RateFormatted = _displayFormatter.Currency(paymentEntity.Rate, i.Currency, DisplayFormatter.CurrencyFormat.Symbol),
                         PaymentMethod = paymentMethodId.ToPrettyString(),
                         Link = link,
                         Id = txId,

--- a/BTCPayServer/Controllers/UIInvoiceController.UI.cs
+++ b/BTCPayServer/Controllers/UIInvoiceController.UI.cs
@@ -360,8 +360,8 @@ namespace BTCPayServer.Controllers
             if (paymentMethod != null)
             {
                 accounting = paymentMethod.Calculate();
-                cryptoPaid = accounting.Paid.ToDecimal(MoneyUnit.BTC);
-                dueAmount = accounting.TotalDue.ToDecimal(MoneyUnit.BTC);
+                cryptoPaid = accounting.Paid;
+                dueAmount = accounting.TotalDue;
                 paidAmount = cryptoPaid.RoundToSignificant(appliedDivisibility);
             }
 
@@ -556,7 +556,7 @@ namespace BTCPayServer.Controllers
                     {
                         var accounting = data.Calculate();
                         var paymentMethodId = data.GetId();
-                        var overpaidAmount = accounting.OverpaidHelper.ToDecimal(MoneyUnit.BTC);
+                        var overpaidAmount = accounting.OverpaidHelper;
 
                         if (overpaidAmount > 0)
                         {
@@ -567,8 +567,8 @@ namespace BTCPayServer.Controllers
                         {
                             PaymentMethodId = paymentMethodId,
                             PaymentMethod = paymentMethodId.ToPrettyString(),
-                            Due = _displayFormatter.Currency(accounting.Due.ToDecimal(MoneyUnit.BTC), paymentMethodId.CryptoCode),
-                            Paid = _displayFormatter.Currency(accounting.CryptoPaid.ToDecimal(MoneyUnit.BTC), paymentMethodId.CryptoCode),
+                            Due = _displayFormatter.Currency(accounting.Due, paymentMethodId.CryptoCode),
+                            Paid = _displayFormatter.Currency(accounting.CryptoPaid, paymentMethodId.CryptoCode),
                             Overpaid = _displayFormatter.Currency(overpaidAmount, paymentMethodId.CryptoCode),
                             Address = data.GetPaymentMethodDetails().GetPaymentDestination(),
                             Rate = ExchangeRate(data.GetId().CryptoCode, data),
@@ -823,7 +823,6 @@ namespace BTCPayServer.Controllers
             var dto = invoice.EntityToDTO();
             var accounting = paymentMethod.Calculate();
             var paymentMethodHandler = _paymentMethodHandlerDictionary[paymentMethodId];
-            var divisibility = _CurrencyNameTable.GetNumberFormatInfo(paymentMethod.GetId().CryptoCode, false)?.CurrencyDecimalDigits;
 
             switch (lang?.ToLowerInvariant())
             {
@@ -881,10 +880,10 @@ namespace BTCPayServer.Controllers
                 OnChainWithLnInvoiceFallback = storeBlob.OnChainWithLnInvoiceFallback,
                 CryptoImage = Request.GetRelativePathOrAbsolute(paymentMethodHandler.GetCryptoImage(paymentMethodId)),
                 BtcAddress = paymentMethodDetails.GetPaymentDestination(),
-                BtcDue = accounting.Due.ShowMoney(divisibility),
-                BtcPaid = accounting.Paid.ShowMoney(divisibility),
+                BtcDue = accounting.ShowMoney(accounting.Due),
+                BtcPaid = accounting.ShowMoney(accounting.Paid),
                 InvoiceCurrency = invoice.Currency,
-                OrderAmount = (accounting.TotalDue - accounting.NetworkFee).ShowMoney(divisibility),
+                OrderAmount = accounting.ShowMoney(accounting.TotalDue - accounting.NetworkFee),
                 IsUnsetTopUp = invoice.IsUnsetTopUp(),
                 CustomerEmail = invoice.RefundMail,
                 RequiresRefundEmail = invoice.RequiresRefundEmail ?? storeBlob.RequiresRefundEmail,

--- a/BTCPayServer/Controllers/UIInvoiceController.cs
+++ b/BTCPayServer/Controllers/UIInvoiceController.cs
@@ -508,7 +508,7 @@ namespace BTCPayServer.Controllers
                         await fetchingByCurrencyPair[new CurrencyPair(supportedPaymentMethod.PaymentId.CryptoCode, criteria.Value.Currency)];
                     if (currentRateToCrypto?.BidAsk != null)
                     {
-                        var amount = paymentMethod.Calculate().Due.GetValue(network as BTCPayNetwork);
+                        var amount = paymentMethod.Calculate().Due;
                         var limitValueCrypto = criteria.Value.Value / currentRateToCrypto.BidAsk.Bid;
 
                         if (amount < limitValueCrypto && criteria.Above)

--- a/BTCPayServer/Controllers/UIInvoiceController.cs
+++ b/BTCPayServer/Controllers/UIInvoiceController.cs
@@ -314,6 +314,7 @@ namespace BTCPayServer.Controllers
                 entity.RefundMail = entity.Metadata.BuyerEmail;
             }
             entity.Status = InvoiceStatusLegacy.New;
+            entity.UpdateTotals();
             HashSet<CurrencyPair> currencyPairsToFetch = new HashSet<CurrencyPair>();
             var rules = storeBlob.GetRateRules(_NetworkProvider);
             var excludeFilter = storeBlob.GetExcludedPaymentMethods(); // Here we can compose filters from other origin with PaymentFilter.Any()
@@ -391,6 +392,7 @@ namespace BTCPayServer.Controllers
             }
             entity.SetSupportedPaymentMethods(supported);
             entity.SetPaymentMethods(paymentMethods);
+            entity.UpdateTotals();
             foreach (var app in await getAppsTaggingStore)
             {
                 entity.InternalTags.Add(AppService.GetAppInternalTag(app.Id));

--- a/BTCPayServer/Controllers/UIInvoiceController.cs
+++ b/BTCPayServer/Controllers/UIInvoiceController.cs
@@ -392,7 +392,6 @@ namespace BTCPayServer.Controllers
             }
             entity.SetSupportedPaymentMethods(supported);
             entity.SetPaymentMethods(paymentMethods);
-            entity.UpdateTotals();
             foreach (var app in await getAppsTaggingStore)
             {
                 entity.InternalTags.Add(AppService.GetAppInternalTag(app.Id));

--- a/BTCPayServer/Controllers/UIInvoiceController.cs
+++ b/BTCPayServer/Controllers/UIInvoiceController.cs
@@ -121,7 +121,7 @@ namespace BTCPayServer.Controllers
         internal async Task<InvoiceEntity> CreateInvoiceCoreRaw(BitpayCreateInvoiceRequest invoice, StoreData store, string serverUrl, List<string>? additionalTags = null, CancellationToken cancellationToken = default, Action<InvoiceEntity>? entityManipulator = null)
         {
             var storeBlob = store.GetStoreBlob();
-            var entity = _InvoiceRepository.CreateNewInvoice();
+            var entity = _InvoiceRepository.CreateNewInvoice(store.Id);
             entity.ExpirationTime = invoice.ExpirationTime is DateTimeOffset v ? v : entity.InvoiceTime + storeBlob.InvoiceExpiration;
             entity.MonitoringExpiration = entity.ExpirationTime + storeBlob.MonitoringExpiration;
             if (entity.ExpirationTime - TimeSpan.FromSeconds(30.0) < entity.InvoiceTime)
@@ -237,7 +237,7 @@ namespace BTCPayServer.Controllers
         public async Task<InvoiceEntity> CreateInvoiceCoreRaw(CreateInvoiceRequest invoice, StoreData store, string serverUrl, List<string>? additionalTags = null, CancellationToken cancellationToken = default, Action<InvoiceEntity>? entityManipulator = null)
         {
             var storeBlob = store.GetStoreBlob();
-            var entity = _InvoiceRepository.CreateNewInvoice();
+            var entity = _InvoiceRepository.CreateNewInvoice(store.Id);
             entity.ServerUrl = serverUrl;
             entity.ExpirationTime = entity.InvoiceTime + (invoice.Checkout.Expiration ?? storeBlob.InvoiceExpiration);
             entity.MonitoringExpiration = entity.ExpirationTime + (invoice.Checkout.Monitoring ?? storeBlob.MonitoringExpiration);
@@ -403,7 +403,7 @@ namespace BTCPayServer.Controllers
             }
             using (logs.Measure("Saving invoice"))
             {
-                entity = await _InvoiceRepository.CreateInvoiceAsync(store.Id, entity, additionalSearchTerms);
+                await _InvoiceRepository.CreateInvoiceAsync(entity, additionalSearchTerms);
                 foreach (var method in paymentMethods)
                 {
                     if (method.GetPaymentMethodDetails() is BitcoinLikeOnChainPaymentMethod bp)

--- a/BTCPayServer/Controllers/UILNURLController.cs
+++ b/BTCPayServer/Controllers/UILNURLController.cs
@@ -548,7 +548,7 @@ namespace BTCPayServer
             lnurlRequest.Metadata = JsonConvert.SerializeObject(lnUrlMetadata.Select(kv => new[] { kv.Key, kv.Value }));
             if (i.Type != InvoiceType.TopUp)
             {
-                lnurlRequest.MinSendable = new LightMoney(pm.Calculate().Due.ToDecimal(MoneyUnit.Satoshi), LightMoneyUnit.Satoshi);
+                lnurlRequest.MinSendable = LightMoney.Coins(pm.Calculate().Due);
                 if (!allowOverpay)
                     lnurlRequest.MaxSendable = lnurlRequest.MinSendable;
             }

--- a/BTCPayServer/Data/Payouts/BitcoinLike/BitcoinLikePayoutHandler.cs
+++ b/BTCPayServer/Data/Payouts/BitcoinLike/BitcoinLikePayoutHandler.cs
@@ -303,7 +303,7 @@ public class BitcoinLikePayoutHandler : IPayoutHandler
                     bip21.Add(newUri.Uri.ToString());
                     break;
                 case AddressClaimDestination addressClaimDestination:
-                    var bip21New = network.GenerateBIP21(addressClaimDestination.Address.ToString(), new Money(blob.CryptoAmount.Value, MoneyUnit.BTC));
+                    var bip21New = network.GenerateBIP21(addressClaimDestination.Address.ToString(), blob.CryptoAmount.Value);
                     bip21New.QueryParams.Add("payout", payout.Id);
                     bip21.Add(bip21New.ToString());
                     break;

--- a/BTCPayServer/Extensions.cs
+++ b/BTCPayServer/Extensions.cs
@@ -392,20 +392,6 @@ namespace BTCPayServer
             return controller.View("PostRedirect", redirectVm);
         }
 
-        public static string ToSql<TEntity>(this IQueryable<TEntity> query) where TEntity : class
-        {
-            var enumerator = query.Provider.Execute<IEnumerable<TEntity>>(query.Expression).GetEnumerator();
-            var relationalCommandCache = enumerator.Private("_relationalCommandCache");
-            var selectExpression = relationalCommandCache.Private<Microsoft.EntityFrameworkCore.Query.SqlExpressions.SelectExpression>("_selectExpression");
-            var factory = relationalCommandCache.Private<Microsoft.EntityFrameworkCore.Query.IQuerySqlGeneratorFactory>("_querySqlGeneratorFactory");
-
-            var sqlGenerator = factory.Create();
-            var command = sqlGenerator.GetCommand(selectExpression);
-
-            string sql = command.CommandText;
-            return sql;
-        }
-
         public static BTCPayNetworkProvider ConfigureNetworkProvider(this IConfiguration configuration, Logs logs)
         {
             var _networkType = DefaultConfiguration.GetNetworkType(configuration);

--- a/BTCPayServer/Extensions.cs
+++ b/BTCPayServer/Extensions.cs
@@ -39,6 +39,7 @@ namespace BTCPayServer
 {
     public static class Extensions
     {
+        public static DateTimeOffset TruncateMilliSeconds(this DateTimeOffset dt) => new (dt.Year, dt.Month, dt.Day, dt.Hour, dt.Minute, dt.Second, 0, dt.Offset);
         public static decimal? GetDue(this InvoiceCryptoInfo invoiceCryptoInfo)
         {
             if (invoiceCryptoInfo is null)

--- a/BTCPayServer/Extensions.cs
+++ b/BTCPayServer/Extensions.cs
@@ -30,6 +30,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using NBitcoin;
 using NBitcoin.Payment;
+using NBitpayClient;
 using NBXplorer.Models;
 using Newtonsoft.Json;
 using InvoiceCryptoInfo = BTCPayServer.Services.Invoices.InvoiceCryptoInfo;
@@ -38,6 +39,14 @@ namespace BTCPayServer
 {
     public static class Extensions
     {
+        public static decimal? GetDue(this InvoiceCryptoInfo invoiceCryptoInfo)
+        {
+            if (invoiceCryptoInfo is null)
+                return null;
+            if (decimal.TryParse(invoiceCryptoInfo.Due, NumberStyles.Any, CultureInfo.InvariantCulture, out var v))
+                return v;
+            return null;
+        }
         public static Task<BufferizedFormFile> Bufferize(this IFormFile formFile)
         {
             return BufferizedFormFile.Bufferize(formFile);

--- a/BTCPayServer/HostedServices/InvoiceWatcher.cs
+++ b/BTCPayServer/HostedServices/InvoiceWatcher.cs
@@ -348,7 +348,7 @@ namespace BTCPayServer.HostedServices
                         if ((onChainPaymentData.ConfirmationCount < network.MaxTrackedConfirmation && payment.Accounted)
                             && (onChainPaymentData.Legacy || invoice.MonitoringExpiration < DateTimeOffset.UtcNow))
                         {
-                            var client = _explorerClientProvider.GetExplorerClient(payment.PaymentCurrency);
+                            var client = _explorerClientProvider.GetExplorerClient(payment.Currency);
                             var transactionResult = client is null ? null : await client.GetTransactionAsync(onChainPaymentData.Outpoint.Hash);
                             var confirmationCount = transactionResult?.Confirmations ?? 0;
                             onChainPaymentData.ConfirmationCount = confirmationCount;

--- a/BTCPayServer/HostedServices/InvoiceWatcher.cs
+++ b/BTCPayServer/HostedServices/InvoiceWatcher.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using BTCPayServer.Client.Models;
 using BTCPayServer.Events;
 using BTCPayServer.Logging;
+using BTCPayServer.Payments;
 using BTCPayServer.Services.Invoices;
 using BTCPayServer.Services.Notifications;
 using BTCPayServer.Services.Notifications.Blobs;
@@ -83,31 +84,13 @@ namespace BTCPayServer.HostedServices
                 if (invoice.ExceptionStatus == InvoiceExceptionStatus.PaidPartial)
                     context.Events.Add(new InvoiceEvent(invoice, InvoiceEvent.ExpiredPaidPartial) { PaidPartial = paidPartial });
             }
-            var allPaymentMethods = invoice.GetPaymentMethods();
-            var paymentMethod = GetNearestClearedPayment(allPaymentMethods, out var accounting);
-            if (allPaymentMethods.Any() && paymentMethod == null)
-                return;
-            if (accounting is null && invoice.Price is 0m)
-            {
-                accounting = new PaymentMethodAccounting()
-                {
-                    Due = Money.Zero,
-                    Paid = Money.Zero,
-                    CryptoPaid = Money.Zero,
-                    DueUncapped = Money.Zero,
-                    NetworkFee = Money.Zero,
-                    TotalDue = Money.Zero,
-                    TxCount = 0,
-                    TxRequired = 0,
-                    MinimumTotalDue = Money.Zero,
-                    NetworkFeeAlreadyPaid = Money.Zero
-                };
-            }
+
+            var hasPayment = invoice.GetPayments(true).Any();
             if (invoice.Status == InvoiceStatusLegacy.New || invoice.Status == InvoiceStatusLegacy.Expired)
             {
                 var isPaid = invoice.IsUnsetTopUp() ?
-                    accounting.Paid > Money.Zero :
-                    accounting.Paid >= accounting.MinimumTotalDue;
+                    hasPayment :
+                    !invoice.IsUnderPaid;
                 if (isPaid)
                 {
                     if (invoice.Status == InvoiceStatusLegacy.New)
@@ -117,13 +100,15 @@ namespace BTCPayServer.HostedServices
                         if (invoice.IsUnsetTopUp())
                         {
                             invoice.ExceptionStatus = InvoiceExceptionStatus.None;
-                            invoice.Price = (accounting.Paid - accounting.NetworkFeeAlreadyPaid).ToDecimal(MoneyUnit.BTC) * paymentMethod.Rate;
-                            accounting = paymentMethod.Calculate();
+                            // We know there is at least one payment because hasPayment is true
+                            var payment = invoice.GetPayments(true).First();
+                            invoice.Price = payment.InvoicePaidAmount.Net;
+                            invoice.UpdateTotals();
                             context.BlobUpdated();
                         }
                         else
                         {
-                            invoice.ExceptionStatus = accounting.Paid > accounting.TotalDue ? InvoiceExceptionStatus.PaidOver : InvoiceExceptionStatus.None;
+                            invoice.ExceptionStatus = invoice.IsOverPaid ? InvoiceExceptionStatus.PaidOver : InvoiceExceptionStatus.None;
                         }
                         context.MarkDirty();
                     }
@@ -135,7 +120,7 @@ namespace BTCPayServer.HostedServices
                     }
                 }
 
-                if (accounting.Paid < accounting.MinimumTotalDue && invoice.GetPayments(true).Count != 0 && invoice.ExceptionStatus != InvoiceExceptionStatus.PaidPartial)
+                if (hasPayment && invoice.IsUnderPaid && invoice.ExceptionStatus != InvoiceExceptionStatus.PaidPartial)
                 {
                     invoice.ExceptionStatus = InvoiceExceptionStatus.PaidPartial;
                     context.MarkDirty();
@@ -145,43 +130,43 @@ namespace BTCPayServer.HostedServices
             // Just make sure RBF did not cancelled a payment
             if (invoice.Status == InvoiceStatusLegacy.Paid)
             {
-                if (accounting.MinimumTotalDue <= accounting.Paid && accounting.Paid <= accounting.TotalDue && invoice.ExceptionStatus == InvoiceExceptionStatus.PaidOver)
+                if (!invoice.IsUnderPaid && !invoice.IsOverPaid && invoice.ExceptionStatus == InvoiceExceptionStatus.PaidOver)
                 {
                     invoice.ExceptionStatus = InvoiceExceptionStatus.None;
                     context.MarkDirty();
                 }
 
-                if (accounting.Paid > accounting.TotalDue && invoice.ExceptionStatus != InvoiceExceptionStatus.PaidOver)
+                if (invoice.IsOverPaid && invoice.ExceptionStatus != InvoiceExceptionStatus.PaidOver)
                 {
                     invoice.ExceptionStatus = InvoiceExceptionStatus.PaidOver;
                     context.MarkDirty();
                 }
 
-                if (accounting.Paid < accounting.MinimumTotalDue)
+                if (invoice.IsUnderPaid)
                 {
                     invoice.Status = InvoiceStatusLegacy.New;
-                    invoice.ExceptionStatus = accounting.Paid == Money.Zero ? InvoiceExceptionStatus.None : InvoiceExceptionStatus.PaidPartial;
+                    invoice.ExceptionStatus = hasPayment ? InvoiceExceptionStatus.PaidPartial : InvoiceExceptionStatus.None;
                     context.MarkDirty();
                 }
             }
 
             if (invoice.Status == InvoiceStatusLegacy.Paid)
             {
-                var confirmedAccounting =
-                    paymentMethod?.Calculate(p => p.GetCryptoPaymentData().PaymentConfirmed(p, invoice.SpeedPolicy)) ??
-                    accounting;
+                var unconfPayments = invoice.GetPayments(true).Where(p => !p.GetCryptoPaymentData().PaymentConfirmed(p, invoice.SpeedPolicy)).ToList();
+                var unconfirmedPaid = unconfPayments.Select(p => p.InvoicePaidAmount.Net).Sum();
+                var minimumDue = invoice.MinimumNetDue + unconfirmedPaid;
 
                 if (// Is after the monitoring deadline
                    (invoice.MonitoringExpiration < DateTimeOffset.UtcNow)
                    &&
                    // And not enough amount confirmed
-                   (confirmedAccounting.Paid < accounting.MinimumTotalDue))
+                   (minimumDue > 0.0m))
                 {
                     context.Events.Add(new InvoiceEvent(invoice, InvoiceEvent.FailedToConfirm));
                     invoice.Status = InvoiceStatusLegacy.Invalid;
                     context.MarkDirty();
                 }
-                else if (confirmedAccounting.Paid >= accounting.MinimumTotalDue)
+                else if (minimumDue <= 0.0m)
                 {
                     invoice.Status = InvoiceStatusLegacy.Confirmed;
                     context.Events.Add(new InvoiceEvent(invoice, InvoiceEvent.Confirmed));
@@ -191,9 +176,11 @@ namespace BTCPayServer.HostedServices
 
             if (invoice.Status == InvoiceStatusLegacy.Confirmed)
             {
-                var completedAccounting = paymentMethod?.Calculate(p => p.GetCryptoPaymentData().PaymentCompleted(p)) ??
-                                          accounting;
-                if (completedAccounting.Paid >= accounting.MinimumTotalDue)
+                var unconfPayments = invoice.GetPayments(true).Where(p => !p.GetCryptoPaymentData().PaymentCompleted(p)).ToList();
+                var unconfirmedPaid = unconfPayments.Select(p => p.InvoicePaidAmount.Net).Sum();
+                var minimumDue = invoice.MinimumNetDue + unconfirmedPaid;
+
+                if (minimumDue <= 0.0m)
                 {
                     context.Events.Add(new InvoiceEvent(invoice, InvoiceEvent.Completed));
                     invoice.Status = InvoiceStatusLegacy.Complete;
@@ -201,25 +188,6 @@ namespace BTCPayServer.HostedServices
                 }
             }
 
-        }
-
-        public static PaymentMethod GetNearestClearedPayment(PaymentMethodDictionary allPaymentMethods, out PaymentMethodAccounting accounting)
-        {
-            PaymentMethod result = null;
-            accounting = null;
-            decimal nearestToZero = 0.0m;
-            foreach (var paymentMethod in allPaymentMethods)
-            {
-                var currentAccounting = paymentMethod.Calculate();
-                var distanceFromZero = Math.Abs(currentAccounting.DueUncapped.ToDecimal(MoneyUnit.BTC));
-                if (result == null || distanceFromZero < nearestToZero)
-                {
-                    result = paymentMethod;
-                    nearestToZero = distanceFromZero;
-                    accounting = currentAccounting;
-                }
-            }
-            return result;
         }
 
         private void Watch(string invoiceId)
@@ -380,7 +348,7 @@ namespace BTCPayServer.HostedServices
                         if ((onChainPaymentData.ConfirmationCount < network.MaxTrackedConfirmation && payment.Accounted)
                             && (onChainPaymentData.Legacy || invoice.MonitoringExpiration < DateTimeOffset.UtcNow))
                         {
-                            var client = _explorerClientProvider.GetExplorerClient(payment.GetCryptoCode());
+                            var client = _explorerClientProvider.GetExplorerClient(payment.PaymentCurrency);
                             var transactionResult = client is null ? null : await client.GetTransactionAsync(onChainPaymentData.Outpoint.Hash);
                             var confirmationCount = transactionResult?.Confirmations ?? 0;
                             onChainPaymentData.ConfirmationCount = confirmationCount;

--- a/BTCPayServer/HostedServices/TransactionLabelMarkerHostedService.cs
+++ b/BTCPayServer/HostedServices/TransactionLabelMarkerHostedService.cs
@@ -103,7 +103,7 @@ namespace BTCPayServer.HostedServices
                     invoiceEvent.Payment.GetPaymentMethodId()?.PaymentType == BitcoinPaymentType.Instance &&
                     invoiceEvent.Payment.GetCryptoPaymentData() is BitcoinLikePaymentData bitcoinLikePaymentData:
                     {
-                        var walletId = new WalletId(invoiceEvent.Invoice.StoreId, invoiceEvent.Payment.PaymentCurrency);
+                        var walletId = new WalletId(invoiceEvent.Invoice.StoreId, invoiceEvent.Payment.Currency);
                         var transactionId = bitcoinLikePaymentData.Outpoint.Hash;
                         var labels = new List<Attachment>
                     {

--- a/BTCPayServer/HostedServices/TransactionLabelMarkerHostedService.cs
+++ b/BTCPayServer/HostedServices/TransactionLabelMarkerHostedService.cs
@@ -103,7 +103,7 @@ namespace BTCPayServer.HostedServices
                     invoiceEvent.Payment.GetPaymentMethodId()?.PaymentType == BitcoinPaymentType.Instance &&
                     invoiceEvent.Payment.GetCryptoPaymentData() is BitcoinLikePaymentData bitcoinLikePaymentData:
                     {
-                        var walletId = new WalletId(invoiceEvent.Invoice.StoreId, invoiceEvent.Payment.GetCryptoCode());
+                        var walletId = new WalletId(invoiceEvent.Invoice.StoreId, invoiceEvent.Payment.PaymentCurrency);
                         var transactionId = bitcoinLikePaymentData.Outpoint.Hash;
                         var labels = new List<Attachment>
                     {

--- a/BTCPayServer/PaymentRequest/PaymentRequestHub.cs
+++ b/BTCPayServer/PaymentRequest/PaymentRequestHub.cs
@@ -167,7 +167,7 @@ namespace BTCPayServer.PaymentRequest
                                 new object[]
                                 {
                                     data.GetValue(),
-                                    invoiceEvent.Payment.GetCryptoCode(),
+                                    invoiceEvent.Payment.PaymentCurrency,
                                     invoiceEvent.Payment.GetPaymentMethodId()?.PaymentType?.ToString()
                                 }, cancellationToken);
                         }

--- a/BTCPayServer/PaymentRequest/PaymentRequestHub.cs
+++ b/BTCPayServer/PaymentRequest/PaymentRequestHub.cs
@@ -167,7 +167,7 @@ namespace BTCPayServer.PaymentRequest
                                 new object[]
                                 {
                                     data.GetValue(),
-                                    invoiceEvent.Payment.PaymentCurrency,
+                                    invoiceEvent.Payment.Currency,
                                     invoiceEvent.Payment.GetPaymentMethodId()?.PaymentType?.ToString()
                                 }, cancellationToken);
                         }

--- a/BTCPayServer/PaymentRequest/PaymentRequestService.cs
+++ b/BTCPayServer/PaymentRequest/PaymentRequestService.cs
@@ -123,18 +123,14 @@ namespace BTCPayServer.PaymentRequest
 
                             string txId = paymentData.GetPaymentId();
                             string link = GetTransactionLink(paymentMethodId, txId);
-                            var paymentMethod = entity.GetPaymentMethod(paymentMethodId);
-                            var amount = paymentData.GetValue();
-                            var rate = paymentMethod.Rate;
-                            var paid = (amount - paymentEntity.NetworkFee) * rate;
 
                             return new ViewPaymentRequestViewModel.PaymentRequestInvoicePayment
                             {
-                                Amount = amount,
-                                Paid = paid,
+                                Amount = paymentEntity.PaidAmount.Gross,
+                                Paid = paymentEntity.InvoicePaidAmount.Net,
                                 ReceivedDate = paymentEntity.ReceivedTime.DateTime,
-                                PaidFormatted = _displayFormatter.Currency(paid, blob.Currency, DisplayFormatter.CurrencyFormat.Symbol),
-                                RateFormatted = _displayFormatter.Currency(rate, blob.Currency, DisplayFormatter.CurrencyFormat.Symbol),
+                                PaidFormatted = _displayFormatter.Currency(paymentEntity.InvoicePaidAmount.Net, blob.Currency, DisplayFormatter.CurrencyFormat.Symbol),
+                                RateFormatted = _displayFormatter.Currency(paymentEntity.Rate, blob.Currency, DisplayFormatter.CurrencyFormat.Symbol),
                                 PaymentMethod = paymentMethodId.ToPrettyString(),
                                 Link = link,
                                 Id = txId,

--- a/BTCPayServer/Payments/Bitcoin/BitcoinLikePaymentHandler.cs
+++ b/BTCPayServer/Payments/Bitcoin/BitcoinLikePaymentHandler.cs
@@ -211,7 +211,7 @@ namespace BTCPayServer.Payments.Bitcoin
                     new Key().GetScriptPubKey(supportedPaymentMethod.AccountDerivation.ScriptPubKeyType());
                 var dust = txOut.GetDustThreshold();
                 var amount = paymentMethod.Calculate().Due;
-                if (amount < dust)
+                if (amount < dust.ToDecimal(MoneyUnit.BTC))
                     throw new PaymentMethodUnavailableException("Amount below the dust threshold. For amounts of this size, it is recommended to enable an off-chain (Lightning) payment method");
             }
             if (preparePaymentObject is null)

--- a/BTCPayServer/Payments/LNURLPay/PaymentTypes.LNURL.cs
+++ b/BTCPayServer/Payments/LNURLPay/PaymentTypes.LNURL.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using BTCPayServer.Abstractions.Extensions;
 using BTCPayServer.Client.Models;
 using BTCPayServer.Payments.Lightning;
@@ -28,7 +29,7 @@ namespace BTCPayServer.Payments
         }
 
         public override string GetPaymentLink(BTCPayNetworkBase network, InvoiceEntity invoice, IPaymentMethodDetails paymentMethodDetails,
-            Money cryptoInfoDue, string serverUri)
+            decimal cryptoInfoDue, string serverUri)
         {
             if (!paymentMethodDetails.Activated)
             {
@@ -70,11 +71,12 @@ namespace BTCPayServer.Payments
 
         public override void PopulateCryptoInfo(InvoiceEntity invoice, PaymentMethod details, InvoiceCryptoInfo invoiceCryptoInfo, string serverUrl)
         {
+            var due = invoiceCryptoInfo.Due is null ? 0.0m : decimal.Parse(invoiceCryptoInfo.Due, NumberStyles.Any, CultureInfo.InvariantCulture);
             invoiceCryptoInfo.PaymentUrls = new InvoiceCryptoInfo.InvoicePaymentUrls()
             {
                 AdditionalData = new Dictionary<string, JToken>()
                 {
-                    {"LNURLP", JToken.FromObject(GetPaymentLink(details.Network, invoice, details.GetPaymentMethodDetails(), invoiceCryptoInfo.Due,
+                    {"LNURLP", JToken.FromObject(GetPaymentLink(details.Network, invoice, details.GetPaymentMethodDetails(), due,
                         serverUrl))}
                 }
             };

--- a/BTCPayServer/Payments/LNURLPay/PaymentTypes.LNURL.cs
+++ b/BTCPayServer/Payments/LNURLPay/PaymentTypes.LNURL.cs
@@ -71,12 +71,11 @@ namespace BTCPayServer.Payments
 
         public override void PopulateCryptoInfo(InvoiceEntity invoice, PaymentMethod details, InvoiceCryptoInfo invoiceCryptoInfo, string serverUrl)
         {
-            var due = invoiceCryptoInfo.Due is null ? 0.0m : decimal.Parse(invoiceCryptoInfo.Due, NumberStyles.Any, CultureInfo.InvariantCulture);
             invoiceCryptoInfo.PaymentUrls = new InvoiceCryptoInfo.InvoicePaymentUrls()
             {
                 AdditionalData = new Dictionary<string, JToken>()
                 {
-                    {"LNURLP", JToken.FromObject(GetPaymentLink(details.Network, invoice, details.GetPaymentMethodDetails(), due,
+                    {"LNURLP", JToken.FromObject(GetPaymentLink(details.Network, invoice, details.GetPaymentMethodDetails(), invoiceCryptoInfo.GetDue().Value,
                         serverUrl))}
                 }
             };

--- a/BTCPayServer/Payments/Lightning/LightningLikePaymentHandler.cs
+++ b/BTCPayServer/Payments/Lightning/LightningLikePaymentHandler.cs
@@ -73,7 +73,7 @@ namespace BTCPayServer.Payments.Lightning
             decimal due = Extensions.RoundUp(invoice.Price / paymentMethod.Rate, network.Divisibility);
             try
             {
-                due = paymentMethod.Calculate().Due.ToDecimal(MoneyUnit.BTC);
+                due = paymentMethod.Calculate().Due;
             }
             catch (Exception)
             {

--- a/BTCPayServer/Payments/Lightning/LightningListener.cs
+++ b/BTCPayServer/Payments/Lightning/LightningListener.cs
@@ -200,7 +200,7 @@ namespace BTCPayServer.Payments.Lightning
                 if (inv.Name == InvoiceEvent.ReceivedPayment && inv.Invoice.Status == InvoiceStatusLegacy.New && inv.Invoice.ExceptionStatus == InvoiceExceptionStatus.PaidPartial)
                 {
                     var pm = inv.Invoice.GetPaymentMethods().First();
-                    if (pm.Calculate().Due.GetValue(pm.Network as BTCPayNetwork) > 0m)
+                    if (pm.Calculate().Due > 0m)
                     {
                         await CreateNewLNInvoiceForBTCPayInvoice(inv.Invoice);
                     }

--- a/BTCPayServer/Payments/PayJoin/PayJoinEndpointController.cs
+++ b/BTCPayServer/Payments/PayJoin/PayJoinEndpointController.cs
@@ -302,7 +302,7 @@ namespace BTCPayServer.Payments.PayJoin
                     var paymentDetails = paymentMethod?.GetPaymentMethodDetails() as Payments.Bitcoin.BitcoinLikeOnChainPaymentMethod;
                     if (paymentMethod is null || paymentDetails is null || !paymentDetails.PayjoinEnabled)
                         continue;
-                    due = paymentMethod.Calculate().TotalDue - output.Value;
+                    due = Money.Coins(paymentMethod.Calculate().TotalDue) - output.Value;
                     if (due > Money.Zero)
                     {
                         break;

--- a/BTCPayServer/Payments/PaymentTypes.Bitcoin.cs
+++ b/BTCPayServer/Payments/PaymentTypes.Bitcoin.cs
@@ -103,10 +103,9 @@ namespace BTCPayServer.Payments
         public override void PopulateCryptoInfo(InvoiceEntity invoice, PaymentMethod details, InvoiceCryptoInfo cryptoInfo,
             string serverUrl)
         {
-            var due = cryptoInfo.Due is null ? 0.0m : decimal.Parse(cryptoInfo.Due, NumberStyles.Any, CultureInfo.InvariantCulture);
             cryptoInfo.PaymentUrls = new InvoiceCryptoInfo.InvoicePaymentUrls()
             {
-                BIP21 = GetPaymentLink(details.Network, invoice, details.GetPaymentMethodDetails(), due, serverUrl),
+                BIP21 = GetPaymentLink(details.Network, invoice, details.GetPaymentMethodDetails(), cryptoInfo.GetDue().Value, serverUrl),
             };
         }
     }

--- a/BTCPayServer/Payments/PaymentTypes.Bitcoin.cs
+++ b/BTCPayServer/Payments/PaymentTypes.Bitcoin.cs
@@ -67,7 +67,7 @@ namespace BTCPayServer.Payments
         }
 
         public override string GetPaymentLink(BTCPayNetworkBase network, InvoiceEntity invoice, IPaymentMethodDetails paymentMethodDetails,
-            Money cryptoInfoDue, string serverUri)
+            decimal cryptoInfoDue, string serverUri)
         {
             if (!paymentMethodDetails.Activated)
             {
@@ -103,9 +103,10 @@ namespace BTCPayServer.Payments
         public override void PopulateCryptoInfo(InvoiceEntity invoice, PaymentMethod details, InvoiceCryptoInfo cryptoInfo,
             string serverUrl)
         {
+            var due = cryptoInfo.Due is null ? 0.0m : decimal.Parse(cryptoInfo.Due, NumberStyles.Any, CultureInfo.InvariantCulture);
             cryptoInfo.PaymentUrls = new InvoiceCryptoInfo.InvoicePaymentUrls()
             {
-                BIP21 = GetPaymentLink(details.Network, invoice, details.GetPaymentMethodDetails(), cryptoInfo.Due, serverUrl),
+                BIP21 = GetPaymentLink(details.Network, invoice, details.GetPaymentMethodDetails(), due, serverUrl),
             };
         }
     }

--- a/BTCPayServer/Payments/PaymentTypes.Lightning.cs
+++ b/BTCPayServer/Payments/PaymentTypes.Lightning.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Globalization;
 using BTCPayServer.Client.Models;
 using BTCPayServer.Controllers.Greenfield;
 using BTCPayServer.Payments.Lightning;
@@ -52,7 +53,7 @@ namespace BTCPayServer.Payments
         }
 
         public override string GetPaymentLink(BTCPayNetworkBase network, InvoiceEntity invoice, IPaymentMethodDetails paymentMethodDetails,
-            Money cryptoInfoDue, string serverUri)
+            decimal cryptoInfoDue, string serverUri)
         {
             if (!paymentMethodDetails.Activated)
             {
@@ -92,7 +93,7 @@ namespace BTCPayServer.Payments
         {
             invoiceCryptoInfo.PaymentUrls = new InvoiceCryptoInfo.InvoicePaymentUrls()
             {
-                BOLT11 = GetPaymentLink(details.Network, invoice, details.GetPaymentMethodDetails(), invoiceCryptoInfo.Due,
+                BOLT11 = GetPaymentLink(details.Network, invoice, details.GetPaymentMethodDetails(), invoiceCryptoInfo.GetDue().Value,
                     serverUrl)
             };
         }

--- a/BTCPayServer/Payments/PaymentTypes.cs
+++ b/BTCPayServer/Payments/PaymentTypes.cs
@@ -85,7 +85,7 @@ namespace BTCPayServer.Payments
         public abstract ISupportedPaymentMethod DeserializeSupportedPaymentMethod(BTCPayNetworkBase network, JToken value);
         public abstract string GetTransactionLink(BTCPayNetworkBase network, string txId);
         public abstract string GetPaymentLink(BTCPayNetworkBase network, InvoiceEntity invoice, IPaymentMethodDetails paymentMethodDetails,
-            Money cryptoInfoDue, string serverUri);
+            decimal cryptoInfoDue, string serverUri);
         public abstract string InvoiceViewPaymentPartialName { get; }
 
         public abstract object GetGreenfieldData(ISupportedPaymentMethod supportedPaymentMethod, bool canModifyStore);

--- a/BTCPayServer/Plugins/Crowdfund/CrowdfundPlugin.cs
+++ b/BTCPayServer/Plugins/Crowdfund/CrowdfundPlugin.cs
@@ -89,15 +89,7 @@ namespace BTCPayServer.Plugins.Crowdfund
                 .GroupBy(entity => entity.Metadata.ItemCode)
                 .Select(entities =>
                 {
-                    var total = entities
-                        .Sum(entity => entity.GetPayments(true)
-                            .Sum(pay =>
-                            {
-                                var paymentMethodId = pay.GetPaymentMethodId();
-                                var value = pay.GetCryptoPaymentData().GetValue() - pay.NetworkFee;
-                                var rate = entity.GetPaymentMethod(paymentMethodId).Rate;
-                                return rate * value;
-                            }));
+                    var total = entities.Sum(entity => entity.PaidAmount.Net);
                     var itemCode = entities.Key;
                     var perk = perks.FirstOrDefault(p => p.Id == itemCode);
                     return new ItemStats
@@ -167,13 +159,7 @@ namespace BTCPayServer.Plugins.Crowdfund
                                      !string.IsNullOrEmpty(entity.Metadata.ItemCode))
                     .GroupBy(entity => entity.Metadata.ItemCode)
                     .ToDictionary(entities => entities.Key, entities =>
-                        entities.Sum(entity => entity.GetPayments(true).Sum(pay =>
-                        {
-                            var paymentMethodId = pay.GetPaymentMethodId();
-                            var value = pay.GetCryptoPaymentData().GetValue() - pay.NetworkFee;
-                            var rate = entity.GetPaymentMethod(paymentMethodId).Rate;
-                            return rate * value;
-                        })));
+                        entities.Sum(entity => entity.PaidAmount.Net));
             }
 
             var perks = AppService.Parse( settings.PerksTemplate, false);

--- a/BTCPayServer/Plugins/NFC/NFCController.cs
+++ b/BTCPayServer/Plugins/NFC/NFCController.cs
@@ -119,7 +119,7 @@ namespace BTCPayServer.Plugins.NFC
                 }
                 else
                 {
-                    due = new LightMoney(lnPaymentMethod.Calculate().Due);
+                    due = LightMoney.Coins(lnPaymentMethod.Calculate().Due);
                 }
 
                 if (info.MinWithdrawable > due || due > info.MaxWithdrawable)
@@ -135,10 +135,10 @@ namespace BTCPayServer.Plugins.NFC
 
             if (lnurlPaymentMethod is not null)
             {
-                Money due;
+                decimal due;
                 if (invoice.Type == InvoiceType.TopUp && request.Amount is not null)
                 {
-                    due = new Money(request.Amount.Value, MoneyUnit.Satoshi);
+                    due = new Money(request.Amount.Value, MoneyUnit.Satoshi).ToDecimal(MoneyUnit.BTC);
                 }
                 else if (invoice.Type == InvoiceType.TopUp)
                 {
@@ -152,7 +152,7 @@ namespace BTCPayServer.Plugins.NFC
                 try
                 {
                     httpClient = CreateHttpClient(info.Callback);
-                    var amount = LightMoney.Satoshis(due.Satoshi);
+                    var amount = LightMoney.Coins(due);
                     var actionPath = Url.Action(nameof(UILNURLController.GetLNURLForInvoice), "UILNURL",
                         new { invoiceId = request.InvoiceId, cryptoCode = "BTC", amount = amount.MilliSatoshi });
                     var url = Request.GetAbsoluteUri(actionPath);

--- a/BTCPayServer/Program.cs
+++ b/BTCPayServer/Program.cs
@@ -14,6 +14,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 
 [assembly: InternalsVisibleTo("BTCPayServer.Tests")]
+
 namespace BTCPayServer
 {
     class Program

--- a/BTCPayServer/Services/Altcoins/Monero/Payments/MoneroLikePaymentMethodHandler.cs
+++ b/BTCPayServer/Services/Altcoins/Monero/Payments/MoneroLikePaymentMethodHandler.cs
@@ -93,7 +93,7 @@ namespace BTCPayServer.Services.Altcoins.Monero.Payments
             {
                 var cryptoInfo = invoiceResponse.CryptoInfo.First(o => o.GetpaymentMethodId() == paymentMethodId);
                 model.InvoiceBitcoinUrl = MoneroPaymentType.Instance.GetPaymentLink(network, null,
-                    new MoneroLikeOnChainPaymentMethodDetails() {DepositAddress = cryptoInfo.Address}, cryptoInfo.Due,
+                    new MoneroLikeOnChainPaymentMethodDetails() {DepositAddress = cryptoInfo.Address}, cryptoInfo.GetDue().Value,
                     null);
                 model.InvoiceBitcoinUrlQR = model.InvoiceBitcoinUrl;
             }

--- a/BTCPayServer/Services/Altcoins/Monero/Payments/MoneroPaymentType.cs
+++ b/BTCPayServer/Services/Altcoins/Monero/Payments/MoneroPaymentType.cs
@@ -49,10 +49,10 @@ namespace BTCPayServer.Services.Altcoins.Monero.Payments
             return string.Format(CultureInfo.InvariantCulture, network.BlockExplorerLink, txId);
         }
 
-        public override string GetPaymentLink(BTCPayNetworkBase network, InvoiceEntity invoice, IPaymentMethodDetails paymentMethodDetails, Money cryptoInfoDue, string serverUri)
+        public override string GetPaymentLink(BTCPayNetworkBase network, InvoiceEntity invoice, IPaymentMethodDetails paymentMethodDetails, decimal cryptoInfoDue, string serverUri)
         {
             return paymentMethodDetails.Activated
-                ? $"{(network as MoneroLikeSpecificBtcPayNetwork).UriScheme}:{paymentMethodDetails.GetPaymentDestination()}?tx_amount={cryptoInfoDue.ToDecimal(MoneyUnit.BTC)}"
+                ? $"{(network as MoneroLikeSpecificBtcPayNetwork).UriScheme}:{paymentMethodDetails.GetPaymentDestination()}?tx_amount={cryptoInfoDue}"
                 : string.Empty;
         }
 

--- a/BTCPayServer/Services/Altcoins/Monero/Services/MoneroListener.cs
+++ b/BTCPayServer/Services/Altcoins/Monero/Services/MoneroListener.cs
@@ -119,7 +119,7 @@ namespace BTCPayServer.Services.Altcoins.Monero.Services
         private async Task ReceivedPayment(InvoiceEntity invoice, PaymentEntity payment)
         {
             _logger.LogInformation(
-                $"Invoice {invoice.Id} received payment {payment.GetCryptoPaymentData().GetValue()} {payment.PaymentCurrency} {payment.GetCryptoPaymentData().GetPaymentId()}");
+                $"Invoice {invoice.Id} received payment {payment.GetCryptoPaymentData().GetValue()} {payment.Currency} {payment.GetCryptoPaymentData().GetPaymentId()}");
             var paymentData = (MoneroLikePaymentData)payment.GetCryptoPaymentData();
             var paymentMethod = invoice.GetPaymentMethod(payment.Network, MoneroPaymentType.Instance);
             if (paymentMethod != null &&
@@ -128,7 +128,7 @@ namespace BTCPayServer.Services.Altcoins.Monero.Services
                 monero.GetPaymentDestination() == paymentData.GetDestination() &&
                 paymentMethod.Calculate().Due > 0.0m)
             {
-                var walletClient = _moneroRpcProvider.WalletRpcClients[payment.PaymentCurrency];
+                var walletClient = _moneroRpcProvider.WalletRpcClients[payment.Currency];
 
                 var address = await walletClient.SendCommandAsync<CreateAddressRequest, CreateAddressResponse>(
                     "create_address",

--- a/BTCPayServer/Services/Altcoins/Monero/Services/MoneroListener.cs
+++ b/BTCPayServer/Services/Altcoins/Monero/Services/MoneroListener.cs
@@ -126,7 +126,7 @@ namespace BTCPayServer.Services.Altcoins.Monero.Services
                 paymentMethod.GetPaymentMethodDetails() is MoneroLikeOnChainPaymentMethodDetails monero &&
                 monero.Activated && 
                 monero.GetPaymentDestination() == paymentData.GetDestination() &&
-                paymentMethod.Calculate().Due > Money.Zero)
+                paymentMethod.Calculate().Due > 0.0m)
             {
                 var walletClient = _moneroRpcProvider.WalletRpcClients[payment.PaymentCurrency];
 

--- a/BTCPayServer/Services/Altcoins/Monero/Services/MoneroListener.cs
+++ b/BTCPayServer/Services/Altcoins/Monero/Services/MoneroListener.cs
@@ -119,7 +119,7 @@ namespace BTCPayServer.Services.Altcoins.Monero.Services
         private async Task ReceivedPayment(InvoiceEntity invoice, PaymentEntity payment)
         {
             _logger.LogInformation(
-                $"Invoice {invoice.Id} received payment {payment.GetCryptoPaymentData().GetValue()} {payment.GetCryptoCode()} {payment.GetCryptoPaymentData().GetPaymentId()}");
+                $"Invoice {invoice.Id} received payment {payment.GetCryptoPaymentData().GetValue()} {payment.PaymentCurrency} {payment.GetCryptoPaymentData().GetPaymentId()}");
             var paymentData = (MoneroLikePaymentData)payment.GetCryptoPaymentData();
             var paymentMethod = invoice.GetPaymentMethod(payment.Network, MoneroPaymentType.Instance);
             if (paymentMethod != null &&
@@ -128,7 +128,7 @@ namespace BTCPayServer.Services.Altcoins.Monero.Services
                 monero.GetPaymentDestination() == paymentData.GetDestination() &&
                 paymentMethod.Calculate().Due > Money.Zero)
             {
-                var walletClient = _moneroRpcProvider.WalletRpcClients[payment.GetCryptoCode()];
+                var walletClient = _moneroRpcProvider.WalletRpcClients[payment.PaymentCurrency];
 
                 var address = await walletClient.SendCommandAsync<CreateAddressRequest, CreateAddressResponse>(
                     "create_address",

--- a/BTCPayServer/Services/Altcoins/Zcash/Payments/ZcashLikePaymentMethodHandler.cs
+++ b/BTCPayServer/Services/Altcoins/Zcash/Payments/ZcashLikePaymentMethodHandler.cs
@@ -93,7 +93,7 @@ namespace BTCPayServer.Services.Altcoins.Zcash.Payments
             {
                 var cryptoInfo = invoiceResponse.CryptoInfo.First(o => o.GetpaymentMethodId() == paymentMethodId);
                 model.InvoiceBitcoinUrl = ZcashPaymentType.Instance.GetPaymentLink(network, null,
-                    new ZcashLikeOnChainPaymentMethodDetails() {DepositAddress = cryptoInfo.Address}, cryptoInfo.Due,
+                    new ZcashLikeOnChainPaymentMethodDetails() {DepositAddress = cryptoInfo.Address}, cryptoInfo.GetDue().Value,
                     null);
                 model.InvoiceBitcoinUrlQR = model.InvoiceBitcoinUrl;
             }

--- a/BTCPayServer/Services/Altcoins/Zcash/Payments/ZcashPaymentType.cs
+++ b/BTCPayServer/Services/Altcoins/Zcash/Payments/ZcashPaymentType.cs
@@ -49,10 +49,10 @@ namespace BTCPayServer.Services.Altcoins.Zcash.Payments
             return string.Format(CultureInfo.InvariantCulture, network.BlockExplorerLink, txId);
         }
 
-        public override string GetPaymentLink(BTCPayNetworkBase network, InvoiceEntity invoice, IPaymentMethodDetails paymentMethodDetails, Money cryptoInfoDue, string serverUri)
+        public override string GetPaymentLink(BTCPayNetworkBase network, InvoiceEntity invoice, IPaymentMethodDetails paymentMethodDetails, decimal cryptoInfoDue, string serverUri)
         {
             return paymentMethodDetails.Activated
-                ? $"{(network as ZcashLikeSpecificBtcPayNetwork).UriScheme}:{paymentMethodDetails.GetPaymentDestination()}?amount={cryptoInfoDue.ToDecimal(MoneyUnit.BTC)}"
+                ? $"{(network as ZcashLikeSpecificBtcPayNetwork).UriScheme}:{paymentMethodDetails.GetPaymentDestination()}?amount={cryptoInfoDue}"
                 : string.Empty;
         }
 

--- a/BTCPayServer/Services/Altcoins/Zcash/Services/ZcashListener.cs
+++ b/BTCPayServer/Services/Altcoins/Zcash/Services/ZcashListener.cs
@@ -114,7 +114,7 @@ namespace BTCPayServer.Services.Altcoins.Zcash.Services
         private async Task ReceivedPayment(InvoiceEntity invoice, PaymentEntity payment)
         {
             _logger.LogInformation(
-                $"Invoice {invoice.Id} received payment {payment.GetCryptoPaymentData().GetValue()} {payment.GetCryptoCode()} {payment.GetCryptoPaymentData().GetPaymentId()}");
+                $"Invoice {invoice.Id} received payment {payment.GetCryptoPaymentData().GetValue()} {payment.PaymentCurrency} {payment.GetCryptoPaymentData().GetPaymentId()}");
             var paymentData = (ZcashLikePaymentData)payment.GetCryptoPaymentData();
             var paymentMethod = invoice.GetPaymentMethod(payment.Network, ZcashPaymentType.Instance);
             if (paymentMethod != null &&
@@ -123,7 +123,7 @@ namespace BTCPayServer.Services.Altcoins.Zcash.Services
                 Zcash.GetPaymentDestination() == paymentData.GetDestination() &&
                 paymentMethod.Calculate().Due > Money.Zero)
             {
-                var walletClient = _ZcashRpcProvider.WalletRpcClients[payment.GetCryptoCode()];
+                var walletClient = _ZcashRpcProvider.WalletRpcClients[payment.PaymentCurrency];
 
                 var address = await walletClient.SendCommandAsync<CreateAddressRequest, CreateAddressResponse>(
                     "create_address",

--- a/BTCPayServer/Services/Altcoins/Zcash/Services/ZcashListener.cs
+++ b/BTCPayServer/Services/Altcoins/Zcash/Services/ZcashListener.cs
@@ -121,7 +121,7 @@ namespace BTCPayServer.Services.Altcoins.Zcash.Services
                 paymentMethod.GetPaymentMethodDetails() is ZcashLikeOnChainPaymentMethodDetails Zcash &&
                 Zcash.Activated && 
                 Zcash.GetPaymentDestination() == paymentData.GetDestination() &&
-                paymentMethod.Calculate().Due > Money.Zero)
+                paymentMethod.Calculate().Due > 0.0m)
             {
                 var walletClient = _ZcashRpcProvider.WalletRpcClients[payment.PaymentCurrency];
 

--- a/BTCPayServer/Services/Altcoins/Zcash/Services/ZcashListener.cs
+++ b/BTCPayServer/Services/Altcoins/Zcash/Services/ZcashListener.cs
@@ -114,7 +114,7 @@ namespace BTCPayServer.Services.Altcoins.Zcash.Services
         private async Task ReceivedPayment(InvoiceEntity invoice, PaymentEntity payment)
         {
             _logger.LogInformation(
-                $"Invoice {invoice.Id} received payment {payment.GetCryptoPaymentData().GetValue()} {payment.PaymentCurrency} {payment.GetCryptoPaymentData().GetPaymentId()}");
+                $"Invoice {invoice.Id} received payment {payment.GetCryptoPaymentData().GetValue()} {payment.Currency} {payment.GetCryptoPaymentData().GetPaymentId()}");
             var paymentData = (ZcashLikePaymentData)payment.GetCryptoPaymentData();
             var paymentMethod = invoice.GetPaymentMethod(payment.Network, ZcashPaymentType.Instance);
             if (paymentMethod != null &&
@@ -123,7 +123,7 @@ namespace BTCPayServer.Services.Altcoins.Zcash.Services
                 Zcash.GetPaymentDestination() == paymentData.GetDestination() &&
                 paymentMethod.Calculate().Due > 0.0m)
             {
-                var walletClient = _ZcashRpcProvider.WalletRpcClients[payment.PaymentCurrency];
+                var walletClient = _ZcashRpcProvider.WalletRpcClients[payment.Currency];
 
                 var address = await walletClient.SendCommandAsync<CreateAddressRequest, CreateAddressResponse>(
                     "create_address",

--- a/BTCPayServer/Services/Apps/AppHubStreamer.cs
+++ b/BTCPayServer/Services/Apps/AppHubStreamer.cs
@@ -40,7 +40,7 @@ namespace BTCPayServer.Services.Apps
                         await _HubContext.Clients.Group(appId).SendCoreAsync(AppHub.PaymentReceived, new object[]
                             {
                         data.GetValue(),
-                        invoiceEvent.Payment.PaymentCurrency,
+                        invoiceEvent.Payment.Currency,
                         invoiceEvent.Payment.GetPaymentMethodId()?.PaymentType?.ToString()
                             }, cancellationToken);
                     }

--- a/BTCPayServer/Services/Apps/AppHubStreamer.cs
+++ b/BTCPayServer/Services/Apps/AppHubStreamer.cs
@@ -40,7 +40,7 @@ namespace BTCPayServer.Services.Apps
                         await _HubContext.Clients.Group(appId).SendCoreAsync(AppHub.PaymentReceived, new object[]
                             {
                         data.GetValue(),
-                        invoiceEvent.Payment.GetCryptoCode(),
+                        invoiceEvent.Payment.PaymentCurrency,
                         invoiceEvent.Payment.GetPaymentMethodId()?.PaymentType?.ToString()
                             }, cancellationToken);
                     }

--- a/BTCPayServer/Services/Apps/AppService.cs
+++ b/BTCPayServer/Services/Apps/AppService.cs
@@ -183,18 +183,11 @@ namespace BTCPayServer.Services.Apps
                     }
                 }
                 else
-                {
-                    var fiatPrice = e.GetPayments(true).Sum(pay =>
-                    {
-                        var paymentMethodId = pay.GetPaymentMethodId();
-                        var value = pay.GetCryptoPaymentData().GetValue() - pay.NetworkFee;
-                        var rate = e.GetPaymentMethod(paymentMethodId).Rate;
-                        return rate * value;
-                    });
+                {;
                     res.Add(new InvoiceStatsItem
                     {
                         ItemCode = e.Metadata.ItemCode,
-                        FiatPrice = fiatPrice,
+                        FiatPrice = e.PaidAmount.Net,
                         Date = e.InvoiceTime.Date
                     });
                 }

--- a/BTCPayServer/Services/Invoices/Amounts.cs
+++ b/BTCPayServer/Services/Invoices/Amounts.cs
@@ -1,0 +1,19 @@
+namespace BTCPayServer.Services.Invoices
+{
+    public class Amounts
+    {
+        public string Currency { get; set; }
+        /// <summary>
+        /// An amount with fee included
+        /// </summary>
+        public decimal Gross { get; set; }
+        /// <summary>
+        /// An amount without fee included
+        /// </summary>
+        public decimal Net { get; set; }
+        public override string ToString()
+        {
+            return $"{Currency}: Net={Net}, Gross={Gross}";
+        }
+    }
+}

--- a/BTCPayServer/Services/Invoices/Export/InvoiceExport.cs
+++ b/BTCPayServer/Services/Invoices/Export/InvoiceExport.cs
@@ -64,23 +64,19 @@ namespace BTCPayServer.Services.Invoices.Export
             {
                 foreach (var payment in payments)
                 {
-                    var cryptoCode = payment.GetPaymentMethodId().CryptoCode;
                     var pdata = payment.GetCryptoPaymentData();
-
-                    var pmethod = invoice.GetPaymentMethod(payment.GetPaymentMethodId());
-                    var paidAfterNetworkFees = pdata.GetValue() - payment.NetworkFee;
-                    invoiceDue -= paidAfterNetworkFees * pmethod.Rate;
+                    invoiceDue -= payment.InvoicePaidAmount.Net;
 
                     var target = new ExportInvoiceHolder
                     {
                         ReceivedDate = payment.ReceivedTime.UtcDateTime,
                         PaymentId = pdata.GetPaymentId(),
-                        CryptoCode = cryptoCode,
-                        ConversionRate = pmethod.Rate,
+                        CryptoCode = payment.PaymentCurrency,
+                        ConversionRate = payment.Rate,
                         PaymentType = payment.GetPaymentMethodId().PaymentType.ToPrettyString(),
                         Destination = pdata.GetDestination(),
-                        Paid = pdata.GetValue().ToString(CultureInfo.InvariantCulture),
-                        PaidCurrency = Math.Round(pdata.GetValue() * pmethod.Rate, currency.NumberDecimalDigits).ToString(CultureInfo.InvariantCulture),
+                        Paid = payment.PaidAmount.Gross.ToString(CultureInfo.InvariantCulture),
+                        PaidCurrency = Math.Round(payment.InvoicePaidAmount.Gross, currency.NumberDecimalDigits).ToString(CultureInfo.InvariantCulture),
                         // Adding NetworkFee because Paid doesn't take into account network fees
                         // so if fee is 10000 satoshis, customer can essentially send infinite number of tx
                         // and merchant effectivelly would receive 0 BTC, invoice won't be paid

--- a/BTCPayServer/Services/Invoices/Export/InvoiceExport.cs
+++ b/BTCPayServer/Services/Invoices/Export/InvoiceExport.cs
@@ -71,7 +71,7 @@ namespace BTCPayServer.Services.Invoices.Export
                     {
                         ReceivedDate = payment.ReceivedTime.UtcDateTime,
                         PaymentId = pdata.GetPaymentId(),
-                        CryptoCode = payment.PaymentCurrency,
+                        CryptoCode = payment.Currency,
                         ConversionRate = payment.Rate,
                         PaymentType = payment.GetPaymentMethodId().PaymentType.ToPrettyString(),
                         Destination = pdata.GetDestination(),

--- a/BTCPayServer/Services/Invoices/InvoiceEntity.cs
+++ b/BTCPayServer/Services/Invoices/InvoiceEntity.cs
@@ -389,7 +389,7 @@ namespace BTCPayServer.Services.Invoices
             Rates = new Dictionary<string, decimal>();
             foreach (var p in GetPaymentMethods())
             {
-                Rates.TryAdd(p.PaymentCurrency, p.Rate);
+                Rates.TryAdd(p.Currency, p.Rate);
             }
             PaidAmount = new Amounts()
             {
@@ -636,7 +636,7 @@ namespace BTCPayServer.Services.Invoices
                         dto.MinerFees.TryAdd(cryptoInfo.CryptoCode, minerInfo);
 
 #pragma warning disable 618
-                        if (info.PaymentCurrency == "BTC")
+                        if (info.Currency == "BTC")
                         {
                             dto.BTCPrice = cryptoInfo.Price;
                             dto.Rate = cryptoInfo.Rate;
@@ -716,12 +716,12 @@ namespace BTCPayServer.Services.Invoices
                     {
                         continue;
                     }
-                    r.PaymentCurrency = paymentMethodId.CryptoCode;
+                    r.Currency = paymentMethodId.CryptoCode;
                     r.PaymentType = paymentMethodId.PaymentType.ToString();
                     r.ParentEntity = this;
                     if (Networks != null)
                     {
-                        r.Network = Networks.GetNetwork<BTCPayNetworkBase>(r.PaymentCurrency);
+                        r.Network = Networks.GetNetwork<BTCPayNetworkBase>(r.Currency);
                         if (r.Network is null)
                             continue;
                     }
@@ -747,7 +747,7 @@ namespace BTCPayServer.Services.Invoices
             foreach (var v in paymentMethods)
             {
                 var clone = serializer.ToObject<PaymentMethod>(serializer.ToString(v));
-                clone.PaymentCurrency = null;
+                clone.Currency = null;
                 clone.PaymentType = null;
                 obj.Add(new JProperty(v.GetId().ToString(), JObject.Parse(serializer.ToString(clone))));
             }
@@ -1049,7 +1049,7 @@ namespace BTCPayServer.Services.Invoices
         [JsonIgnore]
         public BTCPayNetworkBase Network { get; set; }
         [JsonProperty(PropertyName = "cryptoCode", DefaultValueHandling = DefaultValueHandling.Ignore)]
-        public string PaymentCurrency { get; set; }
+        public string Currency { get; set; }
         [JsonProperty(PropertyName = "paymentType", DefaultValueHandling = DefaultValueHandling.Ignore)]
         [Obsolete("Use GetId().PaymentType instead")]
         public string PaymentType { get; set; }
@@ -1064,14 +1064,14 @@ namespace BTCPayServer.Services.Invoices
         public PaymentMethodId GetId()
         {
 #pragma warning disable CS0618 // Type or member is obsolete
-            return new PaymentMethodId(PaymentCurrency, string.IsNullOrEmpty(PaymentType) ? PaymentTypes.BTCLike : PaymentTypes.Parse(PaymentType));
+            return new PaymentMethodId(Currency, string.IsNullOrEmpty(PaymentType) ? PaymentTypes.BTCLike : PaymentTypes.Parse(PaymentType));
 #pragma warning restore CS0618 // Type or member is obsolete
         }
 
         public void SetId(PaymentMethodId id)
         {
 #pragma warning disable CS0618 // Type or member is obsolete
-            PaymentCurrency = id.CryptoCode;
+            Currency = id.CryptoCode;
             PaymentType = id.PaymentType.ToString();
 #pragma warning restore CS0618 // Type or member is obsolete
         }

--- a/BTCPayServer/Services/Invoices/InvoiceEntity.cs
+++ b/BTCPayServer/Services/Invoices/InvoiceEntity.cs
@@ -1176,7 +1176,10 @@ namespace BTCPayServer.Services.Invoices
             accounting.Paid = Coins(i.PaidAmount.Gross / Rate, precision);
             accounting.CryptoPaid = Coins(thisPaymentMethodPayments.Sum(p => p.PaidAmount.Gross), precision);
 
-            accounting.DueUncapped = Coins((grossDue - i.PaidAmount.Gross)/ Rate, precision);
+            // This one deal with the fact where it might looks like a slight over payment due to the dust of another payment method.
+            // So if we detect the NetDue is zero, just cap dueUncapped to 0
+            var dueUncapped = i.NetDue == 0.0m ? 0.0m : grossDue - i.PaidAmount.Gross;
+            accounting.DueUncapped = Coins(dueUncapped / Rate, precision);
             accounting.Due = Max(accounting.DueUncapped, 0.0m);
             
             accounting.NetworkFee = Coins((grossDue - i.Price) / Rate, precision);

--- a/BTCPayServer/Services/Invoices/InvoiceEntity.cs
+++ b/BTCPayServer/Services/Invoices/InvoiceEntity.cs
@@ -397,8 +397,8 @@ namespace BTCPayServer.Services.Invoices
             };
             foreach (var payment in GetPayments(false))
             {
-                payment.InvoiceCurrency = Currency;
                 payment.Rate = Rates[payment.Currency];
+                payment.InvoiceEntity = this;
                 payment.UpdateAmounts();
                 if (payment.Accounted)
                 {
@@ -1142,7 +1142,6 @@ namespace BTCPayServer.Services.Invoices
                 DepositAddress = bitcoinPaymentMethod.DepositAddress;
             }
             PaymentMethodDetails = JObject.Parse(paymentMethod.GetPaymentType().SerializePaymentMethodDetails(Network, paymentMethod));
-
 #pragma warning restore CS0618 // Type or member is obsolete
             return this;
         }
@@ -1291,8 +1290,8 @@ namespace BTCPayServer.Services.Invoices
         [JsonIgnore]
         public decimal Rate { get; set; }
         [JsonIgnore]
-        public string InvoiceCurrency { get; set; }
         /// <summary>
+        public string InvoiceCurrency => InvoiceEntity.Currency;
         /// The amount paid by this payment in the <see cref="Currency"/>
         /// </summary>
         [JsonIgnore]
@@ -1302,6 +1301,8 @@ namespace BTCPayServer.Services.Invoices
         /// </summary>
         [JsonIgnore]
         public Amounts InvoicePaidAmount { get; set; }
+        [JsonIgnore]
+        public InvoiceEntity InvoiceEntity { get; set; }
 
         public void UpdateAmounts()
         {

--- a/BTCPayServer/Services/Invoices/InvoiceEntity.cs
+++ b/BTCPayServer/Services/Invoices/InvoiceEntity.cs
@@ -445,7 +445,7 @@ namespace BTCPayServer.Services.Invoices
         public decimal MinimumNetDue { get; set; }
         public bool IsUnderPaid => MinimumNetDue > 0;
         [JsonIgnore]
-        public bool IsOverPaid => NetDue > 0;
+        public bool IsOverPaid => NetDue < 0;
 
 
         /// <summary>

--- a/BTCPayServer/Services/Invoices/InvoiceEntity.cs
+++ b/BTCPayServer/Services/Invoices/InvoiceEntity.cs
@@ -398,7 +398,7 @@ namespace BTCPayServer.Services.Invoices
             foreach (var payment in GetPayments(false))
             {
                 payment.InvoiceCurrency = Currency;
-                payment.Rate = Rates[payment.PaymentCurrency];
+                payment.Rate = Rates[payment.Currency];
                 payment.UpdateAmounts();
                 if (payment.Accounted)
                 {
@@ -475,7 +475,7 @@ namespace BTCPayServer.Services.Invoices
         }
         public List<PaymentEntity> GetPayments(string cryptoCode, bool accountedOnly)
         {
-            return GetPayments(accountedOnly).Where(p => p.PaymentCurrency == cryptoCode).ToList();
+            return GetPayments(accountedOnly).Where(p => p.Currency == cryptoCode).ToList();
         }
         public List<PaymentEntity> GetPayments(BTCPayNetworkBase network, bool accountedOnly)
         {
@@ -1270,17 +1270,17 @@ namespace BTCPayServer.Services.Invoices
             get; set;
         }
 
-        string _PaymentCurrency;
+        string _Currency;
         [JsonProperty("cryptoCode")]
-        public string PaymentCurrency
+        public string Currency
         {
             get
             {
-                return _PaymentCurrency ?? "BTC";
+                return _Currency ?? "BTC";
             }
             set
             {
-                _PaymentCurrency = value;
+                _Currency = value;
             }
         }
 
@@ -1293,7 +1293,7 @@ namespace BTCPayServer.Services.Invoices
         [JsonIgnore]
         public string InvoiceCurrency { get; set; }
         /// <summary>
-        /// The amount paid by this payment in the <see cref="PaymentCurrency"/>
+        /// The amount paid by this payment in the <see cref="Currency"/>
         /// </summary>
         [JsonIgnore]
         public Amounts PaidAmount { get; set; }
@@ -1311,7 +1311,7 @@ namespace BTCPayServer.Services.Invoices
             var value = pd.GetValue();
             PaidAmount = new Amounts()
             {
-                Currency = PaymentCurrency,
+                Currency = Currency,
                 Gross = value,
                 Net = value - NetworkFee
             };
@@ -1393,7 +1393,7 @@ namespace BTCPayServer.Services.Invoices
             {
                 return null;
             }
-            return new PaymentMethodId(PaymentCurrency ?? "BTC", paymentType);
+            return new PaymentMethodId(Currency ?? "BTC", paymentType);
 #pragma warning restore CS0618 // Type or member is obsolete
         }
     }

--- a/BTCPayServer/Services/Invoices/InvoiceRepository.cs
+++ b/BTCPayServer/Services/Invoices/InvoiceRepository.cs
@@ -12,7 +12,6 @@ using BTCPayServer.Logging;
 using BTCPayServer.Models.InvoicingModels;
 using BTCPayServer.Payments;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Logging;
 using NBitcoin;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -30,16 +29,13 @@ namespace BTCPayServer.Services.Invoices
             NBitcoin.JsonConverters.Serializer.RegisterFrontConverters(DefaultSerializerSettings);
         }
 
-        public Logs Logs { get; }
-
         private readonly ApplicationDbContextFactory _applicationDbContextFactory;
         private readonly EventAggregator _eventAggregator;
         private readonly BTCPayNetworkProvider _btcPayNetworkProvider;
 
         public InvoiceRepository(ApplicationDbContextFactory contextFactory,
-            BTCPayNetworkProvider networks, EventAggregator eventAggregator, Logs logs)
+            BTCPayNetworkProvider networks, EventAggregator eventAggregator)
         {
-            Logs = logs;
             _applicationDbContextFactory = contextFactory;
             _btcPayNetworkProvider = networks;
             _eventAggregator = eventAggregator;

--- a/BTCPayServer/Services/Invoices/InvoiceRepository.cs
+++ b/BTCPayServer/Services/Invoices/InvoiceRepository.cs
@@ -246,7 +246,6 @@ namespace BTCPayServer.Services.Invoices
                 await context.SaveChangesAsync().ConfigureAwait(false);
             }
 
-
             return invoice;
         }
 
@@ -254,7 +253,9 @@ namespace BTCPayServer.Services.Invoices
         {
             var temp = new InvoiceData();
             temp.SetBlob(invoice);
-            return temp.GetBlob(_btcPayNetworkProvider);
+            var entity = temp.GetBlob(_btcPayNetworkProvider);
+            entity.UpdateTotals();
+            return entity;
         }
 
         public async Task AddInvoiceLogs(string invoiceId, InvoiceLogs logs)

--- a/BTCPayServer/Services/Invoices/InvoiceRepository.cs
+++ b/BTCPayServer/Services/Invoices/InvoiceRepository.cs
@@ -617,6 +617,7 @@ namespace BTCPayServer.Services.Invoices
                 entity.Metadata.BuyerEmail = entity.RefundMail;
             }
             entity.Archived = invoice.Archived;
+            entity.UpdateTotals();
             return entity;
         }
 
@@ -828,9 +829,8 @@ namespace BTCPayServer.Services.Invoices
                              {
                                  var paymentMethodContribution = new InvoiceStatistics.Contribution();
                                  paymentMethodContribution.PaymentMethodId = pay.GetPaymentMethodId();
-                                 paymentMethodContribution.Value = pay.GetCryptoPaymentData().GetValue() - pay.NetworkFee;
-                                 var rate = p.GetPaymentMethod(paymentMethodContribution.PaymentMethodId).Rate;
-                                 paymentMethodContribution.CurrencyValue = rate * paymentMethodContribution.Value;
+                                 paymentMethodContribution.CurrencyValue = pay.InvoicePaidAmount.Net;
+                                 paymentMethodContribution.Value = pay.PaidAmount.Net;
                                  return paymentMethodContribution;
                              })
                              .ToArray();

--- a/BTCPayServer/Services/Invoices/PaymentService.cs
+++ b/BTCPayServer/Services/Invoices/PaymentService.cs
@@ -51,7 +51,7 @@ namespace BTCPayServer.Services.Invoices
             {
                 Version = 1,
 #pragma warning disable CS0618
-                CryptoCode = network.CryptoCode,
+                PaymentCurrency = network.CryptoCode,
 #pragma warning restore CS0618
                 ReceivedTime = date.UtcDateTime,
                 Accounted = accounted,

--- a/BTCPayServer/Services/Invoices/PaymentService.cs
+++ b/BTCPayServer/Services/Invoices/PaymentService.cs
@@ -51,7 +51,7 @@ namespace BTCPayServer.Services.Invoices
             {
                 Version = 1,
 #pragma warning disable CS0618
-                PaymentCurrency = network.CryptoCode,
+                Currency = network.CryptoCode,
 #pragma warning restore CS0618
                 ReceivedTime = date.UtcDateTime,
                 Accounted = accounted,


### PR DESCRIPTION
The logic to calculate if an invoice is overpaid or not, and how much a payment method still need to pay was overly complicated.

This refactor introduce two concept: Gross amounts and Net amounts.

* For the exact amount of the payment, you can use `Gross Payment Amount`. This term is widely used to describe the total or overall amount of money transferred before any deductions or fees are taken into account.

* For the amount of the payment that goes into paying the amount (the exact amount minus the fee), you could use `Net Payment Amount`. This term usually refers to the amount of money actually received after all deductions or fees have been subtracted from the gross amount.

I am renaming `payment.CryptoCode` to `payment.Currency`, as a payment method might not be a crypto currency in the future.

I also removed the coupling with `NBitcoin.Money` in `PaymentMethod.Calculate()` result.
This is interesting as it might allow us for example to accept sub sat payment on lightning.

The introduction of Gross Amount and Net Amount may also allow some future flexibility on additional fee than network fee.

Note that the calculation is a bit complicated to deal with this fact:
* Imagine that you need to pay exactly `0.123456789 BTC` (9 decimals) for an invoice given the rate.
* But BTC payment divisibility is 8 decimals, as such the user will pay `0.12345679 BTC` or a tenth of a satoshi more than needed
* But this extra 0.1 satoshi shouldn't be considered an overpayment. Therefore, `invoice.Dust` keep track of the amount in invoice's currency of this 0.1 satoshi, and make sure the the `invoice.NetDue` get capped to zero rather than some small negative number.
* This problem is the same in the `paymentMethod.Calculate()`, which calculate due amount from the perspective of a payment method. Even if LTC could pay exactly the missing 0.1 sat of BTC, it shouldn't show a negative `DueUncapped`.
* Same thing for lightning payment. The divisibility of lightning payment is millisat (not yet done). From it's perspective, there would be an over payment of 100 milli sats. But this shouldn't be the case since the exact amount asked has been paid in BTC. As such, we need to set the `DueUncapped` to 0 if the `invoice.NetDue` is zero.

Note that prior to this PR, `DueUncapped` would be negative for those small dust, so this is a change of behavior that I don't believe should be impactful.