### PR TITLE
Prevent double BOLT11 payment with LNUrlWithdraw

### DIFF
--- a/BTCPayServer.Client/BTCPayServerClient.StorePayoutProcessors.cs
+++ b/BTCPayServer.Client/BTCPayServerClient.StorePayoutProcessors.cs
@@ -19,14 +19,14 @@ public partial class BTCPayServerClient
         await SendHttpRequest($"api/v1/stores/{storeId}/payout-processors/{processor}/{paymentMethod}", null, HttpMethod.Delete, token);
     }
 
-    public virtual async Task<IEnumerable<LightningAutomatedPayoutSettings>> GetStoreLightningAutomatedPayoutProcessors(string storeId, string? paymentMethod = null, CancellationToken token = default)
+    public virtual async Task<IEnumerable<LightningAutomatedPayoutSettings>> GetStoreLightningAutomatedPayoutProcessors(string storeId, string? payoutMethodId = null, CancellationToken token = default)
     {
-        return await SendHttpRequest<IEnumerable<LightningAutomatedPayoutSettings>>($"api/v1/stores/{storeId}/payout-processors/LightningAutomatedPayoutSenderFactory{(paymentMethod is null ? string.Empty : $"/{paymentMethod}")}", null, HttpMethod.Get, token);
+        return await SendHttpRequest<IEnumerable<LightningAutomatedPayoutSettings>>($"api/v1/stores/{storeId}/payout-processors/LightningAutomatedPayoutSenderFactory{(payoutMethodId is null ? string.Empty : $"/{payoutMethodId}")}", null, HttpMethod.Get, token);
     }
 
-    public virtual async Task<LightningAutomatedPayoutSettings> UpdateStoreLightningAutomatedPayoutProcessors(string storeId, string paymentMethod, LightningAutomatedPayoutSettings request, CancellationToken token = default)
+    public virtual async Task<LightningAutomatedPayoutSettings> UpdateStoreLightningAutomatedPayoutProcessors(string storeId, string payoutMethodId, LightningAutomatedPayoutSettings request, CancellationToken token = default)
     {
-        return await SendHttpRequest<LightningAutomatedPayoutSettings>($"api/v1/stores/{storeId}/payout-processors/LightningAutomatedPayoutSenderFactory/{paymentMethod}", request, HttpMethod.Put, token);
+        return await SendHttpRequest<LightningAutomatedPayoutSettings>($"api/v1/stores/{storeId}/payout-processors/LightningAutomatedPayoutSenderFactory/{payoutMethodId}", request, HttpMethod.Put, token);
     }
 
     public virtual async Task<OnChainAutomatedPayoutSettings> UpdateStoreOnChainAutomatedPayoutProcessors(string storeId, string paymentMethod, OnChainAutomatedPayoutSettings request, CancellationToken token = default)

--- a/BTCPayServer.Tests/SeleniumTester.cs
+++ b/BTCPayServer.Tests/SeleniumTester.cs
@@ -183,15 +183,17 @@ retry:
             Driver.AssertNoError();
             CreatedUser = usr;
             Password = "123456";
+            IsAdmin = isAdmin;
             return usr;
         }
         string CreatedUser;
 
         public string Password { get; private set; }
+        public bool IsAdmin { get; private set; }
 
         public TestAccount AsTestAccount()
         {
-            return new TestAccount(Server) { RegisterDetails = new Models.AccountViewModels.RegisterViewModel() { Password = "123456", Email = CreatedUser } };
+            return new TestAccount(Server) { StoreId = StoreId, Email = CreatedUser, Password = Password, RegisterDetails = new Models.AccountViewModels.RegisterViewModel() { Password = "123456", Email = CreatedUser }, IsAdmin = IsAdmin };
         }
 
         public (string storeName, string storeId) CreateNewStore(bool keepId = true)

