### PR TITLE
Blazor Customizable Dashboard proof of concept

### DIFF
--- a/BTCPayServer/Blazor/BlazorExtensions.cs
+++ b/BTCPayServer/Blazor/BlazorExtensions.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.JSInterop;
 
 namespace BTCPayServer.Blazor
@@ -8,6 +9,15 @@ namespace BTCPayServer.Blazor
         {
             // The peculiar thing in prerender is that Blazor circuit isn't yet created, so we can't use JSInterop
             return !(bool)runtime.GetType().GetProperty("IsInitialized").GetValue(runtime);
+        }
+
+        public static IServiceCollection AddWidgets(this IServiceCollection serviceCollection)
+        {
+            serviceCollection.AddSingleton<WidgetService>();
+            serviceCollection.AddSingleton<AvailableWidget,AvailableWidget>(_ => InvoiceWidget.AvailableWidget);
+            
+            return serviceCollection;
+            
         }
     }
 }

--- a/BTCPayServer/Blazor/Dashboard.razor
+++ b/BTCPayServer/Blazor/Dashboard.razor
@@ -1,0 +1,322 @@
+﻿@using Newtonsoft.Json.Linq
+@inject WidgetService WidgetService
+<div class="d-flex justify-content-start gap-4 mb-4">
+    <h3>Dashboard</h3>
+
+    <div class="d-flex gap-4">
+        @if (EditMode)
+        {
+            <button class="btn btn-link" disabled="@WidgetEditMode" @onclick="() => EditMode = !EditMode">Done</button>
+
+            <div class="input-group">
+                <select class="form-select" @bind="NewWidgetType"  disabled="@WidgetEditMode" >
+
+                    <option value="">Select</option>
+                    @foreach (var widget in WidgetService.AvailableWidgets)
+                    {
+                        <option value="@widget.Type">@widget.Name</option>
+                    }
+                </select>
+
+                <button class="btn btn-outline-primary" @onclick="AddNew" disabled="@(string.IsNullOrEmpty(NewWidgetType) || WidgetEditMode)">Add</button>
+            </div>
+        }
+        else
+        {
+            <button class="btn btn-link" @onclick="() => EditMode = !EditMode">Edit</button>
+        }
+
+
+    </div>
+    <style>   
+    .db{
+        display: grid;
+        grid-template-columns: repeat(12, minmax(0, 1fr));
+        grid-gap: 10px;
+    }
+    
+    
+@@media (max-width: 1199px) {
+   .db{
+        grid-template-columns: repeat(6, minmax(0, 1fr));
+}
+    }
+</style>
+
+</div>
+<div class="db">
+
+    @{
+        var lastEnd = 1; // Initialize lastEnd to the start of the grid
+    }
+      @foreach (var widget in Widgets)
+        {
+            var actualLastEnd = lastEnd;
+            var start = lastEnd ;
+
+            // Apply the widget offset
+            start += widget.Offset;
+
+            // If start position is beyond the grid, reset to the first column
+            if (start > 12)
+                start = 1;
+
+            lastEnd = start + widget.ColumnSize;
+
+            // If the widget overflows the grid, move it to a new row
+            if (lastEnd > 13)
+            {
+                start = lastEnd - 13; // Start at the beginning of a new row with offset applied
+                
+            }
+            start = Math.Max(1, start);
+
+            lastEnd = start + widget.ColumnSize;
+            
+            
+              
+            //if there are columns between the last widget and the current one, add gap widgets 1 col each
+            // so if the last end if not 13 and the start is not 1 and start  != lastEnd
+//create a <div > for every grid column to fill the gap
+            if (EditMode && start != actualLastEnd && (start != 1 || actualLastEnd != 13))
+            {
+                int i = actualLastEnd;
+                while (i != start)
+                {
+                    if(i == 13)
+                        i = 1;
+                    <div class="widget bg-transparent border-2" style="border-style: dotted; border-color: var(--btcpay-primary-border-active); grid-column-start: @i; grid-column-end: @(i+1);">
+                    </div>
+
+                    i++;
+                    if(i == 13)
+                        i = 1;
+                }
+                
+            }
+
+            
+
+            var availableWidget = WidgetService.AvailableWidgets.FirstOrDefault(w => w.Type == widget.Type);
+
+      
+        
+        // var start = lastEnd;
+        // if (start is > 13 or 0)
+        //     start = 1;
+        // start += widget.Offset;
+        // if (start is >= 13 or 0)
+        //     start = 1;
+        // lastEnd = start + widget.ColumnSize;
+        // if (lastEnd > 13)
+        // {
+        //     start = widget.Offset +1;
+        //     lastEnd = start + widget.ColumnSize;
+        // }
+        //
+        // var availableWidget = WidgetService.AvailableWidgets.FirstOrDefault(w => w.Type == widget.Type);
+
+        <div class="widget bg-light" style=" grid-column-start: @start; grid-column-end: @(widget.ColumnSize +start);">
+
+            @if (availableWidget is null)
+            {
+                <h2>Widget unavailable..</h2>
+                @if (EditMode)
+                {
+                    <button class="btn btn-link" @onclick="() => RemoveWidget(widget)">Remove</button>
+                }
+            }
+            else
+            {
+                var dynamicComponentParameters = new Dictionary<string, object>
+                {
+                    {"StoreId", StoreId},
+                    {"Readonly", !EditMode || WidgetEditMode},
+                    {"Size", widget.ColumnSize},
+                    {"Config", widget.Config},
+                    {"ConfigChanged", EventCallback.Factory.Create<JObject>(this, (newConfig) => OnConfigChanged(widget, newConfig))},
+                    {"EditModeChanged", EventCallback.Factory.Create<bool>(this, (newConfig) => WidgetEditMode = newConfig)},
+                    {"OnRemove", EventCallback.Factory.Create(this, () => RemoveWidget(widget))},
+                };
+                <DynamicComponent @key="widget.Id" Type="@availableWidget.ComponentType" Parameters="dynamicComponentParameters" />
+            }
+            @if (EditMode && !WidgetEditMode)
+            {
+                <div class="d-flex flex-wrap mt-4">
+                    <input class="form-control form-control-sm w-25 my-1" type="number" min="0" title="order" @bind="widget.Order" />
+                    <input class="form-control form-control-sm w-25 my-1" type="number" min="@availableWidget.MinSize" max="@availableWidget.MaxSize" title="size" @bind="widget.ColumnSize" />
+                    <input class="form-control form-control-sm w-25 my-1" type="number" min="0" title="offset" @bind="widget.Offset" />
+                </div>
+            }
+        </div>
+    }
+    @while(EditMode &&  lastEnd != 13 )
+    {
+        <div class="widget bg-transparent border-2" style="border-style: dotted; border-color: var(--btcpay-primary-border-active); grid-column-start: @lastEnd; grid-column-end: @(lastEnd+1);">
+        </div>
+        lastEnd++;
+    }
+    
+    
+</div>
+
+
+@code {
+
+    public bool WidgetEditMode { get; set; }
+    public bool EditMode { get; set; }
+    public string NewWidgetType { get; set; }
+
+    public async Task OnConfigChanged(Widget widget, JObject newConfig)
+    {
+        //replace the widget with the new one
+        widget.Config = newConfig;
+        await WidgetService.SetWidgetSet(StoreId, new WidgetSet() {Widgets = Widgets});
+    }
+
+    public List<Widget> Widgets { get; set; } = new List<Widget>();
+
+
+    private async Task RemoveWidget(Widget widget)
+    {
+        //loop through widgets and adjust the order
+        Widgets.Remove(widget);
+
+        widget.OnResize -= OnResize;
+        widget.OnNewOrder -= OnNewOrder;
+        widget.OnNewOffset -= OnNewOffset;
+        foreach (var w in Widgets)
+        {
+            if (w.Order > widget.Order)
+            {
+                w.Order--;
+            }
+        }
+        
+        await WidgetService.SetWidgetSet(StoreId, new WidgetSet() {Widgets = Widgets});
+    }
+
+    private async Task AddNew()
+    {
+        var widget = new Widget()
+        {
+            ColumnSize = 3,
+            Order = Widgets.Count,
+            Offset = 0,
+            Type = NewWidgetType
+        };
+        widget.OnResize += OnResize;
+        widget.OnNewOrder += OnNewOrder;
+        widget.OnNewOffset += OnNewOffset;
+        Widgets.Add(widget);
+        NewWidgetType = null;
+        _ = WidgetService.SetWidgetSet(StoreId, new WidgetSet() {Widgets = Widgets});
+    }
+
+
+    private void OnNewOrder(object sender, (int oldOrder, int newOrder) e)
+    {
+//switch the order with the widget that has the new order
+        var widget = Widgets.FirstOrDefault(w => w.Order == e.newOrder && w != sender);
+        if (widget != null)
+        {
+            widget.Order = e.oldOrder;
+            if (sender is Widget senderWidget)
+            {
+                //switch the offsets too
+                (senderWidget.Offset, widget.Offset) = (widget.Offset, senderWidget.Offset);
+            }
+            Widgets = Widgets.OrderBy(w => w.Order).ToList();
+            
+            _ = WidgetService.SetWidgetSet(StoreId, new WidgetSet() {Widgets = Widgets});
+        }
+
+        InvokeAsync(StateHasChanged);
+    }
+
+    private void OnResize(object sender, (int oldSize, int newSize) e)
+    {
+        if (sender is Widget w)
+        {
+            //find the next wudget and adjust its offset
+            var nextWidget = Widgets.FirstOrDefault(widget => widget.Order > w.Order);
+            if (nextWidget != null)
+            {
+                // var newOffset = 0;
+                // if (e.newSize > e.oldSize)
+                // {
+                //     newOffset = nextWidget.Offset - e.newSize - e.oldSize;
+                // }
+                // else if (e.newSize < e.oldSize)
+                // {
+                //     
+                //     newOffset =  nextWidget.Offset + Math.Abs( e.newSize - e.oldSize);
+                // }
+                //
+                // var wDict = Widgets.ToDictionary(w => w.Order, w => (w.ColumnSize, w.Offset));
+                // wDict[w.Order] = (e.oldSize, w.Offset);
+                //
+                // var widgetOldDimensions =  ComputeStartOfWidget(wDict, w.Order);
+                // var widgetNewDimensions =  ComputeStartOfWidget(Widgets.ToDictionary(w => w.Order, w => (w.ColumnSize, w.Offset)),w.Order);
+                // var nextWidgetOldDimensions =  ComputeStartOfWidget(wDict, nextWidget.Order);
+                // var nextWidgetNewDimensions =  ComputeStartOfWidget(Widgets.ToDictionary(w => w.Order, w => (w.ColumnSize, w.Offset)),nextWidget.Order);
+                //
+                // //try not to move the widget if it was on another row
+                // if (widgetNewDimensions.row == nextWidgetNewDimensions.row)
+                // {
+                //     
+                //     nextWidget.Offset = newOffset+ nextWidget.ColumnSize > 12 ? Math.Max(0, 12 - nextWidget.ColumnSize) : Math.Max(0, newOffset);
+                // }
+                // else
+                // {
+                //     
+                // }
+                
+                
+                
+               
+            }
+        }
+        _ = WidgetService.SetWidgetSet(StoreId, new WidgetSet() {Widgets = Widgets});
+    }
+
+    private (int row, int col) ComputeStartOfWidget(Dictionary<int,(int size, int offset)> orderToSize, int target)
+    {
+        var currRow = 1;
+        var currCol = 1;
+        foreach (var widget in orderToSize.OrderBy(w => w.Key))
+        {
+            currCol += widget.Value.size + widget.Value.offset;
+            if (currCol > 12)
+            {
+                currRow++;
+                currCol = 1;
+            }
+            if(widget.Key == target)
+                return (currRow, currCol);
+            
+        }
+
+        return (currRow, currCol);
+    }
+    private void OnNewOffset(object sender, (int oldSize, int newSize) e)
+    {
+        _ = WidgetService.SetWidgetSet(StoreId, new WidgetSet() {Widgets = Widgets});
+    }
+
+    [Parameter] public string StoreId { get; set; }
+
+    protected override async Task OnParametersSetAsync()
+    {
+        var set = await WidgetService.GetWidgetSet(StoreId);
+        Widgets = set?.Widgets ?? [];
+        foreach (var widget in Widgets)
+        {
+            widget.OnResize += OnResize;
+            widget.OnNewOrder += OnNewOrder;
+            widget.OnNewOffset += OnNewOffset;
+        }
+        await base.OnParametersSetAsync();
+    }
+
+}

