### PR TITLE
Bumping LND to 0.18.3-beta

### DIFF
--- a/BTCPayServer.Tests/docker-compose.altcoins.yml
+++ b/BTCPayServer.Tests/docker-compose.altcoins.yml
@@ -227,7 +227,7 @@ services:
       - "5432"
 
   merchant_lnd:
-    image: btcpayserver/lnd:v0.18.1-beta
+    image: btcpayserver/lnd:v0.18.3-beta
     restart: unless-stopped
     environment:
       LND_CHAIN: "btc"
@@ -262,7 +262,7 @@ services:
       - bitcoind
 
   customer_lnd:
-    image: btcpayserver/lnd:v0.18.1-beta
+    image: btcpayserver/lnd:v0.18.3-beta
     restart: unless-stopped
     environment:
       LND_CHAIN: "btc"

--- a/BTCPayServer.Tests/docker-compose.yml
+++ b/BTCPayServer.Tests/docker-compose.yml
@@ -213,7 +213,7 @@ services:
       - "5432"
 
   merchant_lnd:
-    image: btcpayserver/lnd:v0.18.1-beta
+    image: btcpayserver/lnd:v0.18.3-beta
     restart: unless-stopped
     environment:
       LND_CHAIN: "btc"
@@ -250,7 +250,7 @@ services:
       - bitcoind
 
   customer_lnd:
-    image: btcpayserver/lnd:v0.18.1-beta
+    image: btcpayserver/lnd:v0.18.3-beta
     restart: unless-stopped
     environment:
       LND_CHAIN: "btc"


### PR DESCRIPTION
Updating our devenv to use LND 0.18.3

Used it in BTCPayServer.Lightning library and it's good to go, passed all the tests:
https://github.com/btcpayserver/BTCPayServer.Lightning/pull/164