### PR TITLE
POS fixes

### DIFF
--- a/BTCPayServer.Tests/SeleniumTests.cs
+++ b/BTCPayServer.Tests/SeleniumTests.cs
@@ -988,14 +988,14 @@ namespace BTCPayServer.Tests
             Assert.True(s.Driver.PageSource.Contains("Tea shop"), "Unable to create PoS");
             Assert.True(s.Driver.PageSource.Contains("Cart"), "PoS not showing correct default view");
             Assert.True(s.Driver.PageSource.Contains("Take my money"), "PoS not showing correct default view");
-            Assert.Equal(5, s.Driver.FindElements(By.CssSelector(".posItem:not(.d-none)")).Count);
+            Assert.Equal(6, s.Driver.FindElements(By.CssSelector(".posItem:not(.d-none)")).Count);
 
             var drinks = s.Driver.FindElement(By.CssSelector("label[for='Category-Drinks']"));
             Assert.Equal("Drinks", drinks.Text);
             drinks.Click();
             Assert.Single(s.Driver.FindElements(By.CssSelector(".posItem:not(.d-none)")));
             s.Driver.FindElement(By.CssSelector("label[for='Category-*']")).Click();
-            Assert.Equal(5, s.Driver.FindElements(By.CssSelector(".posItem:not(.d-none)")).Count);
+            Assert.Equal(6, s.Driver.FindElements(By.CssSelector(".posItem:not(.d-none)")).Count);
 
             s.Driver.Url = posBaseUrl + "/static";
             Assert.False(s.Driver.PageSource.Contains("Cart"), "Static PoS not showing correct view");

--- a/BTCPayServer.Tests/ThirdPartyTests.cs
+++ b/BTCPayServer.Tests/ThirdPartyTests.cs
@@ -292,7 +292,7 @@ retry:
         [Fact]
         public async Task CanGetRateCryptoCurrenciesByDefault()
         {
-            string[] brokenShitcoins = { };
+            string[] brokenShitcoins = { "BTG", "BTX" };
             var provider = new BTCPayNetworkProvider(ChainName.Mainnet);
             var factory = FastTests.CreateBTCPayRateFactory();
             var fetcher = new RateFetcher(factory);
@@ -306,9 +306,13 @@ retry:
             foreach ((CurrencyPair key, Task<RateResult> value) in result)
             {
                 var rateResult = await value;
-                TestLogs.LogInformation($"Testing {key}");
-                if (brokenShitcoins.Contains(key.ToString()))
+                if (brokenShitcoins.Contains(key.Left))
+                {
+                    TestLogs.LogInformation($"Skipping {key} because it is marked as broken");
                     continue;
+                }
+                    
+                TestLogs.LogInformation($"Testing {key}");
                 Assert.True(rateResult.BidAsk != null, $"Impossible to get the rate {rateResult.EvaluatedRule}");
             }
 
@@ -325,9 +329,12 @@ retry:
                 foreach ((CurrencyPair key, Task<RateResult> value) in result)
                 {
                     var rateResult = await value;
-                    TestLogs.LogInformation($"Testing {key} when default currency is {k.Key}");
-                    if (brokenShitcoins.Contains(key.ToString()))
+                    if (brokenShitcoins.Contains(key.Left))
+                    {
+                        TestLogs.LogInformation($"Skipping {key} because it is marked as broken");
                         continue;
+                    }
+                    TestLogs.LogInformation($"Testing {key} when default currency is {k.Key}");
                     Assert.True(rateResult.BidAsk != null, $"Impossible to get the rate {rateResult.EvaluatedRule}");
                 }
             }

--- a/BTCPayServer.Tests/UnitTest1.cs
+++ b/BTCPayServer.Tests/UnitTest1.cs
@@ -2859,7 +2859,7 @@ namespace BTCPayServer.Tests
             using var tester = CreateServerTester();
             await tester.StartAsync();
             var user = tester.NewAccount();
-            user.GrantAccess();
+            await user.GrantAccessAsync();
             var controller = tester.PayTester.GetController<UIServerController>(user.UserId, user.StoreId);
 
             var fileSystemStorageConfiguration = Assert.IsType<FileSystemStorageConfiguration>(Assert
@@ -2873,7 +2873,6 @@ namespace BTCPayServer.Tests
             Assert.Equal(nameof(StorageProvider), shouldBeRedirectingToLocalStorageConfigPage.ActionName);
             Assert.Equal(StorageProvider.FileSystem,
                 shouldBeRedirectingToLocalStorageConfigPage.RouteValues["provider"]);
-
 
             await CanUploadRemoveFiles(controller);
         }
