### PR TITLE
Introduce auto update and killswitch options on plugins

### DIFF
--- a/BTCPayServer.Abstractions/Contracts/INotificationHandler.cs
+++ b/BTCPayServer.Abstractions/Contracts/INotificationHandler.cs
@@ -24,6 +24,7 @@ namespace BTCPayServer.Abstractions.Contracts
         public DateTimeOffset Created { get; set; }
         public string Body { get; set; }
         public string ActionLink { get; set; }
+        public string ActionText { get; set; } = "Details";
         public bool Seen { get; set; }
     }
 }

--- a/BTCPayServer/Controllers/UIServerController.Plugins.cs
+++ b/BTCPayServer/Controllers/UIServerController.Plugins.cs
@@ -73,9 +73,9 @@ namespace BTCPayServer.Controllers
 
             return RedirectToAction("ListPlugins");
         }
+
         [HttpPost("server/plugins/enable")]
-        public IActionResult EnablePlugin(
-            [FromServices] PluginService pluginService, string plugin)
+        public IActionResult EnablePlugin([FromServices] PluginService pluginService, string plugin)
         {
             pluginService.CancelCommands(plugin);
             pluginService.Enable(plugin);
@@ -89,8 +89,7 @@ namespace BTCPayServer.Controllers
         }
 
         [HttpPost("server/plugins/cancel")]
