### PR TITLE
Add topups to payouts

### DIFF
--- a/BTCPayServer.Data/DBScripts/002.RefactorPayouts.sql
+++ b/BTCPayServer.Data/DBScripts/002.RefactorPayouts.sql
@@ -7,6 +7,7 @@ UPDATE "Payouts" SET
     "Currency" = split_part("PayoutMethodId", '_', 1),
     "PayoutMethodId"=
         CASE
+            WHEN ("Blob"->>'Amount')::NUMERIC < 0 THEN 'TOPUP'
             WHEN split_part("PayoutMethodId", '_', 2) = 'LightningLike' THEN split_part("PayoutMethodId", '_', 1) || '-LN'
             ELSE split_part("PayoutMethodId", '_', 1) || '-CHAIN'
         END;

--- a/BTCPayServer.Tests/DatabaseTests.cs
+++ b/BTCPayServer.Tests/DatabaseTests.cs
@@ -59,6 +59,14 @@ namespace BTCPayServer.Tests
                     PullPaymentDataId = null as string,
                     PaymentMethodId = "BTC_LightningLike",
                     Blob = "{\"Amount\": \"10.0\", \"Revision\": 0, \"Destination\": \"address\", \"CryptoAmount\": null, \"MinimumConfirmation\": 1}"
+                },
+                new
+                {
+                    Id = "p4",
+                    StoreId = "store1",
+                    PullPaymentDataId = null as string,
+                    PaymentMethodId = "BTC_LightningLike",
+                    Blob = "{\"Amount\": \"-10.0\", \"Revision\": 0, \"Destination\": \"address\", \"CryptoAmount\": null, \"MinimumConfirmation\": 1}"
                 }
             };
             await conn.ExecuteAsync("INSERT INTO \"Payouts\"(\"Id\", \"StoreDataId\", \"PullPaymentDataId\", \"PaymentMethodId\", \"Blob\", \"State\", \"Date\") VALUES (@Id, @StoreId, @PullPaymentDataId, @PaymentMethodId, @Blob::JSONB, 'state', NOW())", parameters);
@@ -74,6 +82,9 @@ namespace BTCPayServer.Tests
             Assert.True(migrated);
 
             migrated = await conn.ExecuteScalarAsync<bool>("SELECT 't'::BOOLEAN FROM \"Payouts\" WHERE \"Id\"='p3' AND \"Amount\" IS NULL AND \"OriginalAmount\"=10.0 AND \"OriginalCurrency\"='BTC'");
+            Assert.True(migrated);
+
+            migrated = await conn.ExecuteScalarAsync<bool>("SELECT 't'::BOOLEAN FROM \"Payouts\" WHERE \"Id\"='p4' AND \"Amount\" IS NULL AND \"OriginalAmount\"=-10.0 AND \"OriginalCurrency\"='BTC' AND \"PayoutMethodId\"='TOPUP'");
             Assert.True(migrated);
         }
     }

--- a/BTCPayServer/HostedServices/PullPaymentHostedService.cs
+++ b/BTCPayServer/HostedServices/PullPaymentHostedService.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using BTCPayServer.Abstractions.Extensions;
 using BTCPayServer.Client.Models;
 using BTCPayServer.Data;
+using BTCPayServer.Events;
 using BTCPayServer.Logging;
 using BTCPayServer.Models.WalletViewModels;
 using BTCPayServer.Payments;
@@ -273,7 +274,7 @@ namespace BTCPayServer.HostedServices
 
             return await query.FirstOrDefaultAsync(data => data.Id == pullPaymentId);
         }
-
+        record TopUpRequest(string PullPaymentId, InvoiceEntity InvoiceEntity);
         class PayoutRequest
         {
             public PayoutRequest(TaskCompletionSource<ClaimRequest.ClaimResponse> completionSource,
@@ -336,8 +337,19 @@ namespace BTCPayServer.HostedServices
             {
                 payoutHandler.StartBackgroundCheck(Subscribe);
             }
-
+            _eventAggregator.Subscribe<Events.InvoiceEvent>(TopUpInvoiceCore);
             return new[] { Loop() };
+        }
+
+        private void TopUpInvoiceCore(InvoiceEvent evt)
+        {
+            if (evt.EventCode == InvoiceEventCode.Completed || evt.EventCode == InvoiceEventCode.MarkedCompleted)
+            {
+                foreach (var pullPaymentId in evt.Invoice.GetInternalTags("PULLPAY#"))
+                {
+                    _Channel.Writer.TryWrite(new TopUpRequest(pullPaymentId, evt.Invoice));
+                }
+            }
         }
 
         private void Subscribe(params Type[] events)
@@ -352,6 +364,11 @@ namespace BTCPayServer.HostedServices
         {
             await foreach (var o in _Channel.Reader.ReadAllAsync())
             {
+                if (o is TopUpRequest topUp)
+                {
+                    await HandleTopUp(topUp);
+                }
+
                 if (o is PayoutRequest req)
                 {
                     await HandleCreatePayout(req);
@@ -384,6 +401,38 @@ namespace BTCPayServer.HostedServices
                     }
                 }
             }
+        }
+
+        private async Task HandleTopUp(TopUpRequest topUp)
+        {
+            var pp = await this.GetPullPayment(topUp.PullPaymentId, false);
+            using var ctx = _dbContextFactory.CreateContext();
+
+            var payout = new Data.PayoutData()
+            {
+                Id = Encoders.Base58.EncodeData(RandomUtils.GetBytes(20)),
+                PayoutMethodId = PayoutMethodIds.TopUp.ToString(),
+                Date = DateTimeOffset.UtcNow,
+                State = PayoutState.Completed,
+                PullPaymentDataId = pp.Id,
+                Destination = topUp.InvoiceEntity.Id,
+                StoreDataId = pp.StoreId
+            };
+            if (topUp.InvoiceEntity.Currency != pp.Currency ||
+                pp.Currency is not ("SATS" or "BTC"))
+                return;
+            payout.Currency = pp.Currency;
+            payout.Amount = -topUp.InvoiceEntity.Price;
+            payout.OriginalCurrency = payout.Currency;
+            payout.OriginalAmount = payout.Amount.Value;
+            var payoutBlob = new PayoutBlob()
+            {
+                Destination = topUp.InvoiceEntity.Id,
+                Metadata = new JObject()
+            };
+            payout.SetBlob(payoutBlob, _jsonSerializerSettings);
+            await ctx.Payouts.AddAsync(payout);
+            await ctx.SaveChangesAsync();
         }
 
         public bool SupportsLNURL(PullPaymentData pp, PullPaymentBlob blob = null)
@@ -842,6 +891,10 @@ namespace BTCPayServer.HostedServices
             return time;
         }
 
+        public static string GetInternalTag(string ppId)
+        {
+            return $"PULLPAY#{ppId}";
+        }
 
         class InternalPayoutPaidRequest
         {

--- a/BTCPayServer/Payouts/PayoutTypes.cs
+++ b/BTCPayServer/Payouts/PayoutTypes.cs
@@ -2,6 +2,10 @@ using BTCPayServer.Payments;
 
 namespace BTCPayServer.Payouts
 {
+    public class PayoutMethodIds
+    {
+        public static readonly PayoutMethodId TopUp = PayoutMethodId.Parse("TOPUP");
+    }
     public class PayoutTypes
     {
         public static readonly PayoutType LN = new("LN");


### PR DESCRIPTION
This come from 1.13.x.

I decided to use a different `PayoutMethodId` for topups as it doesn't have to be on LN.
Note that this PR isn't enough to make a topup on a pull payments. You can only do this by adding an internal tag to the invoice. (Which only plugins can do)