### PR TITLE
Truncate Center Component: Fix Vue rendering

### DIFF
--- a/BTCPayServer/Components/TruncateCenter/Default.cshtml
+++ b/BTCPayServer/Components/TruncateCenter/Default.cshtml
@@ -4,22 +4,23 @@
     var isTruncated = !string.IsNullOrEmpty(Model.Start) && !string.IsNullOrEmpty(Model.End);
     @if (Model.Copy) classes += " truncate-center--copy";
     @if (Model.Elastic) classes += " truncate-center--elastic";
+    var prefix = Model.IsVue ? ":" : "";
 }
-<span class="truncate-center @classes"@(!string.IsNullOrEmpty(Model.Id) ? $"id={Model.Id}" : null) data-text=@Safe.Json(Model.Text)>
+<span class="truncate-center @classes" id="@Model.Id" data-text="@Model.Text">
     @if (Model.IsVue)
     {
-        <span class="truncate-center-truncated" data-bs-toggle="tooltip" :title=@Safe.Json(Model.Text)>
+		<span class="truncate-center-truncated" data-bs-toggle="tooltip" :title="@Model.Text">
             @if (Model.Elastic)
             {
-                <span class="truncate-center-start" v-text=@Safe.Json(Model.Text)></span>
+                <span class="truncate-center-start" v-text="@Model.Text"></span>
             }
             else
             {
-                <span class="truncate-center-start" v-text="@Safe.Raw($"{Model.Text}.length > 2 * {Model.Padding} ? ({Model.Text}.slice(0, {Model.Padding}) + '…') : {Model.Text}")"></span>
+				<span class="truncate-center-start" v-text="@(Model.Text).length > 2 * @(Model.Padding) ? (@(Model.Text).slice(0, @(Model.Padding)) + '…') : @(Model.Text)"></span>
             }
-            <span class="truncate-center-end" v-text=@Safe.Json($"{Model.Text}.slice(-{Model.Padding})") v-if="@Safe.Raw($"{Model.Text}.length > 2 * {Model.Padding}")"></span>
+            <span class="truncate-center-end" v-text="@(Model.Text).slice(-@(Model.Padding))" v-if="@(Model.Text).length > 2 * @(Model.Padding)"></span>
         </span>
-        <span class="truncate-center-text" v-text=@Safe.Json(Model.Text)></span>
+        <span class="truncate-center-text" v-text="@Model.Text"></span>
     }
     else
     {
@@ -34,13 +35,13 @@
     }
     @if (Model.Copy)
     {
-        <button type="button" class="btn btn-link p-0" @(Model.IsVue ? ":" : string.Empty)data-clipboard=@Safe.Json(Model.Text)>
+        <button type="button" class="btn btn-link p-0" @(prefix)data-clipboard="@Model.Text">
             <vc:icon symbol="actions-copy" />
         </button>
     }
     @if (!string.IsNullOrEmpty(Model.Link))
     {
-        <a @(Model.IsVue ? ":" : "")href="@Model.Link" rel="noreferrer noopener" target="_blank">
+		<a @(prefix)href="@Model.Link" rel="noreferrer noopener" target="_blank">
             <vc:icon symbol="info" />
         </a>
     }

--- a/BTCPayServer/Components/TruncateCenter/Default.cshtml
+++ b/BTCPayServer/Components/TruncateCenter/Default.cshtml
@@ -15,10 +15,9 @@
             }
             else
             {
-                <span class="truncate-center-start" v-text=@Safe.Json($"{Model.Text}.slice(0, {Model.Padding})")></span>
-                <span>…</span>
+                <span class="truncate-center-start" v-text="@Safe.Raw($"{Model.Text}.length > 2 * {Model.Padding} ? ({Model.Text}.slice(0, {Model.Padding}) + '…') : {Model.Text}")"></span>
             }
-            <span class="truncate-center-end" v-text=@Safe.Json($"{Model.Text}.slice(-{Model.Padding})")></span>
+            <span class="truncate-center-end" v-text=@Safe.Json($"{Model.Text}.slice(-{Model.Padding})") v-if="@Safe.Raw($"{Model.Text}.length > 2 * {Model.Padding}")"></span>
         </span>
         <span class="truncate-center-text" v-text=@Safe.Json(Model.Text)></span>
     }


### PR DESCRIPTION
Context: #6065. Had to use `Safe.Raw` instead of `Safe.Json` to render the comparison, which contains an `>` that otherwise would have been escaped.