### PR TITLE
Receipt fixes and improvements

### DIFF
--- a/BTCPayServer/Controllers/UIInvoiceController.UI.cs
+++ b/BTCPayServer/Controllers/UIInvoiceController.UI.cs
@@ -254,7 +254,7 @@ namespace BTCPayServer.Controllers
                         Amount = paymentEntity.PaidAmount.Gross,
                         Paid = paymentEntity.InvoicePaidAmount.Net,
                         ReceivedDate = paymentEntity.ReceivedTime.DateTime,
-                        AmountFormatted = _displayFormatter.Currency(paymentEntity.PaidAmount.Gross, paymentEntity.PaidAmount.Currency, DisplayFormatter.CurrencyFormat.None),
+                        AmountFormatted = _displayFormatter.Currency(paymentEntity.PaidAmount.Gross, paymentEntity.PaidAmount.Currency),
                         PaidFormatted = _displayFormatter.Currency(paymentEntity.InvoicePaidAmount.Net, i.Currency, DisplayFormatter.CurrencyFormat.Symbol),
                         RateFormatted = _displayFormatter.Currency(paymentEntity.Rate, i.Currency, DisplayFormatter.CurrencyFormat.Symbol),
                         PaymentMethod = paymentMethodId.ToPrettyString(),

--- a/BTCPayServer/PaymentRequest/PaymentRequestService.cs
+++ b/BTCPayServer/PaymentRequest/PaymentRequestService.cs
@@ -135,7 +135,7 @@ namespace BTCPayServer.PaymentRequest
                                 Amount = paymentEntity.PaidAmount.Gross,
                                 Paid = paymentEntity.InvoicePaidAmount.Net,
                                 ReceivedDate = paymentEntity.ReceivedTime.DateTime,
-                                AmountFormatted = _displayFormatter.Currency(paymentEntity.PaidAmount.Gross, paymentEntity.PaidAmount.Currency, DisplayFormatter.CurrencyFormat.None),
+                                AmountFormatted = _displayFormatter.Currency(paymentEntity.PaidAmount.Gross, paymentEntity.PaidAmount.Currency),
                                 PaidFormatted = _displayFormatter.Currency(paymentEntity.InvoicePaidAmount.Net, blob.Currency, DisplayFormatter.CurrencyFormat.Symbol),
                                 RateFormatted = _displayFormatter.Currency(paymentEntity.Rate, blob.Currency, DisplayFormatter.CurrencyFormat.Symbol),
                                 PaymentMethod = paymentMethodId.ToPrettyString(),

--- a/BTCPayServer/Views/UIInvoice/InvoiceReceipt.cshtml
+++ b/BTCPayServer/Views/UIInvoice/InvoiceReceipt.cshtml
@@ -31,7 +31,7 @@
         </script>
     }
     <style>
-        #InvoiceReceipt { --wrap-max-width: 720px; }
+        #InvoiceReceipt { --wrap-max-width: 768px; }
         #InvoiceSummary { gap: var(--btcpay-space-l); }
         #PaymentDetails table tbody tr:first-child td { padding-top: 1rem; }
         #PaymentDetails table tbody:not(:last-child) tr:last-child > th,td { padding-bottom: 1rem; }

--- a/BTCPayServer/Views/UIInvoice/InvoiceReceipt.cshtml
+++ b/BTCPayServer/Views/UIInvoice/InvoiceReceipt.cshtml
@@ -86,7 +86,6 @@
                         </div>
                     }
                 </div>
-                </div>
                 
                 @if (isProcessing)
                 {

--- a/BTCPayServer/Views/UIInvoice/InvoiceReceipt.cshtml
+++ b/BTCPayServer/Views/UIInvoice/InvoiceReceipt.cshtml
@@ -121,7 +121,7 @@
                                         <tr>
                                             <td class="date-col">@payment.ReceivedDate.ToBrowserDate()</td>
                                             <td class="amount-col">@payment.PaidFormatted</td>
-                                            <td class="amount-col">@payment.AmountFormatted @payment.PaymentMethod</td>
+                                            <td class="amount-col">@payment.AmountFormatted</td>
                                         </tr>
                                         @if (!string.IsNullOrEmpty(payment.Destination))
                                         {

--- a/BTCPayServer/Views/UIInvoice/InvoiceReceiptPrint.cshtml
+++ b/BTCPayServer/Views/UIInvoice/InvoiceReceiptPrint.cshtml
@@ -163,6 +163,42 @@
                                             }
                                         }
                                     </tbody>
