### PR TITLE
Fix: Adding a label to a base58 addresses in the Send Wallet screen wasn't working

### DIFF
--- a/BTCPayServer/Controllers/UIWalletsController.cs
+++ b/BTCPayServer/Controllers/UIWalletsController.cs
@@ -750,7 +750,7 @@ namespace BTCPayServer.Controllers
             foreach (var transactionOutput in vm.Outputs.Where(output => output.Labels?.Any() is true))
             {
                 var labels = transactionOutput.Labels.Where(s => !string.IsNullOrWhiteSpace(s)).ToArray();
-                var walletObjectAddress = new WalletObjectId(walletId, WalletObjectData.Types.Address, transactionOutput.DestinationAddress.ToLowerInvariant());
+                var walletObjectAddress = new WalletObjectId(walletId, WalletObjectData.Types.Address, transactionOutput.DestinationAddress);
                 var obj = await WalletRepository.GetWalletObject(walletObjectAddress);
                 if (obj is null)
                 {

--- a/Changelog.md
+++ b/Changelog.md
@@ -14,6 +14,7 @@
 * Pull payment QR scan fixes (#5950) @dennisreimann
 * Server email settings: Fix missing password field (#5952 #5949) @dennisreimann
 * Fix: Some valid taproot PSBT couldn't parsed and show better error message (#5715 #5993) @NicolasDorier
+* Fix: Adding a label to a base58 addresses in the `Send Wallet` screen wasn't working (#6011) @NicolasDorier
 
 ### Improvements
 


### PR DESCRIPTION
### How to reproduce

1. In the Send Wallet, create a new transaction sending to a base58 address.
2. Add a label
3. Sign the transaction

### Expected

The output in the transaction has the label

### Actual

No label appear