@@ -2906,7 +2905,7 @@ namespace BTCPayServer.Tests
 
             //create a temporary link to file
             var tmpLinkGenerate = Assert.IsType<RedirectToActionResult>(await controller.CreateTemporaryFileUrl(fileId,
-                new UIServerController.CreateTemporaryFileUrlViewModel()
+                new UIServerController.CreateTemporaryFileUrlViewModel
                 {
                     IsDownload = true,
                     TimeAmount = 1,

--- a/BTCPayServer/Storage/Services/Providers/FileSystemStorage/FileSystemFileProviderService.cs
+++ b/BTCPayServer/Storage/Services/Providers/FileSystemStorage/FileSystemFileProviderService.cs
@@ -52,7 +52,7 @@ namespace BTCPayServer.Storage.Services.Providers.FileSystemStorage
             BlobUrlAccess access = BlobUrlAccess.Read)
         {
 
-            var localFileDescriptor = new TemporaryLocalFileDescriptor()
+            var localFileDescriptor = new TemporaryLocalFileDescriptor
             {
                 Expiry = expiry,
                 FileId = storedFile.Id,
@@ -60,9 +60,11 @@ namespace BTCPayServer.Storage.Services.Providers.FileSystemStorage
             };
             var name = Guid.NewGuid().ToString();
             var fullPath = Path.Combine(_datadirs.Value.TempStorageDir, name);
-            if (!File.Exists(fullPath))
+            var fileInfo = new FileInfo(fullPath);
+            if (!fileInfo.Exists)
             {
-                await File.Create(fullPath).DisposeAsync();
+                fileInfo.Directory?.Create();
+                await File.Create(fileInfo.FullName).DisposeAsync();
             }
 
             await File.WriteAllTextAsync(Path.Combine(_datadirs.Value.TempStorageDir, name), JsonConvert.SerializeObject(localFileDescriptor));

--- a/BTCPayServer/Views/Shared/PointOfSale/Public/Cart.cshtml
+++ b/BTCPayServer/Views/Shared/PointOfSale/Public/Cart.cshtml
@@ -1,8 +1,6 @@
 @using BTCPayServer.Plugins.PointOfSale.Models
 @using BTCPayServer.Services
-@using Newtonsoft.Json.Linq;
-@using BTCPayServer.Abstractions.TagHelpers
-@using Microsoft.AspNetCore.Mvc.TagHelpers
+@using Newtonsoft.Json.Linq
 @inject DisplayFormatter DisplayFormatter
 @inject BTCPayServer.Security.ContentSecurityPolicies Csp
 @model BTCPayServer.Plugins.PointOfSale.Models.ViewPointOfSaleViewModel
@@ -65,8 +63,8 @@
                             ? item.PriceType == ViewPointOfSaleViewModel.ItemPriceType.Topup ? Model.CustomButtonText : Model.ButtonText
                             : item.BuyButtonText;
                         buttonText = buttonText.Replace("{0}", formatted).Replace("{Price}", formatted);
-                        var categories = new JArray(item.Categories ?? Array.Empty<string>());
-                        <div class="col posItem" :class="{ 'posItem--inStock': inStock(@index) }" data-index="@index" data-search="@Safe.RawEncode(item.Title + " " + item.Description)"  data-categories="@Safe.Json(categories)">
+                        var categories = new JArray(item.Categories ?? new object[] { });
+                        <div class="col posItem" :class="{ 'posItem--inStock': inStock(@index) }" data-index="@index" data-search="@Safe.RawEncode(item.Title + " " + item.Description)" data-categories='@Safe.Json(categories)'>
                             <div class="card h-100 px-0" v-on:click="addToCart(@index)">
                                 @if (!string.IsNullOrWhiteSpace(item.Image))
                                 {

--- a/BTCPayServer/wwwroot/pos/cart.js
+++ b/BTCPayServer/wwwroot/pos/cart.js
@@ -160,10 +160,8 @@ document.addEventListener("DOMContentLoaded",function () {
             }
         },
         mounted() {
-            const self =this;
-            nextTick(() => {
-                self.$cart = new bootstrap.Offcanvas("#cart", {backdrop: false})
-            })
+            this.$cart = new bootstrap.Offcanvas(this.$refs.cart, { backdrop: false })
+
             window.addEventListener('pagehide', () => {
                 if (this.payButtonLoading) {
                     this.unsetPayButtonLoading();


### PR DESCRIPTION
The recent fixes lead to some new regressions. This fixes #5224, fixes #5217, fixes #5213.

To ensure that this still fixes the original issues, I added some `"` and `'` to the category names, titles and description tags, because those initially broke things. Can you give the fixes for the original issues a second look, @kukks?

![grafik](https://github.com/btcpayserver/btcpayserver/assets/886/dec1e910-ea15-43fe-8b5e-96c7af5efb7e)
