### PR TITLE
Preventing entering of negative tips and discounts in POS

### DIFF
--- a/BTCPayServer/Plugins/PointOfSale/Controllers/UIPointOfSaleController.cs
+++ b/BTCPayServer/Plugins/PointOfSale/Controllers/UIPointOfSaleController.cs
@@ -147,12 +147,17 @@ namespace BTCPayServer.Plugins.PointOfSale.Controllers
                                                         CancellationToken cancellationToken = default)
         {
             var app = await _appService.GetApp(appId, PointOfSaleAppType.AppType);
-            if (string.IsNullOrEmpty(choiceKey) && amount <= 0)
-            {
+
+            // not allowing negative tips or discounts
+            if (tip < 0 || discount < 0)
                 return RedirectToAction(nameof(ViewPointOfSale), new { appId });
-            }
+
+            if (string.IsNullOrEmpty(choiceKey) && amount <= 0)
+                return RedirectToAction(nameof(ViewPointOfSale), new { appId });
+
             if (app == null)
                 return NotFound();
+            
             var settings = app.GetSettings<PointOfSaleSettings>();
             settings.DefaultView = settings.EnableShoppingCart ? PosViewType.Cart : settings.DefaultView;
             var currentView = viewType ?? settings.DefaultView;

--- a/BTCPayServer/wwwroot/pos/common.js
+++ b/BTCPayServer/wwwroot/pos/common.js
@@ -31,6 +31,9 @@ const posCommon = {
             if (this.tipPercent) {
                 return parseFloat((this.amountMinusDiscountNumeric * (this.tipPercent / 100)).toFixed(this.currencyInfo.divisibility))
             } else {
+                if (this.tip < 0) {
+                    this.tip = 0
+                }
                 const value = parseFloat(this.tip)
                 return isNaN(value) ? 0.0 : parseFloat(value.toFixed(this.currencyInfo.divisibility))
             }
@@ -64,6 +67,7 @@ const posCommon = {
         discountPercent (val) {
             const value = parseFloat(val)
             if (isNaN(value)) this.discountPercent = null
+            else if (value < 0) this.discountPercent = '0'
             else if (value > 100) this.discountPercent = '100'
             else this.discountPercent = value.toString()
         },


### PR DESCRIPTION
Fix: #5192

I have added server side check that will prevent tips and discounts being sent in as negative numbers.
Also, I've added client side checks that will prevent these amounts being negative during calculations.

`min` validation on `input` still prevented form from being submitted as you can see from screenshot

![image](https://github.com/btcpayserver/btcpayserver/assets/5191402/490b6d73-c439-42fa-974e-f99a1d262bf0)

but calculations were running, so to prevent confusion I've added extra check.