### PR TITLE
Prevent payment request to be created when a wallet is not set up

### DIFF
--- a/BTCPayServer.Tests/SeleniumTests.cs
+++ b/BTCPayServer.Tests/SeleniumTests.cs
@@ -1199,7 +1199,6 @@ namespace BTCPayServer.Tests
             s.Driver.FindElement(By.Id("StoreNav-PaymentRequests")).Click();
             s.Driver.FindElement(By.Id("CreatePaymentRequest")).Click();
             // Should give us an error message if we try to create an invoice before adding a wallet
-            var rr = s.Driver.PageSource;
             Assert.Contains("To create an invoice, you need to", s.Driver.PageSource);
             s.AddDerivationScheme();
             s.Driver.FindElement(By.Id("StoreNav-PaymentRequests")).Click();

--- a/BTCPayServer.Tests/SeleniumTests.cs
+++ b/BTCPayServer.Tests/SeleniumTests.cs
@@ -1195,8 +1195,13 @@ namespace BTCPayServer.Tests
             await s.StartAsync();
             s.RegisterNewUser();
             s.CreateNewStore();
-            s.AddDerivationScheme();
 
+            s.Driver.FindElement(By.Id("StoreNav-PaymentRequests")).Click();
+            s.Driver.FindElement(By.Id("CreatePaymentRequest")).Click();
+            // Should give us an error message if we try to create an invoice before adding a wallet
+            var rr = s.Driver.PageSource;
+            Assert.Contains("To create an invoice, you need to", s.Driver.PageSource);
+            s.AddDerivationScheme();
             s.Driver.FindElement(By.Id("StoreNav-PaymentRequests")).Click();
             s.Driver.FindElement(By.Id("CreatePaymentRequest")).Click();
             s.Driver.FindElement(By.Id("Title")).SendKeys("Pay123");

--- a/BTCPayServer.Tests/SeleniumTests.cs
+++ b/BTCPayServer.Tests/SeleniumTests.cs
@@ -565,9 +565,11 @@ namespace BTCPayServer.Tests
             s.RegisterNewUser(true);
             s.CreateNewStore();
             s.GoToInvoices();
-            s.Driver.FindElement(By.Id("CreateNewInvoice")).Click();
+
             // Should give us an error message if we try to create an invoice before adding a wallet
+            s.Driver.FindElement(By.Id("CreateNewInvoice")).Click();
             Assert.Contains("To create an invoice, you need to", s.Driver.PageSource);
+
             s.AddDerivationScheme();
             s.GoToInvoices();
             s.CreateInvoice();
@@ -1195,11 +1197,12 @@ namespace BTCPayServer.Tests
             await s.StartAsync();
             s.RegisterNewUser();
             s.CreateNewStore();
-
             s.Driver.FindElement(By.Id("StoreNav-PaymentRequests")).Click();
+            
+            // Should give us an error message if we try to create a payment request before adding a wallet
             s.Driver.FindElement(By.Id("CreatePaymentRequest")).Click();
-            // Should give us an error message if we try to create an invoice before adding a wallet
-            Assert.Contains("To create an invoice, you need to", s.Driver.PageSource);
+            Assert.Contains("To create a payment request, you need to", s.Driver.PageSource);
+
             s.AddDerivationScheme();
             s.Driver.FindElement(By.Id("StoreNav-PaymentRequests")).Click();
             s.Driver.FindElement(By.Id("CreatePaymentRequest")).Click();

--- a/BTCPayServer/Controllers/UIInvoiceController.UI.cs
+++ b/BTCPayServer/Controllers/UIInvoiceController.UI.cs
@@ -1161,14 +1161,6 @@ namespace BTCPayServer.Controllers
                 nameof(SelectListItem.Text));
         }
 
-        private bool AnyPaymentMethodAvailable(StoreData store)
-        {
-            var storeBlob = store.GetStoreBlob();
-            var excludeFilter = storeBlob.GetExcludedPaymentMethods();
-
-            return store.GetSupportedPaymentMethods(_NetworkProvider).Where(s => !excludeFilter.Match(s.PaymentId)).Any();
-        }
-
         [HttpGet("/stores/{storeId}/invoices/create")]
         [HttpGet("invoices/create")]
         [Authorize(AuthenticationSchemes = AuthenticationSchemes.Cookie)]
@@ -1181,7 +1173,7 @@ namespace BTCPayServer.Controllers
                 if (store == null)
                     return NotFound();
 
