### PR TITLE
TransactionLinkProviders: Don't force single item

### DIFF
--- a/BTCPayServer.Tests/docker-compose.altcoins.yml
+++ b/BTCPayServer.Tests/docker-compose.altcoins.yml
@@ -193,6 +193,7 @@ services:
   merchant_lightningd:
     image: btcpayserver/lightning:v24.05
     stop_signal: SIGKILL
+    restart: unless-stopped
     environment:
       EXPOSE_TCP: "true"
       LIGHTNINGD_CHAIN: "btc"
@@ -216,6 +217,7 @@ services:
       - "merchant_lightningd_datadir:/root/.lightning"
     depends_on:
       - bitcoind
+
   postgres:
     image:  postgres:13.4
     environment:

--- a/BTCPayServer.Tests/docker-compose.yml
+++ b/BTCPayServer.Tests/docker-compose.yml
@@ -179,6 +179,7 @@ services:
   merchant_lightningd:
     image: btcpayserver/lightning:v24.05
     stop_signal: SIGKILL
+    restart: unless-stopped
     environment:
       EXPOSE_TCP: "true"
       LIGHTNINGD_CHAIN: "btc"

--- a/BTCPayServer/Services/TransactionLinkProviders.cs
+++ b/BTCPayServer/Services/TransactionLinkProviders.cs
@@ -29,7 +29,7 @@ public class TransactionLinkProviders : Dictionary<PaymentMethodId, TransactionL
         {
             foreach ((var pmi, var prov) in this)
             {
-                var overrideLink = links.SingleOrDefault(item =>
+                var overrideLink = links.FirstOrDefault(item =>
                     item.CryptoCode.Equals(pmi.CryptoCode, StringComparison.InvariantCultureIgnoreCase) ||
                     item.CryptoCode.Equals(pmi.ToString(), StringComparison.InvariantCultureIgnoreCase));
                 prov.OverrideBlockExplorerLink = overrideLink?.Link ?? prov.BlockExplorerLinkDefault;

--- a/BTCPayServer/Views/UIServer/Policies.cshtml
+++ b/BTCPayServer/Views/UIServer/Policies.cshtml
@@ -231,7 +231,7 @@
             {
                 var pmi = linkProviders[lpi].Key;
                 var defaultLink = linkProviders[lpi].Value.BlockExplorerLinkDefault;
-                var existingOverride = Model.BlockExplorerLinks?.SingleOrDefault(tuple => PaymentMethodId.Parse(tuple.CryptoCode) == pmi);
+                var existingOverride = Model.BlockExplorerLinks?.FirstOrDefault(tuple => PaymentMethodId.Parse(tuple.CryptoCode) == pmi);
                 if (existingOverride is null)
                 {
                     existingOverride = new PoliciesSettings.BlockExplorerOverrideItem { CryptoCode = pmi.ToStringNormalized(), Link = null };


### PR DESCRIPTION
Fixes #6077. Not sure if this is the correct way to solve it though. @NicolasDorier shall it be a single item? It looks like with the Altcoin build there might be cases, in which there are multiple.