### PR TITLE
Fix Monero development environment with wallet load

### DIFF
--- a/BTCPayServer.Tests/docker-compose.altcoins.yml
+++ b/BTCPayServer.Tests/docker-compose.altcoins.yml
@@ -311,6 +311,7 @@ services:
         - "tor_datadir:/home/tor/.tor"
         - "torrcdir:/usr/local/etc/tor"
         - "tor_servicesdir:/var/lib/tor/hidden_services"
+
   monerod:
       image: btcpayserver/monero:0.18.3.3
       restart: unless-stopped
@@ -320,6 +321,7 @@ services:
           - "monero_data:/home/monero/.bitmonero"
       ports:
           - "18081:18081"
+
   monero_wallet:
       image: btcpayserver/monero:0.18.3.3
       restart: unless-stopped
@@ -331,6 +333,7 @@ services:
           - "./monero_wallet:/wallet"
       depends_on:
           - monerod
+
   litecoind:
     restart: unless-stopped
     image: btcpayserver/litecoin:0.18.1

--- a/BTCPayServer/Plugins/Altcoins/Monero/RPC/Models/OpenWallerErrorResponse.cs
+++ b/BTCPayServer/Plugins/Altcoins/Monero/RPC/Models/OpenWallerErrorResponse.cs
@@ -1,0 +1,10 @@
+using Newtonsoft.Json;
+
+namespace BTCPayServer.Services.Altcoins.Monero.RPC.Models
+{
+    public partial class OpenWalletErrorResponse
+    {
+        [JsonProperty("code")] public int Code { get; set; }
+        [JsonProperty("message")] public string Message { get; set; }
+    }
+}

--- a/BTCPayServer/Plugins/Altcoins/Monero/RPC/Models/OpenWalletRequest.cs
+++ b/BTCPayServer/Plugins/Altcoins/Monero/RPC/Models/OpenWalletRequest.cs
@@ -1,0 +1,10 @@
+using Newtonsoft.Json;
+
+namespace BTCPayServer.Services.Altcoins.Monero.RPC.Models
+{
+    public partial class OpenWalletRequest
+    {
+        [JsonProperty("filename")] public string Filename { get; set; }
+        [JsonProperty("password")] public string Password { get; set; }
+    }
+}

--- a/BTCPayServer/Plugins/Altcoins/Monero/RPC/Models/OpenWalletResponse.cs
+++ b/BTCPayServer/Plugins/Altcoins/Monero/RPC/Models/OpenWalletResponse.cs
@@ -1,0 +1,12 @@
+using Newtonsoft.Json;
+
+namespace BTCPayServer.Services.Altcoins.Monero.RPC.Models
+{
+    public partial class OpenWalletResponse
+    {
+        [JsonProperty("id")] public string Id { get; set; }
+        [JsonProperty("jsonrpc")] public string Jsonrpc { get; set; }
+        [JsonProperty("result")] public object Result { get; set; }
+        [JsonProperty("error")] public OpenWalletErrorResponse Error { get; set; }
+    }
+}

--- a/BTCPayServer/Properties/launchSettings.json
+++ b/BTCPayServer/Properties/launchSettings.json
@@ -72,6 +72,47 @@
       },
       "applicationUrl": "https://localhost:14142/"
     },