-                if (!AnyPaymentMethodAvailable(store))
+                if (store.AnyPaymentMethodAvailable(_NetworkProvider))
                 {
                     TempData.SetStatusMessageModel(new StatusMessageModel
                     {
@@ -1190,7 +1182,6 @@ namespace BTCPayServer.Controllers
                         AllowDismiss = false
                     });
                 }
-
                 HttpContext.SetStoreData(store);
             }
             else
@@ -1239,8 +1230,7 @@ namespace BTCPayServer.Controllers
             {
                 return View(model);
             }
-
-            if (!AnyPaymentMethodAvailable(store))
+            if (!store.AnyPaymentMethodAvailable(_NetworkProvider))
             {
                 TempData.SetStatusMessageModel(new StatusMessageModel
                 {
@@ -1250,7 +1240,6 @@ namespace BTCPayServer.Controllers
                 });
                 return View(model);
             }
-
             try
             {
                 var metadata = metadataObj is null ? new InvoiceMetadata() : InvoiceMetadata.FromJObject(metadataObj);

--- a/BTCPayServer/Controllers/UIInvoiceController.UI.cs
+++ b/BTCPayServer/Controllers/UIInvoiceController.UI.cs
@@ -1161,6 +1161,16 @@ namespace BTCPayServer.Controllers
                 nameof(SelectListItem.Text));
         }
 
+        private void SetStatusMessage(StoreData store)
+        {
+            TempData.SetStatusMessageModel(new StatusMessageModel
+            {
+                Severity = StatusMessageModel.StatusSeverity.Error,
+                Html = $"To create an invoice, you need to <a href='{Url.Action(nameof(UIStoresController.SetupWallet), "UIStores", new { cryptoCode = _NetworkProvider.DefaultNetwork.CryptoCode, storeId = store.Id })}' class='alert-link'>set up a wallet</a> first",
+                AllowDismiss = false
+            });
+        }
+
         [HttpGet("/stores/{storeId}/invoices/create")]
         [HttpGet("invoices/create")]
         [Authorize(AuthenticationSchemes = AuthenticationSchemes.Cookie)]
@@ -1172,15 +1182,9 @@ namespace BTCPayServer.Controllers
                 var store = await _StoreRepository.FindStore(model.StoreId, GetUserId());
                 if (store == null)
                     return NotFound();
-
                 if (!store.AnyPaymentMethodAvailable(_NetworkProvider))
                 {
-                    TempData.SetStatusMessageModel(new StatusMessageModel
-                    {
-                        Severity = StatusMessageModel.StatusSeverity.Error,
-                        Html = $"To create an invoice, you need to <a href='{Url.Action(nameof(UIStoresController.SetupWallet), "UIStores", new { cryptoCode = _NetworkProvider.DefaultNetwork.CryptoCode, storeId = store.Id })}' class='alert-link'>set up a wallet</a> first",
-                        AllowDismiss = false
-                    });
+                    SetStatusMessage(store);
                 }
                 HttpContext.SetStoreData(store);
             }
@@ -1232,12 +1236,7 @@ namespace BTCPayServer.Controllers
             }
             if (!store.AnyPaymentMethodAvailable(_NetworkProvider))
             {
-                TempData.SetStatusMessageModel(new StatusMessageModel
-                {
-                    Severity = StatusMessageModel.StatusSeverity.Error,
-                    Html = $"To create an invoice, you need to <a href='{Url.Action(nameof(UIStoresController.SetupWallet), "UIStores", new { cryptoCode = _NetworkProvider.DefaultNetwork.CryptoCode, storeId = store.Id })}' class='alert-link'>set up a wallet</a> first",
-                    AllowDismiss = false
-                });
+                SetStatusMessage(store);
                 return View(model);
             }
             try

--- a/BTCPayServer/Controllers/UIInvoiceController.UI.cs
+++ b/BTCPayServer/Controllers/UIInvoiceController.UI.cs
@@ -1,11 +1,8 @@
 #nullable enable
 using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.Linq;
-using System.Net.Mime;
 using System.Net.WebSockets;
-using System.Reflection.Metadata;
 using System.Threading;
 using System.Threading.Tasks;
 using BTCPayServer.Abstractions.Constants;
@@ -32,10 +29,8 @@ using Microsoft.AspNetCore.Mvc.Rendering;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.EntityFrameworkCore;
 using NBitcoin;
