### PR TITLE
Require non interactivity for boltcard payments

### DIFF
--- a/BTCPayServer/Controllers/UIBoltcardController.cs
+++ b/BTCPayServer/Controllers/UIBoltcardController.cs
@@ -65,6 +65,6 @@ public class UIBoltcardController : Controller
         if (!cardKey.CheckSunMac(c, piccData))
             return BadRequest(new LNUrlStatusResponse { Status = "ERROR", Reason = "Replayed or expired query" });
         LNURLController.ControllerContext.HttpContext = HttpContext;
-        return await LNURLController.GetLNURLForPullPayment("BTC", registration.PullPaymentId, pr, $"{p}-{c}", cancellationToken);
+        return await LNURLController.GetLNURLForPullPayment("BTC", registration.PullPaymentId, pr, $"{p}-{c}", true, cancellationToken);
     }
 }

--- a/BTCPayServer/Controllers/UILNURLController.cs
+++ b/BTCPayServer/Controllers/UILNURLController.cs
@@ -99,11 +99,11 @@ namespace BTCPayServer
         [HttpGet("withdraw/pp/{pullPaymentId}")]
         public Task<IActionResult> GetLNURLForPullPayment(string cryptoCode, string pullPaymentId, [FromQuery] string pr, CancellationToken cancellationToken)
         {
-            return GetLNURLForPullPayment(cryptoCode, pullPaymentId, pr, pullPaymentId, cancellationToken);
+            return GetLNURLForPullPayment(cryptoCode, pullPaymentId, pr, pullPaymentId, false, cancellationToken);
         }
 
         [NonAction]
-        internal async Task<IActionResult> GetLNURLForPullPayment(string cryptoCode, string pullPaymentId, string pr, string k1, CancellationToken cancellationToken)
+        internal async Task<IActionResult> GetLNURLForPullPayment(string cryptoCode, string pullPaymentId, string pr, string k1, bool nonInteractiveOnly, CancellationToken cancellationToken)
         {
             var network = GetNetwork(cryptoCode);
             if (network is null || !network.SupportLightning)
@@ -172,8 +172,18 @@ namespace BTCPayServer
             });
             var processorBlob = processors.FirstOrDefault()?.HasTypedBlob<LightningAutomatedPayoutBlob>().GetBlob();
 			var instantProcessing = processorBlob?.ProcessNewPayoutsInstantly is true;
+            if (nonInteractiveOnly && !instantProcessing)
+            {
+                return BadRequest(new LNUrlStatusResponse { Status = "ERROR", Reason = "Payment cancelled: The payer must activate the lightning automated payment process and must check \"Process approved payouts instantly\"." });
+            }
+
 			var interval = processorBlob?.Interval.TotalMinutes;
 			var autoApprove = pp.GetBlob().AutoApproveClaims;
+            if (nonInteractiveOnly && !autoApprove)
+            {
+                return BadRequest(new LNUrlStatusResponse { Status = "ERROR", Reason = "Payment cancelled: The payer must activate \"Automatically approve claims\" in the settings of the pull payment." });
+            }
+
 			var claimResponse = await _pullPaymentHostedService.Claim(new ClaimRequest
             {
                 Destination = new BoltInvoiceClaimDestination(pr, result),


### PR DESCRIPTION
## Old behavior

If you paid via Boltcard and didn't:
* Set auto-approval on the Pull Payment
* Set up the Lightning automated processor with immediate payout
then the checkout would show this:

![image](https://github.com/user-attachments/assets/62f71834-7669-4352-a08a-668e71ea812a)

The merchant would be confused, as would the user, who likely wouldn't know what to do with this message.

## New behavior

When paying with a Boltcard backed by BTCPay Server, the pull payment should require auto-approval, and the Lightning automated processor with immediate payout must be enabled for the store.

If that's not the case, the new behavior will display a red alert box indicating that the payment has been canceled.

For regular pull payments, interactivity is allowed, enabling the payer to manually approve an LNURLWithdraw request at a later time

## Rationale

The rationale is that a Boltcard is likely used for merchant payments and shouldn't remain in a 'Pending' state, as this would leave both the merchant and the user uncertain about whether the payment has been sent or received. (or be sent later)

However, someone looking to sweep a pull payment may be fine with waiting for the creator of the pull payment to accept their request at a later time.