### PR TITLE
UI: Inactive toggle hover color fix

### DIFF
--- a/BTCPayServer/wwwroot/main/bootstrap/bootstrap.css
+++ b/BTCPayServer/wwwroot/main/bootstrap/bootstrap.css
@@ -12862,7 +12862,7 @@ input.btcpay-toggle {
 
 input.btcpay-toggle:checked,
 .btcpay-toggle.btcpay-toggle--active {
-  background: var(--btcpay-toggle-bg-active);
+  background: var(--btcpay-toggle-bg-hover);
 }
 
 input.btcpay-toggle:not(:disabled):checked:hover,

--- a/BTCPayServer/wwwroot/main/themes/default.css
+++ b/BTCPayServer/wwwroot/main/themes/default.css
@@ -239,7 +239,7 @@
   --btcpay-form-shadow-invalid: var(--btcpay-danger-shadow);
 
   --btcpay-toggle-bg: var(--btcpay-neutral-500);
-  --btcpay-toggle-bg-hover: var(--btcpay-primary-bg-hover);
+  --btcpay-toggle-bg-hover: var(--btcpay-neutral-600);
   --btcpay-toggle-bg-active: var(--btcpay-primary);
   --btcpay-toggle-bg-active-hover: var(--btcpay-primary-bg-active);
 


### PR DESCRIPTION
@pavlenex noted, that before the inactive state had the primary highlight color on hover, which makes it seem like it is already active. This changes it to use a slightly darker/lighter neutral version for inactive state hover.