### PR TITLE
UI: Deprecate the custom CSS options

### DIFF
--- a/BTCPayServer/Views/Shared/Crowdfund/Public/ViewCrowdfund.cshtml
+++ b/BTCPayServer/Views/Shared/Crowdfund/Public/ViewCrowdfund.cshtml
@@ -14,7 +14,7 @@
 	}
 }
 <!DOCTYPE html>
-<html class="h-100" @(Env.IsDeveloping ? " data-devenv" : "")>
+<html class="h-100" @(Env.IsDeveloping ? " data-devenv" : "") id="Crowdfund-@Model.AppId">
 <head>
     <partial name="LayoutHead"/>
     <link href="~/vendor/bootstrap-vue/bootstrap-vue.min.css" asp-append-version="true" rel="stylesheet"/>

--- a/BTCPayServer/Views/Shared/Crowdfund/UpdateCrowdfund.cshtml
+++ b/BTCPayServer/Views/Shared/Crowdfund/UpdateCrowdfund.cshtml
@@ -284,31 +284,6 @@
                         </div>
                     </div>
                     <div class="accordion-item">
-                        <h2 class="accordion-header" id="additional-custom-css-header">
-                            <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#additional-custom-css" aria-expanded="false" aria-controls="additional-custom-css">
-                                Custom CSS
-                                <vc:icon symbol="caret-down" />
-                            </button>
-                        </h2>
-                        <div id="additional-custom-css" class="accordion-collapse collapse" aria-labelledby="additional-custom-css-header">
-                            <div class="accordion-body">
-                                <div class="form-group">
-                                    <label asp-for="CustomCSSLink" class="form-label"></label>
-                                    <a href="https://docs.btcpayserver.org/Development/Theme/#2-bootstrap-themes" target="_blank" rel="noreferrer noopener" title="More information...">
-                                        <vc:icon symbol="info" />
-                                    </a>
-                                    <input asp-for="CustomCSSLink" class="form-control" />
-                                    <span asp-validation-for="CustomCSSLink" class="text-danger"></span>
-                                </div>
-                                <div class="form-group mb-4">
-                                    <label asp-for="EmbeddedCSS" class="form-label"></label>
-                                    <textarea asp-for="EmbeddedCSS" rows="10" cols="40" class="form-control"></textarea>
-                                    <span asp-validation-for="EmbeddedCSS" class="text-danger"></span>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                    <div class="accordion-item">
                         <h2 class="accordion-header" id="additional-notification-header">
                             <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#additional-notification" aria-expanded="false" aria-controls="additional-notification">
                                 Notification URL Callbacks
@@ -325,6 +300,36 @@
                             </div>
                         </div>
                     </div>
+                    @* We are deprecating the custom CSS options in favor of the store branding approach.
+                       Display this section only if these values are set. *@
+                    @if (!string.IsNullOrWhiteSpace(Model.CustomCSSLink) || !string.IsNullOrWhiteSpace(Model.EmbeddedCSS))
+                    {
+                        <div class="accordion-item">
+                            <h2 class="accordion-header" id="additional-custom-css-header">
+                                <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#additional-custom-css" aria-expanded="false" aria-controls="additional-custom-css">
+                                    Custom CSS
+                                    <vc:icon symbol="caret-down" />
+                                </button>
+                            </h2>
+                            <div id="additional-custom-css" class="accordion-collapse collapse" aria-labelledby="additional-custom-css-header">
+                                <div class="accordion-body">
+                                    <div class="form-group">
+                                        <label asp-for="CustomCSSLink" class="form-label"></label>
+                                        <a href="https://docs.btcpayserver.org/Development/Theme/#2-bootstrap-themes" target="_blank" rel="noreferrer noopener" title="More information...">
+                                            <vc:icon symbol="info" />
+                                        </a>
+                                        <input asp-for="CustomCSSLink" class="form-control" />
+                                        <span asp-validation-for="CustomCSSLink" class="text-danger"></span>
+                                    </div>
+                                    <div class="form-group mb-4">
+                                        <label asp-for="EmbeddedCSS" class="form-label"></label>
+                                        <textarea asp-for="EmbeddedCSS" rows="10" cols="40" class="form-control"></textarea>
+                                        <span asp-validation-for="EmbeddedCSS" class="text-danger"></span>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    }
                 </div>
             </div>
         </div>

