### PR TITLE
Guard against running current master

### DIFF
--- a/BTCPayServer.Tests/docker-compose.altcoins.yml
+++ b/BTCPayServer.Tests/docker-compose.altcoins.yml
@@ -12,6 +12,7 @@ services:
       args:
         CONFIGURATION_NAME: Altcoins-Release
     environment:
+      TESTS_EXPERIMENTALV2_CONFIRM: "true"
       TESTS_BTCRPCCONNECTION: server=http://bitcoind:43782;ceiwHEbqWI83:DwubwWsoo3
       TESTS_LTCRPCCONNECTION: server=http://litecoind:43782;ceiwHEbqWI83:DwubwWsoo3
       TESTS_BTCNBXPLORERURL: http://nbxplorer:32838/

--- a/BTCPayServer.Tests/docker-compose.yml
+++ b/BTCPayServer.Tests/docker-compose.yml
@@ -12,6 +12,7 @@ services:
       args:
         CONFIGURATION_NAME: Release
     environment:
+      TESTS_EXPERIMENTALV2_CONFIRM: "true"
       TESTS_BTCRPCCONNECTION: server=http://bitcoind:43782;ceiwHEbqWI83:DwubwWsoo3
       TESTS_BTCNBXPLORERURL: http://nbxplorer:32838/
       TESTS_DB: "Postgres"

--- a/BTCPayServer/Program.cs
+++ b/BTCPayServer/Program.cs
@@ -45,6 +45,12 @@ namespace BTCPayServer
 #endif
                 conf = confBuilder.Build();
 
+
+                var confirm = conf.GetOrDefault<bool>("EXPERIMENTALV2_CONFIRM", false);
+                if(!confirm)
+                {
+                    throw new ConfigException("You are running an experimental version of BTCPay Server that is the basis for v2. Many things will change and break, including irreversible database migrations. THERE IS NO WAY BACK. Please confirm you understand this by setting the setting EXPERIMENTALV2_CONFIRM=true");
+                }
                 var builder = new WebHostBuilder()
                     .UseKestrel()
                     .UseConfiguration(conf)

--- a/BTCPayServer/Properties/launchSettings.json
+++ b/BTCPayServer/Properties/launchSettings.json
@@ -4,6 +4,7 @@
       "commandName": "Project",
       "launchBrowser": true,
       "environmentVariables": {
+        "EXPERIMENTALV2_CONFIRM": "true",
         "BTCPAY_NETWORK": "regtest",
         "BTCPAY_LAUNCHSETTINGS": "true",
         "BTCPAY_BTCLIGHTNING": "type=clightning;server=tcp://127.0.0.1:30993/",
@@ -37,6 +38,7 @@
       "commandName": "Project",
       "launchBrowser": true,
       "environmentVariables": {
+        "EXPERIMENTALV2_CONFIRM": "true",
         "BTCPAY_NETWORK": "regtest",
         "BTCPAY_LAUNCHSETTINGS": "true",
         "BTCPAY_PORT": "14142",
@@ -74,6 +76,7 @@
       "commandName": "Project",
       "launchBrowser": true,
       "environmentVariables": {
+        "EXPERIMENTALV2_CONFIRM": "true",
         "BTCPAY_NETWORK": "regtest",
         "BTCPAY_LAUNCHSETTINGS": "true",
         "BTCPAY_PORT": "14142",


### PR DESCRIPTION
With a longer release cycle for v2, we need to guard people from running master and corrupting their data. This adds a new requirement in that  a special config must be set when running master. We will remove when v2 rc is ready.