### PR TITLE
Domain mapping constraint: Fix .onion case

### DIFF
--- a/BTCPayServer/Filters/DomainMappingConstraintAttribute.cs
+++ b/BTCPayServer/Filters/DomainMappingConstraintAttribute.cs
@@ -37,11 +37,11 @@ namespace BTCPayServer.Filters
             }
 
             // If we have an appId, we can redirect to the canonical domain
-            if ((string)context.RouteContext.RouteData.Values["appId"] is { } appId && !req.IsOnion())
+            if ((string)context.RouteContext.RouteData.Values["appId"] is { } appId)
             {
                 var redirectDomain = mapping.FirstOrDefault(item => item.AppId == appId)?.Domain;
                 // App is accessed via path, redirect to canonical domain
-                if (!string.IsNullOrEmpty(redirectDomain) && req.Method != "POST" && !req.HasFormContentType)
+                if (!string.IsNullOrEmpty(redirectDomain) && req.Method != "POST" && !req.HasFormContentType && !req.IsOnion())
                 {
                     var uri = new UriBuilder(req.Scheme, redirectDomain);
                     if (req.Host.Port.HasValue)


### PR DESCRIPTION
Fixes #5917, which is a regression introduced in #5776. 

The Tor-check must happen to prevent redirecting, but we must still return true if we already resolved an `appId`.