-        public IActionResult CancelPluginCommands(
-            [FromServices] PluginService pluginService, string plugin)
+        public IActionResult CancelPluginCommands([FromServices] PluginService pluginService, string plugin)
         {
             pluginService.CancelCommands(plugin);
             TempData.SetStatusMessageModel(new StatusMessageModel()
@@ -105,11 +104,9 @@ namespace BTCPayServer.Controllers
         [HttpPost("server/plugins/autoupdate")]
         public async Task<IActionResult> ToggleAutoUpdate( string plugin, bool? autoUpdate)
         {
-            
             var dh = await _SettingsRepository.GetSettingAsync<PluginVersionCheckerDataHolder>() ??
                      new PluginVersionCheckerDataHolder();
-            dh.AutoUpdatePlugins ??= new List<string>();
-            
+            dh.AutoUpdatePlugins ??= [];
             autoUpdate??= !dh.AutoUpdatePlugins.Contains(plugin); 
             if (autoUpdate is true)
             {
@@ -129,14 +126,13 @@ namespace BTCPayServer.Controllers
 
             return RedirectToAction("ListPlugins");
         }
-                [HttpPost("server/plugins/killswitch")]
+
+        [HttpPost("server/plugins/killswitch")]
         public async Task<IActionResult> ToggleKillswitch( string plugin, bool? killswitch)
         {
-            
             var dh = await _SettingsRepository.GetSettingAsync<PluginVersionCheckerDataHolder>() ??
                      new PluginVersionCheckerDataHolder();
-            dh.KillswitchPlugins ??= new List<string>();
-            
+            dh.KillswitchPlugins ??= [];
             killswitch??= !dh.KillswitchPlugins.Contains(plugin); 
             if (killswitch is true)
             {
@@ -185,10 +181,8 @@ namespace BTCPayServer.Controllers
             await _SettingsRepository.UpdateSetting(dh);
         }
         
-
         [HttpPost("server/plugins/install")]
-        public async Task<IActionResult> InstallPlugin(
-            [FromServices] PluginService pluginService, string plugin, bool update = false, string version = null)
+        public async Task<IActionResult> InstallPlugin([FromServices] PluginService pluginService, string plugin, bool update = false, string version = null)
         {
             try
             {

--- a/BTCPayServer/Controllers/UIServerController.Plugins.cs
+++ b/BTCPayServer/Controllers/UIServerController.Plugins.cs
@@ -6,6 +6,7 @@ using BTCPayServer.Abstractions.Contracts;
 using BTCPayServer.Abstractions.Extensions;
 using BTCPayServer.Abstractions.Models;
 using BTCPayServer.Configuration;
+using BTCPayServer.HostedServices;
 using BTCPayServer.Plugins;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -86,6 +87,62 @@ namespace BTCPayServer.Controllers
 
             return RedirectToAction("ListPlugins");
         }
+        
+        [HttpPost("server/plugins/autoupdate")]
+        public async Task<IActionResult> ToggleAutoUpdate( string plugin, bool? autoUpdate)
+        {
+            
+            var dh = await _SettingsRepository.GetSettingAsync<PluginVersionCheckerDataHolder>() ??
+                     new PluginVersionCheckerDataHolder();
+            dh.AutoUpdatePlugins ??= new List<string>();
+            
+            autoUpdate??= !dh.AutoUpdatePlugins.Contains(plugin); 
+            if (autoUpdate is true)
+            {
+                dh.AutoUpdatePlugins.Add(plugin);
+            }
+            else
+            {
+                dh.AutoUpdatePlugins.Remove(plugin);
+            }
+
+            await _SettingsRepository.UpdateSetting(dh);
+            TempData.SetStatusMessageModel(new StatusMessageModel()
+            {
+                Message = $"Auto update {(autoUpdate.Value ? "enabled" : "disabled")} for {plugin}.",
+                Severity = StatusMessageModel.StatusSeverity.Success
+            });
+
+            return RedirectToAction("ListPlugins");
+        }
+                [HttpPost("server/plugins/killswitch")]
+        public async Task<IActionResult> ToggleKillswitch( string plugin, bool? killswitch)
+        {
+            
+            var dh = await _SettingsRepository.GetSettingAsync<PluginVersionCheckerDataHolder>() ??
+                     new PluginVersionCheckerDataHolder();
+            dh.KillswitchPlugins ??= new List<string>();
+            
+            killswitch??= !dh.AutoUpdatePlugins.Contains(plugin); 
+            if (killswitch is true)
+            {
+                dh.KillswitchPlugins.Add(plugin);
+            }
+            else
+            {
+                dh.KillswitchPlugins.Remove(plugin);
+            }
+
+            await _SettingsRepository.UpdateSetting(dh);
+            TempData.SetStatusMessageModel(new StatusMessageModel()
+            {
+                Message = $"Killswitch {(killswitch.Value ? "enabled" : "disabled")} for {plugin}.",
+                Severity = StatusMessageModel.StatusSeverity.Success
+            });
+
+            return RedirectToAction("ListPlugins");
+        }
+        
 
         [HttpPost("server/plugins/install")]
         public async Task<IActionResult> InstallPlugin(

--- a/BTCPayServer/Controllers/UIServerController.Plugins.cs
+++ b/BTCPayServer/Controllers/UIServerController.Plugins.cs
@@ -77,6 +77,7 @@ namespace BTCPayServer.Controllers
         public IActionResult EnablePlugin(
             [FromServices] PluginService pluginService, string plugin)
         {
+            pluginService.CancelCommands(plugin);
             pluginService.Enable(plugin);
             TempData.SetStatusMessageModel(new StatusMessageModel()
             {

--- a/BTCPayServer/HostedServices/PluginKillNotification.cs
+++ b/BTCPayServer/HostedServices/PluginKillNotification.cs
@@ -1,0 +1,58 @@
+﻿using BTCPayServer.Abstractions.Contracts;
+using BTCPayServer.Configuration;
+using BTCPayServer.Controllers;
+using BTCPayServer.Plugins;
+using BTCPayServer.Services.Notifications;
+using Microsoft.AspNetCore.Routing;
+
+namespace BTCPayServer.HostedServices;
+
+internal class PluginKillNotification : BaseNotification
+{
+    private const string TYPE = "pluginkill";
+
+    internal class Handler(LinkGenerator linkGenerator, BTCPayServerOptions options)
+        : NotificationHandler<PluginKillNotification>
+    {
+        public override string NotificationType => TYPE;
+
+        public override (string identifier, string name)[] Meta
+        {
+            get
+            {
+                return [(TYPE, "Plugin update")];
+            }
+        }
+
+        protected override void FillViewModel(PluginKillNotification notification, NotificationViewModel vm)
+        {
+            vm.Identifier = notification.Identifier;
+            vm.Type = notification.NotificationType;
+            vm.Body =
+                $"The plugin {notification.Name} has been disabled through the vulnerability killswitch. Restart the server to apply the changes.";
+            vm.ActionLink = linkGenerator.GetPathByAction(nameof(UIServerController.Maintenance),
+                "UIServer",
+                new {command = "soft-restart"}, options.RootPath);
+            vm.ActionText = "Restart now";
+        }
+    }
+
+    public PluginKillNotification()
+    {
+    }
+
+    public PluginKillNotification(PluginService.AvailablePlugin plugin)
+    {
+        Name = plugin.Name;
+        PluginIdentifier = plugin.Identifier;
+        Version = plugin.Version.ToString();
+    }
+
+    public string PluginIdentifier { get; set; }
+
+    public string Name { get; set; }
+
+    public string Version { get; set; }
+    public override string Identifier => TYPE;
+    public override string NotificationType => TYPE;
+}

--- a/BTCPayServer/HostedServices/PluginUpdateFetcher.cs
+++ b/BTCPayServer/HostedServices/PluginUpdateFetcher.cs
@@ -121,7 +121,7 @@ namespace BTCPayServer.HostedServices
                 {
                     notify.Add(pair.Key);
                 }
-                else if (disabledPlugins.TryGetValue(pair.Key, out var disabledVersion) && disabledVersion < pair.Value)
+                else if (disabledPlugins.TryGetValue(pair.Key, out var disabledVersion) && disabledVersion.Item1 < pair.Value)
                 {
                     notify.Add(pair.Key);
                 }
@@ -134,7 +134,7 @@ namespace BTCPayServer.HostedServices
                 var matched = remotePlugins.FirstOrDefault(p => p.Identifier == plugin.Identifier && p.Version == plugin.Version);
                 if(matched is {Kill: true} && dh.KillswitchPlugins.Contains(plugin.Identifier))
                 {
-                    PluginManager.DisablePlugin(dataDirectories.PluginDir, plugin.Identifier);
+                    PluginManager.DisablePlugin(dataDirectories.PluginDir, plugin.Identifier, "Killswitch");
                 }
             }
             foreach (string pluginUpdate in notify)

--- a/BTCPayServer/HostedServices/PluginUpdateFetcher.cs
+++ b/BTCPayServer/HostedServices/PluginUpdateFetcher.cs
@@ -65,7 +65,7 @@ namespace BTCPayServer.HostedServices
                 var matched = remotePlugins.FirstOrDefault(p => p.Identifier == plugin.Identifier && p.Version == plugin.Version);
                 if(matched is {Kill: true} && dh.KillswitchPlugins.Contains(plugin.Identifier))
                 {
-                    PluginManager.DisablePlugin(dataDirectories.PluginDir, plugin.Identifier, "Killswitch");
+                    PluginManager.DisablePlugin(dataDirectories.PluginDir, plugin.Identifier, "Killswitch activated");
                     
                     notify.TryAdd(plugin.Identifier, "kill");
                 }
@@ -89,13 +89,9 @@ namespace BTCPayServer.HostedServices
                     }
                     await notificationSender.SendNotification(new AdminScope(), new PluginUpdateNotification(plugin, update));
                 }
-                
             }
 
             await settingsRepository.UpdateSetting(dh);
-            
-           
-            
         }
     }
 }

--- a/BTCPayServer/HostedServices/PluginUpdateNotification.cs
+++ b/BTCPayServer/HostedServices/PluginUpdateNotification.cs
@@ -1,0 +1,71 @@
+﻿using BTCPayServer.Abstractions.Contracts;
+using BTCPayServer.Configuration;
+using BTCPayServer.Controllers;
+using BTCPayServer.Plugins;
+using BTCPayServer.Services.Notifications;
+using Microsoft.AspNetCore.Routing;
+
+namespace BTCPayServer.HostedServices;
+
+internal class PluginUpdateNotification : BaseNotification
+{
+    public bool UpdateDownloaded { get; }
+    private const string TYPE = "pluginupdate";
+
+    internal class Handler(LinkGenerator linkGenerator, BTCPayServerOptions options) : NotificationHandler<PluginUpdateNotification>
+    {
+        public override string NotificationType => TYPE;
+
+        public override (string identifier, string name)[] Meta
+        {
+            get
+            {
+                return [(TYPE, "Plugin update")];
+            }
+        }
+
+        protected override void FillViewModel(PluginUpdateNotification notification, NotificationViewModel vm)
+        {
+            vm.Identifier = notification.Identifier;
+            vm.Type = notification.NotificationType;
+            vm.Body = $"New {notification.Name} plugin version {notification.Version} released!";
+            if(notification.UpdateDownloaded)
+                vm.Body += " Update has automatically been scheduled to be installed on the next restart.";
+            if (notification.UpdateDownloaded)
+            {   
+                vm.ActionLink = linkGenerator.GetPathByAction(nameof(UIServerController.Maintenance),
+                    "UIServer",
+                    new {command = "soft-restart"}, options.RootPath);
+                vm.ActionText = "Restart now";
+            }
+            else
+            {
+                    
+                vm.ActionLink = linkGenerator.GetPathByAction(nameof(UIServerController.ListPlugins),
+                    "UIServer",
+                    new {plugin = notification.PluginIdentifier}, options.RootPath);
+            }
+                
+        }
+    }
+
+    public PluginUpdateNotification()
+    {
+    }
+
+    public PluginUpdateNotification(PluginService.AvailablePlugin plugin, bool updateDownloaded)
+    {
+        UpdateDownloaded = updateDownloaded;
+        Name = plugin.Name;
+        PluginIdentifier = plugin.Identifier;
+        Version = plugin.Version.ToString();
+    }
+
+    public string PluginIdentifier { get; set; }
+
+    public string Name { get; set; }
+
+    public string Version { get; set; }
+    public override string Identifier => TYPE;
+    public override string NotificationType => TYPE;
+}

--- a/BTCPayServer/HostedServices/PluginUpdateNotification.cs
+++ b/BTCPayServer/HostedServices/PluginUpdateNotification.cs
@@ -40,12 +40,10 @@ internal class PluginUpdateNotification : BaseNotification
             }
             else
             {
-                    
                 vm.ActionLink = linkGenerator.GetPathByAction(nameof(UIServerController.ListPlugins),
                     "UIServer",
                     new {plugin = notification.PluginIdentifier}, options.RootPath);
             }
-                
         }
     }
 

