### PR TITLE
Remove bittrex

### DIFF
--- a/BTCPayServer.Tests/BTCPayServerTester.cs
+++ b/BTCPayServer.Tests/BTCPayServerTester.cs
@@ -232,17 +232,13 @@ namespace BTCPayServer.Tests
                 ndax.ExchangeRates.Add(new PairRate(CurrencyPair.Parse("BTC_CAD"), new BidAsk(6000m)));
                 rateProvider.Providers.Add("ndax", ndax);
 
-                var bittrex = new MockRateProvider();
-                bittrex.ExchangeRates.Add(new PairRate(CurrencyPair.Parse("DOGE_BTC"), new BidAsk(0.004m)));
-                rateProvider.Providers.Add("bittrex", bittrex);
-
-
                 var bitfinex = new MockRateProvider();
                 bitfinex.ExchangeRates.Add(new PairRate(CurrencyPair.Parse("UST_BTC"), new BidAsk(0.000136m)));
                 rateProvider.Providers.Add("bitfinex", bitfinex);
 
                 var bitpay = new MockRateProvider();
                 bitpay.ExchangeRates.Add(new PairRate(CurrencyPair.Parse("ETB_BTC"), new BidAsk(0.1m)));
+                bitpay.ExchangeRates.Add(new PairRate(CurrencyPair.Parse("DOGE_BTC"), new BidAsk(0.004m)));
                 rateProvider.Providers.Add("bitpay", bitpay);
                 var kraken = new MockRateProvider();
                 kraken.ExchangeRates.Add(new PairRate(CurrencyPair.Parse("ETH_BTC"), new BidAsk(0.1m)));

