### PR TITLE
App Service: Validate IDs when parsing items template

### DIFF
--- a/BTCPayServer.Tests/GreenfieldAPITests.cs
+++ b/BTCPayServer.Tests/GreenfieldAPITests.cs
@@ -367,6 +367,27 @@ namespace BTCPayServer.Tests
                     }
                 )
             );
+            var template = @"[
+              {
+                ""description"": ""Lovely, fresh and tender, Meng Ding Gan Lu ('sweet dew') is grown in the lush Meng Ding Mountains of the southwestern province of Sichuan where it has been cultivated for over a thousand years."",
+                ""id"": ""green-tea"",
+                ""image"": ""~/img/pos-sample/green-tea.jpg"",
+                ""priceType"": ""Fixed"",
+                ""price"": ""1"",
+                ""title"": ""Green Tea"",
+                ""disabled"": false
+              }
+            ]";
+            await AssertValidationError(new[] { "Template" },
+                async () => await client.CreatePointOfSaleApp(
+                    user.StoreId,
+                    new PointOfSaleAppRequest
+                    {
+                        AppName = "good name",
+                        Template = template.Replace(@"""id"": ""green-tea"",", "")
+                    }
+                )
+            );
 
             // Test creating a POS app successfully
             var app = await client.CreatePointOfSaleApp(
@@ -375,7 +396,8 @@ namespace BTCPayServer.Tests
                 {
                     AppName = "test app from API",
                     Currency = "JPY",
-                    Title = "test app title"
+                    Title = "test app title",
+                    Template = template
                 }
             );
             Assert.Equal("test app from API", app.AppName);
@@ -558,6 +580,27 @@ namespace BTCPayServer.Tests
                     }
                 )
             );
+            var template = @"[
+              {
+                ""description"": ""Lovely, fresh and tender, Meng Ding Gan Lu ('sweet dew') is grown in the lush Meng Ding Mountains of the southwestern province of Sichuan where it has been cultivated for over a thousand years."",
+                ""id"": ""green-tea"",
+                ""image"": ""~/img/pos-sample/green-tea.jpg"",
+                ""priceType"": ""Fixed"",
+                ""price"": ""1"",
+                ""title"": ""Green Tea"",
+                ""disabled"": false
+              }
+            ]";
+            await AssertValidationError(new[] { "PerksTemplate" },
+                async () => await client.CreateCrowdfundApp(
+                    user.StoreId,
+                    new CrowdfundAppRequest
+                    {
+                        AppName = "good name",
+                        PerksTemplate = template.Replace(@"""id"": ""green-tea"",", "")
+                    }
+                )
+            );
 
             // Test creating a crowdfund app
             var app = await client.CreateCrowdfundApp(
@@ -565,7 +608,8 @@ namespace BTCPayServer.Tests
                 new CrowdfundAppRequest
                 {
                     AppName = "test app from API",
-                    Title = "test app title"
+                    Title = "test app title",
+                    PerksTemplate = template
                 }
             );
             Assert.Equal("test app from API", app.AppName);

--- a/BTCPayServer.Tests/SeleniumTests.cs
+++ b/BTCPayServer.Tests/SeleniumTests.cs
@@ -1253,6 +1253,15 @@ namespace BTCPayServer.Tests
 
             s.ClickPagePrimary();
             Assert.Contains("App updated", s.FindAlertMessage().Text);
+            
+            s.Driver.ScrollTo(By.Id("CodeTabButton"));
+            s.Driver.FindElement(By.Id("CodeTabButton")).Click();
+            template = s.Driver.FindElement(By.Id("TemplateConfig")).GetAttribute("value");
+            s.Driver.FindElement(By.Id("TemplateConfig")).Clear();
+            s.Driver.FindElement(By.Id("TemplateConfig")).SendKeys(template.Replace(@"""id"": ""green-tea"",", ""));
+
+            s.ClickPagePrimary();
+            Assert.Contains("Invalid template: Missing ID for item \"Green Tea\".", s.Driver.FindElement(By.CssSelector(".validation-summary-errors")).Text);
 
             s.Driver.FindElement(By.Id("ViewApp")).Click();
             var windows = s.Driver.WindowHandles;

--- a/BTCPayServer/Controllers/GreenField/GreenfieldAppsController.cs
+++ b/BTCPayServer/Controllers/GreenField/GreenfieldAppsController.cs
@@ -402,11 +402,11 @@ namespace BTCPayServer.Controllers.Greenfield
                 try
                 {
                     // Just checking if we can serialize
-                    AppService.SerializeTemplate(AppService.Parse(request.Template));
+                    AppService.SerializeTemplate(AppService.Parse(request.Template, true, true));
                 }
-                catch
+                catch (Exception ex)
                 {
-                    ModelState.AddModelError(nameof(request.Template), "Invalid template");
+                    ModelState.AddModelError(nameof(request.Template), ex.Message);
                 }
             }
         }
@@ -486,11 +486,11 @@ namespace BTCPayServer.Controllers.Greenfield
                 try
                 {
                     // Just checking if we can serialize
-                    AppService.SerializeTemplate(AppService.Parse(request.PerksTemplate));
+                    AppService.SerializeTemplate(AppService.Parse(request.PerksTemplate, true, true));
                 }
-                catch
+                catch (Exception ex)
                 {
-                    ModelState.AddModelError(nameof(request.PerksTemplate), "Invalid template");
+                    ModelState.AddModelError(nameof(request.PerksTemplate), $"Invalid template: {ex.Message}");
                 }
             }
 

--- a/BTCPayServer/Plugins/Crowdfund/Controllers/UICrowdfundController.cs
+++ b/BTCPayServer/Plugins/Crowdfund/Controllers/UICrowdfundController.cs
@@ -447,11 +447,11 @@ namespace BTCPayServer.Plugins.Crowdfund.Controllers
 
             try
             {
-                vm.PerksTemplate = AppService.SerializeTemplate(AppService.Parse(vm.PerksTemplate));
+                vm.PerksTemplate = AppService.SerializeTemplate(AppService.Parse(vm.PerksTemplate, true, true));
             }
-            catch
+            catch (Exception ex)
             {
-                ModelState.AddModelError(nameof(vm.PerksTemplate), "Invalid template");
+                ModelState.AddModelError(nameof(vm.PerksTemplate), $"Invalid template: {ex.Message}");
             }
             if (vm.TargetAmount is decimal v && v == 0.0m)
             {

--- a/BTCPayServer/Plugins/PointOfSale/Controllers/UIPointOfSaleController.cs
+++ b/BTCPayServer/Plugins/PointOfSale/Controllers/UIPointOfSaleController.cs
@@ -647,11 +647,11 @@ namespace BTCPayServer.Plugins.PointOfSale.Controllers
                 ModelState.AddModelError(nameof(vm.Currency), "Invalid currency");
             try
             {
-                vm.Template = AppService.SerializeTemplate(AppService.Parse(vm.Template));
+                vm.Template = AppService.SerializeTemplate(AppService.Parse(vm.Template, true, true));
             }
-            catch
+            catch (Exception ex)
             {
-                ModelState.AddModelError(nameof(vm.Template), "Invalid template");
+                ModelState.AddModelError(nameof(vm.Template), $"Invalid template: {ex.Message}");
             }
             if (!ModelState.IsValid)
             {

--- a/BTCPayServer/Views/Shared/Crowdfund/UpdateCrowdfund.cshtml
+++ b/BTCPayServer/Views/Shared/Crowdfund/UpdateCrowdfund.cshtml
@@ -48,7 +48,7 @@
 
     @if (!ViewContext.ModelState.IsValid)
     {
-        <div asp-validation-summary="ModelOnly"></div>
+        <div asp-validation-summary="All" class="@(ViewContext.ModelState.ErrorCount.Equals(1) ? "no-marker" : "")"></div>
     }
     <div class="row">
         <div class="col-sm-10 col-md-9 col-xl-7 col-xxl-6">

--- a/BTCPayServer/Views/Shared/PointOfSale/UpdatePointOfSale.cshtml
+++ b/BTCPayServer/Views/Shared/PointOfSale/UpdatePointOfSale.cshtml
@@ -61,7 +61,7 @@
 
     @if (!ViewContext.ModelState.IsValid)
     {
-        <div asp-validation-summary="ModelOnly"></div>
+        <div asp-validation-summary="All" class="@(ViewContext.ModelState.ErrorCount.Equals(1) ? "no-marker" : "")"></div>
     }
     <div class="row">
         <div class="col-sm-10 col-md-9 col-xl-7 col-xxl-6">

--- a/BTCPayServer/Views/Shared/TemplateEditor.cshtml
+++ b/BTCPayServer/Views/Shared/TemplateEditor.cshtml
@@ -118,13 +118,12 @@
 </template>
 
 <div id="TemplateEditor" class="editor" v-cloak>
-    <h3 class="mt-5 mb-4" v-pre>@Model.title</h3>
+    <h3 class="mt-5 mb-3" v-pre>@Model.title</h3>
     @if (ViewContext.ViewData.ModelState.TryGetValue(Model.templateId, out var errors))
     {
         foreach (var error in errors.Errors)
         {
-            <br />
-            <span class="text-danger" v-pre>@error.ErrorMessage</span>
+            <p class="text-danger" v-pre>@error.ErrorMessage</p>
         }
     }
     <div class="d-flex flex-wrap align-items-end justify-content-between gap-3 mb-3">


### PR DESCRIPTION
Validates missing and duplicate IDs on the edit actions and when creating/updating apps via the API. Fails gracefully by excluding existing items without ID or with duplicate ID for the rest of the cases.

Fixes #6227.