+                                    @if (Model.AdditionalData?.Any() is true && (Model.AdditionalData.ContainsKey("Cart") || Model.AdditionalData.ContainsKey("Subtotal")))
+                                    {
+                                        <tbody>
+                                            @if (Model.AdditionalData.ContainsKey("Cart"))
+                                            {
+                                                @foreach (var (key, value) in (Dictionary<string, object>)Model.AdditionalData["Cart"])
+                                                {
+                                                    <tr>
+                                                        <td class="fw-normal text-secondary">@key</td>
+                                                        <td class="text-end">@value</td>
+                                                    </tr>
+                                                }
+                                            }
+                                            @if (Model.AdditionalData.ContainsKey("Subtotal"))
+                                            {
+                                                <tr>
+                                                    <td class="fw-normal text-secondary">Subtotal</td>
+                                                    <td class="text-end">@Model.AdditionalData["Subtotal"]</td>
+                                                </tr>
+                                            }
+                                            @if (Model.AdditionalData.ContainsKey("Discount"))
+                                            {
+                                                <tr>
+                                                    <td class="fw-normal text-secondary">Discount</td>
+                                                    <td class="text-end">@Model.AdditionalData["Discount"]</td>
+                                                </tr>
+                                            }
+                                            @if (Model.AdditionalData.ContainsKey("Tip"))
+                                            {
+                                                <tr>
+                                                    <td class="fw-normal text-secondary">Tip</td>
+                                                    <td class="text-end">@Model.AdditionalData["Tip"]</td>
+                                                </tr>
+                                            }
+                                        </tbody>
+                                    }
                                     <tfoot>
                                         <tr>
                                             <th class="fw-normal text-secondary"></th>

--- a/BTCPayServer/Views/UIInvoice/InvoiceReceiptPrint.cshtml
+++ b/BTCPayServer/Views/UIInvoice/InvoiceReceiptPrint.cshtml
@@ -10,6 +10,8 @@
     var isFreeInvoice = (Model.Status == InvoiceStatus.New && Model.Amount == 0);
     var isSettled = Model.Status == InvoiceStatus.Settled;
 }
+<!DOCTYPE html>
+<html lang="en">
 <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
@@ -70,171 +72,137 @@
     </style>
 </head>
 
