### PR TITLE
Lightning: Allow LND to be used with non-admin macaroons

### DIFF
--- a/BTCPayServer/BTCPayServer.csproj
+++ b/BTCPayServer/BTCPayServer.csproj
@@ -50,7 +50,7 @@
     <PackageReference Include="YamlDotNet" Version="8.0.0" />
     <PackageReference Include="BIP78.Sender" Version="0.2.2" />
     <PackageReference Include="BTCPayServer.Hwi" Version="2.0.2" />
-    <PackageReference Include="BTCPayServer.Lightning.All" Version="1.5.2" />
+    <PackageReference Include="BTCPayServer.Lightning.All" Version="1.5.3" />
     <PackageReference Include="CsvHelper" Version="15.0.5" />
     <PackageReference Include="Dapper" Version="2.1.24" />
     <PackageReference Include="Fido2" Version="2.0.2" />

--- a/BTCPayServer/Payments/Lightning/LightningLikePaymentHandler.cs
+++ b/BTCPayServer/Payments/Lightning/LightningLikePaymentHandler.cs
@@ -61,7 +61,7 @@ namespace BTCPayServer.Payments.Lightning
 
             if (preparePaymentObject is null)
             {
-                return new LightningLikePaymentMethodDetails()
+                return new LightningLikePaymentMethodDetails
                 {
                     Activated = false
                 };
@@ -144,6 +144,12 @@ namespace BTCPayServer.Payments.Lightning
                 }
                 catch (NotSupportedException)
                 {
+                    // LNDhub, LNbits and others might not support this call, yet we can create invoices.
+                    return new NodeInfo[] {};
+                }
+                catch (UnauthorizedAccessException)
+                {
+                    // LND might return this with restricted macaroon, support this nevertheless..
                     return new NodeInfo[] {};
                 }
                 catch (Exception ex)
@@ -237,7 +243,7 @@ namespace BTCPayServer.Payments.Lightning
 
         public override CheckoutUIPaymentMethodSettings GetCheckoutUISettings()
         {
-            return new CheckoutUIPaymentMethodSettings()
+            return new CheckoutUIPaymentMethodSettings
             {
                 ExtensionPartial = "Lightning/LightningLikeMethodCheckout",
                 CheckoutBodyVueComponentName = "LightningLikeMethodCheckout",

--- a/BTCPayServer/Views/UIStores/SetupLightningNode.cshtml
+++ b/BTCPayServer/Views/UIStores/SetupLightningNode.cshtml
@@ -156,11 +156,13 @@
                                 </li>
                             </ul>
                             <p>
-                                For the macaroon options you need to provide the <code>admin.macaroon</code>.<br/>
+                                For the macaroon options you need to provide a macaroon with the <code>invoices:write</code> permission (e.g. <code>invoice.macaroon</code>, see
+                                <a href="https://docs.lightning.engineering/lightning-network-tools/lnd/macaroons" target="_blank" rel="noreferrer noopener">details</a>). If you
+                                want to display the node connection details, it also needs the <code>info:read</code> permission.<br/>
                                 The path to the LND data directory may vary, the following examples assume <code>/root/.lnd</code>.
                             </p>
                             <p class="mb-2">The <code>macaroon</code> parameter expects the HEX value, it can be obtained using this command:</p>
-                            <pre class="mb-4">xxd -p -c 256 /root/.lnd/data/chain/bitcoin/mainnet/admin.macaroon | tr -d '\n'</pre>
+                            <pre class="mb-4">xxd -p -c 256 /root/.lnd/data/chain/bitcoin/mainnet/invoice.macaroon | tr -d '\n'</pre>
                             <p class="mb-2">
                                 You can omit <code>certthumbprint</code> if the certificate is trusted by your machine.<br/>
                                 The <code>certthumbprint</code> can be obtained using this command:


### PR DESCRIPTION
Requires btcpayserver/BTCPayServer.Lightning#152. Using `invoice.macaroon` suffices, only downside is we cannot display the connection details on the public Lightning node info page.