--- a/BTCPayServer/Blazor/InvoiceWidget.razor
+++ b/BTCPayServer/Blazor/InvoiceWidget.razor
@@ -111,7 +111,7 @@ else
                         <a asp-controller="UIInvoice" asp-action="Invoice" asp-route-invoiceId="@invoice.Id" class="text-break">@invoice.Id</a>
                     </td>
                     <td>
-                        @invoice.Status.ToModernStatus()
+                        @invoice.Status
                     </td>
                     <td class="text-end">
                         <span data-sensitive>@DisplayFormatter.Currency(invoice.Price, invoice.Currency)</span>

--- a/BTCPayServer/Blazor/InvoiceWidget.razor
+++ b/BTCPayServer/Blazor/InvoiceWidget.razor
@@ -1,0 +1,195 @@
+﻿@using BTCPayServer.Services.Invoices
+@using BTCPayServer.Abstractions.Contracts
+@using BTCPayServer.Services
+@inherits BaseWidgetComponent<InvoiceWidget.InvoiceWidgetConfig>
+@inject InvoiceRepository InvoiceRepository
+@inject DisplayFormatter DisplayFormatter 
+
+
+
+@if (Loading)
+{
+    <header class="mb-3">
+        <h3>Invoices</h3>
+
+    </header>
+
+    <div class="spinner-border" role="status">
+        <span class="visually-hidden">Loading...</span>
+    </div>
+}
+else if (EditMode)
+{
+    <header class="mb-3">
+        <h3>Invoices</h3>
+
+    </header>
+
+    <div>
+        <div class="form-group">
+            <label class="form-label">Days</label>
+            <input type="number" @bind="EditConfig.LastDays" min="1" max="100" step="1" class="form-control" />
+        </div>
+        <div class="form-group">
+            <label class="form-label">Limit</label>
+            <input type="number" @bind="EditConfig.LimitToShow" min="1" max="100" step="1" class="form-control" />
+        </div>
+
+        <div class="form-group">
+            <div class="d-flex justify-content-center gap-2">
+                <button class="btn btn-primary btn-sm px-2" @onclick="SaveEdit">Save</button>
+                <button class="btn btn-outline-secondary btn-sm   px-2" @onclick="CancelEdit">Cancel</button>
+                <button class="btn btn-outline-danger btn-sm   px-2" @onclick="Remove">Remove</button>
+            </div>
+        </div>
+
+    </div>
+}
+else if (_invoices is null)
+{  
+    <header class="mb-3">
+        <h3>Invoices</h3>
+
+    </header>
+    <p class="text-secondary my-3">
+        This widget is not yet configured.
+    </p>
+    @if (!Readonly)
+    {
+        <button class="btn btn-link" @onclick="EnterEdit">Edit widget</button>
+    }
+}
+else if (Size <= 6)
+{
+    
+    <div class="balance d-flex align-items-baseline gap-1">
+        <h3 class="d-inline-block me-1">@_invoices.Length</h3>
+        <span class="text-secondary fw-semibold currency">invoices</span>
+    </div>
+    <p class="text-secondary my-3">in last @TypedConfig.LastDays days</p>
+    @if (!Readonly)
+    {
+        <button class="btn btn-link" @onclick="EnterEdit">Edit widget</button>
+    }
+}
+else if (_invoices.Length == 0)
+{
+    <header class="mb-3">
+        <h3>Invoices</h3>
+
+    </header>
+    <p class="text-secondary my-3">
+        There are no recent invoices.
+    </p>
+    @if (!Readonly)
+    {
+        <button class="btn btn-link" @onclick="EnterEdit">Edit widget</button>
+    }
+}
+else
+{
+    <header class="mb-3">
+        <h3>Invoices</h3>
+
+    </header>
+    <div class="table-responsive">
+        <table class="table table-hover mt-3 mb-0">
+            <thead>
+            <tr>
+                <th class="w-125px">Date</th>
+                <th class="text-nowrap">Invoice Id</th>
+                <th>Status</th>
+                <th class="text-end">Amount</th>
+            </tr>
+            </thead>
+            <tbody>
+            @foreach (var invoice in _invoices)
+            {
+                <tr>
+                    <td>@invoice.InvoiceTime.ToTimeAgo()</td>
+                    <td>
+                        <a asp-controller="UIInvoice" asp-action="Invoice" asp-route-invoiceId="@invoice.Id" class="text-break">@invoice.Id</a>
+                    </td>
+                    <td>
+                        @invoice.Status.ToModernStatus()
+                    </td>
+                    <td class="text-end">
+                        <span data-sensitive>@DisplayFormatter.Currency(invoice.Price, invoice.Currency)</span>
+                    </td>
+                </tr>
+            }
+            </tbody>
+        </table>
+    </div>
+    @if (!Readonly)
+    {
+        <button class="btn btn-link" @onclick="EnterEdit">Edit widget</button>
+    }
+}
+
+@code{
+
+    private InvoiceEntity[] _invoices;
+    
+
+    protected override Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender)
+        {
+            _ = Fetch();
+        }
+
+        return base.OnAfterRenderAsync(firstRender);
+    }
+
+    public class InvoiceWidgetConfig
+    {
+        public int LimitToShow { get; set; } = 10;
+        public int LastDays { get; set; } = 30;
+    }
+
+    private async Task Fetch()
+    {
+        Loading = true;
+        try
+        {
+            if (TypedConfig is null)
+            {
+                return;
+            }
+            
+            _invoices = await InvoiceRepository.GetInvoices(new InvoiceQuery()
+            {
+                IncludeArchived = false,
+                StartDate = DateTimeOffset.UtcNow.AddDays(-TypedConfig.LastDays),
+                Take = TypedConfig.LimitToShow,
+                StoreId = new[] {StoreId}
+            });
+            await InvokeAsync(StateHasChanged);
+        }
+        catch (Exception e)
+        {
+            Console.WriteLine(e);
+        }
+        finally
+        {
+            Loading = false;
+        }
+    }
+
+    protected override Task TypedConfigChanged()
+    {
+        _ = Fetch();
+        return base.TypedConfigChanged();
+    }
+
+    public static readonly AvailableWidget AvailableWidget = new AvailableWidget()
+    {
+        Name = "Invoices",
+        Type = nameof(InvoiceWidget),
+        ComponentType = typeof(InvoiceWidget),
+        MaxSize = 13,
+        MinSize = 2
+    };
+
+}

