### PR TITLE
Adding link to API usage examples in docs.

### DIFF
--- a/BTCPayServer/wwwroot/swagger/v1/swagger.template.json
+++ b/BTCPayServer/wwwroot/swagger/v1/swagger.template.json
@@ -19,6 +19,10 @@
       "description": "BTCPay Server Greenfield API"
     }
   ],
+  "externalDocs": {
+    "description": "Check out our examples on how to use the API",
+    "url": "https://docs.btcpayserver.org/Development/GreenFieldExample/"
+  },
   "components": {
     "schemas": {
       "ValidationProblemDetails": {


### PR DESCRIPTION
I tried to find that text "BTCPay Greenfield Plugins API" but it does not exist in the swagger files. Not even searching for "Plugins" brought up relevant text or link. How it looked before:

![screenshot-docs btcpayserver org-2024 02 20-10_32_15](https://github.com/btcpayserver/btcpayserver/assets/1136761/59d90f81-ffee-4ff2-989d-c75e4b6de745)

When adding "externalDocs" the text magically disappeared and was replaced with the proper link, how it looks now:

![screenshot-localhost_14142-2024 02 20-10_31_23](https://github.com/btcpayserver/btcpayserver/assets/1136761/9cf5fd7c-6b96-45e0-8e4a-0adb3bb67a08)


@pavlenex the text is currently "Check out our examples on how to use the API" and it links to https://docs.btcpayserver.org/Development/GreenFieldExample/

Feel free to suggest different naming and/or link to link to. Maybe we should do it like this now but as discussed have a better page to start (or expand what we have with curl examples). Anyway better than status quo.

