### PR TITLE
Remove confirmation tracking from backend

### DIFF
--- a/BTCPayServer.Common/BTCPayNetwork.cs
+++ b/BTCPayServer.Common/BTCPayNetwork.cs
@@ -93,7 +93,6 @@ namespace BTCPayServer
         public virtual bool WalletSupported { get; set; } = true;
         public virtual bool ReadonlyWallet { get; set; } = false;
         public virtual bool VaultSupported { get; set; } = false;
-        public int MaxTrackedConfirmation { get; set; } = 6;
         public bool SupportPayJoin { get; set; } = false;
         public bool SupportLightning { get; set; } = true;
 

--- a/BTCPayServer.Data/Data/PaymentData.Migration.cs
+++ b/BTCPayServer.Data/Data/PaymentData.Migration.cs
@@ -145,6 +145,7 @@ namespace BTCPayServer.Data
 			Created = MilliUnixTimeToDateTime(blob["receivedTime"].Value<long>());
             cryptoData.RemoveIfValue<bool>("rbf", false);
             cryptoData.Remove("legacy");
+            cryptoData.Remove("confirmationCount");
             cryptoData.Remove("networkFee");
             cryptoData.Remove("paymentType");
             cryptoData.RemoveIfNull("outpoint");

--- a/BTCPayServer.Tests/PayJoinTests.cs
+++ b/BTCPayServer.Tests/PayJoinTests.cs
@@ -383,10 +383,6 @@ namespace BTCPayServer.Tests
                     Assert.Equal(2, payments.Count);
                     var originalPayment = payments[0];
                     var coinjoinPayment = payments[1];
-                    Assert.Equal(-1,
-                        handler.ParsePaymentDetails(originalPayment.Details).ConfirmationCount);
-                    Assert.Equal(0,
-                        handler.ParsePaymentDetails(coinjoinPayment.Details).ConfirmationCount);
                     Assert.False(originalPayment.Accounted);
                     Assert.True(coinjoinPayment.Accounted);
                     Assert.Equal(originalPayment.Value,

--- a/BTCPayServer.Tests/TestData/InvoiceMigrationTestVectors.json
+++ b/BTCPayServer.Tests/TestData/InvoiceMigrationTestVectors.json
@@ -598,7 +598,6 @@
       "paymentMethodFee": "0.000002",
       "divisibility": 8,
       "details": {
-        "confirmationCount": 1414,
         "outpoint": "3a6659e189f83f649c0010305def1b8fb78efdbe8c0ce44d56c8c22fff742b55-61"
       }
     },
@@ -626,7 +625,6 @@
       "destination": "3AD9r1UyXXNFA2o3cucBwqX58xNaXvrdsv",
       "divisibility": 8,
       "details": {
-        "confirmationCount": 19,
         "rbf": true,
         "outpoint": "a8be47ca93a1583f60b25fb1279b6c162af731024d169f8d1cd0d29d1d391132-0"
       },
@@ -687,7 +685,6 @@
       "destination": "bc1qdamnd0fjegj4a5efrwx4gvjc69zufmu7ntf5ft",
       "divisibility": 8,
       "details": {
-        "confirmationCount": 6,
         "keyPath": "0/708",
         "outpoint": "2017d89529e7b41569ed1a0f7495f62307c8c1b51a6277669204c3cecce20e2e-22"
       },
@@ -720,7 +717,6 @@
       "divisibility": 8,
       "destination": "bc1qdamnd0fjegj4a5efrwx4gvjc69zufmu7ntf5ft",
       "details": {
-        "confirmationCount": 6,
         "keyPath": "0/708",
         "outpoint": "2017d89529e7b41569ed1a0f7495f62307c8c1b51a6277669204c3cecce20e2e-22",
         "RBF": true

--- a/BTCPayServer/Controllers/UIInvoiceController.UI.cs
+++ b/BTCPayServer/Controllers/UIInvoiceController.UI.cs
@@ -926,15 +926,6 @@ namespace BTCPayServer.Controllers
                     NetworkFeeMode.Never => 0,
                     _ => throw new NotImplementedException()
                 },
