### PR TITLE
Dynamic Reports

### DIFF
--- a/BTCPayServer/Extensions.cs
+++ b/BTCPayServer/Extensions.cs
@@ -139,7 +139,7 @@ namespace BTCPayServer
     where T : ReportProvider
         {
             services.AddSingleton<T>();
-            services.AddSingleton<ReportProvider, T>();
+            services.AddSingleton<ReportProvider, T>(provider => provider.GetService<T>());
             return services;
         }
 

--- a/BTCPayServer/Hosting/BTCPayServerServices.cs
+++ b/BTCPayServer/Hosting/BTCPayServerServices.cs
@@ -327,6 +327,7 @@ namespace BTCPayServer.Hosting
             services.TryAddSingleton<LightningConfigurationProvider>();
             services.TryAddSingleton<LanguageService>();
             services.TryAddSingleton<ReportService>();
+            services.AddHostedService(provider => provider.GetRequiredService<ReportService>());
             services.TryAddSingleton<NBXplorerDashboard>();
             services.AddSingleton<ISyncSummaryProvider, NBXSyncSummaryProvider>();
             services.TryAddSingleton<StoreRepository>();
@@ -360,6 +361,9 @@ namespace BTCPayServer.Hosting
             services.AddReportProvider<OnChainWalletReportProvider>();
             services.AddReportProvider<ProductsReportProvider>();
             services.AddReportProvider<PayoutsReportProvider>();
+            
+            
+            
 
             services.AddHttpClient(WebhookSender.OnionNamedClient)
                 .ConfigurePrimaryHttpMessageHandler<Socks5HttpClientHandler>();

--- a/BTCPayServer/Models/StoreReportsViewModels/DynamicReportViewModel.cs
+++ b/BTCPayServer/Models/StoreReportsViewModels/DynamicReportViewModel.cs
@@ -1,0 +1,9 @@
+﻿using BTCPayServer.Services;
+
+namespace BTCPayServer.Models.StoreReportsViewModels;
+
+public class DynamicReportViewModel:DynamicReportsSettings.DynamicReportSetting
+{
+    public string Name { get; set; }
+    
+}

--- a/BTCPayServer/Models/StoreReportsViewModels/StoreReportsViewModel.cs
+++ b/BTCPayServer/Models/StoreReportsViewModels/StoreReportsViewModel.cs
@@ -1,8 +1,5 @@
-using System;
 using System.Collections.Generic;
 using BTCPayServer.Client.Models;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Converters;
 
 namespace BTCPayServer.Models.StoreReportsViewModels;
 

