### PR TITLE
Rename PaymentMethod => PaymentMethodId

### DIFF
--- a/BTCPayServer.Client/Models/CreatePayoutRequest.cs
+++ b/BTCPayServer.Client/Models/CreatePayoutRequest.cs
@@ -8,6 +8,6 @@ namespace BTCPayServer.Client.Models
         public string Destination { get; set; }
         [JsonConverter(typeof(NumericStringJsonConverter))]
         public decimal? Amount { get; set; }
-        public string PaymentMethod { get; set; }
+        public string PayoutMethodId { get; set; }
     }
 }

--- a/BTCPayServer.Client/Models/LightningAutomatedPayoutSettings.cs
+++ b/BTCPayServer.Client/Models/LightningAutomatedPayoutSettings.cs
@@ -6,7 +6,7 @@ namespace BTCPayServer.Client.Models;
 
 public class LightningAutomatedPayoutSettings
 {
-    public string PaymentMethod { get; set; }
+    public string PaymentMethodId { get; set; }
 
     [JsonConverter(typeof(TimeSpanJsonConverter.Seconds))]
     public TimeSpan IntervalSeconds { get; set; }

--- a/BTCPayServer.Client/Models/LightningAutomatedPayoutSettings.cs
+++ b/BTCPayServer.Client/Models/LightningAutomatedPayoutSettings.cs
@@ -6,7 +6,7 @@ namespace BTCPayServer.Client.Models;
 
 public class LightningAutomatedPayoutSettings
 {
-    public string PaymentMethodId { get; set; }
+    public string PayoutMethodId { get; set; }
 
     [JsonConverter(typeof(TimeSpanJsonConverter.Seconds))]
     public TimeSpan IntervalSeconds { get; set; }

--- a/BTCPayServer.Client/Models/OnChainAutomatedPayoutSettings.cs
+++ b/BTCPayServer.Client/Models/OnChainAutomatedPayoutSettings.cs
@@ -6,7 +6,7 @@ namespace BTCPayServer.Client.Models;
 
 public class OnChainAutomatedPayoutSettings
 {
-    public string PaymentMethod { get; set; }
+    public string PaymentMethodId { get; set; }
 
     [JsonConverter(typeof(TimeSpanJsonConverter.Seconds))]
     public TimeSpan IntervalSeconds { get; set; }

--- a/BTCPayServer.Client/Models/OnChainAutomatedPayoutSettings.cs
+++ b/BTCPayServer.Client/Models/OnChainAutomatedPayoutSettings.cs
@@ -6,7 +6,7 @@ namespace BTCPayServer.Client.Models;
 
 public class OnChainAutomatedPayoutSettings
 {
-    public string PaymentMethodId { get; set; }
+    public string PayoutMethodId { get; set; }
 
     [JsonConverter(typeof(TimeSpanJsonConverter.Seconds))]
     public TimeSpan IntervalSeconds { get; set; }

--- a/BTCPayServer.Client/Models/PaymentMethodCriteriaData.cs
+++ b/BTCPayServer.Client/Models/PaymentMethodCriteriaData.cs
@@ -5,7 +5,7 @@ namespace BTCPayServer.Client.Models;
 
 public class PaymentMethodCriteriaData
 {
-    public string PaymentMethod { get; set; }
+    public string PaymentMethodId { get; set; }
     public string CurrencyCode { get; set; }
     [JsonConverter(typeof(NumericStringJsonConverter))]
     public decimal Amount { get; set; }

--- a/BTCPayServer.Client/Models/PayoutData.cs
+++ b/BTCPayServer.Client/Models/PayoutData.cs
@@ -21,7 +21,7 @@ namespace BTCPayServer.Client.Models
         public string Id { get; set; }
         public string PullPaymentId { get; set; }
         public string Destination { get; set; }
-        public string PaymentMethod { get; set; }
+        public string PayoutMethodId { get; set; }
         public string CryptoCode { get; set; }
         [JsonConverter(typeof(NumericStringJsonConverter))]
         public decimal Amount { get; set; }

--- a/BTCPayServer.Client/Models/RefundInvoiceRequest.cs
+++ b/BTCPayServer.Client/Models/RefundInvoiceRequest.cs
@@ -17,7 +17,7 @@ namespace BTCPayServer.Client.Models
     public class RefundInvoiceRequest
     {
         public string? Name { get; set; } = null;
-        public string? PaymentMethod { get; set; }
+        public string? PayoutMethodId { get; set; }
         public string? Description { get; set; } = null;
         
         [JsonConverter(typeof(StringEnumConverter))]

--- a/BTCPayServer.Data/Data/PayoutProcessorData.cs
+++ b/BTCPayServer.Data/Data/PayoutProcessorData.cs
@@ -16,7 +16,7 @@ public class PayoutProcessorData : IHasBlobUntyped
     public string Id { get; set; }
     public string StoreId { get; set; }
     public StoreData Store { get; set; }
-    public string PaymentMethod { get; set; }
+    public string PayoutMethodId { get; set; }
     public string Processor { get; set; }
 
     [Obsolete("Use Blob2 instead")]
@@ -36,6 +36,6 @@ public class PayoutProcessorData : IHasBlobUntyped
 
     public override string ToString()
     {
-        return $"{Processor} {PaymentMethod} {StoreId}";
+        return $"{Processor} {PayoutMethodId} {StoreId}";
     }
 }

--- a/BTCPayServer.Data/Migrations/20240906010127_renamecol.cs
+++ b/BTCPayServer.Data/Migrations/20240906010127_renamecol.cs
@@ -22,6 +22,10 @@ namespace BTCPayServer.Migrations
                 name: "IX_Payouts_Destination_State",
                 table: "Payouts",
                 newName: "IX_Payouts_DedupId_State");
+            migrationBuilder.RenameColumn(
+             name: "PaymentMethod",
+             table: "PayoutProcessors",
+             newName: "PayoutMethodId");
         }
 
         /// <inheritdoc />

--- a/BTCPayServer.Data/Migrations/ApplicationDbContextModelSnapshot.cs
+++ b/BTCPayServer.Data/Migrations/ApplicationDbContextModelSnapshot.cs
@@ -618,7 +618,7 @@ namespace BTCPayServer.Migrations
                     b.Property<string>("Blob2")
                         .HasColumnType("JSONB");
 
-                    b.Property<string>("PaymentMethod")
+                    b.Property<string>("PayoutMethodId")
                         .HasColumnType("text");
 
                     b.Property<string>("Processor")

--- a/BTCPayServer.Tests/GreenfieldAPITests.cs
+++ b/BTCPayServer.Tests/GreenfieldAPITests.cs
@@ -2172,7 +2172,7 @@ namespace BTCPayServer.Tests
                     RefundVariant = RefundVariant.RateThen
                 });
             });
