### PR TITLE
Store Email Settings: Improve configuration

### DIFF
--- a/BTCPayServer/Models/ServerViewModels/EmailsViewModel.cs
+++ b/BTCPayServer/Models/ServerViewModels/EmailsViewModel.cs
@@ -6,25 +6,27 @@ namespace BTCPayServer.Models.ServerViewModels
 {
     public class EmailsViewModel
     {
+        public EmailSettings Settings { get; set; }
+        public EmailSettings FallbackSettings { get; set; }
+        public bool PasswordSet { get; set; }
+        
+        [MailboxAddress]
+        [Display(Name = "Test Email")]
+        public string TestEmail { get; set; }
+
         public EmailsViewModel()
         {
-
         }
-        public EmailsViewModel(EmailSettings settings)
+
+        public EmailsViewModel(EmailSettings settings, EmailSettings fallbackSettings = null)
         {
             Settings = settings;
+            FallbackSettings = fallbackSettings;
             PasswordSet = !string.IsNullOrEmpty(settings?.Password);
         }
-        public EmailSettings Settings
-        {
-            get; set;
-        }
-        public bool PasswordSet { get; set; }
-        [MailboxAddressAttribute]
-        [Display(Name = "Test Email")]
-        public string TestEmail
-        {
-            get; set;
-        }
+        
+        public bool IsSetup() => Settings?.IsComplete() is true;
+        public bool IsFallbackSetup() => FallbackSettings?.IsComplete() is true;
+        public bool UsesFallback() => IsFallbackSetup() && Settings == FallbackSettings;
     }
 }

--- a/BTCPayServer/Services/PoliciesSettings.cs
+++ b/BTCPayServer/Services/PoliciesSettings.cs
@@ -30,6 +30,14 @@ namespace BTCPayServer.Services
         public bool DisableInstantNotifications { get; set; }
         [Display(Name = "Disable stores from using the server's email settings as backup")]
         public bool DisableStoresToUseServerEmailSettings { get; set; }
+        [JsonIgnore]
+        [Display(Name = "Allow stores to use the server's SMTP email settings as a default")]
+        public bool EnableStoresToUseServerEmailSettings
+        {
+            get => !DisableStoresToUseServerEmailSettings;
+            set { DisableStoresToUseServerEmailSettings = !value; }
+        }
+        
         [Display(Name = "Disable non-admins access to the user creation API endpoint")]
         public bool DisableNonAdminCreateUserApi { get; set; }
 

--- a/BTCPayServer/Views/Shared/EmailsBody.cshtml
+++ b/BTCPayServer/Views/Shared/EmailsBody.cshtml
@@ -1,27 +1,5 @@
 @model BTCPayServer.Models.ServerViewModels.EmailsViewModel
 
-<div class="row">
-    <div class="col-xl-10 col-xxl-constrain">
-        <div class="d-flex flex-wrap gap-3 align-items-center justify-content-between mt-n1 mb-4">
-            <h3 class="mb-0">Email Server</h3>
-            <div class="d-flex">
-                <div class="dropdown only-for-js" id="quick-fill">
-                    <button class="btn btn-secondary dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false" id="QuickFillDropdownToggle">
-                        Quick Fill
-                    </button>
-                    <div class="dropdown-menu" aria-labelledby="QuickFillDropdownToggle">
-                        <a class="dropdown-item" href="" data-server="smtp.gmail.com" data-port="587">Gmail.com</a>
-                        <a class="dropdown-item" href="" data-server="mail.yahoo.com" data-port="587">Yahoo.com</a>
-                        <a class="dropdown-item" href="" data-server="smtp.mailgun.org" data-port="587">Mailgun</a>
-                        <a class="dropdown-item" href="" data-server="smtp.office365.com" data-port="587">Office365</a>
-                        <a class="dropdown-item" href="" data-server="smtp.sendgrid.net" data-port="587">SendGrid</a>
-                    </div>
-                </div>
-            </div>
-        </div>
-    </div>
-</div>
-
 <form method="post" autocomplete="off">
     <div class="row">
         <div class="col-xl-10 col-xxl-constrain">
@@ -30,8 +8,22 @@
                 <div asp-validation-summary="All"></div>
             }
             <div class="form-group">