-                RequiredConfirmations = invoice.SpeedPolicy switch
-                {
-                    SpeedPolicy.HighSpeed => 0,
-                    SpeedPolicy.MediumSpeed => 1,
-                    SpeedPolicy.LowMediumSpeed => 2,
-                    SpeedPolicy.LowSpeed => 6,
-                    _ => null
-                },
-                ReceivedConfirmations = handler is BitcoinLikePaymentHandler  bh ? invoice.GetAllBitcoinPaymentData(bh, false).FirstOrDefault()?.ConfirmationCount : null,
                 Status = invoice.Status.ToString(),
                 // The Tweak is part of the PaymentMethodFee, but let's not show it in the UI as it's negligible.
                 NetworkFee = prompt.PaymentMethodFee - prompt.TweakFee,

--- a/BTCPayServer/Controllers/UIInvoiceController.UI.cs
+++ b/BTCPayServer/Controllers/UIInvoiceController.UI.cs
@@ -955,11 +955,11 @@ namespace BTCPayServer.Controllers
                                           .ToList()
             };
             if (_paymentModelExtensions.TryGetValue(paymentMethodId, out var extension))
-                extension.ModifyPaymentModel(new PaymentModelContext(model, store, storeBlob, invoice, Url, prompt, handler));
+                await extension.ModifyPaymentModel(new PaymentModelContext(model, store, storeBlob, invoice, Url, prompt, handler));
             model.UISettings = _viewProvider.TryGetViewViewModel(prompt, "CheckoutUI")?.View as CheckoutUIPaymentMethodSettings;
             model.PaymentMethodId = paymentMethodId.ToString();
             model.OrderAmountFiat = OrderAmountFromInvoice(model.CryptoCode, invoice, DisplayFormatter.CurrencyFormat.Symbol);
-
+            
             foreach (var paymentPrompt in invoice.GetPaymentPrompts())
             {
                 var vvm = _viewProvider.TryGetViewViewModel(paymentPrompt, "CheckoutUI");

--- a/BTCPayServer/Controllers/UIStoresController.Onchain.cs
+++ b/BTCPayServer/Controllers/UIStoresController.Onchain.cs
@@ -538,12 +538,6 @@ public partial class UIStoresController
             }
         }
 
