### PR TITLE
Do not redirect to archived store after login

### DIFF
--- a/BTCPayServer/Components/StoreSelector/StoreSelector.cs
+++ b/BTCPayServer/Components/StoreSelector/StoreSelector.cs
@@ -41,14 +41,13 @@ namespace BTCPayServer.Components.StoreSelector
                         .FirstOrDefault()?
                         .Network.CryptoCode;
                     var walletId = cryptoCode != null ? new WalletId(store.Id, cryptoCode) : null;
-                    var role = store.GetStoreRoleOfUser(userId);
                     return new StoreSelectorOption
                     {
                         Text = store.StoreName,
                         Value = store.Id,
                         Selected = store.Id == currentStore?.Id,
                         WalletId = walletId,
-                        Store = store,
+                        Store = store
                     };
                 })
                 .OrderBy(s => s.Text)

--- a/BTCPayServer/Controllers/UIHomeController.cs
+++ b/BTCPayServer/Controllers/UIHomeController.cs
@@ -84,8 +84,9 @@ namespace BTCPayServer.Controllers
                 }
 
                 var stores = await _storeRepository.GetStoresByUserId(userId);
-                return stores.Any()
-                    ? RedirectToStore(userId, stores.First())
+                var activeStore = stores.FirstOrDefault(s => !s.Archived);
+                return activeStore != null
+                    ? RedirectToStore(userId, activeStore)
                     : RedirectToAction(nameof(UIUserStoresController.CreateStore), "UIUserStores");
             }
 


### PR DESCRIPTION
Now that we have archived stores, we need to exclude them from the selection of the default store the user gets redirected to after login.