+    "Altcoins": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "BTCPAY_EXPERIMENTALV2_CONFIRM": "true",
+        "BTCPAY_NETWORK": "regtest",
+        "BTCPAY_LAUNCHSETTINGS": "true",
+        "BTCPAY_PORT": "14142",
+        "BTCPAY_HttpsUseDefaultCertificate": "true",
+        "BTCPAY_VERBOSE": "true",
+        "BTCPAY_LTCEXPLORERURL": "http://127.0.0.1:32838/",
+        "BTCPAY_LBTCEXPLORERURL": "http://127.0.0.1:32838/",
+        "BTCPAY_BTCLIGHTNING": "type=clightning;server=tcp://127.0.0.1:30993/",
+        "BTCPAY_BTCEXTERNALLNDREST": "type=lnd-rest;server=http://lnd:lnd@127.0.0.1:35531/;allowinsecure=true",
+        "BTCPAY_BTCEXTERNALLNDSEEDBACKUP": "../BTCPayServer.Tests/TestData/LndSeedBackup/walletunlock.json",
+        "BTCPAY_BTCEXTERNALSPARK": "server=/spark/btc/;cookiefile=fake",
+        "BTCPAY_BTCEXTERNALCHARGE": "server=https://127.0.0.1:53280/mycharge/btc/;cookiefilepath=fake",
+        "BTCPAY_BTCEXTERNALRTL": "server=/rtl/api/authenticate/cookie;cookiefile=fake",
+        "BTCPAY_BTCEXTERNALTHUNDERHUB": "server=/thub/sso;cookiefile=fake",
+        "BTCPAY_BTCEXTERNALTORQ": "server=/torq/cookie-login;cookiefile=fake",
+        "BTCPAY_EXTERNALSERVICES": "totoservice:totolink;Lightning Terminal:/lit/;",
+        "BTCPAY_EXTERNALCONFIGURATOR": "passwordfile=testpwd;server=/configurator",
+        "BTCPAY_BTCEXPLORERURL": "http://127.0.0.1:32838/",
+        "BTCPAY_ALLOW-ADMIN-REGISTRATION": "true",
+        "BTCPAY_DISABLE-REGISTRATION": "false",
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "BTCPAY_CHAINS": "btc,ltc,lbtc,xmr",
+        "BTCPAY_POSTGRES": "User ID=postgres;Include Error Detail=true;Host=127.0.0.1;Port=39372;Database=btcpayserver",
+        "BTCPAY_DEBUGLOG": "debug.log",
+        "BTCPAY_TORRCFILE": "../BTCPayServer.Tests/TestData/Tor/torrc",
+        "BTCPAY_SOCKSENDPOINT": "localhost:9050",
+        "BTCPAY_DOCKERDEPLOYMENT": "true",
+        "BTCPAY_RECOMMENDED-PLUGINS": "",
+        "BTCPAY_CHEATMODE": "true",
+        "BTCPAY_EXPLORERPOSTGRES": "User ID=postgres;Include Error Detail=true;Host=127.0.0.1;Port=39372;Database=nbxplorer",
+        "BTCPAY_XMR_DAEMON_URI": "http://127.0.0.1:18081",
+        "BTCPAY_XMR_WALLET_DAEMON_URI": "http://127.0.0.1:18082",
+        "BTCPAY_XMR_WALLET_DAEMON_WALLETDIR": "/path/to/monero_wallet"
+      },
+      "applicationUrl": "https://localhost:14142/"
+    },
     "Altcoins-HTTPS": {
       "commandName": "Project",
       "launchBrowser": true,
@@ -98,7 +139,7 @@
         "BTCPAY_ALLOW-ADMIN-REGISTRATION": "true",
         "BTCPAY_DISABLE-REGISTRATION": "false",
         "ASPNETCORE_ENVIRONMENT": "Development",
-        "BTCPAY_CHAINS": "btc,ltc,lbtc",
+        "BTCPAY_CHAINS": "btc,ltc,lbtc,xmr",
         "BTCPAY_POSTGRES": "User ID=postgres;Include Error Detail=true;Host=127.0.0.1;Port=39372;Database=btcpayserver",
         "BTCPAY_SSHCONNECTION": "root@127.0.0.1:21622",
         "BTCPAY_SSHPASSWORD": "opD3i2282D",
@@ -108,7 +149,10 @@
         "BTCPAY_DOCKERDEPLOYMENT": "true",
         "BTCPAY_RECOMMENDED-PLUGINS": "",
         "BTCPAY_CHEATMODE": "true",
-        "BTCPAY_EXPLORERPOSTGRES": "User ID=postgres;Include Error Detail=true;Host=127.0.0.1;Port=39372;Database=nbxplorer"
+        "BTCPAY_EXPLORERPOSTGRES": "User ID=postgres;Include Error Detail=true;Host=127.0.0.1;Port=39372;Database=nbxplorer",
+        "BTCPAY_XMR_DAEMON_URI": "http://127.0.0.1:18081",
+        "BTCPAY_XMR_WALLET_DAEMON_URI": "http://127.0.0.1:18082",
+        "BTCPAY_XMR_WALLET_DAEMON_WALLETDIR": "/path/to/monero_wallet"
       },
       "applicationUrl": "https://localhost:14142/"
     }

--- a/BTCPayServer/Services/Altcoins/Monero/UI/MoneroLikeStoreController.cs
+++ b/BTCPayServer/Services/Altcoins/Monero/UI/MoneroLikeStoreController.cs
@@ -253,10 +253,28 @@ namespace BTCPayServer.Services.Altcoins.Monero.UI
                         }
                     }
 
+                    try
+                    {
+                        var response = await _MoneroRpcProvider.WalletRpcClients[cryptoCode].SendCommandAsync<OpenWalletRequest, OpenWalletResponse>("open_wallet", new OpenWalletRequest
+                        {
+                            Filename = "wallet",
+                            Password = viewModel.WalletPassword
+                        });
+                        if (response?.Error != null)
+                        {
+                            throw new Exception(response.Error.Message);
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        ModelState.AddModelError(nameof(viewModel.AccountIndex), $"Could not open the wallet: {ex.Message}");
+                        return View(viewModel);
+                    }
+
                     return RedirectToAction(nameof(GetStoreMoneroLikePaymentMethod), new
                     {
                         cryptoCode,
-                        StatusMessage = "View-only wallet files uploaded. If they are valid the wallet will soon become available."
+                        StatusMessage = "View-only wallet files uploaded. The wallet will soon become available."
 
                     });
                 }
@@ -343,7 +361,7 @@ namespace BTCPayServer.Services.Altcoins.Monero.UI
             public IFormFile WalletKeysFile { get; set; }
             [Display(Name = "Wallet Password")]
             public string WalletPassword { get; set; }
-            [Display(Name = "Consider the invoice settled when the payment transaction ï¿½")]
+            [Display(Name = "Consider the invoice settled when the payment transaction …")]
             public MoneroLikeSettlementThresholdChoice SettlementConfirmationThresholdChoice { get; set; }
             [Display(Name = "Required Confirmations"), Range(0, 100)]
             public long? CustomSettlementConfirmationThreshold { get; set; }

--- a/BTCPayServer/Views/UIMoneroLikeStore/GetStoreMoneroLikePaymentMethods.cshtml
+++ b/BTCPayServer/Views/UIMoneroLikeStore/GetStoreMoneroLikePaymentMethods.cshtml
@@ -1,7 +1,6 @@
 @model BTCPayServer.Services.Altcoins.Monero.UI.UIMoneroLikeStoreController.MoneroLikePaymentMethodListViewModel
 
 @{
-    Layout = "../Shared/_NavLayout.cshtml";
     ViewData.SetActivePage("Monero Settings", "Monero Settings", "Monero Settings");
 }
 


### PR DESCRIPTION
This PR includes:
- fix / removal of `_NavLayout` introduced in https://github.com/btcpayserver/btcpayserver/pull/5744
- launch setting for xmr with shitcoins https-less profile
- open wallet rpc for proper load up / verification and docker compose code decoupling (once merged.. we can revert the revert https://github.com/btcpayserver/btcpayserver-docker/pull/907 back to wallet-dir)