-<body style="margin:0; padding:0; background-color:#fff">
-    <center>
-        <div>
-            <partial name="_StatusMessage" model="@(new ViewDataDictionary(ViewData) { { "Margin", "mb-4" } })" />
-
-            <div class="justify-content-center">
-                <partial name="_StoreHeader" model="(Model.StoreName, Model.LogoFileId)" />
-                <div id="InvoiceSummary" class="bg-tile">
-                    @if (isProcessing)
-                    {
-                        <div class="lead text-center fw-semibold" id="invoice-processing">
-                            The invoice has detected a payment but is still waiting to be settled.
-                        </div>
-                    }
-                    else if (!isSettled)
-                    {
-                        <div class="lead text-center fw-semibold" id="invoice-unsettled">
-                            The invoice is not settled.
-                        </div>
-                    }
-                    else
-                    {
-                        <div id="PaymentDetails" class="bg-tile">
-                            <div class="table-responsive my-0">
-                                <table class="table table-borderless table-sm small my-0" style="max-width: 500px">
-                                    <thead>
-                                        <tr>
-                                            <th class="fw-normal text-secondary"></th>
-                                            <th class="fw-normal text-secondary"></th>
-                                        </tr>
-                                    </thead>
-                                    <tbody>
-                                        <tr>
-                                            <td class="fw-normal text-nowrap text-secondary">Date/Time</td>
-                                            <td>@Model.Timestamp.ToBrowserDate()</td>
-                                        </tr>
-                                        @if (!string.IsNullOrEmpty(Model.OrderId))
-                                        {
-                                            <tr>
-                                                <td class="fw-normal text-nowrap text-secondary">Order ID</td>
-                                                <td>@Model.OrderId</td>
-                                            </tr>
-                                        }
-                                        @if (Model.AdditionalData?.Any() is true && (Model.AdditionalData.ContainsKey("Cart") || Model.AdditionalData.ContainsKey("Subtotal") || Model.AdditionalData.ContainsKey("Total")))
-                                        {
-                                            <tbody>
-                                                @if (Model.AdditionalData.ContainsKey("Cart"))
-                                                {
-                                                    @foreach (var (key, value) in (Dictionary<string, object>)Model.AdditionalData["Cart"])
-                                                    {
-                                                        <tr>
-                                                            <td class="fw-normal text-secondary">@key</td>
-                                                            <td class="text-end">@value</td>
-                                                        </tr>
-                                                    }
-                                                }
-                                                @if (Model.AdditionalData.ContainsKey("Subtotal"))
-                                                {
-                                                    <tr>
-                                                        <td class="fw-normal text-secondary">Subtotal</td>
-                                                        <td class="text-end">@Model.AdditionalData["Subtotal"]</td>
-                                                    </tr>
-                                                }
-                                                @if (Model.AdditionalData.ContainsKey("Discount"))
-                                                {
-                                                    <tr>
-                                                        <td class="fw-normal text-secondary">Discount</td>
-                                                        <td class="text-end">@Model.AdditionalData["Discount"]</td>
-                                                    </tr>
-                                                }
-                                                @if (Model.AdditionalData.ContainsKey("Tip"))
-                                                {
-                                                    <tr>
-                                                        <td class="fw-normal text-secondary">Tip</td>
-                                                        <td class="text-end">@Model.AdditionalData["Tip"]</td>
-                                                    </tr>
-                                                }
-                                                @if (Model.AdditionalData.ContainsKey("Total"))
-                                                {
-                                                    <tr>
-                                                        <td class="fw-normal text-secondary">Total</td>
-                                                        <td class="text-end">@Model.AdditionalData["Total"]</td>
-                                                    </tr>
-                                                }
-                                            </tbody>
-                                        }
-                                        else
-                                        {
-                                            <tr>
-                                                <td class="fw-normal text-nowrap text-secondary">Paid</td>
-                                                <td class="text-end">@DisplayFormatter.Currency(Model.Amount, Model.Currency, DisplayFormatter.CurrencyFormat.Symbol)</td>
-                                            </tr>
-                                        }
-                                        @if (Model.Payments?.Any() is true)
-                                        {
-                                            @for (var i = 0; i < Model.Payments.Count; i++)
-                                            {
-                                                var payment = Model.Payments[i];
-                                                @if (Model.Payments.Count > 1)
-                                                {
-                                                    <tr>
-                                                        <td colspan="2" class="fw-normal text-nowrap text-secondary">Payment @(i + 1)</td>
-                                                    </tr>
-                                                    <tr>
-                                                        <td class="fw-normal text-nowrap text-secondary">Received</td>
-                                                        <td>@payment.ReceivedDate.ToBrowserDate()</td>
-                                                    </tr>
-                                                }
-                                                <tr>
-                                                    <td class="fw-normal text-nowrap text-secondary">@(Model.Payments.Count == 1 ? "Paid" : "")</td>
-                                                    <td class="text-end">@payment.AmountFormatted</td>
-                                                </tr>
-                                                <tr>
-                                                    <td class="fw-normal text-nowrap text-secondary"></td>
-                                                    <td class="text-end">@payment.PaidFormatted</td>
-                                                </tr>
-                                                <tr>
-                                                    <td class="fw-normal text-nowrap text-secondary">Rate</td>
-                                                    <td class="text-end">@payment.RateFormatted</td>
-                                                </tr>
-                                                @if (!string.IsNullOrEmpty(payment.Destination))
-                                                {
-                                                    <tr>
-                                                        <td class="fw-normal text-nowrap text-secondary">Destination</td>
-                                                        <td class="text-break">@payment.Destination</td>
-                                                    </tr>
-                                                }
-                                                @if (!string.IsNullOrEmpty(payment.PaymentProof))
-                                                {
-                                                    <tr>
-                                                        <td class="fw-normal text-nowrap text-secondary">Pay Proof</td>
-                                                        <td class="text-break">@payment.PaymentProof</td>
-                                                    </tr>
-                                                }
-                                            }
-                                        }
-                                    </tbody>
-                                    
-                                    <tfoot>
-                                        <tr>
-                                            <th class="fw-normal text-secondary"></th>
-                                            <th class="fw-normal text-secondary"></th>
-                                        </tr>
-                                    </tfoot>
-                                </table>
-                            </div>
-                        </div>
-
-                        if (Model.ReceiptOptions.ShowQR is true)
-                        {
-                            <vc:qr-code style="width:" data="@Context.Request.GetCurrentUrl()" size="128"></vc:qr-code>
-                        }
-                    }
-                </div>
+<body class="m-0 p-0 bg-white">
+<center>
+    <partial name="_StoreHeader" model="(Model.StoreName, Model.LogoFileId)" />
+    <div id="InvoiceSummary" style="max-width:600px">
+        @if (isProcessing)
+        {
+            <div class="lead text-center fw-semibold" id="invoice-processing">
+                The invoice has detected a payment but is still waiting to be settled.
             </div>
-        </div>
-
-        <footer class="store-footer" style="padding: 0.5rem;">
-            <a class="store-powered-by" style="color: #000;" href="https://btcpayserver.org" target="_blank" rel="noreferrer noopener">
-                Powered by <partial name="_StoreFooterLogo" />
-            </a>
-        </footer>
-    </center>
+        }
+        else if (!isSettled)
+        {
+            <div class="lead text-center fw-semibold" id="invoice-unsettled">
+                The invoice is not settled.
+            </div>
+        }
+        else
+        {
+            <div id="PaymentDetails">
+                <div class="my-2 text-center small">
+                    @if (!string.IsNullOrEmpty(Model.OrderId))
+                    {
+                        <div>Order ID: @Model.OrderId</div>
+                    }
+                    @Model.Timestamp.ToBrowserDate()
+                </div>
+                <table class="table table-borderless table-sm small my-0">
+                    <tr>
+                        <td class="text-nowrap text-secondary">Total</td>
+                        <td class="text-end fw-semibold">@DisplayFormatter.Currency(Model.Amount, Model.Currency, DisplayFormatter.CurrencyFormat.Symbol)</td>
+                    </tr>
+                    <tr>
+                        <td colspan="2"><hr class="w-100 my-0"/></td>
+                    </tr>
+                    @if (Model.AdditionalData?.Any() is true && (Model.AdditionalData.ContainsKey("Cart") || Model.AdditionalData.ContainsKey("Subtotal") || Model.AdditionalData.ContainsKey("Total")))
+                    {
+                        @if (Model.AdditionalData.ContainsKey("Cart"))
+                        {
+                            @foreach (var (key, value) in (Dictionary<string, object>)Model.AdditionalData["Cart"])
+                            {
+                                <tr>
+                                    <td class="text-secondary">@key</td>
+                                    <td class="text-end">@value</td>
+                                </tr>
+                            }
+                        }
+                        @if (Model.AdditionalData.ContainsKey("Subtotal"))
+                        {
+                            <tr>
+                                <td class="text-secondary">Subtotal</td>
+                                <td class="text-end">@Model.AdditionalData["Subtotal"]</td>
+                            </tr>
+                        }
+                        @if (Model.AdditionalData.ContainsKey("Discount"))
+                        {
+                            <tr>
+                                <td class="text-secondary">Discount</td>
+                                <td class="text-end">@Model.AdditionalData["Discount"]</td>
+                            </tr>
+                        }
+                        @if (Model.AdditionalData.ContainsKey("Tip"))
+                        {
+                            <tr>
+                                <td class="text-secondary">Tip</td>
+                                <td class="text-end">@Model.AdditionalData["Tip"]</td>
+                            </tr>
+                        }
+                        <tr>
+                            <td colspan="2"><hr class="w-100 my-0"/></td>
+                        </tr>
+                    }
+                    @if (Model.Payments?.Any() is true)
+                    {
+                        @for (var i = 0; i < Model.Payments.Count; i++)
+                        {
+                            var payment = Model.Payments[i];
+                            @if (Model.Payments.Count > 1)
+                            {
+                                <tr>
+                                    <td colspan="2" class="text-nowrap text-secondary">Payment @(i + 1)</td>
+                                </tr>
+                                <tr>
+                                    <td class="text-nowrap">Received</td>
+                                    <td>@payment.ReceivedDate.ToBrowserDate()</td>
+                                </tr>
+                            }
+                            <tr>
+                                <td class="text-nowrap text-secondary">@(Model.Payments.Count == 1 ? "Paid" : "")</td>
+                                <td class="text-end">@payment.AmountFormatted</td>
+                            </tr>
+                            <tr>
+                                <td colspan="2" class="text-end">@payment.PaidFormatted</td>
+                            </tr>
+                            <tr>
+                                <td class="text-nowrap text-secondary">Rate</td>
+                                <td class="text-end">@payment.RateFormatted</td>
+                            </tr>
+                            @if (!string.IsNullOrEmpty(payment.Destination))
+                            {
+                                <tr>
+                                    <td class="text-nowrap text-secondary">Destination</td>
+                                    <td class="text-break">@payment.Destination</td>
+                                </tr>
+                            }
+                            @if (!string.IsNullOrEmpty(payment.PaymentProof))
+                            {
+                                <tr>
+                                    <td class="text-nowrap text-secondary">Pay Proof</td>
+                                    <td class="text-break">@payment.PaymentProof</td>
+                                </tr>
+                            }
+                        }
+                        <tr>
+                            <td colspan="2"><hr class="w-100 my-0"/></td>
+                        </tr>
+                    }
+                </table>
+            </div>
+            if (Model.ReceiptOptions.ShowQR is true)
+            {
+                <vc:qr-code data="@Context.Request.GetCurrentUrl()" size="128" />
+            }
+        }
+    </div>
+    <div class="store-footer pb-3 mb-4">
+        <a class="store-powered-by" style="color:#000;">Powered by <partial name="_StoreFooterLogo" /></a>
+    </div>
+    <hr class="w-100 my-0 bg-none"/>
+</center>
 </body>