--- a/BTCPayServer/Services/ReportService.cs
+++ b/BTCPayServer/Services/ReportService.cs
@@ -1,20 +1,101 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 using BTCPayServer.Client.Models;
 using BTCPayServer.Services.Reporting;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 
 namespace BTCPayServer.Services
 {
-    public class ReportService
+    public class ReportService : IHostedService
     {
-        public ReportService(IEnumerable<ReportProvider> reportProviders)
+        private readonly SettingsRepository _settingsRepository;
+        private readonly IServiceProvider _serviceProvider;
+
+        public ReportService(IEnumerable<ReportProvider> reportProviders, SettingsRepository settingsRepository,
+            IServiceProvider serviceProvider)
         {
+            _settingsRepository = settingsRepository;
+    
+            _serviceProvider = serviceProvider;
             foreach (var r in reportProviders)
             {
                 ReportProviders.Add(r.Name, r);
             }
         }
 
-        public Dictionary<string, ReportProvider> ReportProviders { get; } = new Dictionary<string, ReportProvider>();
+        public Dictionary<string, ReportProvider> ReportProviders { get; } = new();
+
+        public async Task StartAsync(CancellationToken cancellationToken)
+        {
+            var result = await _settingsRepository.GetSettingAsync<DynamicReportsSettings>();
+            if (result?.Reports?.Any() is true)
+            {
+                foreach (var report in result.Reports)
+                {
+                    var reportProvider = ActivatorUtilities.CreateInstance<PostgresReportProvider>(_serviceProvider);
+                    reportProvider.Setting = report.Value;
+                    reportProvider.ReportName = report.Key;
+                    ReportProviders.TryAdd(report.Key, reportProvider);
+                }
+            }
+        }
+
+        public async Task UpdateDynamicReport(string name, DynamicReportsSettings.DynamicReportSetting setting)
+        {
+            ReportProviders.TryGetValue(name, out var report);
+            if (report is not null && report is not PostgresReportProvider)
+            {
+                throw new InvalidOperationException("Only PostgresReportProvider can be updated dynamically");
+            }
+
+            var result = await _settingsRepository.GetSettingAsync<DynamicReportsSettings>() ?? new DynamicReportsSettings();
+            if (report is PostgresReportProvider postgresReportProvider)
+            {
+                if (setting is null)
+                {
+                    //remove report
+                    ReportProviders.Remove(name);
+
+                    result.Reports.Remove(name);
+                    await _settingsRepository.UpdateSetting(result);
+                }
+                else
+                {
+                    postgresReportProvider.Setting = setting;
+                    result.Reports[name] = setting;
+                    postgresReportProvider.ReportName = name;
+                    await _settingsRepository.UpdateSetting(result);
+                }
+            }
+            else if (setting is not null)
+            {
+                var reportProvider = ActivatorUtilities.CreateInstance<PostgresReportProvider>(_serviceProvider);
+                reportProvider.Setting = setting;
+
+                reportProvider.ReportName = name;
+                result.Reports[name] = setting;
+                await _settingsRepository.UpdateSetting(result);
+                ReportProviders.TryAdd(name, reportProvider);
+            }
+        }
+
+        public async Task StopAsync(CancellationToken cancellationToken)
+        {
+        }
+    }
+
+    public class DynamicReportsSettings
+    {
+        public Dictionary<string, DynamicReportSetting> Reports { get; set; } = new();
+
+        public class DynamicReportSetting
+        {
+            public string Sql { get; set; }
+            public bool AllowForNonAdmins { get; set; }
+        }
     }
 }

--- a/BTCPayServer/Services/Reporting/PostgresReportProvider.cs
+++ b/BTCPayServer/Services/Reporting/PostgresReportProvider.cs
@@ -1,0 +1,127 @@
+﻿#nullable enable
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using BTCPayServer.Abstractions.Models;
+using BTCPayServer.Client;
+using BTCPayServer.Client.Models;
+using BTCPayServer.Data;
+using BTCPayServer.Security;
+using Dapper;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+
+namespace BTCPayServer.Services.Reporting;
+
+public class PostgresReportProvider : ReportProvider
+{
+    public string ReportName { get; set; }
+    public override string Name => ReportName;
+    public DynamicReportsSettings.DynamicReportSetting Setting { get; set; }
+
+    private readonly ApplicationDbContextFactory _dbContextFactory;
+    private readonly IOptions<DatabaseOptions> _options;
+    private readonly IHttpContextAccessor _httpContextAccessor;
+    public PostgresReportProvider( ApplicationDbContextFactory dbContextFactory, 
+        IOptions<DatabaseOptions> options, IHttpContextAccessor httpContextAccessor)
+    {
+        _dbContextFactory = dbContextFactory;
+        _options = options;
+        _httpContextAccessor = httpContextAccessor;
+    }
+    public override bool IsAvailable()
+    {
+        return _options.Value.DatabaseType == DatabaseType.Postgres &&
+               Setting.AllowForNonAdmins || _httpContextAccessor.HttpContext?.User.IsInRole(Roles.ServerAdmin) is true;
+    }
+    public override async Task Query(QueryContext queryContext, CancellationToken cancellation)
+    {
+        await ExecuteQuery(_dbContextFactory, queryContext,Setting.Sql, cancellation);
+    }
+
+    public static async Task ExecuteQuery(ApplicationDbContextFactory dbContextFactory, QueryContext queryContext, string sql,
+        CancellationToken cancellation)
+    {
+        await using var dbContext = dbContextFactory.CreateContext();
+        await using var connection = dbContext.Database.GetDbConnection();
+        await connection.OpenAsync(cancellation);
+        await using var transaction = await connection.BeginTransactionAsync(cancellation);
+        try
+        {
+
+        var rows = (await connection.QueryAsync(sql, new
+        {
+            queryContext.From,
+            queryContext.To,
+            queryContext.StoreId
+        }))?.ToArray();
+        if (rows?.Any() is true)
+        {
+            var firstRow = new RouteValueDictionary(rows.First());
+            queryContext.ViewDefinition = new ViewDefinition()
+            {
+                Fields = firstRow.Keys.Select(f => new StoreReportResponse.Field(f, ObjectToFieldType(firstRow[f])))
+                    .ToList(),
+                Charts = new()
+            };
+        }
+        else
+        {
+            return;
+        }
+
+        foreach (var row in rows)
+        {
+            var rowParsed = new RouteValueDictionary(row);
+            var data = queryContext.CreateData();
+            foreach (var field in queryContext.ViewDefinition.Fields)
+            {
+                var rowFieldValue = rowParsed[field.Name];
+                field.Type ??= ObjectToFieldType(rowFieldValue);
+                data.Add(rowFieldValue);
+            }
+
+            queryContext.Data.Add(data);
+        }
+
+        queryContext.ViewDefinition.Fields.Where(field => field.Type is null).ToList()
+            .ForEach(field => field.Type = "string");
+        
+        }
+        finally
+        {
+            
+            await transaction.RollbackAsync(cancellation);
+        }
+    }
+
+    private static string? ObjectToFieldType(object? value)
+    {
+
+        if (value is null)
+            return null;
+        if(value is string)
+            return "string";
+        if(value is DateTime)
+            return "datetime";
+        if(value is DateTimeOffset)
+            return "datetime";
+        if(value is bool)
+            return "boolean";
+        if(value is int)
+            return "amount";
+        if(value is decimal)
+            return "amount";
+        if(value is long)
+            return "amount";
+        if(value is double)
+            return "amount";
+            
+            
+        return "string";
+    }
+}

