### PR TITLE
Do not activate Blazor in Wizard screens

### DIFF
--- a/BTCPayServer.Abstractions/Extensions/ViewsRazor.cs
+++ b/BTCPayServer.Abstractions/Extensions/ViewsRazor.cs
@@ -20,6 +20,15 @@ namespace BTCPayServer.Abstractions.Extensions
             Relative
         }
 
+        public static void SetBlazorAllowed(this ViewDataDictionary viewData, bool allowed)
+        {
+            viewData["BlazorAllowed"] = allowed;
+        }
+        public static bool IsBlazorAllowed(this ViewDataDictionary viewData)
+        {
+            return viewData["BlazorAllowed"] is not false;
+        }
+
         public static void SetActivePage<T>(this ViewDataDictionary viewData, T activePage, string title = null, string activeId = null)
             where T : IConvertible
         {

--- a/BTCPayServer/Views/Shared/LayoutFoot.cshtml
+++ b/BTCPayServer/Views/Shared/LayoutFoot.cshtml
@@ -4,7 +4,7 @@
 <script src="~/vendor/flatpickr/flatpickr.js" asp-append-version="true"></script>
 <script src="~/js/copy-to-clipboard.js" asp-append-version="true"></script>
 <script src="~/main/utils.js" asp-append-version="true"></script>
-@if (User.Identity.IsAuthenticated)
+@if (User.Identity.IsAuthenticated && ViewData.IsBlazorAllowed())
 {
 	<script src="~/_blazorfiles/_framework/blazor.server.js" autostart="false" asp-append-version="true"></script>
 }

--- a/BTCPayServer/Views/Shared/_LayoutWizard.cshtml
+++ b/BTCPayServer/Views/Shared/_LayoutWizard.cshtml
@@ -1,5 +1,6 @@
-﻿@{
-    Layout = "_LayoutSimple";
+@{
+	Layout = "_LayoutSimple";
+	ViewData.SetBlazorAllowed(false);
 }
 
 @section PageHeadContent {

--- a/BTCPayServer/Views/UIPaymentRequest/ViewPaymentRequest.cshtml
+++ b/BTCPayServer/Views/UIPaymentRequest/ViewPaymentRequest.cshtml
@@ -27,6 +27,7 @@
                 return status.ToString().ToLowerInvariant();
         }
     }
+	ViewData.SetBlazorAllowed(false);
 }
 
 <!DOCTYPE html>

--- a/BTCPayServer/Views/UIPullPayment/ViewPullPayment.cshtml
+++ b/BTCPayServer/Views/UIPullPayment/ViewPullPayment.cshtml
@@ -7,22 +7,23 @@
 @inject DisplayFormatter DisplayFormatter
 @model BTCPayServer.Models.ViewPullPaymentModel
 @{
-    ViewData["Title"] = Model.Title;
+	ViewData["Title"] = Model.Title;
 	Csp.UnsafeEval();
-    Layout = null;
-    string StatusTextClass(string status)
-    {
-        switch (status)
-        {
-            case "Completed":
-            case "In Progress":
-                return "bg-success";
-            case "Cancelled":
-                return "bg-danger";
-            default:
-                return "bg-warning";
-        }
-    }
+	Layout = null;
+	string StatusTextClass(string status)
+	{
+		switch (status)
+		{
+			case "Completed":
+			case "In Progress":
+				return "bg-success";
+			case "Cancelled":
+				return "bg-danger";
+			default:
+				return "bg-warning";
+		}
+	}
+	ViewData.SetBlazorAllowed(false);
 }
 <!DOCTYPE html>
 <html lang="en" @(Env.IsDeveloping ? " data-devenv" : "")>

--- a/BTCPayServer/_ViewImports.cshtml
+++ b/BTCPayServer/_ViewImports.cshtml
@@ -9,6 +9,7 @@
 @using BTCPayServer.Models.StoreViewModels
 @using BTCPayServer.Data
 @using Microsoft.AspNetCore.Routing;
+@using BTCPayServer.Abstractions.Extensions;
 @inject Safe Safe
 @addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
 @addTagHelper *, BTCPayServer


### PR DESCRIPTION
Blazor isn't used in Wizard screens (such as vault screen)

As such, it is better to not have connection to Blazor in them, as they have their own websocket connection.
I noticed browser tends to have very slow websocket connection if we create too many of them.

Same thing, PullPayment and PaymentRequest shouldn't attempt to use Blazor.