### PR TITLE
Hide 'Connection established' when connection to server come back

### DIFF
--- a/BTCPayServer/wwwroot/main/site.js
+++ b/BTCPayServer/wwwroot/main/site.js
@@ -391,10 +391,16 @@ if (window.Blazor) {
                 $title.textContent = isConnected ? 'Connection established' : 'Connection interrupted';
                 $body.innerHTML = isConnected ? '' : 'Please <a href="">refresh the page</a>.'; // use empty link on purpose
                 $body.classList.toggle('d-none', isConnected);
-                if (!isConnected && !isUnloading) {
+                if (!isUnloading) {
                     const toast = new bootstrap.Toast($status, { autohide: false });
-                    if (!toast.isShown())
-                        toast.show();
+                    if (isConnected) {
+                        if (toast.isShown())
+                            toast.hide();
+                    }
+                    else {
+                        if (!toast.isShown())
+                            toast.show();
+                    }
                 }
             });
         }


### PR DESCRIPTION
When the connection is momentarily cut to the server and reestablished, then the "Connection established" toast would appear, and then it needs to be manually closed.

If the connection is back, we should just hide the toast automatically rather than polluting visual space.


