### PR TITLE
Unset link targt for payment scheme links

### DIFF
--- a/BTCPayServer/Views/Shared/Bitcoin/BitcoinLikeMethodCheckout-v2.cshtml
+++ b/BTCPayServer/Views/Shared/Bitcoin/BitcoinLikeMethodCheckout-v2.cshtml
@@ -24,7 +24,7 @@
                 <label v-t="'lightning'"></label>
             </div>
         </div>
-        <a v-if="model.invoiceBitcoinUrl && model.showPayInWalletButton" class="btn btn-primary rounded-pill w-100 mt-4" target="_top" id="PayInWallet"
+        <a v-if="model.invoiceBitcoinUrl && model.showPayInWalletButton" class="btn btn-primary rounded-pill w-100 mt-4" id="PayInWallet"
            :href="model.invoiceBitcoinUrl" :title="$t(hasPayjoin ? 'BIP21 payment link with PayJoin support' : 'BIP21 payment link')" v-t="'pay_in_wallet'"></a>
         @await Component.InvokeAsync("UiExtensionPoint", new {location = "checkout-v2-bitcoin-post-content", model = Model})
     </div>

--- a/BTCPayServer/Views/Shared/Bitcoin/BitcoinLikeMethodCheckout.cshtml
+++ b/BTCPayServer/Views/Shared/Bitcoin/BitcoinLikeMethodCheckout.cshtml
@@ -15,7 +15,7 @@
                     </div>
                 </div>
                 <div class="payment__details__instruction__open-wallet" v-if="srvModel.invoiceBitcoinUrl && srvModel.showPayInWalletButton">
-                    <a class="payment__details__instruction__open-wallet__btn action-button" target="_top" v-bind:href="srvModel.invoiceBitcoinUrl">
+                    <a class="payment__details__instruction__open-wallet__btn action-button" v-bind:href="srvModel.invoiceBitcoinUrl">
                         <span>{{$t("Open in wallet")}}</span>
                     </a>
                 </div>

--- a/BTCPayServer/Views/Shared/Lightning/LightningLikeMethodCheckout-v2.cshtml
+++ b/BTCPayServer/Views/Shared/Lightning/LightningLikeMethodCheckout-v2.cshtml
@@ -15,7 +15,7 @@
                 <label v-t="'lightning'"></label>
             </div>
         </div>
-        <a v-if="model.invoiceBitcoinUrl && model.showPayInWalletButton" class="btn btn-primary rounded-pill w-100 mt-4" target="_top" id="PayInWallet"
+        <a v-if="model.invoiceBitcoinUrl && model.showPayInWalletButton" class="btn btn-primary rounded-pill w-100 mt-4" id="PayInWallet"
            :href="model.invoiceBitcoinUrl" v-t="'pay_in_wallet'"></a>
         <div v-if="!model.invoiceBitcoinUrl && !model.btcAddress" class="alert alert-danger">This payment method is not available when using an insecure connection. Please use HTTPS or Tor.</div>
         @await Component.InvokeAsync("UiExtensionPoint", new {location = "checkout-v2-lightning-post-content", model = Model})

--- a/BTCPayServer/Views/Shared/Lightning/LightningLikeMethodCheckout.cshtml
+++ b/BTCPayServer/Views/Shared/Lightning/LightningLikeMethodCheckout.cshtml
@@ -28,7 +28,7 @@
                 </div>
             </div>
             <div class="payment__details__instruction__open-wallet" v-if="srvModel.invoiceBitcoinUrl && srvModel.showPayInWalletButton">
-                <a class="payment__details__instruction__open-wallet__btn action-button" target="_top" v-bind:href="srvModel.invoiceBitcoinUrl">
+                <a class="payment__details__instruction__open-wallet__btn action-button" v-bind:href="srvModel.invoiceBitcoinUrl">
                     <span>{{$t("Open in wallet")}}</span>
                 </a>
             </div>


### PR DESCRIPTION
Potential fix for #5266 — see the discussion in that issue for details.

This change should be non-invasive, I tested the links in regular as well as modal mode and they worked in Firefox, Brave and Chrome.