### PR TITLE
Use PullPaymentId to derive the cardkey of Boltcard

### DIFF
--- a/BTCPayServer.Tests/SeleniumTests.cs
+++ b/BTCPayServer.Tests/SeleniumTests.cs
@@ -2151,7 +2151,7 @@ namespace BTCPayServer.Tests
                 var ppid = lnurl.AbsoluteUri.Split("/").Last();
                 var issuerKey = new IssuerKey(SettingsRepositoryExtensions.FixedKey());
                 var uid = RandomNumberGenerator.GetBytes(7);
-                var cardKey = issuerKey.CreateCardKey(uid, 0);
+                var cardKey = issuerKey.CreatePullPaymentCardKey(uid, 0, ppid);
                 var keys = cardKey.DeriveBoltcardKeys(issuerKey);
                 await db.LinkBoltcardToPullPayment(ppid, issuerKey, uid);
                 var piccData = new byte[] { 0xc7 }.Concat(uid).Concat(new byte[] { 1, 0, 0, 0, 0, 0, 0, 0 }).ToArray();

--- a/BTCPayServer/BTCPayServer.csproj
+++ b/BTCPayServer/BTCPayServer.csproj
@@ -46,7 +46,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="BTCPayServer.NTag424" Version="1.0.18" />
+    <PackageReference Include="BTCPayServer.NTag424" Version="1.0.19" />
     <PackageReference Include="YamlDotNet" Version="8.0.0" />
     <PackageReference Include="BIP78.Sender" Version="0.2.2" />
     <PackageReference Include="BTCPayServer.Hwi" Version="2.0.2" />

--- a/BTCPayServer/Controllers/GreenField/GreenfieldPullPaymentController.cs
+++ b/BTCPayServer/Controllers/GreenField/GreenfieldPullPaymentController.cs
@@ -1,6 +1,7 @@
 #nullable enable
 using System;
 using System.Collections.Generic;
+using System.IO.IsolatedStorage;
 using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading;
@@ -218,7 +219,7 @@ namespace BTCPayServer.Controllers.Greenfield
 
             var issuerKey = await _settingsRepository.GetIssuerKey(_env);
             var version = await _dbContextFactory.LinkBoltcardToPullPayment(pullPaymentId, issuerKey, request.UID, request.OnExisting);
-            var keys = issuerKey.CreateCardKey(request.UID, version).DeriveBoltcardKeys(issuerKey);
+            var keys = issuerKey.CreatePullPaymentCardKey(request.UID, version, pullPaymentId).DeriveBoltcardKeys(issuerKey);
 
             var boltcardUrl = Url.Action(nameof(UIBoltcardController.GetWithdrawRequest), "UIBoltcard");
             boltcardUrl = Request.GetAbsoluteUri(boltcardUrl);

--- a/BTCPayServer/Controllers/UIBoltcardController.cs
+++ b/BTCPayServer/Controllers/UIBoltcardController.cs
@@ -61,7 +61,7 @@ public class UIBoltcardController : Controller
         var registration = await ContextFactory.GetBoltcardRegistration(issuerKey, piccData, updateCounter: pr is not null);
         if (registration?.PullPaymentId is null)
             return BadRequest(new LNUrlStatusResponse { Status = "ERROR", Reason = "Replayed or expired query" });
-        var cardKey = issuerKey.CreateCardKey(piccData.Uid, registration.Version);
+        var cardKey = issuerKey.CreatePullPaymentCardKey(piccData.Uid, registration.Version, registration.PullPaymentId);
         if (!cardKey.CheckSunMac(c, piccData))
             return BadRequest(new LNUrlStatusResponse { Status = "ERROR", Reason = "Replayed or expired query" });
         LNURLController.ControllerContext.HttpContext = HttpContext;

--- a/BTCPayServer/Controllers/UIPullPaymentController.Boltcard.cs
+++ b/BTCPayServer/Controllers/UIPullPaymentController.Boltcard.cs
@@ -111,7 +111,7 @@ next:
                                     try
                                     {
                                         var version = await _dbContextFactory.LinkBoltcardToPullPayment(pullPaymentId, issuerKey, uid);
-                                        var cardKey = issuerKey.CreateCardKey(uid, version);
+                                        var cardKey = issuerKey.CreatePullPaymentCardKey(uid, version, pullPaymentId);
                                         await ntag.SetupBoltcard(boltcardUrl, BoltcardKeys.Default, cardKey.DeriveBoltcardKeys(issuerKey));
                                     }
                                     catch
@@ -135,7 +135,7 @@ next:
                                 }
                                 else if (cardOrigin is CardOrigin.ThisIssuer thisIssuer)
                                 {
-                                    var cardKey = issuerKey.CreateCardKey(thisIssuer.Registration.UId, thisIssuer.Registration.Version);
+                                    var cardKey = issuerKey.CreatePullPaymentCardKey(thisIssuer.Registration.UId, thisIssuer.Registration.Version, pullPaymentId);
                                     await ntag.ResetCard(issuerKey, cardKey);
                                     await _dbContextFactory.SetBoltcardResetState(issuerKey, thisIssuer.Registration.UId);
                                     await vaultClient.Show(VaultMessageType.Ok, "Card reset succeed", cts.Token);

--- a/BTCPayServer/Extensions.cs
+++ b/BTCPayServer/Extensions.cs
@@ -19,6 +19,7 @@ using BTCPayServer.Lightning;
 using BTCPayServer.Logging;
 using BTCPayServer.Models;
 using BTCPayServer.Models.StoreViewModels;
+using BTCPayServer.NTag424;
 using BTCPayServer.Payments;
 using BTCPayServer.Payments.Bitcoin;
 using BTCPayServer.Security;
@@ -41,6 +42,11 @@ namespace BTCPayServer
 {
     public static class Extensions
     {
+        public static CardKey CreatePullPaymentCardKey(this IssuerKey issuerKey, byte[] uid, int version, string pullPaymentId)
+        {
+            var data = Encoding.UTF8.GetBytes(pullPaymentId);
+            return issuerKey.CreateCardKey(uid, version, data);
+        }
         public static DateTimeOffset TruncateMilliSeconds(this DateTimeOffset dt) => new (dt.Year, dt.Month, dt.Day, dt.Hour, dt.Minute, dt.Second, 0, dt.Offset);
         public static decimal? GetDue(this InvoiceCryptoInfo invoiceCryptoInfo)
         {


### PR DESCRIPTION
This is a breaking change. Boltcards registered during 1.12.0 will not work.

Doing this so the keys get different depending on the pull payment.
This mean that somebody only owning the UID of a card can't just request the other keys to the service without the pull payment id.