--- a/BTCPayServer/Views/Shared/PointOfSale/Public/_Layout.cshtml
+++ b/BTCPayServer/Views/Shared/PointOfSale/Public/_Layout.cshtml
@@ -30,7 +30,7 @@
     }
 }
 <!DOCTYPE html>
-<html class="h-100" lang="en" @(Env.IsDeveloping ? " data-devenv" : "")>
+<html class="h-100" lang="en" @(Env.IsDeveloping ? " data-devenv" : "") id="POS-@Model.AppId">
 <head>
     <partial name="LayoutHead" />
     <meta name="apple-mobile-web-app-capable" content="yes">

--- a/BTCPayServer/Views/Shared/PointOfSale/UpdatePointOfSale.cshtml
+++ b/BTCPayServer/Views/Shared/PointOfSale/UpdatePointOfSale.cshtml
@@ -266,31 +266,36 @@
                             </div>
                         </div>
                     </div>
-                    <div class="accordion-item">
-                        <h2 class="accordion-header" id="additional-custom-css-header">
-                            <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#additional-custom-css" aria-expanded="false" aria-controls="additional-custom-css">
-                                Custom CSS
-                                <vc:icon symbol="caret-down" />
-                            </button>
-                        </h2>
-                        <div id="additional-custom-css" class="accordion-collapse collapse" aria-labelledby="additional-custom-css-header">
-                            <div class="accordion-body">
-                                <div class="form-group">
-                                    <label asp-for="CustomCSSLink" class="form-label"></label>
-                                    <a href="https://docs.btcpayserver.org/Development/Theme/#2-bootstrap-themes" target="_blank" rel="noreferrer noopener" title="More information...">
-                                        <vc:icon symbol="info" />
-                                    </a>
-                                    <input asp-for="CustomCSSLink" class="form-control" />
-                                    <span asp-validation-for="CustomCSSLink" class="text-danger"></span>
-                                </div>
-                                <div class="form-group">
-                                    <label asp-for="EmbeddedCSS" class="form-label"></label>
-                                    <textarea asp-for="EmbeddedCSS" rows="10" cols="40" class="form-control"></textarea>
-                                    <span asp-validation-for="EmbeddedCSS" class="text-danger"></span>
+                    @* We are deprecating the custom CSS options in favor of the store branding approach.
+                       Display this section only if these values are set. *@
+                    @if (!string.IsNullOrWhiteSpace(Model.CustomCSSLink) || !string.IsNullOrWhiteSpace(Model.EmbeddedCSS))
+                    {
+                        <div class="accordion-item">
+                            <h2 class="accordion-header" id="additional-custom-css-header">
+                                <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#additional-custom-css" aria-expanded="false" aria-controls="additional-custom-css">
+                                    Custom CSS
+                                    <vc:icon symbol="caret-down" />
+                                </button>
+                            </h2>
+                            <div id="additional-custom-css" class="accordion-collapse collapse" aria-labelledby="additional-custom-css-header">
+                                <div class="accordion-body">
+                                    <div class="form-group">
+                                        <label asp-for="CustomCSSLink" class="form-label"></label>
+                                        <a href="https://docs.btcpayserver.org/Development/Theme/#2-bootstrap-themes" target="_blank" rel="noreferrer noopener" title="More information...">
+                                            <vc:icon symbol="info" />
+                                        </a>
+                                        <input asp-for="CustomCSSLink" class="form-control" />
+                                        <span asp-validation-for="CustomCSSLink" class="text-danger"></span>
+                                    </div>
+                                    <div class="form-group">
+                                        <label asp-for="EmbeddedCSS" class="form-label"></label>
+                                        <textarea asp-for="EmbeddedCSS" rows="10" cols="40" class="form-control"></textarea>
+                                        <span asp-validation-for="EmbeddedCSS" class="text-danger"></span>
+                                    </div>
                                 </div>
                             </div>
                         </div>
-                    </div>
+                    }
                 </div>
             </div>
         </div>

