### PR TITLE
Fix form value setter

### DIFF
--- a/BTCPayServer.Abstractions/Form/Form.cs
+++ b/BTCPayServer.Abstractions/Form/Form.cs
@@ -105,31 +105,7 @@ public class Form
         }
     }
 
-    public void SetValues(JObject values)
-    {
-        var fields = GetAllFields().ToDictionary(k => k.FullName, k => k.Field);
-        SetValues(fields, new List<string>(), values);
-    }
-
-    private void SetValues(Dictionary<string, Field> fields, List<string> path, JObject values)
-    {
-        foreach (var prop in values.Properties())
-        {
-            List<string> propPath = new List<string>(path.Count + 1);
-            propPath.AddRange(path);
-            propPath.Add(prop.Name);
-            if (prop.Value.Type == JTokenType.Object)
-            {
-                SetValues(fields, propPath, (JObject)prop.Value);
-            }
-            else if (prop.Value.Type == JTokenType.String)
-            {
-                var fullName = string.Join('_', propPath.Where(s => !string.IsNullOrEmpty(s)));
-                if (fields.TryGetValue(fullName, out var f) && !f.Constant)
-                    f.Value = prop.Value.Value<string>();
-            }
-        }
-    }
+    
 
 
 }

--- a/BTCPayServer.Tests/FormTests.cs
+++ b/BTCPayServer.Tests/FormTests.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using BTCPayServer.Abstractions.Form;
 using BTCPayServer.Forms;
 using Microsoft.AspNetCore.Http;
@@ -10,16 +11,24 @@ using Xunit.Abstractions;
 
 namespace BTCPayServer.Tests;
 
-[Trait("Fast", "Fast")]
+[Trait("Integration", "Integration")]
 public class FormTests : UnitTestBase
 {
     public FormTests(ITestOutputHelper helper) : base(helper)
     {
     }
 
-    [Fact]
-    public void CanParseForm()
+
+    [Fact(Timeout = TestUtils.TestTimeout)]
+    [Trait("Integration", "Integration")]  
+    public async Task CanParseForm()
     {
+        using var tester = CreateServerTester();
+        await tester.StartAsync();
+        var user = tester.NewAccount();
+        user.GrantAccess();
+        var service = tester.PayTester.GetService<FormDataService>();
+
         var form = new Form()
         {
             Fields = new List<Field>
@@ -40,8 +49,6 @@ public class FormTests : UnitTestBase
                 }
             }
         };
-        var providers = new FormComponentProviders(new List<IFormComponentProvider>());
-        var service = new FormDataService(null, providers);
         Assert.False(service.IsFormSchemaValid(form.ToString(), out _, out _));
         form = new Form
         {
@@ -164,7 +171,7 @@ public class FormTests : UnitTestBase
         Assert.Equal("original", obj["invoice"]["test"].Value<string>());
         Assert.Equal("updated", obj["invoice_item3"].Value<string>());
         Clear(form);
-        form.SetValues(obj);
+        service.SetValues(form, obj);
         obj = service.GetValues(form);
         Assert.Equal("original", obj["invoice"]["test"].Value<string>());
         Assert.Equal("updated", obj["invoice_item3"].Value<string>());
@@ -182,10 +189,12 @@ public class FormTests : UnitTestBase
                 }
             }
         };
-        form.SetValues(obj);
+        
+        service.SetValues(form, obj);
         obj = service.GetValues(form);
         Assert.Null(obj["test"].Value<string>());
-        form.SetValues(new JObject { ["test"] = "hello" });
+        
+        service.SetValues(form, new JObject { ["test"] = "hello" });
         obj = service.GetValues(form);
         Assert.Equal("hello", obj["test"].Value<string>());
     }

--- a/BTCPayServer.Tests/FormTests.cs
+++ b/BTCPayServer.Tests/FormTests.cs
@@ -11,6 +11,7 @@ using Xunit.Abstractions;
 
 namespace BTCPayServer.Tests;
 
+[Collection(nameof(NonParallelizableCollectionDefinition))]
 [Trait("Integration", "Integration")]
 public class FormTests : UnitTestBase
 {

--- a/BTCPayServer/Controllers/UICustodianAccountsController.cs
+++ b/BTCPayServer/Controllers/UICustodianAccountsController.cs
@@ -223,7 +223,7 @@ namespace BTCPayServer.Controllers
 
             var blob = custodianAccount.GetBlob();
             var configForm = await custodian.GetConfigForm(blob, HttpContext.RequestAborted);
-            configForm.SetValues(blob);
+            _formDataService.SetValues(configForm, blob);
 
             var vm = new EditCustodianAccountViewModel();
             vm.CustodianAccount = custodianAccount;
@@ -280,14 +280,14 @@ namespace BTCPayServer.Controllers
             // First, we restore the previous form based on the previous blob that was
             // stored in config
             var form = await custodian.GetConfigForm(b, HttpContext.RequestAborted);
-            form.SetValues(b);
+            _formDataService.SetValues(form, b);
             // Then we apply new values overriding the previous blob from the Form params
             form.ApplyValuesFromForm(Request.Form);
             // We extract the new resulting blob, and request what is the next form based on it
             b = _formDataService.GetValues(form);
             form = await custodian.GetConfigForm(_formDataService.GetValues(form), HttpContext.RequestAborted);
             // We set all the values to this blob, and validate the form
-            form.SetValues(b);
+            _formDataService.SetValues(form, b);
             _formDataService.Validate(form, ModelState);
             return form;
         }
