### PR TITLE
OnlyIfSupportAttribute should use PaymentMethodId

### DIFF
--- a/BTCPayServer/Filters/OnlyIfSupportAttribute.cs
+++ b/BTCPayServer/Filters/OnlyIfSupportAttribute.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Threading.Tasks;
+using BTCPayServer.Payments;
+using BTCPayServer.Services.Invoices;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.Extensions.DependencyInjection;
@@ -8,22 +10,21 @@ namespace BTCPayServer.Filters
 {
     public class OnlyIfSupportAttribute : Attribute, IAsyncActionFilter
     {
-        private readonly string _cryptoCode;
+        private readonly string _paymentMethodId;
 
-        public OnlyIfSupportAttribute(string cryptoCode)
+        public OnlyIfSupportAttribute(string paymentMethodId)
         {
-            _cryptoCode = cryptoCode;
+            _paymentMethodId = paymentMethodId;
         }
 
         public async Task OnActionExecutionAsync(ActionExecutingContext context, ActionExecutionDelegate next)
         {
-            var options = context.HttpContext.RequestServices.GetService<BTCPayNetworkProvider>();
-            if (options.GetNetwork(_cryptoCode) == null)
+            var handlers = context.HttpContext.RequestServices.GetService<PaymentMethodHandlerDictionary>();
+            if (!handlers.Support(PaymentMethodId.Parse(_paymentMethodId)))
             {
                 context.Result = new NotFoundResult();
                 return;
             }
-
             await next();
         }
     }

--- a/BTCPayServer/Services/Altcoins/Monero/RPC/MoneroDaemonCallbackController.cs
+++ b/BTCPayServer/Services/Altcoins/Monero/RPC/MoneroDaemonCallbackController.cs
@@ -4,7 +4,7 @@ using Microsoft.AspNetCore.Mvc;
 namespace BTCPayServer.Services.Altcoins.Monero.RPC
 {
     [Route("[controller]")]
-    [OnlyIfSupportAttribute("XMR")]
+    [OnlyIfSupportAttribute("XMR-CHAIN")]
     public class MoneroLikeDaemonCallbackController : Controller
     {
         private readonly EventAggregator _eventAggregator;

--- a/BTCPayServer/Services/Altcoins/Monero/UI/MoneroLikeStoreController.cs
+++ b/BTCPayServer/Services/Altcoins/Monero/UI/MoneroLikeStoreController.cs
@@ -29,7 +29,7 @@ using Microsoft.AspNetCore.Mvc.Rendering;
 namespace BTCPayServer.Services.Altcoins.Monero.UI
 {
     [Route("stores/{storeId}/monerolike")]
-    [OnlyIfSupportAttribute("XMR")]
+    [OnlyIfSupportAttribute("XMR-CHAIN")]
     [Authorize(AuthenticationSchemes = AuthenticationSchemes.Cookie)]
     [Authorize(Policy = Policies.CanModifyStoreSettings, AuthenticationSchemes = AuthenticationSchemes.Cookie)]
     [Authorize(Policy = Policies.CanModifyServerSettings, AuthenticationSchemes = AuthenticationSchemes.Cookie)]

--- a/BTCPayServer/Services/Altcoins/Zcash/RPC/ZcashDaemonCallbackController.cs
+++ b/BTCPayServer/Services/Altcoins/Zcash/RPC/ZcashDaemonCallbackController.cs
@@ -4,7 +4,7 @@ using Microsoft.AspNetCore.Mvc;
 namespace BTCPayServer.Services.Altcoins.Zcash.RPC
 {
     [Route("[controller]")]
-    [OnlyIfSupportAttribute("ZEC")]
+    [OnlyIfSupportAttribute("ZEC-CHAIN")]
     public class ZcashLikeDaemonCallbackController : Controller
     {
         private readonly EventAggregator _eventAggregator;

--- a/BTCPayServer/Services/Altcoins/Zcash/UI/ZcashLikeStoreController.cs
+++ b/BTCPayServer/Services/Altcoins/Zcash/UI/ZcashLikeStoreController.cs
@@ -30,7 +30,7 @@ using Microsoft.AspNetCore.Mvc.Rendering;
 namespace BTCPayServer.Services.Altcoins.Zcash.UI
 {
     [Route("stores/{storeId}/Zcashlike")]
-    [OnlyIfSupportAttribute("ZEC")]
+    [OnlyIfSupportAttribute("ZEC-CHAIN")]
     [Authorize(AuthenticationSchemes = AuthenticationSchemes.Cookie)]
     [Authorize(Policy = Policies.CanModifyStoreSettings, AuthenticationSchemes = AuthenticationSchemes.Cookie)]
     [Authorize(Policy = Policies.CanModifyServerSettings, AuthenticationSchemes = AuthenticationSchemes.Cookie)]


### PR DESCRIPTION
Reported by @b0l0k 

Note that in your plugin, you don't need this attribute. As if your plugin is activated, the controllers should be available.

This attribute is only used for XMR, ZEC because they are shipped in core and I didn't want their controllers exposed if not needed for security reason.