--- a/BTCPayServer/Hosting/BTCPayServerServices.cs
+++ b/BTCPayServer/Hosting/BTCPayServerServices.cs
@@ -438,6 +438,7 @@ namespace BTCPayServer.Hosting
             services.AddSingleton<INotificationHandler, NewVersionNotification.Handler>();
             services.AddSingleton<INotificationHandler, NewUserRequiresApprovalNotification.Handler>();
             services.AddSingleton<INotificationHandler, PluginUpdateNotification.Handler>();
+            services.AddSingleton<INotificationHandler, PluginKillNotification.Handler>();
             services.AddSingleton<INotificationHandler, InvoiceEventNotification.Handler>();
             services.AddSingleton<INotificationHandler, PayoutNotification.Handler>();
             services.AddSingleton<INotificationHandler, ExternalPayoutTransactionNotification.Handler>();

--- a/BTCPayServer/Plugins/PluginService.cs
+++ b/BTCPayServer/Plugins/PluginService.cs
@@ -119,6 +119,7 @@ namespace BTCPayServer.Plugins
             public Version Version { get; set; }
             public string Description { get; set; }
             public bool SystemPlugin { get; set; } = false;
+            public bool Kill { get; set; } = false;
 
             public IBTCPayServerPlugin.PluginDependency[] Dependencies { get; set; } = Array.Empty<IBTCPayServerPlugin.PluginDependency>();
             public string Documentation { get; set; }

