### PR TITLE
Plugins: Move "Manage Plugins" to Server Settings

### DIFF
--- a/BTCPayServer/Components/MainNav/Default.cshtml
+++ b/BTCPayServer/Components/MainNav/Default.cshtml
@@ -185,19 +185,15 @@
                             }
                         </ul>
                         <ul class="navbar-nav">
-                            <li class="nav-item" permission="@Policies.CanModifyServerSettings">
-                                <a asp-area="" asp-controller="UIServer" asp-action="ListPlugins" class="nav-link @ViewData.IsActivePage(ServerNavPages.Plugins)" id="Nav-ManagePlugins">
-                                    @if (PluginService.GetDisabledPlugins().Any())
-                                    {
+                            @if (PluginService.GetDisabledPlugins().Any())
+                            {
+                                <li class="nav-item" permission="@Policies.CanModifyServerSettings">
+                                    <a asp-area="" asp-controller="UIServer" asp-action="ListPlugins" class="nav-link @ViewData.IsActivePage(ServerNavPages.Plugins)" id="Nav-ManagePlugins">
                                         <span class="me-2 btcpay-status btcpay-status--disabled"></span>
-                                    }
-                                    else
-                                    {
-                                        <vc:icon symbol="manage-plugins" />
-                                    }
-                                    <span>Manage Plugins</span>
-                                </a>
-                            </li>
+                                        <span>Manage Plugins</span>
+                                    </a>
+                                </li>
+                            }
                             @if (Model.Store != null && Model.ArchivedAppsCount > 0)
                             {
                                 <li class="nav-item nav-item-sub" permission="@Policies.CanModifyStoreSettings">

--- a/BTCPayServer/Views/UIServer/ListPlugins.cshtml
+++ b/BTCPayServer/Views/UIServer/ListPlugins.cshtml
@@ -4,7 +4,6 @@
 @inject BTCPayServerOptions BTCPayServerOptions
 @inject PluginService PluginService
 @{
-    Layout = "_Layout";
     ViewData.SetActivePage(ServerNavPages.Plugins);
     var installed = Model.Installed.ToDictionary(plugin => plugin.Identifier, plugin => plugin.Version);
     var installedWithoutSystemPlugins = Model.Installed.Where(i => !i.SystemPlugin).ToList();

--- a/BTCPayServer/Views/UIServer/_Nav.cshtml
+++ b/BTCPayServer/Views/UIServer/_Nav.cshtml
@@ -10,6 +10,7 @@
             <a asp-controller="UIServer" id="SectionNav-@ServerNavPages.Emails" class="nav-link @ViewData.IsActivePage(ServerNavPages.Emails)" asp-action="Emails">Email</a>
             <a asp-controller="UIServer" id="SectionNav-@ServerNavPages.Policies" class="nav-link @ViewData.IsActivePage(ServerNavPages.Policies)" asp-action="Policies">Policies</a>
             <a asp-controller="UIServer" id="SectionNav-@ServerNavPages.Services" class="nav-link @ViewData.IsActivePage(ServerNavPages.Services)" asp-action="Services">Services</a>
+            <a asp-controller="UIServer" id="SectionNav-@ServerNavPages.Plugins" class="nav-link @ViewData.IsActivePage(ServerNavPages.Plugins)" asp-action="ListPlugins">Plugins</a>
             <a asp-controller="UIServer" id="SectionNav-@ServerNavPages.Theme" class="nav-link @ViewData.IsActivePage(ServerNavPages.Theme)" asp-action="Theme">Theme</a>
             @if (_btcPayServerOptions.DockerDeployment)
             {


### PR DESCRIPTION
The idea behind moving the Manage Plugins section back into Server Settings is that people aren't directly guided to install plugins, because they see that item in the nav menu. There's an ongoing discussion about how to best handle this, so for now I'll leave this as a draft.