### PR TITLE
Add Blazor server

### DIFF
--- a/BTCPayServer/Blazor/_Imports.razor
+++ b/BTCPayServer/Blazor/_Imports.razor
@@ -1,0 +1,7 @@
+@using System.Net.Http
+@using Microsoft.AspNetCore.Authorization
+@using Microsoft.AspNetCore.Components.Authorization
+@using Microsoft.AspNetCore.Components.Forms
+@using Microsoft.AspNetCore.Components.Routing
+@using Microsoft.AspNetCore.Components.Web
+@using Microsoft.JSInterop

--- a/BTCPayServer/Views/Shared/LayoutFoot.cshtml
+++ b/BTCPayServer/Views/Shared/LayoutFoot.cshtml
@@ -1,7 +1,11 @@
-﻿<script src="~/vendor/jquery/jquery.min.js" asp-append-version="true"></script>
+<script src="~/vendor/jquery/jquery.min.js" asp-append-version="true"></script>
 <script src="~/vendor/bootstrap/bootstrap.bundle.min.js" asp-append-version="true"></script>
 <script src="~/vendor/moment/moment.min.js" asp-append-version="true"></script>
 <script src="~/vendor/flatpickr/flatpickr.js" asp-append-version="true"></script>
 <script src="~/js/copy-to-clipboard.js" asp-append-version="true"></script>
 <script src="~/main/utils.js" asp-append-version="true"></script>
+@if (User.Identity.IsAuthenticated)
+{
+	<script src="~/_blazorfiles/_framework/blazor.server.js" autostart="false" asp-append-version="true"></script>
+}
 <script src="~/main/site.js" asp-append-version="true"></script>

--- a/BTCPayServer/Views/Shared/_Footer.cshtml
+++ b/BTCPayServer/Views/Shared/_Footer.cshtml
@@ -39,6 +39,12 @@
                     <span>Copy Tor URL</span>
                 </button>
             }
+			@if (User.Identity.IsAuthenticated)
+			{
+				<div class="blazor-status">
+					<span class="blazor-status__img btcpay-status"></span> <span class="blazor-status__text"></span>
+				</div>
+			}
         </div>
         @if (User.Identity.IsAuthenticated)
         {

--- a/BTCPayServer/Views/Shared/_Footer.cshtml
+++ b/BTCPayServer/Views/Shared/_Footer.cshtml
@@ -39,12 +39,6 @@
                     <span>Copy Tor URL</span>
                 </button>
             }
-			@if (User.Identity.IsAuthenticated)
-			{
-				<div class="blazor-status">
-					<span class="blazor-status__img btcpay-status"></span> <span class="blazor-status__text"></span>
-				</div>
-			}
         </div>
         @if (User.Identity.IsAuthenticated)
         {
@@ -54,3 +48,19 @@
         }
     </div>
 </footer>
+@if (User.Identity.IsAuthenticated)
+{
+    <div id="StatusUpdates" class="toast-container">
+        <div id="BlazorStatus" class="toast blazor-status" role="alert" aria-live="assertive" aria-atomic="true">
+            <div class="toast-header">
+                <span class="blazor-status__state btcpay-status"></span>
+                <h6 class="blazor-status__title ms-2 mb-0 me-auto"></h6>
+                <button type="button" class="btn-close" data-bs-dismiss="toast" aria-label="Close">
+                    <vc:icon symbol="close" />
+                </button>
+            </div>
+            <div class="toast-body blazor-status__body text-secondary pt-0"></div>
+        </div>
+    </div>
+
+}

--- a/BTCPayServer/Views/UIReports/StoreReports.cshtml
+++ b/BTCPayServer/Views/UIReports/StoreReports.cshtml
@@ -21,7 +21,7 @@
 
 <div class="sticky-header">
     <div class="d-flex flex-wrap align-items-center justify-content-between gap-3 mb-3">
-        <h2 class="mb-0">@ViewData["Title"]</h2>
+		<h2 class="mb-0">@ViewData["Title"]</h2>
         <div class="d-flex flex-wrap gap-3">
 	        <a cheat-mode="true" class="btn btn-outline-info text-nowrap" asp-action="StoreReports" asp-route-fakeData="true" asp-route-viewName="@Model.Request?.ViewName">Create fake date</a>
 	        <button id="exportCSV" class="btn btn-primary text-nowrap" type="button">

--- a/BTCPayServer/wwwroot/main/layout.css
+++ b/BTCPayServer/wwwroot/main/layout.css
@@ -444,6 +444,22 @@
     top: .125rem;
 }
 
