### PR TITLE
Greenfield: Make checkout type V2 default for new stores

### DIFF
--- a/BTCPayServer.Client/Models/StoreBaseData.cs
+++ b/BTCPayServer.Client/Models/StoreBaseData.cs
@@ -37,8 +37,11 @@ namespace BTCPayServer.Client.Models
         public bool AnyoneCanCreateInvoice { get; set; }
         public string DefaultCurrency { get; set; }
         public bool RequiresRefundEmail { get; set; }
+
         [JsonConverter(typeof(StringEnumConverter))]
-        public CheckoutType CheckoutType { get; set; }
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public CheckoutType? CheckoutType { get; set; }
+
         public bool LightningAmountInSatoshi { get; set; }
         public bool LightningPrivateRouteHints { get; set; }
         public bool OnChainWithLnInvoiceFallback { get; set; }

--- a/BTCPayServer.Tests/GreenfieldAPITests.cs
+++ b/BTCPayServer.Tests/GreenfieldAPITests.cs
@@ -1284,15 +1284,18 @@ namespace BTCPayServer.Tests
             var client = await user.CreateClient(Policies.Unrestricted);
 
             //create store
-            var newStore = await client.CreateStore(new CreateStoreRequest() { Name = "A" });
+            var newStore = await client.CreateStore(new CreateStoreRequest { Name = "A" });
+            Assert.Equal("A", newStore.Name);
+            Assert.Equal(CheckoutType.V2, newStore.CheckoutType);
 
             //update store
             Assert.Empty(newStore.PaymentMethodCriteria);
             await client.GenerateOnChainWallet(newStore.Id, "BTC", new GenerateOnChainWalletRequest());
-            var updatedStore = await client.UpdateStore(newStore.Id, new UpdateStoreRequest()
+            var updatedStore = await client.UpdateStore(newStore.Id, new UpdateStoreRequest
             {
                 Name = "B",
-                PaymentMethodCriteria = new List<PaymentMethodCriteriaData>()
+                CheckoutType = CheckoutType.V1,
+                PaymentMethodCriteria = new List<PaymentMethodCriteriaData>
             {
                 new()
                 {
@@ -1304,6 +1307,7 @@ namespace BTCPayServer.Tests
              }
             });
             Assert.Equal("B", updatedStore.Name);
+            Assert.Equal(CheckoutType.V1, updatedStore.CheckoutType);
             var s = (await client.GetStore(newStore.Id));
             Assert.Equal("B", s.Name);
             var pmc = Assert.Single(s.PaymentMethodCriteria);

--- a/BTCPayServer/Controllers/GreenField/GreenfieldStoresController.cs
+++ b/BTCPayServer/Controllers/GreenField/GreenfieldStoresController.cs
@@ -185,7 +185,6 @@ namespace BTCPayServer.Controllers.Greenfield
             blob.NetworkFeeMode = restModel.NetworkFeeMode;
             blob.DefaultCurrency = restModel.DefaultCurrency;
             blob.RequiresRefundEmail = restModel.RequiresRefundEmail;
-            blob.CheckoutType = restModel.CheckoutType;
             blob.ReceiptOptions = InvoiceDataBase.ReceiptOptions.Merge(restModel.Receipt, null);
             blob.LightningAmountInSatoshi = restModel.LightningAmountInSatoshi;
             blob.LightningPrivateRouteHints = restModel.LightningPrivateRouteHints;
@@ -206,6 +205,8 @@ namespace BTCPayServer.Controllers.Greenfield
             blob.LightningDescriptionTemplate = restModel.LightningDescriptionTemplate;
             blob.PaymentTolerance = restModel.PaymentTolerance;
             blob.PayJoinEnabled = restModel.PayJoinEnabled;
+            if (restModel.CheckoutType.HasValue)
+                blob.CheckoutType = restModel.CheckoutType.Value;
             if (restModel.AutoDetectLanguage.HasValue)
                 blob.AutoDetectLanguage = restModel.AutoDetectLanguage.Value;
             if (restModel.ShowPayInWalletButton.HasValue)

--- a/BTCPayServer/Data/StoreBlob.cs
+++ b/BTCPayServer/Data/StoreBlob.cs
@@ -40,7 +40,7 @@ namespace BTCPayServer.Data
         public NetworkFeeMode NetworkFeeMode { get; set; }
 
         [JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
-        [DefaultValue(CheckoutType.V1)]
+        [DefaultValue(CheckoutType.V2)]
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.Populate)]
         public CheckoutType CheckoutType { get; set; }
         public bool RequiresRefundEmail { get; set; }

--- a/BTCPayServer/wwwroot/swagger/v1/swagger.template.json
+++ b/BTCPayServer/wwwroot/swagger/v1/swagger.template.json
@@ -83,7 +83,7 @@
         "type": "string",
         "description": "`\"V1\"`: The original checkout form   \n`\"V2\"`: The new experimental checkout form",
         "nullable": true,
-        "default": "V1",
+        "default": "V2",
         "x-enumNames": [
           "V1",
           "V2"


### PR DESCRIPTION
It's the default for stores created via the UI, let's make it the default for the API too.