### PR TITLE
refactor: make `BeforeFetchingRates` function public

### DIFF
--- a/BTCPayServer/Payments/IPaymentMethodHandler.cs
+++ b/BTCPayServer/Payments/IPaymentMethodHandler.cs
@@ -295,7 +295,7 @@ namespace BTCPayServer.Payments
         /// </summary>
         public List<string> TrackedDestinations { get; } = new();
 
-        internal async Task BeforeFetchingRates()
+        public async Task BeforeFetchingRates()
         {
             await Handler.BeforeFetchingRates(this);
             // We need to fetch the rates necessary for the evaluation of the payment method criteria


### PR DESCRIPTION
This function is useful when a payment method wants to update its payment prompt after receiving a partial payment, like ln does.
Right now, plugins cant do the same since its `internal`.