### PR TITLE
Remove dead code from multi db support

### DIFF
--- a/BTCPayServer.Data/Migrations/20230529135505_WebhookDeliveriesCleanup.cs
+++ b/BTCPayServer.Data/Migrations/20230529135505_WebhookDeliveriesCleanup.cs
@@ -17,62 +17,59 @@ namespace BTCPayServer.Migrations
     {
         protected override void Up(MigrationBuilder migrationBuilder)
         {
-            if (migrationBuilder.IsNpgsql())
+            migrationBuilder.Sql("DROP TABLE IF EXISTS \"InvoiceWebhookDeliveries\", \"WebhookDeliveries\";");
+
+            migrationBuilder.CreateTable(
+            name: "WebhookDeliveries",
+            columns: table => new
             {
-                migrationBuilder.Sql("DROP TABLE IF EXISTS \"InvoiceWebhookDeliveries\", \"WebhookDeliveries\";");
-
-                migrationBuilder.CreateTable(
-                name: "WebhookDeliveries",
-                columns: table => new
-                {
-                    Id = table.Column<string>(type: "TEXT", nullable: false),
-                    WebhookId = table.Column<string>(type: "TEXT", nullable: false),
-                    Timestamp = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
-                    Pruned = table.Column<bool>(type: "BOOLEAN", nullable: false),
-                    Blob = table.Column<string>(type: "JSONB", nullable: false)
-                },
-                constraints: table =>
-                {
-                    table.PrimaryKey("PK_WebhookDeliveries", x => x.Id);
-                    table.ForeignKey(
-                        name: "FK_WebhookDeliveries_Webhooks_WebhookId",
-                        column: x => x.WebhookId,
-                        principalTable: "Webhooks",
-                        principalColumn: "Id",
-                        onDelete: ReferentialAction.Cascade);
-                });
+                Id = table.Column<string>(type: "TEXT", nullable: false),
+                WebhookId = table.Column<string>(type: "TEXT", nullable: false),
+                Timestamp = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                Pruned = table.Column<bool>(type: "BOOLEAN", nullable: false),
+                Blob = table.Column<string>(type: "JSONB", nullable: false)
+            },
+            constraints: table =>
+            {
+                table.PrimaryKey("PK_WebhookDeliveries", x => x.Id);
+                table.ForeignKey(
+                    name: "FK_WebhookDeliveries_Webhooks_WebhookId",
+                    column: x => x.WebhookId,
+                    principalTable: "Webhooks",
+                    principalColumn: "Id",
+                    onDelete: ReferentialAction.Cascade);
+            });
 
 
-                migrationBuilder.CreateIndex(
-                    name: "IX_WebhookDeliveries_WebhookId",
-                    table: "WebhookDeliveries",
-                    column: "WebhookId");
-                migrationBuilder.Sql("CREATE INDEX \"IX_WebhookDeliveries_Timestamp\" ON \"WebhookDeliveries\"(\"Timestamp\") WHERE \"Pruned\" IS FALSE");
+            migrationBuilder.CreateIndex(
+                name: "IX_WebhookDeliveries_WebhookId",
+                table: "WebhookDeliveries",
+                column: "WebhookId");
+            migrationBuilder.Sql("CREATE INDEX \"IX_WebhookDeliveries_Timestamp\" ON \"WebhookDeliveries\"(\"Timestamp\") WHERE \"Pruned\" IS FALSE");
 
-                migrationBuilder.CreateTable(
-                name: "InvoiceWebhookDeliveries",
-                columns: table => new
-                {
-                    InvoiceId = table.Column<string>(type: "TEXT", nullable: false),
-                    DeliveryId = table.Column<string>(type: "TEXT", nullable: false)
-                },
-                constraints: table =>
-                {
-                    table.PrimaryKey("PK_InvoiceWebhookDeliveries", x => new { x.InvoiceId, x.DeliveryId });
-                    table.ForeignKey(
-                        name: "FK_InvoiceWebhookDeliveries_WebhookDeliveries_DeliveryId",
-                        column: x => x.DeliveryId,
-                        principalTable: "WebhookDeliveries",
-                        principalColumn: "Id",
-                        onDelete: ReferentialAction.Cascade);
-                    table.ForeignKey(
-                        name: "FK_InvoiceWebhookDeliveries_Invoices_InvoiceId",
-                        column: x => x.InvoiceId,
-                        principalTable: "Invoices",
-                        principalColumn: "Id",
-                        onDelete: ReferentialAction.Cascade);
-                });
-            }
+            migrationBuilder.CreateTable(
+            name: "InvoiceWebhookDeliveries",
+            columns: table => new
+            {
+                InvoiceId = table.Column<string>(type: "TEXT", nullable: false),
+                DeliveryId = table.Column<string>(type: "TEXT", nullable: false)
+            },
+            constraints: table =>
+            {
+                table.PrimaryKey("PK_InvoiceWebhookDeliveries", x => new { x.InvoiceId, x.DeliveryId });
+                table.ForeignKey(
+                    name: "FK_InvoiceWebhookDeliveries_WebhookDeliveries_DeliveryId",
+                    column: x => x.DeliveryId,
+                    principalTable: "WebhookDeliveries",
+                    principalColumn: "Id",
+                    onDelete: ReferentialAction.Cascade);
+                table.ForeignKey(
+                    name: "FK_InvoiceWebhookDeliveries_Invoices_InvoiceId",
+                    column: x => x.InvoiceId,
+                    principalTable: "Invoices",
+                    principalColumn: "Id",
+                    onDelete: ReferentialAction.Cascade);
+            });
         }
 
         protected override void Down(MigrationBuilder migrationBuilder)

