### PR TITLE
Cleanup AddressesInvoices table

### DIFF
--- a/BTCPayServer.Data/Data/AddressInvoiceData.cs
+++ b/BTCPayServer.Data/Data/AddressInvoiceData.cs
@@ -9,7 +9,6 @@ namespace BTCPayServer.Data
         public string Address { get; set; }
         public InvoiceData InvoiceData { get; set; }
         public string InvoiceDataId { get; set; }
-        public DateTimeOffset? CreatedTime { get; set; }
 
 
         internal static void OnModelCreating(ModelBuilder builder)

--- a/BTCPayServer.Data/Migrations/20240405052858_cleanup_address_invoices.cs
+++ b/BTCPayServer.Data/Migrations/20240405052858_cleanup_address_invoices.cs
@@ -1,0 +1,32 @@
+using System;
+using BTCPayServer.Data;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace BTCPayServer.Migrations
+{
+    [DbContext(typeof(ApplicationDbContext))]
+    [Migration("20240405052858_cleanup_address_invoices")]
+    public partial class cleanup_address_invoices : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            if (migrationBuilder.IsNpgsql())
+            {
+                migrationBuilder.Sql(@"
+DELETE FROM ""AddressInvoices"" WHERE ""Address"" LIKE '%_LightningLike';
+ALTER TABLE ""AddressInvoices"" DROP COLUMN IF EXISTS ""CreatedTime"";
+VACUUM (FULL, ANALYZE) ""AddressInvoices"";", true);
+            }
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+        }
+    }
+}

--- a/BTCPayServer.Data/Migrations/ApplicationDbContextModelSnapshot.cs
+++ b/BTCPayServer.Data/Migrations/ApplicationDbContextModelSnapshot.cs
@@ -63,9 +63,6 @@ namespace BTCPayServer.Migrations
                     b.Property<string>("Address")
                         .HasColumnType("text");
 
-                    b.Property<DateTimeOffset?>("CreatedTime")
-                        .HasColumnType("timestamp with time zone");
-
                     b.Property<string>("InvoiceDataId")
                         .HasColumnType("text");
 

--- a/BTCPayServer/Services/Invoices/InvoiceRepository.cs
+++ b/BTCPayServer/Services/Invoices/InvoiceRepository.cs
@@ -245,7 +245,6 @@ namespace BTCPayServer.Services.Invoices
                         await context.AddressInvoices.AddAsync(new AddressInvoiceData()
                         {
                             InvoiceDataId = invoice.Id,
-                            CreatedTime = DateTimeOffset.UtcNow,
                             Address = trackedDestination
                         });
                     }
@@ -363,7 +362,6 @@ retry:
                         await context.AddressInvoices.AddAsync(new AddressInvoiceData()
                         {
                             InvoiceDataId = invoiceId,
-                            CreatedTime = DateTimeOffset.UtcNow,
                             Address = tracked
                         });
                     }


### PR DESCRIPTION
* We are putting `bolt11` in this table, but we never use it, so delete those rows.
* Remove `CreatedTime` column that is never used. If needed we could just join `InvoiceData` and pick up the time there.

On mainnet server, I saved around 30MB with this.