-            Assert.Contains("PaymentMethod: Please select one of the payment methods which were available for the original invoice", validationError.Message);
+            Assert.Contains("PayoutMethodId: Please select one of the payment methods which were available for the original invoice", validationError.Message);
 
             // test RefundVariant.RateThen
             var pp = await client.RefundInvoice(user.StoreId, invoice.Id, new RefundInvoiceRequest()

--- a/BTCPayServer.Tests/GreenfieldAPITests.cs
+++ b/BTCPayServer.Tests/GreenfieldAPITests.cs
@@ -1071,19 +1071,19 @@ namespace BTCPayServer.Tests
             {
                 Destination = destination,
                 Amount = 1_000_000m,
-                PaymentMethod = "BTC",
+                PayoutMethodId = "BTC",
             }));
 
             await this.AssertAPIError("archived", async () => await unauthenticated.CreatePayout(pps[1].Id, new CreatePayoutRequest()
             {
                 Destination = destination,
-                PaymentMethod = "BTC"
+                PayoutMethodId = "BTC"
             }));
 
             var payout = await unauthenticated.CreatePayout(pps[0].Id, new CreatePayoutRequest()
             {
                 Destination = destination,
-                PaymentMethod = "BTC"
+                PayoutMethodId = "BTC"
             });
 
             payouts = await unauthenticated.GetPayouts(pps[0].Id);
@@ -1092,7 +1092,7 @@ namespace BTCPayServer.Tests
             Assert.Equal(payout.Id, payout2.Id);
             Assert.Equal(destination, payout2.Destination);
             Assert.Equal(PayoutState.AwaitingApproval, payout.State);
-            Assert.Equal("BTC-CHAIN", payout2.PaymentMethod);
+            Assert.Equal("BTC-CHAIN", payout2.PayoutMethodId);
             Assert.Equal("BTC", payout2.CryptoCode);
             Assert.Null(payout.PaymentMethodAmount);
 
@@ -1103,14 +1103,14 @@ namespace BTCPayServer.Tests
             {
                 Destination = destination2,
                 Amount = 0.00001m,
-                PaymentMethod = "BTC"
+                PayoutMethodId = "BTC"
             }));
 
             TestLogs.LogInformation("Can't create too low payout");
             await this.AssertAPIError("amount-too-low", async () => await unauthenticated.CreatePayout(pps[0].Id, new CreatePayoutRequest()
             {
                 Destination = destination2,
-                PaymentMethod = "BTC"
+                PayoutMethodId = "BTC"
             }));
 
             TestLogs.LogInformation("Can archive payout");
@@ -1126,7 +1126,7 @@ namespace BTCPayServer.Tests
             payout = await unauthenticated.CreatePayout(pps[0].Id, new CreatePayoutRequest()
             {
                 Destination = destination,
-                PaymentMethod = "BTC"
+                PayoutMethodId = "BTC"
             });
 
             var start = RoundSeconds(DateTimeOffset.Now + TimeSpan.FromDays(7.0));
@@ -1144,7 +1144,7 @@ namespace BTCPayServer.Tests
             {
                 Amount = 1.0m,
                 Destination = destination,
-                PaymentMethod = "BTC"
+                PayoutMethodId = "BTC"
             }));
 
             var expires = RoundSeconds(DateTimeOffset.Now - TimeSpan.FromDays(7.0));
