### PR TITLE
UI: Form validation summary matches alert style

### DIFF
--- a/BTCPayServer/Views/Shared/CreateOrEditRole.cshtml
+++ b/BTCPayServer/Views/Shared/CreateOrEditRole.cshtml
@@ -31,7 +31,7 @@
 <div class="row">
     <div class="col-xxl-constrain">
         <form method="post">
-            <div asp-validation-summary="ModelOnly" class="text-danger"></div>
+            <div asp-validation-summary="ModelOnly"></div>
 
             <div class="form-group" style="max-width:320px">
                 <label asp-for="Role" class="form-label"></label>

--- a/BTCPayServer/Views/Shared/Crowdfund/UpdateCrowdfund.cshtml
+++ b/BTCPayServer/Views/Shared/Crowdfund/UpdateCrowdfund.cshtml
@@ -42,7 +42,7 @@
 
     <input type="hidden" asp-for="StoreId" />
     <input type="hidden" asp-for="Archived" />
-    <div asp-validation-summary="ModelOnly" class="text-danger"></div>
+    <div asp-validation-summary="ModelOnly"></div>
 
     <div class="row">
         <div class="col-sm-10 col-md-9 col-xl-7 col-xxl-6">

--- a/BTCPayServer/Views/Shared/EmailsBody.cshtml
+++ b/BTCPayServer/Views/Shared/EmailsBody.cshtml
@@ -27,7 +27,7 @@
         <div class="col-xl-10 col-xxl-constrain">
             @if (!ViewContext.ModelState.IsValid)
             {
-                <div asp-validation-summary="All" class="text-danger"></div>
+                <div asp-validation-summary="All"></div>
             }
             <div class="form-group">
                 <label asp-for="Settings.Server" class="form-label">SMTP Server</label>

--- a/BTCPayServer/Views/Shared/PointOfSale/UpdatePointOfSale.cshtml
+++ b/BTCPayServer/Views/Shared/PointOfSale/UpdatePointOfSale.cshtml
@@ -43,7 +43,7 @@
 
     <input type="hidden" asp-for="StoreId" />
     <input type="hidden" asp-for="Archived" />
-    <div asp-validation-summary="ModelOnly" class="text-danger"></div>
+    <div asp-validation-summary="ModelOnly"></div>
 
     <div class="row">
         <div class="col-sm-10 col-md-9 col-xl-7 col-xxl-6">

--- a/BTCPayServer/Views/UIAccount/ForgotPassword.cshtml
+++ b/BTCPayServer/Views/UIAccount/ForgotPassword.cshtml
@@ -10,7 +10,7 @@
 </p>
 
 <form asp-action="ForgotPassword" method="post">
-    <div asp-validation-summary="All" class="text-danger"></div>
+    <div asp-validation-summary="All"></div>
     <div class="form-group">
         <label asp-for="Email" class="form-label"></label>
         <input asp-for="Email" class="form-control" />

--- a/BTCPayServer/Views/UIAccount/Login.cshtml
+++ b/BTCPayServer/Views/UIAccount/Login.cshtml
@@ -9,7 +9,7 @@
 
 <form asp-route-returnurl="@ViewData["ReturnUrl"]" method="post" id="login-form" asp-action="Login">
     <fieldset disabled="@(ViewData.ContainsKey("disabled") ? "disabled" : null)">
-        <div asp-validation-summary="ModelOnly" class="text-danger"></div>
+        <div asp-validation-summary="ModelOnly"></div>
         <div class="form-group">
             <label asp-for="Email" class="form-label"></label>
             <input asp-for="Email" class="form-control" required autofocus/>

--- a/BTCPayServer/Views/UIAccount/LoginWith2fa.cshtml
+++ b/BTCPayServer/Views/UIAccount/LoginWith2fa.cshtml
@@ -3,7 +3,7 @@
 <div class="twoFaBox">
     <h2 class="h3 mb-3">Two-Factor Authentication</h2>
     <form method="post" asp-route-returnUrl="@ViewData["ReturnUrl"]" asp-action="LoginWith2fa">
