### PR TITLE
remove decimals for Colombian (COP) and Argentina's Peso (ARS)

### DIFF
--- a/BTCPayServer.Rating/Currencies.json
+++ b/BTCPayServer.Rating/Currencies.json
@@ -1,4 +1,4 @@
-﻿[
+[
    {
       "name":"Afghan Afghani",
       "code":"AFN",
@@ -58,7 +58,7 @@
    {
       "name":"Argentine Peso",
       "code":"ARS",
-      "divisibility":2,
+      "divisibility":0,
       "symbol":null,
       "crypto":false
    },
@@ -289,7 +289,7 @@
    {
       "name":"Colombian Peso",
       "code":"COP",
-      "divisibility":2,
+      "divisibility":0,
       "symbol":null,
       "crypto":false
    },

--- a/BTCPayServer.Rating/CurrencyNameTable.cs
+++ b/BTCPayServer.Rating/CurrencyNameTable.cs
@@ -77,7 +77,19 @@ namespace BTCPayServer.Services.Rates
                             continue;
                         try
                         {
-                            _CurrencyProviders.TryAdd(new RegionInfo(culture.LCID).ISOCurrencySymbol, culture);
+                            if (new RegionInfo(culture.LCID).ISOCurrencySymbol.Equals("ARS") || new RegionInfo(culture.LCID).ISOCurrencySymbol.Equals("COP"))
+                            {
+                                var modifiedCulture = new CultureInfo(culture.Name);
+                                NumberFormatInfo modifiedNumberFormat = (NumberFormatInfo)modifiedCulture.NumberFormat.Clone();
+                                modifiedNumberFormat.CurrencyDecimalDigits = 0;
+                                modifiedCulture.NumberFormat = modifiedNumberFormat;
+
+                                _CurrencyProviders.TryAdd(new RegionInfo(culture.LCID).ISOCurrencySymbol, modifiedCulture);
+                            }
+                            else
+                            {
+                                _CurrencyProviders.TryAdd(new RegionInfo(culture.LCID).ISOCurrencySymbol, culture);
+                            }
                         }
                         catch { }
                     }

--- a/BTCPayServer.Tests/FastTests.cs
+++ b/BTCPayServer.Tests/FastTests.cs
@@ -790,7 +790,7 @@ namespace BTCPayServer.Tests
                 (0.0005m, "0.0005 USD", "USD"), (0.001m, "0.001 USD", "USD"), (0.01m, "0.01 USD", "USD"),
                 (0.1m, "0.10 USD", "USD"), (0.1m, "0,10 EUR", "EUR"), (1000m, "1,000 JPY", "JPY"),
                 (1000.0001m, "1,000.00 INR", "INR"),
-                (0.0m, "0.00 USD", "USD")
+                (0.0m, "0.00 USD", "USD"), (1m, "1 COP", "COP"), (1m, "1 ARS", "ARS")
             })
             {
                 var actual = displayFormatter.Currency(test.Item1, test.Item3);

--- a/BTCPayServer.Tests/FastTests.cs
+++ b/BTCPayServer.Tests/FastTests.cs
@@ -797,6 +797,8 @@ namespace BTCPayServer.Tests
                 actual = actual.Replace("￥", "¥"); // Hack so JPY test pass on linux as well
                 Assert.Equal(test.Item2, actual);
             }
+            Assert.Equal(0, CurrencyNameTable.Instance.GetNumberFormatInfo("ARS").CurrencyDecimalDigits);
+            Assert.Equal(0, CurrencyNameTable.Instance.GetNumberFormatInfo("COP").CurrencyDecimalDigits);
         }
 
         [Fact]

--- a/BTCPayServer/Plugins/PointOfSale/Controllers/UIPointOfSaleController.cs
+++ b/BTCPayServer/Plugins/PointOfSale/Controllers/UIPointOfSaleController.cs
@@ -92,6 +92,8 @@ namespace BTCPayServer.Plugins.PointOfSale.Controllers
                 EmbeddedCSS = settings.EmbeddedCSS,
                 CustomCSSLink = settings.CustomCSSLink
             };
