### PR TITLE
Remove period concept from PullPayment

### DIFF
--- a/BTCPayServer.Client/Models/CreatePullPaymentRequest.cs
+++ b/BTCPayServer.Client/Models/CreatePullPaymentRequest.cs
@@ -12,8 +12,6 @@ namespace BTCPayServer.Client.Models
         [JsonProperty(ItemConverterType = typeof(NumericStringJsonConverter))]
         public decimal Amount { get; set; }
         public string Currency { get; set; }
-        [JsonConverter(typeof(TimeSpanJsonConverter.Seconds))]
-        public TimeSpan? Period { get; set; }
         [JsonConverter(typeof(TimeSpanJsonConverter.Days))]
         [JsonProperty("BOLT11Expiration")]
         public TimeSpan? BOLT11Expiration { get; set; }

--- a/BTCPayServer.Client/Models/PullPaymentBaseData.cs
+++ b/BTCPayServer.Client/Models/PullPaymentBaseData.cs
@@ -24,8 +24,6 @@ namespace BTCPayServer.Client.Models
         public string Currency { get; set; }
         [JsonConverter(typeof(NumericStringJsonConverter))]
         public decimal Amount { get; set; }
-        [JsonConverter(typeof(TimeSpanJsonConverter.Seconds))]
-        public TimeSpan? Period { get; set; }
         [JsonConverter(typeof(TimeSpanJsonConverter.Days))]
         [JsonProperty("BOLT11Expiration")]
         public TimeSpan BOLT11Expiration { get; set; }

--- a/BTCPayServer.Data/Data/PayoutData.cs
+++ b/BTCPayServer.Data/Data/PayoutData.cs
@@ -54,17 +54,5 @@ namespace BTCPayServer.Data
                 .Property(o => o.Proof)
                 .HasColumnType("JSONB");
         }
-
-        // utility methods
-        public bool IsInPeriod(PullPaymentData pp, DateTimeOffset now)
-        {
-            var period = pp.GetPeriod(now);
-            if (period is { } p)
-            {
-                return p.Start <= Date && (p.End is not { } end || Date < end);
-            }
-
-            return false;
-        }
     }
 }

--- a/BTCPayServer.Data/Data/PullPaymentData.cs
+++ b/BTCPayServer.Data/Data/PullPaymentData.cs
@@ -4,11 +4,13 @@ using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
 using System.Linq;
 using System.Text;
+using BTCPayServer.Abstractions.Extensions;
 using BTCPayServer.Client.Models;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NBitcoin;
+using static System.Runtime.InteropServices.JavaScript.JSType;
 
 namespace BTCPayServer.Data
 {
@@ -22,7 +24,6 @@ namespace BTCPayServer.Data
         public StoreData StoreData { get; set; }
         [MaxLength(50)]
         public string StoreId { get; set; }
-        public long? Period { get; set; }
         public DateTimeOffset StartDate { get; set; }
         public DateTimeOffset? EndDate { get; set; }
         public bool Archived { get; set; }
@@ -49,26 +50,24 @@ namespace BTCPayServer.Data
                 return null;
             if (EndDate is DateTimeOffset end && now >= end)
                 return null;
-            DateTimeOffset startPeriod = StartDate;
-            DateTimeOffset? endPeriod = null;
-            if (Period is long periodSeconds)
-            {
-                var period = TimeSpan.FromSeconds(periodSeconds);
-                var timeToNow = now - StartDate;
-                var periodCount = (long)timeToNow.TotalSeconds / (long)period.TotalSeconds;
-                startPeriod = StartDate + (period * periodCount);
-                endPeriod = startPeriod + period;
-            }
-            if (EndDate is DateTimeOffset end2 &&
-                ((endPeriod is null) ||
-                (endPeriod is DateTimeOffset endP && endP > end2)))
-                endPeriod = end2;
-            return (startPeriod, endPeriod);
+            return (StartDate, EndDate);
         }
 
         public bool HasStarted()
         {
             return HasStarted(DateTimeOffset.UtcNow);
+        }
+        public TimeSpan? EndsIn() => EndsIn(DateTimeOffset.UtcNow);
+        public TimeSpan? EndsIn(DateTimeOffset now)
+        {
+            if (EndDate is DateTimeOffset e)
+            {
+                var resetIn = (e - now);
+                if (resetIn < TimeSpan.Zero)
+                    resetIn = TimeSpan.Zero;
+                return resetIn;
+            }
+            return null;
         }
         public bool HasStarted(DateTimeOffset now)
         {
@@ -97,32 +96,6 @@ namespace BTCPayServer.Data
 
     public static class PayoutExtensions
     {
-        public static IQueryable<PayoutData> GetPayoutInPeriod(this IQueryable<PayoutData> payouts, PullPaymentData pp)
-        {
-            return GetPayoutInPeriod(payouts, pp, DateTimeOffset.UtcNow);
-        }
-        public static IQueryable<PayoutData> GetPayoutInPeriod(this IQueryable<PayoutData> payouts, PullPaymentData pp, DateTimeOffset now)
-        {
-            var request = payouts.Where(p => p.PullPaymentDataId == pp.Id);
-            var period = pp.GetPeriod(now);
-            if (period is { } p)
-            {
-                var start = p.Start;
-                if (p.End is DateTimeOffset end)
-                {
-                    return request.Where(p => p.Date >= start && p.Date < end);
-                }
-                else
-                {
-                    return request.Where(p => p.Date >= start);
-                }
-            }
-            else
-            {
-                return request.Where(p => false);
-            }
-        }
-
         public static string GetStateString(this PayoutState state)
         {
             switch (state)

--- a/BTCPayServer.Data/Migrations/20240501015052_noperiod.cs
+++ b/BTCPayServer.Data/Migrations/20240501015052_noperiod.cs
@@ -1,0 +1,31 @@
+using BTCPayServer.Data;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace BTCPayServer.Migrations
+{
+    [DbContext(typeof(ApplicationDbContext))]
+    [Migration("20240501015052_noperiod")]
+    public partial class noperiod : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Period",
+                table: "PullPayments");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<long>(
+                name: "Period",
+                table: "PullPayments",
+                type: "bigint",
+                nullable: true);
+        }
+    }
+}

