### PR TITLE
Refactor: Add GetMonitoredInvoices to fetch pending invoices or those with pending payments

### DIFF
--- a/BTCPayServer.Data/BTCPayServer.Data.csproj
+++ b/BTCPayServer.Data/BTCPayServer.Data.csproj
@@ -21,5 +21,6 @@
     <None Remove="DBScripts\001.InvoiceFunctions.sql" />
     <None Remove="DBScripts\002.RefactorPayouts.sql" />
     <None Remove="DBScripts\003.RefactorPendingInvoicesPayments.sql" />
+    <None Remove="DBScripts\004.MonitoredInvoices.sql" />
   </ItemGroup>
 </Project>

--- a/BTCPayServer.Data/DBScripts/003.RefactorPendingInvoicesPayments.sql
+++ b/BTCPayServer.Data/DBScripts/003.RefactorPendingInvoicesPayments.sql
@@ -5,5 +5,5 @@ $$ LANGUAGE sql IMMUTABLE;
 
 CREATE INDEX "IX_Invoices_Pending" ON "Invoices"((1)) WHERE is_pending("Status");
 CREATE INDEX "IX_Payments_Pending" ON "Payments"((1)) WHERE is_pending("Status");
-
 DROP TABLE "PendingInvoices";
+ANALYZE "Invoices";

--- a/BTCPayServer.Data/DBScripts/004.MonitoredInvoices.sql
+++ b/BTCPayServer.Data/DBScripts/004.MonitoredInvoices.sql
@@ -1,0 +1,22 @@
+CREATE OR REPLACE FUNCTION get_prompt(invoice_blob JSONB, payment_method_id TEXT)
+RETURNS JSONB AS $$
+    SELECT invoice_blob->'prompts'->payment_method_id
+$$ LANGUAGE sql IMMUTABLE;
+
+
+CREATE OR REPLACE FUNCTION get_monitored_invoices(payment_method_id TEXT)
+RETURNS TABLE (invoice_id TEXT, payment_id TEXT) AS $$
+WITH cte AS (
+-- Get all the invoices which are pending. Even if no payments.
+SELECT i."Id" invoice_id, p."Id" payment_id FROM "Invoices" i LEFT JOIN "Payments" p ON i."Id" = p."InvoiceDataId"
+        WHERE is_pending(i."Status")
+UNION ALL
+-- For invoices not pending, take all of those which have pending payments
+SELECT i."Id", p."Id" FROM "Invoices" i INNER JOIN "Payments" p ON i."Id" = p."InvoiceDataId"
+        WHERE is_pending(p."Status") AND NOT is_pending(i."Status"))
+SELECT cte.* FROM cte
+LEFT JOIN "Payments" p ON cte.payment_id=p."Id"
+LEFT JOIN "Invoices" i ON cte.invoice_id=i."Id"
+WHERE (p."Type" IS NOT NULL AND p."Type" = payment_method_id) OR
+      (p."Type" IS NULL AND get_prompt(i."Blob2", payment_method_id) IS NOT NULL AND (get_prompt(i."Blob2", payment_method_id)->'activated')::BOOLEAN IS NOT FALSE);
+$$ LANGUAGE SQL STABLE;

--- a/BTCPayServer.Data/Migrations/20240919034505_monitoredinvoices.cs
+++ b/BTCPayServer.Data/Migrations/20240919034505_monitoredinvoices.cs
@@ -1,0 +1,15 @@
+using BTCPayServer.Data;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace BTCPayServer.Migrations
+{
+    [DbContext(typeof(ApplicationDbContext))]
+    [Migration("20240919034505_monitoredinvoices")]
+    [DBScript("004.MonitoredInvoices.sql")]
+    public partial class monitoredinvoices : DBScriptsMigration
+    {
+    }
+}

--- a/BTCPayServer.Tests/UnitTest1.cs
+++ b/BTCPayServer.Tests/UnitTest1.cs
@@ -3157,6 +3157,12 @@ namespace BTCPayServer.Tests
             var invoiceId = GetInvoiceId(resp);
             await acc.PayOnChain(invoiceId);
 
