### PR TITLE
Fixing the language selector box on checkout

### DIFF
--- a/BTCPayServer/wwwroot/checkout-v2/checkout.css
+++ b/BTCPayServer/wwwroot/checkout-v2/checkout.css
@@ -158,7 +158,7 @@ section dl > div dd {
     color: var(--btcpay-body-text-muted);
 }
 #DefaultLang {
-    width: calc(var(--text-width, 110px) + 3.5rem);
+    width: calc(var(--text-width, 110px) + 4rem);
     color: var(--btcpay-body-text-muted);
     background-color: var(--btcpay-body-bg);
     box-shadow: none;


### PR DESCRIPTION
This issue had been marked as resolved but still didn't show the entire word. The first picture is the original issue, the second is what is currently up, and the third is mine.
![image](https://github.com/btcpayserver/btcpayserver/assets/80845794/b0068b7f-c9b2-4075-a4fa-eeecbfd669d7)
![image](https://github.com/btcpayserver/btcpayserver/assets/80845794/9eb89367-793b-4c4c-bd20-e28de7f83cea)
<img width="194" alt="Screen Shot 2023-08-03 at 5 54 22 PM" src="https://github.com/btcpayserver/btcpayserver/assets/80845794/69b607b0-c634-4836-8dcf-0ae566705f05">

