### PR TITLE
Fix: Labels wouldn't be properly applied to some wallet's transactions

### DIFF
--- a/BTCPayServer.Data/Migrations/20240220000000_FixWalletObjectsWithEmptyWalletId.cs
+++ b/BTCPayServer.Data/Migrations/20240220000000_FixWalletObjectsWithEmptyWalletId.cs
@@ -1,0 +1,26 @@
+using BTCPayServer.Data;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace BTCPayServer.Migrations
+{
+    [DbContext(typeof(ApplicationDbContext))]
+    [Migration("20240220000000_FixWalletObjectsWithEmptyWalletId")]
+    public partial class FixWalletObjectsWithEmptyWalletId : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            if (migrationBuilder.IsNpgsql())
+            {
+                migrationBuilder.Sql("DELETE FROM \"WalletObjects\" WHERE \"WalletId\"='';");
+            }
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+        }
+    }
+}

--- a/BTCPayServer/Controllers/GreenField/GreenfieldPullPaymentController.cs
+++ b/BTCPayServer/Controllers/GreenField/GreenfieldPullPaymentController.cs
@@ -386,7 +386,8 @@ namespace BTCPayServer.Controllers.Greenfield
                 Destination = destination.destination,
                 PullPaymentId = pullPaymentId,
                 Value = request.Amount,
-                PaymentMethodId = paymentMethodId
+                PaymentMethodId = paymentMethodId,
+                StoreId = pp.StoreId
             });
 
             return HandleClaimResult(result);

--- a/BTCPayServer/Controllers/UIInvoiceController.UI.cs
+++ b/BTCPayServer/Controllers/UIInvoiceController.UI.cs
@@ -612,7 +612,7 @@ namespace BTCPayServer.Controllers
                     await _InvoiceRepository.MassArchive(selectedItems, false);
                     TempData[WellKnownTempData.SuccessMessage] = $"{selectedItems.Length} invoice{(selectedItems.Length == 1 ? "" : "s")} unarchived.";
                     break;
-                case "cpfp":
+                case "cpfp" when storeId is not null:
                     var network = _NetworkProvider.DefaultNetwork;
                     var explorer = _ExplorerClients.GetExplorerClient(network);
                     if (explorer is null)

--- a/BTCPayServer/Controllers/UIPullPaymentController.cs
+++ b/BTCPayServer/Controllers/UIPullPaymentController.cs
@@ -261,7 +261,8 @@ namespace BTCPayServer.Controllers
                 Destination = destination,
                 PullPaymentId = pullPaymentId,
                 Value = vm.ClaimedAmount,
-                PaymentMethodId = paymentMethodId
+                PaymentMethodId = paymentMethodId,
+                StoreId = pp.StoreId
             });
 
             if (result.Result != ClaimRequest.ClaimResult.Ok)

--- a/BTCPayServer/WalletId.cs
+++ b/BTCPayServer/WalletId.cs
@@ -1,49 +1,41 @@
+#nullable enable
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Text.RegularExpressions;
 using BTCPayServer.Payments;
 
 namespace BTCPayServer
 {
-    public class WalletId
+    public record WalletId
     {
         static readonly Regex _WalletStoreRegex = new Regex("^S-([a-zA-Z0-9]{30,60})-([a-zA-Z]{2,5})$");
-        public static bool TryParse(string str, out WalletId walletId)
+        public static bool TryParse(string str, [MaybeNullWhen(false)] out WalletId walletId)
         {
             ArgumentNullException.ThrowIfNull(str);
             walletId = null;
-            WalletId w = new WalletId();
             var match = _WalletStoreRegex.Match(str);
             if (!match.Success)
                 return false;
-            w.StoreId = match.Groups[1].Value;
-            w.CryptoCode = match.Groups[2].Value.ToUpperInvariant();
-            walletId = w;
+            var storeId = match.Groups[1].Value;
+            var cryptoCode = match.Groups[2].Value.ToUpperInvariant();
+            walletId = new WalletId(storeId, cryptoCode);
             return true;
-        }
-        public WalletId()
-        {
-
         }
         public WalletId(string storeId, string cryptoCode)
         {
+            ArgumentNullException.ThrowIfNull(storeId);
+            ArgumentNullException.ThrowIfNull(cryptoCode);
             StoreId = storeId;
             CryptoCode = cryptoCode;
         }
-        public string StoreId { get; set; }
-        public string CryptoCode { get; set; }
+        public string StoreId { get; }
+        public string CryptoCode { get; }
 
         public PaymentMethodId GetPaymentMethodId()
         {
             return new PaymentMethodId(CryptoCode, PaymentTypes.BTCLike);
         }
-        public override bool Equals(object obj)
-        {
-            WalletId item = obj as WalletId;
-            if (item == null)
-                return false;
-            return ToString().Equals(item.ToString(), StringComparison.InvariantCulture);
-        }
-
+       
         public static WalletId Parse(string id)
         {
             if (TryParse(id, out var v))
@@ -51,24 +43,6 @@ namespace BTCPayServer
             throw new FormatException("Invalid WalletId");
         }
 
-        public static bool operator ==(WalletId a, WalletId b)
-        {
-            if (System.Object.ReferenceEquals(a, b))
-                return true;
-            if (((object)a == null) || ((object)b == null))
-                return false;
-            return a.ToString() == b.ToString();
-        }
-
-        public static bool operator !=(WalletId a, WalletId b)
-        {
-            return !(a == b);
-        }
-
-        public override int GetHashCode()
-        {
-            return ToString().GetHashCode(StringComparison.Ordinal);
-        }
         public override string ToString()
         {
             if (StoreId == null || CryptoCode == null)


### PR DESCRIPTION
Noticed this exception in my log while debugging something unrelated:

```bash
    System.FormatException: Invalid WalletId
   at BTCPayServer.WalletId.Parse(String id) in C:\Sources\btcpayserver\BTCPayServer\WalletId.cs:line 51
   at BTCPayServer.Services.WalletRepository.GetWalletObjects(GetWalletObjectsQuery queryObject) in C:\Sources\btcpayserver\BTCPayServer\Services\WalletRepository.cs:line 186
   at BTCPayServer.Services.WalletRepository.GetWalletObjects(GetWalletObjectsQuery queryObject) in C:\Sources\btcpayserver\BTCPayServer\Services\WalletRepository.cs:line 212
   at BTCPayServer.HostedServices.TransactionLabelMarkerHostedService.ProcessEvent(Object evt, CancellationToken cancellationToken) in C:\Sources\btcpayserver\BTCPayServer\HostedServices\TransactionLabelMarkerHostedService.cs:line 78
   at BTCPayServer.HostedServices.EventHostedServiceBase.ProcessEvents(CancellationToken cancellationToken) in C:\Sources\btcpayserver\BTCPayServer\HostedServices\EventHostedServiceBase.cs:line 44
```

It turns out that we were missing passing some parameter to `ClaimRequest` at some places.
I am not sure why nobody ever reported this. This caused wallet transactions to stop being properly labeled.

I added a migration script that will clean the database of the bogus entries.