### PR TITLE
V2 compatibility: Re-add deprecated navigation methods

### DIFF
--- a/BTCPayServer.Abstractions/Extensions/ViewsRazor.cs
+++ b/BTCPayServer.Abstractions/Extensions/ViewsRazor.cs
@@ -55,7 +55,7 @@ namespace BTCPayServer.Abstractions.Extensions
             viewData[ACTIVE_CATEGORY_KEY] = activeCategory;
         }
 
-        public static bool IsActiveCategory(this ViewDataDictionary viewData, string category, object id = null)
+        public static bool IsCategoryActive(this ViewDataDictionary viewData, string category, object id = null)
         {
             if (!viewData.ContainsKey(ACTIVE_CATEGORY_KEY)) return false;
             var activeId = viewData[ACTIVE_ID_KEY];
@@ -65,12 +65,12 @@ namespace BTCPayServer.Abstractions.Extensions
             return categoryMatch && idMatch;
         }
 
-        public static bool IsActiveCategory<T>(this ViewDataDictionary viewData, T category, object id = null)
+        public static bool IsCategoryActive<T>(this ViewDataDictionary viewData, T category, object id = null)
         {
-            return IsActiveCategory(viewData, category.ToString(), id);
+            return IsCategoryActive(viewData, category.ToString(), id);
         }
 
-        public static bool IsActivePage(this ViewDataDictionary viewData, string page, string category, object id = null)
+        public static bool IsPageActive(this ViewDataDictionary viewData, string page, string category, object id = null)
         {
             if (!viewData.ContainsKey(ACTIVE_PAGE_KEY)) return false;
             var activeId = viewData[ACTIVE_ID_KEY];
@@ -82,7 +82,7 @@ namespace BTCPayServer.Abstractions.Extensions
             return categoryAndPageMatch && idMatch;
         }
         
