### PR TITLE
Removed what's new button and info #5608

### DIFF
--- a/BTCPayServer/Views/UIStores/Dashboard.cshtml
+++ b/BTCPayServer/Views/UIStores/Dashboard.cshtml
@@ -17,36 +17,6 @@
 
 <div class="d-flex align-items-center justify-content-between">
     <h2 class="mb-0">@ViewData["Title"]</h2>
-    @if (Model.IsSetUp)
-    {
-        <button type="button" class="btn btn-secondary only-for-js" data-bs-toggle="modal" data-bs-target="#WhatsNew">What's New</button>
-    }
-</div>
-
-<div class="modal fade" id="WhatsNew" tabindex="-1" aria-labelledby="WhatsNewTitle" aria-hidden="true">
-    <div class="modal-dialog">
-        <div class="modal-content">
-            <div class="modal-header">
-                <h4 class="modal-title" id="WhatsNewTitle">What's New</h4>
-                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close">
-                    <vc:icon symbol="close"/>
-                </button>
-            </div>
-            <div class="modal-body">
-                <h5 class="alert-heading">Updated in <a href="https://blog.btcpayserver.org/btcpay-server-1-10-0/" target="_blank" rel="noreferrer noopener">v1.10.0</a></h5>
-                <p class="mb-2">We've added some more options for refunds and an editor for creating custom forms. You can now also define your own roles with customized access to store features.</p>
-                <p class="mb-0">The invoice filter got a facelift and you now have the option to hide sensitive data in the UI (such as amounts and balances).</p>
-                <hr style="height:1px;background-color:var(--btcpay-body-text-muted);margin:var(--btcpay-space-m) 0;" />
-                <h5 class="alert-heading">Updated in <a href="https://blog.btcpayserver.org/btcpay-server-1-9-0/" target="_blank" rel="noreferrer noopener">v1.9.0</a></h5>
-                <p class="mb-2">Lots of improvements for our new checkout experience, which is now also the default for new stores — better NFC support, improved receipts and … confetti! 🎉</p>
-                <p class="mb-0">You'll also notice that wallet labels are featured more prominently. And the invoice details page now contains all the information you'd expect.</p>
-                <hr style="height:1px;background-color:var(--btcpay-body-text-muted);margin:var(--btcpay-space-m) 0;" />
-                <h5 class="alert-heading">Updated in <a href="https://blog.btcpayserver.org/btcpay-server-1-8-0/" target="_blank" rel="noreferrer noopener">v1.8.0</a></h5>
-                <p class="mb-2">Bear markets are for building: This version brings custom checkout forms, store branding options, a redesigned Point of Sale keypad view, new notification icons and address labeling.</p>
-                <p class="mb-0">You like that? Consider <a href="https://opensats.org/projects/btcpayserver" target="_blank" rel="noreferrer noopener">supporting BTCPay Server via OpenSats</a>.</p>
-            </div>
-        </div>
-    </div>
 </div>
 
 @if (Model.IsSetUp)


### PR DESCRIPTION
This update resolves #5608 by removing the 'What's New' button and the information that comes with it.