### PR TITLE
Greenfield: Fix payment method update regression

### DIFF
--- a/BTCPayServer/Controllers/GreenField/GreenfieldStorePaymentMethodsController.cs
+++ b/BTCPayServer/Controllers/GreenField/GreenfieldStorePaymentMethodsController.cs
@@ -115,7 +115,7 @@ namespace BTCPayServer.Controllers.Greenfield
             if (request?.Enabled is { } enabled)
             {
                 var storeBlob = Store.GetStoreBlob();
-                storeBlob.SetExcluded(paymentMethodId, enabled);
+                storeBlob.SetExcluded(paymentMethodId, !enabled);
                 Store.SetStoreBlob(storeBlob);
             }
             await _storeRepository.UpdateStore(Store);

--- a/BTCPayServer/wwwroot/swagger/v1/swagger.template.json
+++ b/BTCPayServer/wwwroot/swagger/v1/swagger.template.json
@@ -108,7 +108,8 @@
       },
       "PaymentMethodId": {
         "type": "string",
-        "description": "Payment method IDs are a combination of crypto code and payment type. Available payment method IDs for Bitcoin are:  \n- `\"BTC-OnChain\"` (with the equivalent of `\"BTC\"`)   \n-`\"BTC-LightningLike\"`: Any supported LN-based payment method (Lightning or LNURL)   \n- `\"BTC-LightningNetwork\"`: Lightning   \n- `\"BTC-LNURLPAY\"`: LNURL   \n   \nNote: Separator can be either `-` or `_`."
+        "description": "Payment method IDs are a combination of crypto code and payment type. Available payment method IDs for Bitcoin are:  \n- `\"BTC-CHAIN\"`: Onchain   \n-`\"BTC-LN\"`: Lightning   \n- `\"BTC-LNURL\"`: LNURL",
+          "example": "BTC-CHAIN"
       }
     },
     "securitySchemes": {

--- a/BTCPayServer/wwwroot/swagger/v1/swagger.template.stores-payment-methods.json
+++ b/BTCPayServer/wwwroot/swagger/v1/swagger.template.stores-payment-methods.json
@@ -345,11 +345,6 @@
                     }
                 }
             },
-            "PaymentMethodId": {
-                "type": "string",
-                "description": "The payment method id (`BTC-CHAIN`, `BTC-LN`, `BTC-LNURL`)",
-                "example": "BTC-CHAIN"
-            },
             "GenericPaymentMethodData": {
                 "type": "object",
                 "additionalProperties": false,


### PR DESCRIPTION
Do not exclude if `enabled` is `true`. Got introduced in #5809.

Also contains an update for the Swagger docs, which unifies and updates the `PaymentMethodId` schmea description.