-        if (store.SpeedPolicy != vm.SpeedPolicy)
-        {
-            store.SpeedPolicy = vm.SpeedPolicy;
-            needUpdate = true;
-        }
-
         if (needUpdate)
         {
             store.SetPaymentMethodConfig(handler, derivation);
@@ -593,6 +587,12 @@ public partial class UIStoresController
         blob.ShowRecommendedFee = vm.ShowRecommendedFee;
         blob.RecommendedFeeBlockTarget = vm.RecommendedFeeBlockTarget;
         blob.PayJoinEnabled = vm.PayJoinEnabled;
+
+        if (store.SpeedPolicy != vm.SpeedPolicy)
+        {
+            store.SpeedPolicy = vm.SpeedPolicy;
+            needUpdate = true;
+        }
 
         if (store.SetStoreBlob(blob))
         {

--- a/BTCPayServer/Models/InvoicingModels/InvoiceDetailsModel.cs
+++ b/BTCPayServer/Models/InvoicingModels/InvoiceDetailsModel.cs
@@ -13,7 +13,6 @@ namespace BTCPayServer.Models.InvoicingModels
     public class OnchainPaymentViewModel
     {
         public string Crypto { get; set; }
-        public string Confirmations { get; set; }
         public BitcoinAddress DepositAddress { get; set; }
         public string Amount { get; set; }
         public string TransactionId { get; set; }

--- a/BTCPayServer/Models/InvoicingModels/PaymentModel.cs
+++ b/BTCPayServer/Models/InvoicingModels/PaymentModel.cs
@@ -70,7 +70,6 @@ namespace BTCPayServer.Models.InvoicingModels
         public bool Activated { get; set; }
         public string InvoiceCurrency { get; set; }
         public string ReceiptLink { get; set; }
-        public int? RequiredConfirmations { get; set; }
         public long? ReceivedConfirmations { get; set; }
 
         public HashSet<string> ExtensionPartials { get; } = new HashSet<string>();

--- a/BTCPayServer/Models/InvoicingModels/PaymentModel.cs
+++ b/BTCPayServer/Models/InvoicingModels/PaymentModel.cs
@@ -70,6 +70,7 @@ namespace BTCPayServer.Models.InvoicingModels
         public bool Activated { get; set; }
         public string InvoiceCurrency { get; set; }
         public string ReceiptLink { get; set; }
+        public int? RequiredConfirmations { get; set; }
         public long? ReceivedConfirmations { get; set; }
 
         public HashSet<string> ExtensionPartials { get; } = new HashSet<string>();

--- a/BTCPayServer/Payments/Bitcoin/BitcoinLikePaymentData.cs
+++ b/BTCPayServer/Payments/Bitcoin/BitcoinLikePaymentData.cs
@@ -17,13 +17,11 @@ namespace BTCPayServer.Payments.Bitcoin
         public BitcoinLikePaymentData(OutPoint outpoint, bool rbf, KeyPath keyPath)
         {
             Outpoint = outpoint;
-            ConfirmationCount = 0;
             RBF = rbf;
             KeyPath = keyPath;
         }
         [JsonConverter(typeof(SaneOutpointJsonConverter))]
         public OutPoint Outpoint { get; set; }
-        public long ConfirmationCount { get; set; }
         [JsonProperty("RBF")]
         public bool RBF { get; set; }
         [JsonConverter(typeof(NBitcoin.JsonConverters.KeyPathJsonConverter))]

--- a/BTCPayServer/Payments/IPaymentModelExtension.cs
+++ b/BTCPayServer/Payments/IPaymentModelExtension.cs
@@ -1,3 +1,4 @@
+using System.Threading.Tasks;
 using BTCPayServer.Models.InvoicingModels;
 using BTCPayServer.Services.Invoices;
 using Microsoft.AspNetCore.Mvc;
@@ -18,6 +19,6 @@ namespace BTCPayServer.Payments
         string DisplayName { get; }
         string Image { get; }
         string Badge { get; }
-        void ModifyPaymentModel(PaymentModelContext context);
+        Task ModifyPaymentModel(PaymentModelContext context);
     }
 }

--- a/BTCPayServer/Payments/LNURLPay/LNURLPayPaymentModelExtension.cs
+++ b/BTCPayServer/Payments/LNURLPay/LNURLPayPaymentModelExtension.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Linq;
 using BTCPayServer.Payments.Lightning;
 using NBitcoin;
+using System.Threading.Tasks;
 
 namespace BTCPayServer.Payments.LNURLPay
 {
@@ -37,7 +38,7 @@ namespace BTCPayServer.Payments.LNURLPay
         public string Badge => "⚡";
 
         private const string UriScheme = "lightning:";
-        public void ModifyPaymentModel(PaymentModelContext context)
+        public Task ModifyPaymentModel(PaymentModelContext context)
         {
             var lnurl = paymentLinkExtension.GetPaymentLink(context.Prompt, context.UrlHelper);
             if (lnurl is not null)
@@ -51,6 +52,7 @@ namespace BTCPayServer.Payments.LNURLPay
             {
                 BitcoinPaymentModelExtension.PreparePaymentModelForAmountInSats(context.Model, context.Prompt.Rate, _displayFormatter);
             }
+            return Task.CompletedTask;
         }
     }
 }

--- a/BTCPayServer/Payments/Lightning/LightningPaymentModelExtension.cs
+++ b/BTCPayServer/Payments/Lightning/LightningPaymentModelExtension.cs
@@ -6,6 +6,7 @@ using BTCPayServer.Services;
 using Org.BouncyCastle.Crypto.Modes.Gcm;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 
 namespace BTCPayServer.Payments.Lightning
 {
@@ -37,13 +38,13 @@ namespace BTCPayServer.Payments.Lightning
 
         public string Image => Network.LightningImagePath;
         public string Badge => "⚡";
-        public void ModifyPaymentModel(PaymentModelContext context)
+        public Task ModifyPaymentModel(PaymentModelContext context)
         {
             if (!Handlers.TryGetValue(PaymentMethodId, out var o) || o is not LightningLikePaymentHandler handler)
-                return;
+                return Task.CompletedTask;
             var paymentPrompt = context.InvoiceEntity.GetPaymentPrompt(PaymentMethodId);
             if (paymentPrompt is null)
-                return;
+                return Task.CompletedTask;
             context.Model.InvoiceBitcoinUrl = _PaymentLinkExtension.GetPaymentLink(context.Prompt, context.UrlHelper);
             if (context.Model.InvoiceBitcoinUrl is not null)
                 context.Model.InvoiceBitcoinUrlQR = $"lightning:{context.Model.InvoiceBitcoinUrl.ToUpperInvariant()?.Substring("LIGHTNING:".Length)}";
@@ -52,6 +53,7 @@ namespace BTCPayServer.Payments.Lightning
             {
                 BitcoinPaymentModelExtension.PreparePaymentModelForAmountInSats(context.Model, paymentPrompt.Rate, _displayFormatter);
             }
+            return Task.CompletedTask;
         }
     }
 }

