### PR TITLE
Fix divisibility in invoice details of lightning amounts

### DIFF
--- a/BTCPayServer.Tests/FastTests.cs
+++ b/BTCPayServer.Tests/FastTests.cs
@@ -20,6 +20,7 @@ using BTCPayServer.Data;
 using BTCPayServer.HostedServices;
 using BTCPayServer.Hosting;
 using BTCPayServer.JsonConverters;
+using BTCPayServer.Lightning;
 using BTCPayServer.Logging;
 using BTCPayServer.Payments;
 using BTCPayServer.Payments.Bitcoin;

--- a/BTCPayServer.Tests/FastTests.cs
+++ b/BTCPayServer.Tests/FastTests.cs
@@ -506,7 +506,6 @@ namespace BTCPayServer.Tests
 
             var paymentMethod = entity.GetPaymentPrompts().TryGet(PaymentTypes.CHAIN.GetPaymentMethodId("BTC"));
             var accounting = paymentMethod.Calculate();
-            Assert.Equal(1.0m, accounting.ToSmallestUnit(Money.Satoshis(1.0m).ToDecimal(MoneyUnit.BTC)));
             Assert.Equal(1.1m, accounting.Due);
             Assert.Equal(1.1m, accounting.TotalDue);
 

--- a/BTCPayServer.Tests/SeleniumTests.cs
+++ b/BTCPayServer.Tests/SeleniumTests.cs
@@ -19,6 +19,7 @@ using BTCPayServer.NTag424;
 using BTCPayServer.Payments;
 using BTCPayServer.Services;
 using BTCPayServer.Services.Invoices;
+using BTCPayServer.Services.Rates;
 using BTCPayServer.Services.Wallets;
 using BTCPayServer.Views.Manage;
 using BTCPayServer.Views.Server;
@@ -1906,7 +1907,7 @@ namespace BTCPayServer.Tests
             Assert.EndsWith("psbt/ready", s.Driver.Url);
             s.Driver.FindElement(By.CssSelector("button[value=broadcast]")).Click();
             Assert.Equal(walletTransactionUri.ToString(), s.Driver.Url);
-            var bip21 = invoice.EntityToDTO(s.Server.PayTester.GetService<Dictionary<PaymentMethodId, IPaymentMethodBitpayAPIExtension>>()).CryptoInfo.First().PaymentUrls.BIP21;
+            var bip21 = invoice.EntityToDTO(s.Server.PayTester.GetService<Dictionary<PaymentMethodId, IPaymentMethodBitpayAPIExtension>>(), s.Server.PayTester.GetService<CurrencyNameTable>()).CryptoInfo.First().PaymentUrls.BIP21;
             //let's make bip21 more interesting
             bip21 += "&label=Solid Snake&message=Snake? Snake? SNAAAAKE!";
             var parsedBip21 = new BitcoinUrlBuilder(bip21, Network.RegTest);

--- a/BTCPayServer/Controllers/GreenField/GreenfieldNotificationsController.cs
+++ b/BTCPayServer/Controllers/GreenField/GreenfieldNotificationsController.cs
@@ -94,6 +94,8 @@ namespace BTCPayServer.Controllers.Greenfield
         public async Task<IActionResult> GetNotificationSettings()
         {
             var user = await _userManager.GetUserAsync(User);
+            if (user is null)
+                return NotFound();
             var model = GetNotificationSettingsData(user);
             return Ok(model);
         }
@@ -103,6 +105,8 @@ namespace BTCPayServer.Controllers.Greenfield
         public async Task<IActionResult> UpdateNotificationSettings(UpdateNotificationSettingsRequest request)
         {
             var user = await _userManager.GetUserAsync(User);
+            if (user is null)
+                return NotFound();
             if (request.Disabled.Contains("all"))
             {
                 user.DisabledNotifications = "all";

--- a/BTCPayServer/Controllers/UIInvoiceController.UI.cs
+++ b/BTCPayServer/Controllers/UIInvoiceController.UI.cs
@@ -576,10 +576,10 @@ namespace BTCPayServer.Controllers
                             PaymentMethodRaw = data,
                             PaymentMethodId = paymentMethodId,
                             PaymentMethod = paymentMethodId.ToString(),
-                            TotalDue = _displayFormatter.Currency(accounting.TotalDue, data.Currency),
-                            Due = hasPayment ? _displayFormatter.Currency(accounting.Due, data.Currency) : null,
-                            Paid = hasPayment ? _displayFormatter.Currency(accounting.PaymentMethodPaid, data.Currency) : null,
-                            Overpaid = hasPayment ? _displayFormatter.Currency(overpaidAmount, data.Currency) : null,
+                            TotalDue = _displayFormatter.Currency(accounting.TotalDue, data.Currency, divisibility: data.Divisibility),
+                            Due = hasPayment ? _displayFormatter.Currency(accounting.Due, data.Currency, divisibility: data.Divisibility) : null,
+                            Paid = hasPayment ? _displayFormatter.Currency(accounting.PaymentMethodPaid, data.Currency, divisibility: data.Divisibility) : null,
+                            Overpaid = hasPayment ? _displayFormatter.Currency(overpaidAmount, data.Currency, divisibility: data.Divisibility) : null,
                             Address = data.Destination
                         };
                     }).ToList(),
