### PR TITLE
Fix: An unactivated payment method failing to activate would crash the checkout

### DIFF
--- a/BTCPayServer/Services/Altcoins/Monero/Payments/MoneroCheckoutModelExtension.cs
+++ b/BTCPayServer/Services/Altcoins/Monero/Payments/MoneroCheckoutModelExtension.cs
@@ -37,26 +37,18 @@ namespace BTCPayServer.Services.Altcoins.Monero.Payments
             if (context is not { Handler: MoneroLikePaymentMethodHandler handler })
                 return;
             context.Model.CheckoutBodyComponentName = BitcoinCheckoutModelExtension.CheckoutBodyComponentName;
-            if (context.Model.Activated)
-            {
-                var details = context.InvoiceEntity.GetPayments(true)
+            var details = context.InvoiceEntity.GetPayments(true)
                     .Select(p => p.GetDetails<MoneroLikePaymentData>(handler))
                     .Where(p => p is not null)
                     .FirstOrDefault();
-                if (details is not null)
-                {
-                    context.Model.ReceivedConfirmations = details.ConfirmationCount;
-                    context.Model.RequiredConfirmations = (int)MoneroListener.ConfirmationsRequired(details, context.InvoiceEntity.SpeedPolicy);
-                }
-
-                context.Model.InvoiceBitcoinUrl = paymentLinkExtension.GetPaymentLink(context.Prompt, context.UrlHelper);
-                context.Model.InvoiceBitcoinUrlQR = context.Model.InvoiceBitcoinUrl;
-            }
-            else
+            if (details is not null)
             {
-                context.Model.InvoiceBitcoinUrl = "";
-                context.Model.InvoiceBitcoinUrlQR = "";
+                context.Model.ReceivedConfirmations = details.ConfirmationCount;
+                context.Model.RequiredConfirmations = (int)MoneroListener.ConfirmationsRequired(details, context.InvoiceEntity.SpeedPolicy);
             }
+
+            context.Model.InvoiceBitcoinUrl = paymentLinkExtension.GetPaymentLink(context.Prompt, context.UrlHelper);
+            context.Model.InvoiceBitcoinUrlQR = context.Model.InvoiceBitcoinUrl;
         }
     }
 }

--- a/BTCPayServer/Services/Altcoins/Zcash/Payments/ZcashCheckoutModelExtension.cs
+++ b/BTCPayServer/Services/Altcoins/Zcash/Payments/ZcashCheckoutModelExtension.cs
@@ -37,25 +37,17 @@ namespace BTCPayServer.Services.Altcoins.Zcash.Payments
             if (context is not { Handler: ZcashLikePaymentMethodHandler handler })
                 return;
 			context.Model.CheckoutBodyComponentName = BitcoinCheckoutModelExtension.CheckoutBodyComponentName;
-			if (context.Model.Activated)
-            {
-                var details = context.InvoiceEntity.GetPayments(true)
+            var details = context.InvoiceEntity.GetPayments(true)
                     .Select(p => p.GetDetails<ZcashLikePaymentData>(handler))
                     .Where(p => p is not null)
                     .FirstOrDefault();
-                if (details is not null)
-                {
-                    context.Model.ReceivedConfirmations = details.ConfirmationCount;
-                    context.Model.RequiredConfirmations = (int)ZcashListener.ConfirmationsRequired(context.InvoiceEntity.SpeedPolicy);
-                }
-                context.Model.InvoiceBitcoinUrl = paymentLinkExtension.GetPaymentLink(context.Prompt, context.UrlHelper);
-                context.Model.InvoiceBitcoinUrlQR = context.Model.InvoiceBitcoinUrl;
-            }
-            else
+            if (details is not null)
             {
-                context.Model.InvoiceBitcoinUrl = "";
-                context.Model.InvoiceBitcoinUrlQR = "";
+                context.Model.ReceivedConfirmations = details.ConfirmationCount;
+                context.Model.RequiredConfirmations = (int)ZcashListener.ConfirmationsRequired(context.InvoiceEntity.SpeedPolicy);
             }
+            context.Model.InvoiceBitcoinUrl = paymentLinkExtension.GetPaymentLink(context.Prompt, context.UrlHelper);
+            context.Model.InvoiceBitcoinUrlQR = context.Model.InvoiceBitcoinUrl;
         }
     }
 }


### PR DESCRIPTION
Reported by @pavlenex on https://github.com/btcpayserver/btcpayserver/issues/6266

Repro:
* Select `Only enable the payment method after user explicitly chooses it` in the Checkout Appearance section of your store
* Activate Bitcoin and Lightning for the store
* Create a 0.01USD invoice

Expected:
* Checkout opens and propose to pay on Lightning

Actual:
* The checkout crash

This PR fix the problem, and also simplify `ModifyCheckoutModel` from extensions, as the method can now assume that the payment method has been activated.