--- a/BTCPayServer.Data/Migrations/20231121031609_removecurrentrefund.cs
+++ b/BTCPayServer.Data/Migrations/20231121031609_removecurrentrefund.cs
@@ -13,20 +13,17 @@ namespace BTCPayServer.Migrations
     {
         protected override void Up(MigrationBuilder migrationBuilder)
         {
-            if (migrationBuilder.IsNpgsql())
-            {
-                migrationBuilder.DropForeignKey(
-                    name: "FK_Invoices_Refunds_Id_CurrentRefundId",
-                    table: "Invoices");
+            migrationBuilder.DropForeignKey(
+                name: "FK_Invoices_Refunds_Id_CurrentRefundId",
+                table: "Invoices");
 
-                migrationBuilder.DropIndex(
-                    name: "IX_Invoices_Id_CurrentRefundId",
-                    table: "Invoices");
+            migrationBuilder.DropIndex(
+                name: "IX_Invoices_Id_CurrentRefundId",
+                table: "Invoices");
 
-                migrationBuilder.DropColumn(
-                    name: "CurrentRefundId",
-                    table: "Invoices");
-            }
+            migrationBuilder.DropColumn(
+                name: "CurrentRefundId",
+                table: "Invoices");
         }
 
         protected override void Down(MigrationBuilder migrationBuilder)

--- a/BTCPayServer.Data/Migrations/20231219031609_appssettingstojson.cs
+++ b/BTCPayServer.Data/Migrations/20231219031609_appssettingstojson.cs
@@ -13,10 +13,7 @@ namespace BTCPayServer.Migrations
     {
         protected override void Up(MigrationBuilder migrationBuilder)
         {
-            if (migrationBuilder.IsNpgsql())
-            {
-                migrationBuilder.Sql("ALTER TABLE \"Apps\" ALTER COLUMN \"Settings\" TYPE JSONB USING \"Settings\"::JSONB");
-            }
+            migrationBuilder.Sql("ALTER TABLE \"Apps\" ALTER COLUMN \"Settings\" TYPE JSONB USING \"Settings\"::JSONB");
         }
 
         protected override void Down(MigrationBuilder migrationBuilder)

--- a/BTCPayServer.Data/Migrations/20240220000000_FixWalletObjectsWithEmptyWalletId.cs
+++ b/BTCPayServer.Data/Migrations/20240220000000_FixWalletObjectsWithEmptyWalletId.cs
@@ -13,10 +13,7 @@ namespace BTCPayServer.Migrations
     {
         protected override void Up(MigrationBuilder migrationBuilder)
         {
-            if (migrationBuilder.IsNpgsql())
-            {
-                migrationBuilder.Sql("DELETE FROM \"WalletObjects\" WHERE \"WalletId\"='';");
-            }
+            migrationBuilder.Sql("DELETE FROM \"WalletObjects\" WHERE \"WalletId\"='';");
         }
 
         protected override void Down(MigrationBuilder migrationBuilder)

--- a/BTCPayServer.Data/Migrations/20240229000000_PayoutAndPullPaymentToJsonBlob.cs
+++ b/BTCPayServer.Data/Migrations/20240229000000_PayoutAndPullPaymentToJsonBlob.cs
@@ -13,12 +13,9 @@ namespace BTCPayServer.Migrations
     {
         protected override void Up(MigrationBuilder migrationBuilder)
         {
-            if (migrationBuilder.IsNpgsql())
-            {
-                migrationBuilder.Sql("ALTER TABLE \"Payouts\" ALTER COLUMN \"Blob\" TYPE JSONB USING regexp_replace(convert_from(\"Blob\",'UTF8'), '\\\\u0000', '', 'g')::JSONB");
-                migrationBuilder.Sql("ALTER TABLE \"Payouts\" ALTER COLUMN \"Proof\" TYPE JSONB USING regexp_replace(convert_from(\"Proof\",'UTF8'), '\\\\u0000', '', 'g')::JSONB");
-                migrationBuilder.Sql("ALTER TABLE \"PullPayments\" ALTER COLUMN \"Blob\" TYPE JSONB USING regexp_replace(convert_from(\"Blob\",'UTF8'), '\\\\u0000', '', 'g')::JSONB");
-            }
+            migrationBuilder.Sql("ALTER TABLE \"Payouts\" ALTER COLUMN \"Blob\" TYPE JSONB USING regexp_replace(convert_from(\"Blob\",'UTF8'), '\\\\u0000', '', 'g')::JSONB");
+            migrationBuilder.Sql("ALTER TABLE \"Payouts\" ALTER COLUMN \"Proof\" TYPE JSONB USING regexp_replace(convert_from(\"Proof\",'UTF8'), '\\\\u0000', '', 'g')::JSONB");
+            migrationBuilder.Sql("ALTER TABLE \"PullPayments\" ALTER COLUMN \"Blob\" TYPE JSONB USING regexp_replace(convert_from(\"Blob\",'UTF8'), '\\\\u0000', '', 'g')::JSONB");
         }
 
         protected override void Down(MigrationBuilder migrationBuilder)

--- a/BTCPayServer.Data/Migrations/20240229092905_AddManagerAndEmployeeToStoreRoles.cs
+++ b/BTCPayServer.Data/Migrations/20240229092905_AddManagerAndEmployeeToStoreRoles.cs
@@ -1,4 +1,4 @@
-﻿using BTCPayServer.Data;
+using BTCPayServer.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Migrations;
@@ -11,25 +11,17 @@ namespace BTCPayServer.Migrations
     [DbContext(typeof(ApplicationDbContext))]
     [Migration("20240229092905_AddManagerAndEmployeeToStoreRoles")]
     public partial class AddManagerAndEmployeeToStoreRoles : Migration
-    {
-        object GetPermissionsData(MigrationBuilder migrationBuilder, string[] permissions)
-        {
-            return migrationBuilder.IsNpgsql()
-                ? permissions
-                : JsonConvert.SerializeObject(permissions);
-        }
-        
+    {   
         protected override void Up(MigrationBuilder migrationBuilder)
         {
-            var permissionsType = migrationBuilder.IsNpgsql() ? "TEXT[]" : "TEXT";
             migrationBuilder.InsertData(
                 "StoreRoles",
                 columns: new[] { "Id", "Role", "Permissions" },
-                columnTypes: new[] { "TEXT", "TEXT", permissionsType },
+                columnTypes: new[] { "TEXT", "TEXT", "TEXT[]" },
                 values: new object[,]
                 {
                     {
-                        "Manager", "Manager", GetPermissionsData(migrationBuilder, new[]
+                        "Manager", "Manager", new[]
                         {
                             "btcpay.store.canviewstoresettings",
                             "btcpay.store.canmodifyinvoices",
@@ -37,17 +29,17 @@ namespace BTCPayServer.Migrations
                             "btcpay.store.canmodifypaymentrequests",
                             "btcpay.store.canmanagepullpayments",
                             "btcpay.store.canmanagepayouts"
-                        })
+                        }
                     },
                     {
-                        "Employee", "Employee", GetPermissionsData(migrationBuilder, new[]
+                        "Employee", "Employee", new[]
                         {
                             "btcpay.store.canmodifyinvoices",
                             "btcpay.store.canmodifypaymentrequests",
                             "btcpay.store.cancreatenonapprovedpullpayments",
                             "btcpay.store.canviewpayouts",
                             "btcpay.store.canviewpullpayments"
-                        })
+                        }
                     }
                 });
             
@@ -57,16 +49,16 @@ namespace BTCPayServer.Migrations
                 keyColumnTypes: new[] { "TEXT" },
                 keyValues: new[] { "Guest" },
                 columns: new[] { "Permissions" },
-                columnTypes: new[] { permissionsType },
+                columnTypes: new[] { "TEXT[]" },
                 values: new object[]
                 {
-                    GetPermissionsData(migrationBuilder, new[]
+                    new[]
                     {
                         "btcpay.store.canmodifyinvoices",
                         "btcpay.store.canviewpaymentrequests",
                         "btcpay.store.canviewpullpayments",
                         "btcpay.store.canviewpayouts"
-                    })
+                    }
                 });
         }
 
@@ -75,23 +67,22 @@ namespace BTCPayServer.Migrations
             migrationBuilder.DeleteData("StoreRoles", "Id", "Manager");
             migrationBuilder.DeleteData("StoreRoles", "Id", "Employee");
             
-            var permissionsType = migrationBuilder.IsNpgsql() ? "TEXT[]" : "TEXT";
             migrationBuilder.UpdateData(
                 "StoreRoles",
                 keyColumns: new[] { "Id" },
                 keyColumnTypes: new[] { "TEXT" },
                 keyValues: new[] { "Guest" },
                 columns: new[] { "Permissions" },
-                columnTypes: new[] { permissionsType },
+                columnTypes: new[] { "TEXT[]" },
                 values: new object[]
                 {
-                    GetPermissionsData(migrationBuilder, new[]
+                    new[]
                     {
                         "btcpay.store.canviewstoresettings",
                         "btcpay.store.canmodifyinvoices",
                         "btcpay.store.canviewcustodianaccounts",
                         "btcpay.store.candeposittocustodianaccount"
-                    })
+                    }
                 });
         }
     }