+#StatusUpdates {
+    position: fixed;
+    top: var(--content-padding-top);
+    right: var(--content-padding-horizontal);
+}
+#StatusUpdates .blazor-status {
+    width: 16rem;
+    border-color: var(--btcpay-border-color);
+}
+#StatusUpdates .blazor-status__title {
+    color: var(--btcpay-body-text);
+}
+#StatusUpdates .blazor-status__body {
+    padding-left: 2.45rem;
+}
+
 @media (max-width: 991px) {
     :root {
         --header-height: var(--mobile-header-height);
@@ -689,6 +705,12 @@
 @media (min-width: 992px) and (max-height: 799px) {
     :root {
         --content-padding-top: 1.25rem;
+    }
+}
+
+@media (min-width: 992px) and (min-height: 800px) {
+    #StatusUpdates {
+        top: 1.25rem;
     }
 }
 

--- a/BTCPayServer/wwwroot/main/site.css
+++ b/BTCPayServer/wwwroot/main/site.css
@@ -1064,3 +1064,8 @@ input.ts-wrapper.form-control:not(.ts-hidden-accessible,.ts-inline) {
 .btn[data-clipboard-confirming] {
     color: var(--btcpay-success) !important;
 }
+
+.blazor-status {
+    display: inline-block;
+}
+

--- a/BTCPayServer/wwwroot/main/site.css
+++ b/BTCPayServer/wwwroot/main/site.css
@@ -1065,7 +1065,8 @@ input.ts-wrapper.form-control:not(.ts-hidden-accessible,.ts-inline) {
     color: var(--btcpay-success) !important;
 }
 
-.blazor-status {
-    display: inline-block;
+.blazor-status .btn-close .icon {
+    width: .75rem;
+    height: .75rem;
 }
 

--- a/BTCPayServer/wwwroot/main/site.js
+++ b/BTCPayServer/wwwroot/main/site.js
@@ -361,11 +361,21 @@ if (window.Blazor) {
                 try {
                     if (await Blazor.reconnect())
                         break;
-                    this.setBlazorStatus(false, 'Please refresh the page.');
+
+                    var refresh = document.createElement('span');
+                    refresh.appendChild(document.createTextNode('Please '));
+                    var refreshLink = document.createElement('a');
+                    refreshLink.href = "#";
+                    refreshLink.textContent = "refresh";
+                    refreshLink.addEventListener('click', (event) => { event.preventDefault(); window.location.reload(); });
+                    refresh.appendChild(refreshLink);
+                    refresh.appendChild(document.createTextNode(' the page.'));
+
+                    this.setBlazorStatus(false, refresh);
                     console.warn('Error while reconnecting to Blazor hub (Broken circuit)');
                 }
                 catch (err) {
-                    this.setBlazorStatus(false, err);
+                    this.setBlazorStatus(false, err + '. Reconnecting...');
                     console.warn(`Error while reconnecting to Blazor hub (${err})`);
                 }
                 i++;
@@ -386,14 +396,19 @@ if (window.Blazor) {
                 const $body = $status.querySelector('.blazor-status__body');
                 $state.classList.remove('btcpay-status--enabled');
                 $state.classList.remove('btcpay-status--disabled');
-                $state.classList.remove('btcpay-status--pending');
                 $state.classList.add('btcpay-status--' + (isConnected ? 'enabled' : 'disabled'));
                 $title.textContent = `Backend ${isConnected ? 'connected' : 'disconnected'}`;
-                $body.textContent = text || '';
+                if (text instanceof Node) {
+                    $body.innerHTML = '';
+                    $body.appendChild(text);
+                } else
+                    $body.textContent = text || '';
+
                 $body.classList.toggle('d-none', !text);
                 if (!isConnected && !isUnloading) {
                     const toast = new bootstrap.Toast($status, { autohide: false });
-                    toast.show();
+                    if (!toast.isShown())
+                        toast.show();
                 }
             });
         }


### PR DESCRIPTION
This PR focus in adding Blazor server as a dependency. It will make the development of components easier.
Blazor is inserted in the `_Footer.cshtml`, so it will be available to all the backend code.

## UX Challenge for Blazor

Blazor is a front end technology from Microsoft that will make the development of component way easier and modular.
However, all Blazor components instantiated in a Razor page have their state both on the client and on the server for each user.

The state of blazor components on the server is called "Circuit".

If the user disconnect or navigate to a new page, then the circuit get removed from server's memory after 3 minutes, and a new circuit get created on the new page.

When the user is disconnected from the server, then any blazor components can't be interacted with (let's say a client try to click on a button from a blazor component, then nothing will happen).

If the user reconnect before 3 minutes, when it is reconnected, it will work again as expected.

If the user doesn't reconnect before 3 minutes, then the circuit on the server get destroyed and the user need to refresh the page of his browser to make a new circuit.

So we need a non intrusive way to tell to the user "Hey, you aren't connected to the server anymore things might not work anymore, we are trying to reconnect...", or "Hey we can't reconnect to the server, please refresh your page.".

I added an indicator in the bottom.
![image](https://github.com/btcpayserver/btcpayserver/assets/3020646/94a7cdf0-22b2-47ce-ada8-f8e341ddb4ce)

I am not sure @dstrukt  would approve this.

Note: It isn't possible to create a new circuit without refreshing the page. (due to encryption of blazor components on the server rendered page)

## Notes on several hacks to make it works

I documented two hacks I needed to do in `Startup.cs` in order for blazor to work without side effect.

One hack was needed because Blazor need the default StaticFile middleware, but we aren't using any default. They fixed it in .NET 8.0, so we'll be able to remove it later. There is a github thread about it on https://github.com/dotnet/aspnetcore/issues/19578 

The other hack was needed because blazor assumes the page is the root page of the website. They documented a way to work around with the `<base>` directive. However, we shouldn't use this, as this may impact code which reasonably assume that the paths in HTML are relative to the current page. (ie: If I am on https://btcpay/store/A then a `<a href="Settings"` refers to `https://btcpay/store/A/Settings`. Or a `<form>` without action, assume the same action as the current page)
Github thread about it is https://github.com/dotnet/aspnetcore/issues/43191

## Security notes

Blazor server makes it easy to run denial of services by creating lot's of circuit. (ie: Refresh the page many time)
Also, Blazor server exposes to Javascript some callable dotnet code. As such, I believe it is safer to not expose Blazor to unauthenticated user.

This mean we can't use Blazor server for unauthenticated pages such as point of sale.