-
 <script>
     window.print();
 </script>
+</html>

--- a/BTCPayServer/Views/UIInvoice/InvoiceReceiptPrint.cshtml
+++ b/BTCPayServer/Views/UIInvoice/InvoiceReceiptPrint.cshtml
@@ -104,7 +104,7 @@
                                     <tbody>
                                         <tr>
                                             <td class="fw-normal text-nowrap text-secondary">Paid</td>
-                                            <td>@DisplayFormatter.Currency(Model.Amount, Model.Currency, DisplayFormatter.CurrencyFormat.Symbol)</td>
+                                            <td class="text-end">@DisplayFormatter.Currency(Model.Amount, Model.Currency, DisplayFormatter.CurrencyFormat.Symbol)</td>
                                         </tr>
                                         <tr>
                                             <td class="fw-normal text-nowrap text-secondary">Date/Time</td>
@@ -135,15 +135,15 @@
                                                 </tr>
                                                 <tr>
                                                     <td class="fw-normal text-nowrap text-secondary"></td>
-                                                    <td>@payment.AmountFormatted @payment.PaymentMethod</td>
+                                                    <td class="text-end">@payment.AmountFormatted @payment.PaymentMethod</td>
                                                 </tr>
                                                 <tr>
                                                     <td class="fw-normal text-nowrap text-secondary"></td>