--- a/BTCPayServer.Tests/SeleniumTests.cs
+++ b/BTCPayServer.Tests/SeleniumTests.cs
@@ -2487,7 +2487,16 @@ namespace BTCPayServer.Tests
                 $"LNurl w payout test {DateTime.UtcNow.Ticks}",
                 TimeSpan.FromHours(1), CancellationToken.None));
             var response = await info.SendRequest(bolt2.BOLT11, s.Server.PayTester.HttpClient, null,null);
-            await TestUtils.EventuallyAsync(async () =>
+            // Oops!
+            Assert.Equal("The request has been approved. The sender needs to send the payment manually. (Or activate the lightning automated payment processor)", response.Reason);
+			var account = await s.AsTestAccount().CreateClient();
+			await account.UpdateStoreLightningAutomatedPayoutProcessors(s.StoreId, "BTC-LN", new()
+			{
+				ProcessNewPayoutsInstantly = true,
+				IntervalSeconds = TimeSpan.FromSeconds(60)
+			});
+			// Now it should process to complete
+			await TestUtils.EventuallyAsync(async () =>
             {
                 s.Driver.Navigate().Refresh();
                 Assert.Contains(bolt2.BOLT11, s.Driver.PageSource);
@@ -2577,7 +2586,9 @@ namespace BTCPayServer.Tests
                 $"LNurl w payout test {DateTime.UtcNow.Ticks}",
                 TimeSpan.FromHours(1), CancellationToken.None));
             response = await info.SendRequest(bolt2.BOLT11, s.Server.PayTester.HttpClient, null,null);
-            TestUtils.Eventually(() =>
+			// Nope, you need to approve the claim automatically
+			Assert.Equal("The request has been recorded, but still need to be approved before execution.", response.Reason);
+			TestUtils.Eventually(() =>
             {
                 s.Driver.Navigate().Refresh();
                 Assert.Contains(bolt2.BOLT11, s.Driver.PageSource);

--- a/BTCPayServer/PayoutProcessors/BaseAutomatedPayoutProcessor.cs
+++ b/BTCPayServer/PayoutProcessors/BaseAutomatedPayoutProcessor.cs
@@ -22,6 +22,7 @@ namespace BTCPayServer.PayoutProcessors;
 public class AutomatedPayoutConstants
 {
     public const double MinIntervalMinutes = 1.0;
+    public const double DefaultIntervalMinutes = 60.0;
     public const double MaxIntervalMinutes = 24 * 60; //1 day
     public static void ValidateInterval(ModelStateDictionary modelState, TimeSpan timeSpan, string parameterName)
     {

--- a/BTCPayServer/PayoutProcessors/Lightning/LightningAutomatedPayoutProcessor.cs
+++ b/BTCPayServer/PayoutProcessors/Lightning/LightningAutomatedPayoutProcessor.cs
@@ -82,10 +82,10 @@ public class LightningAutomatedPayoutProcessor : BaseAutomatedPayoutProcessor<Li
         }
 
         var blob = payoutData.GetBlob(_btcPayNetworkJsonSerializerSettings);
-        var claim = await _payoutHandler.ParseClaimDestination(blob.Destination, CancellationToken);
         try
         {
-            switch (claim.destination)
+			var claim = await _payoutHandler.ParseClaimDestination(blob.Destination, CancellationToken);
+			switch (claim.destination)
             {
                 case LNURLPayClaimDestinaton lnurlPayClaimDestinaton:
                     var lnurlResult = await UILightningLikePayoutController.GetInvoiceFromLNURL(payoutData,


### PR DESCRIPTION
Reported by @pavlenex 

When paying from BTCPay Server with a Boltcard and a store with automated payout processor, then double payments could happen: First as part of the LNURLWithdraw route, then as part of the automated payout processor.

In practice this wouldn't be a problem as it is impossible to pay the same BOLT11 twice. But this double attempt was shown if the boltcard was backed by Blink.

Anyway, we shouldn't try to send a payment outside of payout processors for security reason.

## Breaking change

This change will require the user of the boltcard to activate the lightning payment processor with `ProcessNewPayoutsInstantly` set to `true` on his store.
I will do such check in the Boltcard plugins to avoid having user surprised by this behavior.