### PR TITLE
Greenfield: Add missing invoice metadata to Lightning Address

### DIFF
--- a/BTCPayServer.Client/Models/LightningAddressData.cs
+++ b/BTCPayServer.Client/Models/LightningAddressData.cs
@@ -1,3 +1,5 @@
+using Newtonsoft.Json.Linq;
+
 namespace BTCPayServer.Client.Models;
 
 public class LightningAddressData
@@ -6,5 +8,5 @@ public class LightningAddressData
     public string CurrencyCode { get; set; }
     public decimal? Min { get; set; }
     public decimal? Max { get; set; }
-
+    public JObject InvoiceMetadata { get; set; }
 }

--- a/BTCPayServer.Tests/GreenfieldAPITests.cs
+++ b/BTCPayServer.Tests/GreenfieldAPITests.cs
@@ -3594,6 +3594,7 @@ namespace BTCPayServer.Tests
             var store2 = (await adminClient.CreateStore(new CreateStoreRequest() { Name = "test2" })).Id;
             var address1 = Guid.NewGuid().ToString("n").Substring(0, 8);
             var address2 = Guid.NewGuid().ToString("n").Substring(0, 8);
+            var address3 = Guid.NewGuid().ToString("n").Substring(0, 8);
 
             Assert.Empty(await adminClient.GetStoreLightningAddresses(store.Id));
             Assert.Empty(await adminClient.GetStoreLightningAddresses(store2));
@@ -3621,6 +3622,17 @@ namespace BTCPayServer.Tests
             await adminClient.RemoveStoreLightningAddress(store2, address2);
 
             Assert.Empty(await adminClient.GetStoreLightningAddresses(store2));
+            
+            var store3 = (await adminClient.CreateStore(new CreateStoreRequest { Name = "test3" })).Id;
+            Assert.Empty(await adminClient.GetStoreLightningAddresses(store3));
+            var metadata = JObject.FromObject(new { test = 123 });
+            await adminClient.AddOrUpdateStoreLightningAddress(store3, address3, new LightningAddressData
+            {
+                InvoiceMetadata = metadata
+            });
+            var lnAddresses = await adminClient.GetStoreLightningAddresses(store3);
+            Assert.Single(lnAddresses);
+            Assert.Equal(metadata, lnAddresses[0].InvoiceMetadata);
         }
 
         [Fact(Timeout = 60 * 2 * 1000)]

--- a/BTCPayServer/Controllers/GreenField/GreenfieldStoreLightningAddressesController.cs
+++ b/BTCPayServer/Controllers/GreenField/GreenfieldStoreLightningAddressesController.cs
@@ -1,4 +1,5 @@
 #nullable enable
+using System;
 using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
@@ -8,6 +9,8 @@ using BTCPayServer.Data;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Cors;
 using Microsoft.AspNetCore.Mvc;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using AuthenticationSchemes = BTCPayServer.Abstractions.Constants.AuthenticationSchemes;
 using LightningAddressData = BTCPayServer.Client.Models.LightningAddressData;
 
@@ -31,12 +34,13 @@ namespace BTCPayServer.Controllers.Greenfield
             var blob = data.GetBlob();
             if (blob is null)
                 return new LightningAddressData();
-            return new LightningAddressData()
+            return new LightningAddressData
             {
                 Username = data.Username,
                 Max = blob.Max,
                 Min = blob.Min,
-                CurrencyCode = blob.CurrencyCode
+                CurrencyCode = blob.CurrencyCode,
+                InvoiceMetadata = blob.InvoiceMetadata
             };
         }
 
@@ -83,16 +87,17 @@ namespace BTCPayServer.Controllers.Greenfield
                 ModelState.AddModelError(nameof(data.Min), "Minimum must be greater than 0 if provided.");
                 return this.CreateValidationError(ModelState);
             }
-
-            if (await _lightningAddressService.Set(new Data.LightningAddressData()
+            
+            if (await _lightningAddressService.Set(new Data.LightningAddressData
             {
                 StoreDataId = storeId,
                 Username = username
-            }.SetBlob(new LightningAddressDataBlob()
+            }.SetBlob(new LightningAddressDataBlob
             {
                 Max = data.Max,
                 Min = data.Min,
-                CurrencyCode = data.CurrencyCode
+                CurrencyCode = data.CurrencyCode,
+                InvoiceMetadata = data.InvoiceMetadata
             })))
             {
                 return await GetStoreLightningAddress(storeId, username);

--- a/BTCPayServer/wwwroot/swagger/v1/swagger.template.stores-lightning-addresses.json
+++ b/BTCPayServer/wwwroot/swagger/v1/swagger.template.stores-lightning-addresses.json
@@ -246,7 +246,7 @@
                         "description": "The maximum amount in sats this ln address allows"
                     },
                     "invoiceMetadata": {
-                        "type": "string",
+                        "type": "object",
                         "nullable": true,
                         "description": "The invoice metadata as JSON."
                     }

--- a/BTCPayServer/wwwroot/swagger/v1/swagger.template.stores-lightning-addresses.json
+++ b/BTCPayServer/wwwroot/swagger/v1/swagger.template.stores-lightning-addresses.json
@@ -244,6 +244,11 @@
                         "type": "string",
                         "nullable": true,
                         "description": "The maximum amount in sats this ln address allows"
+                    },
+                    "invoiceMetadata": {
+                        "type": "string",
+                        "nullable": true,
+                        "description": "The invoice metadata as JSON."
                     }
                 }
             }


### PR DESCRIPTION
Closes #6067.

Can also be backported to `v1.13.x`.