--- a/BTCPayServer/Plugins/PluginService.cs
+++ b/BTCPayServer/Plugins/PluginService.cs
@@ -157,9 +157,15 @@ namespace BTCPayServer.Plugins
             PluginManager.CancelCommands(_dataDirectories.Value.PluginDir, plugin);
         }
 
-        public Dictionary<string, Version> GetDisabledPlugins()
+        public Dictionary<string, (Version, string DisabledReason)> GetDisabledPlugins()
         {
             return PluginManager.GetDisabledPlugins(_dataDirectories.Value.PluginDir);
+        }
+
+        public void Enable(string plugin)
+        {
+            var dest = _dataDirectories.Value.PluginDir;
+            PluginManager.QueueCommands(dest, ("enable", plugin));
         }
     }
 }

--- a/BTCPayServer/Program.cs
+++ b/BTCPayServer/Program.cs
@@ -91,7 +91,7 @@ namespace BTCPayServer
             {
                 logs.Configuration.LogError(e, $"Disabling plugin {pluginName} as it crashed on startup");
                 var pluginDir = new DataDirectories().Configure(conf).PluginDir;
-                PluginManager.DisablePlugin(pluginDir, pluginName);
+                PluginManager.DisablePlugin(pluginDir, pluginName, "Crashed on startup");
             }
             finally
             {

--- a/BTCPayServer/Views/UINotifications/Index.cshtml
+++ b/BTCPayServer/Views/UINotifications/Index.cshtml
@@ -80,7 +80,7 @@
                                         </button>
                                         @if (!string.IsNullOrEmpty(item.ActionLink))
                                         {
-                                            <a href="@item.ActionLink" class="btn btn-link p-0" rel="noreferrer noopener">Details</a>
+                                            <a href="@item.ActionLink" class="btn btn-link p-0" rel="noreferrer noopener">@item.ActionText</a>
                                         }
                                     </div>
                                 </td>

--- a/BTCPayServer/Views/UIServer/ListPlugins.cshtml
+++ b/BTCPayServer/Views/UIServer/ListPlugins.cshtml
@@ -1,7 +1,11 @@
 @using BTCPayServer.Configuration
+@using BTCPayServer.HostedServices
 @using BTCPayServer.Plugins
+@using BTCPayServer.Services
+@using Microsoft.AspNetCore.Mvc.TagHelpers
 @model BTCPayServer.Controllers.UIServerController.ListPluginsViewModel
 @inject BTCPayServerOptions BTCPayServerOptions
+@inject SettingsRepository SettingsRepository
 @inject PluginService PluginService
 @{
     Layout = "_Layout";
@@ -13,6 +17,8 @@
         .Where(plugin => !installed.ContainsKey(plugin.Identifier))
         .GroupBy(plugin => plugin.Identifier)
         .ToList();
+    var autoUpdate = (await SettingsRepository.GetSettingAsync<PluginVersionCheckerDataHolder>())?.AutoUpdatePlugins ?? new();
+    var killswitch = (await SettingsRepository.GetSettingAsync<PluginVersionCheckerDataHolder>())?.KillswitchPlugins ?? new();
     
     foreach (var availableAndNotInstalledItem in availableAndNotInstalledx)
     {
@@ -84,7 +90,7 @@
                             @plugin
                             @if (version != null)
                             {
-                                <span>({version})</span>
+                                <span>(@version)</span>
                             }
                         </span>
                         <form asp-action="UnInstallPlugin" asp-route-plugin="@plugin">
@@ -287,6 +293,17 @@
                                 </form>
                             }
                         }
+
+                        <form asp-action="ToggleAutoUpdate" asp-route-plugin="@plugin.Identifier">
+                            <button type="submit" class="btn btn-outline-secondary">
+                                @(autoUpdate.Contains(plugin.Identifier) ? "Disable auto update" : "Enable auto update")
+                            </button>
+                        </form>   
+                        <form asp-action="ToggleKillswitch" asp-route-plugin="@plugin.Identifier">
+                            <button type="submit" class="btn btn-outline-secondary">
+                                @(killswitch.Contains(plugin.Identifier) ? "Disable killswitch" : "Enable killswitch")
+                            </button>
+                        </form>
                     </div>
                 </div>
             </div>

--- a/BTCPayServer/Views/UIServer/ListPlugins.cshtml
+++ b/BTCPayServer/Views/UIServer/ListPlugins.cshtml
@@ -484,28 +484,28 @@
                       
                     </div>
                       @if (pendingAction == "install")
-                                            {
-                                                <div class="card-footer border-0 ">
-                                            <form asp-action="ToggleAutoUpdate" asp-route-plugin="@plugin.Identifier" class="form-group" data-bs-toggle="tooltip" title=" @(autoUpdate.Contains(plugin.Identifier) ? "Disable" : "Enable") automatic updates for this plugin. You will still need to restart BTCPay Server to apply the update.">
-                                                <label class="d-flex align-items-center">
-                                                    <button type="submit" class="btcpay-toggle me-3 @if (autoUpdate.Contains(plugin.Identifier)) { @("btcpay-toggle--active") }" value="scripting-@(autoUpdate.Contains(plugin.Identifier) ? "off" : "on")">@(autoUpdate.Contains(plugin.Identifier) ? "Disable" : "Enable") automatic updates</button>
-                                                    <div class="">
-                                                        <span>Automatic updates</span>
-                                                    </div>
-                                                </label>
-                                            </form>
-                    
-                                            <form asp-action="ToggleKillswitch" asp-route-plugin="@plugin.Identifier" class="form-group"
-                                                  data-bs-toggle="tooltip" title="@(killswitch.Contains(plugin.Identifier) ? "Disable" : "Enable") killswitch for this plugin. The plugin server would notify your BTCpay server to disable this plugin if it is found to be vulnerable. You will still need to restart BTCPay Server to apply.">
-                                                <label class="d-flex align-items-center">
-                                                    <button type="submit" class="btcpay-toggle me-3 @if (killswitch.Contains(plugin.Identifier)) { @("btcpay-toggle--active") }" value="scripting-@(killswitch.Contains(plugin.Identifier) ? "off" : "on")">@(killswitch.Contains(plugin.Identifier) ? "Disable" : "Enable") killswitch</button>
-                                                    <div class="">
-                                                        <span>Kill switch</span>
-                                                    </div>
-                                                </label>
-                                            </form>
-                                        </div>
-                                            }
+                    {
+                        <div class="card-footer border-0 ">
+                            <form asp-action="ToggleAutoUpdate" asp-route-plugin="@plugin.Identifier" class="form-group" data-bs-toggle="tooltip" title=" @(autoUpdate.Contains(plugin.Identifier) ? "Disable" : "Enable") automatic updates for this plugin. You will still need to restart BTCPay Server to apply the update.">
+                                <label class="d-flex align-items-center">
+                                    <button type="submit" class="btcpay-toggle me-3 @if (autoUpdate.Contains(plugin.Identifier)) { @("btcpay-toggle--active") }" value="scripting-@(autoUpdate.Contains(plugin.Identifier) ? "off" : "on")">@(autoUpdate.Contains(plugin.Identifier) ? "Disable" : "Enable") automatic updates</button>
+                                    <div class="">
+                                        <span>Automatic updates</span>
+                                    </div>
+                                </label>
+                            </form>
+
+                            <form asp-action="ToggleKillswitch" asp-route-plugin="@plugin.Identifier" class="form-group"
+                                  data-bs-toggle="tooltip" title="@(killswitch.Contains(plugin.Identifier) ? "Disable" : "Enable") killswitch for this plugin. The plugin server would notify your BTCpay server to disable this plugin if it is found to be vulnerable. You will still need to restart BTCPay Server to apply.">
+                                <label class="d-flex align-items-center">
+                                    <button type="submit" class="btcpay-toggle me-3 @if (killswitch.Contains(plugin.Identifier)) { @("btcpay-toggle--active") }" value="scripting-@(killswitch.Contains(plugin.Identifier) ? "off" : "on")">@(killswitch.Contains(plugin.Identifier) ? "Disable" : "Enable") killswitch</button>
+                                    <div class="">
+                                        <span>Vulnerability kill switch</span>
+                                    </div>
+                                </label>
+                            </form>
+                        </div>
+                    }
                 </div>
             </div>
         }

