### PR TITLE
Bumping LND to 0.18.1-beta

### DIFF
--- a/BTCPayServer.Tests/docker-compose.altcoins.yml
+++ b/BTCPayServer.Tests/docker-compose.altcoins.yml
@@ -229,7 +229,7 @@ services:
       - "5432"
 
   merchant_lnd:
-    image: btcpayserver/lnd:v0.18.0-beta
+    image: btcpayserver/lnd:v0.18.1-beta
     restart: unless-stopped
     environment:
       LND_CHAIN: "btc"
@@ -264,7 +264,7 @@ services:
       - bitcoind
 
   customer_lnd:
-    image: btcpayserver/lnd:v0.18.0-beta
+    image: btcpayserver/lnd:v0.18.1-beta
     restart: unless-stopped
     environment:
       LND_CHAIN: "btc"

--- a/BTCPayServer.Tests/docker-compose.yml
+++ b/BTCPayServer.Tests/docker-compose.yml
@@ -215,7 +215,7 @@ services:
       - "5432"
 
   merchant_lnd:
-    image: btcpayserver/lnd:v0.18.0-beta
+    image: btcpayserver/lnd:v0.18.1-beta
     restart: unless-stopped
     environment:
       LND_CHAIN: "btc"
@@ -252,7 +252,7 @@ services:
       - bitcoind
 
   customer_lnd:
-    image: btcpayserver/lnd:v0.18.0-beta
+    image: btcpayserver/lnd:v0.18.1-beta
     restart: unless-stopped
     environment:
       LND_CHAIN: "btc"


### PR DESCRIPTION
Updating our devenv to use LND 0.18.1

Used it in BTCPayServer.Lightning library and it's good to go, passed all the tests:
https://github.com/btcpayserver/BTCPayServer.Lightning/pull/162