### PR TITLE
Remove CurrentRefund property in InvoiceData

### DIFF
--- a/BTCPayServer.Data/Data/InvoiceData.cs
+++ b/BTCPayServer.Data/Data/InvoiceData.cs
@@ -30,9 +30,6 @@ namespace BTCPayServer.Data
         public List<PendingInvoiceData> PendingInvoices { get; set; }
         public List<InvoiceSearchData> InvoiceSearchData { get; set; }
         public List<RefundData> Refunds { get; set; }
-        public string CurrentRefundId { get; set; }
-        [ForeignKey("Id,CurrentRefundId")]
-        public RefundData CurrentRefund { get; set; }
 
 
         internal static void OnModelCreating(ModelBuilder builder, DatabaseFacade databaseFacade)
@@ -42,8 +39,6 @@ namespace BTCPayServer.Data
                 .WithMany(a => a.Invoices).OnDelete(DeleteBehavior.Cascade);
             builder.Entity<InvoiceData>().HasIndex(o => o.StoreDataId);
             builder.Entity<InvoiceData>().HasIndex(o => o.OrderId);
-            builder.Entity<InvoiceData>()
-                .HasOne(o => o.CurrentRefund);
             builder.Entity<InvoiceData>().HasIndex(o => o.Created);
 
             if (databaseFacade.IsNpgsql())

--- a/BTCPayServer.Data/Data/RefundData.cs
+++ b/BTCPayServer.Data/Data/RefundData.cs
@@ -13,7 +13,6 @@ namespace BTCPayServer.Data
         public PullPaymentData PullPaymentData { get; set; }
         public InvoiceData InvoiceData { get; set; }
 
-
         internal static void OnModelCreating(ModelBuilder builder)
         {
             builder.Entity<RefundData>()

--- a/BTCPayServer.Data/Migrations/20231121031609_removecurrentrefund.cs
+++ b/BTCPayServer.Data/Migrations/20231121031609_removecurrentrefund.cs
@@ -1,0 +1,36 @@
+using BTCPayServer.Data;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace BTCPayServer.Migrations
+{
+    [DbContext(typeof(ApplicationDbContext))]
+    [Migration("20231121031609_removecurrentrefund")]
+    public partial class removecurrentrefund : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            if (migrationBuilder.IsNpgsql())
+            {
+                migrationBuilder.DropForeignKey(
+                    name: "FK_Invoices_Refunds_Id_CurrentRefundId",
+                    table: "Invoices");
+
+                migrationBuilder.DropIndex(
+                    name: "IX_Invoices_Id_CurrentRefundId",
+                    table: "Invoices");
+
+                migrationBuilder.DropColumn(
+                    name: "CurrentRefundId",
+                    table: "Invoices");
+            }
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+        }
+    }
+}

--- a/BTCPayServer.Data/Migrations/ApplicationDbContextModelSnapshot.cs
+++ b/BTCPayServer.Data/Migrations/ApplicationDbContextModelSnapshot.cs
@@ -287,9 +287,6 @@ namespace BTCPayServer.Migrations
                     b.Property<DateTimeOffset>("Created")
                         .HasColumnType("TEXT");
 
-                    b.Property<string>("CurrentRefundId")
-                        .HasColumnType("TEXT");
-
                     b.Property<string>("CustomerEmail")
                         .HasColumnType("TEXT");
 
@@ -315,8 +312,6 @@ namespace BTCPayServer.Migrations
                     b.HasIndex("OrderId");
 
                     b.HasIndex("StoreDataId");
-
-                    b.HasIndex("Id", "CurrentRefundId");
 
                     b.ToTable("Invoices");
                 });
@@ -1250,12 +1245,6 @@ namespace BTCPayServer.Migrations
                         .WithMany("Invoices")
                         .HasForeignKey("StoreDataId")
                         .OnDelete(DeleteBehavior.Cascade);
-
-                    b.HasOne("BTCPayServer.Data.RefundData", "CurrentRefund")
-                        .WithMany()
-                        .HasForeignKey("Id", "CurrentRefundId");
-
-                    b.Navigation("CurrentRefund");
 
                     b.Navigation("StoreData");
                 });

--- a/BTCPayServer/Components/StoreNumbers/StoreNumbers.cs
+++ b/BTCPayServer/Components/StoreNumbers/StoreNumbers.cs
@@ -55,7 +55,8 @@ public class StoreNumbers : ViewComponent
             .Where(p => p.PullPaymentData.StoreId == vm.Store.Id && !p.PullPaymentData.Archived && p.State == PayoutState.AwaitingApproval)
             .CountAsync();
         vm.RefundsIssued = await ctx.Invoices
-            .Where(i => i.StoreData.Id == vm.Store.Id && !i.Archived && i.CurrentRefundId != null && i.Created >= offset)
+            .Where(i => i.StoreData.Id == vm.Store.Id && !i.Archived && i.Created >= offset)
+            .SelectMany(i => i.Refunds)
             .CountAsync();
 
         return View(vm);