--- a/BTCPayServer.Tests/FastTests.cs
+++ b/BTCPayServer.Tests/FastTests.cs
@@ -1005,7 +1005,7 @@ Assert.Equal("2b0e251e", nunchuk.AccountKeySettings[1].RootFingerprint.ToString(
         public async Task CheckRatesProvider()
         {
             var spy = new SpyRateProvider();
-            RateRules.TryParse("X_X = bittrex(X_X);", out var rateRules);
+            RateRules.TryParse("X_X = bitpay(X_X);", out var rateRules);
 
             var factory = CreateBTCPayRateFactory();
             factory.Providers.Clear();
@@ -1013,7 +1013,7 @@ Assert.Equal("2b0e251e", nunchuk.AccountKeySettings[1].RootFingerprint.ToString(
             factory.Providers.Clear();
             var fetch = new BackgroundFetcherRateProvider(spy);
             fetch.DoNotAutoFetchIfExpired = true;
-            factory.Providers.Add("bittrex", fetch);
+            factory.Providers.Add("bitpay", fetch);
             var fetchedRate = await fetcher.FetchRate(CurrencyPair.Parse("BTC_USD"), rateRules, default);
             spy.AssertHit();
             fetchedRate = await fetcher.FetchRate(CurrencyPair.Parse("BTC_USD"), rateRules, default);
@@ -1614,7 +1614,7 @@ Assert.Equal("2b0e251e", nunchuk.AccountKeySettings[1].RootFingerprint.ToString(
             StringBuilder builder = new StringBuilder();
             builder.AppendLine("// Some cool comments");
             builder.AppendLine("DOGE_X = DOGE_BTC * BTC_X * 1.1");
-            builder.AppendLine("DOGE_BTC = Bittrex(DOGE_BTC)");
+            builder.AppendLine("DOGE_BTC = bitpay(DOGE_BTC)");
             builder.AppendLine("// Some other cool comments");
             builder.AppendLine("BTC_usd = kraken(BTC_USD)");
             builder.AppendLine("BTC_X = Coinbase(BTC_X);");
@@ -1625,7 +1625,7 @@ Assert.Equal("2b0e251e", nunchuk.AccountKeySettings[1].RootFingerprint.ToString(
             Assert.Equal(
                 "// Some cool comments\n" +
                 "DOGE_X = DOGE_BTC * BTC_X * 1.1;\n" +
-                "DOGE_BTC = bittrex(DOGE_BTC);\n" +
+                "DOGE_BTC = bitpay(DOGE_BTC);\n" +
                 "// Some other cool comments\n" +
                 "BTC_USD = kraken(BTC_USD);\n" +
                 "BTC_X = coinbase(BTC_X);\n" +
@@ -1633,10 +1633,10 @@ Assert.Equal("2b0e251e", nunchuk.AccountKeySettings[1].RootFingerprint.ToString(
                 rules.ToString());
             var tests = new[]
             {
-                (Pair: "DOGE_USD", Expected: "bittrex(DOGE_BTC) * kraken(BTC_USD) * 1.1"),
+                (Pair: "DOGE_USD", Expected: "bitpay(DOGE_BTC) * kraken(BTC_USD) * 1.1"),
                 (Pair: "BTC_USD", Expected: "kraken(BTC_USD)"),
                 (Pair: "BTC_CAD", Expected: "coinbase(BTC_CAD)"),
-                (Pair: "DOGE_CAD", Expected: "bittrex(DOGE_BTC) * coinbase(BTC_CAD) * 1.1"),
+                (Pair: "DOGE_CAD", Expected: "bitpay(DOGE_BTC) * coinbase(BTC_CAD) * 1.1"),
                 (Pair: "LTC_CAD", Expected: "coinaverage(LTC_CAD) * 1.02"),
                 (Pair: "SATS_CAD", Expected: "0.00000001 * coinbase(BTC_CAD)"),
                 (Pair: "Sats_USD", Expected: "0.00000001 * kraken(BTC_USD)")
@@ -1646,13 +1646,13 @@ Assert.Equal("2b0e251e", nunchuk.AccountKeySettings[1].RootFingerprint.ToString(
                 Assert.Equal(test.Expected, rules.GetRuleFor(CurrencyPair.Parse(test.Pair)).ToString());
             }
             rules.Spread = 0.2m;
-            Assert.Equal("(bittrex(DOGE_BTC) * kraken(BTC_USD) * 1.1) * (0.8, 1.2)", rules.GetRuleFor(CurrencyPair.Parse("DOGE_USD")).ToString());
+            Assert.Equal("(bitpay(DOGE_BTC) * kraken(BTC_USD) * 1.1) * (0.8, 1.2)", rules.GetRuleFor(CurrencyPair.Parse("DOGE_USD")).ToString());
             ////////////////
 
             // Check errors conditions
             builder = new StringBuilder();
             builder.AppendLine("DOGE_X = LTC_CAD * BTC_X * 1.1");
-            builder.AppendLine("DOGE_BTC = Bittrex(DOGE_BTC)");
+            builder.AppendLine("DOGE_BTC = bitpay(DOGE_BTC)");
             builder.AppendLine("BTC_usd = kraken(BTC_USD)");
             builder.AppendLine("LTC_CHF = LTC_CHF * 1.01");
             builder.AppendLine("BTC_X = Coinbase(BTC_X)");
@@ -1673,7 +1673,7 @@ Assert.Equal("2b0e251e", nunchuk.AccountKeySettings[1].RootFingerprint.ToString(
             // Check if we can resolve exchange rates
             builder = new StringBuilder();
             builder.AppendLine("DOGE_X = DOGE_BTC * BTC_X * 1.1");
-            builder.AppendLine("DOGE_BTC = Bittrex(DOGE_BTC)");
+            builder.AppendLine("DOGE_BTC = bitpay(DOGE_BTC)");
             builder.AppendLine("BTC_usd = kraken(BTC_USD)");
             builder.AppendLine("BTC_X = Coinbase(BTC_X)");
             builder.AppendLine("X_X = CoinAverage(X_X) * 1.02");
@@ -1681,10 +1681,10 @@ Assert.Equal("2b0e251e", nunchuk.AccountKeySettings[1].RootFingerprint.ToString(
 
             var tests2 = new[]
             {
-                (Pair: "DOGE_USD", Expected: "bittrex(DOGE_BTC) * kraken(BTC_USD) * 1.1", ExpectedExchangeRates: "bittrex(DOGE_BTC),kraken(BTC_USD)"),
+                (Pair: "DOGE_USD", Expected: "bitpay(DOGE_BTC) * kraken(BTC_USD) * 1.1", ExpectedExchangeRates: "bitpay(DOGE_BTC),kraken(BTC_USD)"),
                 (Pair: "BTC_USD", Expected: "kraken(BTC_USD)", ExpectedExchangeRates: "kraken(BTC_USD)"),
                 (Pair: "BTC_CAD", Expected: "coinbase(BTC_CAD)", ExpectedExchangeRates: "coinbase(BTC_CAD)"),
-                (Pair: "DOGE_CAD", Expected: "bittrex(DOGE_BTC) * coinbase(BTC_CAD) * 1.1", ExpectedExchangeRates: "bittrex(DOGE_BTC),coinbase(BTC_CAD)"),
+                (Pair: "DOGE_CAD", Expected: "bitpay(DOGE_BTC) * coinbase(BTC_CAD) * 1.1", ExpectedExchangeRates: "bitpay(DOGE_BTC),coinbase(BTC_CAD)"),
                 (Pair: "LTC_CAD", Expected: "coinaverage(LTC_CAD) * 1.02", ExpectedExchangeRates: "coinaverage(LTC_CAD)"),
                 (Pair: "SATS_USD", Expected: "0.00000001 * kraken(BTC_USD)", ExpectedExchangeRates: "kraken(BTC_USD)"),
                 (Pair: "SATS_EUR", Expected: "0.00000001 * coinbase(BTC_EUR)", ExpectedExchangeRates: "coinbase(BTC_EUR)")
@@ -1696,11 +1696,11 @@ Assert.Equal("2b0e251e", nunchuk.AccountKeySettings[1].RootFingerprint.ToString(
                 Assert.Equal(test.ExpectedExchangeRates, string.Join(',', rule.ExchangeRates.OfType<object>().ToArray()));
             }
             var rule2 = rules.GetRuleFor(CurrencyPair.Parse("DOGE_CAD"));
-            rule2.ExchangeRates.SetRate("bittrex", CurrencyPair.Parse("DOGE_BTC"), new BidAsk(5000m));
+            rule2.ExchangeRates.SetRate("bitpay", CurrencyPair.Parse("DOGE_BTC"), new BidAsk(5000m));
             rule2.Reevaluate();
             Assert.True(rule2.HasError);
             Assert.Equal("5000 * ERR_RATE_UNAVAILABLE(coinbase, BTC_CAD) * 1.1", rule2.ToString(true));
-            Assert.Equal("bittrex(DOGE_BTC) * coinbase(BTC_CAD) * 1.1", rule2.ToString(false));
+            Assert.Equal("bitpay(DOGE_BTC) * coinbase(BTC_CAD) * 1.1", rule2.ToString(false));
             rule2.ExchangeRates.SetRate("coinbase", CurrencyPair.Parse("BTC_CAD"), new BidAsk(2000.4m));
             rule2.Reevaluate();
             Assert.False(rule2.HasError);

--- a/BTCPayServer.Tests/ThirdPartyTests.cs
+++ b/BTCPayServer.Tests/ThirdPartyTests.cs
@@ -297,10 +297,9 @@ retry:
             }
         }
 
-        [Fact()]
+        [Fact]
         public void CanSolveTheDogesRatesOnKraken()
         {
-            var provider = CreateNetworkProvider(ChainName.Mainnet);
             var factory = FastTests.CreateBTCPayRateFactory();
             var fetcher = new RateFetcher(factory);
 
@@ -320,7 +319,7 @@ retry:
             var fetcher = new RateFetcher(factory);
             var provider = CreateNetworkProvider(ChainName.Mainnet);
             var b = new StoreBlob();
-            string[] temporarilyBroken = { "COP", "UGX" };
+            string[] temporarilyBroken = Array.Empty<string>();
             foreach (var k in StoreBlob.RecommendedExchanges)
             {
                 b.DefaultCurrency = k.Key;

--- a/BTCPayServer.Tests/UnitTest1.cs
+++ b/BTCPayServer.Tests/UnitTest1.cs
@@ -1419,7 +1419,7 @@ namespace BTCPayServer.Tests
                 StringComparison.OrdinalIgnoreCase);
 
             rateVm.ScriptTest = "BTC_USD,BTC_CAD,DOGE_USD,DOGE_CAD";
-            rateVm.Script = "DOGE_X = bittrex(DOGE_BTC) * BTC_X;\n" +
+            rateVm.Script = "DOGE_X = bitpay(DOGE_BTC) * BTC_X;\n" +
                             "X_CAD = ndax(X_CAD);\n" +
                             "X_X = coingecko(X_X);";
             rateVm.Spread = 50;

--- a/BTCPayServer/Data/StoreBlob.cs
+++ b/BTCPayServer/Data/StoreBlob.cs
@@ -167,7 +167,7 @@ namespace BTCPayServer.Data
 
         public RateRules GetDefaultRateRules(BTCPayNetworkProvider networkProvider)
         {
-            StringBuilder builder = new StringBuilder();
+            var builder = new StringBuilder();
             foreach (var network in networkProvider.GetAll())
             {
                 if (network.DefaultRateRules.Length != 0)
@@ -177,7 +177,7 @@ namespace BTCPayServer.Data
                     {
                         builder.AppendLine(line);
                     }
-                    builder.AppendLine($"////////");
+                    builder.AppendLine("////////");
                     builder.AppendLine();
                 }
             }
@@ -185,7 +185,7 @@ namespace BTCPayServer.Data
             var preferredExchange = string.IsNullOrEmpty(PreferredExchange) ? GetRecommendedExchange() : PreferredExchange;
             builder.AppendLine(CultureInfo.InvariantCulture, $"X_X = {preferredExchange}(X_X);");
 
-            BTCPayServer.Rating.RateRules.TryParse(builder.ToString(), out var rules);
+            RateRules.TryParse(builder.ToString(), out var rules);
             rules.Spread = Spread;
             return rules;
         }

--- a/BTCPayServer/Hosting/BTCPayServerServices.cs
+++ b/BTCPayServer/Hosting/BTCPayServerServices.cs
@@ -517,7 +517,6 @@ namespace BTCPayServer.Hosting
         {
             // We need to be careful to only add exchanges which OnGetTickers implementation make only 1 request
             services.AddRateProviderExchangeSharp<ExchangeBinanceAPI>(new("binance", "Binance", "https://api.binance.com/api/v1/ticker/24hr"));
-            services.AddRateProviderExchangeSharp<ExchangeBittrexAPI>(new("bittrex", "Bittrex", "https://bittrex.com/api/v1.1/public/getmarketsummaries"));
             services.AddRateProviderExchangeSharp<ExchangePoloniexAPI>(new("poloniex", "Poloniex", " https://api.poloniex.com/markets/price"));
             services.AddRateProviderExchangeSharp<ExchangeNDAXAPI>(new("ndax", "NDAX", "https://ndax.io/api/returnTicker"));
 

--- a/BTCPayServer/Plugins/Altcoins/AltcoinsPlugin.Dogecoin.cs
+++ b/BTCPayServer/Plugins/Altcoins/AltcoinsPlugin.Dogecoin.cs
@@ -21,7 +21,7 @@ public partial class AltcoinsPlugin
             DefaultRateRules = new[]
             {
                                 "DOGE_X = DOGE_BTC * BTC_X",
-                                "DOGE_BTC = bittrex(DOGE_BTC)"
+                                "DOGE_BTC = bitpay(DOGE_BTC)"
                 },
             CryptoImagePath = "imlegacy/dogecoin.png",
             DefaultSettings = BTCPayDefaultSettings.GetDefaultSettings(ChainName),

--- a/BTCPayServer/Plugins/Altcoins/AltcoinsPlugin.Groestlcoin.cs
+++ b/BTCPayServer/Plugins/Altcoins/AltcoinsPlugin.Groestlcoin.cs
@@ -20,7 +20,7 @@ public partial class AltcoinsPlugin
             DefaultRateRules = new[]
             {
                     "GRS_X = GRS_BTC * BTC_X",
-                    "GRS_BTC = bittrex(GRS_BTC)"
+                    "GRS_BTC = upbit(GRS_BTC)"
                 },
             CryptoImagePath = "imlegacy/groestlcoin.png",
             LightningImagePath = "imlegacy/groestlcoin-lightning.svg",

--- a/BTCPayServer/Plugins/Altcoins/AltcoinsPlugin.Monacoin.cs
+++ b/BTCPayServer/Plugins/Altcoins/AltcoinsPlugin.Monacoin.cs
@@ -20,7 +20,8 @@ public partial class AltcoinsPlugin
             DefaultRateRules = new[]
             {
                                 "MONA_X = MONA_BTC * BTC_X",
-                                "MONA_BTC = bittrex(MONA_BTC)"
+                                "MONA_JPY = bitbank(MONA_JPY",
+                                "MONA_BTC = MONA_JPY * JPY_BTC"
                 },
             CryptoImagePath = "imlegacy/monacoin.png",
             LightningImagePath = "imlegacy/mona-lightning.svg",

--- a/BTCPayServer/Plugins/Altcoins/AltcoinsPlugin.Monacoin.cs
+++ b/BTCPayServer/Plugins/Altcoins/AltcoinsPlugin.Monacoin.cs
@@ -12,7 +12,7 @@ public partial class AltcoinsPlugin
     public void InitMonacoin(IServiceCollection services)
     {
         var nbxplorerNetwork = NBXplorerNetworkProvider.GetFromCryptoCode("MONA");
-        var network = new BTCPayNetwork()
+        var network = new BTCPayNetwork
         {
             CryptoCode = nbxplorerNetwork.CryptoCode,
             DisplayName = "Monacoin",
@@ -20,7 +20,7 @@ public partial class AltcoinsPlugin
             DefaultRateRules = new[]
             {
                                 "MONA_X = MONA_BTC * BTC_X",
-                                "MONA_JPY = bitbank(MONA_JPY",
+                                "MONA_JPY = bitbank(MONA_JPY)",
                                 "MONA_BTC = MONA_JPY * JPY_BTC"
                 },
             CryptoImagePath = "imlegacy/monacoin.png",

--- a/BTCPayServer/Views/UIStores/Rates.cshtml
+++ b/BTCPayServer/Views/UIStores/Rates.cshtml
@@ -97,18 +97,18 @@ BTC_USD = kraken(BTC_USD);</code></pre>
 X_X = kraken(X_X);</code></pre>
                     <p>A given currency pair match the most specific rule. If two rules are matching and are as specific, the first rule will be chosen.</p>
                     <p>
-                        But now, what if you want to support <code>DOGE</code>? The problem with <code>DOGE</code> is that most exchange do not have any pair for it. But <code>bittrex</code> has a <code>DOGE_BTC</code> pair. <br />
+                        But now, what if you want to support <code>DOGE</code>? The problem with <code>DOGE</code> is that most exchange do not have any pair for it. But <code>bitpay</code> has a <code>DOGE_BTC</code> pair. <br />
                         Luckily, the rule engine allow you to reference rules:
                     </p>
-                    <pre><code class="text hljs">DOGE_X = bittrex(DOGE_BTC) * BTC_X;
+                    <pre><code class="text hljs">DOGE_X = bitpay(DOGE_BTC) * BTC_X;
 X_CAD = ndax(X_CAD);
 X_X = kraken(X_X);</code></pre>
                     <p>
-                        With <code>DOGE_USD</code> will be expanded to <code>bittrex(DOGE_BTC) * kraken(BTC_USD)</code>. And <code>DOGE_CAD</code> will be expanded to <code>bittrex(DOGE_BTC) * ndax(BTC_CAD)</code>. <br />
+                        With <code>DOGE_USD</code> will be expanded to <code>bitpay(DOGE_BTC) * kraken(BTC_USD)</code>. And <code>DOGE_CAD</code> will be expanded to <code>bitpay(DOGE_BTC) * ndax(BTC_CAD)</code>. <br />
                         However, we advise you to write it that way to increase coverage so that <code>DOGE_BTC</code> is also supported:
                     </p>
                     <pre><code class="text hljs">DOGE_X = DOGE_BTC * BTC_X;
-DOGE_BTC = bittrex(DOGE_BTC);
+DOGE_BTC = bitpay(DOGE_BTC);
 X_CAD = ndax(X_CAD);
 X_X = kraken(X_X);</code></pre>
                     <p>


### PR DESCRIPTION
bittrex is dead https://www.coindesk.com/business/2023/11/21/crypto-exchange-bittrex-global-to-shut-down/#:~:text=Crypto%20exchange%20Bittrex%20Global%20is,only%20withdrawals%20will%20be%20available.