### PR TITLE
NFC improvements

### DIFF
--- a/BTCPayServer/Views/Shared/Bitcoin/BitcoinLikeMethodCheckout-v2.cshtml
+++ b/BTCPayServer/Views/Shared/Bitcoin/BitcoinLikeMethodCheckout-v2.cshtml
@@ -32,7 +32,7 @@
 
 <script>
     Vue.component('BitcoinLikeMethodCheckout', {
-        props: ["model"],
+        props: ['model', 'nfcSupported', 'nfcScanning'],
         template: "#bitcoin-method-checkout-template",
         components: {
             qrcode: VueQrcode

--- a/BTCPayServer/Views/Shared/Bitcoin/BitcoinLikeMethodCheckout-v2.cshtml
+++ b/BTCPayServer/Views/Shared/Bitcoin/BitcoinLikeMethodCheckout-v2.cshtml
@@ -32,7 +32,7 @@
 
 <script>
     Vue.component('BitcoinLikeMethodCheckout', {
-        props: ['model', 'nfcSupported', 'nfcScanning'],
+        props: ['model', 'nfcSupported', 'nfcScanning', 'nfcErrorMessage'],
         template: "#bitcoin-method-checkout-template",
         components: {
             qrcode: VueQrcode

--- a/BTCPayServer/Views/Shared/Bitcoin/BitcoinLikeMethodCheckout.cshtml
+++ b/BTCPayServer/Views/Shared/Bitcoin/BitcoinLikeMethodCheckout.cshtml
@@ -79,7 +79,7 @@
 <script type="text/javascript">
     Vue.component('BitcoinLikeMethodCheckout',
         {
-            props: ['srvModel', 'nfcSupported', 'nfcScanning'],
+            props: ['srvModel', 'nfcSupported', 'nfcScanning', 'nfcErrorMessage'],
             template: "#bitcoin-method-checkout-template",
             components: {
                 qrcode: VueQrcode
@@ -107,7 +107,7 @@
     });
 
     Vue.component('BitcoinLikeMethodCheckoutHeader', {
-        props: ['srvModel', 'nfcSupported', 'nfcScanning'],
+        props: ['srvModel', 'nfcSupported', 'nfcScanning', 'nfcErrorMessage'],
         template: "#bitcoin-method-checkout-header-template",
         data: function() {
             return {

--- a/BTCPayServer/Views/Shared/Bitcoin/BitcoinLikeMethodCheckout.cshtml
+++ b/BTCPayServer/Views/Shared/Bitcoin/BitcoinLikeMethodCheckout.cshtml
@@ -79,7 +79,7 @@
 <script type="text/javascript">
     Vue.component('BitcoinLikeMethodCheckout',
         {
-            props: ["srvModel"],
+            props: ['srvModel', 'nfcSupported', 'nfcScanning'],
             template: "#bitcoin-method-checkout-template",
             components: {
                 qrcode: VueQrcode
@@ -107,7 +107,7 @@
     });
 
     Vue.component('BitcoinLikeMethodCheckoutHeader', {
-        props: ["srvModel"],
+        props: ['srvModel', 'nfcSupported', 'nfcScanning'],
         template: "#bitcoin-method-checkout-header-template",
         data: function() {
             return {

--- a/BTCPayServer/Views/Shared/Lightning/LightningLikeMethodCheckout-v2.cshtml
+++ b/BTCPayServer/Views/Shared/Lightning/LightningLikeMethodCheckout-v2.cshtml
@@ -24,7 +24,7 @@
 
 <script>
     Vue.component('LightningLikeMethodCheckout', {
-        props: ['model', 'nfcSupported', 'nfcScanning'],
+        props: ['model', 'nfcSupported', 'nfcScanning', 'nfcErrorMessage'],
         template: "#lightning-method-checkout-template",
         components: {
             qrcode: VueQrcode

--- a/BTCPayServer/Views/Shared/Lightning/LightningLikeMethodCheckout-v2.cshtml
+++ b/BTCPayServer/Views/Shared/Lightning/LightningLikeMethodCheckout-v2.cshtml
@@ -24,7 +24,7 @@
 
 <script>
     Vue.component('LightningLikeMethodCheckout', {
-        props: ["model"],
+        props: ['model', 'nfcSupported', 'nfcScanning'],
         template: "#lightning-method-checkout-template",
         components: {
             qrcode: VueQrcode

--- a/BTCPayServer/Views/Shared/Lightning/LightningLikeMethodCheckout.cshtml
+++ b/BTCPayServer/Views/Shared/Lightning/LightningLikeMethodCheckout.cshtml
@@ -80,7 +80,7 @@
 <script type="text/javascript">
     Vue.component('LightningLikeMethodCheckout',
         {
-            props: ["srvModel"],
+            props: ['srvModel', 'nfcSupported', 'nfcScanning'],
             template: "#lightning-method-checkout-template",
             components: {
                 qrcode: VueQrcode

--- a/BTCPayServer/Views/Shared/Lightning/LightningLikeMethodCheckout.cshtml
+++ b/BTCPayServer/Views/Shared/Lightning/LightningLikeMethodCheckout.cshtml
@@ -80,7 +80,7 @@
 <script type="text/javascript">
     Vue.component('LightningLikeMethodCheckout',
         {
-            props: ['srvModel', 'nfcSupported', 'nfcScanning'],
+            props: ['srvModel', 'nfcSupported', 'nfcScanning', 'nfcErrorMessage'],
             template: "#lightning-method-checkout-template",
             components: {
                 qrcode: VueQrcode

--- a/BTCPayServer/Views/Shared/NFC/CheckoutEnd.cshtml
+++ b/BTCPayServer/Views/Shared/NFC/CheckoutEnd.cshtml
@@ -1,5 +1,6 @@
 <template id="lnurl-withdraw-template">
     <div v-if="display" class="mt-4">
+        <div v-if="nfcErrorMessage" class="alert alert-danger" v-text="nfcErrorMessage"></div>
         <template v-if="isV2">
             <button class="btn btn-secondary rounded-pill w-100" type="button" id="PayByNFC"
                     :disabled="nfcScanning || submitting" v-on:click="handleClick">{{btnText}}</button>
@@ -24,7 +25,8 @@ Vue.component("lnurl-withdraw-checkout", {
         model: Object,
         isV2: Boolean,
         nfcSupported: Boolean,
-        nfcScanning: Boolean
+        nfcScanning: Boolean,
+        nfcErrorMessage: String
     },
     computed: {
         display () {

--- a/BTCPayServer/Views/Shared/NFC/CheckoutEnd.cshtml
+++ b/BTCPayServer/Views/Shared/NFC/CheckoutEnd.cshtml
@@ -1,48 +1,30 @@
-@using BTCPayServer.Abstractions.Extensions
-@using BTCPayServer.Abstractions.TagHelpers
 <template id="lnurl-withdraw-template">
-    <template v-if="display">
-        <div class="mt-4">
-            <p id="CheatSuccessMessage" class="alert alert-success text-break" v-if="successMessage" v-text="successMessage"></p>
-            <p id="CheatErrorMessage" class="alert alert-danger text-break" v-if="errorMessage" v-text="errorMessage"></p>
-            <template v-if="isV2">
-                <button class="btn btn-secondary rounded-pill w-100" type="button" id="PayByNFC"
-                    :disabled="scanning || submitting" v-on:click="handleClick">{{btnText}}</button>
-            </template>
-            <bp-loading-button v-else>
-                <button class="action-button" style="margin: 0 45px;width:calc(100% - 90px) !important" :disabled="scanning || submitting" v-on:click="handleClick" id="PayByNFC"
-                        :class="{ 'loading': scanning || submitting, 'action-button': supported, 'btn btn-text w-100': !supported  }">
+    <div v-if="display" class="mt-4">
+        <template v-if="isV2">
+            <button class="btn btn-secondary rounded-pill w-100" type="button" id="PayByNFC"
+                    :disabled="nfcScanning || submitting" v-on:click="handleClick">{{btnText}}</button>
+        </template>
+        <template v-else>
+            <bp-loading-button>
+                <button class="action-button" style="margin: 0 45px;width:calc(100% - 90px) !important" :disabled="nfcScanning || submitting" v-on:click="handleClick" id="PayByNFC"
+                        :class="{ 'action-button': nfcSupported, 'btn btn-text w-100': !nfcSupported  }">
                     <span class="button-text">{{btnText}}</span>
                     <div class="loader-wrapper">
                         @await Html.PartialAsync("~/Views/UIInvoice/Checkout-Spinner.cshtml")
                     </div>
                 </button>
             </bp-loading-button>
-        </div>
-    </template>
+        </template>
+    </div>
 </template>
 <script>
-class NDEFReaderWrapper {
-    constructor() {
-        this.onreading = null;
-        this.onreadingerror = null;
-    }
-
-    async scan(opts) {
-        if (opts && opts.signal){
-            opts.signal.addEventListener('abort', () => {
-                window.parent.postMessage('nfc:abort', '*');
-            });
-        }
-        window.parent.postMessage('nfc:startScan', '*');
-    }
-}
-
 Vue.component("lnurl-withdraw-checkout", {
     template: "#lnurl-withdraw-template",
     props: {
         model: Object,
-        isV2: Boolean
+        isV2: Boolean,
+        nfcSupported: Boolean,
+        nfcScanning: Boolean
     },
     computed: {
         display () {
@@ -62,16 +44,16 @@ Vue.component("lnurl-withdraw-checkout", {
                 (activePaymentMethodId === 'BTC' && isUnified && lnurlwAvailable) ||
                 // Lightning with LNURL available
                 (activePaymentMethodId === 'BTC_LightningLike' && lnurlwAvailable))
-            return isAvailable && (this.supported || this.testFallback)
+            return isAvailable && (this.nfcSupported || this.testFallback)
         },
         testFallback () {
-            return !this.supported && window.location.search.match('lnurlwtest=(1|true)')
+            return !this.nfcSupported && window.location.search.match('lnurlwtest=(1|true)')
         },
         btnText () {
-            if (this.supported) {
+            if (this.nfcSupported) {
                 if (this.submitting) {
                     return this.isV2 ? this.$t('submitting_nfc') : 'Submitting NFC …'
-                } else if (this.scanning) {
+                } else if (this.nfcScanning) {
                     return this.isV2 ? this.$t('scanning_nfc') : 'Scanning NFC …'
                 } else {
                     return this.isV2 ? this.$t('pay_by_nfc') : 'Pay by NFC'
@@ -84,35 +66,20 @@ Vue.component("lnurl-withdraw-checkout", {
     data () {
         return {
             url: @Safe.Json(Context.Request.GetAbsoluteUri(Url.Action("SubmitLNURLWithdrawForInvoice", "NFC"))),
-            supported: 'NDEFReader' in window,
-            scanning: false,
-            submitting: false,
-            permissionGranted: false,
-            readerAbortController: null,
             amount: 0,
-            successMessage: null,
-            errorMessage: null
+            submitting: false
         }
     },
-    async mounted () {
-        if (!this.supported) return;
-        try {
-            this.permissionGranted = navigator.permissions &&
-                (await navigator.permissions.query({ name: 'nfc' })).state === 'granted'
-        } catch (e) {}
-        if (this.permissionGranted) {
-            this.startScan()
-        }
+    beforeMount () {
+        this.$root.$on('read-nfc-data', this.sendData)
     },
     beforeDestroy () {
-        if (this.readerAbortController) {
-            this.readerAbortController.abort()
-        }
+        this.$root.$off('read-nfc-data')
     },
     methods: {
         async handleClick () {
-            if (this.supported) {
-                this.startScan()
+            if (this.nfcSupported) {
+                this.$emit('start-nfc-scan')
             } else {
                 if (this.model.isUnsetTopUp) {
                     this.handleUnsetTopUp()
@@ -132,94 +99,29 @@ Vue.component("lnurl-withdraw-checkout", {
                 try {
                     this.amount = parseInt(amountStr)
                 } catch {
-                    alert("Please provide a valid number amount in sats");
+                    alert("Please provide a valid number amount in sats")
                 }
             }
             return false
         },
-        async startScan () {
-            if (this.scanning || this.submitting) {
-                return;
-            }
-            if (this.model.isUnsetTopUp) {
-                this.handleUnsetTopUp()
-                if (!this.amount) {
-                    return;
-                }
-            }
-            this.submitting = false;
-            this.scanning = true;
-            try {
-                const inModal = window.self !== window.top;
-                const ndef = inModal ? new NDEFReaderWrapper() : new NDEFReader();
-                this.readerAbortController = new AbortController()
-                this.readerAbortController.signal.onabort = () => {
-                    this.scanning = false;
-                };
-                
-                await ndef.scan({ signal: this.readerAbortController.signal })
-
-                ndef.onreadingerror = () => this.reportNfcError('Could not read NFC tag')
-
-                ndef.onreading = async ({ message }) => {
-                    const record = message.records[0]
-                    const textDecoder = new TextDecoder('utf-8')
-                    const lnurl = textDecoder.decode(record.data)
-                    await this.sendData(lnurl)
-                }
-                
-                if (inModal) {
-                    // receive messages from iframe
-                    window.addEventListener('message', async event => {
-                        // deny messages from other origins
-                        if (event.origin !== window.location.origin) return
-                        
-                        const { action, data } = event.data
-                        switch (action) {
-                            case 'nfc:data':
-                                await this.sendData(data)
-                                break;
-                            case 'nfc:error':
-                                this.reportNfcError('Could not read NFC tag')
-                                break;
-                        }
-                    });
-                }
-                
-                // we came here, so the user must have allowed NFC access
-                this.permissionGranted = true;
-            } catch (error) {
-                this.reportNfcError(`NFC scan failed: ${error}`);
-            }
-        },
-        async sendData (lnurl) {
-            this.submitting = true;
-            this.successMessage = null;
-            this.errorMessage = null;
-            
-            if (this.isV2) this.$root.playSound('nfcRead');
+        async sendData (data) {
+            this.submitting = true
+            this.$emit('handle-nfc-data')
             
             // Post LNURL-Withdraw data to server
-            const body = JSON.stringify({ lnurl, invoiceId: this.model.invoiceId, amount: this.amount })
+            const body = JSON.stringify({ lnurl: data, invoiceId: this.model.invoiceId, amount: this.amount })
             const opts = { method: 'POST', headers: { 'Content-Type': 'application/json' }, body }
             const response = await fetch(this.url, opts)
             
             // Handle response
             try {
                 const result = await response.text()
-                if (response.ok) {
-                    this.successMessage = result;
-                } else {
-                    this.reportNfcError(result);
-                }
+                const action = response.ok ? 'handle-nfc-result' : 'handle-nfc-error'
+                this.$emit(action, result)
             } catch (error) {
-                this.reportNfcError(error);
+                this.$emit('handle-nfc-error', error)
             }
-            this.submitting = false;
-        },
-        reportNfcError(message) {
-            this.errorMessage = message;
-            if (this.isV2) this.$root.playSound('error');
+            this.submitting = false
         }
     }
 });

--- a/BTCPayServer/Views/Shared/NFC/CheckoutEnd.cshtml
+++ b/BTCPayServer/Views/Shared/NFC/CheckoutEnd.cshtml
@@ -1,5 +1,5 @@
 <template id="lnurl-withdraw-template">
-    <div v-if="display" class="mt-4">
+    <div v-if="display" class="mt-4" id="NFC">
         <div v-if="nfcErrorMessage" class="alert alert-danger" v-text="nfcErrorMessage"></div>
         <template v-if="isV2">
             <button class="btn btn-secondary rounded-pill w-100" type="button" id="PayByNFC"

--- a/BTCPayServer/Views/Shared/NFC/LNURLNFCPostContent-v2.cshtml
+++ b/BTCPayServer/Views/Shared/NFC/LNURLNFCPostContent-v2.cshtml
@@ -1,1 +1,1 @@
-﻿<lnurl-withdraw-checkout :model="model" :is-v2="true" :nfc-supported="nfcSupported" :nfc-scanning="nfcScanning" v-on="$listeners" />
+﻿<lnurl-withdraw-checkout :model="model" :is-v2="true" :nfc-supported="nfcSupported" :nfc-scanning="nfcScanning" :nfc-error-message="nfcErrorMessage" v-on="$listeners" />

--- a/BTCPayServer/Views/Shared/NFC/LNURLNFCPostContent-v2.cshtml
+++ b/BTCPayServer/Views/Shared/NFC/LNURLNFCPostContent-v2.cshtml
@@ -1,1 +1,1 @@
-﻿<lnurl-withdraw-checkout :model="model" :is-v2="true" />
+﻿<lnurl-withdraw-checkout :model="model" :is-v2="true" :nfc-supported="nfcSupported" :nfc-scanning="nfcScanning" v-on="$listeners" />

--- a/BTCPayServer/Views/Shared/NFC/LNURLNFCPostContent.cshtml
+++ b/BTCPayServer/Views/Shared/NFC/LNURLNFCPostContent.cshtml
@@ -1,1 +1,1 @@
-﻿<lnurl-withdraw-checkout :model="srvModel" :nfc-supported="nfcSupported" :nfc-scanning="nfcScanning" v-on="$listeners" />
+﻿<lnurl-withdraw-checkout :model="srvModel" :nfc-supported="nfcSupported" :nfc-scanning="nfcScanning" :nfc-error-message="nfcErrorMessage" v-on="$listeners" />

--- a/BTCPayServer/Views/Shared/NFC/LNURLNFCPostContent.cshtml
+++ b/BTCPayServer/Views/Shared/NFC/LNURLNFCPostContent.cshtml
@@ -1,1 +1,1 @@
-﻿<lnurl-withdraw-checkout :model="srvModel" />
+﻿<lnurl-withdraw-checkout :model="srvModel" :nfc-supported="nfcSupported" :nfc-scanning="nfcScanning" v-on="$listeners" />

--- a/BTCPayServer/Views/UIInvoice/Checkout-Body.cshtml
+++ b/BTCPayServer/Views/UIInvoice/Checkout-Body.cshtml
@@ -183,12 +183,15 @@
         </form>
     </div>
     <div v-if="showPaymentUI">
+        <div v-if="(nfc.successMessage || nfc.errorMessage)" class="alert mx-1" :class="{'alert-success': !!nfc.successMessage, 'alert-danger': !!nfc.errorMessage }" v-text="nfc.successMessage || nfc.errorMessage"></div>
         <component v-if="srvModel.uiSettings && srvModel.uiSettings.checkoutBodyVueComponentName && srvModel.activated"
-                   v-bind:srv-model="srvModel"
-                   v-bind:is="srvModel.uiSettings.checkoutBodyVueComponentName">
-        </component>
+                   :is="srvModel.uiSettings.checkoutBodyVueComponentName" :srv-model="srvModel"
+                   :nfc-supported="nfc.supported" :nfc-scanning="nfc.scanning"
+                   v-on:start-nfc-scan="startNFCScan"
+                   v-on:handle-nfc-data="handleNFCData"
+                   v-on:handle-nfc-error="handleNFCError"
+                   v-on:handle-nfc-result="handleNFCResult" />
     </div>
-
     <div class="bp-view" id="paid" v-bind:class="{ 'active': invoicePaid && !showEmailForm}">
         <div class="status-block">
             <div class="success-block">

--- a/BTCPayServer/Views/UIInvoice/Checkout-Body.cshtml
+++ b/BTCPayServer/Views/UIInvoice/Checkout-Body.cshtml
@@ -183,10 +183,12 @@
         </form>
     </div>
     <div v-if="showPaymentUI">
-        <div v-if="(nfc.successMessage || nfc.errorMessage)" class="alert mx-1" :class="{'alert-success': !!nfc.successMessage, 'alert-danger': !!nfc.errorMessage }" v-text="nfc.successMessage || nfc.errorMessage"></div>
         <component v-if="srvModel.uiSettings && srvModel.uiSettings.checkoutBodyVueComponentName && srvModel.activated"
-                   :is="srvModel.uiSettings.checkoutBodyVueComponentName" :srv-model="srvModel"
-                   :nfc-supported="nfc.supported" :nfc-scanning="nfc.scanning"
+                   :is="srvModel.uiSettings.checkoutBodyVueComponentName"
+                   :srv-model="srvModel"
+                   :nfc-scanning="nfc.scanning"
+                   :nfc-supported="nfc.supported"
+                   :nfc-error-message="nfc.errorMessage"
                    v-on:start-nfc-scan="startNFCScan"
                    v-on:handle-nfc-data="handleNFCData"
                    v-on:handle-nfc-error="handleNFCError"

--- a/BTCPayServer/Views/UIInvoice/Checkout.cshtml
+++ b/BTCPayServer/Views/UIInvoice/Checkout.cshtml
@@ -211,10 +211,9 @@
                 supported: 'NDEFReader' in window,
                 scanning: false,
                 submitting: false,
+                errorMessage: null,
                 permissionGranted: false,
-                readerAbortController: null,
-                successMessage: null,
-                errorMessage: null
+                readerAbortController: null
             }
         },
         computed: {

--- a/BTCPayServer/Views/UIInvoice/Checkout.cshtml
+++ b/BTCPayServer/Views/UIInvoice/Checkout.cshtml
@@ -206,7 +206,16 @@
             lineItemsExpanded: false,
             changingCurrencies: false,
             loading: true,
-            isModal: initialSrvModel.isModal
+            isModal: initialSrvModel.isModal,
+            nfc: {
+                supported: 'NDEFReader' in window,
+                scanning: false,
+                submitting: false,
+                permissionGranted: false,
+                readerAbortController: null,
+                successMessage: null,
+                errorMessage: null
+            }
         },
         computed: {
             expiringSoon: function(){
@@ -233,7 +242,7 @@
                     : null;
             }
         },
-        mounted: function(){
+        mounted: async function(){
             this.startProgressTimer();
             this.listenIn();
             this.onDataCallback(this.srvModel);
@@ -244,6 +253,14 @@
             jQuery("invoice").fadeOut(0).fadeIn(300);
             window.closePaymentMethodDialog = this.closePaymentMethodDialog.bind(this);
             this.loading = false;
+            if (this.nfc.supported) {
+                this.setupNFC();
+            }
+        },
+        beforeDestroy () {
+            if (this.nfc.readerAbortController) {
+                this.nfc.readerAbortController.abort()
+            }
         },
         methods: {
             onlyExpandLineItems: function() {
@@ -403,6 +420,71 @@
                 } else {
                     this.emailAddressInputInvalid = true;
                 }
+            },
+            async setupNFC () {
+                try {
+                    this.$set(this.nfc, 'permissionGranted', navigator.permissions && (await navigator.permissions.query({ name: 'nfc' })).state === 'granted');
+                } catch (e) {}
+                if (this.nfc.permissionGranted) {
+                    await this.startNFCScan();
+                }
+            },
+            async startNFCScan () {
+                if (this.nfc.scanning) return;
+                this.$set(this.nfc, 'scanning', true);
+                try {
+                    const inModal = window.self !== window.top;
+                    const ndef = inModal ? new NDEFReaderWrapper() : new NDEFReader();
+                    this.nfc.readerAbortController = new AbortController()
+                    this.nfc.readerAbortController.signal.onabort = () => {
+                        this.$set(this.nfc, 'scanning', false);
+                    };
+            
+                    await ndef.scan({ signal: this.nfc.readerAbortController.signal })
+                    ndef.onreadingerror = () => this.reportNfcError('Could not read NFC tag')
+                    ndef.onreading = async ({ message }) => {
+                        const record = message.records[0]
+                        const textDecoder = new TextDecoder('utf-8')
+                        const decoded = textDecoder.decode(record.data)
+                        this.$emit('read-nfc-data', decoded)
+                    }
+            
+                    if (inModal) {
+                        // receive messages from iframe
+                        window.addEventListener('message', async event => {
+                            // deny messages from other origins
+                            if (event.origin !== window.location.origin) return
+            
+                            const { action, data } = event.data
+                            switch (action) {
+                                case 'nfc:data':
+                                    this.$emit('read-nfc-data', data)
+                                    break;
+                                case 'nfc:error':
+                                    this.handleNFCError('Could not read NFC tag')
+                                    break;
+                            }
+                        });
+                    }
+            
+                    // we came here, so the user must have allowed NFC access
+                    this.$set(this.nfc, 'permissionGranted', true);
+                } catch (error) {
+                    this.handleNFCError(`NFC scan failed: ${error}`);
+                }
+            },
+            handleNFCData() { // child component reports it is handling the data
+                this.$set(this.nfc, 'errorMessage', null);
+                this.$set(this.nfc, 'successMessage', null);
+                this.$set(this.nfc, 'submitting', true);
+            },
+            handleNFCResult(message) { // child component reports result for handling the data
+                this.$set(this.nfc, 'submitting', false);
+                this.$set(this.nfc, 'successMessage', message);
+            },
+            handleNFCError(message) { // internal or via child component reporting failure of handling the data
+                this.$set(this.nfc, 'submitting', false);
+                this.$set(this.nfc, 'errorMessage', message);
             }
         }
     });

--- a/BTCPayServer/Views/UIInvoice/CheckoutV2.cshtml
+++ b/BTCPayServer/Views/UIInvoice/CheckoutV2.cshtml
@@ -110,7 +110,10 @@
                     </div>
                 }
                 <component v-if="paymentMethodComponent" :is="paymentMethodComponent"
-                           :model="srvModel" :nfc-supported="nfc.supported" :nfc-scanning="nfc.scanning"
+                           :model="srvModel"
+                           :nfc-scanning="nfc.scanning"
+                           :nfc-supported="nfc.supported"
+                           :nfc-error-message="nfc.errorMessage"
                            v-on:start-nfc-scan="startNFCScan"
                            v-on:handle-nfc-data="handleNFCData"
                            v-on:handle-nfc-error="handleNFCError"
@@ -240,11 +243,6 @@
             </a>
             <select asp-for="DefaultLang" asp-items="@LangService.GetLanguageSelectListItems()" class="form-select" v-on:change="changeLanguage"></select>
         </footer>
-        <div class="toast-container">
-            <div class="toast fade align-items-center border-0" :class="{'text-bg-success': !!nfc.successMessage, 'text-bg-danger': !!nfc.errorMessage, 'show': (nfc.successMessage || nfc.errorMessage) }" role="alert" aria-live="assertive" aria-atomic="true">
-                <div class="toast-body text-break" v-text="nfc.successMessage || nfc.errorMessage"></div>
-            </div>
-        </div>
     </div>
     <noscript>
         <div class="p-5 text-center">

--- a/BTCPayServer/Views/UIInvoice/CheckoutV2.cshtml
+++ b/BTCPayServer/Views/UIInvoice/CheckoutV2.cshtml
@@ -109,7 +109,12 @@
                         </div>
                     </div>
                 }
-                <component v-if="paymentMethodComponent" :is="paymentMethodComponent" :model="srvModel" />
+                <component v-if="paymentMethodComponent" :is="paymentMethodComponent"
+                           :model="srvModel" :nfc-supported="nfc.supported" :nfc-scanning="nfc.scanning"
+                           v-on:start-nfc-scan="startNFCScan"
+                           v-on:handle-nfc-data="handleNFCData"
+                           v-on:handle-nfc-error="handleNFCError"
+                           v-on:handle-nfc-result="handleNFCResult" />
             </section>
             <section id="result" v-else>
                 <div v-if="isProcessing" id="processing" key="processing">
@@ -235,6 +240,11 @@
             </a>
             <select asp-for="DefaultLang" asp-items="@LangService.GetLanguageSelectListItems()" class="form-select" v-on:change="changeLanguage"></select>
         </footer>
+        <div class="toast-container">
+            <div class="toast fade align-items-center border-0" :class="{'text-bg-success': !!nfc.successMessage, 'text-bg-danger': !!nfc.errorMessage, 'show': (nfc.successMessage || nfc.errorMessage) }" role="alert" aria-live="assertive" aria-atomic="true">
+                <div class="toast-body text-break" v-text="nfc.successMessage || nfc.errorMessage"></div>
+            </div>
+        </div>
     </div>
     <noscript>
         <div class="p-5 text-center">

--- a/BTCPayServer/wwwroot/checkout-v2/checkout.css
+++ b/BTCPayServer/wwwroot/checkout-v2/checkout.css
@@ -175,3 +175,10 @@ section dl > div dd {
 .payment-box .plugins > .payment {
     margin-top: var(--btcpay-space-l);
 }
+
+@media (max-width: 400px) {
+    /* Pull it up if there's no store header */
+    #Checkout-v2 > main.tile:first-child {
+        margin-top: calc(var(--wrap-padding-vertical) * -1);
+    }
+}

--- a/BTCPayServer/wwwroot/checkout-v2/checkout.css
+++ b/BTCPayServer/wwwroot/checkout-v2/checkout.css
@@ -74,21 +74,6 @@ section dl > div dd {
     word-break: break-word;
     max-width: 62.5%;
 }
-.toast-container {
-    position: fixed;
-    top: 0;
-    left: 50%;
-    transform: translateX(-50%);
-    width: calc(var(--wrap-max-width) - 3rem);
-    min-width: 256px;
-    margin-top: var(--wrap-padding-vertical);
-    padding: 0 1rem;
-}
-.toast-container .toast {
-    --btcpay-toast-max-width: 100%;
-    --btcpay-bg-opacity: .95;
-    text-align: center;
-}
 .info {
     color: var(--btcpay-neutral-700);
     background-color: var(--btcpay-body-bg);

--- a/BTCPayServer/wwwroot/checkout-v2/checkout.css
+++ b/BTCPayServer/wwwroot/checkout-v2/checkout.css
@@ -74,6 +74,21 @@ section dl > div dd {
     word-break: break-word;
     max-width: 62.5%;
 }
+.toast-container {
+    position: fixed;
+    top: 0;
+    left: 50%;
+    transform: translateX(-50%);
+    width: calc(var(--wrap-max-width) - 3rem);
+    min-width: 256px;
+    margin-top: var(--wrap-padding-vertical);
+    padding: 0 1rem;
+}
+.toast-container .toast {
+    --btcpay-toast-max-width: 100%;
+    --btcpay-bg-opacity: .95;
+    text-align: center;
+}
 .info {
     color: var(--btcpay-neutral-700);
     background-color: var(--btcpay-body-bg);

--- a/BTCPayServer/wwwroot/checkout-v2/checkout.js
+++ b/BTCPayServer/wwwroot/checkout-v2/checkout.js
@@ -441,6 +441,10 @@ function initApp() {
                 this.playSound('error');
                 this.$set(this.nfc, 'submitting', false);
                 this.$set(this.nfc, 'errorMessage', message);
+                const $nfc = document.getElementById('NFC');
+                if ($nfc) {
+                    $nfc.scrollIntoView({ block: 'end', inline: 'center', behavior: 'smooth' });
+                }
             }
         }
     });

--- a/BTCPayServer/wwwroot/checkout-v2/checkout.js
+++ b/BTCPayServer/wwwroot/checkout-v2/checkout.js
@@ -101,10 +101,9 @@ function initApp() {
                     supported: 'NDEFReader' in window,
                     scanning: false,
                     submitting: false,
+                    errorMessage: null,
                     permissionGranted: false,
-                    readerAbortController: null,
-                    successMessage: null,
-                    errorMessage: null
+                    readerAbortController: null
                 }
             }
         },
@@ -432,13 +431,11 @@ function initApp() {
             },
             handleNFCData() { // child component reports it is handling the data
                 this.playSound('nfcRead');
-                this.$set(this.nfc, 'errorMessage', null);
-                this.$set(this.nfc, 'successMessage', null);
                 this.$set(this.nfc, 'submitting', true);
+                this.$set(this.nfc, 'errorMessage', null);
             },
-            handleNFCResult(message) { // child component reports result for handling the data
+            handleNFCResult() { // child component reports result for handling the data
                 this.$set(this.nfc, 'submitting', false);
-                this.$set(this.nfc, 'successMessage', message);
             },
             handleNFCError(message) { // internal or via child component reporting failure of handling the data
                 this.playSound('error');

--- a/BTCPayServer/wwwroot/checkout/js/checkout.js
+++ b/BTCPayServer/wwwroot/checkout/js/checkout.js
@@ -1,3 +1,19 @@
+class NDEFReaderWrapper {
+    constructor() {
+        this.onreading = null;
+        this.onreadingerror = null;
+    }
+
+    async scan(opts) {
+        if (opts && opts.signal){
+            opts.signal.addEventListener('abort', () => {
+                window.parent.postMessage('nfc:abort', '*');
+            });
+        }
+        window.parent.postMessage('nfc:startScan', '*');
+    }
+}
+
 delegate('click', '.payment-method', e => {
     const el = e.target.closest('.payment-method')
     closePaymentMethodDialog(el.dataset.paymentMethod);


### PR DESCRIPTION
Moves most of the NFC code out of the LNURL component and on Vue app level, so that 

- it keeps the scanning active even on the result page, so that the native scanning functionality does not take over in case the card is held too long on the scanner. Closes #5507
- it can provide more prominent visual feedback on NFC operations. Closes #5508

Downside: I had to duplicate that code in V1 and V2, as the shared partial/component isn't used anymore. However, this can also be seen as a good thing moving forward, as it got rid of some plase where we were using a check f the componnet is used in V2 context.

![v1](https://github.com/btcpayserver/btcpayserver/assets/886/5fee1cf2-1cf3-4690-9b5a-dccb9fcb158a)
 
GitHub does not allow me to upload the video I recorded for v2, but @rockstardev can test and see if it works the way he envisioned it. 