### PR TITLE
Fix: Error while connecting to websockets without reverse proxy

### DIFF
--- a/BTCPayServer/Controllers/UIInvoiceController.UI.cs
+++ b/BTCPayServer/Controllers/UIInvoiceController.UI.cs
@@ -1028,11 +1028,11 @@ namespace BTCPayServer.Controllers
             return Json(model);
         }
 
-        [HttpGet("i/{invoiceId}/status/ws")]
-        [HttpGet("i/{invoiceId}/{paymentMethodId}/status/ws")]
-        [HttpGet("invoice/{invoiceId}/status/ws")]
-        [HttpGet("invoice/{invoiceId}/{paymentMethodId}/status")]
-        [HttpGet("invoice/status/ws")]
+        [Route("i/{invoiceId}/status/ws")]
+        [Route("i/{invoiceId}/{paymentMethodId}/status/ws")]
+        [Route("invoice/{invoiceId}/status/ws")]
+        [Route("invoice/{invoiceId}/{paymentMethodId}/status")]
+        [Route("invoice/status/ws")]
         public async Task<IActionResult> GetStatusWebSocket(string invoiceId, CancellationToken cancellationToken)
         {
             if (!HttpContext.WebSockets.IsWebSocketRequest)

--- a/BTCPayServer/Controllers/UIPullPaymentController.Boltcard.cs
+++ b/BTCPayServer/Controllers/UIPullPaymentController.Boltcard.cs
@@ -46,7 +46,7 @@ namespace BTCPayServer.Controllers
             public record OtherIssuer() : CardOrigin;
             public record ThisIssuerReset(BoltcardRegistration Registration) : ThisIssuer(Registration);
         }
-        [HttpGet]
+
         [Route("pull-payments/{pullPaymentId}/nfc/bridge")]
         public async Task<IActionResult> VaultNFCBridgeConnection(string pullPaymentId)
         {

--- a/BTCPayServer/Controllers/UIVaultController.cs
+++ b/BTCPayServer/Controllers/UIVaultController.cs
@@ -34,8 +34,6 @@ namespace BTCPayServer.Controllers
             _authorizationService = authorizationService;
         }
 
-
-        [HttpGet]
         [Route("{cryptoCode}/xpub")]
         [Route("wallets/{walletId}/xpub")]
         public async Task<IActionResult> VaultBridgeConnection(string cryptoCode = null,


### PR DESCRIPTION
When not using a web proxy, modern browser connects to the server throught HTTP/2.

A bug prevented browsers to connect to some of websocket routes, especially:
* The websocket refreshing the state of the checkout page when the invoice's status change.
* The websocket used for BTCPay Server Vault integration (Boltcard and Hardware wallet related)