@@ -1160,7 +1160,7 @@ namespace BTCPayServer.Tests
             {
                 Amount = 1.0m,
                 Destination = destination,
-                PaymentMethod = "BTC"
+                PayoutMethodId = "BTC"
             }));
 
             await this.AssertValidationError(new[] { "ExpiresAt" }, async () => await client.CreatePullPayment(storeId, new Client.Models.CreatePullPaymentRequest()
@@ -1188,7 +1188,7 @@ namespace BTCPayServer.Tests
             payout = await unauthenticated.CreatePayout(pp.Id, new CreatePayoutRequest()
             {
                 Destination = destination,
-                PaymentMethod = "BTC"
+                PayoutMethodId = "BTC"
             });
             await this.AssertAPIError("old-revision", async () => await client.ApprovePayout(storeId, payout.Id, new ApprovePayoutRequest()
             {
@@ -1222,7 +1222,7 @@ namespace BTCPayServer.Tests
             payout = await unauthenticated.CreatePayout(test3.Id, new CreatePayoutRequest()
             {
                 Destination = destination,
-                PaymentMethod = "BTC"
+                PayoutMethodId = "BTC"
             });
             payout = await client.ApprovePayout(storeId, payout.Id, new ApprovePayoutRequest());
             // The payout should round the value of the payment down to the network of the payment method
@@ -1342,7 +1342,7 @@ namespace BTCPayServer.Tests
                 await nonApproved.CreatePayout(acc.StoreId, new CreatePayoutThroughStoreRequest()
                 {
                     Amount = 100,
-                    PaymentMethod = "BTC",
+                    PayoutMethodId = "BTC",
                     Approved = true,
                     Destination = new Key().GetAddress(ScriptPubKeyType.TaprootBIP86, Network.RegTest).ToString()
                 });
@@ -1360,7 +1360,7 @@ namespace BTCPayServer.Tests
             await approved.CreatePayout(acc.StoreId, new CreatePayoutThroughStoreRequest()
             {
                 Amount = 100,
-                PaymentMethod = "BTC",
+                PayoutMethodId = "BTC",
                 Approved = true,
                 Destination = new Key().GetAddress(ScriptPubKeyType.TaprootBIP86, Network.RegTest).ToString()
             });
@@ -1381,7 +1381,7 @@ namespace BTCPayServer.Tests
             var payout = await client.CreatePayout(storeId, new CreatePayoutThroughStoreRequest()
             {
                 Approved = false,
-                PaymentMethod = "BTC",
+                PayoutMethodId = "BTC",
                 Amount = 0.0001m,
                 Destination = address.ToString(),
 
@@ -1408,7 +1408,7 @@ namespace BTCPayServer.Tests
             payout = await client.CreatePayout(storeId, new CreatePayoutThroughStoreRequest()
             {
                 Approved = true,
-                PaymentMethod = "BTC",
+                PayoutMethodId = "BTC",
                 Amount = 0.0001m,
                 Destination = address.ToString()
             });
@@ -1535,7 +1535,7 @@ namespace BTCPayServer.Tests
                 {
                     Amount = 10,
                     Above = true,
-                    PaymentMethod = "BTC",
+                    PaymentMethodId = "BTC",
                     CurrencyCode = "USD"
                 }
              }
@@ -1550,7 +1550,7 @@ namespace BTCPayServer.Tests
             //check that pmc equals the one we set
             Assert.Equal(10, pmc.Amount);
             Assert.True(pmc.Above);
-            Assert.Equal("BTC-CHAIN", pmc.PaymentMethod);
+            Assert.Equal("BTC-CHAIN", pmc.PaymentMethodId);
             Assert.Equal("USD", pmc.CurrencyCode);
             updatedStore = await client.UpdateStore(newStore.Id, new UpdateStoreRequest() { Name = "B" });
             Assert.Empty(newStore.PaymentMethodCriteria);
@@ -2138,7 +2138,7 @@ namespace BTCPayServer.Tests
             {
                 await client.RefundInvoice(user.StoreId, "lol fake invoice id", new RefundInvoiceRequest()
                 {
-                    PaymentMethod = method.PaymentMethodId,
+                    PayoutMethodId = method.PaymentMethodId,
                     RefundVariant = RefundVariant.RateThen
                 });
             });
@@ -2146,7 +2146,7 @@ namespace BTCPayServer.Tests
             // test validation error for when invoice is not yet in the state in which it can be refunded
             var apiError = await AssertAPIError("non-refundable", () => client.RefundInvoice(user.StoreId, invoice.Id, new RefundInvoiceRequest()
             {
-                PaymentMethod = method.PaymentMethodId,
+                PayoutMethodId = method.PaymentMethodId,
                 RefundVariant = RefundVariant.RateThen
             }));
             Assert.Equal("Cannot refund this invoice", apiError.Message);
@@ -2164,11 +2164,11 @@ namespace BTCPayServer.Tests
             });
 
             // test validation for the payment method
-            var validationError = await AssertValidationError(new[] { "PaymentMethod" }, async () =>
+            var validationError = await AssertValidationError(new[] { "PayoutMethodId" }, async () =>
             {
                 await client.RefundInvoice(user.StoreId, invoice.Id, new RefundInvoiceRequest()
                 {
-                    PaymentMethod = "fake payment method",
+                    PayoutMethodId = "fake payment method",
                     RefundVariant = RefundVariant.RateThen
                 });
             });
@@ -2177,7 +2177,7 @@ namespace BTCPayServer.Tests
             // test RefundVariant.RateThen
             var pp = await client.RefundInvoice(user.StoreId, invoice.Id, new RefundInvoiceRequest()
             {
-                PaymentMethod = method.PaymentMethodId,
+                PayoutMethodId = method.PaymentMethodId,
                 RefundVariant = RefundVariant.RateThen
             });
             Assert.Equal("BTC", pp.Currency);
@@ -2188,7 +2188,7 @@ namespace BTCPayServer.Tests
             // test RefundVariant.CurrentRate
             pp = await client.RefundInvoice(user.StoreId, invoice.Id, new RefundInvoiceRequest()
             {
-                PaymentMethod = method.PaymentMethodId,
+                PayoutMethodId = method.PaymentMethodId,
                 RefundVariant = RefundVariant.CurrentRate
             });
             Assert.Equal("BTC", pp.Currency);
@@ -2198,7 +2198,7 @@ namespace BTCPayServer.Tests
             // test RefundVariant.Fiat
             pp = await client.RefundInvoice(user.StoreId, invoice.Id, new RefundInvoiceRequest()
             {
-                PaymentMethod = method.PaymentMethodId,
+                PayoutMethodId = method.PaymentMethodId,
                 RefundVariant = RefundVariant.Fiat,
                 Name = "my test name"
             });
@@ -2212,7 +2212,7 @@ namespace BTCPayServer.Tests
             {
                 await client.RefundInvoice(user.StoreId, invoice.Id, new RefundInvoiceRequest()
                 {
-                    PaymentMethod = method.PaymentMethodId,
+                    PayoutMethodId = method.PaymentMethodId,
                     RefundVariant = RefundVariant.Custom,
                 });
             });
@@ -2221,7 +2221,7 @@ namespace BTCPayServer.Tests
 
             pp = await client.RefundInvoice(user.StoreId, invoice.Id, new RefundInvoiceRequest()
             {
-                PaymentMethod = method.PaymentMethodId,
+                PayoutMethodId = method.PaymentMethodId,
                 RefundVariant = RefundVariant.Custom,
                 CustomAmount = 69420,
                 CustomCurrency = "JPY"
@@ -2233,7 +2233,7 @@ namespace BTCPayServer.Tests
             // should auto-approve if currencies match
             pp = await client.RefundInvoice(user.StoreId, invoice.Id, new RefundInvoiceRequest()
             {
-                PaymentMethod = method.PaymentMethodId,
+                PayoutMethodId = method.PaymentMethodId,
                 RefundVariant = RefundVariant.Custom,
                 CustomAmount = 0.00069420m,
                 CustomCurrency = "BTC"
@@ -2245,7 +2245,7 @@ namespace BTCPayServer.Tests
             {
                 await client.RefundInvoice(user.StoreId, invoice.Id, new RefundInvoiceRequest
                 {
-                    PaymentMethod = method.PaymentMethodId,
+                    PayoutMethodId = method.PaymentMethodId,
                     RefundVariant = RefundVariant.RateThen,
                     SubtractPercentage = 101
                 });
@@ -2255,7 +2255,7 @@ namespace BTCPayServer.Tests
             // should auto-approve
             pp = await client.RefundInvoice(user.StoreId, invoice.Id, new RefundInvoiceRequest
             {
-                PaymentMethod = method.PaymentMethodId,
+                PayoutMethodId = method.PaymentMethodId,
                 RefundVariant = RefundVariant.RateThen,
                 SubtractPercentage = 6.15m
             });
@@ -2268,7 +2268,7 @@ namespace BTCPayServer.Tests
             {
                 await client.RefundInvoice(user.StoreId, invoice.Id, new RefundInvoiceRequest
                 {
-                    PaymentMethod = method.PaymentMethodId,
+                    PayoutMethodId = method.PaymentMethodId,
                     RefundVariant = RefundVariant.OverpaidAmount
                 });
             });
@@ -2298,7 +2298,7 @@ namespace BTCPayServer.Tests
 
             pp = await client.RefundInvoice(user.StoreId, invoice.Id, new RefundInvoiceRequest
             {
-                PaymentMethod = method.PaymentMethodId,
+                PayoutMethodId = method.PaymentMethodId,
                 RefundVariant = RefundVariant.OverpaidAmount
             });
             Assert.Equal("BTC", pp.Currency);
@@ -2308,7 +2308,7 @@ namespace BTCPayServer.Tests
             // once more with subtract percentage
             pp = await client.RefundInvoice(user.StoreId, invoice.Id, new RefundInvoiceRequest
             {
-                PaymentMethod = method.PaymentMethodId,
+                PayoutMethodId = method.PaymentMethodId,
                 RefundVariant = RefundVariant.OverpaidAmount,
                 SubtractPercentage = 21m
             });
@@ -2321,7 +2321,7 @@ namespace BTCPayServer.Tests
             await client.MarkInvoiceStatus(user.StoreId, invoice.Id, new MarkInvoiceStatusRequest { Status = InvoiceStatus.Settled });
             var refund = await client.RefundInvoice(user.StoreId, invoice.Id, new RefundInvoiceRequest
             {
-                PaymentMethod = method.PaymentMethodId,
+                PayoutMethodId = method.PaymentMethodId,
                 RefundVariant = RefundVariant.CurrentRate
             });
             Assert.Equal(1.0m, refund.Amount);
@@ -4018,7 +4018,7 @@ namespace BTCPayServer.Tests
                 new CreatePayoutThroughStoreRequest()
                 {
                     Approved = true,
-                    PaymentMethod = "BTC_LightningNetwork",
+                    PayoutMethodId = "BTC_LightningNetwork",
                     Destination = customerInvoice.BOLT11
                 });
             Assert.Equal(payout.Metadata.ToString(), new JObject().ToString()); //empty
@@ -4037,7 +4037,7 @@ namespace BTCPayServer.Tests
                 new CreatePayoutThroughStoreRequest()
                 {
                     Approved = true,
-                    PaymentMethod = "BTC",
+                    PayoutMethodId = "BTC",
                     Destination = (await tester.ExplorerNode.GetNewAddressAsync()).ToString(),
                     Amount = 0.0001m,
                     Metadata = JObject.FromObject(new
@@ -4068,7 +4068,7 @@ namespace BTCPayServer.Tests
                 {
                     Approved = true,
                     Amount = new Money(100, MoneyUnit.Satoshi).ToDecimal(MoneyUnit.BTC),
-                    PaymentMethod = "BTC_LightningNetwork",
+                    PayoutMethodId = "BTC_LightningNetwork",
                     Destination = customerInvoice.BOLT11
                 });
             Assert.Equal(payout2.Amount, new Money(100, MoneyUnit.Satoshi).ToDecimal(MoneyUnit.BTC));
@@ -4098,7 +4098,7 @@ namespace BTCPayServer.Tests
             {
                 Amount = 0.0001m,
                 Approved = true,
-                PaymentMethod = "BTC",
+                PayoutMethodId = "BTC",
                 Destination = (await adminClient.GetOnChainWalletReceiveAddress(admin.StoreId, "BTC", true)).Address,
             });
 
@@ -4106,7 +4106,7 @@ namespace BTCPayServer.Tests
             {
                 Amount = 0.00001m,
                 Approved = false,
-                PaymentMethod = "BTC",
+                PayoutMethodId = "BTC",
                 Destination = (await adminClient.GetOnChainWalletReceiveAddress(admin.StoreId, "BTC", true)).Address,
             });
 
@@ -4123,7 +4123,7 @@ namespace BTCPayServer.Tests
                 PullPaymentId = pullPayment.Id,
                 Amount = 10,
                 Approved = false,
-                PaymentMethod = "BTC",
+                PayoutMethodId = "BTC",
                 Destination = (await adminClient.GetOnChainWalletReceiveAddress(admin.StoreId, "BTC", true)).Address,
             });
             await adminClient.ApprovePayout(admin.StoreId, notapprovedPayoutWithPullPayment.Id,
@@ -4254,7 +4254,7 @@ namespace BTCPayServer.Tests
                 PullPaymentId = pullPayment.Id,
                 Amount = 0.5m,
                 Approved = true,
-                PaymentMethod = "BTC",
+                PayoutMethodId = "BTC",
                 Destination = (await adminClient.GetOnChainWalletReceiveAddress(admin.StoreId, "BTC", true)).Address,
             });
             TestLogs.LogInformation("Waiting before hook...");
@@ -4300,7 +4300,7 @@ namespace BTCPayServer.Tests
             {
                 Amount = 0.1m,
                 Approved = true,
-                PaymentMethod = "BTC",
+                PayoutMethodId = "BTC",
                 Destination = (await adminClient.GetOnChainWalletReceiveAddress(admin.StoreId, "BTC", true)).Address,
             });
 
@@ -4316,7 +4316,7 @@ namespace BTCPayServer.Tests
             {
                 Amount = 0.3m,
                 Approved = true,
-                PaymentMethod = "BTC",
+                PayoutMethodId = "BTC",
                 Destination = (await adminClient.GetOnChainWalletReceiveAddress(admin.StoreId, "BTC", true)).Address,
             });
 
