### PR TITLE
(bug) handle null XMR settings

### DIFF
--- a/BTCPayServer/Services/Altcoins/Monero/UI/MoneroLikeStoreController.cs
+++ b/BTCPayServer/Services/Altcoins/Monero/UI/MoneroLikeStoreController.cs
@@ -104,14 +104,19 @@ namespace BTCPayServer.Services.Altcoins.Monero.UI
                 new SelectListItem(
                     $"{account.AccountIndex} - {(string.IsNullOrEmpty(account.Label) ? "No label" : account.Label)}",
                     account.AccountIndex.ToString(CultureInfo.InvariantCulture)));
-            var settlementThresholdChoice = settings.InvoiceSettledConfirmationThreshold switch
+
+            var settlementThresholdChoice = MoneroLikeSettlementThresholdChoice.StoreSpeedPolicy;
+            if (settings != null && settings.InvoiceSettledConfirmationThreshold is { } confirmations)
             {
-                null => MoneroLikeSettlementThresholdChoice.StoreSpeedPolicy,
-                0 => MoneroLikeSettlementThresholdChoice.ZeroConfirmation,
-                1 => MoneroLikeSettlementThresholdChoice.AtLeastOne,
-                10 => MoneroLikeSettlementThresholdChoice.AtLeastTen,
-                _ => MoneroLikeSettlementThresholdChoice.Custom
-            };
+                settlementThresholdChoice = confirmations switch
+                {
+                    0 => MoneroLikeSettlementThresholdChoice.ZeroConfirmation,
+                    1 => MoneroLikeSettlementThresholdChoice.AtLeastOne,
+                    10 => MoneroLikeSettlementThresholdChoice.AtLeastTen,
+                    _ => MoneroLikeSettlementThresholdChoice.Custom
+                };
+            }
+
             return new MoneroLikePaymentMethodViewModel()
             {
                 WalletFileFound = System.IO.File.Exists(fileAddress),
@@ -124,9 +129,11 @@ namespace BTCPayServer.Services.Altcoins.Monero.UI
                 Accounts = accounts == null ? null : new SelectList(accounts, nameof(SelectListItem.Value),
                     nameof(SelectListItem.Text)),
                 SettlementConfirmationThresholdChoice = settlementThresholdChoice,
-                CustomSettlementConfirmationThreshold = settlementThresholdChoice is MoneroLikeSettlementThresholdChoice.Custom
-                    ? settings.InvoiceSettledConfirmationThreshold
-                    : null
+                CustomSettlementConfirmationThreshold =
+                    settings != null &&
+                    settlementThresholdChoice is MoneroLikeSettlementThresholdChoice.Custom
+                        ? settings.InvoiceSettledConfirmationThreshold
+                        : null
             };
         }
 


### PR DESCRIPTION
# Overview

This PR resolves a crash which would occur in v1.13.0 whenever the user had no previously configured their XMR wallet settings. The cause of the crash was that code introduced in https://github.com/btcpayserver/btcpayserver/pull/5807 assumed that the `settings` variable was non-nullable but that is not the case. Could be related to #5881 

# Reproduction

Create a new postgres database, then w/ XMR enabled as an altcoin start up btcpayserver. After setting up you admin account and completing the "Create your first store" page the server will error:

![image](https://github.com/btcpayserver/btcpayserver/assets/3156577/24f8b84c-fb24-41f4-9887-b76a08dbc431)

# After Fix

The error does not occur and you can see the default store page.

![image](https://github.com/btcpayserver/btcpayserver/assets/3156577/db66443c-5485-4d9f-901c-015fd0fb62cd)

And an example test transaction:

![image](https://github.com/btcpayserver/btcpayserver/assets/3156577/53cc6fb2-af6a-4f7a-b579-04b4c9d96ce6)
![image](https://github.com/btcpayserver/btcpayserver/assets/3156577/7f20de8a-a95c-439a-82e2-4ca5bb6c591e)
![image](https://github.com/btcpayserver/btcpayserver/assets/3156577/d3d3fd7b-314b-4c74-92d6-c66f086faaa6)