--- a/BTCPayServer/Views/UIPaymentRequest/EditPaymentRequest.cshtml
+++ b/BTCPayServer/Views/UIPaymentRequest/EditPaymentRequest.cshtml
@@ -124,32 +124,37 @@
         </div>
     </div>
 
-    <div class="row">
-        <div class="col-xl-8 col-xxl-constrain">
-            <h4 class="mt-5 mb-2">Additional Options</h4>
-            <div class="form-group">
-                <div class="accordion" id="additional">
-                    <div class="accordion-item">
-                        <h2 class="accordion-header" id="additional-custom-css-header">
-                            <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#additional-custom-css" aria-expanded="false" aria-controls="additional-custom-css">
-                                Custom CSS
-                                <vc:icon symbol="caret-down" />
-                            </button>
-                        </h2>
-                        <div id="additional-custom-css" class="accordion-collapse collapse" aria-labelledby="additional-custom-css-header">
-                            <div class="accordion-body">
-                                <div class="form-group">
-                                    <label asp-for="CustomCSSLink" class="form-label"></label>
-                                    <a href="https://docs.btcpayserver.org/Development/Theme/#2-bootstrap-themes" target="_blank" rel="noreferrer noopener" title="More information...">
-                                        <vc:icon symbol="info" />
-                                    </a>
-                                    <input asp-for="CustomCSSLink" class="form-control" />
-                                    <span asp-validation-for="CustomCSSLink" class="text-danger"></span>
-                                </div>
-                                <div class="form-group">
-                                    <label asp-for="EmbeddedCSS" class="form-label"></label>
-                                    <textarea asp-for="EmbeddedCSS" rows="10" cols="40" class="form-control"></textarea>
-                                    <span asp-validation-for="EmbeddedCSS" class="text-danger"></span>
+    @* We are deprecating the custom CSS options in favor of the store branding approach.
+       Display this section only if these values are set. *@
+    @if (!string.IsNullOrWhiteSpace(Model.CustomCSSLink) || !string.IsNullOrWhiteSpace(Model.EmbeddedCSS))
+    {
+        <div class="row">
+            <div class="col-xl-8 col-xxl-constrain">
+                <h4 class="mt-5 mb-2">Additional Options</h4>
+                <div class="form-group">
+                    <div class="accordion" id="additional">
+                        <div class="accordion-item">
+                            <h2 class="accordion-header" id="additional-custom-css-header">
+                                <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#additional-custom-css" aria-expanded="false" aria-controls="additional-custom-css">
+                                    Custom CSS
+                                    <vc:icon symbol="caret-down" />
+                                </button>
+                            </h2>
+                            <div id="additional-custom-css" class="accordion-collapse collapse" aria-labelledby="additional-custom-css-header">
+                                <div class="accordion-body">
+                                    <div class="form-group">
+                                        <label asp-for="CustomCSSLink" class="form-label"></label>
+                                        <a href="https://docs.btcpayserver.org/Development/Theme/#2-bootstrap-themes" target="_blank" rel="noreferrer noopener" title="More information...">
+                                            <vc:icon symbol="info" />
+                                        </a>
+                                        <input asp-for="CustomCSSLink" class="form-control" />
+                                        <span asp-validation-for="CustomCSSLink" class="text-danger"></span>
+                                    </div>
+                                    <div class="form-group">
+                                        <label asp-for="EmbeddedCSS" class="form-label"></label>
+                                        <textarea asp-for="EmbeddedCSS" rows="10" cols="40" class="form-control"></textarea>
+                                        <span asp-validation-for="EmbeddedCSS" class="text-danger"></span>
+                                    </div>
                                 </div>
                             </div>
                         </div>
@@ -157,7 +162,7 @@
                 </div>
             </div>
         </div>
-    </div>
+    }
 </form>
 
 @if (!string.IsNullOrEmpty(Model.Id))

--- a/BTCPayServer/Views/UIPaymentRequest/ViewPaymentRequest.cshtml
+++ b/BTCPayServer/Views/UIPaymentRequest/ViewPaymentRequest.cshtml
@@ -32,7 +32,7 @@
 }
 
 <!DOCTYPE html>
