### PR TITLE
Permissions: Remove deprecated custodian account policies

### DIFF
--- a/BTCPayServer.Data/Migrations/20240904092905_UpdateStoreOwnerRole.cs
+++ b/BTCPayServer.Data/Migrations/20240904092905_UpdateStoreOwnerRole.cs
@@ -1,0 +1,54 @@
+using BTCPayServer.Data;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Newtonsoft.Json;
+
+#nullable disable
+
+namespace BTCPayServer.Migrations
+{
+    [DbContext(typeof(ApplicationDbContext))]
+    [Migration("20240904092905_UpdateStoreOwnerRole")]
+    public partial class UpdateStoreOwnerRole : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.UpdateData(
+                "StoreRoles",
+                keyColumns: new[] { "Id" },
+                keyColumnTypes: new[] { "TEXT" },
+                keyValues: new[] { "Owner" },
+                columns: new[] { "Permissions" },
+                columnTypes: new[] { "TEXT[]" },
+                values: new object[]
+                {
+                    new[]
+                    {
+                        "btcpay.store.canmodifystoresettings"
+                    }
+                });
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.UpdateData(
+                "StoreRoles",
+                keyColumns: new[] { "Id" },
+                keyColumnTypes: new[] { "TEXT" },
+                keyValues: new[] { "Owner" },
+                columns: new[] { "Permissions" },
+                columnTypes: new[] { "TEXT[]" },
+                values: new object[]
+                {
+                    new[]
+                    {
+                        "btcpay.store.canmodifystoresettings",
+                        "btcpay.store.cantradecustodianaccount",
+                        "btcpay.store.canwithdrawfromcustodianaccount",
+                        "btcpay.store.candeposittocustodianaccount"
+                    }
+                });
+        }
+    }
+}


### PR DESCRIPTION
Updates the store owner role and removes these three deprecated policies:

- `btcpay.store.cantradecustodianaccount`
- `btcpay.store.canwithdrawfromcustodianaccount`
- `btcpay.store.candeposittocustodianaccount`