### PR TITLE
Checkout v2: Clicking QR code copies full payment URI

### DIFF
--- a/BTCPayServer/Views/Shared/Bitcoin/BitcoinLikeMethodCheckout-v2.cshtml
+++ b/BTCPayServer/Views/Shared/Bitcoin/BitcoinLikeMethodCheckout-v2.cshtml
@@ -6,7 +6,7 @@
 <template id="bitcoin-method-checkout-template">
     @await Component.InvokeAsync("UiExtensionPoint", new {location = "checkout-v2-bitcoin-pre-content", model = Model})
     <div class="payment-box">
-        <div v-if="model.invoiceBitcoinUrlQR" class="qr-container" :data-qr-value="model.invoiceBitcoinUrlQR" :data-clipboard="model.btcAddress">
+        <div v-if="model.invoiceBitcoinUrlQR" class="qr-container" :data-qr-value="model.invoiceBitcoinUrlQR" :data-clipboard="model.invoiceBitcoinUrl" data-clipboard-confirm-element="#Address_@Model.PaymentMethodId [data-clipboard]">
             <div>
                 <qrcode :value="model.invoiceBitcoinUrlQR" tag="div" :options="qrOptions" />
             </div>

--- a/BTCPayServer/Views/Shared/Lightning/LightningLikeMethodCheckout-v2.cshtml
+++ b/BTCPayServer/Views/Shared/Lightning/LightningLikeMethodCheckout-v2.cshtml
@@ -3,7 +3,7 @@
 <template id="lightning-method-checkout-template">
     <div class="payment-box">
         @await Component.InvokeAsync("UiExtensionPoint" ,  new { location="checkout-v2-lightning-pre-content", model = Model})
-        <div v-if="model.invoiceBitcoinUrlQR" class="qr-container" :data-qr-value="model.invoiceBitcoinUrlQR" :data-clipboard="model.btcAddress">
+        <div v-if="model.invoiceBitcoinUrlQR" class="qr-container" :data-qr-value="model.invoiceBitcoinUrlQR" :data-clipboard="model.invoiceBitcoinUrl" data-clipboard-confirm-element="#Lightning_@Model.PaymentMethodId [data-clipboard]">
             <div>
                 <qrcode :value="model.invoiceBitcoinUrlQR" tag="div" :options="qrOptions" />
             </div>

--- a/BTCPayServer/wwwroot/js/copy-to-clipboard.js
+++ b/BTCPayServer/wwwroot/js/copy-to-clipboard.js
@@ -4,8 +4,10 @@ function confirmCopy(el, message) {
     if (hasIcon) {
         el.innerHTML = el.innerHTML.replace('#copy', '#checkmark');
     } else {
+        const { width, height } = el.getBoundingClientRect();
         el.dataset.clipboardInitial = el.innerHTML;
-        el.style.minWidth = el.getBoundingClientRect().width + 'px';
+        el.style.minWidth = width + 'px';
+        el.style.minHeight = height + 'px';
         el.innerHTML = confirmHTML;
     }
     el.dataset.clipboardConfirming = true;
@@ -28,7 +30,7 @@ window.copyToClipboard = async function (e, data) {
     e.preventDefault();
     const item = e.target.closest('[data-clipboard]') || e.target.closest('[data-clipboard-target]') || e.target;
     const confirm = item.dataset.clipboardConfirmElement
-        ? document.getElementById(item.dataset.clipboardConfirmElement) || item
+        ? document.querySelector(item.dataset.clipboardConfirmElement) || item
         : item.querySelector('[data-clipboard-confirm]') || item;
     const message = confirm.getAttribute('data-clipboard-confirm') || 'Copied';
     // Check compatibility and permissions:


### PR DESCRIPTION
Before it copied only the destination value (Bitcoin address or Lightning BOLT11). This didn't include the BOLT11 in case of the unified QR code. Now it will copy the full payment URI, which is the same as the QR represents:

- Unified: `bitcoin:ADDRESS?amount=AMOUNT&lightning=BOLT11`
- Bitcoin: `bitcoin:ADDRESS?amount=AMOUNT`
- Lightning: `lightning:BOLT11`

This also changes the copy confirmation so that the QR code is not replaced with the confirm message "Copied".

Fixes #5625.