### PR TITLE
Remove Legacy Status from the code

### DIFF
--- a/BTCPayServer.Client/Models/InvoiceExceptionStatus.cs
+++ b/BTCPayServer.Client/Models/InvoiceExceptionStatus.cs
@@ -5,7 +5,6 @@ public enum InvoiceExceptionStatus
     PaidLate,
     PaidPartial,
     Marked,
-    Invalid,
     PaidOver
 }
 

--- a/BTCPayServer.Data/Data/InvoiceData.Migration.cs
+++ b/BTCPayServer.Data/Data/InvoiceData.Migration.cs
@@ -349,7 +349,24 @@ namespace BTCPayServer.Data
             if (blob["defaultPaymentMethod"] is not (null or { Type : JTokenType.Null }))
                 blob["defaultPaymentMethod"] = MigrationExtensions.MigratePaymentMethodId(blob["defaultPaymentMethod"].Value<string>());
             blob.Remove("derivationStrategies");
-
+            Status = Status switch
+            {
+                "new" => "New",
+                "paid" => "Processing",
+                "complete" or "confirmed" => "Settled",
+                "expired" => "Expired",
+                null or "invalid" => "Invalid",
+                _ => throw new NotSupportedException($"Unknown Status for invoice ({Status})")
+            };
+            ExceptionStatus = ExceptionStatus switch
+            {
+                "marked" => "Marked",
+                "paidLate" => "PaidLate",
+                "paidPartial" => "PaidPartial",
+                "paidOver" => "PaidOver",
+                null or "" => "",
+                _ => throw new NotSupportedException($"Unknown ExceptionStatus for invoice ({ExceptionStatus})")
+            };
             blob["version"] = 3;
             Blob2 = blob.ToString(Formatting.None);
         }

--- a/BTCPayServer.Rating/Services/RateProviderFactory.cs
+++ b/BTCPayServer.Rating/Services/RateProviderFactory.cs
@@ -3,14 +3,9 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
-using System.Security.Cryptography;
 using System.Threading;
 using System.Threading.Tasks;
 using BTCPayServer.Rating;
-using BTCPayServer.Rating.Providers;
-using ExchangeSharp;
-using NBitcoin;
-using Newtonsoft.Json.Linq;
 
 namespace BTCPayServer.Services.Rates
 {

--- a/BTCPayServer.Tests/AltcoinTests/AltcoinTests.cs
+++ b/BTCPayServer.Tests/AltcoinTests/AltcoinTests.cs
@@ -336,7 +336,7 @@ namespace BTCPayServer.Tests
                     Assert.Equal("paid", invoice.Status);
                     checkout = (Models.InvoicingModels.PaymentModel)((JsonResult)controller.GetStatus(invoice.Id)
                         .GetAwaiter().GetResult()).Value;
-                    Assert.Equal("paid", checkout.Status);
+                    Assert.Equal("Processing", checkout.Status);
                 });
             }
         }

--- a/BTCPayServer.Tests/PayJoinTests.cs
+++ b/BTCPayServer.Tests/PayJoinTests.cs
@@ -285,7 +285,7 @@ namespace BTCPayServer.Tests
             await TestUtils.EventuallyAsync(async () =>
             {
                 var invoice = await invoiceRepository.GetInvoice(invoiceId);
-                Assert.Equal(InvoiceStatusLegacy.Paid, invoice.Status);
+                Assert.Equal(InvoiceStatus.Processing, invoice.Status);
                 Assert.Equal(0.023m, invoice.Price);
             });
         }
@@ -344,7 +344,7 @@ namespace BTCPayServer.Tests
                 await TestUtils.EventuallyAsync(async () =>
                 {
                     var invoice = await s.Server.PayTester.GetService<InvoiceRepository>().GetInvoice(invoiceId);
-                    Assert.Equal(InvoiceStatusLegacy.Paid, invoice.Status);
+                    Assert.Equal(InvoiceStatus.Processing, invoice.Status);
                 });
 
                 s.SelectStoreContext(receiver.storeId);
@@ -396,7 +396,7 @@ namespace BTCPayServer.Tests
                 await TestUtils.EventuallyAsync(async () =>
                 {
                     var invoice = await s.Server.PayTester.GetService<InvoiceRepository>().GetInvoice(invoiceId);
-                    Assert.Equal(InvoiceStatusLegacy.Paid, invoice.Status);
+                    Assert.Equal(InvoiceStatus.Processing, invoice.Status);
                 });
                 s.GoToInvoices(receiver.storeId);
                 paymentValueRowColumn = s.Driver.FindElement(By.Id($"invoice_details_{invoiceId}"))