--- a/BTCPayServer/Payments/PayJoin/PayJoinEndpointController.cs
+++ b/BTCPayServer/Payments/PayJoin/PayJoinEndpointController.cs
@@ -500,7 +500,6 @@ namespace BTCPayServer.Payments.PayJoin
             var outpoint = new OutPoint(ctx.OriginalTransaction.GetHash(), originalPaymentOutput.Index);
             var details = new BitcoinLikePaymentData(outpoint, ctx.OriginalTransaction.RBF, paymentAddressIndex)
             {
-                ConfirmationCount = -1,
                 PayjoinInformation = new PayjoinInformation()
                 {
                     CoinjoinTransactionHash = GetExpectedHash(newPsbt, coins),

--- a/BTCPayServer/Plugins/Altcoins/Monero/MoneroLikeSpecificBtcPayNetwork.cs
+++ b/BTCPayServer/Plugins/Altcoins/Monero/MoneroLikeSpecificBtcPayNetwork.cs
@@ -2,7 +2,6 @@ namespace BTCPayServer.Plugins.Altcoins;
 
 public class MoneroLikeSpecificBtcPayNetwork : BTCPayNetworkBase
 {
-    public int MaxTrackedConfirmation = 10;
     public string UriScheme { get; set; }
 }
 

--- a/BTCPayServer/Plugins/Altcoins/Zcash/ZcashLikeSpecificBtcPayNetwork.cs
+++ b/BTCPayServer/Plugins/Altcoins/Zcash/ZcashLikeSpecificBtcPayNetwork.cs
@@ -2,6 +2,5 @@ namespace BTCPayServer.Plugins.Altcoins;
 
 public class ZcashLikeSpecificBtcPayNetwork : BTCPayNetworkBase
 {
-    public int MaxTrackedConfirmation = 10;
     public string UriScheme { get; set; }
 }

--- a/BTCPayServer/Services/Altcoins/Monero/Payments/MoneroLikePaymentData.cs
+++ b/BTCPayServer/Services/Altcoins/Monero/Payments/MoneroLikePaymentData.cs
@@ -11,7 +11,6 @@ namespace BTCPayServer.Services.Altcoins.Monero.Payments
         public long SubaddressIndex { get; set; }
         public long SubaccountIndex { get; set; }
         public long BlockHeight { get; set; }
-        public long ConfirmationCount { get; set; }
         public string TransactionId { get; set; }
         public long? InvoiceSettledConfirmationThreshold { get; set; }
 

--- a/BTCPayServer/Services/Altcoins/Monero/Payments/MoneroPaymentModelExtension.cs
+++ b/BTCPayServer/Services/Altcoins/Monero/Payments/MoneroPaymentModelExtension.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using BTCPayServer.Payments;
 using BTCPayServer.Services.Invoices;
 
@@ -26,7 +27,7 @@ namespace BTCPayServer.Services.Altcoins.Monero.Payments
         public string Image => _network.CryptoImagePath;
         public string Badge => "";
 
-        public void ModifyPaymentModel(PaymentModelContext context)
+        public Task ModifyPaymentModel(PaymentModelContext context)
         {
             if (context.Model.Activated)
             {
@@ -38,6 +39,7 @@ namespace BTCPayServer.Services.Altcoins.Monero.Payments
                 context.Model.InvoiceBitcoinUrl = "";
                 context.Model.InvoiceBitcoinUrlQR = "";
             }
+            return Task.CompletedTask;
         }
     }
 }

