### PR TITLE
ui+checkout: fix language cutoff bug

### DIFF
--- a/BTCPayServer/wwwroot/checkout-v2/checkout.css
+++ b/BTCPayServer/wwwroot/checkout-v2/checkout.css
@@ -158,7 +158,7 @@ section dl > div dd {
     color: var(--btcpay-body-text-muted);
 }
 #DefaultLang {
-    width: calc(var(--text-width, 110px) + 3rem);
+    width: calc(var(--text-width, 110px) + 3.5rem);
     color: var(--btcpay-body-text-muted);
     background-color: var(--btcpay-body-bg);
     box-shadow: none;


### PR DESCRIPTION
fixes #5206 

Was able to fix with a bumping of the calculated value, few of the longer examples with the fix.

<img width="220" alt="Screen Shot 2023-07-28 at 1 04 02 PM" src="https://github.com/btcpayserver/btcpayserver/assets/6250771/a1b594dd-2a06-4a87-86cd-4cde15fd32aa">
<img width="151" alt="Screen Shot 2023-07-28 at 1 04 07 PM" src="https://github.com/btcpayserver/btcpayserver/assets/6250771/62c94f00-49de-4a4f-8be6-4f4a9509023f">
<img width="245" alt="Screen Shot 2023-07-28 at 1 03 58 PM" src="https://github.com/btcpayserver/btcpayserver/assets/6250771/e0311001-b192-434d-9c7f-54b107df2ba6">
