### PR TITLE
POS: Keypad error should sit below the header

### DIFF
--- a/BTCPayServer/wwwroot/pos/keypad.css
+++ b/BTCPayServer/wwwroot/pos/keypad.css
@@ -3,6 +3,9 @@
     overflow: hidden;
     position: relative;
 }
+#PosKeypad .alert {
+    margin-top: var(--btcpay-space-xl);
+}
 
 button[data-bs-toggle] {
     position: absolute;


### PR DESCRIPTION
Fixes #6054.

![grafik](https://github.com/btcpayserver/btcpayserver/assets/886/02da49fb-3cbd-4ccc-858e-5b3345280be3)