-                <label asp-for="Settings.Server" class="form-label">SMTP Server</label>
-                <input asp-for="Settings.Server" data-fill="server" class="form-control"/>
+                <div class="d-flex flex-wrap gap-2 align-items-center justify-content-between">
+                    <label asp-for="Settings.Server" class="form-label">SMTP Server</label>
+                    <div class="dropdown only-for-js mt-n2" id="quick-fill">
+                        <button class="btn btn-link p-0 dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false" id="QuickFillDropdownToggle">
+                            Quick Fill
+                        </button>
+                        <div class="dropdown-menu" aria-labelledby="QuickFillDropdownToggle">
+                            <a class="dropdown-item" href="" data-server="smtp.gmail.com" data-port="587">Gmail.com</a>
+                            <a class="dropdown-item" href="" data-server="mail.yahoo.com" data-port="587">Yahoo.com</a>
+                            <a class="dropdown-item" href="" data-server="smtp.mailgun.org" data-port="587">Mailgun</a>
+                            <a class="dropdown-item" href="" data-server="smtp.office365.com" data-port="587">Office365</a>
+                            <a class="dropdown-item" href="" data-server="smtp.sendgrid.net" data-port="587">SendGrid</a>
+                        </div>
+                    </div>
+                </div>
+                <input asp-for="Settings.Server" data-fill="server" class="form-control" />
                 <span asp-validation-for="Settings.Server" class="text-danger"></span>
             </div>
             <div class="form-group">
@@ -53,7 +45,6 @@
             <div class="form-group">
                 @if (!Model.PasswordSet)
                 {
-
                     <label asp-for="Settings.Password" class="form-label"></label>
                     <input asp-for="Settings.Password" type="password" class="form-control"/>
                     <span asp-validation-for="Settings.Password" class="text-danger"></span>

--- a/BTCPayServer/Views/UIServer/Emails.cshtml
+++ b/BTCPayServer/Views/UIServer/Emails.cshtml
@@ -3,6 +3,7 @@
     ViewData.SetActivePage(ServerNavPages.Emails, "Emails");
 }
 