--- a/BTCPayServer/Services/Altcoins/Monero/UI/MoneroPaymentViewModel.cs
+++ b/BTCPayServer/Services/Altcoins/Monero/UI/MoneroPaymentViewModel.cs
@@ -5,7 +5,6 @@ namespace BTCPayServer.Services.Altcoins.Monero.UI
     public class MoneroPaymentViewModel
     {
         public string Crypto { get; set; }
-        public string Confirmations { get; set; }
         public string DepositAddress { get; set; }
         public string Amount { get; set; }
         public string TransactionId { get; set; }

--- a/BTCPayServer/Services/Altcoins/Zcash/Payments/ZcashLikePaymentData.cs
+++ b/BTCPayServer/Services/Altcoins/Zcash/Payments/ZcashLikePaymentData.cs
@@ -11,7 +11,6 @@ namespace BTCPayServer.Services.Altcoins.Zcash.Payments
         public long SubaddressIndex { get; set; }
         public long SubaccountIndex { get; set; }
         public long BlockHeight { get; set; }
-        public long ConfirmationCount { get; set; }
         public string TransactionId { get; set; }
         public string GetPaymentProof()
         {

--- a/BTCPayServer/Services/Altcoins/Zcash/Payments/ZcashPaymentModelExtension.cs
+++ b/BTCPayServer/Services/Altcoins/Zcash/Payments/ZcashPaymentModelExtension.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using BTCPayServer.Payments;
 using BTCPayServer.Services.Invoices;
 
@@ -26,7 +27,7 @@ namespace BTCPayServer.Services.Altcoins.Zcash.Payments
         public string Image => _network.CryptoImagePath;
         public string Badge => "";
 
-        public void ModifyPaymentModel(PaymentModelContext context)
+        public Task ModifyPaymentModel(PaymentModelContext context)
         {
             if (context.Model.Activated)
             {
@@ -38,6 +39,7 @@ namespace BTCPayServer.Services.Altcoins.Zcash.Payments
                 context.Model.InvoiceBitcoinUrl = "";
                 context.Model.InvoiceBitcoinUrlQR = "";
             }
+            return Task.CompletedTask;
         }
     }
 }

--- a/BTCPayServer/Services/Altcoins/Zcash/Services/ZcashListener.cs
+++ b/BTCPayServer/Services/Altcoins/Zcash/Services/ZcashListener.cs
@@ -329,12 +329,11 @@ namespace BTCPayServer.Services.Altcoins.Zcash.Services
                 SubaccountIndex = subaccountIndex,
                 SubaddressIndex = subaddressIndex,
                 TransactionId = txId,
-                ConfirmationCount = confirmations,
                 BlockHeight = blockHeight
             };
             var paymentData = new Data.PaymentData()
             {
-                Status = GetStatus(details, invoice.SpeedPolicy) ? PaymentStatus.Settled : PaymentStatus.Processing,
+                Status = GetStatus(details, invoice.SpeedPolicy, confirmations) ? PaymentStatus.Settled : PaymentStatus.Processing,
                 Amount = ZcashMoney.Convert(totalAmount),
                 Created = DateTimeOffset.UtcNow,
                 Id = $"{txId}#{subaccountIndex}#{subaddressIndex}",
@@ -362,18 +361,18 @@ namespace BTCPayServer.Services.Altcoins.Zcash.Services
             }
         }
 
-        private bool GetStatus(ZcashLikePaymentData details, SpeedPolicy speedPolicy)
+        private bool GetStatus(ZcashLikePaymentData details, SpeedPolicy speedPolicy, long confirmations)
         {
 			switch (speedPolicy)
 			{
 				case SpeedPolicy.HighSpeed:
-					return details.ConfirmationCount >= 0;
+					return confirmations >= 0;
 				case SpeedPolicy.MediumSpeed:
-					return details.ConfirmationCount >= 1;
+					return confirmations >= 1;
 				case SpeedPolicy.LowMediumSpeed:
-					return details.ConfirmationCount >= 2;
+					return confirmations >= 2;
 				case SpeedPolicy.LowSpeed:
-					return details.ConfirmationCount >= 6;
+					return confirmations >= 6;
 				default:
 					return false;
 			}

--- a/BTCPayServer/Services/Altcoins/Zcash/UI/ZcashPaymentViewModel.cs
+++ b/BTCPayServer/Services/Altcoins/Zcash/UI/ZcashPaymentViewModel.cs
@@ -5,7 +5,6 @@ namespace BTCPayServer.Services.Altcoins.Zcash.UI
     public class ZcashPaymentViewModel
     {
         public string Crypto { get; set; }
-        public string Confirmations { get; set; }
         public string DepositAddress { get; set; }
         public string Amount { get; set; }
         public string TransactionId { get; set; }

--- a/BTCPayServer/Services/Invoices/InvoiceRepository.cs
+++ b/BTCPayServer/Services/Invoices/InvoiceRepository.cs
@@ -170,27 +170,6 @@ retry:
             _eventAggregator.Publish(new InvoiceNeedUpdateEvent(invoiceId));
         }
 
-        public async Task ExtendInvoiceMonitor(string invoiceId)
-        {
-retry:
-            using (var ctx = _applicationDbContextFactory.CreateContext())
-            {
-                var invoiceData = await ctx.Invoices.FindAsync(invoiceId);
-
-                var invoice = invoiceData.GetBlob();
-                invoice.MonitoringExpiration = invoice.MonitoringExpiration.AddHours(1);
-                invoiceData.SetBlob(invoice);
-                try
-                {
-                    await ctx.SaveChangesAsync();
-                }
-                catch (DbUpdateConcurrencyException)
-                {
-                    goto retry;
-                }
-            }
-        }
-
         public async Task CreateInvoiceAsync(InvoiceCreationContext creationContext)
         {
             var invoice = creationContext.InvoiceEntity;
@@ -354,20 +333,6 @@ retry:
                 {
                     goto retry;
                 }
-            }
-        }
-
-        public async Task AddPendingInvoiceIfNotPresent(string invoiceId)
-        {
-            using var context = _applicationDbContextFactory.CreateContext();
-            if (!context.PendingInvoices.Any(a => a.Id == invoiceId))
-            {
-                context.PendingInvoices.Add(new PendingInvoiceData() { Id = invoiceId });
-                try
-                {
-                    await context.SaveChangesAsync();
-                }
-                catch (DbUpdateException) { } // Already exists
             }
         }
 