-                                                    <td>@payment.PaidFormatted</td>
+                                                    <td class="text-end">@payment.PaidFormatted</td>
                                                 </tr>
                                                 <tr>
                                                     <td class="fw-normal text-nowrap text-secondary">Rate</td>
-                                                    <td>@payment.RateFormatted</td>
+                                                    <td class="text-end">@payment.RateFormatted</td>
                                                 </tr>
 
                                                 @if (!string.IsNullOrEmpty(payment.Destination))

--- a/BTCPayServer/Views/UIInvoice/InvoiceReceiptPrint.cshtml
+++ b/BTCPayServer/Views/UIInvoice/InvoiceReceiptPrint.cshtml
@@ -103,10 +103,6 @@
                                     </thead>
                                     <tbody>
                                         <tr>
-                                            <td class="fw-normal text-nowrap text-secondary">Paid</td>
-                                            <td class="text-end">@DisplayFormatter.Currency(Model.Amount, Model.Currency, DisplayFormatter.CurrencyFormat.Symbol)</td>
-                                        </tr>
-                                        <tr>
                                             <td class="fw-normal text-nowrap text-secondary">Date/Time</td>
                                             <td>@Model.Timestamp.ToBrowserDate()</td>
                                         </tr>
@@ -117,7 +113,56 @@
                                                 <td>@Model.OrderId</td>
                                             </tr>
                                         }
