### PR TITLE
Greenfield: Remove unused checkout type setting from POS

### DIFF
--- a/BTCPayServer.Client/Models/CreateAppRequest.cs
+++ b/BTCPayServer.Client/Models/CreateAppRequest.cs
@@ -42,7 +42,6 @@ namespace BTCPayServer.Client.Models
         public bool? Archived { get; set; } = null;
         public string FormId { get; set; } = null;
         public string EmbeddedCSS { get; set; } = null;
-        public CheckoutType? CheckoutType { get; set; } = null;
     }
 
     public enum CrowdfundResetEvery

--- a/BTCPayServer/Controllers/GreenField/GreenfieldAppsController.cs
+++ b/BTCPayServer/Controllers/GreenField/GreenfieldAppsController.cs
@@ -291,8 +291,7 @@ namespace BTCPayServer.Controllers.Greenfield
                 EmbeddedCSS = request.EmbeddedCSS,
                 RedirectAutomatically = request.RedirectAutomatically,
                 RequiresRefundEmail = BoolToRequiresRefundEmail(request.RequiresRefundEmail) ?? RequiresRefundEmail.InheritFromStore,
-                FormId = request.FormId,
-                CheckoutType = request.CheckoutType ?? CheckoutType.V1
+                FormId = request.FormId
             };
         }
 

--- a/BTCPayServer/Services/Apps/PointOfSaleSettings.cs
+++ b/BTCPayServer/Services/Apps/PointOfSaleSettings.cs
@@ -113,6 +113,5 @@ namespace BTCPayServer.Services.Apps
         public string NotificationUrl { get; set; }
         public string RedirectUrl { get; set; }
         public bool? RedirectAutomatically { get; set; }
-        public CheckoutType CheckoutType { get; internal set; }
     }
 }

--- a/BTCPayServer/wwwroot/swagger/v1/swagger.template.apps.json
+++ b/BTCPayServer/wwwroot/swagger/v1/swagger.template.apps.json
@@ -903,9 +903,6 @@
                         "description": "Whether refund email is required when paying the invoice. Defaults to what is set in the store settings",
                         "nullable": true
                     },
-                    "checkoutType": {
-                        "$ref": "#/components/schemas/CheckoutType"
-                    },
                     "formId": {
                         "type": "string",
                         "description": "Form ID to request customer data",


### PR DESCRIPTION
Cam across this while browsing the API docs: The checkout type setting isn't used for the POS, so we should simply remove it as this is configured on the store-level.