--- a/BTCPayServer/Views/UIReports/DynamicReport.cshtml
+++ b/BTCPayServer/Views/UIReports/DynamicReport.cshtml
@@ -1,0 +1,113 @@
+@using BTCPayServer.Abstractions.Extensions
+@using BTCPayServer.Security
+@using BTCPayServer.Services
+@using BTCPayServer.Services.Reporting
+@using BTCPayServer.Views.Stores
+@using BTCPayServer.Abstractions.Contracts
+@using Newtonsoft.Json
+@inject IScopeProvider ScopeProvider
+@inject ReportService ReportService
+@model BTCPayServer.Models.StoreReportsViewModels.DynamicReportViewModel
+@{
+    var storeId = ScopeProvider.GetCurrentStoreId();
+    var reportName = Context.Request.Query["reportName"].ToString();
+    reportName = string.IsNullOrEmpty(reportName) ? null : reportName;
+    var existingReports = ReportService.ReportProviders.Where(pair => pair.Value is PostgresReportProvider).Select(pair => pair.Key).ToList();
+    ViewData.SetActivePage(StoreNavPages.Reporting, reportName is null ? "Create dynamic report" : $"Edit {reportName} dynamic report", reportName);
+}
+
+
+<form method="post" asp-action="DynamicReport" asp-controller="UIReports" asp-route-reportName="reportName">
+    <div class="sticky-header-setup"></div>
+    <div class="sticky-header d-sm-flex align-items-center justify-content-between">
+        <h2 class="mb-0">@ViewData["Title"]</h2>
+        <div class="d-flex gap-3 mt-3 mt-sm-0">
+            @if (reportName is null)
+            {
+                <button type="submit" class="btn btn-primary" id="SaveButton">Create</button>
+            }
+            else
+            {
+                <button type="submit" class="btn btn-primary order-sm-1" id="SaveButton">Save</button>
+                <button name="command" value="remove" type="submit" class="btn btn-danger order-sm-1">Remove</button>
+                <a class="btn btn-secondary" asp-controller="UIReports" asp-action="StoreReports" asp-route-storeId="@storeId" asp-route-viewName="@reportName">View</a>
+            }
+            @if (existingReports.Count > 0)
+            {
+                <select onChange="window.location.href=this.value" class="form-select" name="selectedReport">
+                    <option selected="@(reportName is null)" value="@Url.Action("DynamicReport", "UIReports")">Create nw report</option>
+                    @foreach (var rep in existingReports)
+                    {
+                        <option selected="@(rep == reportName)" value="@Url.Action("DynamicReport", "UIReports", new {reportName = rep})">Edit @rep</option>
+                    }
+                </select>
+            }
+        </div>
+    </div>
+
+    <partial name="_StatusMessage" />
+
+    <div class="row">
+        <div class="col-xl-8 col-xxl-constrain">
+            <div asp-validation-summary="ModelOnly" class="text-danger"></div>
+            @if (reportName is null)
+            {
+                <div class="form-group">
+                    <label asp-for="Name" class="form-label" data-required></label>
+                    <input asp-for="Name" class="form-control" required />
+                    <span asp-validation-for="Name" class="text-danger"></span>
+                </div>
+            }
+            else
+            {
+                <input type="hidden" asp-for="Name" />
+            }
+            <div class="form-group form-check">
+                <input type="checkbox" class="form-check-input" asp-for="AllowForNonAdmins" />
+                <label asp-for="AllowForNonAdmins" class="form-check-label"></label>
+                <span asp-validation-for="AllowForNonAdmins" class="text-danger"></span>
+            </div>
+        </div>
+    </div>
+
+    <div class="row">
+        <div class="col-xl-10 col-xxl-constrain">
+            <div class="form-group">
+                <label asp-for="Sql" class="form-label"></label>
+                <textarea asp-for="Sql" class="form-control"></textarea>
+                <span asp-validation-for="Sql" class="text-danger"></span>
+            </div>
+        </div>
+    </div>
+    @if (TempData.TryGetValue("Data", out var dataV) && dataV is string dataS)
+    {
+        var queryContext = JsonConvert.DeserializeObject<QueryContext>(dataS);
+        <div class="row">
+            <div class="col-12 table-responsive">
+                <table class="table">
+                    <thead>
+                    <tr>
+                        @foreach (var column in queryContext.ViewDefinition.Fields)
+                        {
+                            <th>@column.Name</th>
+                        }
+                    </tr>
+                    </thead>
+                    <tbody>
+                    @foreach (var row in queryContext.Data)
+                    {
+                        <tr>
+
+                            @foreach (var column in row)
+                            {
+                                <td>@column</td>
+                            }
+                        </tr>
+                    }
+                </table>
+            </div>
+        </div>
+        <table></table>
+    }
+
+</form>

