### PR TITLE
Apps: Allow authenticated, non-owner users permissioned access

### DIFF
--- a/BTCPayServer.Tests/BTCPayServer.Tests.csproj
+++ b/BTCPayServer.Tests/BTCPayServer.Tests.csproj
@@ -24,7 +24,7 @@
     <PackageReference Include="Newtonsoft.Json.Schema" Version="3.0.15" />
     <PackageReference Include="Selenium.Support" Version="4.1.1" />
     <PackageReference Include="Selenium.WebDriver" Version="4.1.1" />
-	<PackageReference Include="Selenium.WebDriver.ChromeDriver" Version="119.0.6045.10500" />
+	<PackageReference Include="Selenium.WebDriver.ChromeDriver" Version="121.0.6167.8500" />
 	<PackageReference Include="xunit" Version="2.6.6" />
 	<PackageReference Include="xunit.runner.visualstudio" Version="2.5.6">
       <PrivateAssets>all</PrivateAssets>

--- a/BTCPayServer/Security/CookieAuthorizationHandler.cs
+++ b/BTCPayServer/Security/CookieAuthorizationHandler.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Linq;
 using System.Threading.Tasks;
 using BTCPayServer.Abstractions.Constants;
 using BTCPayServer.Abstractions.Contracts;
@@ -74,10 +73,10 @@ namespace BTCPayServer.Security
                 // resolve from app
                 if (routeData.Values.TryGetValue("appId", out var vAppId) && vAppId is string appId)
                 {
-                    app = await _appService.GetAppDataIfOwner(userId, appId);
+                    app = await _appService.GetAppData(userId, appId);
                     if (storeId == null)
                     {
-                        storeId = app?.StoreDataId ?? String.Empty;
+                        storeId = app?.StoreDataId ?? string.Empty;
                     }
                     else if (app?.StoreDataId != storeId)
                     {
@@ -90,7 +89,7 @@ namespace BTCPayServer.Security
                     paymentRequest = await _paymentRequestRepository.FindPaymentRequest(payReqId, userId);
                     if (storeId == null)
                     {
-                        storeId = paymentRequest?.StoreDataId ?? String.Empty;
+                        storeId = paymentRequest?.StoreDataId ?? string.Empty;
                     }
                     else if (paymentRequest?.StoreDataId != storeId)
                     {
@@ -103,7 +102,7 @@ namespace BTCPayServer.Security
                     invoice = await _invoiceRepository.GetInvoice(invoiceId);
                     if (storeId == null)
                     {
-                        storeId = invoice?.StoreId ?? String.Empty;
+                        storeId = invoice?.StoreId ?? string.Empty;
                     }
                     else if (invoice?.StoreId != storeId)
                     {

--- a/BTCPayServer/Views/UIStores/StoreUsers.cshtml
+++ b/BTCPayServer/Views/UIStores/StoreUsers.cshtml
@@ -33,7 +33,7 @@
                     </select>
                 </div>
                 <div class="ms-3">
-                    <button type="submit" role="button" class="btn btn-primary">Add User</button>
+                    <button type="submit" role="button" class="btn btn-primary" id="AddUser">Add User</button>
                 </div>
             </div>
         </form>


### PR DESCRIPTION
Before this, the app lookup was constrained by the user having at least `CanModifyStoreSettings` permissions. This changes it to require the user being associated with a store, leaving the fine-grained authorization checks up to the individual actions.

Fixes #5698. 