### PR TITLE
Improve checkout page load time by fetching recommended fee in the background periodically

### DIFF
--- a/BTCPayServer.Tests/ServerTester.cs
+++ b/BTCPayServer.Tests/ServerTester.cs
@@ -39,7 +39,7 @@ namespace BTCPayServer.Tests
             if (!Directory.Exists(_Directory))
                 Directory.CreateDirectory(_Directory);
 
-            NetworkProvider = networkProvider;
+            _NetworkProvider = networkProvider;
             ExplorerNode = new RPCClient(RPCCredentialString.Parse(GetEnvironment("TESTS_BTCRPCCONNECTION", "server=http://127.0.0.1:43782;ceiwHEbqWI83:DwubwWsoo3")), NetworkProvider.GetNetwork<BTCPayNetwork>("BTC").NBitcoinNetwork);
             ExplorerNode.ScanRPCCapabilities();
 
@@ -214,8 +214,14 @@ namespace BTCPayServer.Tests
         {
             return new TestAccount(this);
         }
-
-        public BTCPayNetworkProvider NetworkProvider { get; private set; }
+        BTCPayNetworkProvider _NetworkProvider;
+        public BTCPayNetworkProvider NetworkProvider
+        {
+            get
+            {
+                return PayTester?.Networks ?? _NetworkProvider;
+            }
+        }
         public RPCClient ExplorerNode
         {
             get; set;

--- a/BTCPayServer.Tests/ThirdPartyTests.cs
+++ b/BTCPayServer.Tests/ThirdPartyTests.cs
@@ -91,7 +91,13 @@ namespace BTCPayServer.Tests
                     "test" + isTestnet,
                     prov.GetService<IHttpClientFactory>(),
                     isTestnet);
+                mempoolSpaceFeeProvider.CachedOnly = true;
+                await Assert.ThrowsAsync<InvalidOperationException>(() => mempoolSpaceFeeProvider.GetFeeRateAsync());
+                mempoolSpaceFeeProvider.CachedOnly = false;
                 var rates = await mempoolSpaceFeeProvider.GetFeeRatesAsync();
+                mempoolSpaceFeeProvider.CachedOnly = true;
+                await mempoolSpaceFeeProvider.GetFeeRateAsync();
+                mempoolSpaceFeeProvider.CachedOnly = false;
                 Assert.NotEmpty(rates);
                 
                 
@@ -121,10 +127,7 @@ namespace BTCPayServer.Tests
                 //ENSURE THESE ARE LOGICAL
                 Assert.True(recommendedFees[0].FeeRate >= recommendedFees[1].FeeRate, $"{recommendedFees[0].Target}:{recommendedFees[0].FeeRate} >= {recommendedFees[1].Target}:{recommendedFees[1].FeeRate}");
                 Assert.True(recommendedFees[1].FeeRate >= recommendedFees[2].FeeRate, $"{recommendedFees[1].Target}:{recommendedFees[1].FeeRate} >= {recommendedFees[2].Target}:{recommendedFees[2].FeeRate}");
-                Assert.True(recommendedFees[2].FeeRate >= recommendedFees[3].FeeRate, $"{recommendedFees[2].Target}:{recommendedFees[2].FeeRate} >= {recommendedFees[3].Target}:{recommendedFees[3].FeeRate}");
-                
-                
-                
+                Assert.True(recommendedFees[2].FeeRate >= recommendedFees[3].FeeRate, $"{recommendedFees[2].Target}:{recommendedFees[2].FeeRate} >= {recommendedFees[3].Target}:{recommendedFees[3].FeeRate}");                
             }
         }
         [Fact]

--- a/BTCPayServer/Hosting/BTCPayServerServices.cs
+++ b/BTCPayServer/Hosting/BTCPayServerServices.cs
@@ -368,7 +368,8 @@ namespace BTCPayServer.Hosting
             services.TryAddSingleton<WalletReceiveService>();
             services.AddSingleton<IHostedService>(provider => provider.GetService<WalletReceiveService>());
             services.TryAddSingleton<CurrencyNameTable>(CurrencyNameTable.Instance);
-            services.TryAddSingleton<IFeeProviderFactory, FeeProviderFactory>();
+            services.AddScheduledTask<FeeProviderFactory>(TimeSpan.FromMinutes(3.0));
+            services.AddSingleton<IFeeProviderFactory, FeeProviderFactory>(f => f.GetRequiredService<FeeProviderFactory>());
 
             services.Configure<MvcOptions>((o) =>
             {


### PR DESCRIPTION
A failure to fetch rates on mempool.space shouldn't result in slow display of the checkout page.
* Removed timeout for querying mempool.space
* Refresh the fee rate periodically every 3 minutes
* If fee of mempool aren't in the cache when requesting it, fallback directly to NBX
* Bump cache expiration to 25min