--- a/BTCPayServer/Views/UIServer/ListPlugins.cshtml
+++ b/BTCPayServer/Views/UIServer/ListPlugins.cshtml
@@ -88,14 +88,28 @@
                     <div class="d-flex flex-wrap align-items-center justify-content-between gap-3">
                         <span>
                             @plugin
-                            @if (version != null)
+                            @if (version.v != null)
                             {
-                                <span>(@version)</span>
+                                <span>(@version.v)</span>
                             }
                         </span>
-                        <form asp-action="UnInstallPlugin" asp-route-plugin="@plugin">
-                            <button type="submit" class="btn btn-sm btn-outline-danger">Uninstall</button>
-                        </form>
+                        @if(!string.IsNullOrEmpty(version.reason ))
+                        {
+                            <span>@version.reason</span>
+                        }
+                        @if(!Model.Commands.Any(tuple => tuple.plugin == plugin && tuple.command == "delete"))
+                        {
+                            <form asp-action="UnInstallPlugin" asp-route-plugin="@plugin">
+                                <button type="submit" class="btn btn-sm btn-outline-danger">Uninstall</button>
+                            </form>
+                        }
+                        
+                        @if (!Model.Commands.Any(tuple => tuple.plugin == plugin && tuple.command == "enable"))
+                        {
+                            <form asp-action="EnablePlugin" asp-route-plugin="@plugin">
+                                <button type="submit" class="btn btn-sm btn-outline-secondary">Re-enable</button>
+                            </form>
+                        }
                     </div>
                 </li>
             }
