### PR TITLE
Improve UX for uninstalling disabled plugins

### DIFF
--- a/BTCPayServer/Controllers/UIServerController.Plugins.cs
+++ b/BTCPayServer/Controllers/UIServerController.Plugins.cs
@@ -59,6 +59,16 @@ namespace BTCPayServer.Controllers
             public Dictionary<string, AvailablePlugin> DownloadedPluginsByIdentifier { get; set; } = new Dictionary<string, AvailablePlugin>();
         }
 
+        [HttpPost("server/plugins/uninstall-all")]
+        public IActionResult UnInstallAllDisabledPlugin(
+            [FromServices] PluginService pluginService, string plugin)
+        {
+            var disabled = pluginService.GetDisabledPlugins();
+            foreach (var d in disabled)
+                pluginService.UninstallPlugin(d.Key);
+            return RedirectToAction(nameof(ListPlugins));
+        }
+
         [HttpPost("server/plugins/uninstall")]
         public IActionResult UnInstallPlugin(
             [FromServices] PluginService pluginService, string plugin)

--- a/BTCPayServer/HostedServices/EventHostedServiceBase.cs
+++ b/BTCPayServer/HostedServices/EventHostedServiceBase.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Collections.Generic;
 using System.Threading;
@@ -17,8 +18,8 @@ namespace BTCPayServer.HostedServices
 
         public EventAggregator EventAggregator => _EventAggregator;
 
-        private List<IEventAggregatorSubscription> _Subscriptions;
-        private CancellationTokenSource _Cts;
+        private List<IEventAggregatorSubscription> _Subscriptions = new List<IEventAggregatorSubscription>();
+        private CancellationTokenSource _Cts = new CancellationTokenSource();
         public CancellationToken CancellationToken => _Cts.Token;
         public EventHostedServiceBase(EventAggregator eventAggregator, Logs logs)
         {
@@ -78,9 +79,7 @@ namespace BTCPayServer.HostedServices
 
         public virtual Task StartAsync(CancellationToken cancellationToken)
         {
-            _Subscriptions = new List<IEventAggregatorSubscription>();
             SubscribeToEvents();
-            _Cts = new CancellationTokenSource();
             _ProcessingEvents = ProcessEvents(_Cts.Token);
             return Task.CompletedTask;
         }
@@ -88,8 +87,8 @@ namespace BTCPayServer.HostedServices
 
         public virtual async Task StopAsync(CancellationToken cancellationToken)
         {
-            _Subscriptions?.ForEach(subscription => subscription.Dispose());
-            _Cts?.Cancel();
+            _Subscriptions.ForEach(subscription => subscription.Dispose());
+            _Cts.Cancel();
             try
             {
                 await _ProcessingEvents;

--- a/BTCPayServer/Views/UIServer/ListPlugins.cshtml
+++ b/BTCPayServer/Views/UIServer/ListPlugins.cshtml
@@ -68,10 +68,25 @@
     </div>
 </div>
 
+@if (Model.Commands.Any())
+{
+	<div class="alert alert-info mb-4 d-flex align-items-center justify-content-between">
+		You need to restart BTCPay Server in order to update your active plugins.
+		@if (Model.CanShowRestart)
+		{
+			<form method="post" asp-action="Maintenance" class="mt-2">
+				<button type="submit" name="command" value="soft-restart" class="btn btn-info" asp-action="Maintenance">Restart now</button>
+			</form>
+		}
+	</div>
+}
 @if (Model.Disabled.Any())
 {
     <div class="alert alert-danger mb-4 d-flex align-items-center justify-content-between">
         Some plugins were disabled due to fatal errors. They may be incompatible with this version of BTCPay Server.
+		<form asp-action="UnInstallAllDisabledPlugin" class="mt-2">
+			<button type="submit" name="command" value="soft-restart" class="btn btn-danger">Uninstall all disabled plugins</button>
+		</form>
     </div>
     <div class="mb-5">
         <h3 class="mb-4">Disabled Plugins</h3>
@@ -87,26 +102,23 @@
                                 <span>(@version)</span>
                             }
                         </span>
-                        <form asp-action="UnInstallPlugin" asp-route-plugin="@plugin">
-                            <button type="submit" class="btn btn-sm btn-outline-danger">Uninstall</button>
-                        </form>
+						@{
+							var uninstalled = Model.Commands.Any(c => c.plugin == plugin && c.command == "delete");
+						}
+						<form asp-action="UnInstallPlugin" asp-route-plugin="@plugin">
+							@if (uninstalled)
+							{
+								<button type="submit" class="btn btn-sm btn-outline-danger" disabled>Marked for deletion</button>
+							}
+							else
+							{
+								<button type="submit" class="btn btn-sm btn-outline-danger">Uninstall</button>
+							}
+						</form>
                     </div>
                 </li>
             }
         </ul>
-    </div>
-}
-
-@if (Model.Commands.Any())
-{
-    <div class="alert alert-info mb-4 d-flex align-items-center justify-content-between">
-        You need to restart BTCPay Server in order to update your active plugins.
-        @if (Model.CanShowRestart)
-        {
-            <form method="post" asp-action="Maintenance" class="mt-2">
-                <button type="submit" name="command" value="soft-restart" class="btn btn-info" asp-action="Maintenance">Restart now</button>
-            </form>
-        }
     </div>
 }
 


### PR DESCRIPTION
When updating to BTCPay 2.0, a lot of plugins will crash and get disabled.
This PR:
* Add a button to uninstall them all in one click
* Change the state of the "uninstall" button when it has already been clicked.

@pavlenex 

![image](https://github.com/user-attachments/assets/db7aa6e2-84d4-471c-b873-02a600991f2f)
