### PR TITLE
Checkout: Display description if present

### DIFF
--- a/BTCPayServer/Views/UIInvoice/Checkout.cshtml
+++ b/BTCPayServer/Views/UIInvoice/Checkout.cshtml
@@ -52,6 +52,7 @@
                 </button>
             </nav>
             <section id="payment" v-if="isActive">
+                <div v-if="srvModel.itemDesc && srvModel.itemDesc !== srvModel.storeName" v-text="srvModel.itemDesc" class="fw-semibold text-center text-muted mb-3"></div>
                 <div class="d-flex justify-content-center mt-1 text-center">
                     @if (Model.IsUnsetTopUp)
                     {


### PR DESCRIPTION
This is mostly for the POS, where either an individual item title might be the description, or in case of the cart and keypad, the name of the app will be displayed. The description is omitted if it matches the store name, to avoid duplicate titles.

I think we left this one out for Checkout v2 to save on vertical space. 

Closes #5023.

Here's a sample where the description is "Flavoured Birell Beer" ...

![grafik](https://github.com/btcpayserver/btcpayserver/assets/886/ab4b0e26-5ae8-4fea-9f84-728b7cf297c7)
