### PR TITLE
Show Lightning node availability in navigation

### DIFF
--- a/BTCPayServer/Components/MainNav/Default.cshtml
+++ b/BTCPayServer/Components/MainNav/Default.cshtml
@@ -79,8 +79,11 @@
                                     <li class="nav-item">
                                         @if (isSetUp)
                                         {
+                                            var status = scheme.Enabled
+                                                ? scheme.Available ? "enabled" : "disabled"
+                                                : "pending";
                                             <a asp-area="" asp-controller="UIStores" asp-action="Lightning" asp-route-cryptoCode="@scheme.CryptoCode" asp-route-storeId="@Model.Store.Id" class="nav-link @ViewData.IsActivePage(StoreNavPages.Lightning) @ViewData.IsActivePage(StoreNavPages.LightningSettings)" id="@($"StoreNav-Lightning{scheme.CryptoCode}")">
-                                                <span class="me-2 btcpay-status btcpay-status--@(scheme.Enabled ? "enabled" : "pending")"></span>
+                                                <span class="me-2 btcpay-status btcpay-status--@status"></span>
 												<span>@PrettyName.PrettyName(scheme.PaymentMethodId)</span>
                                             </a>
                                         }

--- a/BTCPayServer/Controllers/UIPublicLightningNodeInfoController.cs
+++ b/BTCPayServer/Controllers/UIPublicLightningNodeInfoController.cs
@@ -5,7 +5,6 @@ using System.Threading.Tasks;
 using BTCPayServer.Data;
 using BTCPayServer.Filters;
 using BTCPayServer.Lightning;
-using BTCPayServer.Logging;
 using BTCPayServer.Models;
 using BTCPayServer.Payments;
 using BTCPayServer.Payments.Lightning;
@@ -55,7 +54,6 @@ namespace BTCPayServer.Controllers
             try
             {
                 var paymentMethodDetails = store.GetPaymentMethodConfig<LightningPaymentMethodConfig>(pmi, _handlers);
-                var network = _BtcPayNetworkProvider.GetNetwork<BTCPayNetwork>(cryptoCode);
                 var nodeInfo = await handler.GetNodeInfo(paymentMethodDetails, null, throws: true);
 
                 vm.Available = true;

--- a/BTCPayServer/Models/StoreViewModels/StoreLightningNode.cs
+++ b/BTCPayServer/Models/StoreViewModels/StoreLightningNode.cs
@@ -9,5 +9,6 @@ namespace BTCPayServer.Models.StoreViewModels
         public string Address { get; set; }
         public bool Enabled { get; set; }
         public bool Available { get; set; }
+        public string CacheKey { get; set; }
     }
 }

--- a/BTCPayServer/Models/StoreViewModels/StoreLightningNode.cs
+++ b/BTCPayServer/Models/StoreViewModels/StoreLightningNode.cs
@@ -8,5 +8,6 @@ namespace BTCPayServer.Models.StoreViewModels
         public PaymentMethodId PaymentMethodId { get; set; }
         public string Address { get; set; }
         public bool Enabled { get; set; }
+        public bool Available { get; set; }
     }
 }

--- a/BTCPayServer/Payments/Lightning/LightningLikePaymentHandler.cs
+++ b/BTCPayServer/Payments/Lightning/LightningLikePaymentHandler.cs
@@ -1,11 +1,8 @@
 #nullable enable
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using AngleSharp.Dom;
-using BTCPayServer.Abstractions.Extensions;
 using BTCPayServer.Client;
 using BTCPayServer.Client.Models;
 using BTCPayServer.Configuration;
@@ -13,17 +10,12 @@ using BTCPayServer.Data;
 using BTCPayServer.HostedServices;
 using BTCPayServer.Lightning;
 using BTCPayServer.Lightning.LndHub;
-using BTCPayServer.Logging;
-using BTCPayServer.Models;
-using BTCPayServer.Models.InvoicingModels;
 using BTCPayServer.Payments.Bitcoin;
 using BTCPayServer.Security;
 using BTCPayServer.Services;
-using BTCPayServer.Services.Invoices;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.Extensions.Options;
 using NBitcoin;
-using NBitcoin.Protocol;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
@@ -41,7 +33,6 @@ namespace BTCPayServer.Payments.Lightning
         private readonly LightningClientFactoryService _lightningClientFactory;
         private readonly BTCPayNetwork _Network;
         private readonly SocketFactory _socketFactory;
-        private readonly DisplayFormatter _displayFormatter;
         private readonly ISettingsAccessor<PoliciesSettings> _policies;
         private readonly IOptions<LightningNetworkOptions> _lightningNetworkOptions;
 