--- a/BTCPayServer.Data/Migrations/20240304003640_addinvoicecolumns.cs
+++ b/BTCPayServer.Data/Migrations/20240304003640_addinvoicecolumns.cs
@@ -18,7 +18,7 @@ namespace BTCPayServer.Migrations
             migrationBuilder.AddColumn<decimal>(
                 name: "Amount",
                 table: "Invoices",
-                type: migrationBuilder.IsNpgsql() ? "NUMERIC" : "TEXT",
+                type: "NUMERIC",
                 nullable: true);
 
             migrationBuilder.AddColumn<string>(

--- a/BTCPayServer.Data/Migrations/20240317024757_payments_refactor.cs
+++ b/BTCPayServer.Data/Migrations/20240317024757_payments_refactor.cs
@@ -18,7 +18,7 @@ namespace BTCPayServer.Migrations
             migrationBuilder.AddColumn<decimal>(
                 name: "Amount",
                 table: "Payments",
-                type: migrationBuilder.IsNpgsql() ? "NUMERIC" : "TEXT",
+                type: "NUMERIC",
                 nullable: true);
 
             migrationBuilder.AddColumn<DateTimeOffset>(
@@ -37,13 +37,11 @@ namespace BTCPayServer.Migrations
                 table: "Payments",
                 type: "TEXT",
                 nullable: true);
-            if (migrationBuilder.IsNpgsql())
-            {
-                migrationBuilder.AlterColumn<bool?>(
-                    name: "Accounted",
-                    table: "Payments",
-                    nullable: true);
-            }
+
+            migrationBuilder.AlterColumn<bool?>(
+                name: "Accounted",
+                table: "Payments",
+                nullable: true);
         }
 
         /// <inheritdoc />

