### PR TITLE
Fix missing normalization of Settled invoice status

### DIFF
--- a/BTCPayServer/Services/Invoices/InvoiceRepository.cs
+++ b/BTCPayServer/Services/Invoices/InvoiceRepository.cs
@@ -806,7 +806,7 @@ retry:
             {
                 "new" => "New",
                 "paid" or "processing" => "Processing",
-                "complete" or "confirmed" => "Settled",
+                "complete" or "confirmed" or "settled" => "Settled",
                 "expired" => "Expired",
                 "invalid" => "Invalid",
                 _ => null


### PR DESCRIPTION
Addition to #5982, which fixes lookups for invoices with status `Settled` (e.g. for Sales tiles on the Dashboard).