### PR TITLE
(feat) monero settlement thresholds

### DIFF
--- a/BTCPayServer/Services/Altcoins/Monero/MoneroLikeExtensions.cs
+++ b/BTCPayServer/Services/Altcoins/Monero/MoneroLikeExtensions.cs
@@ -73,7 +73,7 @@ namespace BTCPayServer.Services.Altcoins.Monero
                 var daemonPassword =
                     configuration.GetOrDefault<string>(
                         $"{moneroLikeSpecificBtcPayNetwork.CryptoCode}_daemon_password", null);
-                if (daemonUri == null || walletDaemonUri == null)
+                if (daemonUri == null || walletDaemonUri == null || walletDaemonWalletDirectory == null)
                 {
                     throw new ConfigException($"{moneroLikeSpecificBtcPayNetwork.CryptoCode} is misconfigured");
                 }

--- a/BTCPayServer/Services/Altcoins/Monero/Payments/MoneroLikeOnChainPaymentMethodDetails.cs
+++ b/BTCPayServer/Services/Altcoins/Monero/Payments/MoneroLikeOnChainPaymentMethodDetails.cs
@@ -29,6 +29,7 @@ namespace BTCPayServer.Services.Altcoins.Monero.Payments
         public long AddressIndex { get; set; }
         public string DepositAddress { get; set; }
         public decimal NextNetworkFee { get; set; }
+        public long? InvoiceSettledConfirmationThreshold { get; set; }
     }
 }
 #endif

--- a/BTCPayServer/Services/Altcoins/Monero/Payments/MoneroLikePaymentData.cs
+++ b/BTCPayServer/Services/Altcoins/Monero/Payments/MoneroLikePaymentData.cs
@@ -16,6 +16,7 @@ namespace BTCPayServer.Services.Altcoins.Monero.Payments
         public long BlockHeight { get; set; }
         public long ConfirmationCount { get; set; }
         public string TransactionId { get; set; }
+        public long? InvoiceSettledConfirmationThreshold { get; set; }
 
         public BTCPayNetworkBase Network { get; set; }
         public long LockTime { get; set; } = 0;
@@ -48,6 +49,12 @@ namespace BTCPayServer.Services.Altcoins.Monero.Payments
             {
                 return false;
             }
+
+            if (InvoiceSettledConfirmationThreshold.HasValue)
+            {
+                return ConfirmationCount >= InvoiceSettledConfirmationThreshold;
+            }
+
             switch (speedPolicy)
             {
                 case SpeedPolicy.HighSpeed:

--- a/BTCPayServer/Services/Altcoins/Monero/Payments/MoneroLikePaymentMethodHandler.cs
+++ b/BTCPayServer/Services/Altcoins/Monero/Payments/MoneroLikePaymentMethodHandler.cs
@@ -59,6 +59,7 @@ namespace BTCPayServer.Services.Altcoins.Monero.Payments
                 AccountIndex = supportedPaymentMethod.AccountIndex,
                 AddressIndex = address.AddressIndex,
                 DepositAddress = address.Address,
+                InvoiceSettledConfirmationThreshold = supportedPaymentMethod.InvoiceSettledConfirmationThreshold,
                 Activated = true
             };
 

--- a/BTCPayServer/Services/Altcoins/Monero/Payments/MoneroSupportedPaymentMethod.cs
+++ b/BTCPayServer/Services/Altcoins/Monero/Payments/MoneroSupportedPaymentMethod.cs
@@ -9,6 +9,7 @@ namespace BTCPayServer.Services.Altcoins.Monero.Payments
 
         public string CryptoCode { get; set; }
         public long AccountIndex { get; set; }
+        public long? InvoiceSettledConfirmationThreshold { get; set; }
         [JsonIgnore]
         public PaymentMethodId PaymentId => new PaymentMethodId(CryptoCode, MoneroPaymentType.Instance);
     }