@@ -294,15 +308,27 @@
                             }
                         }
 
-                        <form asp-action="ToggleAutoUpdate" asp-route-plugin="@plugin.Identifier">
-                            <button type="submit" class="btn btn-outline-secondary">
-                                @(autoUpdate.Contains(plugin.Identifier) ? "Disable auto update" : "Enable auto update")
-                            </button>
-                        </form>   
-                        <form asp-action="ToggleKillswitch" asp-route-plugin="@plugin.Identifier">
-                            <button type="submit" class="btn btn-outline-secondary">
-                                @(killswitch.Contains(plugin.Identifier) ? "Disable killswitch" : "Enable killswitch")
-                            </button>
+                   
+                      
+                    </div>
+                    <div class="card-footer border-0 ">
+                        <form asp-action="ToggleAutoUpdate" asp-route-plugin="@plugin.Identifier" class="form-group" data-bs-toggle="tooltip" title=" @(autoUpdate.Contains(plugin.Identifier) ? "Disable" : "Enable") automatic updates for this plugin. You will still need to restart BTCPay Server to apply the update.">
+                            <label class="d-flex align-items-center">
+                                <button type="submit" class="btcpay-toggle me-3 @if (autoUpdate.Contains(plugin.Identifier)) { @("btcpay-toggle--active") }" value="scripting-@(autoUpdate.Contains(plugin.Identifier) ? "off" : "on")">@(autoUpdate.Contains(plugin.Identifier) ? "Disable" : "Enable") automatic updates</button>
+                                <div class="">
+                                    <span>Automatic updates</span>
+                                </div>
+                            </label>
+                        </form>
+
+                        <form asp-action="ToggleKillswitch" asp-route-plugin="@plugin.Identifier" class="form-group"
+                              data-bs-toggle="tooltip" title="@(killswitch.Contains(plugin.Identifier) ? "Disable" : "Enable") killswitch for this plugin. The plugin server would notify your BTCpay server to disable this plugin if it is found to be vulnerable. You will still need to restart BTCPay Server to apply.">
+                            <label class="d-flex align-items-center">
+                                <button type="submit" class="btcpay-toggle me-3 @if (killswitch.Contains(plugin.Identifier)) { @("btcpay-toggle--active") }" value="scripting-@(killswitch.Contains(plugin.Identifier) ? "off" : "on")">@(killswitch.Contains(plugin.Identifier) ? "Disable" : "Enable") killswitch</button>
+                                <div class="">
+                                    <span>Vulnerability kill switch</span>
+                                </div>
+                            </label>
                         </form>
                     </div>
                 </div>