-<html lang="en" @(Env.IsDeveloping ? " data-devenv" : "")>
+<html lang="en" @(Env.IsDeveloping ? " data-devenv" : "") id="PaymentRequest-@Model.Id">
 <head>
     <partial name="LayoutHead"/>
     <link href="~/vendor/bootstrap-vue/bootstrap-vue.min.css" asp-append-version="true" rel="stylesheet"/>

--- a/BTCPayServer/Views/UIPullPayment/EditPullPayment.cshtml
+++ b/BTCPayServer/Views/UIPullPayment/EditPullPayment.cshtml
@@ -54,32 +54,37 @@
         </div>
     </div>
 
-    <div class="row">
-        <div class="col-xl-8 col-xxl-constrain">
-            <h4 class="mt-5 mb-2">Additional Options</h4>
-            <div class="form-group">
-                <div class="accordion" id="additional">
-                    <div class="accordion-item">
-                        <h2 class="accordion-header" id="additional-custom-css-header">
-                            <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#additional-custom-css" aria-expanded="false" aria-controls="additional-custom-css">
-                                Custom CSS
-                                <vc:icon symbol="caret-down" />
-                            </button>
-                        </h2>
-                        <div id="additional-custom-css" class="accordion-collapse collapse" aria-labelledby="additional-custom-css-header">
-                            <div class="accordion-body">
-                                <div class="form-group">
-                                    <label asp-for="CustomCSSLink" class="form-label"></label>
-                                    <a href="https://docs.btcpayserver.org/Development/Theme/#2-bootstrap-themes" target="_blank" rel="noreferrer noopener">
-                                        <vc:icon symbol="info" />
-                                    </a>
-                                    <input asp-for="CustomCSSLink" class="form-control" />
-                                    <span asp-validation-for="CustomCSSLink" class="text-danger"></span>
-                                </div>
-                                <div class="form-group">
-                                    <label asp-for="EmbeddedCSS" class="form-label"></label>
-                                    <textarea asp-for="EmbeddedCSS" rows="10" cols="40" class="form-control"></textarea>
-                                    <span asp-validation-for="EmbeddedCSS" class="text-danger"></span>
+    @* We are deprecating the custom CSS options in favor of the store branding approach.
+       Display this section only if these values are set. *@
+    @if (!string.IsNullOrWhiteSpace(Model.CustomCSSLink) || !string.IsNullOrWhiteSpace(Model.EmbeddedCSS))
+    {
+        <div class="row">
+            <div class="col-xl-8 col-xxl-constrain">
+                <h4 class="mt-5 mb-2">Additional Options</h4>
+                <div class="form-group">
+                    <div class="accordion" id="additional">
+                        <div class="accordion-item">
+                            <h2 class="accordion-header" id="additional-custom-css-header">
+                                <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#additional-custom-css" aria-expanded="false" aria-controls="additional-custom-css">
+                                    Custom CSS
+                                    <vc:icon symbol="caret-down" />
+                                </button>
+                            </h2>
+                            <div id="additional-custom-css" class="accordion-collapse collapse" aria-labelledby="additional-custom-css-header">
+                                <div class="accordion-body">
+                                    <div class="form-group">
+                                        <label asp-for="CustomCSSLink" class="form-label"></label>
+                                        <a href="https://docs.btcpayserver.org/Development/Theme/#2-bootstrap-themes" target="_blank" rel="noreferrer noopener">
+                                            <vc:icon symbol="info" />
+                                        </a>
+                                        <input asp-for="CustomCSSLink" class="form-control" />
+                                        <span asp-validation-for="CustomCSSLink" class="text-danger"></span>
+                                    </div>
+                                    <div class="form-group">
+                                        <label asp-for="EmbeddedCSS" class="form-label"></label>
+                                        <textarea asp-for="EmbeddedCSS" rows="10" cols="40" class="form-control"></textarea>
+                                        <span asp-validation-for="EmbeddedCSS" class="text-danger"></span>
+                                    </div>
                                 </div>
                             </div>
                         </div>
@@ -87,5 +92,5 @@
                 </div>
             </div>
         </div>
-    </div>
+    }
 </form>

--- a/BTCPayServer/Views/UIPullPayment/ViewPullPayment.cshtml
+++ b/BTCPayServer/Views/UIPullPayment/ViewPullPayment.cshtml
@@ -25,7 +25,7 @@
 	ViewData.SetBlazorAllowed(false);
 }
 <!DOCTYPE html>
