### PR TITLE
Changelog v1.12

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -18,6 +18,7 @@
 * POS Keypad: Add plus and change clear functionality (#5396) @dennisreimann @dstrukt
 * Forms: Support adjusting invoice amount by multiplier, enables percentage-based discount codes (#5463) @Kukks
 * Can pair or reset a Boltcard to a pull payment (#5419) @NicolasDorier
+* Plugins: Allow scheduling installs/updates of future plugins (#5537) @Kukks
 
 ### Bug fixes
 
@@ -26,6 +27,7 @@
 * Wallet: Use application/jsonl as MIME type for BIP329 label export (#5489) @dennisreimann
 * Wallet: Fill label from BIP21 (#5428) @dennisreimann
 * Greenfield: LNURLPay store payment method fixes (#5446) @dennisreimann
+* Greenfield: Fix invoice refund permission (#5558) @Kukks
 * Do not activate Blazor in Wizard screens (#5435) @NicolasDorier
 * Pull Payment: Display the amount of claims (#5427) @NicolasDorier
 * Dashboard: LND limbo balance had the wrong unit (a 1 BTC limbo balance would show as 0.001 BTC) @NicolasDorier
@@ -42,22 +44,26 @@
 * POS Cart: Horizontal scrollable filters (#5391) @dennisreimann
 * POS and Crowdfund: Item editor improvements (#5418 #5449) @dennisreimann
 * Reporting: UI improvements (#5432) @dennisreimann @dstrukt
-* Wallet: Use Mempool.space fee estimation (#5490) @Kukks @NicolasDorier
+* Wallet: Use Mempool.space fee estimation (#5490 #5556) @Kukks @NicolasDorier
 * Wallet: Update Passport instructions for import (#5423) @sethforprivacy
 * Plugins: Send notification when a new plugin version is available (#5450) @Kukks
 * Plugins: Improve crash detection on startup and hint at disabled plugins (#5514) @dennisreimann
+* Plugins: Add disclaimer (#5552) @dennisreimann
+* Server Policies: Add warnings for certain options (#5554) @dennisreimann
 * Greenfield: Remove unused checkout type setting from POS (#5512) @dennisreimann
 * Greenfield: Make checkout type V2 default for new stores (#5495) @dennisreimann
 * Domain mapping: Redirect root app to canonical URL (#5471) @dennisreimann
 * Lightning: Make implementations extendible by plugins (#5422) @Kukks
 * Lightning: Upgrade LND to 0.17.2-beta @rockstardev
 * Store Branding: Use store logo as favicon (#5519) @dennisreimann
+* Rate Providers: Remove Bittrex (#5553) @Kukks
 * UI: Unify list views (#5399) @dennisreimann @dstrukt
 * UI: Unify public page styles (#5460 #5462 #5466) @dennisreimann @dstrukt
 * UI: Add system option for theme switch (#5473) @dennisreimann
 * UI: Pull payment improvements (#5453) @dennisreimann
 * UI: Switch pos data to metadata in invoice create view (#5412) @Kukks
 * UI: Improve invoice's webhooks table (#5545) @NicolasDorier
+* UI: Remove forced center alignment for POS description (#5555) @dennisreimann
 
 ## 1.11.7
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,14 @@
 
 ## 1.12.0
 
+### Noteworthy
+
+* With this release we upgrade to .NET 8, which also requires a current version of the Docker engine (>= 20.10.10).
+  We will try to migrate outdated versions when upgrading BTCPay Server, but if you see these [symptoms](https://docs.linuxserver.io/FAQ/#symptoms) after updating, please [upgrade Docker engine manually](https://docs.docker.com/engine/install/).
+* We changed a lot of things under the hood, making the Lightning integrations extendible by plugins and also preparing the
+  migration of Altcoins to plugins. If you are using plugins, you will most likely find them disabled after this update, because
+  new versions compatible with BTCPay Server v1.12 are required. Please see the "Manage Plugins" section once updated.
+
 ### New feature
 
 * Webhooks: Support for Payment Requests, Payouts and extendibility by plugins (#5421) @Kukks

--- a/Changelog.md
+++ b/Changelog.md
@@ -12,6 +12,7 @@
 
 ### Bug fixes
 
+* Webhooks: Re-add OverPaid property to WebhookInvoiceSettledEvent (#5538 #5496) @dennisreimann
 * Apps: Filter list lookups by available app types (#5482) @dennisreimann
 * Wallet: Use application/jsonl as MIME type for BIP329 label export (#5489) @dennisreimann
 * Wallet: Fill label from BIP21 (#5428) @dennisreimann

--- a/Changelog.md
+++ b/Changelog.md
@@ -8,7 +8,6 @@
 * Support BIP129 Multisig wallet import (#5389) @Kukks
 * POS Keypad: Add plus and change clear functionality (#5396) @dennisreimann @dstrukt
 * Forms: Support adjusting invoice amount by multiplier, enables percentage-based discount codes (#5463) @Kukks
-* Pluginify BTCPayNetworkProvider: Prerequisite for moving altcoins to plugins (#5331) @NicolasDorier
 
 ### Bug fixes
 
@@ -18,7 +17,6 @@
 * Greenfield: LNURLPay store payment method fixes (#5446) @dennisreimann
 * Do not activate Blazor in Wizard screens (#5435) @NicolasDorier
 * Pull Payment: Display the amount of claims (#5427) @NicolasDorier
-* Fix qemu package in ARM Docker files (#5504) @greimela
 
 ### Improvements
 
@@ -39,7 +37,6 @@
 * Greenfield: Remove unused checkout type setting from POS (#5512) @dennisreimann
 * Greenfield: Make checkout type V2 default for new stores (#5495) @dennisreimann
 * Domain mapping: Redirect root app to canonical URL (#5471) @dennisreimann
-* Make wallet object system much more performant (#5441) @Kukks @NicolasDorier
 * Lightning: Make implementations extendible by plugins (#5422) @Kukks
 * Lightning: Upgrade LND to 0.17.2-beta @rockstardev
 * Store Branding: Use store logo as favicon (#5519) @dennisreimann
@@ -48,8 +45,6 @@
 * UI: Add system option for theme switch (#5473) @dennisreimann
 * UI: Pull payment improvements (#5453) @dennisreimann
 * UI: Switch pos data to metadata in invoice create view (#5412) @Kukks
-* Vault: Simplify logic by introducing a VaultClient (#5434) @NicolasDorier
-* Update SSH.NET to 2023.0.0 (#5404) @WojciechNagorski
 
 ## 1.11.7
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,56 @@
 # Changelog
 
+## 1.12.0
+
+### New feature
+
+* Webhooks: Support for Payment Requests, Payouts and extendibility by plugins (#5421) @Kukks
+* Support BIP129 Multisig wallet import (#5389) @Kukks
+* POS Keypad: Add plus and change clear functionality (#5396) @dennisreimann
+* Forms: Support adjusting invoice amount by multiplier, enables percentage-based discount codes (#5463) @Kukks
+* Pluginify BTCPayNetworkProvider: Prerequisite for moving altcoins to plugins (#5331) @NicolasDorier
+
+### Bug fixes
+
+* Apps: Filter list lookups by available app types (#5482) @dennisreimann
+* Wallet: Use application/jsonl as MIME type for BIP329 label export (#5489) @dennisreimann
+* Wallet: Fill label from BIP21 (#5428) @dennisreimann
+* Greenfield: LNURLPay store payment method fixes (#5446) @dennisreimann
+* Do not activate Blazor in Wizard screens (#5435) @NicolasDorier
+* Pull Payment: Display the amount of claims (#5427) @NicolasDorier
+* Fix qemu package in ARM Docker files (#5504) @greimela
+
+### Improvements
+
+* Upgrade to .NET 8.0 (#5479) @NicolasDorier
+* Enhance fine grain permissions (#5502) @Kukks
+* Checkout: NFC improvements (#5509) @dennisreimann
+* Checkout: Receipt improvements (#5505) @rockstardev @dennisreimann
+* Payment Request: Improve public view (#5413) @dennisreimann @dstrukt
+* POS Keypad: List recent transactions (#5478) @dennisreimann @dstrukt
+* POS Cart: Add options for search and categories display (#5438) @dennisreimann
+* POS Cart: Horizontal scrollable filters (#5391) @dennisreimann
+* POS and Crowdfund: Item editor improvements (#5418 #5449) @dennisreimann
+* Reporting: UI improvements (#5432) @dennisreimann
+* Wallet: Use Mempool.space fee estimation (#5490) @Kukks @NicolasDorier
+* Wallet: Update Passport instructions for import (#5423) @sethforprivacy
+* Plugins: Send notification when a new plugin version is available (#5450) @Kukks
+* Plugins: Improve crash detection on startup and hint at disabled plugins (#5514) @dennisreimann
+* Greenfield: Remove unused checkout type setting from POS (#5512) @dennisreimann
+* Greenfield: Make checkout type V2 default for new stores (#5495) @dennisreimann
+* Domain mapping: Redirect root app to canonical URL (#5471) @dennisreimann
+* Make wallet object system much more performant (#5441) @Kukks @NicolasDorier
+* Lightning: Make implementations extendible by plugins (#5422) @Kukks
+* Lightning: Upgrade LND to 0.17.2-beta @rockstardev
+* Store Branding: Use store logo as favicon (#5519) @dennisreimann
+* UI: Unify list views (#5399) @dennisreimann
+* UI: Unify public page styles (#5460 #5462 #5466) @dennisreimann
+* UI: Add system option for theme switch (#5473) @dennisreimann
+* UI: Pull payment improvements (#5453) @dennisreimann
+* UI: Switch pos data to metadata in invoice create view (#5412) @Kukks
+* Vault: Simplify logic by introducing a VaultClient (#5434) @NicolasDorier
+* Update SSH.NET to 2023.0.0 (#5404) @WojciechNagorski
+
 ## 1.11.7
 
 ### New feature

--- a/Changelog.md
+++ b/Changelog.md
@@ -8,6 +8,7 @@
 * Support BIP129 Multisig wallet import (#5389) @Kukks
 * POS Keypad: Add plus and change clear functionality (#5396) @dennisreimann @dstrukt
 * Forms: Support adjusting invoice amount by multiplier, enables percentage-based discount codes (#5463) @Kukks
+* Can pair or reset a Boltcard to a pull payment (#5419) @NicolasDorier
 
 ### Bug fixes
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -17,6 +17,7 @@
 * Greenfield: LNURLPay store payment method fixes (#5446) @dennisreimann
 * Do not activate Blazor in Wizard screens (#5435) @NicolasDorier
 * Pull Payment: Display the amount of claims (#5427) @NicolasDorier
+* Dashboard: LND limbo balance had the wrong unit (a 1 BTC limbo balance would show as 0.001 BTC) @NicolasDorier
 
 ### Improvements
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -57,6 +57,7 @@
 * UI: Add system option for theme switch (#5473) @dennisreimann
 * UI: Pull payment improvements (#5453) @dennisreimann
 * UI: Switch pos data to metadata in invoice create view (#5412) @Kukks
+* UI: Improve invoice's webhooks table (#5545) @NicolasDorier
 
 ## 1.11.7
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -6,7 +6,7 @@
 
 * Webhooks: Support for Payment Requests, Payouts and extendibility by plugins (#5421) @Kukks
 * Support BIP129 Multisig wallet import (#5389) @Kukks
-* POS Keypad: Add plus and change clear functionality (#5396) @dennisreimann
+* POS Keypad: Add plus and change clear functionality (#5396) @dennisreimann @dstrukt
 * Forms: Support adjusting invoice amount by multiplier, enables percentage-based discount codes (#5463) @Kukks
 * Pluginify BTCPayNetworkProvider: Prerequisite for moving altcoins to plugins (#5331) @NicolasDorier
 
@@ -31,7 +31,7 @@
 * POS Cart: Add options for search and categories display (#5438) @dennisreimann
 * POS Cart: Horizontal scrollable filters (#5391) @dennisreimann
 * POS and Crowdfund: Item editor improvements (#5418 #5449) @dennisreimann
-* Reporting: UI improvements (#5432) @dennisreimann
+* Reporting: UI improvements (#5432) @dennisreimann @dstrukt
 * Wallet: Use Mempool.space fee estimation (#5490) @Kukks @NicolasDorier
 * Wallet: Update Passport instructions for import (#5423) @sethforprivacy
 * Plugins: Send notification when a new plugin version is available (#5450) @Kukks
@@ -43,8 +43,8 @@
 * Lightning: Make implementations extendible by plugins (#5422) @Kukks
 * Lightning: Upgrade LND to 0.17.2-beta @rockstardev
 * Store Branding: Use store logo as favicon (#5519) @dennisreimann
-* UI: Unify list views (#5399) @dennisreimann
-* UI: Unify public page styles (#5460 #5462 #5466) @dennisreimann
+* UI: Unify list views (#5399) @dennisreimann @dstrukt
+* UI: Unify public page styles (#5460 #5462 #5466) @dennisreimann @dstrukt
 * UI: Add system option for theme switch (#5473) @dennisreimann
 * UI: Pull payment improvements (#5453) @dennisreimann
 * UI: Switch pos data to metadata in invoice create view (#5412) @Kukks

--- a/Changelog.md
+++ b/Changelog.md
@@ -9,6 +9,7 @@
 * We changed a lot of things under the hood, making the Lightning integrations extendible by plugins and also preparing the
   migration of Altcoins to plugins. If you are using plugins, you will most likely find them disabled after this update, because
   new versions compatible with BTCPay Server v1.12 are required. Please see the "Manage Plugins" section once updated.
+* We are ending support for Postgresql 11 as it reached 5 years after its initial release. Read more about [end-of-life (EOL) of postgresql](https://www.postgresql.org/support/versioning/). While Postgresql 11 should still work with BTCPay Server, we will not keep compatibility moving forward.
 
 ### New feature
 


### PR DESCRIPTION
Preparation for our v1.12.0 release. Contains the [commits and merged PRs since v1.11.7](https://github.com/btcpayserver/btcpayserver/compare/v1.11.7...master) so far.