### PR TITLE
Improve logging of rates in invoices

### DIFF
--- a/BTCPayServer/Payments/IPaymentMethodHandler.cs
+++ b/BTCPayServer/Payments/IPaymentMethodHandler.cs
@@ -179,8 +179,13 @@ namespace BTCPayServer.Payments
                 try
                 {
                     var rateResult = await fetching.Value;
-                    Logs.Write($"The rating rule is {rateResult.Rule}", InvoiceEventData.EventSeverity.Info);
-                    Logs.Write($"The evaluated rating rule is {rateResult.EvaluatedRule}", InvoiceEventData.EventSeverity.Info);
+                    string bidLog = rateResult switch
+                    {
+                        RateResult { BidAsk: { } o } => o.Bid.ToString(),
+                        _ => "???"
+                    };
+
+                    Logs.Write($"Rate for {fetching.Key}: {rateResult.Rule} = {rateResult.EvaluatedRule} = {bidLog}", InvoiceEventData.EventSeverity.Info);
                     if (rateResult is RateResult { BidAsk: { } bidAsk })
                     {
                         InvoiceEntity.AddRate(fetching.Key, bidAsk.Bid);


### PR DESCRIPTION
If there are multiple currency conversions between the invoice currency and each payment method's currency, the logs can become quite confusing.

Here is an example log showing both USDT and BTC with two conversions: EUR to USDT and EUR to BTC.

![image](https://github.com/user-attachments/assets/c6e4d1d1-4755-4b74-a8cb-e8e801bda04d)

As you can see, it’s unclear what is being converted.

This PR streamlines the process, replacing it with a single concise log entry per conversion.

![image](https://github.com/user-attachments/assets/f7bc33d4-fc0c-41b7-9d6e-230005ad3144)