@@ -4333,7 +4333,7 @@ namespace BTCPayServer.Tests
             {
                 Amount = 0.3m,
                 Approved = true,
-                PaymentMethod = "BTC",
+                PayoutMethodId = "BTC",
                 Destination = (await adminClient.GetOnChainWalletReceiveAddress(admin.StoreId, "BTC", true)).Address,
             });
 

--- a/BTCPayServer.Tests/UnitTest1.cs
+++ b/BTCPayServer.Tests/UnitTest1.cs
@@ -1477,7 +1477,7 @@ namespace BTCPayServer.Tests
             {
                 var payouts = await client.GetPayouts(pp.Id);
                 var payout = Assert.Single(payouts);
-                Assert.Equal("TOPUP", payout.PaymentMethod);
+                Assert.Equal("TOPUP", payout.PayoutMethodId);
                 Assert.Equal(invoice.Id, payout.Destination);
                 Assert.Equal(-0.5m, payout.Amount);
             });
@@ -2126,7 +2126,7 @@ namespace BTCPayServer.Tests
                     Amount = 0.0001m,
                     Destination = (await tester.ExplorerNode.GetNewAddressAsync()).ToString(),
                     Approved = true,
-                    PaymentMethod = "BTC"
+                    PayoutMethodId = "BTC"
                 });
             await user.AssertHasWebhookEvent(WebhookEventType.PayoutCreated,  (WebhookPayoutEvent x)=> Assert.Equal(payout.Id, x.PayoutId));
              await client.MarkPayout(user.StoreId, payout.Id, new MarkPayoutRequest(){ State = PayoutState.AwaitingApproval});