--- a/BTCPayServer.Data/Migrations/20240405052858_cleanup_address_invoices.cs
+++ b/BTCPayServer.Data/Migrations/20240405052858_cleanup_address_invoices.cs
@@ -15,13 +15,10 @@ namespace BTCPayServer.Migrations
         /// <inheritdoc />
         protected override void Up(MigrationBuilder migrationBuilder)
         {
-            if (migrationBuilder.IsNpgsql())
-            {
-                migrationBuilder.Sql(@"
+            migrationBuilder.Sql(@"
 DELETE FROM ""AddressInvoices"" WHERE ""Address"" LIKE '%_LightningLike';
 ALTER TABLE ""AddressInvoices"" DROP COLUMN IF EXISTS ""CreatedTime"";
 VACUUM (FULL, ANALYZE) ""AddressInvoices"";", true);
-            }
         }
 
         /// <inheritdoc />

--- a/BTCPayServer/Hosting/MigrationStartupTask.cs
+++ b/BTCPayServer/Hosting/MigrationStartupTask.cs
@@ -196,12 +196,6 @@ namespace BTCPayServer.Hosting
                     settings.FileSystemStorageAsDefault = true;
                     await _Settings.UpdateSetting(settings);
                 }
-                if (!settings.FixSeqAfterSqliteMigration)
-                {
-                    await FixSeqAfterSqliteMigration();
-                    settings.FixSeqAfterSqliteMigration = true;
-                    await _Settings.UpdateSetting(settings);
-                }
                 if (!settings.FixMappedDomainAppType)
                 {
                     await FixMappedDomainAppType();
@@ -325,16 +319,6 @@ namespace BTCPayServer.Hosting
             }
             setting.Value = data.ToString();
             await ctx.SaveChangesAsync();
-        }
-
-
-        private async Task FixSeqAfterSqliteMigration()
-        {
-            await using var ctx = _DBContextFactory.CreateContext();
-            var state = await GetMigrationState(ctx);
-            if (state != "complete")
-                return;
-            await UpdateSequenceInvoiceSearch(ctx);
         }
         static async Task<string> GetMigrationState(ApplicationDbContext postgresContext)
         {

--- a/BTCPayServer/Services/MigrationSettings.cs
+++ b/BTCPayServer/Services/MigrationSettings.cs
@@ -28,7 +28,6 @@ namespace BTCPayServer.Services
         public bool MigrateEmailServerDisableTLSCerts { get; set; }
         public bool MigrateWalletColors { get; set; }
         public bool FileSystemStorageAsDefault { get; set; }
-        public bool FixSeqAfterSqliteMigration { get; set; }
         public bool FixMappedDomainAppType { get; set; }
         public bool MigrateAppYmlToJson { get; set; }
         public bool MigrateToStoreConfig { get; set; }


### PR DESCRIPTION
Remove `migrationBuilder.IsNpgsql()` conditionals, as we always support only postgres from 2.0.