@@ -896,7 +896,8 @@ namespace BTCPayServer.Controllers
                 BtcDue = accounting.ShowMoney(accounting.Due),
                 BtcPaid = accounting.ShowMoney(accounting.Paid),
                 InvoiceCurrency = invoice.Currency,
-                OrderAmount = accounting.ShowMoney(accounting.TotalDue - accounting.PaymentMethodFee),
+                // The Tweak is part of the PaymentMethodFee, but let's not show it in the UI as it's negligible.
+                OrderAmount = accounting.ShowMoney(accounting.TotalDue - (prompt.PaymentMethodFee - prompt.TweakFee)),
                 IsUnsetTopUp = invoice.IsUnsetTopUp(),
                 CustomerEmail = invoice.Metadata.BuyerEmail,
                 ExpirationSeconds = Math.Max(0, (int)(invoice.ExpirationTime - DateTimeOffset.UtcNow).TotalSeconds),
@@ -928,7 +929,8 @@ namespace BTCPayServer.Controllers
                 },
                 ReceivedConfirmations = handler is BitcoinLikePaymentHandler  bh ? invoice.GetAllBitcoinPaymentData(bh, false).FirstOrDefault()?.ConfirmationCount : null,
                 Status = invoice.Status.ToString(),
-                NetworkFee = prompt.PaymentMethodFee,
+                // The Tweak is part of the PaymentMethodFee, but let's not show it in the UI as it's negligible.
+                NetworkFee = prompt.PaymentMethodFee - prompt.TweakFee,
                 IsMultiCurrency = invoice.GetPayments(false).Select(p => p.PaymentMethodId).Concat(new[] { prompt.PaymentMethodId }).Distinct().Count() > 1,
                 StoreId = store.Id,
                 AvailableCryptos = invoice.GetPaymentPrompts()

--- a/BTCPayServer/HostedServices/BitpayIPNSender.cs
+++ b/BTCPayServer/HostedServices/BitpayIPNSender.cs
@@ -11,6 +11,7 @@ using BTCPayServer.Payments;
 using BTCPayServer.Services;
 using BTCPayServer.Services.Invoices;
 using BTCPayServer.Services.Mails;
+using BTCPayServer.Services.Rates;
 using BTCPayServer.Services.Stores;
 using Microsoft.Extensions.Hosting;
 using MimeKit;
@@ -45,6 +46,7 @@ namespace BTCPayServer.HostedServices
         private readonly EmailSenderFactory _EmailSenderFactory;
         private readonly StoreRepository _StoreRepository;
         private readonly Dictionary<PaymentMethodId, IPaymentMethodBitpayAPIExtension> _bitpayExtensions;
