### PR TITLE
Fix build warnings and flaky tests

### DIFF
--- a/BTCPayServer.Tests/Checkoutv2Tests.cs
+++ b/BTCPayServer.Tests/Checkoutv2Tests.cs
@@ -130,9 +130,12 @@ namespace BTCPayServer.Tests
             expirySeconds.SendKeys("3");
             s.Driver.FindElement(By.Id("Expire")).Click();
 
-            var paymentInfo = s.Driver.WaitForElement(By.Id("PaymentInfo"));
-            Assert.Contains("This invoice will expire in", paymentInfo.Text);
-            Assert.DoesNotContain("Please send", paymentInfo.Text);
+            TestUtils.Eventually(() =>
+            {
+                var paymentInfo = s.Driver.WaitForElement(By.Id("PaymentInfo"));
+                Assert.Contains("This invoice will expire in", paymentInfo.Text);
+                Assert.DoesNotContain("Please send", paymentInfo.Text);
+            });
             TestUtils.Eventually(() =>
             {
                 var expiredSection = s.Driver.FindElement(By.Id("unpaid"));
@@ -140,7 +143,6 @@ namespace BTCPayServer.Tests
                 Assert.Contains("Invoice Expired", expiredSection.Text);
                 Assert.Contains("resubmit a payment", expiredSection.Text);
                 Assert.DoesNotContain("This invoice expired with partial payment", expiredSection.Text);
-                
             });
             Assert.True(s.Driver.ElementDoesNotExist(By.Id("ContactLink")));
             Assert.True(s.Driver.ElementDoesNotExist(By.Id("ReceiptLink")));
@@ -164,9 +166,12 @@ namespace BTCPayServer.Tests
             expirySeconds.SendKeys("3");
             s.Driver.FindElement(By.Id("Expire")).Click();
 
-            paymentInfo = s.Driver.WaitForElement(By.Id("PaymentInfo"));
-            Assert.Contains("The invoice hasn't been paid in full.", paymentInfo.Text);
-            Assert.Contains("Please send", paymentInfo.Text);
+            TestUtils.Eventually(() =>
+            {
+                var paymentInfo = s.Driver.WaitForElement(By.Id("PaymentInfo"));
+                Assert.Contains("The invoice hasn't been paid in full.", paymentInfo.Text);
+                Assert.Contains("Please send", paymentInfo.Text);
+            });
             TestUtils.Eventually(() =>
             {
                 var expiredSection = s.Driver.FindElement(By.Id("unpaid"));
@@ -210,7 +215,7 @@ namespace BTCPayServer.Tests
             {
                 s.Driver.FindElement(By.Id("FakePayment")).Click();
                 s.Driver.FindElement(By.Id("mine-block")).Click();
-                paymentInfo = s.Driver.WaitForElement(By.Id("PaymentInfo"));
+                var paymentInfo = s.Driver.WaitForElement(By.Id("PaymentInfo"));
                 Assert.Contains("The invoice hasn't been paid in full", paymentInfo.Text);
                 Assert.Contains("Please send", paymentInfo.Text);
             });
@@ -359,11 +364,13 @@ namespace BTCPayServer.Tests
             expirySeconds.Clear();
             expirySeconds.SendKeys("5");
             s.Driver.FindElement(By.Id("Expire")).Click();
-
-            paymentInfo = s.Driver.WaitForElement(By.Id("PaymentInfo"));
-            Assert.Contains("This invoice will expire in", paymentInfo.Text);
-            Assert.Contains("00:0", paymentInfo.Text);
-            Assert.DoesNotContain("Please send", paymentInfo.Text);
+            TestUtils.Eventually(() =>
+            {
+                var paymentInfo = s.Driver.WaitForElement(By.Id("PaymentInfo"));
+                Assert.Contains("This invoice will expire in", paymentInfo.Text);
+                Assert.Contains("00:0", paymentInfo.Text);
+                Assert.DoesNotContain("Please send", paymentInfo.Text);
+            });
 
             // Configure countdown timer
             s.GoToHome();
@@ -379,7 +386,7 @@ namespace BTCPayServer.Tests
 
             s.GoToInvoiceCheckout(invoiceId);
             s.Driver.WaitUntilAvailable(By.Id("Checkout-v2"));
-            paymentInfo = s.Driver.FindElement(By.Id("PaymentInfo"));
+            var paymentInfo = s.Driver.FindElement(By.Id("PaymentInfo"));
             Assert.False(paymentInfo.Displayed);
             Assert.DoesNotContain("This invoice will expire in", paymentInfo.Text);
 
@@ -387,11 +394,13 @@ namespace BTCPayServer.Tests
             expirySeconds.Clear();
             expirySeconds.SendKeys("599");
             s.Driver.FindElement(By.Id("Expire")).Click();
-
-            paymentInfo = s.Driver.WaitForElement(By.Id("PaymentInfo"));
-            Assert.True(paymentInfo.Displayed);
-            Assert.Contains("This invoice will expire in", paymentInfo.Text);
-            Assert.Contains("09:5", paymentInfo.Text);
+            TestUtils.Eventually(() =>
+            {
+                paymentInfo = s.Driver.WaitForElement(By.Id("PaymentInfo"));
+                Assert.True(paymentInfo.Displayed);
+                Assert.Contains("This invoice will expire in", paymentInfo.Text);
+                Assert.Contains("09:5", paymentInfo.Text);
+            });
 
             // Disable LNURL again
             s.GoToHome();
@@ -457,13 +466,12 @@ namespace BTCPayServer.Tests
                     .GetPaymentMethodDetails().GetPaymentDestination(), Network.RegTest),
                 new Money(0.001m, MoneyUnit.BTC));
 
