### PR TITLE
Invitation process improvements

### DIFF
--- a/BTCPayServer.Data/Data/ApplicationUser.cs
+++ b/BTCPayServer.Data/Data/ApplicationUser.cs
@@ -46,5 +46,6 @@ namespace BTCPayServer.Data
         public bool ShowInvoiceStatusChangeHint { get; set; }
         public string ImageUrl { get; set; }
         public string Name { get; set; }
+        public string InvitationToken { get; set; }
     }
 }

--- a/BTCPayServer.Tests/BTCPayServer.Tests.csproj
+++ b/BTCPayServer.Tests/BTCPayServer.Tests.csproj
@@ -34,7 +34,7 @@
     <PackageReference Include="Newtonsoft.Json.Schema" Version="3.0.15" />
     <PackageReference Include="Selenium.Support" Version="4.1.1" />
     <PackageReference Include="Selenium.WebDriver" Version="4.22.0" />
-	<PackageReference Include="Selenium.WebDriver.ChromeDriver" Version="125.0.6422.14100" />
+	<PackageReference Include="Selenium.WebDriver.ChromeDriver" Version="128.0.6613.11900" />
 	<PackageReference Include="xunit" Version="2.6.6" />
 	<PackageReference Include="xunit.runner.visualstudio" Version="2.5.6">
       <PrivateAssets>all</PrivateAssets>

--- a/BTCPayServer.Tests/SeleniumTester.cs
+++ b/BTCPayServer.Tests/SeleniumTester.cs
@@ -55,6 +55,7 @@ namespace BTCPayServer.Tests
             options.AddArguments($"window-size={windowSize.Width}x{windowSize.Height}");
             options.AddArgument("shm-size=2g");
             options.AddArgument("start-maximized");
+            options.AddArgument("disable-search-engine-choice-screen");
             if (Server.PayTester.InContainer)
             {
                 // Shot in the dark to fix https://stackoverflow.com/questions/53902507/unknown-error-session-deleted-because-of-page-crash-from-unknown-error-cannot

--- a/BTCPayServer.Tests/SeleniumTests.cs
+++ b/BTCPayServer.Tests/SeleniumTests.cs
@@ -371,7 +371,7 @@ namespace BTCPayServer.Tests
             var usr = RandomUtils.GetUInt256().ToString().Substring(64 - 20) + "@a.com";
             s.Driver.FindElement(By.Id("Email")).SendKeys(usr);
             s.ClickPagePrimary();
-            var url = s.FindAlertMessage().FindElement(By.TagName("a")).Text;
+            var url = s.Driver.FindElement(By.Id("InvitationUrl")).GetAttribute("data-text");
 
             s.Logout();
             s.Driver.Navigate().GoToUrl(url);

--- a/BTCPayServer/Controllers/UIAccountController.cs
+++ b/BTCPayServer/Controllers/UIAccountController.cs
@@ -812,7 +812,7 @@ namespace BTCPayServer.Controllers
                 return NotFound();
             }
 
-            var user = await _userManager.FindByInvitationTokenAsync(userId, Uri.UnescapeDataString(code));
+            var user = await _userManager.FindByInvitationTokenAsync<ApplicationUser>(userId, Uri.UnescapeDataString(code));
             if (user == null)
             {
                 return NotFound();
@@ -826,6 +826,9 @@ namespace BTCPayServer.Controllers
                 User = user,
                 RequestUri = Request.GetAbsoluteRootUri()
             });
+            
+            // unset used token
+            await _userManager.UnsetInvitationTokenAsync<ApplicationUser>(user.Id);
             
             if (requiresEmailConfirmation)
             {

--- a/BTCPayServer/Controllers/UIServerController.Users.cs
+++ b/BTCPayServer/Controllers/UIServerController.Users.cs
@@ -262,7 +262,7 @@ namespace BTCPayServer.Controllers
                     {
                         Severity = StatusMessageModel.StatusSeverity.Success,
                         AllowDismiss = false,
-                        Html = $"Account successfully created. {info} share this link with them:<br/><a class='alert-link' href='{callbackUrl}'>{callbackUrl}</a>"
+                        Html = $"Account successfully created. {info} share this link with them: {callbackUrl}"
                     });
                     return RedirectToAction(nameof(ListUsers));
                 }

