### PR TITLE
Automated processor get disabled after some repeated failures

### DIFF
--- a/BTCPayServer.Data/Data/PayoutData.cs
+++ b/BTCPayServer.Data/Data/PayoutData.cs
@@ -1,11 +1,9 @@
 using System;
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
-using System.Text;
 using BTCPayServer.Client.Models;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
-using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NBitcoin;
 
 namespace BTCPayServer.Data
@@ -73,7 +71,7 @@ namespace BTCPayServer.Data
 
             builder.Entity<PayoutData>()
                 .Property(o => o.Blob)
-                .HasColumnType("JSONB");
+                .HasColumnType("jsonb");
             builder.Entity<PayoutData>()
                 .Property(o => o.Proof)
                 .HasColumnType("JSONB");

--- a/BTCPayServer.Data/Migrations/ApplicationDbContextModelSnapshot.cs
+++ b/BTCPayServer.Data/Migrations/ApplicationDbContextModelSnapshot.cs
@@ -560,7 +560,7 @@ namespace BTCPayServer.Migrations
                         .HasColumnType("numeric");
 
                     b.Property<string>("Blob")
-                        .HasColumnType("JSONB");
+                        .HasColumnType("jsonb");
 
                     b.Property<string>("Currency")
                         .HasColumnType("text");

--- a/BTCPayServer.Tests/GreenfieldAPITests.cs
+++ b/BTCPayServer.Tests/GreenfieldAPITests.cs
@@ -17,6 +17,7 @@ using BTCPayServer.NTag424;
 using BTCPayServer.Payments;
 using BTCPayServer.Payments.Lightning;
 using BTCPayServer.PayoutProcessors;
+using BTCPayServer.PayoutProcessors.Lightning;
 using BTCPayServer.Plugins.PointOfSale.Controllers;
 using BTCPayServer.Plugins.PointOfSale.Models;
 using BTCPayServer.Services;
@@ -4177,7 +4178,11 @@ namespace BTCPayServer.Tests
             var resp = await tester.CustomerLightningD.Pay(inv.BOLT11);
             Assert.Equal(PayResult.Ok, resp.Result);
 
+            var ppService = tester.PayTester.GetService<HostedServices.PullPaymentHostedService>();
+            var serializers = tester.PayTester.GetService<BTCPayNetworkJsonSerializerSettings>();
             var store = tester.PayTester.GetService<StoreRepository>();
+            var dbContextFactory = tester.PayTester.GetService<Data.ApplicationDbContextFactory>();
+
             Assert.True(await store.InternalNodePayoutAuthorized(admin.StoreId));
             Assert.False(await store.InternalNodePayoutAuthorized("blah"));
             await admin.MakeAdmin(false);
@@ -4244,6 +4249,36 @@ namespace BTCPayServer.Tests
                     Destination = customerInvoice.BOLT11
                 });
             Assert.Equal(payout2.OriginalAmount, new Money(100, MoneyUnit.Satoshi).ToDecimal(MoneyUnit.BTC));
+
+            // Checking if we can disable a payout...
+            var allLNPayouts = await ppService.GetPayouts(new ()
+            {
+                PayoutIds = new[] { payout2.Id },
+                Processor = LightningAutomatedPayoutSenderFactory.ProcessorName
+            });
+            Assert.NotEmpty(allLNPayouts);
+            var b = JsonConvert.DeserializeObject<Data.PayoutBlob>(allLNPayouts[0].Blob);
+            b.DisableProcessor(LightningAutomatedPayoutSenderFactory.ProcessorName);
+            Assert.Equal(1, b.IncrementErrorCount());
+            Assert.Equal(2, b.IncrementErrorCount());
+            allLNPayouts[0].Blob = JsonConvert.SerializeObject(b);
+            Assert.Equal(3, JsonConvert.DeserializeObject<Data.PayoutBlob>(allLNPayouts[0].Blob).IncrementErrorCount());
+            using var ctx = dbContextFactory.CreateContext();
+            var p = ctx.Payouts.Find(allLNPayouts[0].Id);
+            p.Blob = allLNPayouts[0].Blob;
+            await ctx.SaveChangesAsync();
+            var allLNPayouts2 = await ppService.GetPayouts(new()
+            {
+                PayoutIds = new[] { payout2.Id },
+                Processor = LightningAutomatedPayoutSenderFactory.ProcessorName
+            });
+            Assert.DoesNotContain(allLNPayouts[0].Id, allLNPayouts2.Select(a => a.Id));
+            allLNPayouts2 = await ppService.GetPayouts(new()
+            {
+                PayoutIds = new[] { payout2.Id },
+                Processor = "hello"
+            });
+            Assert.Contains(allLNPayouts[0].Id, allLNPayouts2.Select(a => a.Id));
         }
 
         [Fact(Timeout = 60 * 2 * 1000)]

--- a/BTCPayServer/Data/Payouts/PayoutBlob.cs
+++ b/BTCPayServer/Data/Payouts/PayoutBlob.cs
@@ -1,4 +1,6 @@
+using System;
 using System.Collections.Generic;
+using System.Linq;
 using BTCPayServer.JsonConverters;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -10,10 +12,29 @@ namespace BTCPayServer.Data
         public int MinimumConfirmation { get; set; } = 1;
         public string Destination { get; set; }
         public int Revision { get; set; }
-        
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public string[] DisabledProcessors { get; set; }
         [JsonExtensionData]
         public Dictionary<string, JToken> AdditionalData { get; set; } = new();
 
         public JObject Metadata { get; set; }
+
+        public void DisableProcessor(string processorName)
+        {
+            DisabledProcessors ??= Array.Empty<string>();
+            DisabledProcessors = DisabledProcessors.Concat(new[] { processorName }).ToArray();
+        }
+
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public int? ErrorCount { get; set; }
+
+        public int IncrementErrorCount()
+        {
+            if (ErrorCount is { } c)
+                ErrorCount = c + 1;
+            else
+                ErrorCount = 1;
+            return ErrorCount.Value;
+        }
     }
 }

--- a/BTCPayServer/PayoutProcessors/BaseAutomatedPayoutProcessor.cs
+++ b/BTCPayServer/PayoutProcessors/BaseAutomatedPayoutProcessor.cs
@@ -116,7 +116,8 @@ public abstract class BaseAutomatedPayoutProcessor<T> : BaseAsyncService where T
                 {
                     States = new[] { PayoutState.AwaitingPayment },
                     PayoutMethods = new[] { PayoutProcessorSettings.PayoutMethodId },
-                    Stores = new[] {PayoutProcessorSettings.StoreId}
+					Processor = PayoutProcessorSettings.Processor,
+					Stores = new[] {PayoutProcessorSettings.StoreId}
                 }, context, CancellationToken);
 
             await _pluginHookService.ApplyAction("before-automated-payout-processing",


### PR DESCRIPTION
I noticed that the demo instance get DDoS at every restart by the number of automated payout processors which will never actually be able to be sent. (The store doesn't isn't a hotwallet)

So now, a payout isn't anymore processed if:
* There are more than 10 failures for the lightning payout processor.
* If we detect that a bitcoin payout can't be complete automatically. (Missing the private key)
* We detect that there wasn't enough funds more than 10 times for the Bitcoin payment.

This doesn't mean that the DDoS issue is fixed though. Each automated payment processor is still making a request when the server restart and periodically as well... but this is a step in the right direction.