-        public static bool IsActivePage<T>(this ViewDataDictionary viewData, IEnumerable<T> pages, object id = null)
+        public static bool IsPageActive<T>(this ViewDataDictionary viewData, IEnumerable<T> pages, object id = null)
             where T : IConvertible
         {
             return pages.Any(page => ActivePageClass(viewData, page.ToString(), page.GetType().ToString(), id) == ACTIVE_CLASS);
@@ -95,7 +95,7 @@ namespace BTCPayServer.Abstractions.Extensions
 
         public static string ActiveCategoryClass(this ViewDataDictionary viewData, string category, object id = null)
         {
-            return IsActiveCategory(viewData, category, id) ? ACTIVE_CLASS : null;
+            return IsCategoryActive(viewData, category, id) ? ACTIVE_CLASS : null;
         }
 
         public static string ActivePageClass<T>(this ViewDataDictionary viewData, T page, object id = null)
@@ -106,12 +106,42 @@ namespace BTCPayServer.Abstractions.Extensions
 
         public static string ActivePageClass(this ViewDataDictionary viewData, string page, string category, object id = null)
         {
-            return IsActivePage(viewData, page, category, id) ? ACTIVE_CLASS : null;
+            return IsPageActive(viewData, page, category, id) ? ACTIVE_CLASS : null;
         }
-        
+
         public static string ActivePageClass<T>(this ViewDataDictionary viewData, IEnumerable<T> pages, object id = null) where T : IConvertible
         {
-            return IsActivePage(viewData, pages, id) ? ACTIVE_CLASS : null;
+            return IsPageActive(viewData, pages, id) ? ACTIVE_CLASS : null;
+        }
+
+        [Obsolete("Use ActiveCategoryClass instead")]
+        public static string IsActiveCategory<T>(this ViewDataDictionary viewData, T category, object id = null)
+        {
+            return ActiveCategoryClass(viewData, category, id);
+        }
+
+        [Obsolete("Use ActiveCategoryClass instead")]
+        public static string IsActiveCategory(this ViewDataDictionary viewData, string category, object id = null)
+        {
+            return ActiveCategoryClass(viewData, category, id);
+        }
+
+        [Obsolete("Use ActivePageClass instead")]
+        public static string IsActivePage<T>(this ViewDataDictionary viewData, T page, object id = null) where T : IConvertible
+        {
+            return ActivePageClass(viewData, page, id);
+        }
+
+        [Obsolete("Use ActivePageClass instead")]
+        public static string IsActivePage<T>(this ViewDataDictionary viewData, IEnumerable<T> pages, object id = null) where T : IConvertible
+        {
+            return ActivePageClass(viewData, pages, id);
+        }
+
+        [Obsolete("Use ActivePageClass instead")]
+        public static string IsActivePage(this ViewDataDictionary viewData, string page, string category, object id = null)
+        {
+            return ActivePageClass(viewData, page, category, id);
         }
 
         public static HtmlString ToBrowserDate(this DateTimeOffset date, string netFormat, string jsDateFormat = "short", string jsTimeFormat = "short")

--- a/BTCPayServer/Components/MainNav/Default.cshtml
+++ b/BTCPayServer/Components/MainNav/Default.cshtml
@@ -43,7 +43,7 @@
                                     <span text-translate="true">Settings</span>
                                 </a>
                             </li>
-                            @if (ViewData.IsActivePage([StoreNavPages.General, StoreNavPages.Rates, StoreNavPages.CheckoutAppearance, StoreNavPages.Tokens, StoreNavPages.Users, StoreNavPages.Roles, StoreNavPages.Webhooks, StoreNavPages.PayoutProcessors, StoreNavPages.Emails, StoreNavPages.Forms]))
+                            @if (ViewData.IsPageActive([StoreNavPages.General, StoreNavPages.Rates, StoreNavPages.CheckoutAppearance, StoreNavPages.Tokens, StoreNavPages.Users, StoreNavPages.Roles, StoreNavPages.Webhooks, StoreNavPages.PayoutProcessors, StoreNavPages.Emails, StoreNavPages.Forms]))
                             {
                                 <li class="nav-item nav-item-sub" permission="@Policies.CanModifyStoreSettings">
                                     <a id="StoreNav-@(nameof(StoreNavPages.Rates))" class="nav-link @ViewData.ActivePageClass(StoreNavPages.Rates)" asp-controller="UIStores" asp-action="Rates" asp-route-storeId="@Model.Store.Id" text-translate="true">Rates</a>
@@ -104,7 +104,7 @@
                                             </a>
                                         }
                                     </li>
-                                    @if (ViewData.IsActiveCategory(typeof(WalletsNavPages), scheme.WalletId.ToString()) || ViewData.IsActivePage([WalletsNavPages.Settings], scheme.WalletId.ToString()) || ViewData.IsActivePage([StoreNavPages.OnchainSettings], categoryId))
+                                    @if (ViewData.IsCategoryActive(typeof(WalletsNavPages), scheme.WalletId.ToString()) || ViewData.IsPageActive([WalletsNavPages.Settings], scheme.WalletId.ToString()) || ViewData.IsPageActive([StoreNavPages.OnchainSettings], categoryId))
                                     {
                                         <li class="nav-item nav-item-sub">
                                             <a id="WalletNav-Send" class="nav-link @ViewData.ActivePageClass([WalletsNavPages.Send, WalletsNavPages.PSBT], scheme.WalletId.ToString())" asp-area="" asp-controller="UIWallets" asp-action="WalletSend" asp-route-walletId="@scheme.WalletId">Send</a>
@@ -140,7 +140,7 @@
                                             </a>
                                         }
                                     </li>
-                                    @if (ViewData.IsActivePage([StoreNavPages.Lightning, StoreNavPages.LightningSettings], $"{Model.Store.Id}-{scheme.CryptoCode}"))
+                                    @if (ViewData.IsPageActive([StoreNavPages.Lightning, StoreNavPages.LightningSettings], $"{Model.Store.Id}-{scheme.CryptoCode}"))
                                     {
                                         <li class="nav-item nav-item-sub">
                                             <a id="StoreNav-@(nameof(StoreNavPages.LightningSettings))" class="nav-link @ViewData.ActivePageClass(StoreNavPages.LightningSettings)" asp-controller="UIStores" asp-action="LightningSettings" asp-route-storeId="@Model.Store.Id" asp-route-cryptoCode="@scheme.CryptoCode">Settings</a>
@@ -290,7 +290,7 @@
                     <span text-translate="true">Server Settings</span>
                 </a>
             </li>
-            @if (ViewData.IsActiveCategory(typeof(ServerNavPages)) && !ViewData.IsActivePage([ServerNavPages.Plugins]))
+            @if (ViewData.IsCategoryActive(typeof(ServerNavPages)) && !ViewData.IsPageActive([ServerNavPages.Plugins]))
             {
                 <li class="nav-item nav-item-sub" permission="@Policies.CanModifyServerSettings">
                     <a asp-controller="UIServer" id="SectionNav-@ServerNavPages.Users" class="nav-link @ViewData.ActivePageClass(ServerNavPages.Users)" asp-action="ListUsers" text-translate="true">Users</a>
@@ -379,7 +379,7 @@
                     </li>
                 </ul>
             </li>
-            @if (ViewData.IsActiveCategory(typeof(ManageNavPages)) || ViewData.IsActivePage([ManageNavPages.ChangePassword]))
+            @if (ViewData.IsCategoryActive(typeof(ManageNavPages)) || ViewData.IsPageActive([ManageNavPages.ChangePassword]))
             {
                 <li class="nav-item nav-item-sub">
                     <a id="SectionNav-@ManageNavPages.ChangePassword.ToString()" class="nav-link @ViewData.ActivePageClass(ManageNavPages.ChangePassword)" asp-controller="UIManage" asp-action="ChangePassword" text-translate="true">Password</a>


### PR DESCRIPTION
Gives the new methods a new name and re-adds the old ones (Context: #5744) in order to not break plugins. Simple enough backwartds compatible change, makred the old methods as obsolete to make plugin developers aware that new methods are available.