--- a/BTCPayServer/Views/Shared/Bitcoin/ViewBitcoinLikePaymentData.cshtml
+++ b/BTCPayServer/Views/Shared/Bitcoin/ViewBitcoinLikePaymentData.cshtml
@@ -21,15 +21,6 @@
 			m.Crypto = network.CryptoCode;
             m.DepositAddress = BitcoinAddress.Create(payment.Destination, network.NBitcoinNetwork);
 
-            var confirmationCount = onChainPaymentData.ConfirmationCount;
-            if (confirmationCount >= network.MaxTrackedConfirmation)
-            {
-                m.Confirmations = "At least " + (network.MaxTrackedConfirmation);
-            }
-            else
-            {
-                m.Confirmations = confirmationCount.ToString(CultureInfo.InvariantCulture);
-            }
             if (onChainPaymentData.PayjoinInformation is PayjoinInformation pj)
             {
                 payjoinInformation = pj;
@@ -76,7 +67,6 @@
                             </a>
                         </th>
                     }
-                    <th class="text-end">Confirmations</th>
                     <th class="w-150px text-end">Paid</th>
                 </tr>
                 </thead>
@@ -96,7 +86,6 @@
                         {
                             <td class="text-end text-nowrap">@payment.NetworkFee</td>
                         }
-                        <td class="text-end">@payment.Confirmations</td>
                         <td class="payment-value text-end text-nowrap">
                             <span data-sensitive class="text-success">@DisplayFormatter.Currency(payment.Value, payment.Crypto)</span>
                             @if (!string.IsNullOrEmpty(payment.AdditionalInformation))

--- a/BTCPayServer/Views/Shared/Monero/ViewMoneroLikePaymentData.cshtml
+++ b/BTCPayServer/Views/Shared/Monero/ViewMoneroLikePaymentData.cshtml
@@ -19,16 +19,6 @@
 		m.Crypto = handler.Network.CryptoCode;
 		m.DepositAddress = payment.Destination;
 		m.Amount = payment.Value.ToString(CultureInfo.InvariantCulture);
-        var confirmationCount = onChainPaymentData.ConfirmationCount;
-		if (confirmationCount >= handler.Network.MaxTrackedConfirmation)
-        {
-			m.Confirmations = "At least " + (handler.Network.MaxTrackedConfirmation);
-        }
-        else
-        {
-            m.Confirmations = confirmationCount.ToString(CultureInfo.InvariantCulture);
-        }
-
         m.TransactionId = onChainPaymentData.TransactionId;
         m.ReceivedTime = payment.ReceivedTime;
 		m.TransactionLink = TransactionLinkProviders.GetTransactionLink(m.Crypto, onChainPaymentData.TransactionId);
@@ -46,7 +36,6 @@
                 <th class="w-75px">Crypto</th>
                 <th class="w-175px">Destination</th>
                 <th class="text-nowrap">Payment Proof</th>
