### PR TITLE
Stop using bitpay's CreateInvoice for non bitpay API usage

### DIFF
--- a/BTCPayServer.Tests/Extensions.cs
+++ b/BTCPayServer.Tests/Extensions.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -196,6 +197,7 @@ retry:
             driver.FindElement(selector).Click();
         }
 
+        [DebuggerHidden]
         public static bool ElementDoesNotExist(this IWebDriver driver, By selector)
         {
             Assert.Throws<NoSuchElementException>(() =>

--- a/BTCPayServer/Controllers/BitpayInvoiceController.cs
+++ b/BTCPayServer/Controllers/BitpayInvoiceController.cs
@@ -1,17 +1,23 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using BTCPayServer.Abstractions.Constants;
 using BTCPayServer.Abstractions.Extensions;
 using BTCPayServer.Client;
+using BTCPayServer.Client.Models;
+using BTCPayServer.Data;
 using BTCPayServer.Filters;
 using BTCPayServer.ModelBinders;
 using BTCPayServer.Models;
-using BTCPayServer.Security;
+using BTCPayServer.Payments;
+using BTCPayServer.Security.Greenfield;
 using BTCPayServer.Services.Invoices;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using NBitpayClient;
+using StoreData = BTCPayServer.Data.StoreData;
 
 namespace BTCPayServer.Controllers
 {
@@ -36,7 +42,7 @@ namespace BTCPayServer.Controllers
         {
             if (invoice == null)
                 throw new BitpayHttpException(400, "Invalid invoice");
-            return await _InvoiceController.CreateInvoiceCore(invoice, HttpContext.GetStoreData(), HttpContext.Request.GetAbsoluteRoot(), cancellationToken: cancellationToken);
+            return await CreateInvoiceCore(invoice, HttpContext.GetStoreData(), HttpContext.Request.GetAbsoluteRoot(), cancellationToken: cancellationToken);
         }
 
         [HttpGet]
@@ -66,7 +72,7 @@ namespace BTCPayServer.Controllers
             int? limit = null,
             int? offset = null)
         {
-            if (User.Identity.AuthenticationType == Security.Bitpay.BitpayAuthenticationTypes.Anonymous)
+            if (User.Identity?.AuthenticationType == Security.Bitpay.BitpayAuthenticationTypes.Anonymous)
                 return Forbid(Security.Bitpay.BitpayAuthenticationTypes.Anonymous);
             if (dateEnd != null)
                 dateEnd = dateEnd.Value + TimeSpan.FromDays(1); //Should include the end day
@@ -87,6 +93,134 @@ namespace BTCPayServer.Controllers
                             .Select((o) => o.EntityToDTO()).ToArray();
 
             return Json(DataWrapper.Create(entities));
+        }
+
+         internal async Task<DataWrapper<InvoiceResponse>> CreateInvoiceCore(BitpayCreateInvoiceRequest invoice,
+            StoreData store, string serverUrl, List<string> additionalTags = null,
+            CancellationToken cancellationToken = default, Action<InvoiceEntity> entityManipulator = null)
+        {
+            var entity = await CreateInvoiceCoreRaw(invoice, store, serverUrl, additionalTags, cancellationToken, entityManipulator);
+            var resp = entity.EntityToDTO();
+            return new DataWrapper<InvoiceResponse>(resp) { Facade = "pos/invoice" };
+        }
+
+        internal async Task<InvoiceEntity> CreateInvoiceCoreRaw(BitpayCreateInvoiceRequest invoice, StoreData store, string serverUrl, List<string> additionalTags = null, CancellationToken cancellationToken = default, Action<InvoiceEntity> entityManipulator = null)
+        {
+            var storeBlob = store.GetStoreBlob();
+            var entity = _InvoiceRepository.CreateNewInvoice(store.Id);
+            entity.ExpirationTime = invoice.ExpirationTime is { } v ? v : entity.InvoiceTime + storeBlob.InvoiceExpiration;
+            entity.MonitoringExpiration = entity.ExpirationTime + storeBlob.MonitoringExpiration;
+            if (entity.ExpirationTime - TimeSpan.FromSeconds(30.0) < entity.InvoiceTime)
+            {
+                throw new BitpayHttpException(400, "The expirationTime is set too soon");
+            }
+            if (entity.Price < 0.0m)
+            {
+                throw new BitpayHttpException(400, "The price should be 0 or more.");
+            }
+            if (entity.Price > GreenfieldConstants.MaxAmount)
+            {
+                throw new BitpayHttpException(400, $"The price should less than {GreenfieldConstants.MaxAmount}.");
+            }
+            entity.Metadata.OrderId = invoice.OrderId;
+            entity.Metadata.PosDataLegacy = invoice.PosData;
+            entity.ServerUrl = serverUrl;
+            entity.FullNotifications = invoice.FullNotifications || invoice.ExtendedNotifications;
+            entity.ExtendedNotifications = invoice.ExtendedNotifications;
+            entity.NotificationURLTemplate = invoice.NotificationURL;
+            entity.NotificationEmail = invoice.NotificationEmail;
+            if (additionalTags != null)
+                entity.InternalTags.AddRange(additionalTags);
+            FillBuyerInfo(invoice, entity);
+            
+            var price = invoice.Price;
+            entity.Metadata.ItemCode = invoice.ItemCode;
+            entity.Metadata.ItemDesc = invoice.ItemDesc;
+            entity.Metadata.Physical = invoice.Physical;
+            entity.Metadata.TaxIncluded = invoice.TaxIncluded;
+            entity.Currency = invoice.Currency;
+            if (price is { } vv)
+            {
+                entity.Price = vv;
+                entity.Type = InvoiceType.Standard;
+            }
+            else
+            {
+                entity.Price = 0m;
+                entity.Type = InvoiceType.TopUp;
+            }
+
+            entity.StoreSupportUrl = storeBlob.StoreSupportUrl;
+            entity.RedirectURLTemplate = invoice.RedirectURL ?? store.StoreWebsite;
+            entity.RedirectAutomatically =
+                invoice.RedirectAutomatically.GetValueOrDefault(storeBlob.RedirectAutomatically);
+            entity.RequiresRefundEmail = invoice.RequiresRefundEmail;
+            entity.SpeedPolicy = ParseSpeedPolicy(invoice.TransactionSpeed, store.SpeedPolicy);
+
+            IPaymentFilter excludeFilter = null;
+            if (invoice.PaymentCurrencies?.Any() is true)
+            {
+                invoice.SupportedTransactionCurrencies ??=
+                    new Dictionary<string, InvoiceSupportedTransactionCurrency>();
+                foreach (string paymentCurrency in invoice.PaymentCurrencies)
+                {
+                    invoice.SupportedTransactionCurrencies.TryAdd(paymentCurrency,
+                        new InvoiceSupportedTransactionCurrency() { Enabled = true });
+                }
+            }
+            if (invoice.SupportedTransactionCurrencies != null && invoice.SupportedTransactionCurrencies.Count != 0)
+            {
+                var supportedTransactionCurrencies = invoice.SupportedTransactionCurrencies
+                                                            .Where(c => c.Value.Enabled)
+                                                            .Select(c => PaymentMethodId.TryParse(c.Key, out var p) ? p : null)
+                                                            .Where(c => c != null)
+                                                            .ToHashSet();
+                excludeFilter = PaymentFilter.Where(p => !supportedTransactionCurrencies.Contains(p));
+            }
+            entity.PaymentTolerance = storeBlob.PaymentTolerance;
+            entity.DefaultPaymentMethod = invoice.DefaultPaymentMethod;
+            entity.RequiresRefundEmail = invoice.RequiresRefundEmail;
+
+            return await _InvoiceController.CreateInvoiceCoreRaw(entity, store, excludeFilter, null, cancellationToken, entityManipulator);
+        }
+
+        private void FillBuyerInfo(BitpayCreateInvoiceRequest req, InvoiceEntity invoiceEntity)
+        {
+            var buyerInformation = invoiceEntity.Metadata;
+            buyerInformation.BuyerAddress1 = req.BuyerAddress1;
+            buyerInformation.BuyerAddress2 = req.BuyerAddress2;
+            buyerInformation.BuyerCity = req.BuyerCity;
+            buyerInformation.BuyerCountry = req.BuyerCountry;
+            buyerInformation.BuyerEmail = req.BuyerEmail;
+            buyerInformation.BuyerName = req.BuyerName;
+            buyerInformation.BuyerPhone = req.BuyerPhone;
+            buyerInformation.BuyerState = req.BuyerState;
+            buyerInformation.BuyerZip = req.BuyerZip;
+            var buyer = req.Buyer;
+            if (buyer == null)
+                return;
+            buyerInformation.BuyerAddress1 ??= buyer.Address1;
+            buyerInformation.BuyerAddress2 ??= buyer.Address2;
+            buyerInformation.BuyerCity ??= buyer.City;
+            buyerInformation.BuyerCountry ??= buyer.country;
+            buyerInformation.BuyerEmail ??= buyer.email;
+            buyerInformation.BuyerName ??= buyer.Name;
+            buyerInformation.BuyerPhone ??= buyer.phone;
+            buyerInformation.BuyerState ??= buyer.State;
+            buyerInformation.BuyerZip ??= buyer.zip;
+        }
+        private SpeedPolicy ParseSpeedPolicy(string transactionSpeed, SpeedPolicy defaultPolicy)
+        {
+            if (transactionSpeed == null)
+                return defaultPolicy;
+            var mappings = new Dictionary<string, SpeedPolicy>();
+            mappings.Add("low", SpeedPolicy.LowSpeed);
+            mappings.Add("low-medium", SpeedPolicy.LowMediumSpeed);
+            mappings.Add("medium", SpeedPolicy.MediumSpeed);
+            mappings.Add("high", SpeedPolicy.HighSpeed);
+            if (!mappings.TryGetValue(transactionSpeed, out SpeedPolicy policy))
+                policy = defaultPolicy;
+            return policy;
         }
     }
 }

