### PR TITLE
POS: Remove forced center alignment for description

### DIFF
--- a/BTCPayServer/wwwroot/pos/common.css
+++ b/BTCPayServer/wwwroot/pos/common.css
@@ -5,7 +5,6 @@
 
 .lead {
     max-width: 36em;
-    text-align: center;
     margin: 0 auto 2.5rem;
 }
 .lead :last-child {


### PR DESCRIPTION
Allows to specify the text alignment in the description container via the richt text editor. Before it was center aligned, no matter what one did in the editor.

This is feedback we got in yesterdays call with @MattDHill.