### PR TITLE
Fix qemu package in ARM Docker files

### DIFF
--- a/arm32v7.Dockerfile
+++ b/arm32v7.Dockerfile
@@ -2,7 +2,7 @@
 FROM mcr.microsoft.com/dotnet/sdk:8.0.100-bookworm-slim AS builder
 ENV DOTNET_CLI_TELEMETRY_OPTOUT=1
 RUN apt-get update \
-	&& apt-get install -qq --no-install-recommends qemu qemu-user-static qemu-user binfmt-support
+    && apt-get install -qq --no-install-recommends qemu-system-arm qemu-user-static qemu-user binfmt-support
 
 WORKDIR /source
 COPY nuget.config nuget.config

--- a/arm64v8.Dockerfile
+++ b/arm64v8.Dockerfile
@@ -3,7 +3,7 @@ FROM mcr.microsoft.com/dotnet/sdk:8.0.100-bookworm-slim AS builder
 ENV DOTNET_CLI_TELEMETRY_OPTOUT=1
 ENV LC_ALL en_US.UTF-8
 RUN apt-get update \
-	&& apt-get install -qq --no-install-recommends qemu qemu-user-static qemu-user binfmt-support
+    && apt-get install -qq --no-install-recommends qemu-system-arm qemu-user-static qemu-user binfmt-support
 
 WORKDIR /source
 COPY nuget.config nuget.config


### PR DESCRIPTION
With the new debian bookworm, the `qemu` package has been split into one package per architecture.