### PR TITLE
Greenfield: Can set the label when generating a wallet for store

### DIFF
--- a/BTCPayServer.Client/Models/GenerateOnChainWalletRequest.cs
+++ b/BTCPayServer.Client/Models/GenerateOnChainWalletRequest.cs
@@ -10,6 +10,7 @@ namespace BTCPayServer.Client
 {
     public class GenerateOnChainWalletRequest
     {
+        public string Label { get; set; }
         public int AccountNumber { get; set; } = 0;
         [JsonConverter(typeof(MnemonicJsonConverter))]
         public Mnemonic ExistingMnemonic { get; set; }
@@ -29,6 +30,7 @@ namespace BTCPayServer.Client
     {
         public class ConfigData
         {
+            public string Label { get; set; }
             public string AccountDerivation { get; set; }
             [JsonExtensionData]
             IDictionary<string, JToken> AdditionalData { get; set; }

--- a/BTCPayServer.Tests/GreenfieldAPITests.cs
+++ b/BTCPayServer.Tests/GreenfieldAPITests.cs
@@ -3158,8 +3158,8 @@ namespace BTCPayServer.Tests
 
             await client.RemoveStorePaymentMethod(store.Id, "BTC-CHAIN");
             generateResponse = await client.GenerateOnChainWallet(store.Id, "BTC",
-                new GenerateOnChainWalletRequest() { ExistingMnemonic = allMnemonic, AccountNumber = 1 });
-
+                new GenerateOnChainWalletRequest() { ExistingMnemonic = allMnemonic, AccountNumber = 1, Label = "test" });
+            Assert.Equal("test", generateResponse.Config.Label);
             Assert.Equal(generateResponse.Mnemonic.ToString(), allMnemonic.ToString());
 
             Assert.Equal(new Mnemonic("all all all all all all all all all all all all").DeriveExtKey()

--- a/BTCPayServer/Controllers/GreenField/LocalBTCPayServerClient.cs
+++ b/BTCPayServer/Controllers/GreenField/LocalBTCPayServerClient.cs
@@ -937,17 +937,7 @@ namespace BTCPayServer.Controllers.Greenfield
         {
             return GetFromActionResult<GenerateOnChainWalletResponse>(
                 await GetController<GreenfieldStoreOnChainPaymentMethodsController>().GenerateOnChainWallet(storeId, Payments.PaymentMethodId.Parse(paymentMethodId),
-                    new GenerateWalletRequest()
-                    {
-                        Passphrase = request.Passphrase,
-                        AccountNumber = request.AccountNumber,
-                        ExistingMnemonic = request.ExistingMnemonic?.ToString(),
-                        WordCount = request.WordCount,
-                        WordList = request.WordList,
-                        SavePrivateKeys = request.SavePrivateKeys,
-                        ScriptPubKeyType = request.ScriptPubKeyType,
-                        ImportKeysToRPC = request.ImportKeysToRPC
-                    }));
+                    request));
         }
 
         public override async Task SendEmail(string storeId, SendEmailRequest request,

--- a/BTCPayServer/wwwroot/swagger/v1/swagger.template.stores-payment-methods.on-chain.json
+++ b/BTCPayServer/wwwroot/swagger/v1/swagger.template.stores-payment-methods.on-chain.json
@@ -322,6 +322,10 @@
                 "type": "object",
                 "additionalProperties": false,
                 "properties": {
+                    "label": {
+                        "type": "string",
+                        "description": "A label that will be shown in the UI"
+                    },
                     "existingMnemonic": {
                         "$ref": "#/components/schemas/Mnemonic"
                     },


### PR DESCRIPTION
Reported by @ndeet. It wasn't possible to set the label of the wallet in the generate wallet route.