-<html lang="en" @(Env.IsDeveloping ? " data-devenv" : "")>
+<html lang="en" @(Env.IsDeveloping ? " data-devenv" : "") id="PullPayment-@Model.Id">
 <head>
     <partial name="LayoutHead"/>
     <link href="~/vendor/bootstrap-vue/bootstrap-vue.min.css" asp-append-version="true" rel="stylesheet"/>

--- a/BTCPayServer/Views/UIStorePullPayments/NewPullPayment.cshtml
+++ b/BTCPayServer/Views/UIStorePullPayments/NewPullPayment.cshtml
@@ -75,10 +75,35 @@
             <div class="form-group">
                 <div class="accordion" id="additional">
                     <div class="accordion-item">
+                        <h2 class="accordion-header" id="additional-lightning-header">
+                            <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#additional-lightning" aria-expanded="false" aria-controls="additional-lightning">
+                                Lightning network settings
+                                <vc:icon symbol="caret-down" />
+                            </button>
+                        </h2>
+                        <div id="additional-lightning" class="accordion-collapse collapse" aria-labelledby="additional-lightning-header">
+                            <div class="accordion-body">
+                                <div class="form-group">
+                                    <label asp-for="BOLT11Expiration" class="form-label"></label>
+                                    <div class="input-group">
+                                        <input inputmode="numeric" asp-for="BOLT11Expiration" class="form-control" style="max-width:12ch;" />
+                                        <span class="input-group-text">days</span>
+                                    </div>
+                                    <span asp-validation-for="BOLT11Expiration" class="text-danger"></span>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                @* We are deprecating the custom CSS options in favor of the store branding approach.
+                   Display this section only if these values are set. *@
+                @if (!string.IsNullOrWhiteSpace(Model.CustomCSSLink) || !string.IsNullOrWhiteSpace(Model.EmbeddedCSS))
+                {
+                    <div class="accordion-item">
                         <h2 class="accordion-header" id="additional-custom-css-header">
                             <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#additional-custom-css" aria-expanded="false" aria-controls="additional-custom-css">
                                 Custom CSS
-                                <vc:icon symbol="caret-down"/>
+                                <vc:icon symbol="caret-down" />
                             </button>
                         </h2>
                         <div id="additional-custom-css" class="accordion-collapse collapse" aria-labelledby="additional-custom-css-header">
@@ -88,7 +113,7 @@
                                     <a href="https://docs.btcpayserver.org/Development/Theme/#2-bootstrap-themes" target="_blank" rel="noreferrer noopener" title="More information...">
                                         <vc:icon symbol="info" />
                                     </a>
-                                    <input asp-for="CustomCSSLink" class="form-control"/>
+                                    <input asp-for="CustomCSSLink" class="form-control" />
                                     <span asp-validation-for="CustomCSSLink" class="text-danger"></span>
                                 </div>
                                 <div class="form-group">
@@ -99,27 +124,7 @@
                             </div>
                         </div>
                     </div>
-                    <div class="accordion-item">
-                        <h2 class="accordion-header" id="additional-lightning-header">
-                            <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#additional-lightning" aria-expanded="false" aria-controls="additional-lightning">
-                                Lightning network settings
-                                <vc:icon symbol="caret-down"/>
-                            </button>
-                        </h2>
-                        <div id="additional-lightning" class="accordion-collapse collapse" aria-labelledby="additional-lightning-header">
-                            <div class="accordion-body">
-                                <div class="form-group">
-                                    <label asp-for="BOLT11Expiration" class="form-label"></label>
-                                    <div class="input-group">
-                                        <input inputmode="numeric" asp-for="BOLT11Expiration" class="form-control" style="max-width:12ch;"/>
-                                        <span class="input-group-text">days</span>
-                                    </div>
-                                    <span asp-validation-for="BOLT11Expiration" class="text-danger"></span>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                </div>
+                }
             </div>
         </div>
     </div>


### PR DESCRIPTION
As discussed with @pavlenex we are deprecating the custom CSS options for particular entities (payment request, pull payment, POS, crowdfunding) in favor of the store branding approach.

This displays the custom CSS section only if these values are set already.