@@ -3245,7 +3245,7 @@ namespace BTCPayServer.Tests
                 var inv = await client.CreateInvoice(acc.StoreId, new CreateInvoiceRequest() { Amount = 10m, Currency = "USD" });
                 await acc.PayInvoice(inv.Id);
                 await client.MarkInvoiceStatus(acc.StoreId, inv.Id, new MarkInvoiceStatusRequest() { Status = InvoiceStatus.Settled });
-                var refund = await client.RefundInvoice(acc.StoreId, inv.Id, new RefundInvoiceRequest() { RefundVariant = RefundVariant.Fiat, PaymentMethod = "BTC-CHAIN" });
+                var refund = await client.RefundInvoice(acc.StoreId, inv.Id, new RefundInvoiceRequest() { RefundVariant = RefundVariant.Fiat, PayoutMethodId = "BTC-CHAIN" });
 
                 async Task AssertData(string currency, decimal awaiting, decimal limit, decimal completed, bool fullyPaid)
                 {
@@ -3264,7 +3264,7 @@ namespace BTCPayServer.Tests
                 }
 
                 await AssertData("USD", awaiting: 0.0m, limit: 10.0m, completed: 0.0m, fullyPaid: false);
-                var payout = await client.CreatePayout(refund.Id, new CreatePayoutRequest() { Destination = addr.ToString(), PaymentMethod = "BTC-CHAIN" });
+                var payout = await client.CreatePayout(refund.Id, new CreatePayoutRequest() { Destination = addr.ToString(), PayoutMethodId = "BTC-CHAIN" });
                 await AssertData("USD", awaiting: 10.0m, limit: 10.0m, completed: 0.0m, fullyPaid: false);
                 await client.ApprovePayout(acc.StoreId, payout.Id, new ApprovePayoutRequest());
                 await AssertData("USD", awaiting: 10.0m, limit: 10.0m, completed: 0.0m, fullyPaid: false);

--- a/BTCPayServer/Controllers/GreenField/GreenfieldInvoiceController.cs
+++ b/BTCPayServer/Controllers/GreenField/GreenfieldInvoiceController.cs
@@ -403,7 +403,7 @@ namespace BTCPayServer.Controllers.Greenfield
             }
             PaymentPrompt? paymentPrompt = null;
             PayoutMethodId? payoutMethodId = null;
-            if (request.PaymentMethod is not null && PayoutMethodId.TryParse(request.PaymentMethod, out payoutMethodId))
+            if (request.PayoutMethodId is not null && PayoutMethodId.TryParse(request.PayoutMethodId, out payoutMethodId))
             {
                 var supported = _payoutHandlers.GetSupportedPayoutMethods(store);
                 if (supported.Contains(payoutMethodId))
@@ -414,7 +414,7 @@ namespace BTCPayServer.Controllers.Greenfield
             }
             if (paymentPrompt is null)
             {
-                ModelState.AddModelError(nameof(request.PaymentMethod), "Please select one of the payment methods which were available for the original invoice");
+                ModelState.AddModelError(nameof(request.PayoutMethodId), "Please select one of the payment methods which were available for the original invoice");
             }
             if (request.RefundVariant is null)
                 ModelState.AddModelError(nameof(request.RefundVariant), "`refundVariant` is mandatory");

--- a/BTCPayServer/Controllers/GreenField/GreenfieldPullPaymentController.cs
+++ b/BTCPayServer/Controllers/GreenField/GreenfieldPullPaymentController.cs
@@ -371,7 +371,7 @@ namespace BTCPayServer.Controllers.Greenfield
                 Metadata = blob.Metadata?? new JObject(),
             };
             model.Destination = blob.Destination;
-            model.PaymentMethod = p.PayoutMethodId;
+            model.PayoutMethodId = p.PayoutMethodId;
             model.CryptoCode = p.Currency;
             model.PaymentProof = p.GetProofBlobJson();
             return model;
@@ -381,16 +381,16 @@ namespace BTCPayServer.Controllers.Greenfield
         [AllowAnonymous]
         public async Task<IActionResult> CreatePayout(string pullPaymentId, CreatePayoutRequest request, CancellationToken cancellationToken)
         {
-            if (!PayoutMethodId.TryParse(request?.PaymentMethod, out var payoutMethodId))
+            if (!PayoutMethodId.TryParse(request?.PayoutMethodId, out var payoutMethodId))
             {
-                ModelState.AddModelError(nameof(request.PaymentMethod), "Invalid payment method");
+                ModelState.AddModelError(nameof(request.PayoutMethodId), "Invalid payment method");
                 return this.CreateValidationError(ModelState);
             }
 
             var payoutHandler = _payoutHandlers.TryGet(payoutMethodId);
             if (payoutHandler is null)
             {
-                ModelState.AddModelError(nameof(request.PaymentMethod), "Invalid payment method");
+                ModelState.AddModelError(nameof(request.PayoutMethodId), "Invalid payment method");
                 return this.CreateValidationError(ModelState);
             }
 
@@ -438,16 +438,16 @@ namespace BTCPayServer.Controllers.Greenfield
                 }
             }
 
-            if (request?.PaymentMethod is null || !PayoutMethodId.TryParse(request?.PaymentMethod, out var paymentMethodId))
+            if (request?.PayoutMethodId is null || !PayoutMethodId.TryParse(request?.PayoutMethodId, out var paymentMethodId))
             {
-                ModelState.AddModelError(nameof(request.PaymentMethod), "Invalid payment method");
+                ModelState.AddModelError(nameof(request.PayoutMethodId), "Invalid payment method");
                 return this.CreateValidationError(ModelState);
             }
 
             var payoutHandler = _payoutHandlers.TryGet(paymentMethodId);
             if (payoutHandler is null)
             {
-                ModelState.AddModelError(nameof(request.PaymentMethod), "Invalid payment method");
+                ModelState.AddModelError(nameof(request.PayoutMethodId), "Invalid payment method");
                 return this.CreateValidationError(ModelState);
             }
 

