### PR TITLE
Fix webhook test for payment requests

### DIFF
--- a/BTCPayServer/HostedServices/Webhooks/PaymentRequestWebhookProvider.cs
+++ b/BTCPayServer/HostedServices/Webhooks/PaymentRequestWebhookProvider.cs
@@ -28,9 +28,9 @@ public class PaymentRequestWebhookProvider: WebhookProvider<PaymentRequestEvent>
     public override WebhookEvent CreateTestEvent(string type, object[] args)
     {
         var storeId = args[0].ToString();
-        return new WebhookPayoutEvent(type, storeId)
+        return new WebhookPaymentRequestEvent(type, storeId)
         {
-            PayoutId = "__test__" + Guid.NewGuid() + "__test__"
+            PaymentRequestId = "__test__" + Guid.NewGuid() + "__test__"
         };
     }
 


### PR DESCRIPTION
When testing the webhook for payment requests, we were incorrectly creating a payout webhook instead of a payment request. This would cause an error (but nothing fatal as it is only a test webhook(


Reported on tg