### PR TITLE
Plugins: Improve crash detection on startup and hint at disabled plugins

### DIFF
--- a/BTCPayServer/Components/MainNav/Default.cshtml
+++ b/BTCPayServer/Components/MainNav/Default.cshtml
@@ -7,6 +7,7 @@
 @using BTCPayServer.Client
 @using BTCPayServer.Components.ThemeSwitch
 @using BTCPayServer.Components.UIExtensionPoint
+@using BTCPayServer.Plugins
 @using BTCPayServer.Services
 @using BTCPayServer.Views.Apps
 @using BTCPayServer.Views.CustodianAccounts
@@ -15,6 +16,7 @@
 @inject SignInManager<ApplicationUser> SignInManager
 @inject PoliciesSettings PoliciesSettings
 @inject ThemeSettings Theme
+@inject PluginService PluginService
 
 @model BTCPayServer.Components.MainNav.MainNavViewModel
 
@@ -185,7 +187,14 @@
                         <ul class="navbar-nav">
                             <li class="nav-item" permission="@Policies.CanModifyServerSettings">
                                 <a asp-area="" asp-controller="UIServer" asp-action="ListPlugins" class="nav-link @ViewData.IsActivePage(ServerNavPages.Plugins)" id="Nav-ManagePlugins">
-                                    <vc:icon symbol="manage-plugins"/>
+                                    @if (PluginService.GetDisabledPlugins().Any())
+                                    {
+                                        <span class="me-2 btcpay-status btcpay-status--disabled"></span>
+                                    }
+                                    else
+                                    {
+                                        <vc:icon symbol="manage-plugins" />
+                                    }
                                     <span>Manage Plugins</span>
                                 </a>
                             </li>

--- a/BTCPayServer/Program.cs
+++ b/BTCPayServer/Program.cs
@@ -28,11 +28,11 @@ namespace BTCPayServer
             ServicePointManager.DefaultConnectionLimit = 100;
             IWebHost host = null;
             var processor = new ConsoleLoggerProcessor();
-            CustomConsoleLogProvider loggerProvider = new CustomConsoleLogProvider(processor);
+            var loggerProvider = new CustomConsoleLogProvider(processor);
             using var loggerFactory = new LoggerFactory();
             loggerFactory.AddProvider(loggerProvider);
             var logger = loggerFactory.CreateLogger("Configuration");
-            Logs logs = new Logs();
+            var logs = new Logs();
             logs.Configure(loggerFactory);
             IConfiguration conf = null;
             try
@@ -44,8 +44,6 @@ namespace BTCPayServer
                 confBuilder.AddJsonFile("appsettings.dev.json", true, false);
 #endif
                 conf = confBuilder.Build();
-                if (conf == null)
-                    return;
 
                 var builder = new WebHostBuilder()
                     .UseKestrel()

--- a/BTCPayServer/Views/UIServer/ListPlugins.cshtml
+++ b/BTCPayServer/Views/UIServer/ListPlugins.cshtml
@@ -117,9 +117,25 @@
 {
     <div class="alert alert-danger mb-4 d-flex align-items-center justify-content-between">
         Some plugins were disabled due to fatal errors. They may be incompatible with this version of BTCPay Server.
-        <button class="btn btn-danger" data-bs-toggle="collapse" data-bs-target="#disabled-plugins">View disabled plugins</button>
+    </div>
+    <div class="mb-5">
+        <h3 class="mb-4">Disabled Plugins</h3>
+        <ul class="list-group list-group-flush d-inline-block">
+            @foreach (var d in Model.Disabled)
+            {
+                <li class="list-group-item px-0">
+                    <div class="d-flex flex-wrap align-items-center justify-content-between gap-3">
+                        <span>@d</span>
+                        <form asp-action="UnInstallPlugin" asp-route-plugin="@d">
+                            <button type="submit" class="btn btn-sm btn-outline-danger">Uninstall</button>
+                        </form>
+                    </div>
+                </li>
+            }
+        </ul>
     </div>
 }
+
 @if (Model.Commands.Any())
 {
     <div class="alert alert-info mb-4 d-flex align-items-center justify-content-between">
@@ -466,37 +482,6 @@
                                         <span class="my-2 me-3">@extComm.Key</span>
                                         <form asp-action="CancelPluginCommands" asp-route-plugin="@extComm.Key">
                                             <button type="submit" class="btn btn-outline-secondary">Cancel pending @extComm.Last().command</button>
-                                        </form>
-                                    </div>
-                                </li>
-                            }
-                        </ul>
-                    </div>
-                </div>
-            </div>
-        </div>
-    </div>
-}
-@if (Model.Disabled.Any())
-{
-    <div class="mb-4">
-        <h3 class="mb-4">Disabled Plugins</h3>
-        <button class="btn btn-secondary mb-4" type="button" data-bs-toggle="collapse" data-bs-target="#disabled-plugins">
-            Disabled Plugins
-        </button>
-        <div class="row collapse" id="disabled-plugins">
-            <div class="col col-12 col-lg-6 mb-4">
-                <div class="card">
-                    <div class="card-body">
-                        <h4 class="card-title">Disabled plugins</h4>
-                        <ul class="list-group list-group-flush">
-                            @foreach (var d in Model.Disabled)
-                            {
-                                <li class="list-group-item px-0">
-                                    <div class="d-flex flex-wrap align-items-center justify-content-between mx-3">
-                                        <span class="my-2 me-3">@d</span>
-                                        <form asp-action="UnInstallPlugin" asp-route-plugin="@d">
-                                            <button type="submit" class="btn btn-outline-secondary">Uninstall</button>
                                         </form>
                                     </div>
                                 </li>


### PR DESCRIPTION
As we upgrade to .NET 8 and changed a few things in the Lightning library, we came across an error with LNbank (#5497) which wasn't detected by the exception handler that should disable plugins.

The reason for this was twofold:

- It happened in the `host.StartWithTasksAsync().GetAwaiter().GetResult()` part of the `Main` function, which didn't seem to catch this async error. I made the function async so that we can properly await the result and catch potential errors.
- The `TypeLoadException` didn't contain any reference to the assembly it was coming from (in this case LNbank, which was compiled with `BTCPayServer.Lightning.All (v1.14.1)`). I suspect `TypeLoadException`s are most likely caused by plugins, that's why I parse their error message for the originating assembly (I didn't find another way to get to it) and check if this is part of the plugin dependencies. We need to skip the version comparison here, because the version the plugin was compiled with might not match the one that's provided by the runtime/BTCPay Server, which was causing this problem in the first place.

To make admins more aware of disabled plugins, I added the red status display as icon for the "Manage Plugins" nav item. I also move dthe list of disabled plugins up on that page and cleaned up the list.

![disabled](https://github.com/btcpayserver/btcpayserver/assets/886/8bc70c76-b630-46c0-b75e-50880fd75dea)
 