-
+                                        @if (Model.AdditionalData?.Any() is true && (Model.AdditionalData.ContainsKey("Cart") || Model.AdditionalData.ContainsKey("Subtotal") || Model.AdditionalData.ContainsKey("Total")))
+                                        {
+                                            <tbody>
+                                                @if (Model.AdditionalData.ContainsKey("Cart"))
+                                                {
+                                                    @foreach (var (key, value) in (Dictionary<string, object>)Model.AdditionalData["Cart"])
+                                                    {
+                                                        <tr>
+                                                            <td class="fw-normal text-secondary">@key</td>
+                                                            <td class="text-end">@value</td>
+                                                        </tr>
+                                                    }
+                                                }
+                                                @if (Model.AdditionalData.ContainsKey("Subtotal"))
+                                                {
+                                                    <tr>
+                                                        <td class="fw-normal text-secondary">Subtotal</td>
+                                                        <td class="text-end">@Model.AdditionalData["Subtotal"]</td>
+                                                    </tr>
+                                                }
+                                                @if (Model.AdditionalData.ContainsKey("Discount"))
+                                                {
+                                                    <tr>
+                                                        <td class="fw-normal text-secondary">Discount</td>
+                                                        <td class="text-end">@Model.AdditionalData["Discount"]</td>
+                                                    </tr>
+                                                }
+                                                @if (Model.AdditionalData.ContainsKey("Tip"))
+                                                {
+                                                    <tr>
+                                                        <td class="fw-normal text-secondary">Tip</td>
+                                                        <td class="text-end">@Model.AdditionalData["Tip"]</td>
+                                                    </tr>
+                                                }
+                                                @if (Model.AdditionalData.ContainsKey("Total"))
+                                                {
+                                                    <tr>
+                                                        <td class="fw-normal text-secondary">Total</td>
+                                                        <td class="text-end">@Model.AdditionalData["Total"]</td>
+                                                    </tr>
+                                                }
+                                            </tbody>
+                                        }
+                                        else
+                                        {
+                                            <tr>
+                                                <td class="fw-normal text-nowrap text-secondary">Paid</td>
+                                                <td class="text-end">@DisplayFormatter.Currency(Model.Amount, Model.Currency, DisplayFormatter.CurrencyFormat.Symbol)</td>
+                                            </tr>
+                                        }
                                         @if (Model.Payments?.Any() is true)
                                         {
                                             @for (var i = 0; i < Model.Payments.Count; i++)
@@ -163,42 +208,7 @@
                                             }
                                         }
                                     </tbody>
