### PR TITLE
feat: provide store info to `modify-lnurlp-request` filter

### DIFF
--- a/BTCPayServer/Payments/LNURLPay/StoreLNURLPayRequest.cs
+++ b/BTCPayServer/Payments/LNURLPay/StoreLNURLPayRequest.cs
@@ -1,0 +1,12 @@
+#nullable enable
+using BTCPayServer.Data;
+using LNURL;
+using Newtonsoft.Json;
+
+namespace BTCPayServer.Payments.LNURLPay;
+
+public class StoreLNURLPayRequest : LNURLPayRequest
+{
+    [JsonIgnore]
+    public StoreData? Store { get; set; }
+}


### PR DESCRIPTION
Adds store data to the filter using a new `StoreLNURLPayRequest` class which simply adds a `Store` member.
It is backwards compatible since the cast to `LNURLPayRequest` done by old consumers will still work.

closes: https://github.com/btcpayserver/btcpayserver/issues/6301