--- a/BTCPayServer/Controllers/UIInvoiceController.cs
+++ b/BTCPayServer/Controllers/UIInvoiceController.cs
@@ -11,8 +11,6 @@ using BTCPayServer.Data;
 using BTCPayServer.Events;
 using BTCPayServer.HostedServices;
 using BTCPayServer.Logging;
-using BTCPayServer.Models;
-using BTCPayServer.Models.PaymentRequestViewModels;
 using BTCPayServer.Payments;
 using BTCPayServer.Payments.Bitcoin;
 using BTCPayServer.Rating;
@@ -24,16 +22,13 @@ using BTCPayServer.Services.Invoices;
 using BTCPayServer.Services.PaymentRequests;
 using BTCPayServer.Services.Rates;
 using BTCPayServer.Services.Stores;
-using BTCPayServer.Validation;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
 using NBitcoin;
-using NBitpayClient;
 using Newtonsoft.Json.Linq;
-using BitpayCreateInvoiceRequest = BTCPayServer.Models.BitpayCreateInvoiceRequest;
 using StoreData = BTCPayServer.Data.StoreData;
 
 namespace BTCPayServer.Controllers
@@ -106,98 +101,6 @@ namespace BTCPayServer.Controllers
             _linkGenerator = linkGenerator;
             _authorizationService = authorizationService;
             _appService = appService;