-                                    @if (Model.AdditionalData?.Any() is true && (Model.AdditionalData.ContainsKey("Cart") || Model.AdditionalData.ContainsKey("Subtotal")))
-                                    {
-                                        <tbody>
-                                            @if (Model.AdditionalData.ContainsKey("Cart"))
-                                            {
-                                                @foreach (var (key, value) in (Dictionary<string, object>)Model.AdditionalData["Cart"])
-                                                {
-                                                    <tr>
-                                                        <td class="fw-normal text-secondary">@key</td>
-                                                        <td class="text-end">@value</td>
-                                                    </tr>
-                                                }
-                                            }
-                                            @if (Model.AdditionalData.ContainsKey("Subtotal"))
-                                            {
-                                                <tr>
-                                                    <td class="fw-normal text-secondary">Subtotal</td>
-                                                    <td class="text-end">@Model.AdditionalData["Subtotal"]</td>
-                                                </tr>
-                                            }
-                                            @if (Model.AdditionalData.ContainsKey("Discount"))
-                                            {
-                                                <tr>
-                                                    <td class="fw-normal text-secondary">Discount</td>
-                                                    <td class="text-end">@Model.AdditionalData["Discount"]</td>
-                                                </tr>
-                                            }
-                                            @if (Model.AdditionalData.ContainsKey("Tip"))
-                                            {
-                                                <tr>
-                                                    <td class="fw-normal text-secondary">Tip</td>
-                                                    <td class="text-end">@Model.AdditionalData["Tip"]</td>
-                                                </tr>
-                                            }
-                                        </tbody>
-                                    }
+                                    
                                     <tfoot>
                                         <tr>
                                             <th class="fw-normal text-secondary"></th>

--- a/BTCPayServer/Views/UIInvoice/InvoiceReceiptPrint.cshtml
+++ b/BTCPayServer/Views/UIInvoice/InvoiceReceiptPrint.cshtml
@@ -180,7 +180,7 @@
                                                 }
                                                 <tr>
                                                     <td class="fw-normal text-nowrap text-secondary">@(Model.Payments.Count == 1 ? "Paid" : "")</td>
-                                                    <td class="text-end">@payment.AmountFormatted @payment.PaymentMethod</td>
+                                                    <td class="text-end">@payment.AmountFormatted</td>
                                                 </tr>
                                                 <tr>
                                                     <td class="fw-normal text-nowrap text-secondary"></td>
@@ -190,7 +190,6 @@
                                                     <td class="fw-normal text-nowrap text-secondary">Rate</td>
                                                     <td class="text-end">@payment.RateFormatted</td>
                                                 </tr>
-
                                                 @if (!string.IsNullOrEmpty(payment.Destination))
                                                 {
                                                     <tr>

--- a/BTCPayServer/Views/UIInvoice/InvoiceReceiptPrint.cshtml
+++ b/BTCPayServer/Views/UIInvoice/InvoiceReceiptPrint.cshtml
@@ -173,11 +173,11 @@
                                                     <tr>
                                                         <td colspan="2" class="fw-normal text-nowrap text-secondary">Payment @(i + 1)</td>
                                                     </tr>
+                                                    <tr>
+                                                        <td class="fw-normal text-nowrap text-secondary">Received</td>
+                                                        <td>@payment.ReceivedDate.ToBrowserDate()</td>
+                                                    </tr>
                                                 }
-                                                <tr>
-                                                    <td class="fw-normal text-nowrap text-secondary">Received</td>
-                                                    <td>@payment.ReceivedDate.ToBrowserDate()</td>
-                                                </tr>
                                                 <tr>
                                                     <td class="fw-normal text-nowrap text-secondary"></td>
                                                     <td class="text-end">@payment.AmountFormatted @payment.PaymentMethod</td>

--- a/BTCPayServer/Views/UIInvoice/InvoiceReceiptPrint.cshtml
+++ b/BTCPayServer/Views/UIInvoice/InvoiceReceiptPrint.cshtml
@@ -135,15 +135,15 @@
                                                 </tr>
                                                 <tr>
                                                     <td class="fw-normal text-nowrap text-secondary"></td>
-                                                    <td colspan="2">@payment.AmountFormatted @payment.PaymentMethod</td>
+                                                    <td>@payment.AmountFormatted @payment.PaymentMethod</td>
                                                 </tr>
                                                 <tr>
                                                     <td class="fw-normal text-nowrap text-secondary"></td>
-                                                    <td colspan="2">@payment.PaidFormatted</td>
+                                                    <td>@payment.PaidFormatted</td>
                                                 </tr>
                                                 <tr>
                                                     <td class="fw-normal text-nowrap text-secondary">Rate</td>