--- a/BTCPayServer/Events/UserRegisteredEvent.cs
+++ b/BTCPayServer/Events/UserRegisteredEvent.cs
@@ -11,6 +11,7 @@ public class UserRegisteredEvent
     public UserRegisteredEventKind Kind { get; set; } = UserRegisteredEventKind.Registration;
     public Uri RequestUri { get; set; }
     public ApplicationUser InvitedByUser { get; set; }
+    public bool SendInvitationEmail { get; set; }
     public TaskCompletionSource<Uri> CallbackUrlGenerated;
 }
 

--- a/BTCPayServer/HostedServices/UserEventHostedService.cs
+++ b/BTCPayServer/HostedServices/UserEventHostedService.cs
@@ -77,7 +77,8 @@ public class UserEventHostedService(
                     callbackUrl = generator.InvitationLink(user.Id, code, uri.Scheme, host, uri.PathAndQuery);
                     ev.CallbackUrlGenerated?.SetResult(new Uri(callbackUrl));
 
-                    emailSender.SendInvitation(user.GetMailboxAddress(), callbackUrl);
+                    if (ev.SendInvitationEmail)
+                        emailSender.SendInvitation(user.GetMailboxAddress(), callbackUrl);
                 }
                 else if (requiresEmailConfirmation)
                 {

--- a/BTCPayServer/HostedServices/UserEventHostedService.cs
+++ b/BTCPayServer/HostedServices/UserEventHostedService.cs
@@ -73,7 +73,7 @@ public class UserEventHostedService(
                 emailSender = await emailSenderFactory.GetEmailSender();
                 if (isInvite)
                 {
-                    code = await userManager.GenerateInvitationTokenAsync(user);
+                    code = await userManager.GenerateInvitationTokenAsync<ApplicationUser>(user.Id);
                     callbackUrl = generator.InvitationLink(user.Id, code, uri.Scheme, host, uri.PathAndQuery);
                     ev.CallbackUrlGenerated?.SetResult(new Uri(callbackUrl));
 

--- a/BTCPayServer/Models/ServerViewModels/UsersViewModel.cs
+++ b/BTCPayServer/Models/ServerViewModels/UsersViewModel.cs
@@ -14,7 +14,8 @@ namespace BTCPayServer.Models.ServerViewModels
             public string Id { get; set; }
             public string Email { get; set; }
             public string Name { get; set; }
-
+            [Display(Name = "Invitation URL")]
+            public string InvitationUrl { get; set; }
             [Display(Name = "Image")]
             public IFormFile ImageFile { get; set; }
             public string ImageUrl { get; set; }

--- a/BTCPayServer/UserManagerExtensions.cs
+++ b/BTCPayServer/UserManagerExtensions.cs
@@ -1,5 +1,7 @@
 #nullable enable
+using System;
 using System.Threading.Tasks;
+using BTCPayServer.Data;
 using BTCPayServer.Security;
 using Microsoft.AspNetCore.Identity;
 
@@ -19,15 +21,35 @@ namespace BTCPayServer
             return await userManager.FindByIdAsync(idOrEmail);
         }
 
-        public static async Task<string> GenerateInvitationTokenAsync<TUser>(this UserManager<TUser> userManager, TUser user) where TUser : class
+        public static async Task<string?> GenerateInvitationTokenAsync<TUser>(this UserManager<ApplicationUser> userManager, string userId) where TUser : class
         {
-            return await userManager.GenerateUserTokenAsync(user, InvitationTokenProviderOptions.ProviderName, InvitationPurpose);
+            var token = Guid.NewGuid().ToString("n")[..12];
+            return await userManager.SetInvitationTokenAsync<TUser>(userId, token) ? token : null;
         }
 
-        public static async Task<TUser?> FindByInvitationTokenAsync<TUser>(this UserManager<TUser> userManager, string userId, string token) where TUser : class
+        public static async Task<bool> UnsetInvitationTokenAsync<TUser>(this UserManager<ApplicationUser> userManager, string userId) where TUser : class
+        {
+            return await userManager.SetInvitationTokenAsync<TUser>(userId, null);
+        }
+
+        private static async Task<bool> SetInvitationTokenAsync<TUser>(this UserManager<ApplicationUser> userManager, string userId, string? token) where TUser : class
         {
             var user = await userManager.FindByIdAsync(userId);
-            var isValid = user is not null && await userManager.VerifyUserTokenAsync(user, InvitationTokenProviderOptions.ProviderName, InvitationPurpose, token);
+            if (user == null) return false;
+            var blob = user.GetBlob() ?? new UserBlob();
+            blob.InvitationToken = token;
+            user.SetBlob(blob);
+            await userManager.UpdateAsync(user);
+            return true;
+        }
+
+        public static async Task<ApplicationUser?> FindByInvitationTokenAsync<TUser>(this UserManager<ApplicationUser> userManager, string userId, string token) where TUser : class
+        {
+            var user = await userManager.FindByIdAsync(userId);
+            var isValid = user is not null && (
+                user.GetBlob()?.InvitationToken == token ||
+                // backwards-compatibility with old tokens
+                await userManager.VerifyUserTokenAsync(user, InvitationTokenProviderOptions.ProviderName, InvitationPurpose, token));
             return isValid ? user : null;
         }
     }

--- a/BTCPayServer/Views/UIServer/CreateUser.cshtml
+++ b/BTCPayServer/Views/UIServer/CreateUser.cshtml
@@ -1,6 +1,9 @@
+@using BTCPayServer.TagHelpers
+@using Microsoft.AspNetCore.Mvc.TagHelpers
 @model BTCPayServer.Controllers.RegisterFromAdminViewModel
 @{
     ViewData.SetActivePage(ServerNavPages.Users, "Create account");
+    var canSendEmail = ViewData["CanSendEmail"] is true;
 }
 
 <form method="post" asp-action="CreateUser">
@@ -55,6 +58,17 @@
                     <span asp-validation-for="EmailConfirmed" class="text-danger"></span>
                 </div>
             }