--- a/BTCPayServer/Blazor/WidgetService.cs
+++ b/BTCPayServer/Blazor/WidgetService.cs
@@ -1,0 +1,206 @@
+﻿#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Threading.Tasks;
+using BTCPayServer.Services.Stores;
+using Microsoft.AspNetCore.Components;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace BTCPayServer.Blazor;
+
+public abstract class BaseWidgetComponent<T> : ComponentBase where T : new()
+{
+    public bool Loading
+    {
+        get => _loading;
+        set
+        {
+            if (_loading == value) return;
+            _loading = value;
+            InvokeAsync(StateHasChanged);
+        }
+    }
+
+    public virtual T? TypedConfig
+    {
+        get => _typedConfig;
+        set
+        {
+            _typedConfig = value;
+            
+            InvokeAsync(StateHasChanged);
+            InvokeAsync(TypedConfigChanged);
+        }
+    }
+
+    protected virtual  async Task TypedConfigChanged()
+    {
+        // await CancelEdit();
+    }
+
+    [Parameter]
+    public virtual JObject? Config
+    {
+        get => TypedConfig is null ? null : JObject.FromObject(TypedConfig);
+        set
+        {
+                if(Config is null && value is null)
+                    return;
+                if(Config is not null && value is not null && JToken.DeepEquals(Config, value))
+                    return;
+                TypedConfig = value is null ? default : value.ToObject<T?>();
+        }
+    }
+    
+
+    [Parameter] public int Size { get; set; }
+    [Parameter] public string StoreId { get; set; }
+    [Parameter] public bool Readonly { get; set; }
+
+    [Parameter] public EventCallback<JObject> ConfigChanged { get; set; }
+    [Parameter] public EventCallback<bool> EditModeChanged { get; set; }
+    [Parameter] public EventCallback OnRemove { get; set; }
+
+    protected T? EditConfig { get; set; }
+
+    protected bool EditMode
+    {
+        get => _editMode;
+        set
+        {
+            if (_editMode == value) return;
+            _editMode = value;
+            InvokeAsync(() => EditModeChanged.InvokeAsync(_editMode));
+            InvokeAsync(StateHasChanged);
+        }
+    }
+
+    protected bool _editMode;
+    private bool _loading;
+    private T? _typedConfig;
+
+    protected virtual async Task EnterEdit()
+    {
+        if (EditMode)
+        {
+            return;
+        }
+
+        EditConfig = Config is null ? new T() : Config.DeepClone().ToObject<T>();
+
+        EditMode = true;
+    }
+
+
+    public virtual async Task CancelEdit()
+    {
+        EditMode = false;
+        EditConfig = default;
+    }
+
+    public virtual async Task SaveEdit()
+    {
+        if (EditConfig is null)
+        {
+            return;
+        }
+
+        TypedConfig = EditConfig;
+        await CancelEdit();
+        await ConfigChanged.InvokeAsync(Config);
+    }
+
+    public virtual async Task Remove()
+    {
+        await OnRemove.InvokeAsync();
+    }
+}
+
+public class WidgetService
+{
+    private readonly StoreRepository _storeRepository;
+    public ImmutableArray<AvailableWidget> AvailableWidgets { get; set; }
+
+    public WidgetService(IEnumerable<AvailableWidget> availableWidgets, StoreRepository storeRepository)
+    {
+        _storeRepository = storeRepository;
+        AvailableWidgets = availableWidgets.ToImmutableArray();
+    }
+
+    public async Task<WidgetSet?> GetWidgetSet(string storeId)
+    {
+        var ws = await _storeRepository.GetSettingAsync<WidgetSet>(storeId, nameof(WidgetSet));
+        return ws;
+    }
+
+    public async Task SetWidgetSet(string storeId, WidgetSet? widgetSet)
+    {
+        await _storeRepository.UpdateSetting(storeId, nameof(WidgetSet), widgetSet);
+    }
+}
+
+public class WidgetSet
+{
+    public List<Widget> Widgets { get; set; }
+}
+
+public class AvailableWidget
+{
+    public int MinSize { get; set; }
+    public int MaxSize { get; set; }
+    public string Name { get; set; }
+    public string Type { get; set; }
+    public Type ComponentType { get; set; }
+}
+
+public class Widget
+{
+    private int _columnSize;
+    private int _order;
+    private int _offset;
+    public string Type { get; set; }
+    public JObject Config { get; set; }
+
+    public int ColumnSize
+    {
+        get => _columnSize;
+        set
+        {
+            var oldSize = _columnSize;
+            _columnSize = value;
+            if (_columnSize != oldSize)
+                OnResize?.Invoke(this, (oldSize, _columnSize));
+        }
+    }
+
+    public int Order
+    {
+        get => _order;
+        set
+        {
+            var oldOrder = _order;
+            _order = value;
+            if (_order != oldOrder)
+                OnNewOrder?.Invoke(this, (oldOrder, _order));
+        }
+    }
+    public int Offset
+    {
+        get => _offset;
+        set
+        {
+            var old = _offset;
+            _offset = value;
+            if (_offset != old)
+                OnNewOffset?.Invoke(this, (old, _offset));
+        }
+    }
+
+    [JsonIgnore] public EventHandler<(int oldValue, int newValue)> OnResize { get; set; }
+    [JsonIgnore] public EventHandler<(int oldValue, int newValue)> OnNewOrder { get; set; }
+    [JsonIgnore] public EventHandler<(int oldValue, int newValue)> OnNewOffset { get; set; }
+
+    public string Id { get; set; } = Guid.NewGuid().ToString();
+}

