### PR TITLE
Fix POST redirect form submit

### DIFF
--- a/BTCPayServer/Views/Shared/PostRedirect.cshtml
+++ b/BTCPayServer/Views/Shared/PostRedirect.cshtml
@@ -65,7 +65,7 @@
 		</form>
 	}
 	<script type="text/javascript">
-		document.forms.item(0).submit();
+        HTMLFormElement.prototype.submit.call(document.forms.item(0));
 	</script>
 	<partial name="LayoutFoot" />
 </body>


### PR DESCRIPTION
The `submit()` method cannot be invoked on forms without a submit button. This changes it to call the method via the JS prototype, which can be seen as a workaround.

Checked this in Firefox and Chrome. Fixes #5335.