### PR TITLE
Allow user to input a passphrase for Trezor v1 (Fix #5794)

### DIFF
--- a/BTCPayServer/Controllers/UIVaultController.cs
+++ b/BTCPayServer/Controllers/UIVaultController.cs
@@ -62,7 +62,11 @@ namespace BTCPayServer.Controllers
                 HDFingerprint? fingerprint = null;
                 string password = null;
                 var websocketHelper = new WebSocketHelper(websocket);
-
+                async Task FetchFingerprint()
+                {
+                    fingerprint = (await device.GetXPubAsync(new KeyPath("44'"), cancellationToken)).ExtPubKey.ParentFingerprint;
+                    device = new HwiDeviceClient(hwi, DeviceSelectors.FromFingerprint(fingerprint.Value), deviceEntry.Model, fingerprint) { Password = password };
+                }
                 async Task<bool> RequireDeviceUnlocking()
                 {
                     if (deviceEntry == null)
@@ -93,6 +97,13 @@ namespace BTCPayServer.Controllers
                             return true;
                         }
                     }
+                    if (IsTrezorOne(deviceEntry) && password is null)
+                    {
+                        fingerprint = null; // There will be a new fingerprint
+                        device = new HwiDeviceClient(hwi, DeviceSelectors.FromDeviceType("trezor", deviceEntry.Path), deviceEntry.Model, null);
+                        await websocketHelper.Send("{ \"error\": \"need-passphrase\"}", cancellationToken);
+                        return true;
+                    }
                     return false;
                 }
 
@@ -120,7 +131,7 @@ namespace BTCPayServer.Controllers
                                 }
                                 if (fingerprint is null)
                                 {
-                                    fingerprint = (await device.GetXPubAsync(new KeyPath("44'"), cancellationToken)).ExtPubKey.ParentFingerprint;
+                                    await FetchFingerprint();
                                 }
                                 await websocketHelper.Send("{ \"info\": \"ready\"}", cancellationToken);
                                 o = JObject.Parse(await websocketHelper.NextMessageAsync(cancellationToken));
@@ -213,14 +224,26 @@ namespace BTCPayServer.Controllers
                                 var factory = network.NBXplorerNetwork.DerivationStrategyFactory;
                                 if (fingerprint is null)
                                 {
-                                    fingerprint = (await device.GetXPubAsync(new KeyPath("44'"), cancellationToken)).ExtPubKey.ParentFingerprint;
+                                    await FetchFingerprint();
                                 }
                                 result["fingerprint"] = fingerprint.Value.ToString();
 
                                 DerivationStrategyBase strategy = null;
-                                KeyPath keyPath = null;
-                                BitcoinExtPubKey xpub = null;
 
