### PR TITLE
POS Keypad: Add plus and change clear functionality

### DIFF
--- a/BTCPayServer.Tests/SeleniumTests.cs
+++ b/BTCPayServer.Tests/SeleniumTests.cs
@@ -2218,7 +2218,7 @@ namespace BTCPayServer.Tests
             Assert.Contains("EUR", s.Driver.FindElement(By.Id("Currency")).Text);
             Assert.Contains("0,00", s.Driver.FindElement(By.Id("Amount")).Text);
             Assert.Equal("", s.Driver.FindElement(By.Id("Calculation")).Text);
-            Assert.True(s.Driver.FindElement(By.Id("ModeTablist-amount")).Selected);
+            Assert.True(s.Driver.FindElement(By.Id("ModeTablist-amounts")).Selected);
             Assert.False(s.Driver.FindElement(By.Id("ModeTablist-discount")).Enabled);
             Assert.False(s.Driver.FindElement(By.Id("ModeTablist-tip")).Enabled);
             
@@ -2227,13 +2227,17 @@ namespace BTCPayServer.Tests
             s.Driver.FindElement(By.CssSelector(".keypad [data-key='2']")).Click();
             s.Driver.FindElement(By.CssSelector(".keypad [data-key='3']")).Click();
             s.Driver.FindElement(By.CssSelector(".keypad [data-key='4']")).Click();
-            s.Driver.FindElement(By.CssSelector(".keypad [data-key='.']")).Click();
+            s.Driver.FindElement(By.CssSelector(".keypad [data-key='0']")).Click();
+            s.Driver.FindElement(By.CssSelector(".keypad [data-key='0']")).Click();
+            Assert.Equal("1.234,00", s.Driver.FindElement(By.Id("Amount")).Text);
+            Assert.Equal("", s.Driver.FindElement(By.Id("Calculation")).Text);
+            s.Driver.FindElement(By.CssSelector(".keypad [data-key='+']")).Click();
             s.Driver.FindElement(By.CssSelector(".keypad [data-key='5']")).Click();
             s.Driver.FindElement(By.CssSelector(".keypad [data-key='6']")).Click();
             Assert.Equal("1.234,56", s.Driver.FindElement(By.Id("Amount")).Text);
             Assert.True(s.Driver.FindElement(By.Id("ModeTablist-discount")).Enabled);
             Assert.True(s.Driver.FindElement(By.Id("ModeTablist-tip")).Enabled);
-            Assert.Equal("", s.Driver.FindElement(By.Id("Calculation")).Text);
+            Assert.Equal("1.234,00 € + 0,56 €", s.Driver.FindElement(By.Id("Calculation")).Text);
             
             // Discount: 10%
             s.Driver.FindElement(By.CssSelector("label[for='ModeTablist-discount']")).Click();
@@ -2241,14 +2245,14 @@ namespace BTCPayServer.Tests
             s.Driver.FindElement(By.CssSelector(".keypad [data-key='0']")).Click();
             Assert.Contains("1.111,10", s.Driver.FindElement(By.Id("Amount")).Text);
             Assert.Contains("10% discount", s.Driver.FindElement(By.Id("Discount")).Text);
-            Assert.Contains("1.234,56 € - 123,46 € (10%)", s.Driver.FindElement(By.Id("Calculation")).Text);
+            Assert.Contains("1.234,00 € + 0,56 € - 123,46 € (10%)", s.Driver.FindElement(By.Id("Calculation")).Text);
             
             // Tip: 10%
             s.Driver.FindElement(By.CssSelector("label[for='ModeTablist-tip']")).Click();
             s.Driver.WaitForElement(By.Id("Tip-Custom"));
             s.Driver.FindElement(By.Id("Tip-10")).Click();
             Assert.Contains("1.222,21", s.Driver.FindElement(By.Id("Amount")).Text);
-            Assert.Contains("1.234,56 € - 123,46 € (10%) + 111,11 € (10%)", s.Driver.FindElement(By.Id("Calculation")).Text);
+            Assert.Contains("1.234,00 € + 0,56 € - 123,46 € (10%) + 111,11 € (10%)", s.Driver.FindElement(By.Id("Calculation")).Text);
             
             // Pay
             s.Driver.FindElement(By.Id("pay-button")).Click();

--- a/BTCPayServer/Views/Shared/PointOfSale/Public/VueLight.cshtml
+++ b/BTCPayServer/Views/Shared/PointOfSale/Public/VueLight.cshtml
@@ -1,12 +1,12 @@
-@using Microsoft.AspNetCore.Mvc.TagHelpers
 @model BTCPayServer.Plugins.PointOfSale.Models.ViewPointOfSaleViewModel
 
 <form id="PosKeypad" method="post" asp-action="ViewPointOfSale" asp-route-appId="@Model.AppId" asp-antiforgery="false" v-on:submit="handleFormSubmit" class="d-flex flex-column gap-4 my-auto" v-cloak>
-    <input id="posdata" type="hidden" name="posdata" v-model="posdata">
+    <input type="hidden" name="posdata" v-model="posdata" id="posdata">
+    <input type="hidden" name="amount" v-model="totalNumeric">
     <div ref="display" class="d-flex flex-column align-items-center px-4 mb-auto">
         <div class="fw-semibold text-muted" id="Currency">{{currencyCode}}</div>
         <div class="fw-bold lh-sm" ref="amount" v-bind:style="{ fontSize: `${fontSize}px` }" id="Amount">{{ formatCurrency(total, false) }}</div>