-        <div asp-validation-summary="ModelOnly" class="text-danger"></div>
+        <div asp-validation-summary="ModelOnly"></div>
         <input asp-for="RememberMe" type="hidden"/>
         <div class="form-group">
             <label asp-for="TwoFactorCode" class="form-label"></label>

--- a/BTCPayServer/Views/UIAccount/Register.cshtml
+++ b/BTCPayServer/Views/UIAccount/Register.cshtml
@@ -8,7 +8,7 @@
 
 <form asp-route-returnUrl="@ViewData["ReturnUrl"]" asp-route-logon="true" method="post">
     <fieldset disabled="@(ViewData.ContainsKey("disabled") ? "disabled" : null)" >
-        <div asp-validation-summary="ModelOnly" class="text-danger"></div>
+        <div asp-validation-summary="ModelOnly"></div>
         <div class="form-group">
             <label asp-for="Email" class="form-label"></label>
             <input asp-for="Email" class="form-control" required autofocus />

--- a/BTCPayServer/Views/UIAccount/SecondaryLogin.cshtml
+++ b/BTCPayServer/Views/UIAccount/SecondaryLogin.cshtml
@@ -15,7 +15,7 @@
 
 @if (Model.LoginWith2FaViewModel != null && Model.LoginWithFido2ViewModel != null&& Model.LoginWithLNURLAuthViewModel != null)
 {
-    <div asp-validation-summary="ModelOnly" class="text-danger"></div>
+    <div asp-validation-summary="ModelOnly"></div>
 }
 else if (Model.LoginWith2FaViewModel == null && Model.LoginWithFido2ViewModel == null && Model.LoginWithLNURLAuthViewModel == null)
 {

--- a/BTCPayServer/Views/UIAccount/SetPassword.cshtml
+++ b/BTCPayServer/Views/UIAccount/SetPassword.cshtml
@@ -5,7 +5,7 @@
 }
 
 <form method="post" asp-action="SetPassword">
-    <div asp-validation-summary="All" class="text-danger"></div>
+    <div asp-validation-summary="All"></div>
     <input asp-for="Code" type="hidden"/>
     <input asp-for="EmailSetInternally" type="hidden"/>
     @if (Model.EmailSetInternally)

--- a/BTCPayServer/Views/UIApps/CreateApp.cshtml
+++ b/BTCPayServer/Views/UIApps/CreateApp.cshtml
@@ -14,7 +14,7 @@
 <div class="row">
     <div class="col-xl-8 col-xxl-constrain">
         <form asp-action="CreateApp" asp-route-appType="@Model.AppType">