@@ -790,7 +790,7 @@ retry:
                 await TestUtils.EventuallyAsync(async () =>
                 {
                     var invoice = await tester.PayTester.GetService<InvoiceRepository>().GetInvoice(lastInvoiceId);
-                    Assert.Equal(InvoiceStatusLegacy.Paid, invoice.Status);
+                    Assert.Equal(InvoiceStatus.Processing, invoice.Status);
                     Assert.Equal(InvoiceExceptionStatus.None, invoice.ExceptionStatus);
                     var coins = await btcPayWallet.GetUnspentCoins(receiverUser.DerivationScheme);
                     foreach (var coin in coins)
@@ -1131,7 +1131,7 @@ retry:
                 await TestUtils.EventuallyAsync(async () =>
                 {
                     var invoiceEntity = await tester.PayTester.GetService<InvoiceRepository>().GetInvoice(invoice7.Id);
-                    Assert.Equal(InvoiceStatusLegacy.Paid, invoiceEntity.Status);
+                    Assert.Equal(InvoiceStatus.Processing, invoiceEntity.Status);
                     Assert.Contains(invoiceEntity.GetPayments(false), p => p.Accounted &&
                                                                       handler.ParsePaymentDetails(p.Details).PayjoinInformation is null);
                 });
@@ -1160,7 +1160,7 @@ retry:
                 await TestUtils.EventuallyAsync(async () =>
                 {
                     var invoiceEntity = await tester.PayTester.GetService<InvoiceRepository>().GetInvoice(invoice7.Id);
-                    Assert.Equal(InvoiceStatusLegacy.New, invoiceEntity.Status);
+                    Assert.Equal(InvoiceStatus.New, invoiceEntity.Status);
                     Assert.True(invoiceEntity.GetPayments(false).All(p => !p.Accounted));
                     ourOutpoint = invoiceEntity.GetAllBitcoinPaymentData(handler, false).First().PayjoinInformation.ContributedOutPoints[0];
                 });

--- a/BTCPayServer.Tests/PaymentRequestTests.cs
+++ b/BTCPayServer.Tests/PaymentRequestTests.cs
@@ -208,12 +208,12 @@ namespace BTCPayServer.Tests
                 pair => pair.Key == "Id" && pair.Value.ToString() == invoiceId);
 
             var invoice = user.BitPay.GetInvoice(invoiceId, Facade.Merchant);
-            Assert.Equal(InvoiceState.ToString(InvoiceStatusLegacy.New), invoice.Status);
+            Assert.Equal("new", invoice.Status);
             Assert.IsType<OkObjectResult>(await
                 paymentRequestController.CancelUnpaidPendingInvoice(paymentRequestId, false));
 
             invoice = user.BitPay.GetInvoice(invoiceId, Facade.Merchant);
-            Assert.Equal(InvoiceState.ToString(InvoiceStatusLegacy.Invalid), invoice.Status);
+            Assert.Equal("invalid", invoice.Status);
 
             Assert.IsType<BadRequestObjectResult>(await
                 paymentRequestController.CancelUnpaidPendingInvoice(paymentRequestId, false));

--- a/BTCPayServer.Tests/SeleniumTests.cs
+++ b/BTCPayServer.Tests/SeleniumTests.cs
@@ -2988,7 +2988,7 @@ namespace BTCPayServer.Tests
             await TestUtils.EventuallyAsync(async () =>
             {
                 var inv = await s.Server.PayTester.InvoiceRepository.GetInvoice(i);
-                Assert.Equal(InvoiceStatusLegacy.Complete, inv.Status);
+                Assert.Equal(InvoiceStatus.Settled, inv.Status);
             });
             var greenfield = await s.AsTestAccount().CreateClient();
             var paymentMethods = await greenfield.GetInvoicePaymentMethods(s.StoreId, i);
@@ -3110,7 +3110,7 @@ namespace BTCPayServer.Tests
             await TestUtils.EventuallyAsync(async () =>
             {
                 var inv = await s.Server.PayTester.InvoiceRepository.GetInvoice(invForPP);
-                Assert.Equal(InvoiceStatusLegacy.Complete, inv.Status);
+                Assert.Equal(InvoiceStatus.Settled, inv.Status);
 
                 await using var ctx = s.Server.PayTester.GetService<ApplicationDbContextFactory>().CreateContext();
                 var payoutsData = await ctx.Payouts.Where(p => p.PullPaymentDataId == pullPaymentId).ToListAsync();

--- a/BTCPayServer.Tests/UnitTest1.cs
+++ b/BTCPayServer.Tests/UnitTest1.cs
@@ -409,7 +409,7 @@ namespace BTCPayServer.Tests
             }, evt => evt.InvoiceId == invoice.Id);
 
             var fetchedInvoice = await tester.PayTester.InvoiceRepository.GetInvoice(evt.InvoiceId);
-            Assert.Contains(fetchedInvoice.Status, new[] { InvoiceStatusLegacy.Complete, InvoiceStatusLegacy.Confirmed });
+            Assert.Equal(fetchedInvoice.Status, InvoiceStatus.Settled);
             Assert.Equal(InvoiceExceptionStatus.None, fetchedInvoice.ExceptionStatus);
 
             //BTCPay will attempt to cancel previous bolt11 invoices so that there are less weird edge case scenarios
@@ -1018,7 +1018,7 @@ namespace BTCPayServer.Tests
             await TestUtils.EventuallyAsync(async () =>
             {
                 var i = await tester.PayTester.InvoiceRepository.GetInvoice(invoice2.Id);
-                Assert.Equal(InvoiceStatusLegacy.New, i.Status);
+                Assert.Equal(InvoiceStatus.New, i.Status);
                 Assert.Single(i.GetPayments(false));
                 Assert.False(i.GetPayments(false).First().Accounted);
             });

--- a/BTCPayServer/Components/InvoiceStatus/Default.cshtml
+++ b/BTCPayServer/Components/InvoiceStatus/Default.cshtml
@@ -6,7 +6,7 @@
 
 @{
     var state = Model.State.ToString();
-    var badgeClass = Model.State.Status.ToModernStatus().ToString().ToLower();
+    var badgeClass = Model.State.Status.ToString().ToLower();
     var canMark = !string.IsNullOrEmpty(Model.InvoiceId) && (Model.State.CanMarkComplete() || Model.State.CanMarkInvalid());
 }
 <div class="d-inline-flex align-items-center gap-2">

--- a/BTCPayServer/Controllers/GreenField/GreenfieldInvoiceController.cs
+++ b/BTCPayServer/Controllers/GreenField/GreenfieldInvoiceController.cs
@@ -670,7 +670,7 @@ namespace BTCPayServer.Controllers.Greenfield
                 Type = entity.Type,
                 Id = entity.Id,
                 CheckoutLink = request is null ? null : linkGenerator.CheckoutLink(entity.Id, request.Scheme, request.Host, request.PathBase),
-                Status = entity.Status.ToModernStatus(),
+                Status = entity.Status,
                 AdditionalStatus = entity.ExceptionStatus,
                 Currency = entity.Currency,
                 Archived = entity.Archived,

--- a/BTCPayServer/Controllers/GreenField/GreenfieldLightningNodeApiController.Store.cs
+++ b/BTCPayServer/Controllers/GreenField/GreenfieldLightningNodeApiController.Store.cs
@@ -13,7 +13,6 @@ using BTCPayServer.Payments;
 using BTCPayServer.Payments.Lightning;
 using BTCPayServer.Services;
 using BTCPayServer.Services.Invoices;
-using ExchangeSharp;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Cors;
 using Microsoft.AspNetCore.Mvc;

--- a/BTCPayServer/Controllers/UIInvoiceController.UI.cs
+++ b/BTCPayServer/Controllers/UIInvoiceController.UI.cs
@@ -150,8 +150,8 @@ namespace BTCPayServer.Controllers
                 HasRefund = invoice.Refunds.Any(),
                 CanRefund = invoiceState.CanRefund(),
                 Refunds = invoice.Refunds,
-                ShowCheckout = invoice.Status == InvoiceStatusLegacy.New,
-                ShowReceipt = invoice.Status.ToModernStatus() == InvoiceStatus.Settled && (invoice.ReceiptOptions?.Enabled ?? receipt.Enabled is true),
+                ShowCheckout = invoice.Status == InvoiceStatus.New,
+                ShowReceipt = invoice.Status == InvoiceStatus.Settled && (invoice.ReceiptOptions?.Enabled ?? receipt.Enabled is true),
                 Deliveries = (await _InvoiceRepository.GetWebhookDeliveries(invoiceId))
                                     .Select(c => new Models.StoreViewModels.DeliveryViewModel(c))
                                     .ToList()
@@ -215,7 +215,7 @@ namespace BTCPayServer.Controllers
                 InvoiceId = i.Id,
                 OrderId = i.Metadata?.OrderId,
                 OrderUrl = i.Metadata?.OrderUrl,
-                Status = i.Status.ToModernStatus(),
+                Status = i.Status,
                 Currency = i.Currency,
                 Timestamp = i.InvoiceTime,
                 StoreName = store.StoreName,
@@ -223,7 +223,7 @@ namespace BTCPayServer.Controllers
                 ReceiptOptions = receipt
             };
 