-        <div class="text-muted text-center mt-2" id="Calculation" v-if="showDiscount || enableTips">{{ calculation }}</div>
+        <div class="text-muted text-center mt-2" id="Calculation">{{ calculation }}</div>
     </div>
     <div id="ModeTabs" class="tab-content mb-n2" v-if="showDiscount || enableTips">
         <div id="Mode-Discount" class="tab-pane fade px-2" :class="{ show: mode === 'discount', active: mode === 'discount' }" role="tabpanel" aria-labelledby="ModeTablist-Discount" v-if="showDiscount">
@@ -44,24 +44,17 @@
     </div>
     <div id="ModeTablist" class="nav btcpay-pills align-items-center justify-content-center mb-n2 pb-1" role="tablist" v-if="modes.length > 1">
         <template v-for="m in modes" :key="m.value">
-            <input :id="`ModeTablist-${m.type}`" name="mode" :value="m.type" type="radio" role="tab" data-bs-toggle="pill" :data-bs-target="`#Mode-${m.type}`" :disabled="m.type != 'amount' && amountNumeric == 0" :aria-controls="`Mode-${m.type}`" :aria-selected="mode === m.type" :checked="mode === m.type" v-on:click="mode = m.type">
+            <input :id="`ModeTablist-${m.type}`" name="mode" :value="m.type" type="radio" role="tab" data-bs-toggle="pill" :data-bs-target="`#Mode-${m.type}`" :disabled="m.type != 'amounts' && amountNumeric == 0" :aria-controls="`Mode-${m.type}`" :aria-selected="mode === m.type" :checked="mode === m.type" v-on:click="mode = m.type">
             <label :for="`ModeTablist-${m.type}`">{{ m.title }}</label>
         </template>
     </div>
     <div class="keypad">
-        <button v-for="k in keys" :key="k" v-on:click.prevent="keyPressed(k)" type="button" class="btn btn-secondary btn-lg" :data-key="k">
-            <template v-if="k === 'del'"><vc:icon symbol="caret-right"/></template>
-            <template v-else>{{ k }}</template>
-        </button>
+        <button v-for="k in keys" :key="k" :disabled="k === '+' && mode !== 'amounts'" v-on:click.prevent="keyPressed(k)" v-on:dblclick.prevent="doubleClick(k)" type="button" class="btn btn-secondary btn-lg" :data-key="k">{{ k }}</button>
     </div>
-    <div class="actions px-4 gap-4">
-        <button class="btn btn-lg btn-secondary" type="reset" v-on:click.prevent="clear">Clear</button>
-        <button class="btn btn-lg btn-primary" type="submit" :disabled="payButtonLoading" id="pay-button">
-            <div v-if="payButtonLoading" class="spinner-border spinner-border-sm" id="pay-button-spinner" role="status">
-                <span class="sr-only">Loading...</span>
-            </div>
-            <template v-else>Charge</template>
-        </button>
-    </div>
-    <input class="form-control" type="hidden" name="amount" v-model="totalNumeric">
+    <button class="btn btn-lg btn-primary mx-3" type="submit" :disabled="payButtonLoading" id="pay-button">
+        <div v-if="payButtonLoading" class="spinner-border spinner-border-sm" id="pay-button-spinner" role="status">
+            <span class="sr-only">Loading...</span>
+        </div>
+        <template v-else>Charge</template>
+    </button>
 </form>

--- a/BTCPayServer/wwwroot/pos/common.js
+++ b/BTCPayServer/wwwroot/pos/common.js
@@ -44,14 +44,6 @@ const posCommon = {
         totalNumeric () {
             return parseFloat(parseFloat(this.total).toFixed(this.currencyInfo.divisibility))
         },
-        calculation () {
-            if (!this.tipNumeric && !this.discountNumeric) return null
-            let calc = this.formatCurrency(this.amountNumeric, true)
-            if (this.discountNumeric > 0) calc += ` - ${this.formatCurrency(this.discountNumeric, true)} (${this.discountPercent}%)`
-            if (this.tipNumeric > 0) calc += ` + ${this.formatCurrency(this.tipNumeric, true)}`
-            if (this.tipPercent) calc += ` (${this.tipPercent}%)`
-            return calc
-        },
         posdata () {
             const data = {
                 subTotal: this.amountNumeric,

--- a/BTCPayServer/wwwroot/pos/keypad.css
+++ b/BTCPayServer/wwwroot/pos/keypad.css
@@ -27,9 +27,8 @@
     max-height: 6rem;
     color: var(--btcpay-body-text);
 }
-.keypad .btn[data-key="del"] svg {
-    --btn-icon-size: 2.25rem;
-    transform: rotate(180deg);
+.keypad .btn[data-key="+"] {
+    font-size: 2.25em;
 }
 .btcpay-pills label,
 .btn-secondary.rounded-pill {
@@ -55,15 +54,6 @@
 .keypad .btn:focus,
 .keypad .btn:active {
     z-index: 1;
-}
-
-.actions {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-}
-.actions .btn {
-    flex:  1 1 50%;
 }
 
 #Calculation {


### PR DESCRIPTION
Updated the fucntionality and hope everything works intuitively now. A few notes:

* No more decimal input (`.`)
* The `+` adds an additional amount to the stack. If there is more than one amount, it is shown in the calculation.
* Removed the Clear button at the bottom in favor of the new `C` button
    * `C` clears the current value if there's input already, if not it removes the current input, so that you get to edit the previous input again
    * Double-clicking `C` clears out everything

Closes #5299.