### PR TITLE
Edit dictionary should be in JSON format

### DIFF
--- a/BTCPayServer.Tests/LanguageServiceTests.cs
+++ b/BTCPayServer.Tests/LanguageServiceTests.cs
@@ -50,10 +50,8 @@ namespace BTCPayServer.Tests
             tester.Driver.FindElement(By.Name("Name")).SendKeys("English (Custom)");
             tester.ClickPagePrimary();
             var translations = tester.Driver.FindElement(By.Name("Translations"));
-            var text = translations.Text;
-            text = text.Replace("Password => Password", "Password => Mot de passe");
             translations.Clear();
-            translations.SendKeys("Password => Mot de passe");
+            translations.SendKeys("{ \"Password\": \"Mot de passe\" }");
             tester.ClickPagePrimary();
 
             // Check English (Custom) can be selected
@@ -64,7 +62,7 @@ namespace BTCPayServer.Tests
             // Check if we can remove English (Custom)
             tester.LogIn();
             tester.GoToServer(Views.Server.ServerNavPages.Translations);
-            text = tester.Driver.PageSource;
+            var text = tester.Driver.PageSource;
             Assert.Contains("Select-Cypherpunk", text);
             Assert.DoesNotContain("Select-English (Custom)", text);
             // Cypherpunk is loaded from file, can't edit

--- a/BTCPayServer/Controllers/UIServerController.Translations.cs
+++ b/BTCPayServer/Controllers/UIServerController.Translations.cs
@@ -88,11 +88,11 @@ namespace BTCPayServer.Controllers
                 {
                     prop.Value = "OK";
                 }
-                viewModel.Translations = Translations.CreateFromJson(jobj.ToString()).ToTextFormat();
+                viewModel.Translations = Translations.CreateFromJson(jobj.ToString()).ToJsonFormat();
             }
 
 
-            if (!Translations.TryCreateFromText(viewModel.Translations, out var translations))
+            if (!Translations.TryCreateFromJson(viewModel.Translations, out var translations))
             {
                 ModelState.AddModelError(nameof(viewModel.Translations), "Syntax error");
                 return View(viewModel);

--- a/BTCPayServer/Hosting/LoadTranslationsStartupTask.cs
+++ b/BTCPayServer/Hosting/LoadTranslationsStartupTask.cs
@@ -65,7 +65,7 @@ namespace BTCPayServer.Hosting
                         }
                         var savedHash = dictionary.Metadata.ToObject<DictionaryFileMetadata>().Hash;
                         var translations = Translations.CreateFromText(File.ReadAllText(file));
-                        var currentHash = new uint256(SHA256.HashData(Encoding.UTF8.GetBytes(translations.ToTextFormat())));
+                        var currentHash = new uint256(SHA256.HashData(Encoding.UTF8.GetBytes(translations.ToJsonFormat())));
 
                         if (savedHash != currentHash)
                         {

--- a/BTCPayServer/Models/ServerViewModels/EditDictionaryViewModel.cs
+++ b/BTCPayServer/Models/ServerViewModels/EditDictionaryViewModel.cs
@@ -10,7 +10,7 @@ public class EditDictionaryViewModel
 
     internal EditDictionaryViewModel SetTranslations(Translations translations)
     {
-        Translations = translations.ToTextFormat();
+        Translations = translations.ToJsonFormat();
         Lines = translations.Records.Count;
         return this;
     }

--- a/BTCPayServer/Services/Translations.cs
+++ b/BTCPayServer/Services/Translations.cs
@@ -24,12 +24,12 @@ namespace BTCPayServer.Services
             public record Added(string Key, string Value) : Diff(Key);
             public record Modified(string Key, string NewValue, string OldValue) : Diff(Key);
         }
-        public static bool TryCreateFromText(string text, [MaybeNullWhen(false)] out Translations translations)
+        public static bool TryCreateFromJson(string text, [MaybeNullWhen(false)] out Translations translations)
         {
             translations = null;
             try
             {
-                translations = CreateFromText(text);
+                translations = CreateFromJson(text);
                 return true;
             }
             catch
@@ -143,10 +143,6 @@ namespace BTCPayServer.Services
                 obj.Add(record.Key, record.Value);
             }
             return obj.ToString(Newtonsoft.Json.Formatting.Indented);
-        }
-        public string ToTextFormat()
-        {
-            return string.Join('\n', Records.OrderBy(r => r.Key).Select(r => $"{r.Key} => {r.Value}").ToArray());
         }
     }
 }

--- a/BTCPayServer/Views/UIServer/EditDictionary.cshtml
+++ b/BTCPayServer/Views/UIServer/EditDictionary.cshtml
@@ -27,7 +27,7 @@
 		<div class="flex-fill">
 			<p>
 
-				Translations are formatted as <b>KEY => TRANSLATION</b>; for example, <b>Welcome => Bienvenue</b> translates <b>Welcome</b> to <b>Bienvenue</b>.
+				Translations are formatted as JSON <b>{ "Key": "Translation", "Key2": "Translation2" }</b>; for example, <b>{ "Welcome": "Bienvenue" }</b> translates <b>Welcome</b> to <b>Bienvenue</b>.
 			</p>
 			<p class="mb-0">
 				To use the translation from this dictionary's fallback, you can:


### PR DESCRIPTION
The format was previously `KEY => Translation`.

It is better to use JSON instead, as it will deal with escape, and end of lines properly.
On top of it, it will be easier to translate on chatgpt.