-                <th class="text-end">Confirmations</th>
                 <th class="w-150px text-end">Paid</th>
             </tr>
             </thead>
@@ -57,7 +46,6 @@
                     <td>@payment.Crypto</td>
                     <td><vc:truncate-center text="@payment.DepositAddress" classes="truncate-center-id" /></td>
                     <td><vc:truncate-center text="@payment.TransactionId" link="@payment.TransactionLink" classes="truncate-center-id" /></td>
-                    <td class="text-end">@payment.Confirmations</td>
                     <td class="payment-value text-end text-nowrap">
                         <span data-sensitive class="text-success">@DisplayFormatter.Currency(payment.Amount, payment.Crypto)</span>
                     </td>

--- a/BTCPayServer/Views/Shared/Zcash/ViewZcashLikePaymentData.cshtml
+++ b/BTCPayServer/Views/Shared/Zcash/ViewZcashLikePaymentData.cshtml
@@ -20,15 +20,6 @@
 		m.Crypto = handler.Network.CryptoCode;
         m.DepositAddress = payment.Destination;
         m.Amount = payment.Value.ToString(CultureInfo.InvariantCulture);
-        var confirmationCount = onChainPaymentData.ConfirmationCount;
-		if (confirmationCount >= handler.Network.MaxTrackedConfirmation)
-        {
-			m.Confirmations = "At least " + (handler.Network.MaxTrackedConfirmation);
-        }
-        else
-        {
-            m.Confirmations = confirmationCount.ToString(CultureInfo.InvariantCulture);
-        }
 
         m.TransactionId = onChainPaymentData.TransactionId;
         m.ReceivedTime = payment.ReceivedTime;
@@ -47,7 +38,6 @@
                 <th class="w-75px">Crypto</th>
                 <th class="w-175px">Destination</th>
                 <th class="text-nowrap">Payment Proof</th>
-                <th class="text-end">Confirmations</th>
                 <th class="w-150px text-end">Paid</th>
             </tr>
             </thead>
@@ -58,7 +48,6 @@
                     <td>@payment.Crypto</td>
                     <td><vc:truncate-center text="@payment.DepositAddress" classes="truncate-center-id" /></td>
                     <td><vc:truncate-center text="@payment.TransactionId" link="@payment.TransactionLink" classes="truncate-center-id" /></td>
-                    <td class="text-end">@payment.Confirmations</td>
                     <td class="payment-value text-end text-nowrap">
                         <span data-sensitive class="text-success">@DisplayFormatter.Currency(payment.Amount, payment.Crypto)</span>
                     </td>

--- a/BTCPayServer/Views/UIInvoice/Checkout.cshtml
+++ b/BTCPayServer/Views/UIInvoice/Checkout.cshtml
@@ -127,6 +127,7 @@
                         </span>
                         <h4 v-t="'payment_received'" class="mb-4"></h4>
                         <p class="text-center" v-t="'payment_received_body'"></p>
+                        <p class="text-center" v-if="srvModel.receivedConfirmations !== null && srvModel.requiredConfirmations" v-t="{ path: 'payment_received_confirmations', args: { cryptoCode: realCryptoCode, receivedConfirmations: srvModel.receivedConfirmations, requiredConfirmations: srvModel.requiredConfirmations } }"></p>
                         <div id="PaymentDetails" class="payment-details">
                             <dl class="mb-0">
                                 <div>

--- a/BTCPayServer/Views/UIInvoice/Checkout.cshtml
+++ b/BTCPayServer/Views/UIInvoice/Checkout.cshtml
@@ -127,7 +127,6 @@
                         </span>
                         <h4 v-t="'payment_received'" class="mb-4"></h4>
                         <p class="text-center" v-t="'payment_received_body'"></p>
-                        <p class="text-center" v-if="srvModel.receivedConfirmations !== null && srvModel.requiredConfirmations" v-t="{ path: 'payment_received_confirmations', args: { cryptoCode: realCryptoCode, receivedConfirmations: srvModel.receivedConfirmations, requiredConfirmations: srvModel.requiredConfirmations } }"></p>
                         <div id="PaymentDetails" class="payment-details">
                             <dl class="mb-0">
                                 <div>


### PR DESCRIPTION
This is creating some complexity without clear advantage outside of reporting in InvoiceDetails, and in Checkout.

In a later PR, we might decide to restore this information. But rather than tracking it ourselves, we would directly query NBX.