+<h3 class="mb-4">Email Server</h3>
 <partial name="EmailsBody" model="Model" />
 
 @section PageFootContent {

--- a/BTCPayServer/Views/UIServer/Policies.cshtml
+++ b/BTCPayServer/Views/UIServer/Policies.cshtml
@@ -124,12 +124,12 @@
                     <span asp-validation-for="DisableInstantNotifications" class="text-danger"></span>
                 </div>
                 <div class="form-check my-3">
-                    <input asp-for="DisableStoresToUseServerEmailSettings" type="checkbox" class="form-check-input"/>
-                    <label asp-for="DisableStoresToUseServerEmailSettings" class="form-check-label"></label>
+                    <input asp-for="EnableStoresToUseServerEmailSettings" type="checkbox" class="form-check-input"/>
+                    <label asp-for="EnableStoresToUseServerEmailSettings" class="form-check-label"></label>
                     <a href="https://docs.btcpayserver.org/Notifications/#server-emails" target="_blank" rel="noreferrer noopener">
                         <vc:icon symbol="info" />
                     </a>
-                    <span asp-validation-for="DisableStoresToUseServerEmailSettings" class="text-danger"></span>
+                    <span asp-validation-for="EnableStoresToUseServerEmailSettings" class="text-danger"></span>
                 </div>
             </div>
 

--- a/BTCPayServer/Views/UIServer/Policies.cshtml
+++ b/BTCPayServer/Views/UIServer/Policies.cshtml
@@ -114,6 +114,18 @@
             </div>
 
             <div class="form-group mb-5">
+                <h4 class="mb-3">Email Settings</h4>
+                <div class="form-check my-3">
+                    <input asp-for="EnableStoresToUseServerEmailSettings" type="checkbox" class="form-check-input"/>
+                    <label asp-for="EnableStoresToUseServerEmailSettings" class="form-check-label"></label>
+                    <a href="https://docs.btcpayserver.org/Notifications/#server-emails" target="_blank" rel="noreferrer noopener">
+                        <vc:icon symbol="info" />
+                    </a>
+                    <span asp-validation-for="EnableStoresToUseServerEmailSettings" class="text-danger"></span>
+                </div>
+            </div>
+
+            <div class="form-group mb-5">
                 <h4 class="mb-3">Notification Settings</h4>
                 <div class="form-check my-3">
                     <input asp-for="DisableInstantNotifications" type="checkbox" class="form-check-input"/>
@@ -122,14 +134,6 @@
                         <vc:icon symbol="info" />
                     </a>
                     <span asp-validation-for="DisableInstantNotifications" class="text-danger"></span>
-                </div>
-                <div class="form-check my-3">
-                    <input asp-for="EnableStoresToUseServerEmailSettings" type="checkbox" class="form-check-input"/>
-                    <label asp-for="EnableStoresToUseServerEmailSettings" class="form-check-label"></label>
-                    <a href="https://docs.btcpayserver.org/Notifications/#server-emails" target="_blank" rel="noreferrer noopener">
-                        <vc:icon symbol="info" />
-                    </a>
-                    <span asp-validation-for="EnableStoresToUseServerEmailSettings" class="text-danger"></span>
                 </div>
             </div>
 

--- a/BTCPayServer/Views/UIStores/StoreEmailSettings.cshtml
+++ b/BTCPayServer/Views/UIStores/StoreEmailSettings.cshtml
@@ -2,6 +2,7 @@
 @{
     Layout = "../Shared/_NavLayout.cshtml";
     ViewData.SetActivePage(StoreNavPages.Emails, "Emails", Context.GetStoreData().Id);
+    var hasCustomSettings = Model.IsSetup() && !Model.UsesFallback();
 }
 
 <div class="row mb-4">
@@ -19,7 +20,25 @@
     </div>
 </div>
 
-<partial name="EmailsBody" model="Model" />
+<h3 class="mb-4">Email Server</h3>
+@if (Model.IsFallbackSetup())
+{
+    <label class="d-flex align-items-center mb-4">
+        <input type="checkbox" id="UseCustomSMTP" checked="@hasCustomSettings" class="btcpay-toggle me-3" data-bs-toggle="collapse" data-bs-target="#SmtpSettings" aria-expanded="@hasCustomSettings" aria-controls="SmtpSettings" />
+        <div>
+            <span>Use custom SMTP settings for this store</span>
+            <div class="form-text">Otherwise, the server's SMTP settings will be used to send emails.</div>
+        </div>
+    </label>
+
+    <div class="checkout-settings collapse @(hasCustomSettings ? "show" : "")" id="SmtpSettings">
+        <partial name="EmailsBody" model="Model" />
+    </div>
+}
+else
+{
+    <partial name="EmailsBody" model="Model" />
+}
 
 @section PageFootContent {
     <partial name="_ValidationScriptsPartial" />

--- a/BTCPayServer/Views/UIStores/StoreEmails.cshtml
+++ b/BTCPayServer/Views/UIStores/StoreEmails.cshtml
@@ -117,8 +117,7 @@
                                         	<code>{Payout.Metadata}*</code>
                                         </td>
                                     </tr>
-                                    <tr><td colspan="2">* These fields are JSON objects. You can access properties within them using <a href="https://www.newtonsoft.com/json/help/html/SelectToken.htm#SelectTokenJSONPath" rel="noreferrer noopener" target="_blank">this syntax</a>. One example is <code>{Invoice.Metadata.itemCode}</code>
-</td></tr>
+                                    <tr><td colspan="2">* These fields are JSON objects. You can access properties within them using <a href="https://www.newtonsoft.com/json/help/html/SelectToken.htm#SelectTokenJSONPath" rel="noreferrer noopener" target="_blank">this syntax</a>. One example is <code>{Invoice.Metadata.itemCode}</code></td></tr>
                                 </table>
                             </div>
                         </div>


### PR DESCRIPTION
This works with the existing settings and provides better guidance about the different store email cases. Closes #5623.

## No Fallback

- Either the SMTP settyings on the server level are not configured or the "Disable stores from using the server's email settings as backup" policy is active. 
- Requires configuration of SMTP settings on the store level: No option for using the server fallback.

![no-fallback](https://github.com/btcpayserver/btcpayserver/assets/886/fc3c3902-6944-4db4-80dd-a11693e5c1bf)

## Fallback is present and used

- Toggle indicates the availability of providing custom SMTP settings for the store
- By default the server's SMTP settings will be used

![uses-fallback](https://github.com/btcpayserver/btcpayserver/assets/886/32d10026-55db-41a5-9108-27c7141147be)

## Fallback is present but custom settings are provided

![with-fallback-but-custom](https://github.com/btcpayserver/btcpayserver/assets/886/662db991-196b-4d2c-a0ea-d8a9cb6a6375)
