### PR TITLE
POS: Fix missing store branding property on form error case

### DIFF
--- a/BTCPayServer/Plugins/PointOfSale/Controllers/UIPointOfSaleController.cs
+++ b/BTCPayServer/Plugins/PointOfSale/Controllers/UIPointOfSaleController.cs
@@ -516,10 +516,13 @@ namespace BTCPayServer.Plugins.PointOfSale.Controllers
                 }
             }
 
+            var store = await _appService.GetStore(app);
+            var storeBlob = store.GetStoreBlob();
+
             viewModel.FormName = formData.Name;
             viewModel.Form = form;
-
             viewModel.FormParameters = formParameters;
+            viewModel.StoreBranding = new StoreBrandingViewModel(storeBlob);
             return View("Views/UIForms/View", viewModel);
         }
         

--- a/BTCPayServer/Views/Shared/LayoutHead.cshtml
+++ b/BTCPayServer/Views/Shared/LayoutHead.cshtml
@@ -15,7 +15,7 @@
 <link href="~/main/site.css" asp-append-version="true"  rel="stylesheet" />
 
 <partial name="LayoutHeadTheme" />
-@if (ViewData.TryGetValue("StoreBranding", out var storeBranding))
+@if (ViewData.TryGetValue("StoreBranding", out var storeBranding) && storeBranding != null)
 {
     <partial name="LayoutHeadStoreBranding" model="storeBranding" />
 }


### PR DESCRIPTION
When a POS has a form, which results in an error state, the store branding property was not set. This adds the missing property and also does not render the store branding partial, in case the model property isn't present.

Fixes #5655.