### PR TITLE
Bumping LND to 0.17.4-beta-rc1

### DIFF
--- a/BTCPayServer.Tests/docker-compose.altcoins.yml
+++ b/BTCPayServer.Tests/docker-compose.altcoins.yml
@@ -224,7 +224,7 @@ services:
       - "5432"
 
   merchant_lnd:
-    image: btcpayserver/lnd:v0.17.3-beta
+    image: btcpayserver/lnd:v0.17.4-beta-rc1
     restart: unless-stopped
     environment:
       LND_CHAIN: "btc"
@@ -259,7 +259,7 @@ services:
       - bitcoind
 
   customer_lnd:
-    image: btcpayserver/lnd:v0.17.3-beta
+    image: btcpayserver/lnd:v0.17.4-beta-rc1
     restart: unless-stopped
     environment:
       LND_CHAIN: "btc"

--- a/BTCPayServer.Tests/docker-compose.altcoins.yml
+++ b/BTCPayServer.Tests/docker-compose.altcoins.yml
@@ -224,7 +224,7 @@ services:
       - "5432"
 
   merchant_lnd:
-    image: btcpayserver/lnd:v0.17.4-beta-rc1
+    image: btcpayserver/lnd:v0.17.4-beta
     restart: unless-stopped
     environment:
       LND_CHAIN: "btc"
@@ -259,7 +259,7 @@ services:
       - bitcoind
 
   customer_lnd:
-    image: btcpayserver/lnd:v0.17.4-beta-rc1
+    image: btcpayserver/lnd:v0.17.4-beta
     restart: unless-stopped
     environment:
       LND_CHAIN: "btc"

--- a/BTCPayServer.Tests/docker-compose.yml
+++ b/BTCPayServer.Tests/docker-compose.yml
@@ -211,7 +211,7 @@ services:
       - "5432"
 
   merchant_lnd:
-    image: btcpayserver/lnd:v0.17.4-beta-rc1
+    image: btcpayserver/lnd:v0.17.4-beta
     restart: unless-stopped
     environment:
       LND_CHAIN: "btc"
@@ -248,7 +248,7 @@ services:
       - bitcoind
 
   customer_lnd:
-    image: btcpayserver/lnd:v0.17.4-beta-rc1
+    image: btcpayserver/lnd:v0.17.4-beta
     restart: unless-stopped
     environment:
       LND_CHAIN: "btc"

--- a/BTCPayServer.Tests/docker-compose.yml
+++ b/BTCPayServer.Tests/docker-compose.yml
@@ -211,7 +211,7 @@ services:
       - "5432"
 
   merchant_lnd:
-    image: btcpayserver/lnd:v0.17.3-beta
+    image: btcpayserver/lnd:v0.17.4-beta-rc1
     restart: unless-stopped
     environment:
       LND_CHAIN: "btc"
@@ -248,7 +248,7 @@ services:
       - bitcoind
 
   customer_lnd:
-    image: btcpayserver/lnd:v0.17.3-beta
+    image: btcpayserver/lnd:v0.17.4-beta-rc1
     restart: unless-stopped
     environment:
       LND_CHAIN: "btc"

--- a/BTCPayServer.Tests/docker-customer-lncli.ps1
+++ b/BTCPayServer.Tests/docker-customer-lncli.ps1
@@ -1,0 +1,2 @@
+$container_id="$(docker ps -q --filter label=com.docker.compose.project=btcpayservertests --filter label=com.docker.compose.service=customer_lnd)"
+docker exec -ti $container_id lncli --no-macaroons --rpcserver localhost:10008 $args

--- a/BTCPayServer.Tests/docker-merchant-lncli.ps1
+++ b/BTCPayServer.Tests/docker-merchant-lncli.ps1
@@ -1,0 +1,2 @@
+$container_id="$(docker ps -q --filter label=com.docker.compose.project=btcpayservertests --filter label=com.docker.compose.service=merchant_lnd)"
+docker exec -ti $container_id lncli --no-macaroons --rpcserver localhost:10008 $args

--- a/BTCPayServer/Views/UIServer/LndSeedBackup.cshtml
+++ b/BTCPayServer/Views/UIServer/LndSeedBackup.cshtml
@@ -1,4 +1,4 @@
-﻿@using BTCPayServer.Abstractions.Models
+@using BTCPayServer.Abstractions.Models
 @model LndSeedBackupViewModel
 @{
     ViewData.SetActivePage(ServerNavPages.Services, "LND Seed Backup");
@@ -11,7 +11,7 @@
     <div class="row">
         <div class="col-lg-8">
             <div class="form-group">
-                <p>The LND seed backup is useful to recover funds of your LND wallet in case of a corruption of your server.</p>
+                <p>The LND seed backup is useful to recover on-chain funds of your LND wallet in case of a corruption of your server.</p>
                 <p>The recovering process is documented by LND on <a href="https://github.com/lightningnetwork/lnd/blob/master/docs/recovery.md" rel="noreferrer noopener">this page</a>.</p>
             </div>
             <button class="btn btn-primary @(Model.Removed ? "collapse" : "")" id="details" type="button">See confidential seed information</button>


### PR DESCRIPTION
Updating our devenv to use LND 0.17.4-rc1

Used it in BTCPayServer.Lightning library and it's good to go, passed all the tests:
https://github.com/btcpayserver/BTCPayServer.Lightning/pull/157