### PR TITLE
NFC: Fix error display

### DIFF
--- a/BTCPayServer/Views/Shared/NFC/CheckoutEnd.cshtml
+++ b/BTCPayServer/Views/Shared/NFC/CheckoutEnd.cshtml
@@ -210,7 +210,7 @@ Vue.component("lnurl-withdraw-checkout", {
                 if (response.ok) {
                     this.successMessage = result;
                 } else {
-                    this.reportNfcError(error);
+                    this.reportNfcError(result);
                 }
             } catch (error) {
                 this.reportNfcError(error);


### PR DESCRIPTION
Simple fix, the wrong variable was used. Fixes #5298.

![Screenshot_20230908-124639.png](https://github.com/btcpayserver/btcpayserver/assets/886/8bce3643-51e6-43e2-b1bf-e8863315be45)