+            // Quick unrelated test on GetMonitoredInvoices
+            var invoiceRepo = tester.PayTester.GetService<InvoiceRepository>();
+            var monitored = Assert.Single(await invoiceRepo.GetMonitoredInvoices(PaymentMethodId.Parse("BTC-CHAIN")), i => i.Id == invoiceId);
+            Assert.Single(monitored.Payments);
+            //
+
             app = await client.CreatePointOfSaleApp(acc.StoreId, new PointOfSaleAppRequest
             {
                 AppName = "Cart",

--- a/BTCPayServer/Payments/Bitcoin/NBXplorerListener.cs
+++ b/BTCPayServer/Payments/Bitcoin/NBXplorerListener.cs
@@ -235,7 +235,7 @@ namespace BTCPayServer.Payments.Bitcoin
 
         async Task UpdatePaymentStates(BTCPayWallet wallet)
         {
-            var invoices = await _InvoiceRepository.GetInvoicesWithPendingPayments(PaymentTypes.CHAIN.GetPaymentMethodId(wallet.Network.CryptoCode));
+            var invoices = await _InvoiceRepository.GetMonitoredInvoices(PaymentTypes.CHAIN.GetPaymentMethodId(wallet.Network.CryptoCode));
             await Task.WhenAll(invoices.Select(i => UpdatePaymentStates(wallet, i)).ToArray());
         }
         async Task<InvoiceEntity> UpdatePaymentStates(BTCPayWallet wallet, string invoiceId, bool fireEvents = true)
@@ -384,7 +384,7 @@ namespace BTCPayServer.Payments.Bitcoin
         {
             var handler = _handlers.GetBitcoinHandler(wallet.Network);
             int totalPayment = 0;
-            var invoices = await _InvoiceRepository.GetInvoicesWithPendingPayments(PaymentTypes.CHAIN.GetPaymentMethodId(network.CryptoCode), true);
+            var invoices = await _InvoiceRepository.GetMonitoredInvoices(PaymentTypes.CHAIN.GetPaymentMethodId(network.CryptoCode));
             var coinsPerDerivationStrategy =
                 new Dictionary<DerivationStrategyBase, ReceivedCoin[]>();
             foreach (var i in invoices)

--- a/BTCPayServer/Services/Altcoins/Monero/Services/MoneroListener.cs
+++ b/BTCPayServer/Services/Altcoins/Monero/Services/MoneroListener.cs
@@ -384,7 +384,7 @@ namespace BTCPayServer.Services.Altcoins.Monero.Services
         private async Task UpdateAnyPendingMoneroLikePayment(string cryptoCode)
         {
             var paymentMethodId = PaymentTypes.CHAIN.GetPaymentMethodId(cryptoCode);
-            var invoices = await _invoiceRepository.GetInvoicesWithPendingPayments(paymentMethodId);
+            var invoices = await _invoiceRepository.GetMonitoredInvoices(paymentMethodId);
             if (!invoices.Any())
                 return;
             invoices = invoices.Where(entity => entity.GetPaymentPrompt(paymentMethodId)?.Activated is true).ToArray();

--- a/BTCPayServer/Services/Altcoins/Zcash/Services/ZcashListener.cs
+++ b/BTCPayServer/Services/Altcoins/Zcash/Services/ZcashListener.cs
@@ -374,7 +374,7 @@ namespace BTCPayServer.Services.Altcoins.Zcash.Services
         private async Task UpdateAnyPendingZcashLikePayment(string cryptoCode)
         {
             var paymentMethodId = PaymentTypes.CHAIN.GetPaymentMethodId(cryptoCode);
-            var invoices = await _invoiceRepository.GetInvoicesWithPendingPayments(paymentMethodId);
+            var invoices = await _invoiceRepository.GetMonitoredInvoices(paymentMethodId);
             if (!invoices.Any())
                 return;
             invoices = invoices.Where(entity => entity.GetPaymentPrompt(paymentMethodId).Activated).ToArray();


### PR DESCRIPTION
`GetMonitoredInvoices` is the method that payment methods will need to query when they want to know what they need to refresh.

This replace the former `GetPendingInvoices`.