+        private readonly CurrencyNameTable _currencyNameTable;
         public const string NamedClient = "bitpay-ipn";
         public BitpayIPNSender(
             IHttpClientFactory httpClientFactory,
@@ -53,6 +55,7 @@ namespace BTCPayServer.HostedServices
             InvoiceRepository invoiceRepository,
             StoreRepository storeRepository,
             Dictionary<PaymentMethodId, IPaymentMethodBitpayAPIExtension> bitpayExtensions,
+            CurrencyNameTable currencyNameTable,
             EmailSenderFactory emailSenderFactory)
         {
             _Client = httpClientFactory.CreateClient(NamedClient);
@@ -62,11 +65,12 @@ namespace BTCPayServer.HostedServices
             _EmailSenderFactory = emailSenderFactory;
             _StoreRepository = storeRepository;
             _bitpayExtensions = bitpayExtensions;
+            _currencyNameTable = currencyNameTable;
         }
 
         async Task Notify(InvoiceEntity invoice, InvoiceEvent invoiceEvent, bool extendedNotification, bool sendMail)
         {
-            var dto = invoice.EntityToDTO(_bitpayExtensions);
+            var dto = invoice.EntityToDTO(_bitpayExtensions, _currencyNameTable);
             var notification = new InvoicePaymentNotificationEventWrapper()
             {
                 Data = new InvoicePaymentNotification()

--- a/BTCPayServer/Services/DisplayFormatter.cs
+++ b/BTCPayServer/Services/DisplayFormatter.cs
@@ -31,16 +31,16 @@ public class DisplayFormatter
     /// <param name="currency">Currency code</param>
     /// <param name="format">The format, defaults to amount + code, e.g. 1.234,56 USD</param>
     /// <returns>Formatted amount and currency string</returns>
-    public string Currency(decimal value, string currency, CurrencyFormat format = CurrencyFormat.Code)
+    public string Currency(decimal value, string currency, CurrencyFormat format = CurrencyFormat.Code, int? divisibility = null)
     {
         var provider = _currencyNameTable.GetNumberFormatInfo(currency, true);
         var currencyData = _currencyNameTable.GetCurrencyData(currency, true);
-        var divisibility = currencyData.Divisibility;
-        value = value.RoundToSignificant(ref divisibility);
+        var div = divisibility is int d ? d :  currencyData.Divisibility;
+        value = value.RoundToSignificant(ref div);
         if (divisibility != provider.CurrencyDecimalDigits)
         {
             provider = (NumberFormatInfo)provider.Clone();
-            provider.CurrencyDecimalDigits = divisibility;
+            provider.CurrencyDecimalDigits = div;
         }
         var formatted = value.ToString("C", provider);
 

--- a/BTCPayServer/Services/Invoices/InvoiceEntity.cs
+++ b/BTCPayServer/Services/Invoices/InvoiceEntity.cs
@@ -850,10 +850,6 @@ namespace BTCPayServer.Services.Invoices
         /// </summary>
         public decimal PaymentMethodFee { get; set; }
         /// <summary>
-        /// Amount of fee already paid in the invoice's currency
-        /// </summary>
-        public decimal PaymentMethodFeeAlreadyPaid { get; set; }
-        /// <summary>
         /// Minimum required to be paid in order to accept invoice as paid
         /// </summary>
         public decimal MinimumTotalDue { get; set; }
@@ -884,6 +880,21 @@ namespace BTCPayServer.Services.Invoices
         public int Divisibility { get; set; }
         [JsonConverter(typeof(NumericStringJsonConverter))]
         public decimal PaymentMethodFee { get; set; }
+        /// <summary>
+        /// The additional fee applied by the payment handler when it's unable to charge the user the
+        /// exact amount due.
+        /// </summary>
+        [JsonConverter(typeof(NumericStringJsonConverter))]
+        public decimal TweakFee { get; set; }
+        /// <summary>
+        /// Add an additional fee to the payment method fee. See <see cref="TweakFee"/> for more information.
+        /// </summary>
+        /// <param name="value"></param>
+        public void AddTweakFee(decimal value)
+        {
+            TweakFee += value;
+            PaymentMethodFee += value;
+        }
         public string Destination { get; set; }
         public JToken Details { get; set; }
 
@@ -913,7 +924,6 @@ namespace BTCPayServer.Services.Invoices
             accounting.Due = Max(accounting.DueUncapped, 0.0m);
 
             accounting.PaymentMethodFee = Coins((grossDue - i.Price) / rate, Divisibility);
-            accounting.PaymentMethodFeeAlreadyPaid = Coins(i.PaidFee / rate, Divisibility);
 
             accounting.MinimumTotalDue = Max(Smallest(Divisibility), Coins((grossDue * (1.0m - ((decimal)i.PaymentTolerance / 100.0m))) / rate, Divisibility));
             return accounting;

--- a/BTCPayServer/Views/Shared/Lightning/ViewLightningLikePaymentData.cshtml
+++ b/BTCPayServer/Views/Shared/Lightning/ViewLightningLikePaymentData.cshtml
@@ -22,7 +22,7 @@
 					Type = prettyName.PrettyName(payment.PaymentMethodId),
 					BOLT11 = offChainPaymentData.BOLT11,
 					PaymentProof = offChainPaymentData.Preimage?.ToString(),
-							Amount = DisplayFormatter.Currency(payment.Value, handler.Network.CryptoCode)
+					Amount = DisplayFormatter.Currency(payment.Value, handler.Network.CryptoCode, divisibility: payment.Divisibility)
 				};
 			})
         .Where(model => model != null)


### PR DESCRIPTION
* Lightning payment method calculations are performed at the msat level.
* Since Blink rounds down to sats and doesn’t support msats, a negative payment method fee (the "Tweak Fee") is added to cover the missing msats and prevent underpayment.
* To keep things simple for the customer, the Tweak Fee is not displayed at checkout.
* he checkout shows amounts in sats, while the invoice details page shows them in msats.

The Tweak Fee is a fee, hidden from Checkout, meant to be used when a payment method has a service provider which
have a different way of converting the invoice's amount into the currency of the payment method.
This fee can avoid under/over payments when this case happens.

This is useful for Blink but also Strike @rockstardev. I expect this is a recurrent quirk from payment providers that we should account for.

This fix an issue reported by @ndeet on https://github.com/btcpayserver/btcpayserver/issues/6200 that was caused by Blink truncating amounts to sats instead of msats.