--- a/BTCPayServer/Controllers/GreenField/GreenfieldStoreAutomatedLightningPayoutProcessorsController.cs
+++ b/BTCPayServer/Controllers/GreenField/GreenfieldStoreAutomatedLightningPayoutProcessorsController.cs
@@ -57,7 +57,7 @@ namespace BTCPayServer.Controllers.Greenfield
             var blob = data.HasTypedBlob<LightningAutomatedPayoutBlob>().GetBlob() ?? new LightningAutomatedPayoutBlob();
             return new LightningAutomatedPayoutSettings()
             {
-                PaymentMethod = data.PaymentMethod,
+                PaymentMethodId = data.PaymentMethod,
                 IntervalSeconds = blob.Interval,
                 CancelPayoutAfterFailures = blob.CancelPayoutAfterFailures,
                 ProcessNewPayoutsInstantly = blob.ProcessNewPayoutsInstantly

--- a/BTCPayServer/Controllers/GreenField/GreenfieldStoreAutomatedLightningPayoutProcessorsController.cs
+++ b/BTCPayServer/Controllers/GreenField/GreenfieldStoreAutomatedLightningPayoutProcessorsController.cs
@@ -57,7 +57,7 @@ namespace BTCPayServer.Controllers.Greenfield
             var blob = data.HasTypedBlob<LightningAutomatedPayoutBlob>().GetBlob() ?? new LightningAutomatedPayoutBlob();
             return new LightningAutomatedPayoutSettings()
             {
-                PaymentMethodId = data.PaymentMethod,
+                PayoutMethodId = data.PayoutMethodId,
                 IntervalSeconds = blob.Interval,
                 CancelPayoutAfterFailures = blob.CancelPayoutAfterFailures,
                 ProcessNewPayoutsInstantly = blob.ProcessNewPayoutsInstantly
@@ -94,7 +94,7 @@ namespace BTCPayServer.Controllers.Greenfield
             activeProcessor ??= new PayoutProcessorData();
             activeProcessor.HasTypedBlob<LightningAutomatedPayoutBlob>().SetBlob(FromModel(request));
             activeProcessor.StoreId = storeId;
-            activeProcessor.PaymentMethod = pmi.ToString();
+            activeProcessor.PayoutMethodId = pmi.ToString();
             activeProcessor.Processor = LightningAutomatedPayoutSenderFactory.ProcessorName;
             var tcs = new TaskCompletionSource();
             _eventAggregator.Publish(new PayoutProcessorUpdated()

--- a/BTCPayServer/Controllers/GreenField/GreenfieldStoreAutomatedOnChainPayoutProcessorsController.cs
+++ b/BTCPayServer/Controllers/GreenField/GreenfieldStoreAutomatedOnChainPayoutProcessorsController.cs
@@ -59,7 +59,7 @@ namespace BTCPayServer.Controllers.Greenfield
             return new OnChainAutomatedPayoutSettings()
             {
                 FeeBlockTarget = blob.FeeTargetBlock,
-                PaymentMethodId = data.PaymentMethod,
+                PayoutMethodId = data.PayoutMethodId,
                 IntervalSeconds = blob.Interval,
                 Threshold = blob.Threshold,
                 ProcessNewPayoutsInstantly = blob.ProcessNewPayoutsInstantly
@@ -100,7 +100,7 @@ namespace BTCPayServer.Controllers.Greenfield
             activeProcessor ??= new PayoutProcessorData();
             activeProcessor.HasTypedBlob<OnChainAutomatedPayoutBlob>().SetBlob(FromModel(request));
             activeProcessor.StoreId = storeId;
-            activeProcessor.PaymentMethod = payoutMethodId.ToString();
+            activeProcessor.PayoutMethodId = payoutMethodId.ToString();
             activeProcessor.Processor = OnChainAutomatedPayoutSenderFactory.ProcessorName;
             var tcs = new TaskCompletionSource();
             _eventAggregator.Publish(new PayoutProcessorUpdated()

--- a/BTCPayServer/Controllers/GreenField/GreenfieldStoreAutomatedOnChainPayoutProcessorsController.cs
+++ b/BTCPayServer/Controllers/GreenField/GreenfieldStoreAutomatedOnChainPayoutProcessorsController.cs
@@ -59,7 +59,7 @@ namespace BTCPayServer.Controllers.Greenfield
             return new OnChainAutomatedPayoutSettings()
             {
                 FeeBlockTarget = blob.FeeTargetBlock,
-                PaymentMethod = data.PaymentMethod,
+                PaymentMethodId = data.PaymentMethod,
                 IntervalSeconds = blob.Interval,
                 Threshold = blob.Threshold,
                 ProcessNewPayoutsInstantly = blob.ProcessNewPayoutsInstantly

--- a/BTCPayServer/Controllers/GreenField/GreenfieldStorePayoutProcessorsController.cs
+++ b/BTCPayServer/Controllers/GreenField/GreenfieldStorePayoutProcessorsController.cs
@@ -39,7 +39,7 @@ namespace BTCPayServer.Controllers.Greenfield
                 {
                     Name = datas.Key,
                     FriendlyName = _factories.FirstOrDefault(factory => factory.Processor == datas.Key)?.FriendlyName,
-                    PaymentMethods = datas.Select(data => data.PaymentMethod).ToArray()
+                    PaymentMethods = datas.Select(data => data.PayoutMethodId).ToArray()
                 });
             return Ok(configured);
 

--- a/BTCPayServer/Controllers/GreenField/GreenfieldStoresController.cs
+++ b/BTCPayServer/Controllers/GreenField/GreenfieldStoresController.cs
@@ -215,7 +215,7 @@ namespace BTCPayServer.Controllers.Greenfield
                     Above = criteria.Above,
                     Amount = criteria.Value.Value,
                     CurrencyCode = criteria.Value.Currency,
-                    PaymentMethod = criteria.PaymentMethod.ToString()
+                    PaymentMethodId = criteria.PaymentMethod.ToString()
                 }).ToList() ?? new List<PaymentMethodCriteriaData>()
             };
         }
@@ -277,7 +277,7 @@ namespace BTCPayServer.Controllers.Greenfield
                         Currency = criteria.CurrencyCode,
                         Value = criteria.Amount
                     },
-                    PaymentMethod = PaymentMethodId.Parse(criteria.PaymentMethod)
+                    PaymentMethod = PaymentMethodId.Parse(criteria.PaymentMethodId)
                 }).ToList() ?? new List<PaymentMethodCriteria>();
             model.SetStoreBlob(blob);
         }
@@ -338,9 +338,9 @@ namespace BTCPayServer.Controllers.Greenfield
                         request.AddModelError(data => data.PaymentMethodCriteria[index].CurrencyCode, "CurrencyCode is invalid", this);
                     }
 