--- a/BTCPayServer/Controllers/UIStoresController.Dashboard.cs
+++ b/BTCPayServer/Controllers/UIStoresController.Dashboard.cs
@@ -70,6 +70,12 @@ public partial class UIStoresController
         return View(vm);
     }
 
+    [HttpGet("{storeId}/2")]
+    public async Task<IActionResult> Dashboard2()
+    {
+        return View();
+    }
+
     [HttpGet("{storeId}/dashboard/{cryptoCode}/lightning/balance")]
     [Authorize(Policy = Policies.CanModifyStoreSettings, AuthenticationSchemes = AuthenticationSchemes.Cookie)]
     public IActionResult LightningBalance(string storeId, string cryptoCode)

--- a/BTCPayServer/Hosting/BTCPayServerServices.cs
+++ b/BTCPayServer/Hosting/BTCPayServerServices.cs
@@ -6,6 +6,7 @@ using BTCPayServer.Abstractions.Contracts;
 using BTCPayServer.Abstractions.Extensions;
 using BTCPayServer.Abstractions.Models;
 using BTCPayServer.Abstractions.Services;
+using BTCPayServer.Blazor;
 using BTCPayServer.Client;
 using BTCPayServer.Common;
 using BTCPayServer.Configuration;
@@ -400,6 +401,7 @@ namespace BTCPayServer.Hosting
             services.AddScheduledTask<GithubVersionFetcher>(TimeSpan.FromDays(1));
             services.AddScheduledTask<PluginUpdateFetcher>(TimeSpan.FromDays(1));
 
