### PR TITLE
Search: Display text filters in search input

### DIFF
--- a/BTCPayServer.Tests/FastTests.cs
+++ b/BTCPayServer.Tests/FastTests.cs
@@ -1299,17 +1299,22 @@ bc1qfzu57kgu5jthl934f9xrdzzx8mmemx7gn07tf0grnvz504j6kzusu2v0ku
 
             filter = "status:abed, status:abed2";
             search = new SearchString(filter);
-            Assert.Equal("", search.TextSearch);
+            Assert.Null(search.TextSearch);
+            Assert.Null(search.TextFilters);
             Assert.Equal("status:abed, status:abed2", search.ToString());
             Assert.Throws<KeyNotFoundException>(() => search.Filters["test"]);
             Assert.Equal(2, search.Filters["status"].Count);
             Assert.Equal("abed", search.Filters["status"].First());
             Assert.Equal("abed2", search.Filters["status"].Skip(1).First());
 
-            filter = "StartDate:2019-04-25 01:00 AM, hekki";
+            filter = "StartDate:2019-04-25 01:00 AM, hekki,orderid:MYORDERID,orderid:MYORDERID_2";
             search = new SearchString(filter);
             Assert.Equal("2019-04-25 01:00 AM", search.Filters["startdate"].First());
             Assert.Equal("hekki", search.TextSearch);
+            Assert.Equal("orderid:MYORDERID,orderid:MYORDERID_2", search.TextFilters);
+            Assert.Equal("orderid:MYORDERID,orderid:MYORDERID_2,hekki", search.TextCombined);
+            Assert.Equal("StartDate:2019-04-25 01:00 AM", search.WithoutSearchText());
+            Assert.Equal(filter, search.ToString());
 
             // modify search
             filter = $"status:settled,exceptionstatus:paidLate,unusual:true, fulltext searchterm, storeid:{storeId},startdate:2019-04-25 01:00:00";

--- a/BTCPayServer/Controllers/UIInvoiceController.UI.cs
+++ b/BTCPayServer/Controllers/UIInvoiceController.UI.cs
@@ -1111,7 +1111,7 @@ namespace BTCPayServer.Controllers
                     storeIds.Add(i);
             }
             model.Search = fs;
-            model.SearchText = fs.TextSearch;
+            model.SearchText = fs.TextCombined;
 
             var apps = await _appService.GetAllApps(GetUserId(), false, storeId);
             InvoiceQuery invoiceQuery = GetInvoiceQuery(fs, apps, timezoneOffset);

--- a/BTCPayServer/SearchString.cs
+++ b/BTCPayServer/SearchString.cs
@@ -9,7 +9,8 @@ namespace BTCPayServer
     {
         private const char FilterSeparator = ',';
         private const char ValueSeparator = ':';
-        
+        private static readonly string[] StripFilters = ["status", "exceptionstatus", "unusual", "includearchived", "appid", "startdate", "enddate"];
+
         private readonly string _originalString;
         private readonly int _timezoneOffset;
 
@@ -27,12 +28,17 @@ namespace BTCPayServer
                     .Where(kv => kv.Length == 2)
                     .Select(kv => new KeyValuePair<string, string>(UnifyKey(kv[0]), kv[1]))
                     .ToMultiValueDictionary(o => o.Key, o => o.Value);
-
-            var val = splitted.FirstOrDefault(a => a.IndexOf(ValueSeparator, StringComparison.OrdinalIgnoreCase) == -1);
-            TextSearch = val != null ? val.Trim() : string.Empty;
+            // combine raw search term and filters which don't have a special UI (e.g. orderid)
+            TextSearch = splitted.FirstOrDefault(a => a.IndexOf(ValueSeparator, StringComparison.OrdinalIgnoreCase) == -1)?.Trim();
+            TextFilters = string.Join(FilterSeparator, Filters
+                .Where(f => !StripFilters.Contains(f.Key))
+                .Select(f => string.Join(FilterSeparator, f.Value.Select(v => $"{f.Key}{ValueSeparator}{v}"))));
         }
 
         public string TextSearch { get; private set; }
+        public string TextFilters { get; private set; }
+
+        public string TextCombined => string.Join(FilterSeparator, new []{ TextFilters, TextSearch }.Where(x => !string.IsNullOrEmpty(x)));
 
         public MultiValueDictionary<string, string> Filters { get; }
 
@@ -82,9 +88,10 @@ namespace BTCPayServer
 
         public string WithoutSearchText()
         {
-            return string.IsNullOrEmpty(TextSearch)
-                ? Finalize(ToString())
-                : Finalize(ToString()).Replace(TextSearch, string.Empty);
+            var txt = ToString();
+            if (!string.IsNullOrEmpty(TextSearch)) txt = txt.Replace(TextSearch, string.Empty);
+            if (!string.IsNullOrEmpty(TextFilters)) txt = txt.Replace(TextFilters, string.Empty);
+            return Finalize(txt).Trim();
         }
 
         public string[] GetFilterArray(string key)


### PR DESCRIPTION
This changes the search text input to also display the filters, which don't have a special UI (e.g. dropdown). Those filters (e.g. orderid) were not displayed before and hence could not be reset.

Fixes #5984.

![grafik](https://github.com/btcpayserver/btcpayserver/assets/886/942ed045-acbe-4c26-ba96-80da026d86f6)