--- a/BTCPayServer/Views/UIReports/StoreReports.cshtml
+++ b/BTCPayServer/Views/UIReports/StoreReports.cshtml
@@ -4,6 +4,7 @@
 @using BTCPayServer.Views.Invoice;
 @using BTCPayServer.Views.Stores;
 @using BTCPayServer.Abstractions.Services;
+@using BTCPayServer.Client
 @using Microsoft.AspNetCore.Routing;
 @inject Safe Safe
 @inject BTCPayServer.Security.ContentSecurityPolicies Csp
@@ -34,7 +35,9 @@
         <div class="d-flex flex-wrap gap-3">
 	        <a cheat-mode="true" class="btn btn-outline-info text-nowrap" asp-action="StoreReports" asp-route-fakeData="true" asp-route-viewName="@Model.Request?.ViewName">Create fake date</a>
 	        <button id="exportCSV" class="btn btn-primary text-nowrap" type="button">Export</button>
-        </div>
+
+     		<a permission="@Policies.CanModifyServerSettings"  cheat-mode="true" class="btn btn-outline-info text-nowrap" asp-action="DynamicReport" asp-controller="UIReports" asp-route-reportName=""   asp-route-viewName="@Model.Request?.ViewName">Dynamic reports</a>
+   		</div>
     </div>
 </div>
 <div class="d-flex flex-column flex-sm-row align-items-center gap-3 mb-l">


### PR DESCRIPTION
A bit advanced so may put it in a plugin instead. This allows a server admin to create custom reports, which are saved and appear as normal resports in the Reporting features. These reports are only available to Server admins by default but can be marked viewable by non-admins too. This feature only works on Postgres deployments. Security-wise, all queries are run in a transaction and rolled back every time to prevent queries that modify or corrupt. Filters on the rpoerting page can be applied within the sql as parametrs (such as `@StoreId`, `@From`, and `@To`)

![](https://i.imgur.com/SHi2de4.gif)