### PR TITLE
Reindex Invoices table if corrupt, fix migration timeout

### DIFF
--- a/BTCPayServer/Hosting/MigrationStartupTask.cs
+++ b/BTCPayServer/Hosting/MigrationStartupTask.cs
@@ -868,15 +868,15 @@ WHERE cte.""Id""=p.""Id""
 
         private async Task Migrate(CancellationToken cancellationToken)
         {
-            int cancellationTimeout = 60 * 60 * 24;
-            using (CancellationTokenSource timeout = new CancellationTokenSource(cancellationTimeout))
+            TimeSpan cancellationTimeout = TimeSpan.FromDays(1.0);
+            using (CancellationTokenSource timeout = new CancellationTokenSource((int)cancellationTimeout.TotalMilliseconds))
             using (CancellationTokenSource cts = CancellationTokenSource.CreateLinkedTokenSource(timeout.Token, cancellationToken))
             {
 retry:
                 try
                 {
                     _logger.LogInformation("Running the migration scripts...");
-                    var db = _DBContextFactory.CreateContext(o => o.CommandTimeout(cancellationTimeout + 1));
+                    var db = _DBContextFactory.CreateContext(o => o.CommandTimeout(((int)cancellationTimeout.TotalSeconds) + 1));
                     await db.Database.MigrateAsync(timeout.Token);
                     _logger.LogInformation("All migration scripts ran successfully");
                 }


### PR DESCRIPTION
1. Fix timeout on migrations `TimeoutException` was thrown after a few seconds for big migrations... this should've not been the case.
2. Mainnet demo had a case of corrupted index which prevented the migration to finish. If we detect this issue, we reindex the Invoice table.