-using NBitpayClient;
 using NBXplorer;
 using Newtonsoft.Json.Linq;
-using BitpayCreateInvoiceRequest = BTCPayServer.Models.BitpayCreateInvoiceRequest;
 using StoreData = BTCPayServer.Data.StoreData;
 
 namespace BTCPayServer.Controllers
@@ -1149,58 +1144,34 @@ namespace BTCPayServer.Controllers
             };
         }
 
-        private SelectList GetPaymentMethodsSelectList()
-        {
-            var store = GetCurrentStore();
-            var excludeFilter = store.GetStoreBlob().GetExcludedPaymentMethods();
-
-            return new SelectList(store.GetSupportedPaymentMethods(_NetworkProvider)
-                        .Where(s => !excludeFilter.Match(s.PaymentId))
-                        .Select(method => new SelectListItem(method.PaymentId.ToPrettyString(), method.PaymentId.ToString())),
-                nameof(SelectListItem.Value),
-                nameof(SelectListItem.Text));
-        }
-
-        private void SetStatusMessage(StoreData store)
-        {
-            TempData.SetStatusMessageModel(new StatusMessageModel
-            {
-                Severity = StatusMessageModel.StatusSeverity.Error,
-                Html = $"To create an invoice, you need to <a href='{Url.Action(nameof(UIStoresController.SetupWallet), "UIStores", new { cryptoCode = _NetworkProvider.DefaultNetwork.CryptoCode, storeId = store.Id })}' class='alert-link'>set up a wallet</a> first",
-                AllowDismiss = false
-            });
-        }
-
         [HttpGet("/stores/{storeId}/invoices/create")]
         [HttpGet("invoices/create")]
         [Authorize(AuthenticationSchemes = AuthenticationSchemes.Cookie)]
         [BitpayAPIConstraint(false)]
         public async Task<IActionResult> CreateInvoice(InvoicesModel? model = null)
         {
-            if (model?.StoreId != null)
-            {
-                var store = await _StoreRepository.FindStore(model.StoreId, GetUserId());
-                if (store == null)
-                    return NotFound();
-                if (!store.AnyPaymentMethodAvailable(_NetworkProvider))
-                {
-                    SetStatusMessage(store);
-                }
-                HttpContext.SetStoreData(store);
-            }
-            else
+            if (string.IsNullOrEmpty(model?.StoreId))
             {
                 TempData[WellKnownTempData.ErrorMessage] = "You need to select a store before creating an invoice.";
                 return RedirectToAction(nameof(UIHomeController.Index), "UIHome");
             }
 
-            var storeBlob = HttpContext.GetStoreData()?.GetStoreBlob();
+            var store = await _StoreRepository.FindStore(model.StoreId, GetUserId());
+            if (store == null)
+                return NotFound();
+            
+            if (!store.AnyPaymentMethodAvailable(_NetworkProvider))
+            {
+                return NoPaymentMethodResult(store.Id);
+            }
+            
+            var storeBlob = store.GetStoreBlob();
             var vm = new CreateInvoiceModel
             {
                 StoreId = model.StoreId,
-                Currency = storeBlob?.DefaultCurrency,
-                CheckoutType = storeBlob?.CheckoutType ?? CheckoutType.V2,
-                AvailablePaymentMethods = GetPaymentMethodsSelectList()
+                Currency = storeBlob.DefaultCurrency,
+                CheckoutType = storeBlob.CheckoutType,
+                AvailablePaymentMethods = GetPaymentMethodsSelectList(store)
             };
 
             return View(vm);
@@ -1213,9 +1184,14 @@ namespace BTCPayServer.Controllers
         public async Task<IActionResult> CreateInvoice(CreateInvoiceModel model, CancellationToken cancellationToken)
         {
             var store = HttpContext.GetStoreData();
+            if (!store.AnyPaymentMethodAvailable(_NetworkProvider))
+            {
+                return NoPaymentMethodResult(store.Id);
+            }
+            
             var storeBlob = store.GetStoreBlob();
             model.CheckoutType = storeBlob.CheckoutType;
-            model.AvailablePaymentMethods = GetPaymentMethodsSelectList();
+            model.AvailablePaymentMethods = GetPaymentMethodsSelectList(store);
 
             JObject? metadataObj = null;
             if (!string.IsNullOrEmpty(model.Metadata))
@@ -1232,11 +1208,6 @@ namespace BTCPayServer.Controllers
             
             if (!ModelState.IsValid)
             {
-                return View(model);
-            }
-            if (!store.AnyPaymentMethodAvailable(_NetworkProvider))
-            {
-                SetStatusMessage(store);
                 return View(model);
             }
             try
@@ -1383,6 +1354,27 @@ namespace BTCPayServer.Controllers
                         break;
                 }
             }
