### PR TITLE
[Greenfield] Select default payoutMethodId if none are selected in the Refund route

### DIFF
--- a/BTCPayServer/Controllers/GreenField/GreenfieldInvoiceController.cs
+++ b/BTCPayServer/Controllers/GreenField/GreenfieldInvoiceController.cs
@@ -51,6 +51,7 @@ namespace BTCPayServer.Controllers.Greenfield
         private readonly Dictionary<PaymentMethodId, IPaymentLinkExtension> _paymentLinkExtensions;
         private readonly PayoutMethodHandlerDictionary _payoutHandlers;
         private readonly PaymentMethodHandlerDictionary _handlers;
+        private readonly BTCPayNetworkProvider _networkProvider;
         private readonly DefaultRulesCollection _defaultRules;
 
         public LanguageService LanguageService { get; }
@@ -65,6 +66,7 @@ namespace BTCPayServer.Controllers.Greenfield
             Dictionary<PaymentMethodId, IPaymentLinkExtension> paymentLinkExtensions,
             PayoutMethodHandlerDictionary payoutHandlers,
             PaymentMethodHandlerDictionary handlers,
+            BTCPayNetworkProvider networkProvider,
             DefaultRulesCollection defaultRules)
         {
             _invoiceController = invoiceController;
@@ -79,6 +81,7 @@ namespace BTCPayServer.Controllers.Greenfield
             _paymentLinkExtensions = paymentLinkExtensions;
             _payoutHandlers = payoutHandlers;
             _handlers = handlers;
+            _networkProvider = networkProvider;
             _defaultRules = defaultRules;
             LanguageService = languageService;
         }
@@ -338,6 +341,9 @@ namespace BTCPayServer.Controllers.Greenfield
             }
             PaymentPrompt? paymentPrompt = null;
             PayoutMethodId? payoutMethodId = null;
+            if (request.PayoutMethodId is null)
+                request.PayoutMethodId = invoice.GetDefaultPaymentMethodId(store, _networkProvider)?.ToString();
+
             if (request.PayoutMethodId is not null && PayoutMethodId.TryParse(request.PayoutMethodId, out payoutMethodId))
             {
                 var supported = _payoutHandlers.GetSupportedPayoutMethods(store);

--- a/BTCPayServer/Controllers/UIInvoiceController.UI.cs
+++ b/BTCPayServer/Controllers/UIInvoiceController.UI.cs
@@ -758,34 +758,7 @@ namespace BTCPayServer.Controllers
                 paymentMethodId = null;
             if (paymentMethodId is null)
             {
-                PaymentMethodId? invoicePaymentId = invoice.DefaultPaymentMethod;
-                PaymentMethodId? storePaymentId = store.GetDefaultPaymentId();
-                if (invoicePaymentId is not null)
-                {
-                    if (displayedPaymentMethods.Contains(invoicePaymentId))
-                        paymentMethodId = invoicePaymentId;
-                }
-                if (paymentMethodId is null && storePaymentId is not null)
-                {
-                    if (displayedPaymentMethods.Contains(storePaymentId))
-                        paymentMethodId = storePaymentId;
-                }
-                if (paymentMethodId is null && invoicePaymentId is not null)
-                {
-                    paymentMethodId = invoicePaymentId.FindNearest(displayedPaymentMethods);
-                }
-                if (paymentMethodId is null && storePaymentId is not null)
-                {
-                    paymentMethodId = storePaymentId.FindNearest(displayedPaymentMethods);
-                }
-                if (paymentMethodId is null)
-                {
-                    var defaultBTC = PaymentTypes.CHAIN.GetPaymentMethodId(_NetworkProvider.DefaultNetwork.CryptoCode);
-                    var defaultLNURLPay  = PaymentTypes.LNURL.GetPaymentMethodId(_NetworkProvider.DefaultNetwork.CryptoCode);
-                    paymentMethodId = displayedPaymentMethods.FirstOrDefault(e => e == defaultBTC) ??
-                                      displayedPaymentMethods.FirstOrDefault(e => e == defaultLNURLPay) ??
-                                      displayedPaymentMethods.FirstOrDefault();
-                }
+                paymentMethodId = invoice.GetDefaultPaymentMethodId(store, _NetworkProvider, displayedPaymentMethods);
                 isDefaultPaymentId = true;
             }
             if (paymentMethodId is null)


### PR DESCRIPTION
Proposed by @ndeet, as 2.0 is breaking the refund route via a rename of `paymentMethod` to `payoutMethodId`, the call to the endpoint always failed.

This PR will just instead select the default payment method of the invoice.