### PR TITLE
Keypad: Show recent transactions only when logged in

### DIFF
--- a/BTCPayServer/Plugins/PointOfSale/Controllers/UIPointOfSaleController.cs
+++ b/BTCPayServer/Plugins/PointOfSale/Controllers/UIPointOfSaleController.cs
@@ -523,7 +523,7 @@ namespace BTCPayServer.Plugins.PointOfSale.Controllers
             return View("Views/UIForms/View", viewModel);
         }
         
-        [Authorize(Policy = Policies.CanModifyStoreSettings, AuthenticationSchemes = AuthenticationSchemes.Cookie)]
+        [Authorize(Policy = Policies.CanViewInvoices, AuthenticationSchemes = AuthenticationSchemes.Cookie)]
         [HttpGet("/apps/{appId}/pos/recent-transactions")]
         public async Task<IActionResult> RecentTransactions(string appId)
         {

--- a/BTCPayServer/Views/Shared/PointOfSale/Public/VueLight.cshtml
+++ b/BTCPayServer/Views/Shared/PointOfSale/Public/VueLight.cshtml
@@ -1,3 +1,4 @@
+@using BTCPayServer.Client
 @model BTCPayServer.Plugins.PointOfSale.Models.ViewPointOfSaleViewModel
 
 <form id="app" method="post" asp-action="ViewPointOfSale" asp-route-appId="@Model.AppId" asp-antiforgery="false" v-on:submit="handleFormSubmit" class="d-flex flex-column gap-4 my-auto" v-cloak>
@@ -89,7 +90,7 @@
             </div>
         </div>
     </div>
-    <button type="button" class="btn btn-link p-1" data-bs-toggle="modal" data-bs-target="#RecentTransactions" id="RecentTransactionsToggle">
+    <button type="button" class="btn btn-link p-1" data-bs-toggle="modal" data-bs-target="#RecentTransactions" id="RecentTransactionsToggle" permission="@Policies.CanViewInvoices">
         <vc:icon symbol="manage-plugins"/>
     </button>
 </form>

--- a/BTCPayServer/wwwroot/pos/keypad.js
+++ b/BTCPayServer/wwwroot/pos/keypad.js
@@ -131,11 +131,16 @@ document.addEventListener("DOMContentLoaded",function () {
             async loadRecentTransactions() {
                 this.recentTransactionsLoading = true;
                 const { url } = this.$refs.RecentTransactions.dataset;
-                const response = await fetch(url);
-                if (response.ok) {
-                    this.recentTransactions = await response.json();
+                try {
+                    const response = await fetch(url);
+                    if (response.ok) {
+                        this.recentTransactions = await response.json();
+                    }
+                } catch (error) {
+                    console.error(error);
+                } finally {
+                    this.recentTransactionsLoading = false;
                 }
-                this.recentTransactionsLoading = false;
             }
         },
         created() {


### PR DESCRIPTION
Fixes #5530. For the use case of giving access to cashiers we need to find another solution than showing the recent transactions for signed out users.