--- a/BTCPayServer/Controllers/GreenField/GreenfieldInvoiceController.cs
+++ b/BTCPayServer/Controllers/GreenField/GreenfieldInvoiceController.cs
@@ -515,7 +515,7 @@ namespace BTCPayServer.Controllers.Greenfield
             var ppId = await _pullPaymentService.CreatePullPayment(createPullPayment);
 
             await using var ctx = _dbContextFactory.CreateContext();
-            (await ctx.Invoices.FindAsync(new[] { invoice.Id }, cancellationToken))!.CurrentRefundId = ppId;
+
             ctx.Refunds.Add(new RefundData
             {
                 InvoiceDataId = invoice.Id,
@@ -524,7 +524,6 @@ namespace BTCPayServer.Controllers.Greenfield
             await ctx.SaveChangesAsync(cancellationToken);
 
             var pp = await _pullPaymentService.GetPullPayment(ppId, false);
-
             return this.Ok(CreatePullPaymentData(pp));
         }
 

--- a/BTCPayServer/Controllers/UIInvoiceController.UI.cs
+++ b/BTCPayServer/Controllers/UIInvoiceController.UI.cs
@@ -288,19 +288,19 @@ namespace BTCPayServer.Controllers
             await using var ctx = _dbContextFactory.CreateContext();
             ctx.ChangeTracker.QueryTrackingBehavior = QueryTrackingBehavior.NoTracking;
             var invoice = await ctx.Invoices.Include(i => i.Payments)
-                                            .Include(i => i.CurrentRefund)
+                                            .Include(i => i.Refunds).ThenInclude(i => i.PullPaymentData)
                                             .Include(i => i.StoreData)
                                             .ThenInclude(data => data.UserStores)
-                                            .Include(i => i.CurrentRefund.PullPaymentData)
                                             .Where(i => i.Id == invoiceId)
                                             .FirstOrDefaultAsync(cancellationToken);
             if (invoice is null)
                 return NotFound();
-            if (invoice.CurrentRefund?.PullPaymentDataId is null && GetUserId() is null)
+            var currentRefund = invoice.Refunds.OrderByDescending(r => r.PullPaymentData.StartDate).FirstOrDefault();
+            if (currentRefund?.PullPaymentDataId is null && GetUserId() is null)
                 return NotFound();
             if (!invoice.GetInvoiceState().CanRefund())
                 return NotFound();
-            if (invoice.CurrentRefund?.PullPaymentDataId is string ppId && !invoice.CurrentRefund.PullPaymentData.Archived)
+            if (currentRefund?.PullPaymentDataId is string ppId && !currentRefund.PullPaymentData.Archived)
             {
                 // TODO: Having dedicated UI later on
                 return RedirectToAction(nameof(UIPullPaymentController.ViewPullPayment),
@@ -550,7 +550,6 @@ namespace BTCPayServer.Controllers
                 Html = "Refund successfully created!<br />Share the link to this page with a customer.<br />The customer needs to enter their address and claim the refund.<br />Once a customer claims the refund, you will get a notification and would need to approve and initiate it from your Store > Payouts.",
                 Severity = StatusMessageModel.StatusSeverity.Success
             });
-            (await ctx.Invoices.FindAsync(new[] { invoice.Id }, cancellationToken))!.CurrentRefundId = ppId;
             ctx.Refunds.Add(new RefundData
             {
                 InvoiceDataId = invoice.Id,

--- a/BTCPayServer/Hosting/ToPostgresMigrationStartupTask.cs
+++ b/BTCPayServer/Hosting/ToPostgresMigrationStartupTask.cs
@@ -233,9 +233,6 @@ namespace BTCPayServer.Hosting
                     var rows = await query.ToListAsync();
                     foreach (var row in rows)
                     {
-                        // There is as circular deps between invoice and refund.
-                        if (row is InvoiceData id)
-                            id.CurrentRefundId = null;
                         foreach (var prop in datetimeProperties)
                         {
                             var v = (DateTime)prop.GetValue(row)!;
@@ -261,10 +258,6 @@ namespace BTCPayServer.Hosting
                     }
                     await postgresContext.SaveChangesAsync();
                     postgresContext.ChangeTracker.Clear();
-                }
-                foreach (var invoice in otherContext.Invoices.AsNoTracking().Where(i => i.CurrentRefundId != null))
-                {
-                    postgresContext.Entry(invoice).State = EntityState.Modified;
                 }
                 await postgresContext.SaveChangesAsync();
                 postgresContext.ChangeTracker.Clear();


### PR DESCRIPTION
While [migrating on .NET8.0](https://github.com/btcpayserver/btcpayserver/pull/5479), EF wasn't happy anymore with a dependency cycle (invoice -> refund -> invoice). So I removed the CurrentRefund property from Invoice.

Instead, we define the "CurrentRefund" as the refund with the most recent pull payment.