@@ -318,7 +344,7 @@
         @foreach (var plugin in availableAndNotInstalled)
         {
             var recommended = BTCPayServerOptions.RecommendedPlugins.Any(id => string.Equals(id, plugin.Identifier, StringComparison.InvariantCultureIgnoreCase));
-            Model.Disabled.TryGetValue(plugin.Identifier, out var disabled);
+            var disabled = Model.Disabled.TryGetValue(plugin.Identifier, out var disabledData);
 
             <div class="col col-12 col-md-6 col-lg-12 col-xl-6 col-xxl-4 mb-4">
                 <div class="card h-100" id="@plugin.Identifier">
@@ -337,13 +363,13 @@
                         </div>
                         <h5 class="text-muted d-flex align-items-center mt-1 gap-2">
                             @plugin.Version
-                            @if (disabled is { } && disabled != plugin.Version)
+                            @if (disabled && disabledData.v != plugin.Version)
                             {
-                                <div class="badge bg-light">Disabled (@disabled)</div>
+                                <div class="badge bg-light" data-bs-toggle="tooltip" title="@disabledData.reason" >Disabled (@disabled)</div>
                             }
-                            else if (disabled is { } && disabled == plugin.Version)
+                            else if (disabled && disabledData.v == plugin.Version)
                             {
-                                <div class="badge bg-light">Disabled</div>
+                                <div class="badge bg-light" data-bs-toggle="tooltip" title="@disabledData.reason">Disabled</div>
                             }
                             else if (recommended)
                             {
@@ -422,18 +448,20 @@
                             <form asp-action="CancelPluginCommands" asp-route-plugin="@plugin.Identifier">
                                 <button type="submit" class="btn btn-outline-secondary">Cancel pending @pendingAction @(versionOfPendingInstall is null? "": $"of {versionOfPendingInstall}")</button>
                             </form>
+                            
+                            
                         }
                         @if (pendingAction is null|| !exclusivePendingAction)
                         {
                             if (PluginManager.DependenciesMet(plugin.Dependencies, installed))
                             {
-                                @if (disabled is null)
+                                @if (!disabled)
                                 {
                                     <form asp-action="InstallPlugin" asp-route-plugin="@plugin.Identifier" asp-route-version="@plugin.Version">
                                         <button type="submit" class="btn btn-primary">Install</button>
                                     </form>
                                 }
-                                else if (disabled != plugin.Version)
+                                else if (disabled && disabledData.v != plugin.Version)
                                 {
                                     <form asp-action="InstallPlugin" asp-route-plugin="@plugin.Identifier" asp-route-version="@plugin.Version" asp-route-update="true">
                                         <button type="submit" class="btn btn-primary">Update</button>
@@ -447,13 +475,37 @@
                                 </form>
                             }
                         }
-                        @if (disabled is not null && pendingAction is null)
+                        @if (disabled && pendingAction is null)
                         {
                             <form asp-action="UnInstallPlugin" asp-route-plugin="@plugin.Identifier">
                                 <button type="submit" class="btn btn-sm btn-outline-danger">Uninstall</button>
                             </form>
                         }
+                      
                     </div>
+                      @if (pendingAction == "install")
+                                            {
+                                                <div class="card-footer border-0 ">
+                                            <form asp-action="ToggleAutoUpdate" asp-route-plugin="@plugin.Identifier" class="form-group" data-bs-toggle="tooltip" title=" @(autoUpdate.Contains(plugin.Identifier) ? "Disable" : "Enable") automatic updates for this plugin. You will still need to restart BTCPay Server to apply the update.">
+                                                <label class="d-flex align-items-center">
+                                                    <button type="submit" class="btcpay-toggle me-3 @if (autoUpdate.Contains(plugin.Identifier)) { @("btcpay-toggle--active") }" value="scripting-@(autoUpdate.Contains(plugin.Identifier) ? "off" : "on")">@(autoUpdate.Contains(plugin.Identifier) ? "Disable" : "Enable") automatic updates</button>
+                                                    <div class="">
+                                                        <span>Automatic updates</span>
+                                                    </div>
+                                                </label>
+                                            </form>
+                    
+                                            <form asp-action="ToggleKillswitch" asp-route-plugin="@plugin.Identifier" class="form-group"
+                                                  data-bs-toggle="tooltip" title="@(killswitch.Contains(plugin.Identifier) ? "Disable" : "Enable") killswitch for this plugin. The plugin server would notify your BTCpay server to disable this plugin if it is found to be vulnerable. You will still need to restart BTCPay Server to apply.">
+                                                <label class="d-flex align-items-center">
+                                                    <button type="submit" class="btcpay-toggle me-3 @if (killswitch.Contains(plugin.Identifier)) { @("btcpay-toggle--active") }" value="scripting-@(killswitch.Contains(plugin.Identifier) ? "off" : "on")">@(killswitch.Contains(plugin.Identifier) ? "Disable" : "Enable") killswitch</button>
+                                                    <div class="">
+                                                        <span>Kill switch</span>
+                                                    </div>
+                                                </label>
+                                            </form>
+                                        </div>
+                                            }
                 </div>
             </div>
         }

--- a/BTCPayServer/Views/UIServer/ListPlugins.cshtml
+++ b/BTCPayServer/Views/UIServer/ListPlugins.cshtml
@@ -92,11 +92,12 @@
                             {
                                 <span>(@version.v)</span>
                             }
+                            @if (!string.IsNullOrEmpty(version.reason))
+                            {
+                                <span>@version.reason</span>
+                            }
                         </span>
-                        @if(!string.IsNullOrEmpty(version.reason ))
-                        {
-                            <span>@version.reason</span>
-                        }
+                        
                         @if(!Model.Commands.Any(tuple => tuple.plugin == plugin && tuple.command == "delete"))
                         {
                             <form asp-action="UnInstallPlugin" asp-route-plugin="@plugin">
@@ -107,7 +108,7 @@
                         @if (!Model.Commands.Any(tuple => tuple.plugin == plugin && tuple.command == "enable"))
                         {
                             <form asp-action="EnablePlugin" asp-route-plugin="@plugin">
-                                <button type="submit" class="btn btn-sm btn-outline-secondary">Re-enable</button>
+                                <button type="submit" class="btn btn-sm btn-secondary">Re-enable</button>
                             </form>
                         }
                     </div>


### PR DESCRIPTION
This PR introduces 2 new features that can be toggled on installed plugins:
* Auto update - Once a plugin is installed you get the option to enable autoupdate, which will download and schedule the install for the next restart. A notification will tell you and give you an action to restart.
* Auto killswitch - Once a plugin is installed you get the option to enable the killswitch, where the plugin builder server can mark a specific version of a plugin as "Kill", and your instance will detect this and disable the plugin on the next restart, if the killswitch is enabled on the plugin.

Both are off by default.