@@ -600,7 +600,7 @@ namespace BTCPayServer.Controllers
                     catch (BadConfigException e)
                     {
                         Form configForm = await custodian.GetConfigForm(config);
-                        configForm.SetValues(config);
+                        _formDataService.SetValues(configForm, config);
                         string[] badConfigFields = new string[e.BadConfigKeys.Length];
                         int i = 0;
                         foreach (var oneField in configForm.GetAllFields())

--- a/BTCPayServer/Forms/FieldValueMirror.cs
+++ b/BTCPayServer/Forms/FieldValueMirror.cs
@@ -31,4 +31,9 @@ public class FieldValueMirror : IFormComponentProvider
 
         return rawValue;
     }
+
+    public void SetValue(Field field, JToken value)
+    {
+        //ignored
+    }
 }

--- a/BTCPayServer/Forms/FormDataService.cs
+++ b/BTCPayServer/Forms/FormDataService.cs
@@ -218,4 +218,36 @@ public class FormDataService
         }
         return r;
     }
+    
+    public void SetValues(Form form, JObject values)
+    {
+        
+        var fields = form.GetAllFields().ToDictionary(k => k.FullName, k => k.Field);
+        SetValues(fields, new List<string>(), values);
+    }
+
+    private void SetValues(Dictionary<string, Field> fields, List<string> path, JObject values)
+    {
+        foreach (var prop in values.Properties())
+        {
+            List<string> propPath = new List<string>(path.Count + 1);
+            propPath.AddRange(path);
+            propPath.Add(prop.Name);
+            if (prop.Value.Type == JTokenType.Object)
+            {
+                SetValues(fields, propPath, (JObject)prop.Value);
+            }
+            else if (prop.Value.Type == JTokenType.String)
+            {
+                var fullName = string.Join('_', propPath.Where(s => !string.IsNullOrEmpty(s)));
+                if (fields.TryGetValue(fullName, out var f) && !f.Constant)
+                {
+                    if (_formProviders.TypeToComponentProvider.TryGetValue(f.Type, out var formComponentProvider))
+                    {
+                        formComponentProvider.SetValue(f, prop.Value);
+                    }
+                }
+            }
+        }
+    }
 }

--- a/BTCPayServer/Forms/HtmlFieldsetFormProvider.cs
+++ b/BTCPayServer/Forms/HtmlFieldsetFormProvider.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using BTCPayServer.Abstractions.Form;
+using Newtonsoft.Json.Linq;
 
 namespace BTCPayServer.Forms;
 
@@ -15,6 +16,11 @@ public class HtmlFieldsetFormProvider : IFormComponentProvider
     public string GetValue(Form form, Field field)
     {
         return null;
+    }
+
+    public void SetValue(Field field, JToken value)
+    {
+        //ignored
     }
 
     public void Validate(Form form, Field field)

--- a/BTCPayServer/Forms/IFormComponentProvider.cs
+++ b/BTCPayServer/Forms/IFormComponentProvider.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using BTCPayServer.Abstractions.Form;
+using Newtonsoft.Json.Linq;
 
 namespace BTCPayServer.Forms;
 
@@ -10,6 +11,7 @@ public interface IFormComponentProvider
     void Validate(Form form, Field field);
     void Register(Dictionary<string, IFormComponentProvider> typeToComponentProvider);
     string GetValue(Form form, Field field);
+    void SetValue(Field field, JToken value);
 }
 
 public abstract class FormComponentProviderBase : IFormComponentProvider
@@ -19,6 +21,11 @@ public abstract class FormComponentProviderBase : IFormComponentProvider
     public virtual string GetValue(Form form, Field field)
     {
         return field.Value;
+    }
+
+    public void SetValue(Field field, JToken value)
+    {
+        field.Value = value.ToString();
     }
 
     public abstract void Validate(Form form, Field field);

--- a/BTCPayServer/Plugins/PointOfSale/Controllers/UIPointOfSaleController.cs
+++ b/BTCPayServer/Plugins/PointOfSale/Controllers/UIPointOfSaleController.cs
@@ -277,7 +277,7 @@ namespace BTCPayServer.Plugins.PointOfSale.Controllers
 
                     formResponseJObject = TryParseJObject(formResponse) ?? new JObject();
                     var form = Form.Parse(formData.Config);
-                    form.SetValues(formResponseJObject);
+                    FormDataService.SetValues(form, formResponseJObject);
                     if (!FormDataService.Validate(form, ModelState))
                     {
                         //someone tried to bypass validation


### PR DESCRIPTION
When a mirror field type is used, and then a form is populated with the json output of a previous form result, the value of the mirror is replaced with the mirror value, causing a validation error (the value  becomes the value of mirror field not the name of the field to mirror)