### PR TITLE
POS: Handle flexible price items in cart view

### DIFF
--- a/BTCPayServer.Tests/AltcoinTests/AltcoinTests.cs
+++ b/BTCPayServer.Tests/AltcoinTests/AltcoinTests.cs
@@ -642,7 +642,17 @@ namespace BTCPayServer.Tests
                 vmpos.CustomButtonText = "Nicolas Sexy Hair";
                 vmpos.CustomTipText = "Wanna tip?";
                 vmpos.CustomTipPercentages = "15,18,20";
-                vmpos.Template = "[ { \"id\": \"apple\", \"price\": 5, \"priceType\": \"Fixed\", \"title\": \"good apple\" }, { \"id\": \"orange\", \"title\": \"orange\", \"price\": 10, \"priceType\": \"Fixed\" }, { \"id\": \"donation\", \"title\": \"donation\", \"price\": 1.02, \"priceType\": \"Minimum\" } ]";
+                vmpos.Template = @"
+apple:
+  price: 5.0
+  title: good apple
+orange:
+  price: 10.0
+donation:
+  price: 1.02
+  custom: true
+";
+                vmpos.Template = AppService.SerializeTemplate(MigrationStartupTask.ParsePOSYML(vmpos.Template));
                 Assert.IsType<RedirectToActionResult>(pos.UpdatePointOfSale(app.Id, vmpos).Result);
                 vmpos = await pos.UpdatePointOfSale(app.Id).AssertViewModelAsync<UpdatePointOfSaleViewModel>();
                 Assert.Equal("hello", vmpos.Title);

--- a/BTCPayServer/Plugins/PointOfSale/Controllers/UIPointOfSaleController.cs
+++ b/BTCPayServer/Plugins/PointOfSale/Controllers/UIPointOfSaleController.cs
@@ -623,7 +623,6 @@ namespace BTCPayServer.Plugins.PointOfSale.Controllers
                 return View("PointOfSale/UpdatePointOfSale", vm);
             }
 
-            var storeBlob = GetCurrentStore().GetStoreBlob();
             var settings = new PointOfSaleSettings
             {
                 Title = vm.Title,
@@ -642,11 +641,10 @@ namespace BTCPayServer.Plugins.PointOfSale.Controllers
                 RedirectUrl = vm.RedirectUrl,
                 Description = vm.Description,
                 EmbeddedCSS = vm.EmbeddedCSS,
-                RedirectAutomatically =
-                    string.IsNullOrEmpty(vm.RedirectAutomatically) ? null : bool.Parse(vm.RedirectAutomatically)
+                RedirectAutomatically = string.IsNullOrEmpty(vm.RedirectAutomatically) ? null : bool.Parse(vm.RedirectAutomatically),
+                FormId = vm.FormId
             };
 
-            settings.FormId = vm.FormId;
             app.Name = vm.AppName;
             app.SetSettings(settings);
             await _appService.UpdateOrCreateApp(app);

--- a/BTCPayServer/Plugins/PointOfSale/Controllers/UIPointOfSaleController.cs
+++ b/BTCPayServer/Plugins/PointOfSale/Controllers/UIPointOfSaleController.cs
@@ -171,7 +171,7 @@ namespace BTCPayServer.Plugins.PointOfSale.Controllers
             decimal? price;
             Dictionary<string, InvoiceSupportedTransactionCurrency> paymentMethods = null;
             ViewPointOfSaleViewModel.Item choice = null;