+            services.AddWidgets();
             services.AddReportProvider<PaymentsReportProvider>();
             services.AddReportProvider<OnChainWalletReportProvider>();
             services.AddReportProvider<ProductsReportProvider>();

--- a/BTCPayServer/Views/UIStores/Dashboard2.cshtml
+++ b/BTCPayServer/Views/UIStores/Dashboard2.cshtml
@@ -1,0 +1,8 @@
+﻿@using BTCPayServer.Blazor
+@using BTCPayServer.Abstractions.Contracts
+@inject IScopeProvider ScopeProvider
+
+@(await Html.RenderComponentAsync<Dashboard>(RenderMode.ServerPrerendered, new
+{
+    StoreId = ScopeProvider.GetCurrentStoreId()
+}))


### PR DESCRIPTION
## Blazor Customizable Dashboard - Proof of Concept

This PR introduces a proof-of-concept for a customizable, widget-based store dashboard built with Blazor Server, accessible at `/{storeId}/2`.

### What it does

- **Widget system**: A pluggable architecture where widgets can be registered via DI (`AvailableWidget` + `WidgetService`) and rendered dynamically on a per-store dashboard.
- **12-column CSS grid layout**: Widgets are placed on a responsive 12-column grid (collapses to 6 on smaller screens). Each widget has configurable **size**, **order**, and **offset**.
- **Edit mode**: Users can enter edit mode to add/remove/reorder widgets and adjust their grid placement. Empty grid cells are shown as dotted outlines for visual guidance.
- **Per-widget configuration**: Each widget has its own typed config (stored as JSON via `StoreRepository` settings). Widgets can enter their own edit mode to configure themselves independently.
- **Base component**: `BaseWidgetComponent<T>` provides a reusable base class handling config serialization, edit/save/cancel lifecycle, loading state, and event callbacks.
- **Sample widget**: `InvoiceWidget` demonstrates the system — displays recent invoices with configurable day range and limit, adapts its display based on grid column size (compact count vs. full table).

### Architecture

| Component | Purpose |
|---|---|
| `WidgetService` | Manages available widget registry + persists per-store widget layouts via `StoreRepository` |
| `BaseWidgetComponent<T>` | Abstract base for widgets with typed config, edit mode, and removal support |
| `Dashboard.razor` | Main dashboard component with grid layout, edit mode, and widget orchestration |
| `InvoiceWidget.razor` | Example widget showing recent invoices |
| `BlazorExtensions.AddWidgets()` | DI registration for widget services |
| `Dashboard2.cshtml` | MVC view that bootstraps the Blazor `Dashboard` component via `RenderComponentAsync` |

### Status

This is an **early proof of concept** — not production-ready. Known rough edges:
- Resize offset adjustment logic is partially commented out
- No drag-and-drop (order/size/offset are numeric inputs)
- Only one sample widget (Invoices)
- Layout edge cases with grid wrapping

### How to test

Navigate to `/{storeId}/2` to see the Blazor dashboard. Click **Edit** to enter edit mode, add an Invoices widget, and configure it.