### PR TITLE
POS: Fix alignment of items in static view

### DIFF
--- a/BTCPayServer/Views/Shared/PointOfSale/Public/Static.cshtml
+++ b/BTCPayServer/Views/Shared/PointOfSale/Public/Static.cshtml
@@ -35,7 +35,7 @@
                     : item.BuyButtonText;
                 buttonText = buttonText.Replace("{0}", formatted).Replace("{Price}", formatted);
 
-                <div class="col posItem posItem--displayed">
+                <div class="col posItem posItem--displayed@(x == 0 ? " posItem--first" : null)@(x == Model.Items.Length - 1 && !Model.ShowCustomAmount ? " posItem--last" : null)">
                     <div class="card h-100 px-0" data-id="@x">
                         @if (!string.IsNullOrWhiteSpace(item.Image))
                         {
@@ -86,9 +86,9 @@
             }
             @if (Model.ShowCustomAmount)
             {
-                <div class="col">
+                <div class="col posItem posItem--displayed posItem--last@(Model.Items.Length == 0 ? " posItem--first" : null)">
                     <div class="card h-100 px-0">
-                        <div class="card-body p-3 d-flex flex-column gap-2">
+                        <div class="card-body p-3 d-flex flex-column gap-2 mb-auto">
                             <h5 class="card-title">Custom Amount</h5>
                             <p class="card-text">Create invoice to pay custom amount</p>
                         </div>


### PR DESCRIPTION
Items in static view weren't center aligned. This matches the classes in the cart view. Fixes #5230.