-        }
-
-
-        internal async Task<DataWrapper<InvoiceResponse>> CreateInvoiceCore(BitpayCreateInvoiceRequest invoice,
-            StoreData store, string serverUrl, List<string>? additionalTags = null,
-            CancellationToken cancellationToken = default, Action<InvoiceEntity>? entityManipulator = null)
-        {
-            var entity = await CreateInvoiceCoreRaw(invoice, store, serverUrl, additionalTags, cancellationToken, entityManipulator);
-            var resp = entity.EntityToDTO();
-            return new DataWrapper<InvoiceResponse>(resp) { Facade = "pos/invoice" };
-        }
-
-        internal async Task<InvoiceEntity> CreateInvoiceCoreRaw(BitpayCreateInvoiceRequest invoice, StoreData store, string serverUrl, List<string>? additionalTags = null, CancellationToken cancellationToken = default, Action<InvoiceEntity>? entityManipulator = null)
-        {
-            var storeBlob = store.GetStoreBlob();
-            var entity = _InvoiceRepository.CreateNewInvoice(store.Id);
-            entity.ExpirationTime = invoice.ExpirationTime is DateTimeOffset v ? v : entity.InvoiceTime + storeBlob.InvoiceExpiration;
-            entity.MonitoringExpiration = entity.ExpirationTime + storeBlob.MonitoringExpiration;
-            if (entity.ExpirationTime - TimeSpan.FromSeconds(30.0) < entity.InvoiceTime)
-            {
-                throw new BitpayHttpException(400, "The expirationTime is set too soon");
-            }
-            if (entity.Price < 0.0m)
-            {
-                throw new BitpayHttpException(400, "The price should be 0 or more.");
-            }
-            if (entity.Price > GreenfieldConstants.MaxAmount)
-            {
-                throw new BitpayHttpException(400, $"The price should less than {GreenfieldConstants.MaxAmount}.");
-            }
-            entity.Metadata.OrderId = invoice.OrderId;
-            entity.Metadata.PosDataLegacy = invoice.PosData;
-            entity.ServerUrl = serverUrl;
-            entity.FullNotifications = invoice.FullNotifications || invoice.ExtendedNotifications;
-            entity.ExtendedNotifications = invoice.ExtendedNotifications;
-            entity.NotificationURLTemplate = invoice.NotificationURL;
-            entity.NotificationEmail = invoice.NotificationEmail;
-            if (additionalTags != null)
-                entity.InternalTags.AddRange(additionalTags);
-            FillBuyerInfo(invoice, entity);
-
-            var taxIncluded = invoice.TaxIncluded.HasValue ? invoice.TaxIncluded.Value : 0m;
-            var price = invoice.Price;
-
-            entity.Metadata.ItemCode = invoice.ItemCode;
-            entity.Metadata.ItemDesc = invoice.ItemDesc;
-            entity.Metadata.Physical = invoice.Physical;
-            entity.Metadata.TaxIncluded = invoice.TaxIncluded;
-            entity.Currency = invoice.Currency;
-            if (price is decimal vv)
-            {
-                entity.Price = vv;
-                entity.Type = InvoiceType.Standard;
-            }
-            else
-            {
-                entity.Price = 0m;
-                entity.Type = InvoiceType.TopUp;
-            }
-
-            entity.StoreSupportUrl = storeBlob.StoreSupportUrl;
-            entity.RedirectURLTemplate = invoice.RedirectURL ?? store.StoreWebsite;
-            entity.RedirectAutomatically =
-                invoice.RedirectAutomatically.GetValueOrDefault(storeBlob.RedirectAutomatically);
-            entity.RequiresRefundEmail = invoice.RequiresRefundEmail;
-            entity.SpeedPolicy = ParseSpeedPolicy(invoice.TransactionSpeed, store.SpeedPolicy);
-
-            IPaymentFilter? excludeFilter = null;
-            if (invoice.PaymentCurrencies?.Any() is true)
-            {
-                invoice.SupportedTransactionCurrencies ??=
-                    new Dictionary<string, InvoiceSupportedTransactionCurrency>();
-                foreach (string paymentCurrency in invoice.PaymentCurrencies)
-                {
-                    invoice.SupportedTransactionCurrencies.TryAdd(paymentCurrency,
-                        new InvoiceSupportedTransactionCurrency() { Enabled = true });
-                }
-            }
-            if (invoice.SupportedTransactionCurrencies != null && invoice.SupportedTransactionCurrencies.Count != 0)
-            {
-                var supportedTransactionCurrencies = invoice.SupportedTransactionCurrencies
-                                                            .Where(c => c.Value.Enabled)
-                                                            .Select(c => PaymentMethodId.TryParse(c.Key, out var p) ? p : null)
-                                                            .Where(c => c != null)
-                                                            .ToHashSet();
-                excludeFilter = PaymentFilter.Where(p => !supportedTransactionCurrencies.Contains(p));
-            }
-            entity.PaymentTolerance = storeBlob.PaymentTolerance;
-            entity.DefaultPaymentMethod = invoice.DefaultPaymentMethod;
-            entity.RequiresRefundEmail = invoice.RequiresRefundEmail;
-
-            return await CreateInvoiceCoreRaw(entity, store, excludeFilter, null, cancellationToken, entityManipulator);
         }
 
         internal async Task<InvoiceEntity> CreatePaymentRequestInvoice(Data.PaymentRequestData prData, decimal? amount, decimal amountDue, StoreData storeData, HttpRequest request, CancellationToken cancellationToken)
