### PR TITLE
Bumping LND to 0.17.2-beta

### DIFF
--- a/BTCPayServer.Tests/docker-compose.altcoins.yml
+++ b/BTCPayServer.Tests/docker-compose.altcoins.yml
@@ -224,7 +224,7 @@ services:
       - "5432"
 
   merchant_lnd:
-    image: btcpayserver/lnd:v0.17.1-beta
+    image: btcpayserver/lnd:v0.17.2-beta
     restart: unless-stopped
     environment:
       LND_CHAIN: "btc"
@@ -259,7 +259,7 @@ services:
       - bitcoind
 
   customer_lnd:
-    image: btcpayserver/lnd:v0.17.1-beta
+    image: btcpayserver/lnd:v0.17.2-beta
     restart: unless-stopped
     environment:
       LND_CHAIN: "btc"

--- a/BTCPayServer.Tests/docker-compose.yml
+++ b/BTCPayServer.Tests/docker-compose.yml
@@ -211,7 +211,7 @@ services:
       - "5432"
 
   merchant_lnd:
-    image: btcpayserver/lnd:v0.17.1-beta
+    image: btcpayserver/lnd:v0.17.2-beta
     restart: unless-stopped
     environment:
       LND_CHAIN: "btc"
@@ -248,7 +248,7 @@ services:
       - bitcoind
 
   customer_lnd:
-    image: btcpayserver/lnd:v0.17.1-beta
+    image: btcpayserver/lnd:v0.17.2-beta
     restart: unless-stopped
     environment:
       LND_CHAIN: "btc"


### PR DESCRIPTION
Updating our devenv to use LND 0.17.2

Used it in BTCPayServer.Lightning library and it's good to go, passed all the tests:
https://github.com/btcpayserver/BTCPayServer.Lightning/pull/146