-                                                    <td colspan="2">@payment.RateFormatted</td>
+                                                    <td>@payment.RateFormatted</td>
                                                 </tr>
 
                                                 @if (!string.IsNullOrEmpty(payment.Destination))

--- a/BTCPayServer/Views/UIInvoice/InvoiceReceiptPrint.cshtml
+++ b/BTCPayServer/Views/UIInvoice/InvoiceReceiptPrint.cshtml
@@ -179,7 +179,7 @@
                                                     </tr>
                                                 }
                                                 <tr>
-                                                    <td class="fw-normal text-nowrap text-secondary"></td>
+                                                    <td class="fw-normal text-nowrap text-secondary">@(Model.Payments.Count == 1 ? "Paid" : "")</td>
                                                     <td class="text-end">@payment.AmountFormatted @payment.PaymentMethod</td>
                                                 </tr>
                                                 <tr>
@@ -195,14 +195,14 @@
                                                 {
                                                     <tr>
                                                         <td class="fw-normal text-nowrap text-secondary">Destination</td>
-                                                        <td style="word-break:break-all">@payment.Destination</td>
+                                                        <td class="text-break">@payment.Destination</td>
                                                     </tr>
                                                 }
                                                 @if (!string.IsNullOrEmpty(payment.PaymentProof))
                                                 {
                                                     <tr>
                                                         <td class="fw-normal text-nowrap text-secondary">Pay Proof</td>
-                                                        <td style="word-break:break-all">@payment.PaymentProof</td>
+                                                        <td class="text-break">@payment.PaymentProof</td>
                                                     </tr>
                                                 }
                                             }

--- a/BTCPayServer/Views/UIInvoice/InvoiceReceiptPrint.cshtml
+++ b/BTCPayServer/Views/UIInvoice/InvoiceReceiptPrint.cshtml
@@ -120,13 +120,15 @@
 
                                         @if (Model.Payments?.Any() is true)
                                         {
-                                            @for (int i = 0; i < Model.Payments.Count; i++)
+                                            @for (var i = 0; i < Model.Payments.Count; i++)
                                             {
                                                 var payment = Model.Payments[i];
-                                                <tr>
-                                                    <td colspan="2" class="fw-normal text-nowrap text-secondary">Payment @(i + 1)</td>
-
-                                                </tr>
+                                                @if (Model.Payments.Count > 1)
+                                                {
+                                                    <tr>
+                                                        <td colspan="2" class="fw-normal text-nowrap text-secondary">Payment @(i + 1)</td>
+                                                    </tr>
+                                                }
                                                 <tr>
                                                     <td class="fw-normal text-nowrap text-secondary">Received</td>
                                                     <td>@payment.ReceivedDate.ToBrowserDate()</td>

--- a/BTCPayServer/Views/UIPaymentRequest/ViewPaymentRequest.cshtml
+++ b/BTCPayServer/Views/UIPaymentRequest/ViewPaymentRequest.cshtml
@@ -299,7 +299,7 @@
                                                 <tr>
                                                     <td class="text-break"><vc:truncate-center text="@payment.Id" link="@payment.Link" padding="7" classes="truncate-center-id" /></td>
                                                     <td class="amount-col">@payment.PaidFormatted</td>
-                                                    <td class="text-end text-nowrap">@payment.AmountFormatted @payment.PaymentMethod</td>
+                                                    <td class="text-end text-nowrap">@payment.AmountFormatted</td>
                                                 </tr>
                                             }
                                         }


### PR DESCRIPTION
Started as I noticed an additional `</div>`, which leads to this problem fixed in eb7c92fa74f484867f266fdfce3f0ee2a7ff2138:

![before](https://github.com/btcpayserver/btcpayserver/assets/886/d3636584-062e-481e-b9bb-e25913623dba)
 
While I was at it, I also did more modifications, which might help you @rockstardev and it closes #5498 by re-adding the POS data if present.

![grafik](https://github.com/btcpayserver/btcpayserver/assets/886/bb696f54-38f4-4458-a27c-db29708baab9)
