### PR TITLE
UI: Make store selector list scrollable if necessary

### DIFF
--- a/BTCPayServer/wwwroot/main/layout.css
+++ b/BTCPayServer/wwwroot/main/layout.css
@@ -219,8 +219,10 @@
 
 #StoreSelectorMenu {
     min-width: 100%;
-    max-height: calc(100vh - var(--header-height));
-    overflow-y: scroll;
+    overflow-y: auto;
+    /* gradually try to set better but less supported values and units */
+    max-height: calc(100vh - var(--header-height) - var(--btcpay-space-xxl));
+    max-height: calc(100dvh - var(--header-height));
 }
 
 /* Logo */


### PR DESCRIPTION
Fixes #5754. In theory it was already scrollable, but in practice the `max-height` wasn't accounting for dynamically adjustable elements of the browser chrome window.