### PR TITLE
Apps: Make app name the default title

### DIFF
--- a/BTCPayServer.Tests/GreenfieldAPITests.cs
+++ b/BTCPayServer.Tests/GreenfieldAPITests.cs
@@ -301,6 +301,16 @@ namespace BTCPayServer.Tests
             Assert.Equal("test app title", app.Title);
             Assert.False(app.Archived);
 
+            // Test title falls back to name
+            app = await client.CreatePointOfSaleApp(
+                user.StoreId,
+                new CreatePointOfSaleAppRequest
+                {
+                    AppName = "test app name"
+                }
+            );
+            Assert.Equal("test app name", app.Title);
+
             // Make sure we return a 404 if we try to get an app that doesn't exist
             await AssertHttpError(404, async () =>
             {
@@ -469,6 +479,16 @@ namespace BTCPayServer.Tests
             Assert.Equal(user.StoreId, app.StoreId);
             Assert.Equal("Crowdfund", app.AppType);
             Assert.False(app.Archived);
+
+            // Test title falls back to name
+            app = await client.CreateCrowdfundApp(
+                user.StoreId,
+                new CreateCrowdfundAppRequest
+                {
+                    AppName = "test app name"
+                }
+            );
+            Assert.Equal("test app name", app.Title);
 
             // Make sure we return a 404 if we try to get an app that doesn't exist
             await AssertHttpError(404, async () =>

--- a/BTCPayServer.Tests/SeleniumTests.cs
+++ b/BTCPayServer.Tests/SeleniumTests.cs
@@ -86,8 +86,9 @@ namespace BTCPayServer.Tests
             s.GenerateWallet(isHotWallet: true);
 
             // Point Of Sale
+            var appName = $"PoS-{Guid.NewGuid().ToString()[..21]}";
             s.Driver.FindElement(By.Id("StoreNav-CreatePointOfSale")).Click();
-            s.Driver.FindElement(By.Id("AppName")).SendKeys(Guid.NewGuid().ToString());
+            s.Driver.FindElement(By.Id("AppName")).SendKeys(appName);
             s.Driver.FindElement(By.Id("Create")).Click();
             Assert.Contains("App successfully created", s.FindAlertMessage().Text);
 
@@ -1153,7 +1154,7 @@ namespace BTCPayServer.Tests
             using var s = CreateSeleniumTester(newDb: true);
             await s.StartAsync();
             var userId = s.RegisterNewUser(true);
-            var appName = "PoS" + Guid.NewGuid();
+            var appName = $"PoS-{Guid.NewGuid().ToString()[..21]}";
             s.CreateNewStore();
             s.Driver.FindElement(By.Id("StoreNav-CreatePointOfSale")).Click();
             s.Driver.FindElement(By.Name("AppName")).SendKeys(appName);
@@ -1273,7 +1274,7 @@ namespace BTCPayServer.Tests
             s.CreateNewStore();
             s.AddDerivationScheme();
 
-            var appName = "CF" + Guid.NewGuid();
+            var appName = $"CF-{Guid.NewGuid().ToString()[..21]}";
             s.Driver.FindElement(By.Id("StoreNav-CreateCrowdfund")).Click();
             s.Driver.FindElement(By.Name("AppName")).SendKeys(appName);
             s.Driver.FindElement(By.Id("Create")).Click();
@@ -2513,7 +2514,9 @@ namespace BTCPayServer.Tests
             s.GoToLightningSettings();
             s.Driver.SetCheckbox(By.Id("LNURLEnabled"), true);
             s.Driver.FindElement(By.Id("StoreNav-CreatePointOfSale")).Click();
-            s.Driver.FindElement(By.Id("AppName")).SendKeys(Guid.NewGuid().ToString());
+            
+            var appName = $"PoS-{Guid.NewGuid().ToString()[..21]}";
+            s.Driver.FindElement(By.Id("AppName")).SendKeys(appName);
             s.Driver.FindElement(By.Id("Create")).Click();
             TestUtils.Eventually(() => Assert.Contains("App successfully created", s.FindAlertMessage().Text));
             s.Driver.FindElement(By.CssSelector("label[for='DefaultView_Print']")).Click();
@@ -2562,8 +2565,9 @@ namespace BTCPayServer.Tests
             Assert.Contains("User added successfully", s.FindAlertMessage().Text);
             
             // Setup POS
+            var appName = $"PoS-{Guid.NewGuid().ToString()[..21]}";
             s.Driver.FindElement(By.Id("StoreNav-CreatePointOfSale")).Click();
-            s.Driver.FindElement(By.Id("AppName")).SendKeys(Guid.NewGuid().ToString());
+            s.Driver.FindElement(By.Id("AppName")).SendKeys(appName);
             s.Driver.FindElement(By.Id("Create")).Click();
             TestUtils.Eventually(() => Assert.Contains("App successfully created", s.FindAlertMessage().Text));
             s.Driver.FindElement(By.CssSelector("label[for='DefaultView_Light']")).Click();
@@ -2662,8 +2666,10 @@ namespace BTCPayServer.Tests
             s.CreateNewStore();
             s.GoToStore();
             s.AddLightningNode(LightningConnectionType.CLightning, false);
+
+            var appName = $"PoS-{Guid.NewGuid().ToString()[..21]}";
             s.Driver.FindElement(By.Id("StoreNav-CreatePointOfSale")).Click();
-            s.Driver.FindElement(By.Id("AppName")).SendKeys(Guid.NewGuid().ToString());
+            s.Driver.FindElement(By.Id("AppName")).SendKeys(appName);
             s.Driver.FindElement(By.Id("Create")).Click();
             Assert.Contains("App successfully created", s.FindAlertMessage().Text);
             s.Driver.FindElement(By.CssSelector("label[for='DefaultView_Cart']")).Click();

--- a/BTCPayServer.Tests/SeleniumTests.cs
+++ b/BTCPayServer.Tests/SeleniumTests.cs
@@ -1153,12 +1153,15 @@ namespace BTCPayServer.Tests
             using var s = CreateSeleniumTester(newDb: true);
             await s.StartAsync();
             var userId = s.RegisterNewUser(true);
+            var appName = "PoS" + Guid.NewGuid();
             s.CreateNewStore();
             s.Driver.FindElement(By.Id("StoreNav-CreatePointOfSale")).Click();
-            s.Driver.FindElement(By.Name("AppName")).SendKeys("PoS" + Guid.NewGuid());
+            s.Driver.FindElement(By.Name("AppName")).SendKeys(appName);
             s.Driver.FindElement(By.Id("Create")).Click();
             Assert.Contains("App successfully created", s.FindAlertMessage().Text);
-
+            Assert.Equal(appName, s.Driver.FindElement(By.Id("Title")).GetAttribute("value"));
+            s.Driver.FindElement(By.Id("Title")).Clear();
+            s.Driver.FindElement(By.Id("Title")).SendKeys("Tea shop");
             s.Driver.FindElement(By.CssSelector("label[for='DefaultView_Cart']")).Click();
             s.Driver.FindElement(By.CssSelector(".template-item:nth-of-type(1)")).Click();
             s.Driver.FindElement(By.Id("BuyButtonText")).SendKeys("Take my money");
@@ -1270,11 +1273,13 @@ namespace BTCPayServer.Tests
             s.CreateNewStore();
             s.AddDerivationScheme();
 
+            var appName = "CF" + Guid.NewGuid();
             s.Driver.FindElement(By.Id("StoreNav-CreateCrowdfund")).Click();
-            s.Driver.FindElement(By.Name("AppName")).SendKeys("CF" + Guid.NewGuid());
+            s.Driver.FindElement(By.Name("AppName")).SendKeys(appName);
             s.Driver.FindElement(By.Id("Create")).Click();
             Assert.Contains("App successfully created", s.FindAlertMessage().Text);
-
+            Assert.Equal(appName, s.Driver.FindElement(By.Id("Title")).GetAttribute("value"));
+            s.Driver.FindElement(By.Id("Title")).Clear();
             s.Driver.FindElement(By.Id("Title")).SendKeys("Kukkstarter");
             s.Driver.FindElement(By.CssSelector("div.note-editable.card-block")).SendKeys("1BTC = 1BTC");
             s.Driver.FindElement(By.Id("TargetCurrency")).Clear();

--- a/BTCPayServer/Controllers/GreenField/GreenfieldAppsController.cs
+++ b/BTCPayServer/Controllers/GreenField/GreenfieldAppsController.cs
@@ -238,7 +238,7 @@ namespace BTCPayServer.Controllers.Greenfield
 
             return new CrowdfundSettings
             {
-                Title = request.Title?.Trim(),
+                Title = request.Title?.Trim() ?? request.AppName,
                 Enabled = request.Enabled ?? true,
                 EnforceTargetAmount = request.EnforceTargetAmount ?? false,
                 StartDate = request.StartDate?.UtcDateTime,
@@ -272,7 +272,7 @@ namespace BTCPayServer.Controllers.Greenfield
         {
             return new PointOfSaleSettings
             {
-                Title = request.Title,
+                Title = request.Title ?? request.AppName,
                 DefaultView = (PosViewType)request.DefaultView,
                 ShowCustomAmount = request.ShowCustomAmount,
                 ShowDiscount = request.ShowDiscount,

--- a/BTCPayServer/Plugins/Crowdfund/CrowdfundPlugin.cs
+++ b/BTCPayServer/Plugins/Crowdfund/CrowdfundPlugin.cs
@@ -239,7 +239,7 @@ namespace BTCPayServer.Plugins.Crowdfund
 
         public override Task SetDefaultSettings(AppData appData, string defaultCurrency)
         {
-            var emptyCrowdfund = new CrowdfundSettings { TargetCurrency = defaultCurrency };
+            var emptyCrowdfund = new CrowdfundSettings { Title = appData.Name, TargetCurrency = defaultCurrency };
             appData.SetSettings(emptyCrowdfund);
             return Task.CompletedTask;
         }

--- a/BTCPayServer/Plugins/PointOfSale/PointOfSalePlugin.cs
+++ b/BTCPayServer/Plugins/PointOfSale/PointOfSalePlugin.cs
@@ -118,7 +118,7 @@ namespace BTCPayServer.Plugins.PointOfSale
 
         public override Task SetDefaultSettings(AppData appData, string defaultCurrency)
         {
-            var empty = new PointOfSaleSettings { Currency = defaultCurrency };
+            var empty = new PointOfSaleSettings { Title = appData.Name, Currency = defaultCurrency };
             appData.SetSettings(empty);
             return Task.CompletedTask;
         }


### PR DESCRIPTION
Successor of #5762 with a way simpler approach. Allows the user-facing title to be set, but defaults it to the app name instead of "Tea shop".