### PR TITLE
Add React BTCPay Pay Button component for React developers

### DIFF
--- a/BTCPayServer/Views/Shared/PayButton/PayButton.cshtml
+++ b/BTCPayServer/Views/Shared/PayButton/PayButton.cshtml
@@ -414,6 +414,14 @@
             <button class="btn btn-outline-secondary" data-clipboard-target="#mainCode">
                 <vc:icon symbol="copy"/>&nbsp;Copy Code
             </button>
+            <h5 class="mt-4">
+                React Developers
+            </h5>
+            <p class="mt-1">
+                Use the
+                <a href="https://docs.btcpayserver.org/Apps/#payment-button-for-react-developers" title="React BTCPay Pay Button component for React Developers" target="_blank">React BTCPay Pay Button</a>
+                component instead of the generated code.
+            </p>
         </div>
     </div>
     <div class="row" v-show="errors.any()">


### PR DESCRIPTION
Screenshot Preview:
<img width="1456" alt="Screenshot 2024-04-11 at 7 28 13 AM" src="https://github.com/btcpayserver/btcpayserver/assets/72945059/b3cd5754-d50d-4998-b695-a026593f85c7">
