### PR TITLE
Startup: List configured networks in non-altcoin build warning

### DIFF
--- a/BTCPayServer.Common/BTCPayNetworkProvider.cs
+++ b/BTCPayServer.Common/BTCPayNetworkProvider.cs
@@ -31,18 +31,17 @@ namespace BTCPayServer
             IEnumerable<BTCPayNetworkBase> networks,
             SelectedChains selectedChains,
             NBXplorerNetworkProvider nbxplorerNetworkProvider,
-            Logs logs,
-            IConfiguration configuration)
+            Logs logs)
         {
+            var networksList = networks.ToList();
 #if !ALTCOINS
-            var onlyBTC = networks.Count() == 1 && networks.First().IsBTC;
+            var onlyBTC = networksList.Count == 1 && networksList.First().IsBTC;
             if (!onlyBTC)
-                throw new ConfigException($"This build of BTCPay Server does not support altcoins");
+                throw new ConfigException($"This build of BTCPay Server does not support altcoins. Configured networks: {string.Join(',', networksList.Select(n => n.CryptoCode).ToArray())}");
 #endif
-
             _NBXplorerNetworkProvider = nbxplorerNetworkProvider;
             NetworkType = nbxplorerNetworkProvider.NetworkType;
-            foreach (var network in networks)
+            foreach (var network in networksList)
             {
                 _Networks.Add(network.CryptoCode.ToUpperInvariant(), network);
             }
@@ -53,8 +52,7 @@ namespace BTCPayServer
                     throw new ConfigException($"Invalid chains \"{chain}\"");
             }
 
-            logs.Configuration.LogInformation(
-                "Supported chains: " + String.Join(',', _Networks.Select(n => n.Key).ToArray()));
+            logs.Configuration.LogInformation("Supported chains: {Chains}", string.Join(',', _Networks.Select(n => n.Key).ToArray()));
         }
 
         public BTCPayNetwork BTC => GetNetwork<BTCPayNetwork>("BTC");


### PR DESCRIPTION
In my standard Docker build I see these log entries: `Configuration:  This build of BTCPay Server does not support altcoins`. I'd like to be able to better debug this, because as far as I see there are no other networks configured:

```
BTCPAY_CRYPTOS=btc
BTCPAYGEN_CRYPTO1=btc
```

The rest of the BTCPAYGEN_CRYPTO0X is empty. The log also yields `Configuration:  Supported chains: BTC` at the same time.