### PR TITLE
Dashboard: Paid invoices in the last 7 days

### DIFF
--- a/BTCPayServer/Components/StoreNumbers/Default.cshtml
+++ b/BTCPayServer/Components/StoreNumbers/Default.cshtml
@@ -1,3 +1,4 @@
+@using BTCPayServer.Client
 @model BTCPayServer.Components.StoreNumbers.StoreNumbersViewModel
 
 <div class="widget store-numbers" id="StoreNumbers-@Model.Store.Id">
@@ -23,24 +24,21 @@
     {
         <div class="store-number">
             <header>
+                <h6>Paid invoices in the last @Model.TimeframeDays days</h6>
+                @if (Model.PaidInvoices > 0)
+                {
+                    <a asp-controller="UIInvoice" asp-action="ListInvoices" asp-route-storeId="@Model.Store.Id"  permission="@Policies.CanViewInvoices">View All</a>
+                }
+            </header>
+            <div class="h3">@Model.PaidInvoices</div>
+        </div>
+        <div class="store-number">
+            <header>
                 <h6>Payouts Pending</h6>
-                <a asp-controller="UIStorePullPayments" asp-action="Payouts" asp-route-storeId="@Model.Store.Id">Manage</a>
+                <a asp-controller="UIStorePullPayments" asp-action="Payouts" asp-route-storeId="@Model.Store.Id" permission="@Policies.CanManagePullPayments">Manage</a>
             </header>
             <div class="h3">@Model.PayoutsPending</div>
         </div>
-        @if (Model.Transactions is not null)
-        {
-            <div class="store-number">
-                <header>
-                    <h6>TXs in the last @Model.TransactionDays days</h6>
-                    @if (Model.Transactions.Value > 0)
-                    {
-                        <a asp-controller="UIWallets" asp-action="WalletTransactions" asp-route-walletId="@Model.WalletId">View All</a>
-                    }
-                </header>
-                <div class="h3">@Model.Transactions.Value</div>
-            </div>
-        }
         <div class="store-number">
             <header>
                 <h6>Refunds Issued</h6>

--- a/BTCPayServer/Components/StoreNumbers/StoreNumbersViewModel.cs
+++ b/BTCPayServer/Components/StoreNumbers/StoreNumbersViewModel.cs
@@ -7,9 +7,9 @@ public class StoreNumbersViewModel
     public StoreData Store { get; set; }
     public WalletId WalletId { get; set; }
     public int PayoutsPending { get; set; }
-    public int? Transactions { get; set; }
+    public int TimeframeDays { get; set; } = 7;
+    public int? PaidInvoices { get; set; }
     public int RefundsIssued { get; set; }
-    public int TransactionDays { get; set; } = 7;
     public bool InitialRendering { get; set; }
     public string CryptoCode { get; set; }
 }

--- a/BTCPayServer/Services/Invoices/InvoiceRepository.cs
+++ b/BTCPayServer/Services/Invoices/InvoiceRepository.cs
@@ -738,6 +738,12 @@ namespace BTCPayServer.Services.Invoices
             var data = await query.ToArrayAsync(cancellationToken).ConfigureAwait(false);
             return data.Select(ToEntity).ToArray();
         }
+        
+        public async Task<int> GetInvoiceCount(InvoiceQuery queryObject)
+        {
+            await using var context = _applicationDbContextFactory.CreateContext();
+            return await GetInvoiceQuery(context, queryObject).CountAsync();
+        }
 
         private string NormalizeExceptionStatus(string status)
         {


### PR DESCRIPTION
Adjust the prior number of transactions metric as discussed with @pavlenex. We now show the number of paid invoices instead of transactions, as this metric is more meaningful.

Closes #5300.

![grafik](https://github.com/btcpayserver/btcpayserver/assets/886/f28ddc9e-c2bc-4c60-88a7-905d637f9cf6)
