### PR TITLE
[UI] Do not show unabled payment methods in invoice creation

### DIFF
--- a/BTCPayServer/Controllers/UIAppsController.cs
+++ b/BTCPayServer/Controllers/UIAppsController.cs
@@ -9,6 +9,7 @@ using BTCPayServer.Client;
 using BTCPayServer.Data;
 using BTCPayServer.Models.AppViewModels;
 using BTCPayServer.Services.Apps;
+using BTCPayServer.Services.Invoices;
 using BTCPayServer.Services.Stores;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
@@ -24,6 +25,7 @@ namespace BTCPayServer.Controllers
     {
         public UIAppsController(
             UserManager<ApplicationUser> userManager,
+            PaymentMethodHandlerDictionary handlers,
             BTCPayNetworkProvider networkProvider,
             StoreRepository storeRepository,
             IFileService fileService,
@@ -31,6 +33,7 @@ namespace BTCPayServer.Controllers
             IHtmlHelper html)
         {
             _userManager = userManager;
+            _handlers = handlers;
             _networkProvider = networkProvider;
             _storeRepository = storeRepository;
             _fileService = fileService;
@@ -39,6 +42,7 @@ namespace BTCPayServer.Controllers
         }
 
         private readonly UserManager<ApplicationUser> _userManager;
+        private readonly PaymentMethodHandlerDictionary _handlers;
         private readonly BTCPayNetworkProvider _networkProvider;
         private readonly StoreRepository _storeRepository;
         private readonly IFileService _fileService;
@@ -140,7 +144,7 @@ namespace BTCPayServer.Controllers
             {
                 return NotFound();
             }
-            if (!store.AnyPaymentMethodAvailable())
+            if (!store.AnyPaymentMethodAvailable(_handlers))
             {
                 TempData.SetStatusMessageModel(new StatusMessageModel
                 {

--- a/BTCPayServer/Controllers/UIInvoiceController.UI.cs
+++ b/BTCPayServer/Controllers/UIInvoiceController.UI.cs
@@ -1177,7 +1177,7 @@ namespace BTCPayServer.Controllers
             if (store == null)
                 return NotFound();
 
-            if (!store.AnyPaymentMethodAvailable())
+            if (!store.AnyPaymentMethodAvailable(_handlers))
             {
                 return NoPaymentMethodResult(store.Id);
             }
@@ -1200,7 +1200,7 @@ namespace BTCPayServer.Controllers
         public async Task<IActionResult> CreateInvoice(CreateInvoiceModel model, CancellationToken cancellationToken)
         {
             var store = HttpContext.GetStoreData();
-            if (!store.AnyPaymentMethodAvailable())
+            if (!store.AnyPaymentMethodAvailable(_handlers))
             {
                 return NoPaymentMethodResult(store.Id);
             }
@@ -1370,9 +1370,7 @@ namespace BTCPayServer.Controllers
 
         private SelectList GetPaymentMethodsSelectList(StoreData store)
         {
-            var excludeFilter = store.GetStoreBlob().GetExcludedPaymentMethods();
-            return new SelectList(store.GetPaymentMethodConfigs()
-                    .Where(s => !excludeFilter.Match(s.Key))
+            return new SelectList(store.GetPaymentMethodConfigs(_handlers, true)
                     .Select(method => new SelectListItem(method.Key.ToString(), method.Key.ToString())),
                 nameof(SelectListItem.Value),
                 nameof(SelectListItem.Text));

--- a/BTCPayServer/Controllers/UIPaymentRequestController.cs
+++ b/BTCPayServer/Controllers/UIPaymentRequestController.cs
@@ -33,6 +33,7 @@ namespace BTCPayServer.Controllers
     public class UIPaymentRequestController : Controller
     {
         private readonly UIInvoiceController _InvoiceController;
+        private readonly PaymentMethodHandlerDictionary _handlers;
         private readonly UserManager<ApplicationUser> _UserManager;
         private readonly PaymentRequestRepository _PaymentRequestRepository;
         private readonly PaymentRequestService _PaymentRequestService;
@@ -49,6 +50,7 @@ namespace BTCPayServer.Controllers
 
         public UIPaymentRequestController(
             UIInvoiceController invoiceController,
+            PaymentMethodHandlerDictionary handlers,
             UserManager<ApplicationUser> userManager,
             PaymentRequestRepository paymentRequestRepository,
             PaymentRequestService paymentRequestService,
@@ -63,6 +65,7 @@ namespace BTCPayServer.Controllers
             BTCPayNetworkProvider networkProvider)
         {
             _InvoiceController = invoiceController;
+            _handlers = handlers;
             _UserManager = userManager;
             _PaymentRequestRepository = paymentRequestRepository;
             _PaymentRequestService = paymentRequestService;
@@ -124,7 +127,7 @@ namespace BTCPayServer.Controllers
             {
                 return NotFound();
             }
-            if (!store.AnyPaymentMethodAvailable())
+            if (!store.AnyPaymentMethodAvailable(_handlers))
             {
                 return NoPaymentMethodResult(storeId);
             }
@@ -159,7 +162,7 @@ namespace BTCPayServer.Controllers
             {
                 return NotFound();
             }
-            if (!store.AnyPaymentMethodAvailable())
+            if (!store.AnyPaymentMethodAvailable(_handlers))
             {
                 return NoPaymentMethodResult(store.Id);
             }

--- a/BTCPayServer/Data/StoreDataExtensions.cs
+++ b/BTCPayServer/Data/StoreDataExtensions.cs
@@ -59,9 +59,9 @@ namespace BTCPayServer.Data
             return result;
         }
 
-        public static bool AnyPaymentMethodAvailable(this StoreData storeData)
+        public static bool AnyPaymentMethodAvailable(this StoreData storeData, PaymentMethodHandlerDictionary handlers)
         {
-            return storeData.GetPaymentMethodConfigs(true).Any();
+            return storeData.GetPaymentMethodConfigs(handlers, true).Any();
         }
 
         public static bool SetStoreBlob(this StoreData storeData, StoreBlob storeBlob)


### PR DESCRIPTION
Reported by @pavlenex 

## Repro
1. Create store with BTC and LTC
2. Restart BTCPay without LTC

## Expected
Create Invoice page shouldn't show LTC as a choice.

## Actual
The deactivated payment method is still showing up

![image](https://github.com/user-attachments/assets/79acf05d-658d-4587-a3c4-64e0f57b7756)