-            if (i.Status.ToModernStatus() != InvoiceStatus.Settled)
+            if (i.Status != InvoiceStatus.Settled)
             {
                 return View(vm);
             }
@@ -929,9 +929,7 @@ namespace BTCPayServer.Controllers
                     _ => null
                 },
                 ReceivedConfirmations = handler is BitcoinLikePaymentHandler  bh ? invoice.GetAllBitcoinPaymentData(bh, false).FirstOrDefault()?.ConfirmationCount : null,
-#pragma warning disable CS0618 // Type or member is obsolete
-                Status = invoice.StatusString,
-#pragma warning restore CS0618 // Type or member is obsolete
+                Status = invoice.Status.ToString(),
                 NetworkFee = prompt.PaymentMethodFee,
                 IsMultiCurrency = invoice.GetPayments(false).Select(p => p.PaymentMethodId).Concat(new[] { prompt.PaymentMethodId }).Distinct().Count() > 1,
                 StoreId = store.Id,
@@ -1038,7 +1036,7 @@ namespace BTCPayServer.Controllers
             if (!HttpContext.WebSockets.IsWebSocketRequest)
                 return NotFound();
             var invoice = await _InvoiceRepository.GetInvoice(invoiceId);
-            if (invoice == null || invoice.Status == InvoiceStatusLegacy.Complete || invoice.Status == InvoiceStatusLegacy.Invalid || invoice.Status == InvoiceStatusLegacy.Expired)
+            if (invoice == null || invoice.Status == InvoiceStatus.Settled || invoice.Status == InvoiceStatus.Invalid || invoice.Status == InvoiceStatus.Expired)
                 return NotFound();
             var webSocket = await HttpContext.WebSockets.AcceptWebSocketAsync();
             CompositeDisposable leases = new CompositeDisposable();
@@ -1138,7 +1136,7 @@ namespace BTCPayServer.Controllers
                 model.Invoices.Add(new InvoiceModel
                 {
                     Status = state,
-                    ShowCheckout = invoice.Status == InvoiceStatusLegacy.New,
+                    ShowCheckout = invoice.Status == InvoiceStatus.New,
                     Date = invoice.InvoiceTime,
                     InvoiceId = invoice.Id,
                     OrderId = invoice.Metadata.OrderId ?? string.Empty,
@@ -1322,12 +1320,12 @@ namespace BTCPayServer.Controllers
             if (newState == "invalid")
             {
                 await _InvoiceRepository.MarkInvoiceStatus(invoiceId, InvoiceStatus.Invalid);
-                model.StatusString = new InvoiceState(InvoiceStatusLegacy.Invalid, InvoiceExceptionStatus.Marked).ToString();
+                model.StatusString = new InvoiceState(InvoiceStatus.Invalid, InvoiceExceptionStatus.Marked).ToString();
             }
             else if (newState == "settled")
             {
                 await _InvoiceRepository.MarkInvoiceStatus(invoiceId, InvoiceStatus.Settled);
-                model.StatusString = new InvoiceState(InvoiceStatusLegacy.Complete, InvoiceExceptionStatus.Marked).ToString();
+                model.StatusString = new InvoiceState(InvoiceStatus.Settled, InvoiceExceptionStatus.Marked).ToString();
             }
 
             return Json(model);

--- a/BTCPayServer/Controllers/UIInvoiceController.cs
+++ b/BTCPayServer/Controllers/UIInvoiceController.cs
@@ -235,7 +235,7 @@ namespace BTCPayServer.Controllers
             }
 
             var getAppsTaggingStore = _InvoiceRepository.GetAppsTaggingStore(store.Id);
-            entity.Status = InvoiceStatusLegacy.New;
+            entity.Status = InvoiceStatus.New;
             entity.UpdateTotals();
 
 

--- a/BTCPayServer/Controllers/UILNURLController.cs
+++ b/BTCPayServer/Controllers/UILNURLController.cs
@@ -656,7 +656,7 @@ namespace BTCPayServer
             if (store is null)
                 return NotFound();
 
-            if (i.Status == InvoiceStatusLegacy.New)
+            if (i.Status == InvoiceStatus.New)
             {
                 var pmi = GetLNUrlPaymentMethodId(cryptoCode, store, out var lnurlSupportedPaymentMethod);
                 if (pmi is null)

--- a/BTCPayServer/Controllers/UIPaymentRequestController.cs
+++ b/BTCPayServer/Controllers/UIPaymentRequestController.cs
@@ -392,7 +392,7 @@ namespace BTCPayServer.Controllers
             }
 
             var invoices = result.Invoices.Where(requestInvoice =>
-                requestInvoice.State.Status == InvoiceStatusLegacy.New && !requestInvoice.Payments.Any());
+                requestInvoice.State.Status == InvoiceStatus.New && !requestInvoice.Payments.Any());
 
             if (!invoices.Any())
             {

--- a/BTCPayServer/Data/InvoiceDataExtensions.cs
+++ b/BTCPayServer/Data/InvoiceDataExtensions.cs
@@ -60,7 +60,7 @@ namespace BTCPayServer.Data
         }
         public static InvoiceState GetInvoiceState(this InvoiceData invoiceData)
         {
-            return new InvoiceState(invoiceData.Status ?? "new", invoiceData.ExceptionStatus);
+            return new InvoiceState(invoiceData.Status, invoiceData.ExceptionStatus);
         }
     }
 }