@@ -51,7 +42,6 @@ namespace BTCPayServer.Payments.Lightning
             LightningClientFactoryService lightningClientFactory,
             BTCPayNetwork network,
             SocketFactory socketFactory,
-            DisplayFormatter displayFormatter,
             IOptions<LightningNetworkOptions> options,
             ISettingsAccessor<PoliciesSettings> policies,
             IOptions<LightningNetworkOptions> lightningNetworkOptions)
@@ -61,7 +51,6 @@ namespace BTCPayServer.Payments.Lightning
             _lightningClientFactory = lightningClientFactory;
             _Network = network;
             _socketFactory = socketFactory;
-            _displayFormatter = displayFormatter;
             Options = options;
             _policies = policies;
             _lightningNetworkOptions = lightningNetworkOptions;
@@ -155,7 +144,7 @@ namespace BTCPayServer.Payments.Lightning
             var synced = _Dashboard.IsFullySynched(_Network.CryptoCode, out var summary);
             if (supportedPaymentMethod.IsInternalNode && !synced)
                 throw new PaymentMethodUnavailableException("Full node not available");
-            ;
+
             try
             {
                 using var cts = new CancellationTokenSource(LightningTimeout);

--- a/BTCPayServer/Payments/PaymentTypes.cs
+++ b/BTCPayServer/Payments/PaymentTypes.cs
@@ -1,13 +1,8 @@
 #nullable enable
-using System;
-using System.Linq;
 #if ALTCOINS
 using BTCPayServer.Services.Altcoins.Monero.Payments;
 using BTCPayServer.Services.Altcoins.Zcash.Payments;
 #endif
-using BTCPayServer.Services.Invoices;
-using NBitcoin;
-using Newtonsoft.Json.Linq;
 
 namespace BTCPayServer.Payments
 {

--- a/BTCPayServer/Views/UIPublicLightningNodeInfo/ShowLightningNodeInfo.cshtml
+++ b/BTCPayServer/Views/UIPublicLightningNodeInfo/ShowLightningNodeInfo.cshtml
@@ -18,13 +18,13 @@
             <div class="d-flex flex-column justify-content-center gap-4">
                 <partial name="_StoreHeader" model="(Model.StoreName, Model.StoreBranding)" />
                 <section class="tile">
-                    <h2 class="h4 card-subtitle text-center text-secondary mt-1 mb-3">
+                    <h2 class="h4 card-subtitle text-center text-secondary mt-1 mb-3" id="LightningNodeTitle">
                         <span>@Model.CryptoCode</span>
                         Lightning Node
                     </h2>
                     <h4 class="d-flex align-items-center justify-content-center gap-2 my-4">
                         <span class="btcpay-status btcpay-status--@(Model.Available ? "enabled" : "disabled")" style="margin-top:.1rem;"></span>
-                        @(Model.Available ? "Online" : "Unavailable")
+                        <span id="LightningNodeStatus">@(Model.Available ? "Online" : "Unavailable")</span>
                     </h4>
                     @if (Model.Available)
                     {
@@ -46,6 +46,7 @@
                                 {
                                     var nodeInfo = Model.NodeInfo[i];
                                     var title = nodeInfo.IsTor ? "Tor" : "Clearnet";
+                                    var id = $"LightningNodeUrl{title}";
                                     var value = nodeInfo.ToString();
                                     <div class="tab-pane fade @(i == 0 ? "show active" : "")" id="nodeInfo-@i" role="tabpanel" aria-labelledby="nodeInfo-tab-@i">
                                         <div class="payment-box">
@@ -58,7 +59,7 @@
 											</div>
                                             <div class="input-group mt-3">
                                                 <div class="form-floating">
-                                                    <vc:truncate-center text="@value" padding="15" elastic="true" classes="form-control-plaintext" />
+                                                    <vc:truncate-center text="@value" padding="15" elastic="true" classes="form-control-plaintext" id="@id"/>
                                                     <label>@title</label>
                                                 </div>
                                             </div>


### PR DESCRIPTION
Instead of simply communicating the setup state of the store's LN node, this now also checks its availability.

Closes  #5940.

## Node unavailable

![grafik](https://github.com/btcpayserver/btcpayserver/assets/886/f4f32be8-8853-4cc1-91cc-6d623f11fd32)

## Node not setup

![grafik](https://github.com/btcpayserver/btcpayserver/assets/886/059fea16-abc9-4849-9f1d-72f733830bd9)