-                    if (string.IsNullOrEmpty(pmc.PaymentMethod) || PaymentMethodId.TryParse(pmc.PaymentMethod) is null)
+                    if (string.IsNullOrEmpty(pmc.PaymentMethodId) || PaymentMethodId.TryParse(pmc.PaymentMethodId) is null)
                     {
-                        request.AddModelError(data => data.PaymentMethodCriteria[index].PaymentMethod, "Payment method was invalid", this);
+                        request.AddModelError(data => data.PaymentMethodCriteria[index].PaymentMethodId, "Payment method was invalid", this);
                     }
 
                     if (pmc.Amount < 0)

--- a/BTCPayServer/Hosting/MigrationStartupTask.cs
+++ b/BTCPayServer/Hosting/MigrationStartupTask.cs
@@ -231,7 +231,7 @@ namespace BTCPayServer.Hosting
             var processors = await ctx.PayoutProcessors.ToArrayAsync();
             foreach (var processor in processors)
             {
-                processor.PaymentMethod = processor.GetPayoutMethodId().ToString();
+                processor.PayoutMethodId = processor.GetPayoutMethodId().ToString();
             }
             await ctx.SaveChangesAsync();
         }

--- a/BTCPayServer/PayoutProcessors/BaseAutomatedPayoutProcessor.cs
+++ b/BTCPayServer/PayoutProcessors/BaseAutomatedPayoutProcessor.cs
@@ -54,7 +54,7 @@ public abstract class BaseAutomatedPayoutProcessor<T> : BaseAsyncService where T
         ApplicationDbContextFactory applicationDbContextFactory,
         PaymentMethodHandlerDictionary paymentHandlers,
         IPluginHookService pluginHookService,
-        EventAggregator eventAggregator) : base(logger.CreateLogger($"{payoutProcessorSettings.Processor}:{payoutProcessorSettings.StoreId}:{payoutProcessorSettings.PaymentMethod}"))
+        EventAggregator eventAggregator) : base(logger.CreateLogger($"{payoutProcessorSettings.Processor}:{payoutProcessorSettings.StoreId}:{payoutProcessorSettings.PayoutMethodId}"))
     {
         PaymentMethodId = paymentMethodId;
         _storeRepository = storeRepository;
@@ -114,7 +114,7 @@ public abstract class BaseAutomatedPayoutProcessor<T> : BaseAsyncService where T
                 new PullPaymentHostedService.PayoutQuery()
                 {
                     States = new[] { PayoutState.AwaitingPayment },
-                    PayoutMethods = new[] { PayoutProcessorSettings.PaymentMethod },
+                    PayoutMethods = new[] { PayoutProcessorSettings.PayoutMethodId },
                     Stores = new[] {PayoutProcessorSettings.StoreId}
                 }, context, CancellationToken);
 

--- a/BTCPayServer/PayoutProcessors/Lightning/UILightningAutomatedPayoutProcessorsController.cs
+++ b/BTCPayServer/PayoutProcessors/Lightning/UILightningAutomatedPayoutProcessorsController.cs
@@ -97,7 +97,7 @@ public class UILightningAutomatedPayoutProcessorsController : Controller
         activeProcessor ??= new PayoutProcessorData();
         activeProcessor.HasTypedBlob<LightningAutomatedPayoutBlob>().SetBlob(automatedTransferBlob.ToBlob());
         activeProcessor.StoreId = storeId;
-        activeProcessor.PaymentMethod = PayoutTypes.LN.GetPayoutMethodId(cryptoCode).ToString();
+        activeProcessor.PayoutMethodId = PayoutTypes.LN.GetPayoutMethodId(cryptoCode).ToString();
         activeProcessor.Processor = _lightningAutomatedPayoutSenderFactory.Processor;
         var tcs = new TaskCompletionSource();
         _eventAggregator.Publish(new PayoutProcessorUpdated()

--- a/BTCPayServer/PayoutProcessors/OnChain/UIOnChainAutomatedPayoutProcessorsController.cs
+++ b/BTCPayServer/PayoutProcessors/OnChain/UIOnChainAutomatedPayoutProcessorsController.cs
@@ -107,7 +107,7 @@ public class UIOnChainAutomatedPayoutProcessorsController : Controller
         activeProcessor ??= new PayoutProcessorData();
         activeProcessor.HasTypedBlob<OnChainAutomatedPayoutBlob>().SetBlob(automatedTransferBlob.ToBlob());
         activeProcessor.StoreId = storeId;
-        activeProcessor.PaymentMethod = PayoutTypes.CHAIN.GetPayoutMethodId(cryptoCode).ToString();
+        activeProcessor.PayoutMethodId = PayoutTypes.CHAIN.GetPayoutMethodId(cryptoCode).ToString();
         activeProcessor.Processor = _onChainAutomatedPayoutSenderFactory.Processor;
         var tcs = new TaskCompletionSource();
         _eventAggregator.Publish(new PayoutProcessorUpdated()

--- a/BTCPayServer/PayoutProcessors/PayoutProcessorService.cs
+++ b/BTCPayServer/PayoutProcessors/PayoutProcessorService.cs
@@ -76,7 +76,7 @@ public class PayoutProcessorService : EventHostedServiceBase
         if (query.PayoutMethodIds is not null)
         {
             var paymentMethods = query.PayoutMethodIds.Select(d => d.ToString()).Distinct().ToArray();
-            queryable = queryable.Where(data => paymentMethods.Contains(data.PaymentMethod));
+            queryable = queryable.Where(data => paymentMethods.Contains(data.PayoutMethodId));
         }
 
         return await queryable.ToListAsync();
@@ -146,7 +146,7 @@ public class PayoutProcessorService : EventHostedServiceBase
             }
             catch(Exception ex)
             {
-                Logs.PayServer.LogWarning(ex, $"Payout processor ({data.PaymentMethod}) failed to start. Skipping...");
+                Logs.PayServer.LogWarning(ex, $"Payout processor ({data.PayoutMethodId}) failed to start. Skipping...");
                 return;
             }
             await processor.StartAsync(cancellationToken);

--- a/BTCPayServer/PayoutProcessors/PayoutProcessorsExtensions.cs
+++ b/BTCPayServer/PayoutProcessors/PayoutProcessorsExtensions.cs
@@ -21,6 +21,6 @@ public static class PayoutProcessorsExtensions
 
     public static PayoutMethodId GetPayoutMethodId(this PayoutProcessorData data)
     {
-        return PayoutMethodId.Parse(data.PaymentMethod);
+        return PayoutMethodId.Parse(data.PayoutMethodId);
     }
 }