--- a/BTCPayServer/HostedServices/BitpayIPNSender.cs
+++ b/BTCPayServer/HostedServices/BitpayIPNSender.cs
@@ -5,6 +5,7 @@ using System.Net.Http;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using BTCPayServer.Client.Models;
 using BTCPayServer.Events;
 using BTCPayServer.Payments;
 using BTCPayServer.Services;
@@ -101,11 +102,11 @@ namespace BTCPayServer.HostedServices
             // So here, we just override the status expressed by the notification
             if (invoiceEvent.Name == InvoiceEvent.Confirmed)
             {
-                notification.Data.Status = InvoiceState.ToString(InvoiceStatusLegacy.Confirmed);
+                notification.Data.Status = "confirmed";
             }
             if (invoiceEvent.Name == InvoiceEvent.PaidInFull)
             {
-                notification.Data.Status = InvoiceState.ToString(InvoiceStatusLegacy.Paid);
+                notification.Data.Status = "paid";
             }
             //////////////////
 

--- a/BTCPayServer/HostedServices/Webhooks/InvoiceWebhookProvider.cs
+++ b/BTCPayServer/HostedServices/Webhooks/InvoiceWebhookProvider.cs
@@ -97,8 +97,8 @@ public class InvoiceWebhookProvider : WebhookProvider<InvoiceEvent>
                 return new WebhookInvoiceReceivedPaymentEvent(WebhookEventType.InvoiceReceivedPayment, storeId)
                 {
                     AfterExpiration =
-                        invoiceEvent.Invoice.Status.ToModernStatus() == InvoiceStatus.Expired ||
-                        invoiceEvent.Invoice.Status.ToModernStatus() == InvoiceStatus.Invalid,
+                        invoiceEvent.Invoice.Status == InvoiceStatus.Expired ||
+                        invoiceEvent.Invoice.Status == InvoiceStatus.Invalid,
                     PaymentMethodId = invoiceEvent.Payment.PaymentMethodId.ToString(),
                     Payment = GreenfieldInvoiceController.ToPaymentModel(invoiceEvent.Invoice, invoiceEvent.Payment),
                     StoreId = invoiceEvent.Invoice.StoreId
@@ -107,8 +107,8 @@ public class InvoiceWebhookProvider : WebhookProvider<InvoiceEvent>
                 return new WebhookInvoiceReceivedPaymentEvent(WebhookEventType.InvoicePaymentSettled, storeId)
                 {
                     AfterExpiration =
-                        invoiceEvent.Invoice.Status.ToModernStatus() == InvoiceStatus.Expired ||
-                        invoiceEvent.Invoice.Status.ToModernStatus() == InvoiceStatus.Invalid,
+                        invoiceEvent.Invoice.Status == InvoiceStatus.Expired ||
+                        invoiceEvent.Invoice.Status == InvoiceStatus.Invalid,
                     PaymentMethodId = invoiceEvent.Payment.PaymentMethodId.ToString(),
                     Payment = GreenfieldInvoiceController.ToPaymentModel(invoiceEvent.Invoice, invoiceEvent.Payment),
                     StoreId = invoiceEvent.Invoice.StoreId

--- a/BTCPayServer/Hosting/BTCPayServerServices.cs
+++ b/BTCPayServer/Hosting/BTCPayServerServices.cs
@@ -48,7 +48,6 @@ using BTCPayServer.Services.PaymentRequests;
 using BTCPayServer.Services.Rates;
 using BTCPayServer.Services.Stores;
 using BTCPayServer.Services.Wallets;
-using ExchangeSharp;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
@@ -71,6 +70,8 @@ using BTCPayServer.Services.WalletFileParsing;
 using BTCPayServer.Payments.LNURLPay;
 using System.Collections.Generic;
 using BTCPayServer.Payouts;
+using ExchangeSharp;
+
 
 
 
@@ -658,7 +659,7 @@ o.GetRequiredService<IEnumerable<IPaymentLinkExtension>>().ToDictionary(o => o.P
         {
             services.AddSingleton<TransactionLinkProviders.Entry>(new TransactionLinkProviders.Entry(cryptoCode, provider));
         }
-        public static void AddRateProviderExchangeSharp<T>(this IServiceCollection services, RateSourceInfo rateInfo) where T : ExchangeAPI
+        public static void AddRateProviderExchangeSharp<T>(this IServiceCollection services, RateSourceInfo rateInfo) where T : ExchangeSharp.ExchangeAPI
         {
             services.AddSingleton<IRateProvider, ExchangeSharpRateProvider<T>>(o =>
             {

--- a/BTCPayServer/Models/PaymentRequestViewModels/ListPaymentRequestsViewModel.cs
+++ b/BTCPayServer/Models/PaymentRequestViewModels/ListPaymentRequestsViewModel.cs
@@ -149,8 +149,8 @@ namespace BTCPayServer.Models.PaymentRequestViewModels
         {
             static HashSet<InvoiceState> stateAllowedToDisplay = new HashSet<InvoiceState>
                 {
-                    new InvoiceState(InvoiceStatusLegacy.New, InvoiceExceptionStatus.None),
-                    new InvoiceState(InvoiceStatusLegacy.New, InvoiceExceptionStatus.PaidPartial),
+                    new InvoiceState(InvoiceStatus.New, InvoiceExceptionStatus.None),
+                    new InvoiceState(InvoiceStatus.New, InvoiceExceptionStatus.PaidPartial),
                 };
             public InvoiceList()
             {
@@ -187,7 +187,6 @@ namespace BTCPayServer.Models.PaymentRequestViewModels
             public decimal Amount { get; set; }
             public string AmountFormatted { get; set; }
             public InvoiceState State { get; set; }
-            public InvoiceStatusLegacy Status { get; set; }
             public string StateFormatted { get; set; }
 
             public List<PaymentRequestInvoicePayment> Payments { get; set; }

--- a/BTCPayServer/PaymentRequest/PaymentRequestService.cs
+++ b/BTCPayServer/PaymentRequest/PaymentRequestService.cs
@@ -101,7 +101,7 @@ namespace BTCPayServer.PaymentRequest
             var paymentStats = _invoiceRepository.GetContributionsByPaymentMethodId(blob.Currency, invoices, true);
             var amountDue = blob.Amount - paymentStats.TotalCurrency;
             var pendingInvoice = invoices.OrderByDescending(entity => entity.InvoiceTime)
-                .FirstOrDefault(entity => entity.Status == InvoiceStatusLegacy.New);
+                .FirstOrDefault(entity => entity.Status == InvoiceStatus.New);
             
             return new ViewPaymentRequestViewModel(pr)
             {
@@ -123,8 +123,8 @@ namespace BTCPayServer.PaymentRequest
                     var state = entity.GetInvoiceState();
                     var payments = ViewPaymentRequestViewModel.PaymentRequestInvoicePayment.GetViewModels(entity, _displayFormatter, _transactionLinkProviders, _handlers);
 
-                    if (state.Status == InvoiceStatusLegacy.Invalid ||
-                        state.Status == InvoiceStatusLegacy.Expired && !payments.Any())
+                    if (state.Status == InvoiceStatus.Invalid ||
+                        state.Status == InvoiceStatus.Expired && !payments.Any())
                         return null;
 
                     return new ViewPaymentRequestViewModel.PaymentRequestInvoice

--- a/BTCPayServer/Payments/Lightning/LightningListener.cs
+++ b/BTCPayServer/Payments/Lightning/LightningListener.cs
@@ -202,7 +202,7 @@ retry:
                     _CheckInvoices.Writer.TryWrite(inv.Invoice.Id);
                 }
 
-                if (inv.Name == InvoiceEvent.ReceivedPayment && inv.Invoice.Status == InvoiceStatusLegacy.New && inv.Invoice.ExceptionStatus == InvoiceExceptionStatus.PaidPartial)
+                if (inv.Name == InvoiceEvent.ReceivedPayment && inv.Invoice.Status == InvoiceStatus.New && inv.Invoice.ExceptionStatus == InvoiceExceptionStatus.PaidPartial)
                 {
                     var pm = inv.Invoice.GetPaymentPrompts().First();
                     if (pm.Calculate().Due > 0m)
@@ -213,7 +213,7 @@ retry:
             }));
             leases.Add(_Aggregator.SubscribeAsync<Events.InvoiceDataChangedEvent>(async inv =>
             {
-                if (inv.State.Status == InvoiceStatusLegacy.New &&
+                if (inv.State.Status == InvoiceStatus.New &&
                     inv.State.ExceptionStatus == InvoiceExceptionStatus.PaidPartial)
                 {
                     var invoice = await _InvoiceRepository.GetInvoice(inv.InvoiceId);

--- a/BTCPayServer/Plugins/Crowdfund/CrowdfundPlugin.cs
+++ b/BTCPayServer/Plugins/Crowdfund/CrowdfundPlugin.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using BTCPayServer.Abstractions.Contracts;
 using BTCPayServer.Abstractions.Models;
 using BTCPayServer.Abstractions.Services;
+using BTCPayServer.Client.Models;
 using BTCPayServer.Configuration;
 using BTCPayServer.Data;
 using BTCPayServer.Models;
@@ -113,10 +114,10 @@ namespace BTCPayServer.Plugins.Crowdfund
         public override async Task<object?> GetInfo(AppData appData)
         {
             var settings = appData.GetSettings<CrowdfundSettings>();
-            var resetEvery = settings.StartDate.HasValue ? settings.ResetEvery : CrowdfundResetEvery.Never;
+            var resetEvery = settings.StartDate.HasValue ? settings.ResetEvery : Services.Apps.CrowdfundResetEvery.Never;
             DateTime? lastResetDate = null;
             DateTime? nextResetDate = null;
-            if (resetEvery != CrowdfundResetEvery.Never && settings.StartDate is not null)
+            if (resetEvery != Services.Apps.CrowdfundResetEvery.Never && settings.StartDate is not null)
             {
                 lastResetDate = settings.StartDate.Value;
 
@@ -126,16 +127,16 @@ namespace BTCPayServer.Plugins.Crowdfund
                     lastResetDate = nextResetDate;
                     switch (resetEvery)
                     {
-                        case CrowdfundResetEvery.Hour:
+                        case Services.Apps.CrowdfundResetEvery.Hour:
                             nextResetDate = lastResetDate.Value.AddHours(settings.ResetEveryAmount);
                             break;
-                        case CrowdfundResetEvery.Day:
+                        case Services.Apps.CrowdfundResetEvery.Day:
                             nextResetDate = lastResetDate.Value.AddDays(settings.ResetEveryAmount);
                             break;
-                        case CrowdfundResetEvery.Month:
+                        case Services.Apps.CrowdfundResetEvery.Month:
                             nextResetDate = lastResetDate.Value.AddMonths(settings.ResetEveryAmount);
                             break;
-                        case CrowdfundResetEvery.Year:
+                        case Services.Apps.CrowdfundResetEvery.Year:
                             nextResetDate = lastResetDate.Value.AddYears(settings.ResetEveryAmount);
                             break;
                     }
@@ -206,11 +207,11 @@ namespace BTCPayServer.Plugins.Crowdfund
                 DisqusShortname = settings.DisqusShortname,
                 AnimationsEnabled = settings.AnimationsEnabled,
                 ResetEveryAmount = settings.ResetEveryAmount,
-                ResetEvery = Enum.GetName(typeof(CrowdfundResetEvery), settings.ResetEvery),
+                ResetEvery = Enum.GetName(typeof(Services.Apps.CrowdfundResetEvery), settings.ResetEvery),
                 DisplayPerksRanking = settings.DisplayPerksRanking,
                 PerkCount = perkCount,
                 PerkValue = perkValue,
-                NeverReset = settings.ResetEvery == CrowdfundResetEvery.Never,
+                NeverReset = settings.ResetEvery == Services.Apps.CrowdfundResetEvery.Never,
                 FormUrl = formUrl,
                 Sounds = settings.Sounds,
                 AnimationColors = settings.AnimationColors,
@@ -264,17 +265,17 @@ namespace BTCPayServer.Plugins.Crowdfund
 
         private static bool IsPaid(InvoiceEntity entity)
         {
-            return entity.Status == InvoiceStatusLegacy.Complete || entity.Status == InvoiceStatusLegacy.Confirmed || entity.Status == InvoiceStatusLegacy.Paid;
+            return entity.Status == InvoiceStatus.Settled || entity.Status == InvoiceStatus.Processing;
         }
 
         private static bool IsPending(InvoiceEntity entity)
         {
-            return !(entity.Status == InvoiceStatusLegacy.Complete || entity.Status == InvoiceStatusLegacy.Confirmed);
+            return entity.Status != InvoiceStatus.Settled;
         }
 
         private static bool IsComplete(InvoiceEntity entity)
         {
-            return entity.Status == InvoiceStatusLegacy.Complete || entity.Status == InvoiceStatusLegacy.Confirmed;
+            return entity.Status == InvoiceStatus.Settled;
         }
     }
 }

--- a/BTCPayServer/Plugins/NFC/NFCController.cs
+++ b/BTCPayServer/Plugins/NFC/NFCController.cs
@@ -48,7 +48,7 @@ namespace BTCPayServer.Plugins.NFC
         public async Task<IActionResult> SubmitLNURLWithdrawForInvoice([FromBody] SubmitRequest request)
         {
             var invoice = await _invoiceRepository.GetInvoice(request.InvoiceId);
-            if (invoice?.Status is not InvoiceStatusLegacy.New)
+            if (invoice?.Status is not InvoiceStatus.New)
             {
                 return NotFound();
             }

--- a/BTCPayServer/Plugins/PluginBuilderClient.cs
+++ b/BTCPayServer/Plugins/PluginBuilderClient.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Net.Http;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
-using ExchangeSharp;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using static System.Net.WebRequestMethods;

--- a/BTCPayServer/Plugins/PointOfSale/Controllers/UIPointOfSaleController.cs
+++ b/BTCPayServer/Plugins/PointOfSale/Controllers/UIPointOfSaleController.cs
@@ -539,15 +539,7 @@ namespace BTCPayServer.Plugins.PointOfSale.Controllers
                 return NotFound();
 
             var from = DateTimeOffset.UtcNow - TimeSpan.FromDays(3);
-            var invoices = await AppService.GetInvoicesForApp(_invoiceRepository, app, from, new[]
-                {
-                    InvoiceState.ToString(InvoiceStatusLegacy.New),
-                    InvoiceState.ToString(InvoiceStatusLegacy.Paid),
-                    InvoiceState.ToString(InvoiceStatusLegacy.Confirmed),
-                    InvoiceState.ToString(InvoiceStatusLegacy.Complete),
-                    InvoiceState.ToString(InvoiceStatusLegacy.Expired),
-                    InvoiceState.ToString(InvoiceStatusLegacy.Invalid)
-                });
+            var invoices = await AppService.GetInvoicesForApp(_invoiceRepository, app, from);
             var recent = invoices
                 .Take(10)
                 .Select(i => new JObject
@@ -555,7 +547,7 @@ namespace BTCPayServer.Plugins.PointOfSale.Controllers
                     ["id"] = i.Id,
                     ["date"] = i.InvoiceTime,
                     ["price"] = _displayFormatter.Currency(i.Price, i.Currency, DisplayFormatter.CurrencyFormat.Symbol),
-                    ["status"] = i.GetInvoiceState().Status.ToModernStatus().ToString(),
+                    ["status"] = i.GetInvoiceState().Status.ToString(),
                     ["url"] = Url.Action(nameof(UIInvoiceController.Invoice), "UIInvoice", new { invoiceId = i.Id })
                 });
             return Json(recent);

--- a/BTCPayServer/Plugins/Shopify/ShopifyOrderMarkerHostedService.cs
+++ b/BTCPayServer/Plugins/Shopify/ShopifyOrderMarkerHostedService.cs
@@ -50,15 +50,14 @@ namespace BTCPayServer.Plugins.Shopify
                 var shopifyOrderId = invoice.GetInternalTags(SHOPIFY_ORDER_ID_PREFIX).FirstOrDefault();
                 if (shopifyOrderId != null)
                 {
-                    if (new[] { InvoiceStatusLegacy.Invalid, InvoiceStatusLegacy.Expired }.Contains(invoice.GetInvoiceState()
+                    if (new[] { InvoiceStatus.Invalid, InvoiceStatus.Expired }.Contains(invoice.GetInvoiceState()
                         .Status) && invoice.ExceptionStatus != InvoiceExceptionStatus.None)
                     {
                         //you have failed us, customer
 
                         await RegisterTransaction(invoice, shopifyOrderId, false);
                     }
-                    else if (new[] { InvoiceStatusLegacy.Complete, InvoiceStatusLegacy.Confirmed }.Contains(
-                        invoice.Status))
+                    else if (invoice.Status == InvoiceStatus.Settled)
                     {
                         await RegisterTransaction(invoice, shopifyOrderId, true);
                     }

--- a/BTCPayServer/Plugins/Shopify/UIShopifyController.cs
+++ b/BTCPayServer/Plugins/Shopify/UIShopifyController.cs
@@ -119,7 +119,7 @@ namespace BTCPayServer.Plugins.Shopify
 
             var firstInvoiceStillPending =
                 matchedExistingInvoices.FirstOrDefault(entity =>
-                    entity.GetInvoiceState().Status == InvoiceStatusLegacy.New);
+                    entity.GetInvoiceState().Status == InvoiceStatus.New);
             if (firstInvoiceStillPending != null)
             {
                 return Ok(new
@@ -131,7 +131,7 @@ namespace BTCPayServer.Plugins.Shopify
 
             var firstInvoiceSettled =
                 matchedExistingInvoices.LastOrDefault(entity =>
-                    new[] { InvoiceStatusLegacy.Paid, InvoiceStatusLegacy.Complete, InvoiceStatusLegacy.Confirmed }
+                    new[] { InvoiceStatus.Processing, InvoiceStatus.Settled }
                         .Contains(
                             entity.GetInvoiceState().Status));
 
@@ -153,7 +153,7 @@ namespace BTCPayServer.Plugins.Shopify
             {
                 //if BTCPay was shut down before the tx managed to get registered on shopify, this will fix it on the next UI load in shopify
                 if (client != null && order?.FinancialStatus == "pending" &&
-                    firstInvoiceSettled.Status != InvoiceStatusLegacy.Paid)
+                    firstInvoiceSettled.Status != InvoiceStatus.Processing)
                 {
                     await new OrderTransactionRegisterLogic(client).Process(orderId, firstInvoiceSettled.Id,
                         firstInvoiceSettled.Currency,

--- a/BTCPayServer/Services/Apps/AppService.cs
+++ b/BTCPayServer/Services/Apps/AppService.cs
@@ -7,6 +7,7 @@ using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using BTCPayServer.Client;
+using BTCPayServer.Client.Models;
 using BTCPayServer.Data;
 using BTCPayServer.Models.AppViewModels;
 using BTCPayServer.Plugins.Crowdfund;
@@ -93,9 +94,8 @@ namespace BTCPayServer.Services.Apps
             var paidInvoices = await GetInvoicesForApp(_InvoiceRepository, appData,
                 null, new[]
                 {
-                    InvoiceState.ToString(InvoiceStatusLegacy.Paid),
-                    InvoiceState.ToString(InvoiceStatusLegacy.Confirmed),
-                    InvoiceState.ToString(InvoiceStatusLegacy.Complete)
+                    InvoiceStatus.Processing.ToString(),
+                    InvoiceStatus.Settled.ToString()
                 });
             return await salesType.GetItemStats(appData, paidInvoices);
         }
@@ -141,9 +141,8 @@ namespace BTCPayServer.Services.Apps
             var paidInvoices = await GetInvoicesForApp(_InvoiceRepository, app, DateTimeOffset.UtcNow - TimeSpan.FromDays(numberOfDays),
                 new[]
                 {
-                    InvoiceState.ToString(InvoiceStatusLegacy.Paid),
-                    InvoiceState.ToString(InvoiceStatusLegacy.Confirmed),
-                    InvoiceState.ToString(InvoiceStatusLegacy.Complete)
+                    InvoiceStatus.Processing.ToString(),
+                    InvoiceStatus.Settled.ToString()
                 });
 
             return await salesType.GetSalesStats(app, paidInvoices, numberOfDays);
@@ -185,7 +184,7 @@ namespace BTCPayServer.Services.Apps
                 {
                     res.Add(new InvoiceStatsItem
                     {
-                        ItemCode = e.Metadata.ItemCode ?? typeof(PosViewType).DisplayName(PosViewType.Light.ToString()),
+                        ItemCode = e.Metadata.ItemCode ?? typeof(Plugins.PointOfSale.PosViewType).DisplayName(Plugins.PointOfSale.PosViewType.Light.ToString()),
                         FiatPrice = e.PaidAmount.Net,
                         Date = e.InvoiceTime.Date
                     });
@@ -220,11 +219,7 @@ namespace BTCPayServer.Services.Apps
             {
                 StoreId = new[] { appData.StoreDataId },
                 TextSearch = appData.TagAllInvoices ? null : GetAppSearchTerm(appData),
-                Status = status ?? new[]{
-                    InvoiceState.ToString(InvoiceStatusLegacy.New),
-                    InvoiceState.ToString(InvoiceStatusLegacy.Paid),
-                    InvoiceState.ToString(InvoiceStatusLegacy.Confirmed),
-                    InvoiceState.ToString(InvoiceStatusLegacy.Complete)},
+                Status = status,
                 StartDate = startDate
             });
 
@@ -297,8 +292,8 @@ namespace BTCPayServer.Services.Apps
             {
                 case PointOfSaleAppType.AppType:
                     var settings = app.GetSettings<PointOfSaleSettings>();
-                    string posViewStyle = (settings.EnableShoppingCart ? PosViewType.Cart : settings.DefaultView).ToString();
-                    style = typeof(PosViewType).DisplayName(posViewStyle);
+                    string posViewStyle = (settings.EnableShoppingCart ? Plugins.PointOfSale.PosViewType.Cart : settings.DefaultView).ToString();
+                    style = typeof(Plugins.PointOfSale.PosViewType).DisplayName(posViewStyle);
                     break;
 
                 default:

--- a/BTCPayServer/Services/Fees/MempoolSpaceFeeProvider.cs
+++ b/BTCPayServer/Services/Fees/MempoolSpaceFeeProvider.cs
@@ -7,8 +7,6 @@ using System.Runtime.InteropServices;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
-using AngleSharp.Dom;
-using ExchangeSharp;
 using Microsoft.Extensions.Caching.Memory;
 using NBitcoin;
 using Org.BouncyCastle.Asn1.X509;

--- a/BTCPayServer/Services/InvoiceActivator.cs
+++ b/BTCPayServer/Services/InvoiceActivator.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Linq;
 using System.Threading.Tasks;
+using BTCPayServer.Client.Models;
 using BTCPayServer.Data;
 using BTCPayServer.Events;
 using BTCPayServer.Logging;
@@ -40,7 +41,7 @@ namespace BTCPayServer.Services
         public async Task<bool> ActivateInvoicePaymentMethod(string invoiceId, PaymentMethodId paymentMethodId, bool forceNew = false)
         {
             var invoice = await _invoiceRepository.GetInvoice(invoiceId);
-            if (invoice?.GetInvoiceState().Status is not InvoiceStatusLegacy.New)
+            if (invoice?.GetInvoiceState().Status is not InvoiceStatus.New)
                 return false;
             var store = await _storeRepository.FindStore(invoice.StoreId);
             if (store is null)

--- a/BTCPayServer/Services/Reporting/LegacyInvoiceExportReportProvider.cs
+++ b/BTCPayServer/Services/Reporting/LegacyInvoiceExportReportProvider.cs
@@ -95,8 +95,8 @@ public class LegacyInvoiceExportReportProvider : ReportProvider
                     data.Add(invoiceEntity.Metadata.ItemDesc);
                     data.Add(invoiceEntity.GetInvoiceState().ToString());
 #pragma warning disable CS0618 // Type or member is obsolete
-                    data.Add(invoiceEntity.StatusString);
-                    data.Add(invoiceEntity.ExceptionStatusString);
+                    data.Add(invoiceEntity.Status.ToLegacyStatusString());
+                    data.Add(invoiceEntity.ExceptionStatus.ToLegacyExceptionStatusString());
 #pragma warning restore CS0618 // Type or member is obsolete
                     data.Add(invoiceEntity.Metadata.BuyerEmail);
                     data.Add(payment.Accounted);
@@ -128,10 +128,8 @@ public class LegacyInvoiceExportReportProvider : ReportProvider
                 data.Add(invoiceEntity.Metadata.ItemCode);
                 data.Add(invoiceEntity.Metadata.ItemDesc);
                 data.Add(invoiceEntity.GetInvoiceState().ToString());
-#pragma warning disable CS0618 // Type or member is obsolete
-                data.Add(invoiceEntity.StatusString);
-                data.Add(invoiceEntity.ExceptionStatusString);
-#pragma warning restore CS0618 // Type or member is obsolete
+                data.Add(invoiceEntity.Status.ToLegacyStatusString());
+                data.Add(invoiceEntity.ExceptionStatus.ToLegacyExceptionStatusString());
                 data.Add(invoiceEntity.Metadata.BuyerEmail);
                 data.Add(null); // Accounted
             }

--- a/BTCPayServer/Services/Reporting/ProductsReportProvider.cs
+++ b/BTCPayServer/Services/Reporting/ProductsReportProvider.cs
@@ -42,7 +42,7 @@ public class ProductsReportProvider : ReportProvider
             var values = queryContext.CreateData();
             values.Add(i.InvoiceTime);
             values.Add(i.Id);
-            var status = i.Status.ToModernStatus();
+            var status = i.Status;
             if (status == Client.Models.InvoiceStatus.Expired && i.ExceptionStatus == Client.Models.InvoiceExceptionStatus.None)
                 continue;
             values.Add(status.ToString());

--- a/BTCPayServer/VaultClient.cs
+++ b/BTCPayServer/VaultClient.cs
@@ -5,7 +5,6 @@ using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Amazon.S3.Model.Internal.MarshallTransformations;
-using ExchangeSharp;
 using Newtonsoft.Json.Linq;
 
 namespace BTCPayServer

--- a/BTCPayServer/Views/UIPaymentRequest/ViewPaymentRequest.cshtml
+++ b/BTCPayServer/Views/UIPaymentRequest/ViewPaymentRequest.cshtml
@@ -11,7 +11,7 @@
 	Layout = null;
     string StatusClass(InvoiceState state)
     {
-        var status = state.Status.ToModernStatus();
+        var status = state.Status;
         switch (status)
         {
             case InvoiceStatus.Expired:

--- a/BTCPayServer/wwwroot/checkout/checkout.js
+++ b/BTCPayServer/wwwroot/checkout/checkout.js
@@ -1,8 +1,8 @@
 // These are the legacy states, see InvoiceEntity
-const STATUS_PAYABLE = ['new'];
-const STATUS_PAID = ['paid'];
-const STATUS_SETTLED = ['complete', 'confirmed'];
-const STATUS_INVALID =  ['expired', 'invalid'];
+const STATUS_PAYABLE = ['New'];
+const STATUS_PAID = ['Processing'];
+const STATUS_SETTLED = ['Settled'];
+const STATUS_INVALID =  ['Expired', 'Invalid'];
 const urlParams = new URLSearchParams(window.location.search);
 
 class NDEFReaderWrapper {

--- a/BTCPayServer/wwwroot/shopify/btcpay-shopify.js
+++ b/BTCPayServer/wwwroot/shopify/btcpay-shopify.js
@@ -101,7 +101,7 @@ window.BTCPayShopifyIntegrationModule = function () {
             }
             return;
         }
-        if (["complete", "confirmed", "paid"].indexOf(currentInvoiceData.status.toLowerCase()) >= 0) {
+        if (["settled", "processing"].indexOf(currentInvoiceData.status.toLowerCase()) >= 0) {
             setOrderAsPaid();
         } else if (["invalid", "expired"].indexOf(currentInvoiceData.status.toLowerCase()) >= 0) {
             fail();


### PR DESCRIPTION
We were keeping the logic with legacy bitpay status all around the code. This remove all of that.

## Breaking Changes

* When the Checkout is in modal mode, it posts the message ` { invoiceId, status }` to the parent window. Previously, the status could be `new`, `paid` `complete`, `invalid`, `expired` state. These have been replaced by `New`, `Processing`, `Settled`, `Invalid`, `Expired`.