### PR TITLE
Do not crash when refunding an invoice that has been marked settled (Fix #6003)

### DIFF
--- a/BTCPayServer.Tests/GreenfieldAPITests.cs
+++ b/BTCPayServer.Tests/GreenfieldAPITests.cs
@@ -2247,6 +2247,17 @@ namespace BTCPayServer.Tests
             Assert.Equal("BTC", pp.Currency);
             Assert.True(pp.AutoApproveClaims);
             Assert.Equal(0.79m, pp.Amount);
+
+            // If an invoice doesn't have payment because it has been marked as paid, we should still be able to refund it.
+            invoice = await client.CreateInvoice(user.StoreId, new CreateInvoiceRequest { Amount = 5000.0m, Currency = "USD" });
+            await client.MarkInvoiceStatus(user.StoreId, invoice.Id, new MarkInvoiceStatusRequest { Status = InvoiceStatus.Settled });
+            var refund = await client.RefundInvoice(user.StoreId, invoice.Id, new RefundInvoiceRequest
+            {
+                PaymentMethod = method.PaymentMethodId,
+                RefundVariant = RefundVariant.CurrentRate
+            });
+            Assert.Equal(1.0m, refund.Amount);
+            Assert.Equal("BTC", refund.Currency);
         }
 
         [Fact(Timeout = TestTimeout)]

--- a/BTCPayServer/Controllers/GreenField/GreenfieldInvoiceController.cs
+++ b/BTCPayServer/Controllers/GreenField/GreenfieldInvoiceController.cs
@@ -408,10 +408,7 @@ namespace BTCPayServer.Controllers.Greenfield
                 var supported = _payoutHandlers.GetSupportedPayoutMethods(store);
                 if (supported.Contains(payoutMethodId))
                 {
-                    var paymentMethodId = PaymentMethodId.GetSimilarities([payoutMethodId], invoice.GetPayments(false).Select(p => p.PaymentMethodId))
-                        .OrderByDescending(o => o.similarity)
-                        .Select(o => o.b)
-                        .FirstOrDefault();
+                    var paymentMethodId = invoice.GetClosestPaymentMethodId([payoutMethodId]);
                     paymentPrompt = paymentMethodId is null ? null : invoice.GetPaymentPrompt(paymentMethodId);
                 }
             }
@@ -426,6 +423,14 @@ namespace BTCPayServer.Controllers.Greenfield
 
             var accounting = paymentPrompt.Calculate();
             var cryptoPaid = accounting.Paid;
+            var dueAmount = accounting.TotalDue;
+
+            // If no payment, but settled and marked, assume it has been fully paid
+            if (cryptoPaid is 0 && invoice is { Status: InvoiceStatus.Settled, ExceptionStatus: InvoiceExceptionStatus.Marked })
+            {
+                cryptoPaid = accounting.TotalDue;
+                dueAmount = 0;
+            }
             var cdCurrency = _currencyNameTable.GetCurrencyData(invoice.Currency, true);
             var paidCurrency = Math.Round(cryptoPaid * paymentPrompt.Rate, cdCurrency.Divisibility);
             var rateResult = await _rateProvider.FetchRate(
@@ -491,8 +496,6 @@ namespace BTCPayServer.Controllers.Greenfield
                     {
                         return this.CreateValidationError(ModelState);
                     }
-                    
-                    var dueAmount = accounting.TotalDue;
                     createPullPayment.Currency = paymentPrompt.Currency;
                     createPullPayment.Amount = Math.Round(paidAmount - dueAmount, appliedDivisibility);
                     createPullPayment.AutoApproveClaims = true;


### PR DESCRIPTION
Fix #6003.

The problem is that we were refunding the amount that was paid.
However, if there has been no payment and the invoice marked as settled, we would refund 0.

This add special handling for this case, by assuming we want to reimburse the full amount in this case.