### PR TITLE
Prevent payout double send

### DIFF
--- a/BTCPayServer/Models/WalletViewModels/PayoutsModel.cs
+++ b/BTCPayServer/Models/WalletViewModels/PayoutsModel.cs
@@ -19,6 +19,7 @@ namespace BTCPayServer.Models.WalletViewModels
         public IEnumerable<PaymentMethodId> PaymentMethods { get; set; }
         public PayoutState PayoutState { get; set; }
         public string PullPaymentName { get; set; }
+        public bool HasPayoutProcessor { get; set; }
 
         public class PayoutModel
         {

--- a/BTCPayServer/Views/UIStorePullPayments/Payouts.cshtml
+++ b/BTCPayServer/Views/UIStorePullPayments/Payouts.cshtml
@@ -7,8 +7,6 @@
 @model BTCPayServer.Models.WalletViewModels.PayoutsModel
 
 @inject IEnumerable<IPayoutHandler> PayoutHandlers;
-@inject PayoutProcessorService _payoutProcessorService;
-@inject IEnumerable<IPayoutProcessorFactory> _payoutProcessorFactories;
 @{
     var storeId = Context.GetRouteValue("storeId") as string;
     ViewData.SetActivePage(StoreNavPages.Payouts, $"Payouts{(string.IsNullOrEmpty(Model.PullPaymentName) ? string.Empty : " for pull payment " + Model.PullPaymentName)}", Context.GetStoreData().Id);
@@ -24,15 +22,16 @@
             return;
         stateActions.AddRange(payoutHandler.GetPayoutSpecificActions().Where(pair => pair.Key == Model.PayoutState).SelectMany(pair => pair.Value));
     }
+
     switch (Model.PayoutState)
     {
         case PayoutState.AwaitingApproval:
+            if (!Model.HasPayoutProcessor) stateActions.Add(("approve-pay", "Approve & Send"));
             stateActions.Add(("approve", "Approve"));
-            stateActions.Add(("approve-pay", "Approve & Send"));
             stateActions.Add(("cancel", "Cancel"));
             break;
         case PayoutState.AwaitingPayment:
-            stateActions.Add(("pay", "Send"));
+            if (!Model.HasPayoutProcessor) stateActions.Add(("pay", "Send"));
             stateActions.Add(("cancel", "Cancel"));
             stateActions.Add(("mark-paid", "Mark as already paid"));
             break;
@@ -87,11 +86,7 @@
 
 <partial name="_StatusMessage" />
 
-@if (_payoutProcessorFactories.Any(factory => factory.GetSupportedPaymentMethods().Contains(paymentMethodId)) && !(await _payoutProcessorService.GetProcessors(new PayoutProcessorService.PayoutProcessorQuery()
-{
-    Stores = new[] { storeId },
-    PaymentMethods = new[] { PaymentMethodId.Parse(Model.PaymentMethodId) }
-})).Any())
+@if (!Model.HasPayoutProcessor)
 {
     <div class="alert alert-info mb-5" role="alert" permission="@Policies.CanModifyStoreSettings">
         <strong>Pro tip:</strong> There are supported but unconfigured Payout Processors for this payout payment method.<br/>


### PR DESCRIPTION
Fixes #5913.

- Pulls the check for payout processors out of the view into the controller.
- For the GET action is hides the "send/pay" options
- For the POST action it prevents going to pay after approving, though the hiding of those actions in GET should prevent accessing that anyways.