### PR TITLE
Disable plugins if they crash the Dashboard page

### DIFF
--- a/BTCPayServer/Hosting/BTCPayServerServices.cs
+++ b/BTCPayServer/Hosting/BTCPayServerServices.cs
@@ -291,6 +291,7 @@ namespace BTCPayServer.Hosting
                 });
             services.TryAddSingleton<BTCPayNetworkProvider>();
 
+            services.AddExceptionHandler<PluginExceptionHandler>();
             services.TryAddSingleton<AppService>();
             services.AddTransient<PluginService>();
             services.AddSingleton<PluginHookService>();

--- a/BTCPayServer/Hosting/Startup.cs
+++ b/BTCPayServer/Hosting/Startup.cs
@@ -293,6 +293,7 @@ namespace BTCPayServer.Hosting
 
             app.UseStatusCodePagesWithReExecute("/errors/{0}");
 
+            app.UseExceptionHandler("/errors/{0}");
             app.UsePayServer();
             app.UseRouting();
             app.UseCors();

--- a/BTCPayServer/Plugins/PluginExceptionHandler.cs
+++ b/BTCPayServer/Plugins/PluginExceptionHandler.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using BTCPayServer.Configuration;
+using BTCPayServer.Logging;
+using Microsoft.AspNetCore.Diagnostics;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Hosting.Internal;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace BTCPayServer.Plugins
+{
+    public class PluginExceptionHandler : IExceptionHandler
+    {
+        readonly string _pluginDir;
+        readonly IHostApplicationLifetime _applicationLifetime;
+        private readonly Logs _logs;
+
+        public PluginExceptionHandler(IOptions<DataDirectories> options, IHostApplicationLifetime applicationLifetime, Logs logs)
+        {
+            _applicationLifetime = applicationLifetime;
+            _logs = logs;
+            _pluginDir = options.Value.PluginDir;
+        }
+        public ValueTask<bool> TryHandleAsync(HttpContext httpContext, Exception exception, CancellationToken cancellationToken)
+        {
+            if (!GetDisablePluginIfCrash(httpContext) ||
+                !PluginManager.IsExceptionByPlugin(exception, out var pluginName))
+                return ValueTask.FromResult(false);
+            _logs.Configuration.LogError(exception, $"Unhandled exception caused by plugin '{pluginName}', disabling it and restarting...");
+            _ = Task.Delay(3000).ContinueWith((t) => _applicationLifetime.StopApplication());
+            // Returning true here means we will see Error 500 error message.
+            // Returning false means that the user will see a stacktrace.
+            return ValueTask.FromResult(false);
+        }
+
+        internal static bool GetDisablePluginIfCrash(HttpContext httpContext)
+        {
+            return httpContext.Items.TryGetValue("DisablePluginIfCrash", out object renderingDashboard) ||
+                            renderingDashboard is not true;
+        }
+        internal static void SetDisablePluginIfCrash(HttpContext httpContext)
+        {
+            httpContext.Items.TryAdd("DisablePluginIfCrash", true);
+        }
+    }
+}

--- a/BTCPayServer/Views/UIServer/ListPlugins.cshtml
+++ b/BTCPayServer/Views/UIServer/ListPlugins.cshtml
@@ -84,7 +84,7 @@
                             @plugin
                             @if (version != null)
                             {
-                                <span>({version})</span>
+                                <span>(@version)</span>
                             }
                         </span>
                         <form asp-action="UnInstallPlugin" asp-route-plugin="@plugin">

--- a/BTCPayServer/Views/UIStores/Dashboard.cshtml
+++ b/BTCPayServer/Views/UIStores/Dashboard.cshtml
@@ -9,7 +9,8 @@
 @using BTCPayServer.Client
 @model StoreDashboardViewModel
 @{
-    ViewData.SetActivePage(StoreNavPages.Dashboard, Model.StoreName, Model.StoreId);
+	BTCPayServer.Plugins.PluginExceptionHandler.SetDisablePluginIfCrash(Context);
+	ViewData.SetActivePage(StoreNavPages.Dashboard, Model.StoreName, Model.StoreId);
     var store = ViewContext.HttpContext.GetStoreData();
 }
 


### PR DESCRIPTION
## Reproduce the issue

1. Use the 1.13.x branch and install the Boltcard Extension plugin.
2. Switch to the master branch.

## Expected

The BTCPay Server's dashboard should load properly.

## Actual

It is impossible to open the dashboard page of the BTCPay Server; the user always sees a stacktrace of the crash caused by the plugin.

## Workaround without this PR

Manually remove the plugin from the plugin folder via the operating system's file system.

## How this PR fixes it

When the user opens the dashboard, they will see a stacktrace of the crash. However, the server will then disable the plugin and stop after 3 seconds. When the server is restarted, the dashboard should open properly.

The stacktrace is also shown in the logs.