+            <div class="d-flex my-3">
+                <input asp-for="SendInvitationEmail" type="checkbox" class="btcpay-toggle me-3" disabled="@(canSendEmail ? null : "disabled")" />
+                <div>
+                    <label asp-for="SendInvitationEmail" class="form-check-label"></label>
+                    <span asp-validation-for="SendInvitationEmail" class="text-danger"></span>
+                    @if (!canSendEmail)
+                    {
+                        <div class="text-secondary">Your email server has not been configured. <a asp-controller="UIServer" asp-action="Emails">Please configure it first.</a></div>
+                    }
+                </div>
+            </div>
         </div>
     </div>
 </form>

--- a/BTCPayServer/Views/UIServer/ListUsers.cshtml
+++ b/BTCPayServer/Views/UIServer/ListUsers.cshtml
@@ -55,6 +55,7 @@
                 { Disabled: true } => ("Disabled", "danger"),
                 { Approved: false } => ("Pending Approval", "warning"),
                 { EmailConfirmed: false } => ("Pending Email Verification", "warning"),
+                { InvitationUrl: not null } => ("Pending Invitation", "warning"),
                 _ => ("Active", "success")
             };
             var detailsId = $"user_details_{user.Id}";
@@ -68,7 +69,7 @@
                         }
                     </div>
                 </td>
-                <td>@user.Stores.Count() Store@(user.Stores.Count() == 1 ? "" : "s")</td>
+                <td class="@(user.Stores.Any() ? null : "text-muted")">@user.Stores.Count() Store@(user.Stores.Count() == 1 ? "" : "s")</td>
                 <td>@user.Created?.ToBrowserDate()</td>
                 <td>
                    <span class="user-status badge bg-@status.Item2">@status.Item1</span>
@@ -82,11 +83,11 @@
                         {
                             <a asp-action="ApproveUser" asp-route-userId="@user.Id" asp-route-approved="true" data-bs-toggle="modal" data-bs-target="#ConfirmModal" data-title="Approve user" data-description="This will approve the user <strong>@Html.Encode(user.Email)</strong>." data-confirm="Approve">Approve</a>
                         }
