### PR TITLE
Fix: Closing Balance in Dashboard was showing incorrect value

### DIFF
--- a/BTCPayServer/BTCPayServer.csproj
+++ b/BTCPayServer/BTCPayServer.csproj
@@ -50,7 +50,7 @@
     <PackageReference Include="YamlDotNet" Version="8.0.0" />
     <PackageReference Include="BIP78.Sender" Version="0.2.2" />
     <PackageReference Include="BTCPayServer.Hwi" Version="2.0.2" />
-    <PackageReference Include="BTCPayServer.Lightning.All" Version="1.5.3" />
+    <PackageReference Include="BTCPayServer.Lightning.All" Version="1.5.4" />
     <PackageReference Include="CsvHelper" Version="15.0.5" />
     <PackageReference Include="Dapper" Version="2.1.28" />
     <PackageReference Include="Fido2" Version="2.0.2" />


### PR DESCRIPTION
Include fix https://github.com/btcpayserver/BTCPayServer.Lightning/issues/156 of the lightning library

We were calculating the limbo balance wrong see https://github.com/lightningnetwork/lnd/discussions/8436