### PR TITLE
Sales report dashboard issue #6167 

### DIFF
--- a/BTCPayServer/Components/AppSales/Default.cshtml.js
+++ b/BTCPayServer/Components/AppSales/Default.cshtml.js
@@ -13,7 +13,7 @@ if (!window.appSales) {
                 const min = Math.min(...series);
                 const max = Math.max(...series);
                 const low = min === max ? 0 : Math.max(min - ((max - min) / 5), 0);
-                document.querySelectorAll(`#${id} .sales-count`).innerText = data.salesCount;
+                document.querySelector(`#${id} .sales-count`).innerText = data.salesCount;
                 new Chartist.Bar(`#${id} .ct-chart`, {
                     labels,
                     series: [series]


### PR DESCRIPTION
querySelectorAll returns multiple elements that leads to not updating the required element innerText directly, so i change querySelector that will directly update our .sales-count element innerText.

Please review the changes and let me know if any additional modifications are required.