+            // Check if the currency is COP or ARS (exclude decimal places)
+            bool excludeDivisibility = new[] { "ARS", "COP" }.Contains(settings.Currency);
 
             return View($"PointOfSale/Public/{viewType}", new ViewPointOfSaleViewModel
             {
@@ -110,7 +112,7 @@ namespace BTCPayServer.Plugins.PointOfSale.Controllers
                 CurrencyInfo = new ViewPointOfSaleViewModel.CurrencyInfoData
                 {
                     CurrencySymbol = string.IsNullOrEmpty(numberFormatInfo.CurrencySymbol) ? settings.Currency : numberFormatInfo.CurrencySymbol,
-                    Divisibility = numberFormatInfo.CurrencyDecimalDigits,
+                    Divisibility = excludeDivisibility ? 0 : numberFormatInfo.CurrencyDecimalDigits,
                     DecimalSeparator = numberFormatInfo.CurrencyDecimalSeparator,
                     ThousandSeparator = numberFormatInfo.NumberGroupSeparator,
                     Prefixed = new[] { 0, 2 }.Contains(numberFormatInfo.CurrencyPositivePattern),

--- a/BTCPayServer/Plugins/PointOfSale/Controllers/UIPointOfSaleController.cs
+++ b/BTCPayServer/Plugins/PointOfSale/Controllers/UIPointOfSaleController.cs
@@ -93,7 +93,6 @@ namespace BTCPayServer.Plugins.PointOfSale.Controllers
                 CustomCSSLink = settings.CustomCSSLink
             };
             // Check if the currency is COP or ARS (exclude decimal places)
-            bool excludeDivisibility = new[] { "ARS", "COP" }.Contains(settings.Currency);
 
             return View($"PointOfSale/Public/{viewType}", new ViewPointOfSaleViewModel
             {
@@ -112,7 +111,7 @@ namespace BTCPayServer.Plugins.PointOfSale.Controllers
                 CurrencyInfo = new ViewPointOfSaleViewModel.CurrencyInfoData
                 {
                     CurrencySymbol = string.IsNullOrEmpty(numberFormatInfo.CurrencySymbol) ? settings.Currency : numberFormatInfo.CurrencySymbol,
-                    Divisibility = excludeDivisibility ? 0 : numberFormatInfo.CurrencyDecimalDigits,
+                    Divisibility = numberFormatInfo.CurrencyDecimalDigits,
                     DecimalSeparator = numberFormatInfo.CurrencyDecimalSeparator,
                     ThousandSeparator = numberFormatInfo.NumberGroupSeparator,
                     Prefixed = new[] { 0, 2 }.Contains(numberFormatInfo.CurrencyPositivePattern),

--- a/BTCPayServer/Services/DisplayFormatter.cs
+++ b/BTCPayServer/Services/DisplayFormatter.cs
@@ -34,7 +34,7 @@ public class DisplayFormatter
     public string Currency(decimal value, string currency, CurrencyFormat format = CurrencyFormat.Code)
     {
         var provider = _currencyNameTable.GetNumberFormatInfo(currency, true);
-        var currencyData = _currencyNameTable.GetCurrencyData(currency, true);
+         var currencyData = _currencyNameTable.GetCurrencyData(currency, true);
         var divisibility = currencyData.Divisibility;
         value = value.RoundToSignificant(ref divisibility);
         if (divisibility != provider.CurrencyDecimalDigits)

--- a/BTCPayServer/Services/DisplayFormatter.cs
+++ b/BTCPayServer/Services/DisplayFormatter.cs
@@ -34,7 +34,7 @@ public class DisplayFormatter
     public string Currency(decimal value, string currency, CurrencyFormat format = CurrencyFormat.Code)
     {
         var provider = _currencyNameTable.GetNumberFormatInfo(currency, true);
-         var currencyData = _currencyNameTable.GetCurrencyData(currency, true);
+        var currencyData = _currencyNameTable.GetCurrencyData(currency, true);
         var divisibility = currencyData.Divisibility;
         value = value.RoundToSignificant(ref divisibility);
         if (divisibility != provider.CurrencyDecimalDigits)

--- a/BTCPayServer/wwwroot/pos/common.js
+++ b/BTCPayServer/wwwroot/pos/common.js
@@ -93,10 +93,16 @@ const posCommon = {
         formatCurrency (value, withSymbol) {
             const currency = this.currencyCode
             if (currency === 'BTC' || currency === 'SATS') return this.formatCrypto(value, withSymbol)
-            const { divisibility } = this.currencyInfo
+
+            // Check if the currency is COP or ARS (exclude decimal places)
+            const excludeDecimalPlaces = ['COP', 'ARS'].includes(currency);
+
+            const { divisibility } = this.currencyInfo;
+            const maximumFractionDigits = excludeDecimalPlaces ? 0 : divisibility;
+            const minimumFractionDigits = excludeDecimalPlaces ? 0 : divisibility;
             const locale = this.getLocale(currency);
             const style = withSymbol ? 'currency' : 'decimal'
-            const opts = { currency, style, maximumFractionDigits: divisibility, minimumFractionDigits: divisibility }
+            const opts = { currency, style, maximumFractionDigits, minimumFractionDigits }
             try {
                 return new Intl.NumberFormat(locale, opts).format(value)
             } catch (err) {

--- a/BTCPayServer/wwwroot/pos/common.js
+++ b/BTCPayServer/wwwroot/pos/common.js
@@ -93,16 +93,10 @@ const posCommon = {
         formatCurrency (value, withSymbol) {
             const currency = this.currencyCode
             if (currency === 'BTC' || currency === 'SATS') return this.formatCrypto(value, withSymbol)
-
-            // Check if the currency is COP or ARS (exclude decimal places)
-            const excludeDecimalPlaces = ['COP', 'ARS'].includes(currency);
-
             const { divisibility } = this.currencyInfo;
-            const maximumFractionDigits = excludeDecimalPlaces ? 0 : divisibility;
-            const minimumFractionDigits = excludeDecimalPlaces ? 0 : divisibility;
             const locale = this.getLocale(currency);
             const style = withSymbol ? 'currency' : 'decimal'
-            const opts = { currency, style, maximumFractionDigits, minimumFractionDigits }
+            const opts = { currency, style, maximumFractionDigits: divisibility, minimumFractionDigits: divisibility }
             try {
                 return new Intl.NumberFormat(locale, opts).format(value)
             } catch (err) {


### PR DESCRIPTION
Fix for issue #5708 

Remove decimal places for COP and ARS currencies