### PR TITLE
switch pos to metadata in invoice create view

### DIFF
--- a/BTCPayServer/Controllers/UIInvoiceController.UI.cs
+++ b/BTCPayServer/Controllers/UIInvoiceController.UI.cs
@@ -1307,10 +1307,6 @@ namespace BTCPayServer.Controllers
                     metadata.BuyerEmail = model.BuyerEmail;
                 }
 
-                if (!string.IsNullOrEmpty(model.OrderId))
-                {
-                    metadata.OrderId = model.OrderId;
-                }
                 var result = await CreateInvoiceCoreRaw(new CreateInvoiceRequest()
                 {
                     Amount = model.Amount,

--- a/BTCPayServer/Models/InvoicingModels/CreateInvoiceModel.cs
+++ b/BTCPayServer/Models/InvoicingModels/CreateInvoiceModel.cs
@@ -44,9 +44,8 @@ namespace BTCPayServer.Models.InvoicingModels
         {
             get; set;
         }
-
-        [DisplayName("POS Data")]
-        public string PosData
+        [DisplayName("Metadata")]
+        public string Metadata
         {
             get; set;
         }

--- a/BTCPayServer/Views/UIInvoice/CreateInvoice.cshtml
+++ b/BTCPayServer/Views/UIInvoice/CreateInvoice.cshtml
@@ -104,16 +104,16 @@
                     <div class="accordion-item">
                         <h2 class="accordion-header" id="additional-pos-data-header">
                             <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#additional-pos-data" aria-expanded="false" aria-controls="additional-pos-data">
-                                Point Of Sale Data
+                                Metadata
                                 <vc:icon symbol="caret-down" />
                             </button>
                         </h2>
                         <div id="additional-pos-data" class="accordion-collapse collapse" aria-labelledby="additional-pos-data-header">
-                            <p>Custom data to correlate the invoice with an order. This data can be a simple text, number or JSON object, e.g. <code>{ "orderId": 615, "product": "Pizza" }</code></p>
+                            <p>Custom data to expand the invoice. This data is a JSON object, e.g. <code>{ "orderId": 615, "product": "Pizza" }</code></p>
                             <div class="form-group">
-                                <label asp-for="PosData" class="form-label"></label>
-                                <input asp-for="PosData" class="form-control" />
-                                <span asp-validation-for="PosData" class="text-danger"></span>
+                                <label asp-for="Metadata" class="form-label"></label>
+                                <textarea asp-for="Metadata" class="form-control" rows="10" cols="40"></textarea>
+                                <span asp-validation-for="Metadata" class="text-danger"></span>
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
Since posdata is a legacy thing, we may  as well expose the propert metadata that we recommend. Pos data fits inside the metadata so no functionality is lost.