### PR TITLE
Wizard UI: Constrain navigation width

### DIFF
--- a/BTCPayServer/wwwroot/main/wizard.css
+++ b/BTCPayServer/wwwroot/main/wizard.css
@@ -7,21 +7,7 @@ body {
     display: flex;
     align-items: center;
     justify-content: space-between;
-}
-
-@media (max-width: 575px) {
-    #wizard-navbar {
-        margin-top: -35px;
-    }
-}
-@media (min-width: 576px) {
-    #wizard-navbar {
-        position: absolute;
-        top: 0;
-        left: 0;
-        right: 0;
-        padding: 24px;
-    }
+    margin-top: -2rem;
 }
 
 #wizard-navbar a,


### PR DESCRIPTION
This way the back and close buttons stay within the regular container size on and don't stick to the left and right end on wide screens.

Closes #5693.

![grafik](https://github.com/btcpayserver/btcpayserver/assets/886/ac7ce6ad-0ec5-4f1e-92a6-eddf6d1bf302)