--- a/BTCPayServer.Data/Migrations/ApplicationDbContextModelSnapshot.cs
+++ b/BTCPayServer.Data/Migrations/ApplicationDbContextModelSnapshot.cs
@@ -675,9 +675,6 @@ namespace BTCPayServer.Migrations
                     b.Property<DateTimeOffset?>("EndDate")
                         .HasColumnType("timestamp with time zone");
 
-                    b.Property<long?>("Period")
-                        .HasColumnType("bigint");
-
                     b.Property<DateTimeOffset>("StartDate")
                         .HasColumnType("timestamp with time zone");
 

--- a/BTCPayServer.Tests/FastTests.cs
+++ b/BTCPayServer.Tests/FastTests.cs
@@ -718,43 +718,6 @@ namespace BTCPayServer.Tests
         }
 
         [Fact]
-        public void CanCalculatePeriod()
-        {
-            Data.PullPaymentData data = new Data.PullPaymentData();
-            data.StartDate = Date(0);
-            data.EndDate = null;
-            var period = data.GetPeriod(Date(1)).Value;
-            Assert.Equal(Date(0), period.Start);
-            Assert.Null(period.End);
-            data.EndDate = Date(7);
-            period = data.GetPeriod(Date(1)).Value;
-            Assert.Equal(Date(0), period.Start);
-            Assert.Equal(Date(7), period.End);
-            data.Period = (long)TimeSpan.FromDays(2).TotalSeconds;
-            period = data.GetPeriod(Date(1)).Value;
-            Assert.Equal(Date(0), period.Start);
-            Assert.Equal(Date(2), period.End);
-            period = data.GetPeriod(Date(2)).Value;
-            Assert.Equal(Date(2), period.Start);
-            Assert.Equal(Date(4), period.End);
-            period = data.GetPeriod(Date(6)).Value;
-            Assert.Equal(Date(6), period.Start);
-            Assert.Equal(Date(7), period.End);
-            Assert.Null(data.GetPeriod(Date(7)));
-            Assert.Null(data.GetPeriod(Date(8)));
-            data.EndDate = null;
-            period = data.GetPeriod(Date(6)).Value;
-            Assert.Equal(Date(6), period.Start);
-            Assert.Equal(Date(8), period.End);
-            Assert.Null(data.GetPeriod(Date(-1)));
-        }
-
-        private DateTimeOffset Date(int days)
-        {
-            return new DateTimeOffset(1970, 1, 1, 0, 0, 0, TimeSpan.Zero) + TimeSpan.FromDays(days);
-        }
-
-        [Fact]
         public void CanDetectFileType()
         {
             Assert.True(FileTypeDetector.IsPicture(new byte[] { 0x42, 0x4D }, "test.bmp"));

--- a/BTCPayServer.Tests/GreenfieldAPITests.cs
+++ b/BTCPayServer.Tests/GreenfieldAPITests.cs
@@ -872,7 +872,6 @@ namespace BTCPayServer.Tests
             {
                 Assert.Equal("Test", result.Name);
                 Assert.Equal("Test description", result.Description);
-                Assert.Null(result.Period);
                 // If it contains ? it means that we are resolving an unknown route with the link generator
                 Assert.DoesNotContain("?", result.ViewLink);
                 Assert.False(result.Archived);

--- a/BTCPayServer/Controllers/GreenField/GreenfieldInvoiceController.cs
+++ b/BTCPayServer/Controllers/GreenField/GreenfieldInvoiceController.cs
@@ -567,7 +567,6 @@ namespace BTCPayServer.Controllers.Greenfield
                 Name = ppBlob.Name,
                 Description = ppBlob.Description,
                 Currency = ppBlob.Currency,
-                Period = ppBlob.Period,
                 Archived = pp.Archived,
                 AutoApproveClaims = ppBlob.AutoApproveClaims,
                 BOLT11Expiration = ppBlob.BOLT11Expiration,

--- a/BTCPayServer/Controllers/GreenField/GreenfieldPullPaymentController.cs
+++ b/BTCPayServer/Controllers/GreenField/GreenfieldPullPaymentController.cs
@@ -127,10 +127,6 @@ namespace BTCPayServer.Controllers.Greenfield
             {
                 ModelState.AddModelError(nameof(request.ExpiresAt), $"expiresAt should be higher than startAt");
             }
-            if (request.Period <= TimeSpan.Zero)
-            {
-                ModelState.AddModelError(nameof(request.Period), $"The period should be positive");
-            }
             if (request.BOLT11Expiration < TimeSpan.Zero)
             {
                 ModelState.AddModelError(nameof(request.BOLT11Expiration), $"The BOLT11 expiration should be positive");
@@ -162,7 +158,6 @@ namespace BTCPayServer.Controllers.Greenfield
             {
                 StartsAt = request.StartsAt,
                 ExpiresAt = request.ExpiresAt,
-                Period = request.Period,
                 BOLT11Expiration = request.BOLT11Expiration,
                 Name = request.Name,
                 Description = request.Description,
@@ -188,7 +183,6 @@ namespace BTCPayServer.Controllers.Greenfield
                 Name = ppBlob.Name,
                 Description = ppBlob.Description,
                 Currency = ppBlob.Currency,
-                Period = ppBlob.Period,
                 Archived = pp.Archived,
                 AutoApproveClaims = ppBlob.AutoApproveClaims,
                 BOLT11Expiration = ppBlob.BOLT11Expiration,

--- a/BTCPayServer/Controllers/UIPullPaymentController.cs
+++ b/BTCPayServer/Controllers/UIPullPaymentController.cs
@@ -86,7 +86,7 @@ namespace BTCPayServer.Controllers
                 return NotFound();
 
             var storeBlob = store.GetStoreBlob();
-            var payouts = (await ctx.Payouts.GetPayoutInPeriod(pp)
+            var payouts = (await ctx.Payouts.Where(p => p.PullPaymentDataId == pp.Id)
                     .OrderByDescending(o => o.Date)
                     .ToListAsync())
                 .Select(o => new

--- a/BTCPayServer/Data/PullPayments/PullPaymentBlob.cs
+++ b/BTCPayServer/Data/PullPayments/PullPaymentBlob.cs
@@ -19,8 +19,6 @@ namespace BTCPayServer.Data
         [JsonConverter(typeof(NumericStringJsonConverter))]
         public decimal MinimumClaim { get; set; }
         public PullPaymentView View { get; set; } = new PullPaymentView();
-        [JsonConverter(typeof(TimeSpanJsonConverter.Seconds))]
-        public TimeSpan? Period { get; set; }
 
         [DefaultValue(typeof(TimeSpan), "30.00:00:00")]
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]

--- a/BTCPayServer/Models/ViewPullPaymentModel.cs
+++ b/BTCPayServer/Models/ViewPullPaymentModel.cs
@@ -35,17 +35,16 @@ namespace BTCPayServer.Models
             ExpiryDate = data.EndDate is DateTimeOffset dt ? (DateTime?)dt.UtcDateTime : null;
             Email = blob.View.Email;
             MinimumClaim = blob.MinimumClaim;
-            IsPending = !data.IsExpired();
-            var period = data.GetPeriod(now);
+            IsPending = !data.IsExpired(now);
             if (data.Archived)
             {
                 Status = "Archived";
             }
-            else if (data.IsExpired())
+            else if (data.IsExpired(now))
             {
                 Status = "Expired";
             }
-            else if (period is null)
+            else if (!data.HasStarted(now))
             {
                 Status = "Not yet started";
             }
@@ -54,13 +53,10 @@ namespace BTCPayServer.Models
                 Status = string.Empty;
             }
 
-            ResetIn = string.Empty;
-            if (period?.End is DateTimeOffset pe)
+            EndsIn = string.Empty;
+            if (data.EndsIn(now) is TimeSpan e)
             {
-                var resetIn = (pe - DateTimeOffset.UtcNow);
-                if (resetIn < TimeSpan.Zero)
-                    resetIn = TimeSpan.Zero;
-                ResetIn = resetIn.TimeString();
+                EndsIn = e.TimeString();
             }
         }
 
@@ -76,7 +72,7 @@ namespace BTCPayServer.Models
         public string ResetDeepLink { get; set; }
 
         public string HubPath { get; set; }
-        public string ResetIn { get; set; }
+        public string EndsIn { get; set; }
         public string Email { get; set; }
         public string Status { get; set; }
         public bool IsPending { get; set; }

--- a/BTCPayServer/Models/WalletViewModels/PullPaymentsModel.cs
+++ b/BTCPayServer/Models/WalletViewModels/PullPaymentsModel.cs
@@ -20,7 +20,6 @@ namespace BTCPayServer.Models.WalletViewModels
                 public string CompletedFormatted { get; set; }
                 public string AwaitingFormatted { get; set; }
                 public string LimitFormatted { get; set; }
-                public string ResetIn { get; set; }
                 public string EndIn { get; set; }
                 public decimal Awaiting { get; set; }
                 public decimal Completed { get; set; }

--- a/BTCPayServer/Views/UIPullPayment/ViewPullPayment.cshtml
+++ b/BTCPayServer/Views/UIPullPayment/ViewPullPayment.cshtml
@@ -111,12 +111,12 @@
                                     <span class="fa fa-qrcode"></span> Show QR
                                 </button>
                             </div>
-                            @if (!string.IsNullOrEmpty(Model.ResetIn))
+                            @if (!string.IsNullOrEmpty(Model.EndsIn))
                             {
                                 <p>
-                                    <span class="text-muted text-nowrap">Reset in</span>
+                                    <span class="text-muted text-nowrap">Ends in</span>
                                     &nbsp;
-                                    <span class="text-nowrap">@Model.ResetIn</span>
+                                    <span class="text-nowrap">@Model.EndsIn</span>
                                 </p>
                             }
                             @if (!string.IsNullOrEmpty(Model.Description))

--- a/BTCPayServer/Views/UIStorePullPayments/PullPayments.cshtml
+++ b/BTCPayServer/Views/UIStorePullPayments/PullPayments.cshtml
@@ -87,11 +87,6 @@
             <span>Completed:&nbsp;<span class="float-end">@pp.Progress.CompletedFormatted</span></span>
             <br />
             <span>Limit:&nbsp;<span class="float-end">@pp.Progress.LimitFormatted</span></span>
-            @if (pp.Progress.ResetIn != null)
-            {
-                <br />
-                <span>Resets in:&nbsp;<span class="float-end">@pp.Progress.ResetIn</span></span>
-            }
             @if (pp.Progress.EndIn != null)
             {
                 <br />

--- a/BTCPayServer/wwwroot/swagger/v1/swagger.template.pull-payments.json
+++ b/BTCPayServer/wwwroot/swagger/v1/swagger.template.pull-payments.json
@@ -195,13 +195,6 @@
                                         "example": "BTC",
                                         "description": "The currency of the amount."
                                     },
-                                    "period": {
-                                        "type": "integer",
-                                        "format": "decimal",
-                                        "example": 604800,
-                                        "nullable": true,
-                                        "description": "The length of each period in seconds."
-                                    },
                                     "BOLT11Expiration": {
                                         "type": "string",
                                         "example": 30,
@@ -1178,12 +1171,6 @@
                         "format": "decimal",
                         "example": "1.12000000",
                         "description": "The amount in the currency of this pull payment as a decimal string"
-                    },
-                    "period": {
-                        "type": "integer",
-                        "example": 604800,
-                        "nullable": true,
-                        "description": "The length of each period in seconds"
                     },
                     "BOLT11Expiration": {
                         "type": "string",


### PR DESCRIPTION
Remove the concept of periodicity in Pull Payments (Part of https://github.com/btcpayserver/btcpayserver/issues/5899)

Pull Payments were meant to allow a freelance to get paid every month by giving the ability for the patron to setup a pull payment that reset every month.

This feature has never been exposed in the UI, never asked, and poorly tested. As such, let's remove it for BTCPay 2.0.