-            Dictionary<string, int> cartItems = null;
+            List<PosCartItem> cartItems = null;
             ViewPointOfSaleViewModel.Item[] choices = null;
             if (!string.IsNullOrEmpty(choiceKey))
             {
@@ -208,16 +208,15 @@ namespace BTCPayServer.Plugins.PointOfSale.Controllers
                     return NotFound();
 
                 title = settings.Title;
-                //if cart IS enabled and we detect posdata that matches the cart system's, check inventory for the items
+                // if cart IS enabled and we detect posdata that matches the cart system's, check inventory for the items
                 price = amount;
-                if (currentView == PosViewType.Cart &&
-                    AppService.TryParsePosCartItems(jposData, out cartItems))
+                if (currentView == PosViewType.Cart && AppService.TryParsePosCartItems(jposData, out cartItems))
                 {
                     price = 0.0m;
                     choices = AppService.Parse(settings.Template, false);
                     foreach (var cartItem in cartItems)
                     {
-                        var itemChoice = choices.FirstOrDefault(c => c.Id == cartItem.Key);
+                        var itemChoice = choices.FirstOrDefault(item => item.Id == cartItem.Id);
                         if (itemChoice == null)
                             return NotFound();
 
@@ -225,20 +224,21 @@ namespace BTCPayServer.Plugins.PointOfSale.Controllers
                         {
                             switch (itemChoice.Inventory)
                             {
-                                case int i when i <= 0:
+                                case <= 0:
                                     return RedirectToAction(nameof(ViewPointOfSale), new { appId });
-                                case int inventory when inventory < cartItem.Value:
+                                case { } inventory when inventory < cartItem.Count:
                                     return RedirectToAction(nameof(ViewPointOfSale), new { appId });
                             }
                         }
 
-                        decimal expectedCartItemPrice = 0;
-                        if (itemChoice.PriceType != ViewPointOfSaleViewModel.ItemPriceType.Topup)
-                        {
-                            expectedCartItemPrice = itemChoice.Price ?? 0;
-                        }
+                        var expectedCartItemPrice = itemChoice.PriceType != ViewPointOfSaleViewModel.ItemPriceType.Topup
+                            ? itemChoice.Price ?? 0
+                            : 0;
+                        
+                        if (cartItem.Price < expectedCartItemPrice)
+                            cartItem.Price = expectedCartItemPrice;
 
-                        price += expectedCartItemPrice * cartItem.Value;
+                        price += cartItem.Price * cartItem.Count;
                     }
                     if (customAmount is { } c)
                         price += c;
@@ -315,7 +315,7 @@ namespace BTCPayServer.Plugins.PointOfSale.Controllers
                 {
                     Amount = price,
                     Currency = settings.Currency,
-                    Metadata = new InvoiceMetadata()
+                    Metadata = new InvoiceMetadata
                     {
                         ItemCode = choice?.Id,
                         ItemDesc = title,
@@ -358,17 +358,19 @@ namespace BTCPayServer.Plugins.PointOfSale.Controllers
                             receiptData = new JObject();
                             if (cartItems is not null && choices is not null)
                             {
-                                var selectedChoices = choices.Where(item => cartItems.Keys.Contains(item.Id))
+                                var posCartItems = cartItems.ToList();
+                                var selectedChoices = choices
+                                    .Where(item => posCartItems.Any(cartItem => cartItem.Id == item.Id))
                                     .ToDictionary(item => item.Id);
                                 var cartData = new JObject();
-                                foreach (KeyValuePair<string, int> cartItem in cartItems)
+                                foreach (PosCartItem cartItem in posCartItems)
                                 {
-                                    if (selectedChoices.TryGetValue(cartItem.Key, out var selectedChoice))
-                                    {
-                                        cartData.Add(selectedChoice.Title ?? selectedChoice.Id,
-                                            $"{(selectedChoice.Price is null ? "Any price" : $"{_displayFormatter.Currency((decimal)selectedChoice.Price.Value, settings.Currency, DisplayFormatter.CurrencyFormat.Symbol)}")} x {cartItem.Value} = {(selectedChoice.Price is null ? "Any price" : $"{_displayFormatter.Currency(((decimal)selectedChoice.Price.Value) * cartItem.Value, settings.Currency, DisplayFormatter.CurrencyFormat.Symbol)}")}");
-
-                                    }
+                                    if (!selectedChoices.TryGetValue(cartItem.Id, out var selectedChoice)) continue;
+                                    var singlePrice = _displayFormatter.Currency(cartItem.Price, settings.Currency, DisplayFormatter.CurrencyFormat.Symbol);
+                                    var totalPrice = _displayFormatter.Currency(cartItem.Price * cartItem.Count, settings.Currency, DisplayFormatter.CurrencyFormat.Symbol);
+                                    var ident = selectedChoice.Title ?? selectedChoice.Id;
+                                    var key = selectedChoice.PriceType == ViewPointOfSaleViewModel.ItemPriceType.Fixed ? ident : $"{ident} ({singlePrice})";
+                                    cartData.Add(key, $"{singlePrice} x {cartItem.Count} = {totalPrice}");
                                 }
                                 receiptData.Add("Cart", cartData);
                             }

--- a/BTCPayServer/Services/Apps/AppService.cs
+++ b/BTCPayServer/Services/Apps/AppService.cs
@@ -411,7 +411,6 @@ namespace BTCPayServer.Services.Apps
                 return false;
             if (cartObject is null)
                 return false;
-            
             cartItems = new();
             foreach (var o in cartObject.OfType<JObject>())
             {

--- a/BTCPayServer/Services/Apps/AppService.cs
+++ b/BTCPayServer/Services/Apps/AppService.cs
@@ -402,6 +402,32 @@ namespace BTCPayServer.Services.Apps
             }
         }
 #nullable enable
+        public static bool TryParsePosCartItems(JObject? posData, [MaybeNullWhen(false)] out Dictionary<string, int> cartItems)
+        {
+            cartItems = null;
+            if (posData is null)
+                return false;
+            if (!posData.TryGetValue("cart", out var cartObject))
+                return false;
+            if (cartObject is null)
+                return false;
+            
+            cartItems = new();
+            foreach (var o in cartObject.OfType<JObject>())
+            {
+                var id = o.GetValue("id", StringComparison.InvariantCulture)?.ToString();
+                if (id != null)
+                {
+                    var countStr = o.GetValue("count", StringComparison.InvariantCulture)?.ToString() ?? string.Empty;
+                    if (int.TryParse(countStr, out var count))
+                    {
+                        cartItems.TryAdd(id, count);
+                    }
+                }
+            }
+            return true;
+        }
+        
         public static bool TryParsePosCartItems(JObject? posData, [MaybeNullWhen(false)] out List<PosCartItem> cartItems)
         {
             cartItems = null;

--- a/BTCPayServer/Views/Shared/PointOfSale/Public/Cart.cshtml
+++ b/BTCPayServer/Views/Shared/PointOfSale/Public/Cart.cshtml
@@ -83,7 +83,7 @@
                                         }
                                         @if (item.Inventory.HasValue)
                                         {
-                                            <span class="badge text-bg-warning" v-text="inventoryText(@index)">
+                                            <span class="badge text-bg-warning inventory" v-text="inventoryText(@index)">
                                                 @(item.Inventory > 0 ? $"{item.Inventory} left" : "Sold out")
                                             </span>
                                         }
@@ -95,11 +95,18 @@
                                 </div>
                                 @if (inStock)
                                 {
-                                    <div class="card-footer bg-transparent border-0 pt-0 pb-3">
+                                    <form class="card-footer bg-transparent border-0 pt-0 pb-3">
+                                        @if (item.PriceType != ViewPointOfSaleViewModel.ItemPriceType.Fixed)
+                                        {
+                                            <div class="input-group mb-2">
+                                                <span class="input-group-text">@Model.CurrencySymbol</span>
+                                                <input class="form-control" type="number" min="@(item.Price ?? 0)" step="@Model.Step" name="amount" placeholder="Amount" value="@item.Price" required v-on:click.stop>
+                                            </div>
+                                        }
                                         <button type="button" class="btn btn-primary w-100" :disabled="!inStock(@index)">
                                             @Safe.RawEncode(buttonText)
                                         </button>
-                                    </div>
+                                    </form>
                                     <div class="posItem-added"><vc:icon symbol="checkmark" /></div>
                                 }
                             </div>
@@ -141,7 +148,7 @@
                                 </td>
                                 <td class="align-middle">
                                     <div class="d-flex align-items-center gap-2 justify-content-end quantity">
-                                        <span class="badge text-bg-warning" v-if="item.inventory">
+                                        <span class="badge text-bg-warning inventory" v-if="item.inventory">
                                             {{ item.inventory > 0 ? `${item.inventory} left` : "Sold out" }}
                                         </span>
                                         <div class="d-flex align-items-center gap-2">

--- a/BTCPayServer/wwwroot/pos/cart.js
+++ b/BTCPayServer/wwwroot/pos/cart.js
@@ -121,7 +121,17 @@ document.addEventListener("DOMContentLoaded",function () {
                 if (!this.inStock(index)) return false;
                 
                 const item = this.items[index];
-                let itemInCart = this.cart.find(lineItem => lineItem.id === item.id);
+                const $posItem = this.$refs.posItems.querySelectorAll('.posItem')[index];
+                
+                // Check if price is needed
+                const isFixedPrice = item.priceType.toLowerCase() === 'fixed';
+                if (!isFixedPrice) {
+                    const $amount = $posItem.querySelector('input[name="amount"]');
+                    if (!$amount.reportValidity()) return false;
+                    item.price = parseFloat($amount.value);
+                }
+                
+                let itemInCart = this.cart.find(lineItem => lineItem.id === item.id && lineItem.price === item.price);
 
                 // Add new item because it doesn't exist yet
                 if (!itemInCart) {
@@ -138,7 +148,6 @@ document.addEventListener("DOMContentLoaded",function () {
                 itemInCart.count += 1;
                 
                 // Animate
-                const $posItem = this.$refs.posItems.querySelectorAll('.posItem')[index];
                 if(!$posItem.classList.contains(POS_ITEM_ADDED_CLASS)) $posItem.classList.add(POS_ITEM_ADDED_CLASS);
                 
                 return true;


### PR DESCRIPTION
Allows to set prices for minimum and custom amount items and allows to add multiple of them to the cart. This keeps track of the individual items on a per price basis

Closes #5218. Fixes #5212.

![](https://user-images.githubusercontent.com/886/258312226-bbf7064c-38a5-403b-baee-01ea6b8adbd0.gif)