+                                KeyPath keyPath = (addressType switch
+                                {
+                                    "taproot" => new KeyPath("86'"),
+                                    "segwit" => new KeyPath("84'"),
+                                    "segwitWrapped" => new KeyPath("49'"),
+                                    "legacy" => new KeyPath("44'"),
+                                    _ => null
+                                })?.Derive(network.CoinType).Derive(accountNumber, true);
+                                if (keyPath is null)
+                                {
+                                    await websocketHelper.Send("{ \"error\": \"invalid-addresstype\"}", cancellationToken);
+                                    continue;
+                                }
+                                BitcoinExtPubKey xpub = await device.GetXPubAsync(keyPath);
                                 if (!network.NBitcoinNetwork.Consensus.SupportSegwit && addressType != "legacy")
                                 {
                                     await websocketHelper.Send("{ \"error\": \"segwit-notsupported\"}", cancellationToken);
@@ -234,8 +257,6 @@ namespace BTCPayServer.Controllers
                                 }
                                 if (addressType == "taproot")
                                 {
-                                    keyPath = new KeyPath("86'").Derive(network.CoinType).Derive(accountNumber, true);
-                                    xpub = await device.GetXPubAsync(keyPath);
                                     strategy = factory.CreateDirectDerivationStrategy(xpub, new DerivationStrategyOptions()
                                     {
                                         ScriptPubKeyType = ScriptPubKeyType.TaprootBIP86
@@ -243,8 +264,6 @@ namespace BTCPayServer.Controllers
                                 }
                                 else if (addressType == "segwit")
                                 {
-                                    keyPath = new KeyPath("84'").Derive(network.CoinType).Derive(accountNumber, true);
-                                    xpub = await device.GetXPubAsync(keyPath);
                                     strategy = factory.CreateDirectDerivationStrategy(xpub, new DerivationStrategyOptions()
                                     {
                                         ScriptPubKeyType = ScriptPubKeyType.Segwit
@@ -252,8 +271,6 @@ namespace BTCPayServer.Controllers
                                 }
                                 else if (addressType == "segwitWrapped")
                                 {
-                                    keyPath = new KeyPath("49'").Derive(network.CoinType).Derive(accountNumber, true);
-                                    xpub = await device.GetXPubAsync(keyPath);
                                     strategy = factory.CreateDirectDerivationStrategy(xpub, new DerivationStrategyOptions()
                                     {
                                         ScriptPubKeyType = ScriptPubKeyType.SegwitP2SH
@@ -261,18 +278,12 @@ namespace BTCPayServer.Controllers
                                 }
                                 else if (addressType == "legacy")
                                 {
-                                    keyPath = new KeyPath("44'").Derive(network.CoinType).Derive(accountNumber, true);
-                                    xpub = await device.GetXPubAsync(keyPath);
                                     strategy = factory.CreateDirectDerivationStrategy(xpub, new DerivationStrategyOptions()
                                     {
                                         ScriptPubKeyType = ScriptPubKeyType.Legacy
                                     });
                                 }
-                                else
-                                {
-                                    await websocketHelper.Send("{ \"error\": \"invalid-addresstype\"}", cancellationToken);
-                                    continue;
-                                }
+
                                 result.Add(new JProperty("strategy", strategy.ToString()));
                                 result.Add(new JProperty("accountKey", xpub.ToString()));
                                 result.Add(new JProperty("keyPath", keyPath.ToString()));
@@ -317,7 +328,6 @@ askdevice:
                                 fingerprint = device.Fingerprint;
                                 JObject json = new JObject();
                                 json.Add("model", model);
-                                json.Add("fingerprint", device.Fingerprint?.ToString());
                                 await websocketHelper.Send(json.ToString(), cancellationToken);
                                 break;
                         }
@@ -387,6 +397,10 @@ askdevice:
         private static bool IsTrezorT(HwiEnumerateEntry deviceEntry)
         {
             return deviceEntry.Model.Contains("Trezor_T", StringComparison.OrdinalIgnoreCase);
+        }
+        private static bool IsTrezorOne(HwiEnumerateEntry deviceEntry)
+        {
+            return deviceEntry.Model.Contains("trezor_1", StringComparison.OrdinalIgnoreCase);
         }
 
         public StoreData CurrentStore

--- a/BTCPayServer/Views/Shared/VaultElements.cshtml
+++ b/BTCPayServer/Views/Shared/VaultElements.cshtml
@@ -41,8 +41,10 @@
     </div>
     <div id="passphrase-input" class="mt-4" style="display: none;">
         <div class="form-group">
-            <label for="Password" class="input-group-text"><span class="input-group-addon fa fa-lock"></span></label>
-            <input id="Password" type="password" class="form-control" placeholder="Passphrase" />
+			<div class="input-group">
+				<label for="Password" class="input-group-text"><span class="input-group-addon fa fa-lock"></span></label>
+				<input id="Password" type="password" class="form-control" placeholder="Passphrase (Leave empty if there isn't any passphrase)" />
+			</div>
         </div>
         <div class="form-group">
             <div class="input-group">

--- a/BTCPayServer/Views/UIStores/ImportWallet/ConfirmAddresses.cshtml
+++ b/BTCPayServer/Views/UIStores/ImportWallet/ConfirmAddresses.cshtml
@@ -47,6 +47,7 @@
         </form>
     </div>
 </template>
+
 <div id="btcpayservervault" class="modal fade" tabindex="-1" role="dialog" aria-labelledby="btcpayservervault" aria-hidden="true"></div>
 
 <form method="post" asp-controller="UIStores" asp-action="UpdateWallet" asp-route-storeId="@Model.StoreId" asp-route-cryptoCode="@Model.CryptoCode">
@@ -111,7 +112,6 @@
             document.querySelectorAll("[data-address]").forEach(link => {
                 link.addEventListener("click", async event => {
                     event.preventDefault();
-
                     const $link = event.currentTarget;
                     const address = JSON.parse($link.dataset.address);
                     const rootedKeyPath = JSON.parse($link.dataset.rootedKeyPath);
@@ -132,8 +132,9 @@
                         vaultUI.closeBridge();
                     });
 
-                    while (!await vaultUI.askForDevice()) {}
+                    $$modal.modal("show");
 
+                    while (!await vaultUI.askForDevice()) {}
                     await vaultUI.askForDisplayAddress(rootedKeyPath);
 
                     $$modal.modal("hide");

--- a/BTCPayServer/Views/UIStores/ImportWallet/Hardware.cshtml
+++ b/BTCPayServer/Views/UIStores/ImportWallet/Hardware.cshtml
@@ -1,7 +1,7 @@
 @model WalletSetupViewModel
 @{
-    Layout = "_LayoutWalletSetup";
-    ViewData.SetActivePage(StoreNavPages.OnchainSettings, "Connect your hardware wallet", Context.GetStoreData().Id);
+	Layout = "_LayoutWalletSetup";
+	ViewData.SetActivePage(StoreNavPages.OnchainSettings, "Connect your hardware wallet", Context.GetStoreData().Id);
 }
 
 @section Navbar {


### PR DESCRIPTION
We will now ask a passphrase when signing with a Trezor. This fix #5794.

This also fix `Show on device` link in the addresses confirmation step which wasn't showing the confirmation modal.

The UX isn't very good, it asks for the passphrase confirmation on the device 3 times in total during import, but there is nothing that can be done about it. 

Trezor One has no state, so every times we ask xpub it requires confirmation on the device. We need to ask the xpub two times to the device. Once to get the wallet fingerprint, and one for the actual xpub. And somehow, it seems there is a bug and the second time requires to push button two times on the device.