### PR TITLE
Fix: In pull payment page, the amount of claims wasn't displayed

### DIFF
--- a/BTCPayServer/Controllers/UIPullPaymentController.cs
+++ b/BTCPayServer/Controllers/UIPullPaymentController.cs
@@ -95,6 +95,7 @@ namespace BTCPayServer.Controllers
                 {
                     Id = entity.Entity.Id,
                     Amount = entity.Blob.Amount,
+                    AmountFormatted = _displayFormatter.Currency(entity.Blob.Amount, blob.Currency),
                     Currency = blob.Currency,
                     Status = entity.Entity.State,
                     Destination = entity.Blob.Destination,


### PR DESCRIPTION
Missing claim amount in View Pull Payment.
![image](https://github.com/btcpayserver/btcpayserver/assets/3020646/b54d2df3-1d48-46ae-b96b-b95b9963b20b)
