### PR TITLE
Pull payment: Enable CORS for LNURL request

### DIFF
--- a/BTCPayServer/Controllers/UILNURLController.cs
+++ b/BTCPayServer/Controllers/UILNURLController.cs
@@ -89,11 +89,14 @@ namespace BTCPayServer
             _pluginHookService = pluginHookService;
             _invoiceActivator = invoiceActivator;
         }
+
+        [EnableCors(CorsPolicies.All)]
         [HttpGet("withdraw/pp/{pullPaymentId}")]
         public Task<IActionResult> GetLNURLForPullPayment(string cryptoCode, string pullPaymentId, [FromQuery] string pr, CancellationToken cancellationToken)
         {
             return GetLNURLForPullPayment(cryptoCode, pullPaymentId, pr, pullPaymentId, cancellationToken);
         }
+
         [NonAction]
         internal async Task<IActionResult> GetLNURLForPullPayment(string cryptoCode, string pullPaymentId, string pr, string k1, CancellationToken cancellationToken)
         {


### PR DESCRIPTION
Fixes #6043 and ensures Mutiny Wallet can do the LNURL request.