-            IWebElement closebutton = null;
             TestUtils.Eventually(() =>
             {
-                closebutton = iframe.FindElement(By.Id("close"));
-                Assert.True(closebutton.Displayed);
+                var closeButton = iframe.FindElement(By.Id("close"));
+                Assert.True(closeButton.Displayed);
+                closeButton.Click();
             });
-            closebutton.Click();
             s.Driver.AssertElementNotFound(By.Name("btcpay"));
             Assert.Equal(s.Driver.Url,
                 new Uri(s.ServerUri, $"tests/index.html?invoice={invoiceId}").ToString());

--- a/BTCPayServer.Tests/SeleniumTests.cs
+++ b/BTCPayServer.Tests/SeleniumTests.cs
@@ -2792,7 +2792,7 @@ namespace BTCPayServer.Tests
             // Topup Invoice test
             var i = s.CreateInvoice(storeId, null, cryptoCode);
             s.GoToInvoiceCheckout(i);
-            s.Driver.FindElement(By.Id("copy-tab")).Click();
+            s.Driver.WaitForElement(By.Id("copy-tab")).Click();
             var lnurl = s.Driver.FindElement(By.CssSelector("input.checkoutTextbox")).GetAttribute("value");
             var parsed = LNURL.LNURL.Parse(lnurl, out var tag);
             var fetchedReuqest =
@@ -2831,7 +2831,7 @@ namespace BTCPayServer.Tests
             s.GoToInvoiceCheckout(i);
             s.Driver.FindElement(By.ClassName("payment__currencies_noborder")).Click();
             // BOLT11 is also displayed for standard invoice (not LNURL, even if it is available)
-            s.Driver.FindElement(By.Id("copy-tab")).Click();
+            s.Driver.WaitForElement(By.Id("copy-tab")).Click();
             var bolt11 = s.Driver.FindElement(By.CssSelector("input.checkoutTextbox")).GetAttribute("value");
             Lightning.BOLT11PaymentRequest.Parse(bolt11, s.Server.ExplorerNode.Network);
             var invoiceId = s.Driver.Url.Split('/').Last();
@@ -2888,7 +2888,7 @@ namespace BTCPayServer.Tests
             i = s.CreateInvoice(storeId, null, cryptoCode);
             s.GoToInvoiceCheckout(i);
             s.Driver.FindElement(By.ClassName("payment__currencies_noborder"));
-            s.Driver.FindElement(By.Id("copy-tab")).Click();
+            s.Driver.WaitForElement(By.Id("copy-tab")).Click();
             lnurl = s.Driver.FindElement(By.CssSelector("input.checkoutTextbox")).GetAttribute("value");
             Assert.StartsWith("lnurlp", lnurl);
             LNURL.LNURL.Parse(lnurl, out tag);
@@ -2903,7 +2903,7 @@ namespace BTCPayServer.Tests
             Assert.Contains($"{cryptoCode} Lightning settings successfully updated", s.FindAlertMessage().Text);
             var invForPP = s.CreateInvoice(null, cryptoCode);
             s.GoToInvoiceCheckout(invForPP);
-            s.Driver.FindElement(By.Id("copy-tab")).Click();
+            s.Driver.WaitForElement(By.Id("copy-tab")).Click();
             lnurl = s.Driver.FindElement(By.CssSelector("input.checkoutTextbox")).GetAttribute("value");
             LNURL.LNURL.Parse(lnurl, out tag);
 

--- a/BTCPayServer/Services/Reporting/LegacyInvoiceExportReportProvider.cs
+++ b/BTCPayServer/Services/Reporting/LegacyInvoiceExportReportProvider.cs
@@ -95,8 +95,10 @@ public class LegacyInvoiceExportReportProvider : ReportProvider
                     data.Add(invoiceEntity.Metadata.ItemCode);
                     data.Add(invoiceEntity.Metadata.ItemDesc);
                     data.Add(invoiceEntity.GetInvoiceState().ToString());
+#pragma warning disable CS0618 // Type or member is obsolete
                     data.Add(invoiceEntity.StatusString);
                     data.Add(invoiceEntity.ExceptionStatusString);
+#pragma warning restore CS0618 // Type or member is obsolete
                     data.Add(invoiceEntity.Metadata.BuyerEmail);
                     data.Add(payment.Accounted);
                 }
@@ -127,8 +129,10 @@ public class LegacyInvoiceExportReportProvider : ReportProvider
                 data.Add(invoiceEntity.Metadata.ItemCode);
                 data.Add(invoiceEntity.Metadata.ItemDesc);
                 data.Add(invoiceEntity.GetInvoiceState().ToString());
+#pragma warning disable CS0618 // Type or member is obsolete
                 data.Add(invoiceEntity.StatusString);
                 data.Add(invoiceEntity.ExceptionStatusString);
+#pragma warning restore CS0618 // Type or member is obsolete
                 data.Add(invoiceEntity.Metadata.BuyerEmail);
                 data.Add(null); // Accounted
             }


### PR DESCRIPTION
- Fixes the build warnings around obsoluete properties being used in the legacy report
- Makes the Checkout v2 Selenium tests more robust and less flaky
- Makes the Payjoin Selenium test more robust