--- a/BTCPayServer/wwwroot/swagger/v1/swagger.template.invoices.json
+++ b/BTCPayServer/wwwroot/swagger/v1/swagger.template.invoices.json
@@ -585,7 +585,7 @@
                 ]
             }
         },
-        "/api/v1/stores/{storeId}/invoices/{invoiceId}/payment-methods/{paymentMethod}/activate": {
+        "/api/v1/stores/{storeId}/invoices/{invoiceId}/payment-methods/{paymentMethodId}/activate": {
             "post": {
                 "tags": [
                     "Invoices"
@@ -611,13 +611,7 @@
                         }
                     },
                     {
-                        "name": "paymentMethod",
-                        "in": "path",
-                        "required": true,
-                        "description": "The payment method to activate",
-                        "schema": {
-                            "type": "string"
-                        }
+                        "$ref": "#/components/parameters/PaymentMethodId"
                     }
                 ],
                 "description": "Activate an invoice payment method (if lazy payments mode is enabled)",
@@ -695,13 +689,8 @@
                     "type": "string",
                     "description": "Description of the pull payment"
                   },
-                  "paymentMethod": {
-                      "allOf": [
-                          {
-                              "$ref": "#/components/schemas/PaymentMethodId"
-                          }
-                      ],
-                    "description": "The payment method to use for the refund"
+                  "payoutMethodId": {
+                     "$ref": "#/components/schemas/PayoutMethodId"
                   },
                   "refundVariant": {
                     "type": "string",

--- a/BTCPayServer/wwwroot/swagger/v1/swagger.template.json
+++ b/BTCPayServer/wwwroot/swagger/v1/swagger.template.json
@@ -108,9 +108,14 @@
       },
       "PaymentMethodId": {
         "type": "string",
-        "description": "Payment method IDs are a combination of crypto code and payment type. Available payment method IDs for Bitcoin are:  \n- `\"BTC-CHAIN\"`: Onchain   \n-`\"BTC-LN\"`: Lightning   \n- `\"BTC-LNURL\"`: LNURL",
+        "description": "Payment method IDs. Available payment method IDs for Bitcoin are:  \n- `\"BTC-CHAIN\"`: Onchain   \n-`\"BTC-LN\"`: Lightning   \n- `\"BTC-LNURL\"`: LNURL",
           "example": "BTC-CHAIN"
-      }
+      },
+        "PayoutMethodId": {
+            "type": "string",
+            "description": "Payout method IDs. Available payment method IDs for Bitcoin are:  \n- `\"BTC-CHAIN\"`: Onchain   \n-`\"BTC-LN\"`: Lightning",
+            "example": "BTC-LN"
+        }
     },
     "securitySchemes": {
       "API_Key": {

--- a/BTCPayServer/wwwroot/swagger/v1/swagger.template.payout-processors.json
+++ b/BTCPayServer/wwwroot/swagger/v1/swagger.template.payout-processors.json
@@ -569,8 +569,8 @@
                 "type": "object",
                 "additionalProperties": false,
                 "properties": {
-                    "paymentMethodId": {
-                        "$ref": "#/components/schemas/PaymentMethodId"
+                    "payoutMethodId": {
+                        "$ref": "#/components/schemas/PayoutMethodId"
                     },
                     "intervalSeconds": {
                         "description": "How often should the processor run",
@@ -627,8 +627,8 @@
                 "type": "object",
                 "additionalProperties": false,
                 "properties": {
-                    "paymentMethodId": {
-                        "$ref": "#/components/schemas/PaymentMethodId"
+                    "payoutMethodId": {
+                        "$ref": "#/components/schemas/PayoutMethodId"
                     },
                     "feeTargetBlock": {
                         "type": "number",

--- a/BTCPayServer/wwwroot/swagger/v1/swagger.template.payout-processors.json
+++ b/BTCPayServer/wwwroot/swagger/v1/swagger.template.payout-processors.json
@@ -569,7 +569,7 @@
                 "type": "object",
                 "additionalProperties": false,
                 "properties": {
-                    "paymentMethod": {
+                    "paymentMethodId": {
                         "$ref": "#/components/schemas/PaymentMethodId"
                     },
                     "intervalSeconds": {
@@ -627,7 +627,7 @@
                 "type": "object",
                 "additionalProperties": false,
                 "properties": {
-                    "paymentMethod": {
+                    "paymentMethodId": {
                         "$ref": "#/components/schemas/PaymentMethodId"
                     },
                     "feeTargetBlock": {

--- a/BTCPayServer/wwwroot/swagger/v1/swagger.template.pull-payments.json
+++ b/BTCPayServer/wwwroot/swagger/v1/swagger.template.pull-payments.json
@@ -987,8 +987,8 @@
                         "example": "10399.18",
                         "description": "The amount of the payout in the currency of the pull payment (eg. USD)."
                     },
-                    "paymentMethod": {
-                        "$ref": "#/components/schemas/PaymentMethodId"
+                    "payoutMethodId": {
+                        "$ref": "#/components/schemas/PayoutMethodId"
                     }
                 }
             },
@@ -1097,8 +1097,8 @@
                         "example": "10399.18",
                         "description": "The amount of the payout in the currency of the pull payment (eg. USD)."
                     },
-                    "paymentMethod": {
-                        "$ref": "#/components/schemas/PaymentMethodId"
+                    "payoutMethodId": {
+                        "$ref": "#/components/schemas/PayoutMethodId"
                     },
                     "cryptoCode": {
                         "type": "string",

--- a/BTCPayServer/wwwroot/swagger/v1/swagger.template.stores.json
+++ b/BTCPayServer/wwwroot/swagger/v1/swagger.template.stores.json
@@ -437,7 +437,7 @@
             "PaymentMethodCriteriaData": {
                 "type": "object",
                 "properties": {
-                    "paymentMethod": {
+                    "paymentMethodId": {
                         "allOf": [
                             {
                                 "$ref": "#/components/schemas/PaymentMethodId"


### PR DESCRIPTION
# Breaking Change
* `/api/v1/stores/{storeId}/invoices/{invoiceId}/refund`: The field `paymentMethod` renamed to `payoutMethodId`
* `/api/v1/stores/{storeId}/payout-processors/(LightningAutomatedPayoutSenderFactory|OnChainAutomatedTransferSenderFactory)`: The field `paymentMethod` renamed to `payoutMethodId`
* `/api/v1/stores/{storeId}/payouts`: The field `paymentMethod` renamed to `payoutMethodId`
* `/api/v1/stores/{storeId}`: The field `paymentMethod` renamed to `payoutMethodId`