-            <div asp-validation-summary="ModelOnly" class="text-danger"></div>
+            <div asp-validation-summary="ModelOnly"></div>
             @if (string.IsNullOrEmpty(Model.AppType))
             {
                 <div class="form-group">

--- a/BTCPayServer/Views/UICustodianAccounts/CreateCustodianAccount.cshtml
+++ b/BTCPayServer/Views/UICustodianAccounts/CreateCustodianAccount.cshtml
@@ -20,7 +20,7 @@
 			<input asp-for="Config" type="hidden" />
             @if (!ViewContext.ModelState.IsValid)
             {
-                <div asp-validation-summary="ModelOnly" class="text-danger"></div>
+                <div asp-validation-summary="ModelOnly"></div>
             }
             @if (!string.IsNullOrEmpty(Model.SelectedCustodian))
             {

--- a/BTCPayServer/Views/UICustodianAccounts/EditCustodianAccount.cshtml
+++ b/BTCPayServer/Views/UICustodianAccounts/EditCustodianAccount.cshtml
@@ -21,7 +21,7 @@
 			<input asp-for="Config" type="hidden" />
             @if (!ViewContext.ModelState.IsValid)
             {
-                <div asp-validation-summary="ModelOnly" class="text-danger"></div>
+                <div asp-validation-summary="ModelOnly"></div>
             }
             <partial name="_FormTopMessages" model="Model.ConfigForm"/>
 

--- a/BTCPayServer/Views/UIForms/Modify.cshtml
+++ b/BTCPayServer/Views/UIForms/Modify.cshtml
@@ -211,7 +211,7 @@
                     }
                 </div>
             </div>
-            <div asp-validation-summary="All" class="text-danger"></div>
+            <div asp-validation-summary="All"></div>
             <div class="form-group" style="max-width: 27rem;">
                 <label asp-for="Name" class="form-label" data-required></label>
                 <input asp-for="Name" class="form-control" required />

--- a/BTCPayServer/Views/UIForms/View.cshtml
+++ b/BTCPayServer/Views/UIForms/View.cshtml
@@ -26,7 +26,7 @@
         <main class="flex-grow-1">
             @if (!ViewContext.ModelState.IsValid)
             {
-                <div asp-validation-summary="ModelOnly" class="text-danger"></div>
+                <div asp-validation-summary="ModelOnly"></div>
             }
             <partial name="_FormTopMessages" model="@Model.Form" />
             <div class="d-flex flex-column justify-content-center gap-4">

--- a/BTCPayServer/Views/UIInvoice/CreateInvoice.cshtml
+++ b/BTCPayServer/Views/UIInvoice/CreateInvoice.cshtml
@@ -38,7 +38,7 @@
 
     <div class="row">
         <div class="col-xl-8 col-xxl-constrain">
-            <div asp-validation-summary="ModelOnly" class="text-danger"></div>
+            <div asp-validation-summary="ModelOnly"></div>
             @if (Model.StoreId != null)
             {
                 <input type="hidden" asp-for="StoreId" />

--- a/BTCPayServer/Views/UIInvoice/_RefundModal.cshtml
+++ b/BTCPayServer/Views/UIInvoice/_RefundModal.cshtml
@@ -17,7 +17,7 @@
     
     @if (!ViewContext.ModelState.IsValid)
     {
-        <div asp-validation-summary="All" class="text-danger"></div>
+        <div asp-validation-summary="All"></div>
     }
 
     @switch (Model.RefundStep)

--- a/BTCPayServer/Views/UILightningAutomatedPayoutProcessors/Configure.cshtml
+++ b/BTCPayServer/Views/UILightningAutomatedPayoutProcessors/Configure.cshtml
@@ -15,7 +15,7 @@
         <p>Set a schedule for automated Lightning Network Payouts.</p>
         @if (!ViewContext.ModelState.IsValid)
         {
-            <div asp-validation-summary="All" class="text-danger"></div>
+            <div asp-validation-summary="All"></div>
         }
         <form method="post">
             <div class="form-check">

--- a/BTCPayServer/Views/UIManage/AddApiKey.cshtml
+++ b/BTCPayServer/Views/UIManage/AddApiKey.cshtml
@@ -32,7 +32,7 @@
         <p>Generate a new api key to use BTCPay through its API.</p>
         
         <form method="post" asp-action="AddApiKey" id="Permissions">
-            <div asp-validation-summary="All" class="text-danger"></div>
+            <div asp-validation-summary="All"></div>
         
             <div class="form-group">
                 <label asp-for="Label" class="form-label"></label>

--- a/BTCPayServer/Views/UIManage/AuthorizeAPIKey.cshtml
+++ b/BTCPayServer/Views/UIManage/AuthorizeAPIKey.cshtml
@@ -45,7 +45,7 @@
         <h1>@ViewData["Title"]</h1>
         <p class="lead text-secondary mt-3">@(displayName ?? "An application") is requesting access to your BTCPay Server account.</p>
     </header>
-    <div asp-validation-summary="All" class="text-danger"></div>
+    <div asp-validation-summary="All"></div>
     
     @if (Model.NeedsStorePermission && store == null)
     {

--- a/BTCPayServer/Views/UIManage/ChangePassword.cshtml
+++ b/BTCPayServer/Views/UIManage/ChangePassword.cshtml
@@ -7,7 +7,7 @@
     <div class="col-xl-8 col-xxl-constrain">
         @if (!ViewContext.ModelState.IsValid)
         {
-            <div asp-validation-summary="All" class="text-danger"></div>
+            <div asp-validation-summary="All"></div>
         }
         <form method="post">
             <div class="form-group">

--- a/BTCPayServer/Views/UIManage/EnableAuthenticator.cshtml
+++ b/BTCPayServer/Views/UIManage/EnableAuthenticator.cshtml
@@ -53,7 +53,7 @@
                     <span asp-validation-for="Code" class="text-danger"></span>
                 </div>
                 <button type="submit" class="btn btn-primary mt-2">Verify</button>
-                <div asp-validation-summary="ModelOnly" class="text-danger"></div>
+                <div asp-validation-summary="ModelOnly"></div>
             </form>
         </li>
     </ol>

--- a/BTCPayServer/Views/UIManage/Index.cshtml
+++ b/BTCPayServer/Views/UIManage/Index.cshtml
@@ -9,7 +9,7 @@
     <form method="post">
         @if (!ViewContext.ModelState.IsValid)
         {
-            <div asp-validation-summary="All" class="text-danger"></div>
+            <div asp-validation-summary="All"></div>
         }
         <div class="form-group">
             <div class="col-md-6">

--- a/BTCPayServer/Views/UIManage/SetPassword.cshtml
+++ b/BTCPayServer/Views/UIManage/SetPassword.cshtml
@@ -12,7 +12,7 @@
 <div class="row">
     <div class="col-md-6">
         <form method="post">
-            <div asp-validation-summary="All" class="text-danger"></div>
+            <div asp-validation-summary="All"></div>
             <div class="form-group">
                 <label asp-for="NewPassword" class="form-label"></label>
                 <input asp-for="NewPassword" class="form-control" />

--- a/BTCPayServer/Views/UIOnChainAutomatedPayoutProcessors/Configure.cshtml
+++ b/BTCPayServer/Views/UIOnChainAutomatedPayoutProcessors/Configure.cshtml
@@ -15,7 +15,7 @@
         <p>Set a schedule for automated On-Chain Bitcoin Payouts. </p>
         @if (!ViewContext.ModelState.IsValid)
         {
-            <div asp-validation-summary="All" class="text-danger"></div>
+            <div asp-validation-summary="All"></div>
         }
         <form method="post">
             <div class="form-check">

--- a/BTCPayServer/Views/UIPaymentRequest/EditPaymentRequest.cshtml
+++ b/BTCPayServer/Views/UIPaymentRequest/EditPaymentRequest.cshtml
@@ -41,7 +41,7 @@
 
     <div class="row">
         <div class="col-xl-8 col-xxl-constrain">
-            <div asp-validation-summary="ModelOnly" class="text-danger"></div>
+            <div asp-validation-summary="ModelOnly"></div>
             <div class="form-group">
                 <label asp-for="Title" class="form-label" data-required></label>
                 <input asp-for="Title" class="form-control" required />

--- a/BTCPayServer/Views/UIPullPayment/EditPullPayment.cshtml
+++ b/BTCPayServer/Views/UIPullPayment/EditPullPayment.cshtml
@@ -35,7 +35,7 @@
 
     <div class="row">
         <div class="col-xl-8 col-xxl-constrain">
-            <div asp-validation-summary="ModelOnly" class="text-danger"></div>
+            <div asp-validation-summary="ModelOnly"></div>
             <div class="form-group">
                 <label asp-for="Name" class="form-label" data-required></label>
                 <input asp-for="Name" class="form-control" required />

--- a/BTCPayServer/Views/UIServer/CLightningRestServices.cshtml
+++ b/BTCPayServer/Views/UIServer/CLightningRestServices.cshtml
@@ -7,7 +7,7 @@
 
 @if (!ViewContext.ModelState.IsValid)
 {
-    <div asp-validation-summary="All" class="text-danger"></div>
+    <div asp-validation-summary="All"></div>
 }
 <div class="form-group">
     <p>

--- a/BTCPayServer/Views/UIServer/ConfiguratorService.cshtml
+++ b/BTCPayServer/Views/UIServer/ConfiguratorService.cshtml
@@ -7,7 +7,7 @@
 
 <div class="row">
     <div class="col-md-6">
-        <div asp-validation-summary="All" class="text-danger"></div>
+        <div asp-validation-summary="All"></div>
     </div>
 </div>
 

--- a/BTCPayServer/Views/UIServer/CreateTemporaryFileUrl.cshtml
+++ b/BTCPayServer/Views/UIServer/CreateTemporaryFileUrl.cshtml
@@ -10,7 +10,7 @@
     <div class="col-xl-8 col-xxl-constrain">
         @if (!ViewContext.ModelState.IsValid)
         {
-            <div asp-validation-summary="All" class="text-danger"></div>
+            <div asp-validation-summary="All"></div>
         }
         <form method="post">
             <div class="form-group form-check">

--- a/BTCPayServer/Views/UIServer/CreateUser.cshtml
+++ b/BTCPayServer/Views/UIServer/CreateUser.cshtml
@@ -8,7 +8,7 @@
 <div class="row">
     <div class="col-xl-6 col-xxl-constrain">
         <form method="post" asp-action="CreateUser">
-            <div asp-validation-summary="ModelOnly" class="text-danger"></div>
+            <div asp-validation-summary="ModelOnly"></div>
 
             <div class="form-group">
                 <label asp-for="Email" class="form-label"></label>

--- a/BTCPayServer/Views/UIServer/DynamicDnsService.cshtml
+++ b/BTCPayServer/Views/UIServer/DynamicDnsService.cshtml
@@ -17,7 +17,7 @@
     <div class="col-md-8">
         @if (!ViewContext.ModelState.IsValid)
         {
-            <div asp-validation-summary="All" class="text-danger"></div>
+            <div asp-validation-summary="All"></div>
         }
         <form method="post">
             <div class="form-group">

--- a/BTCPayServer/Views/UIServer/LightningChargeServices.cshtml
+++ b/BTCPayServer/Views/UIServer/LightningChargeServices.cshtml
@@ -9,7 +9,7 @@
     <div class="col-md-8">
         @if (!ViewContext.ModelState.IsValid)
         {
-            <div asp-validation-summary="All" class="text-danger"></div>
+            <div asp-validation-summary="All"></div>
         }
         <div class="form-group">
             <p>Lightning charge is a simple API for invoicing on lightning network, you can use it with several plugins:</p>

--- a/BTCPayServer/Views/UIServer/LightningWalletServices.cshtml
+++ b/BTCPayServer/Views/UIServer/LightningWalletServices.cshtml
@@ -22,7 +22,7 @@
     <div class="col-md-8">
         @if (!ViewContext.ModelState.IsValid)
         {
-            <div asp-validation-summary="All" class="text-danger"></div>
+            <div asp-validation-summary="All"></div>
         }
         <div class="form-group">
             <h5>Browser connection</h5>

--- a/BTCPayServer/Views/UIServer/P2PService.cshtml
+++ b/BTCPayServer/Views/UIServer/P2PService.cshtml
@@ -20,7 +20,7 @@
 
 @if (!ViewContext.ModelState.IsValid)
 {
-    <div asp-validation-summary="All" class="text-danger"></div>
+    <div asp-validation-summary="All"></div>
 }
 
 <h4 class="mb-3">Full node connection</h4>

--- a/BTCPayServer/Views/UIServer/Policies.cshtml
+++ b/BTCPayServer/Views/UIServer/Policies.cshtml
@@ -27,7 +27,7 @@
 
 @if (!ViewContext.ModelState.IsValid)
 {
-    <div asp-validation-summary="All" class="text-danger"></div>
+    <div asp-validation-summary="All"></div>
 }
 
 <div class="row">

--- a/BTCPayServer/Views/UIServer/RPCService.cshtml
+++ b/BTCPayServer/Views/UIServer/RPCService.cshtml
@@ -20,7 +20,7 @@
 
 @if (!ViewContext.ModelState.IsValid)
 {
-    <div asp-validation-summary="All" class="text-danger"></div>
+    <div asp-validation-summary="All"></div>
 }
 
 <h4 class="mb-3">Full node connection</h4>

--- a/BTCPayServer/Views/UIServer/SSHService.cshtml
+++ b/BTCPayServer/Views/UIServer/SSHService.cshtml
@@ -15,7 +15,7 @@
 
         @if (!ViewContext.ModelState.IsValid)
         {
-            <div asp-validation-summary="All" class="text-danger"></div>
+            <div asp-validation-summary="All"></div>
         }
 
         <div class="form-group">

--- a/BTCPayServer/Views/UIServer/Storage.cshtml
+++ b/BTCPayServer/Views/UIServer/Storage.cshtml
@@ -16,7 +16,7 @@
         <form method="post">
             @if (!ViewContext.ModelState.IsValid)
             {
-                <div asp-validation-summary="All" class="text-danger"></div>
+                <div asp-validation-summary="All"></div>
             }
             <div class="form-group">
                 <label asp-for="Provider" class="form-label"></label>

--- a/BTCPayServer/Views/UIShopify/EditShopify.cshtml
+++ b/BTCPayServer/Views/UIShopify/EditShopify.cshtml
@@ -25,7 +25,7 @@
 
         @if (!ViewContext.ModelState.IsValid)
         {
-            <div asp-validation-summary="All" class="text-danger"></div>
+            <div asp-validation-summary="All"></div>
         }
 
         <form method="post" id="shopifyForm">

--- a/BTCPayServer/Views/UIStores/CheckoutAppearance.cshtml
+++ b/BTCPayServer/Views/UIStores/CheckoutAppearance.cshtml
@@ -63,7 +63,7 @@
         <form method="post" enctype="multipart/form-data">
             @if (!ViewContext.ModelState.IsValid)
             {
-                <div asp-validation-summary="All" class="text-danger"></div>
+                <div asp-validation-summary="All"></div>
             }
             <h3 class="mb-3">Invoice Settings</h3>
             @if (Model.PaymentMethods.Any())

--- a/BTCPayServer/Views/UIStores/GeneralSettings.cshtml
+++ b/BTCPayServer/Views/UIStores/GeneralSettings.cshtml
@@ -15,7 +15,7 @@
     <div class="col-xxl-constrain col-xl-8">
         @if (!ViewContext.ModelState.IsValid)
         {
-            <div asp-validation-summary="All" class="text-danger"></div>
+            <div asp-validation-summary="All"></div>
         }
         <form method="post" enctype="multipart/form-data">
             <h3 class="mb-3">General</h3>

--- a/BTCPayServer/Views/UIStores/ImportWallet/ConfirmAddresses.cshtml
+++ b/BTCPayServer/Views/UIStores/ImportWallet/ConfirmAddresses.cshtml
@@ -17,7 +17,7 @@
 
 @if (!ViewContext.ModelState.IsValid)
 {
-    <div asp-validation-summary="All" class="text-danger"></div>
+    <div asp-validation-summary="All"></div>
 }
 
 <partial name="LocalhostBrowserSupport" />

--- a/BTCPayServer/Views/UIStores/ImportWallet/Hardware.cshtml
+++ b/BTCPayServer/Views/UIStores/ImportWallet/Hardware.cshtml
@@ -17,7 +17,7 @@
 
 @if (!ViewContext.ModelState.IsValid)
 {
-    <div asp-validation-summary="All" class="text-danger"></div>
+    <div asp-validation-summary="All"></div>
 }
 
 <partial name="LocalhostBrowserSupport" />

--- a/BTCPayServer/Views/UIStores/ImportWallet/Scan.cshtml
+++ b/BTCPayServer/Views/UIStores/ImportWallet/Scan.cshtml
@@ -19,7 +19,7 @@
 
 @if (!ViewContext.ModelState.IsValid)
 {
-    <div asp-validation-summary="All" class="text-danger"></div>
+    <div asp-validation-summary="All"></div>
 }
 
 <div class="my-5">

--- a/BTCPayServer/Views/UIStores/Rates.cshtml
+++ b/BTCPayServer/Views/UIStores/Rates.cshtml
@@ -10,7 +10,7 @@
         <h3 class="mb-3">@ViewData["Title"]</h3>
         @if (!ViewContext.ModelState.IsValid)
         {
-            <div asp-validation-summary="All" class="text-danger"></div>
+            <div asp-validation-summary="All"></div>
         }
         <form method="post">
             <input type="hidden" asp-for="ShowScripting" />

--- a/BTCPayServer/Views/UIStores/StoreEmails.cshtml
+++ b/BTCPayServer/Views/UIStores/StoreEmails.cshtml
@@ -29,7 +29,7 @@
         </div>
         @if (!ViewContext.ModelState.IsValid)
         {
-            <div asp-validation-summary="All" class="text-danger"></div>
+            <div asp-validation-summary="All"></div>
         }
         else
         {

--- a/BTCPayServer/Views/UIStores/StoreUsers.cshtml
+++ b/BTCPayServer/Views/UIStores/StoreUsers.cshtml
@@ -20,7 +20,7 @@
 
         @if (!ViewContext.ModelState.IsValid)
         {
-            <div asp-validation-summary="All" class="text-danger"></div>
+            <div asp-validation-summary="All"></div>
         }
 
         <form method="post">

--- a/BTCPayServer/Views/UIUserStores/_CreateStoreForm.cshtml
+++ b/BTCPayServer/Views/UIUserStores/_CreateStoreForm.cshtml
@@ -1,7 +1,7 @@
 @model BTCPayServer.Models.StoreViewModels.CreateStoreViewModel
 
 <form asp-action="CreateStore">
-    <div asp-validation-summary="ModelOnly" class="text-danger"></div>
+    <div asp-validation-summary="ModelOnly"></div>
     <div class="form-group">
         <label asp-for="Name" class="form-label" data-required></label>
         <input asp-for="Name" class="form-control w-300px" required />

--- a/BTCPayServer/Views/UIWallets/SignWithSeed.cshtml
+++ b/BTCPayServer/Views/UIWallets/SignWithSeed.cshtml
@@ -37,7 +37,7 @@
     <p class="mb-0">Otherwise you are exposing yourself to malicious site owners, or to malicious plugins installed in your browser.</p>
 </div>
 
-<div asp-validation-summary="All" class="text-danger"></div>
+<div asp-validation-summary="All"></div>
 
 <form method="post" asp-action="SignWithSeed" asp-route-walletId="@walletId">
     <partial name="SigningContext" for="SigningContext"/>

--- a/BTCPayServer/wwwroot/main/site.css
+++ b/BTCPayServer/wwwroot/main/site.css
@@ -27,6 +27,21 @@
     visibility: hidden;
 }
 
+/* Form validation messages should match alert styles */
+.validation-summary-errors {
+    padding: .75rem 1rem;
+    margin-bottom: 1.5rem;
+    color: var(--btcpay-danger-text);
+    background-color: var(--btcpay-danger);
+    border: var(--btcpay-border-width) solid var(--btcpay-danger-border);
+    border-radius: var(--btcpay-border-radius);
+}
+
+.alert > :last-child,
+.validation-summary-errors > :last-child {
+    margin-bottom: 0;
+}
+
 /* General and site-wide Bootstrap modifications */
 p {
     margin-bottom: 1.5rem;


### PR DESCRIPTION
In places where we have a summary of form validation errors, this makes the appear like the Bootstrap danger alerts we use elsewhere. Fixes #5564.

![grafik](https://github.com/btcpayserver/btcpayserver/assets/886/729bfa0d-18c2-4133-8179-4d22ae34776f)
