### PR TITLE
fix: switch to using get_info call for monerod RPC

### DIFF
--- a/BTCPayServer/Plugins/Altcoins/Monero/RPC/Models/GetInfoResponse.cs
+++ b/BTCPayServer/Plugins/Altcoins/Monero/RPC/Models/GetInfoResponse.cs
@@ -3,10 +3,10 @@ using Newtonsoft.Json;
 
 namespace BTCPayServer.Services.Altcoins.Monero.RPC.Models
 {
-    public partial class SyncInfoResponse
+    public partial class GetInfoResponse
     {
         [JsonProperty("height")] public long Height { get; set; }
-        [JsonProperty("peers")] public List<Peer> Peers { get; set; }
+        [JsonProperty("busy_syncing")] public bool BusySyncing { get; set; }
         [JsonProperty("status")] public string Status { get; set; }
         [JsonProperty("target_height")] public long? TargetHeight { get; set; }
     }

--- a/BTCPayServer/Services/Altcoins/Monero/Services/MoneroRPCProvider.cs
+++ b/BTCPayServer/Services/Altcoins/Monero/Services/MoneroRPCProvider.cs
@@ -59,12 +59,12 @@ namespace BTCPayServer.Services.Altcoins.Monero.Services
             try
             {
                 var daemonResult =
-                    await daemonRpcClient.SendCommandAsync<JsonRpcClient.NoRequestModel, SyncInfoResponse>("sync_info",
+                    await daemonRpcClient.SendCommandAsync<JsonRpcClient.NoRequestModel, GetInfoResponse>("get_info",
                         JsonRpcClient.NoRequestModel.Instance);
                 summary.TargetHeight = daemonResult.TargetHeight.GetValueOrDefault(0);
                 summary.CurrentHeight = daemonResult.Height;
                 summary.TargetHeight = summary.TargetHeight == 0 ? summary.CurrentHeight : summary.TargetHeight;
-                summary.Synced = daemonResult.Height >= summary.TargetHeight && summary.CurrentHeight > 0;
+                summary.Synced = !daemonResult.BusySyncing;
                 summary.UpdatedAt = DateTime.UtcNow;
                 summary.DaemonAvailable = true;
             }


### PR DESCRIPTION
Replace the RPC call to `sync_info` in the monero logic with `get_info`, which isn't a restricted call and allows for using a remote node. I'm also replacing the "peers" field with a "busy_syncing" field, since peers was never used and it clears up some logic.

I've only tested this locally, so please let me know if there are any issues.
