### PR TITLE
Pull payment improvements

### DIFF
--- a/BTCPayServer/Controllers/UILNURLController.cs
+++ b/BTCPayServer/Controllers/UILNURLController.cs
@@ -92,7 +92,7 @@ namespace BTCPayServer
         }
 
         [HttpGet("withdraw/pp/{pullPaymentId}")]
-        public async Task<IActionResult> GetLNURLForPullPayment(string cryptoCode, string pullPaymentId, string pr, CancellationToken cancellationToken)
+        public async Task<IActionResult> GetLNURLForPullPayment(string cryptoCode, string pullPaymentId, [FromQuery] string pr, CancellationToken cancellationToken)
         {
             var network = _btcPayNetworkProvider.GetNetwork<BTCPayNetwork>(cryptoCode);
             if (network is null || !network.SupportLightning)

--- a/BTCPayServer/Views/Shared/ShowQR.cshtml
+++ b/BTCPayServer/Views/Shared/ShowQR.cshtml
@@ -19,9 +19,9 @@
                             <a class="btcpay-pill" :class="{ 'active': key === mode }" href="#" v-on:click="mode = key">{{item.title}}</a>
                         </li>
                     </ul>
-                    <div class="input-group input-group-sm mt-3" :data-clipboard="currentFragment" v-if="currentFragment && currentMode.showData">
-                        <input type="text" class="form-control" readonly="readonly" :value="currentFragment" id="qr-code-data-input">
-                        <button type="button" class="btn btn-outline-secondary px-3">
+                    <div class="input-group input-group-sm mt-3" v-if="currentFragment && currentMode.showData">
+                        <input type="text" class="form-control" readonly :value="currentFragment" id="qr-code-data-input">
+                        <button type="button" class="btn btn-outline-secondary px-3" data-clipboard-target="#qr-code-data-input">
                             <vc:icon symbol="copy" />
                         </button>
                     </div>
@@ -112,7 +112,7 @@ function initQRShow(data) {
                 this.mode = "default";
                 this.show();
             },
-            show(){
+            show() {
                 $(`#${this.modalId}`).modal("show");
             }
  		}

--- a/BTCPayServer/Views/UIStorePullPayments/Payouts.cshtml
+++ b/BTCPayServer/Views/UIStorePullPayments/Payouts.cshtml
@@ -203,15 +203,15 @@
                         <tr class="payout mass-action-row">
                             @if (stateActions.Any())
                             {
-                                <td class="only-for-js mass-action-select-col" permission="@Policies.CanModifyStoreSettings">
+                                <td class="only-for-js mass-action-select-col align-middle" permission="@Policies.CanModifyStoreSettings">
                                     <input type="checkbox" class="selection-item-@Model.PayoutState.ToString() form-check-input mass-action-select" asp-for="Payouts[i].Selected" />
                                     <input type="hidden" asp-for="Payouts[i].PayoutId" />
                                 </td>
                             }
-                            <td class="date-col">
+                            <td class="date-col align-middle">
                                 @pp.Date.ToBrowserDate()
                             </td>
-                            <td class="mw-100">
+                            <td class="align-middle">
                                 @if (pp.SourceLink is not null && pp.Source is not null)
                                 {
                                     <a href="@pp.SourceLink" rel="noreferrer noopener">@pp.Source</a>
@@ -221,16 +221,16 @@
                                     <span>@pp.Source</span>
                                 }
                             </td>
-                            <td title="@pp.Destination">
-                                <span class="text-break">@pp.Destination</span>
+                            <td class="align-middle">
+                                <vc:truncate-center text="@pp.Destination" classes="truncate-center-id" />
                             </td>
-                            <td class="amount-col">
+                            <td class="amount-col align-middle">
                                 <span data-sensitive>@pp.Amount</span>
                             </td>
                             @if (Model.PayoutState != PayoutState.AwaitingApproval)
                             {
-                                <td class="text-end">
-                                    @if (!(pp.ProofLink is null))
+                                <td class="text-end align-middle">
+                                    @if (!string.IsNullOrEmpty(pp.ProofLink))
                                     {
                                         <a class="transaction-link" href="@pp.ProofLink" rel="noreferrer noopener">Link</a>
                                     }

--- a/BTCPayServer/wwwroot/main/site.css
+++ b/BTCPayServer/wwwroot/main/site.css
@@ -1078,8 +1078,8 @@ input.ts-wrapper.form-control:not(.ts-hidden-accessible,.ts-inline) {
     content: '';
     position: absolute;
     top: -1px;
-    left: -1px;
-    right: -1px;
+    left: 0;
+    right: 0;
     bottom: 0;
     border-bottom: 1px solid;
     border-color: inherit;


### PR DESCRIPTION
Minor improvements, but 0fef2171b6f138122f4fc03a43e569c8dba19732 is actually important and something I ran across in LNbank too (dennisreimann/btcpayserver-plugin-lnbank@defe9747b8fd58aff8d1e8e907d05456ff154ea7): There are cases in which the payment result is `null`, which need to be handled and the check needs to be deferred to later, as the payment might have been sent. In this case the payout should not get marked as cancelled, but the watch process must take care of setting the result.