### PR TITLE
TimeSpan JSON Converter: Parse strings

### DIFF
--- a/BTCPayServer.Client/JsonConverters/TimeSpanJsonConverter.cs
+++ b/BTCPayServer.Client/JsonConverters/TimeSpanJsonConverter.cs
@@ -58,6 +58,8 @@ namespace BTCPayServer.Client.JsonConverters
                         return null;
                     return TimeSpan.Zero;
                 }
+                if (reader.TokenType == JsonToken.String && TimeSpan.TryParse(reader.Value?.ToString(), out var res))
+                    return res;
                 if (reader.TokenType != JsonToken.Integer)
                     throw new JsonObjectException("Invalid timespan, expected integer", reader);
                 return ToTimespan((long)reader.Value);


### PR DESCRIPTION
Something I came across while working in the app: Without this, the [TimeSpan default values of the StoreBlob](https://github.com/btcpayserver/btcpayserver/blob/master/BTCPayServer/Data/StoreBlob.cs#L84) cannot be parsed and don't get applied properly.