### PR TITLE
Fix flaky tests

### DIFF
--- a/BTCPayServer.Tests/AltcoinTests/AltcoinTests.cs
+++ b/BTCPayServer.Tests/AltcoinTests/AltcoinTests.cs
@@ -310,6 +310,7 @@ namespace BTCPayServer.Tests
                 {
                     invoice = user.BitPay.GetInvoice(invoice.Id);
                     Assert.Equal(firstPayment, invoice.CryptoInfo[0].Paid);
+                    Assert.Equal("paidPartial", invoice.ExceptionStatus?.ToString());
                 });
 
                 Assert.Single(invoice.CryptoInfo); // Only BTC should be presented


### PR DESCRIPTION
`EnsureWebhooksTrigger` and `CanHaveLTCOnlyStore` are flaky because they are using `NetworkFeeMode.MultiplePaymentsOnly` and multiple payments on an invoice.

There is a timing issue where the payment is registered, but the payment method fee for the next required payment isn't yet updated.
This should fix the tests by making sure the invoice's state has been updated before sending the second payment.