--- a/BTCPayServer/Services/Altcoins/Monero/Services/MoneroListener.cs
+++ b/BTCPayServer/Services/Altcoins/Monero/Services/MoneroListener.cs
@@ -324,6 +324,11 @@ namespace BTCPayServer.Services.Altcoins.Monero.Services
             string txId, long confirmations, long blockHeight, long locktime, InvoiceEntity invoice,
             BlockingCollection<(PaymentEntity Payment, InvoiceEntity invoice)> paymentsToUpdate)
         {
+            var network = _networkProvider.GetNetwork(cryptoCode);
+            var moneroPaymentMethodDetails = invoice
+                .GetPaymentMethod(network, MoneroPaymentType.Instance)
+                .GetPaymentMethodDetails() as MoneroLikeOnChainPaymentMethodDetails;
+
             //construct the payment data
             var paymentData = new MoneroLikePaymentData()
             {
@@ -335,7 +340,8 @@ namespace BTCPayServer.Services.Altcoins.Monero.Services
                 Amount = totalAmount,
                 BlockHeight = blockHeight,
                 Network = _networkProvider.GetNetwork(cryptoCode),
-                LockTime = locktime
+                LockTime = locktime,
+                InvoiceSettledConfirmationThreshold = moneroPaymentMethodDetails.InvoiceSettledConfirmationThreshold
             };
 
             //check if this tx exists as a payment to this invoice already

--- a/BTCPayServer/Views/UIMoneroLikeStore/GetStoreMoneroLikePaymentMethod.cshtml
+++ b/BTCPayServer/Views/UIMoneroLikeStore/GetStoreMoneroLikePaymentMethod.cshtml
@@ -12,7 +12,7 @@
 
 <div class="row">
     <div class="col-md-8">
-        <div asp-validation-summary="All" class="text-danger"></div>
+        <div asp-validation-summary="All"></div>
         @if (Model.Summary != null)
         {
             <div class="card">

--- a/BTCPayServer/Views/UIMoneroLikeStore/GetStoreMoneroLikePaymentMethod.cshtml
+++ b/BTCPayServer/Views/UIMoneroLikeStore/GetStoreMoneroLikePaymentMethod.cshtml
@@ -1,6 +1,8 @@
 @using BTCPayServer.Views.Stores
 @using BTCPayServer.Abstractions.Extensions
-@model BTCPayServer.Services.Altcoins.Monero.UI.UIMoneroLikeStoreController.MoneroLikePaymentMethodViewModel
+@using MoneroLikePaymentMethodViewModel = BTCPayServer.Services.Altcoins.Monero.UI.UIMoneroLikeStoreController.MoneroLikePaymentMethodViewModel
+@using MoneroLikeSettlementThresholdChoice = BTCPayServer.Services.Altcoins.Monero.UI.UIMoneroLikeStoreController.MoneroLikeSettlementThresholdChoice;
+@model MoneroLikePaymentMethodViewModel
 
 @{
     Layout = "../Shared/_NavLayout.cshtml";
@@ -90,6 +92,40 @@
                 <label asp-for="Enabled"></label>
                 <input asp-for="Enabled" type="checkbox" class="form-check"/>
                 <span asp-validation-for="Enabled" class="text-danger"></span>
+            </div>
+
+            <div class="form-group">
+                <label asp-for="SettlementConfirmationThresholdChoice" class="form-label"></label>
+                <a href="https://docs.btcpayserver.org/FAQ/Stores/#consider-the-invoice-confirmed-when-the-payment-transaction" target="_blank" rel="noreferrer noopener" title="More information...">
+                    <vc:icon symbol="info" />
+                </a>
+                <select
+                    asp-for="SettlementConfirmationThresholdChoice"
+                    asp-items="Html.GetEnumSelectList<MoneroLikeSettlementThresholdChoice>()"
+                    class="form-select w-auto"
+                    onchange="
+                        document.getElementById('unconfirmed-warning').hidden = this.value !== '@((int)MoneroLikeSettlementThresholdChoice.ZeroConfirmation)';
+                        document.getElementById('custom-confirmation-value').hidden = this.value !== '@((int)MoneroLikeSettlementThresholdChoice.Custom)';">
+                </select>
+                <span asp-validation-for="SettlementConfirmationThresholdChoice" class="text-danger"></span>
+                <p class="info-note my-3 text-warning" id="unconfirmed-warning" role="alert" hidden="@(Model.SettlementConfirmationThresholdChoice is not MoneroLikeSettlementThresholdChoice.ZeroConfirmation)">
+                    <vc:icon symbol="warning" />
+                    Choosing to accept an unconfirmed invoice can lead to double-spending and is strongly discouraged.
+                </p>
+            </div>
+
+            <div class="form-group" id="custom-confirmation-value" hidden="@(Model.SettlementConfirmationThresholdChoice is not MoneroLikeSettlementThresholdChoice.Custom)">
+                <label asp-for="CustomSettlementConfirmationThreshold" class="form-label"></label>
+                <input
+                    asp-for="CustomSettlementConfirmationThreshold"
+                    type="number"
+                    value="@(Model.CustomSettlementConfirmationThreshold)"
+                    class="form-control w-auto"
+                    min="0"
+                    max="100"
+                    pattern="\d+"
+                />
+                <span asp-validation-for="CustomSettlementConfirmationThreshold" class="text-danger"></span>
             </div>
 
             <div class="form-group">


### PR DESCRIPTION
# Overview

This PR adds the ability to configure a monero specific settlement confirmation threshold. The UI for this setting was based of the existing 'speed policy' dropdown. This feature was requested by users in this [bounty item](https://bounties.monero.social/posts/106/2-900m-enable-zero-confirmation-for-monero-on-btcpay-server).

# Bug Fixes

## Treat Monero Wallet Directory Setting as Required

It also fixes a crash which occurs when using the monero feature without having specified a wallet base directory. This is required because the `GetMoneroLikePaymentMethodViewModel` method checks if the wallet file exists and as part of that check it tries to combine the wallet base directory with "wallet" which fails if the wallet base directory is null.

## Labels Without Spaces

It also fixes some of the form labels which were missing spaces.

## Unreadable Validation Messages

Previously the `text-danger` class was being added to the validation summary element causing the text to be red too. This has been fixed and tested on both light and dark themes.

![image](https://github.com/btcpayserver/btcpayserver/assets/3156577/f796d8fa-0ae4-4625-8eeb-630c1c9362a1)


# UI Changes

Adds a new 'Consider the invoice settled when the payment transaction ...' field that defaults to 'Store Speed Policy':

![image](https://github.com/btcpayserver/btcpayserver/assets/3156577/269f2dcf-44a8-4cb0-8387-2071cb4f4126)

The options are as follows:

![image](https://github.com/btcpayserver/btcpayserver/assets/3156577/9cc6b356-b946-419b-acac-38a0202fec4c)

These options were based upon the expected use cases (default, 0 for instant, 1, and then 10 as spendable). When the 'Custom' value is selected an additional field appears in the form:

![image](https://github.com/btcpayserver/btcpayserver/assets/3156577/bdfdd2cb-a9af-4a7a-bd3f-d9b50cf84f3f)

This field is restricted to integer values between 0 and 100:

![image](https://github.com/btcpayserver/btcpayserver/assets/3156577/21a9cb08-b640-46e3-addf-c84c9440e400)
![image](https://github.com/btcpayserver/btcpayserver/assets/3156577/c96b5b4e-e477-4734-870b-e82bc0c042f7)

If you choose custom but don't provide a value an error is displayed:

![image](https://github.com/btcpayserver/btcpayserver/assets/3156577/fd415086-5d72-4c03-bbdb-45b98f48d5f9)


# Testing

To test this change I modified to development docker compose file to run a testnet node. I then created invoices and used the POS app using the different payment thresholds. The zero-confirmation option worked as expected.

A video demonstrating the PR can be viewed [here](https://www.youtube.com/watch?v=HwmNlieh4JI) - the zero conf is demoed first, and then a custom setting of 2 confirmations. It took a long time for the confirmations to come through.
