### PR TITLE
Expose QR code generator

### DIFF
--- a/BTCPayServer/Components/QRCode/QRCode.cs
+++ b/BTCPayServer/Components/QRCode/QRCode.cs
@@ -20,5 +20,15 @@ namespace BTCPayServer.Components.QRCode
             return new HtmlContentViewComponentResult(new HtmlString(
                 $"<img style=\"image-rendering:pixelated;image-rendering:-moz-crisp-edges;min-width:{size}px;min-height:{size}px\" src=\"data:image/png;base64,{b64}\" class=\"qr-code\" />"));
         }
+
+        public HtmlString InvokeHtmlString(string data, int size)
+        {
+            var qrCodeData = _qrGenerator.CreateQrCode(data, QRCodeGenerator.ECCLevel.Q);
+            var qrCode = new PngByteQRCode(qrCodeData);
+            var bytes = qrCode.GetGraphic(5, new byte[] { 0, 0, 0, 255 }, new byte[] { 0xf5, 0xf5, 0xf7, 255 });
+            var b64 = Convert.ToBase64String(bytes);
+            return new HtmlString(
+                $"<img style=\"image-rendering:pixelated;image-rendering:-moz-crisp-edges;width:{size}px;height:{size}px\" src=\"data:image/png;base64,{b64}\" class=\"qr-code\" />");
+        }
     }
 }


### PR DESCRIPTION
Expose QR code generator as htmlstring in order to use it in payroll plugin for QR code display.