+        }
+
+        private SelectList GetPaymentMethodsSelectList(StoreData store)
+        {
+            var excludeFilter = store.GetStoreBlob().GetExcludedPaymentMethods();
+            return new SelectList(store.GetSupportedPaymentMethods(_NetworkProvider)
+                    .Where(s => !excludeFilter.Match(s.PaymentId))
+                    .Select(method => new SelectListItem(method.PaymentId.ToPrettyString(), method.PaymentId.ToString())),
+                nameof(SelectListItem.Value),
+                nameof(SelectListItem.Text));
+        }
+
+        private IActionResult NoPaymentMethodResult(string storeId)
+        {
+            TempData.SetStatusMessageModel(new StatusMessageModel
+            {
+                Severity = StatusMessageModel.StatusSeverity.Error,
+                Html = $"To create an invoice, you need to <a href='{Url.Action(nameof(UIStoresController.SetupWallet), "UIStores", new { cryptoCode = _NetworkProvider.DefaultNetwork.CryptoCode, storeId })}' class='alert-link'>set up a wallet</a> first",
+                AllowDismiss = false
+            });
+            return RedirectToAction(nameof(ListInvoices), new { storeId });
         }
     }
 }

--- a/BTCPayServer/Controllers/UIInvoiceController.UI.cs
+++ b/BTCPayServer/Controllers/UIInvoiceController.UI.cs
@@ -1173,7 +1173,7 @@ namespace BTCPayServer.Controllers
                 if (store == null)
                     return NotFound();
 
-                if (store.AnyPaymentMethodAvailable(_NetworkProvider))
+                if (!store.AnyPaymentMethodAvailable(_NetworkProvider))
                 {
                     TempData.SetStatusMessageModel(new StatusMessageModel
                     {

--- a/BTCPayServer/Controllers/UIPaymentRequestController.cs
+++ b/BTCPayServer/Controllers/UIPaymentRequestController.cs
@@ -107,14 +107,6 @@ namespace BTCPayServer.Controllers
             return View(model);
         }
 
-        private bool AnyPaymentMethodAvailable(StoreData store)
-        {
-            var storeBlob = store.GetStoreBlob();
-            var excludeFilter = storeBlob.GetExcludedPaymentMethods();
-
-            return store.GetSupportedPaymentMethods(_networkProvider).Where(s => !excludeFilter.Match(s.PaymentId)).Any();
-        }
-
         [HttpGet("/stores/{storeId}/payment-requests/edit/{payReqId?}")]
         [Authorize(Policy = Policies.CanViewPaymentRequests, AuthenticationSchemes = AuthenticationSchemes.Cookie)]
         public async Task<IActionResult> EditPaymentRequest(string storeId, string payReqId)
@@ -129,7 +121,7 @@ namespace BTCPayServer.Controllers
             {
                 return NotFound();
             }
-            if (!AnyPaymentMethodAvailable(store))
+            if (!store.AnyPaymentMethodAvailable(_networkProvider))
             {
                 TempData.SetStatusMessageModel(new StatusMessageModel
                 {

--- a/BTCPayServer/Data/StoreDataExtensions.cs
+++ b/BTCPayServer/Data/StoreDataExtensions.cs
@@ -60,6 +60,14 @@ namespace BTCPayServer.Data
             return result;
         }
 
+        public static bool AnyPaymentMethodAvailable(this StoreData storeData, BTCPayNetworkProvider networkProvider)
+        {
+            var storeBlob = GetStoreBlob(storeData);
+            var excludeFilter = storeBlob.GetExcludedPaymentMethods();
+
+            return GetSupportedPaymentMethods(storeData, networkProvider).Where(s => !excludeFilter.Match(s.PaymentId)).Any();
+        }
+
         public static bool SetStoreBlob(this StoreData storeData, StoreBlob storeBlob)
         {
             var original = new Serializer(null).ToString(storeData.GetStoreBlob());


### PR DESCRIPTION
Closes #5602. 

This prevents the user from accessing the payment requests creation form if a wallet is not set up