### PR TITLE
Shopify: Create invoice when the payment page opens

### DIFF
--- a/BTCPayServer/wwwroot/shopify/btcpay-shopify.js
+++ b/BTCPayServer/wwwroot/shopify/btcpay-shopify.js
@@ -160,9 +160,11 @@ window.BTCPayShopifyIntegrationModule = function () {
     }
     showPaymentInstructions();
     window.onPayButtonClicked = onPayButtonClicked.bind(this);
-    getOrCheckInvoice(true).then(function (d) {
-        injectPaymentButtonHtml();
-        handleInvoiceData(d, {backgroundCheck: true})
+    getOrCheckInvoice(false).then(function (d) {
+        if (d) {
+            injectPaymentButtonHtml();
+            handleInvoiceData(d, { backgroundCheck: true })
+        }
     });
 
 };


### PR DESCRIPTION
Fix  https://github.com/btcpayserver/btcpayserver/issues/6105

This will generate the invoice as soon as the page for payment in shopify open.