### PR TITLE
Handle LNURL Payouts failing due to amount restriction

### DIFF
--- a/BTCPayServer.Tests/docker-compose.altcoins.yml
+++ b/BTCPayServer.Tests/docker-compose.altcoins.yml
@@ -194,6 +194,7 @@ services:
   merchant_lightningd:
     image: btcpayserver/lightning:v24.05
     stop_signal: SIGKILL
+    restart: unless-stopped
     environment:
       EXPOSE_TCP: "true"
       LIGHTNINGD_CHAIN: "btc"
@@ -217,6 +218,7 @@ services:
       - "merchant_lightningd_datadir:/root/.lightning"
     depends_on:
       - bitcoind
+
   postgres:
     image:  postgres:13.13
     environment:

--- a/BTCPayServer.Tests/docker-compose.yml
+++ b/BTCPayServer.Tests/docker-compose.yml
@@ -180,6 +180,7 @@ services:
   merchant_lightningd:
     image: btcpayserver/lightning:v24.05
     stop_signal: SIGKILL
+    restart: unless-stopped
     environment:
       EXPOSE_TCP: "true"
       LIGHTNINGD_CHAIN: "btc"

--- a/BTCPayServer/Data/Payouts/LightningLike/LightningLikePayoutHandler.cs
+++ b/BTCPayServer/Data/Payouts/LightningLike/LightningLikePayoutHandler.cs
@@ -89,7 +89,11 @@ namespace BTCPayServer.Data.Payouts.LightningLike
                 {
                     using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(30));
                     using var t = CancellationTokenSource.CreateLinkedTokenSource(timeout.Token, cancellationToken);
-                    var info = (LNURLPayRequest)(await LNURL.LNURL.FetchInformation(lnurl, CreateClient(lnurl), t.Token));
+                    var rawInfo = await LNURL.LNURL.FetchInformation(lnurl, CreateClient(lnurl), t.Token);
+                    if(rawInfo is null)
+                        return (null, "The LNURL / Lightning Address provided was not online.");
+                    if(rawInfo is not LNURLPayRequest info)
+                        return (null, "The LNURL was not a valid LNURL Pay request.");
                     lnurlTag = info.Tag;
                 }
 
@@ -159,9 +163,27 @@ namespace BTCPayServer.Data.Payouts.LightningLike
             return Task.CompletedTask;
         }
 
-        public Task<decimal> GetMinimumPayoutAmount(IClaimDestination claimDestination)
+        public async Task<decimal> GetMinimumPayoutAmount(IClaimDestination claimDestination)
         {
-            return Task.FromResult(Money.Satoshis(1).ToDecimal(MoneyUnit.BTC));
+            if(claimDestination is LNURLPayClaimDestinaton lnurlPayClaimDestinaton)
+            {
+                try
+                {
+                    var lnurl = lnurlPayClaimDestinaton.LNURL.IsValidEmail()
+                        ? LNURL.LNURL.ExtractUriFromInternetIdentifier(lnurlPayClaimDestinaton.LNURL)
+                        : LNURL.LNURL.Parse(lnurlPayClaimDestinaton.LNURL, out var lnurlTag);
+
+                    using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+                    var rawInfo = await LNURL.LNURL.FetchInformation(lnurl, CreateClient(lnurl), timeout.Token);
+                    if (rawInfo is LNURLPayRequest info)
+                        return info.MinSendable.ToDecimal(LightMoneyUnit.BTC);
+                }
+                catch
+                {
+                    // ignored
+                }
+            }
+            return Money.Satoshis(1).ToDecimal(MoneyUnit.BTC);
         }
 
         public Dictionary<PayoutState, List<(string Action, string Text)>> GetPayoutSpecificActions()

--- a/BTCPayServer/Data/Payouts/LightningLike/UILightningLikePayoutController.cs
+++ b/BTCPayServer/Data/Payouts/LightningLike/UILightningLikePayoutController.cs
@@ -253,7 +253,7 @@ namespace BTCPayServer.Data.Payouts.LightningLike
                     Result = PayResult.Error,
                     Destination = blob.Destination,
                     Message =
-                        $"The LNURL provided would not generate an invoice of {lm.MilliSatoshi}msats"
+                        $"The LNURL provided would not generate an invoice of {lm.ToDecimal(LightMoneyUnit.Satoshi)} sats"
                 });
             }
 

--- a/BTCPayServer/Data/Payouts/LightningLike/UILightningLikePayoutController.cs
+++ b/BTCPayServer/Data/Payouts/LightningLike/UILightningLikePayoutController.cs
@@ -245,6 +245,8 @@ namespace BTCPayServer.Data.Payouts.LightningLike
             var lm = new LightMoney(blob.CryptoAmount.Value, LightMoneyUnit.BTC);
             if (lm > lnurlInfo.MaxSendable || lm < lnurlInfo.MinSendable)
             {
+                
+                payoutData.State = PayoutState.Cancelled;
                 return (null, new ResultVM
                 {
                     PayoutId = payoutData.Id,


### PR DESCRIPTION
Payouts to LNURLS that had an amount restriction that did not match the payout amount would get stuck retrying. This cancels them once it happens.