+                        <a asp-action="User" asp-route-userId="@user.Id" class="user-edit">Edit</a>
                         @if (status.Item2 != "warning")
                         {
                             <a asp-action="ToggleUser" asp-route-userId="@user.Id" asp-route-enable="@user.Disabled">@(user.Disabled ? "Enable" : "Disable")</a>
                         }
-                        <a asp-action="User" asp-route-userId="@user.Id" class="user-edit">Edit</a>
                         <a asp-action="DeleteUser" asp-route-userId="@user.Id">Remove</a>
                     </div>
                 </td>
@@ -100,7 +101,21 @@
             </tr>
             <tr id="@detailsId" class="user-details-row collapse">
                 <td colspan="6" class="border-top-0">
-                    @if (user.Stores.Any())
+                    @if (!string.IsNullOrEmpty(user.InvitationUrl))
+                    {
+                        <div class="payment-box m-0">
+                            <div class="qr-container">
+                                <vc:qr-code data="@user.InvitationUrl" />
+                            </div>
+                            <div class="input-group mt-3">
+                                <div class="form-floating">
+                                    <vc:truncate-center text="@user.InvitationUrl" padding="15" elastic="true" classes="form-control-plaintext"/>
+                                    <label>Invitation URL</label>
+                                </div>
+                            </div>
+                        </div>
+                    }
+                    else if (user.Stores.Any())
                     {
                         <ul class="mb-0 p-0">
                             @foreach (var store in user.Stores)
@@ -118,7 +133,7 @@
                     }
                     else
                     {
-                        <span class="text-secondary">No stores</span> 
+                        <span class="text-secondary">No stores</span>
                     }
                 </td>
             </tr>

--- a/BTCPayServer/Views/UIServer/User.cshtml
+++ b/BTCPayServer/Views/UIServer/User.cshtml
@@ -21,6 +21,22 @@
 		<button id="page-primary" name="command" type="submit" class="btn btn-primary" value="Save">Save</button>
     </div>
     <partial name="_StatusMessage" />
+
+    @if (!string.IsNullOrEmpty(Model.InvitationUrl))
+    {
+        <div class="payment-box mx-0 mb-5">
+            <div class="qr-container">
+                <vc:qr-code data="@Model.InvitationUrl" />
+            </div>
+            <div class="input-group mt-3">
+                <div class="form-floating">
+                    <vc:truncate-center text="@Model.InvitationUrl" padding="15" elastic="true" classes="form-control-plaintext"/>
+                    <label>Invitation URL</label>
+                </div>
+            </div>
+        </div>
+    }
+    
     <div class="form-group">
         <label asp-for="Name" class="form-label"></label>
         <input asp-for="Name" class="form-control" />

--- a/BTCPayServer/Views/UIServer/User.cshtml
+++ b/BTCPayServer/Views/UIServer/User.cshtml
@@ -30,8 +30,8 @@
             </div>
             <div class="input-group mt-3">
                 <div class="form-floating">
-                    <vc:truncate-center text="@Model.InvitationUrl" padding="15" elastic="true" classes="form-control-plaintext"/>
-                    <label>Invitation URL</label>
+                    <vc:truncate-center text="@Model.InvitationUrl" padding="15" elastic="true" classes="form-control-plaintext" id="InvitationUrl"/>
+                    <label for="InvitationUrl">Invitation URL</label>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
A combination of three things to enhance the invite flow:

- Make sending invitation email optional when adding a new user on the server-level. Closes #6158.
  - Store-level invites will always send an email, because the user need 
- Generate custom invite token and store it in user blob. Closes btcpayserver/app#46.
  - Up to now, we've generated invite codes using the .NET internals, but this leads to lengthy codes and hence dense QR codes. With this, we can also later on show the invitation URL again to the admin — previously that required a new invite code to be generated.
- Display QR code for user invite. Closes #6157.

![invite](https://github.com/user-attachments/assets/6779a887-13d7-40c1-9bea-6b8d528c0633)
