### PR TITLE
Handle disabled plugin in ui

### DIFF
--- a/BTCPayServer/Views/UIServer/ListPlugins.cshtml
+++ b/BTCPayServer/Views/UIServer/ListPlugins.cshtml
@@ -416,6 +416,12 @@
                                 </form>
                             }
                         }
+                        @if (disabled)
+                        {
+                            <form asp-action="UnInstallPlugin" asp-route-plugin="@plugin.Identifier">
+                                <button type="submit" class="btn btn-sm btn-outline-danger">Uninstall</button>
+                            </form>
+                        }
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
When a plugin is disabled, we should at least show the uninstall option in the plugin option. Eventually we should also detect what version was disabled and offer an update instead