### PR TITLE
Allow users with CanViewPaymentRequests to view payment requests

### DIFF
--- a/BTCPayServer/Controllers/UIPaymentRequestController.cs
+++ b/BTCPayServer/Controllers/UIPaymentRequestController.cs
@@ -26,8 +26,8 @@ using StoreData = BTCPayServer.Data.StoreData;
 
 namespace BTCPayServer.Controllers
 {
-    [Authorize(Policy = Policies.CanModifyStoreSettings, AuthenticationSchemes = AuthenticationSchemes.Cookie)]
     [Route("payment-requests")]
+    [Authorize(Policy = Policies.CanViewPaymentRequests, AuthenticationSchemes = AuthenticationSchemes.Cookie)]
     public class UIPaymentRequestController : Controller
     {
         private readonly UIInvoiceController _InvoiceController;
@@ -69,7 +69,6 @@ namespace BTCPayServer.Controllers
             FormDataService = formDataService;
         }
 
-        
         [HttpGet("/stores/{storeId}/payment-requests")]
         [Authorize(Policy = Policies.CanViewPaymentRequests, AuthenticationSchemes = AuthenticationSchemes.Cookie)]
         public async Task<IActionResult> GetPaymentRequests(string storeId, ListPaymentRequestsViewModel model = null)
@@ -363,6 +362,7 @@ namespace BTCPayServer.Controllers
         }
 
         [HttpGet("{payReqId}/cancel")]
+        [Authorize(Policy = Policies.CanModifyPaymentRequests, AuthenticationSchemes = AuthenticationSchemes.Cookie)]
         public async Task<IActionResult> CancelUnpaidPendingInvoice(string payReqId, bool redirect = true)
         {
             var result = await _PaymentRequestService.GetPaymentRequest(payReqId, GetUserId());

--- a/BTCPayServer/Controllers/UIPaymentRequestController.cs
+++ b/BTCPayServer/Controllers/UIPaymentRequestController.cs
@@ -362,7 +362,7 @@ namespace BTCPayServer.Controllers
         }
 
         [HttpGet("{payReqId}/cancel")]
-        [Authorize(Policy = Policies.CanModifyPaymentRequests, AuthenticationSchemes = AuthenticationSchemes.Cookie)]
+        [AllowAnonymous]
         public async Task<IActionResult> CancelUnpaidPendingInvoice(string payReqId, bool redirect = true)
         {
             var result = await _PaymentRequestService.GetPaymentRequest(payReqId, GetUserId());


### PR DESCRIPTION
I originally tried to reproduce #5549, which I couldn't, but came across this problem where a store user with role `Guest` wasn't able to access the list of payment requests, even though that item appears in the nav list. The `CanViewPaymentRequests` permission on th list action is correct, but access was prevented by the `CanModifyStoreSettings` policy requirement on the controller level, which is adjusted here.