@@ -547,46 +450,6 @@ namespace BTCPayServer.Controllers
                 logs.Write($"{supportedPaymentMethod.PaymentId.CryptoCode}: Unexpected exception ({ex})", InvoiceEventData.EventSeverity.Error);
             }
             return null;
-        }
-
-        private SpeedPolicy ParseSpeedPolicy(string transactionSpeed, SpeedPolicy defaultPolicy)
-        {
-            if (transactionSpeed == null)
-                return defaultPolicy;
-            var mappings = new Dictionary<string, SpeedPolicy>();
-            mappings.Add("low", SpeedPolicy.LowSpeed);
-            mappings.Add("low-medium", SpeedPolicy.LowMediumSpeed);
-            mappings.Add("medium", SpeedPolicy.MediumSpeed);
-            mappings.Add("high", SpeedPolicy.HighSpeed);
-            if (!mappings.TryGetValue(transactionSpeed, out SpeedPolicy policy))
-                policy = defaultPolicy;
-            return policy;
-        }
-
-        private void FillBuyerInfo(BitpayCreateInvoiceRequest req, InvoiceEntity invoiceEntity)
-        {
-            var buyerInformation = invoiceEntity.Metadata;
-            buyerInformation.BuyerAddress1 = req.BuyerAddress1;
-            buyerInformation.BuyerAddress2 = req.BuyerAddress2;
-            buyerInformation.BuyerCity = req.BuyerCity;
-            buyerInformation.BuyerCountry = req.BuyerCountry;
-            buyerInformation.BuyerEmail = req.BuyerEmail;
-            buyerInformation.BuyerName = req.BuyerName;
-            buyerInformation.BuyerPhone = req.BuyerPhone;
-            buyerInformation.BuyerState = req.BuyerState;
-            buyerInformation.BuyerZip = req.BuyerZip;
-            var buyer = req.Buyer;
-            if (buyer == null)
-                return;
-            buyerInformation.BuyerAddress1 ??= buyer.Address1;
-            buyerInformation.BuyerAddress2 ??= buyer.Address2;
-            buyerInformation.BuyerCity ??= buyer.City;
-            buyerInformation.BuyerCountry ??= buyer.country;
-            buyerInformation.BuyerEmail ??= buyer.email;
-            buyerInformation.BuyerName ??= buyer.Name;
-            buyerInformation.BuyerPhone ??= buyer.phone;
-            buyerInformation.BuyerState ??= buyer.State;
-            buyerInformation.BuyerZip ??= buyer.zip;
         }
     }
 }


### PR DESCRIPTION
This move legacy code from the bitpay API we were still using internally.

This code switch to call to greenfield's `CreateInvoiceCoreRaw` method instead for things unrelated to Bitpay's API.
I also moved the Bitpay stuff to the Bitpay's controller.

I also did a refactoring in `PayButtonHandle`. There was a but where `model.CheckoutQueryString` wasn't used if the action was called from javascript.