### PR TITLE
Update CLN support to 24.08.2

### DIFF
--- a/BTCPayServer.Tests/docker-compose.altcoins.yml
+++ b/BTCPayServer.Tests/docker-compose.altcoins.yml
@@ -162,7 +162,7 @@ services:
       - "bitcoin_datadir:/data"
 
   customer_lightningd:
-    image: btcpayserver/lightning:v24.05
+    image: btcpayserver/lightning:v24.08.2
     stop_signal: SIGKILL
     restart: unless-stopped
     environment:
@@ -190,7 +190,7 @@ services:
       - bitcoind
 
   merchant_lightningd:
-    image: btcpayserver/lightning:v24.05
+    image: btcpayserver/lightning:v24.08.2
     stop_signal: SIGKILL
     restart: unless-stopped
     environment:

--- a/BTCPayServer.Tests/docker-compose.yml
+++ b/BTCPayServer.Tests/docker-compose.yml
@@ -148,7 +148,7 @@ services:
       - "bitcoin_datadir:/data"
 
   customer_lightningd:
-    image: btcpayserver/lightning:v24.05
+    image: btcpayserver/lightning:v24.08.2
     stop_signal: SIGKILL
     restart: unless-stopped
     environment:
@@ -176,7 +176,7 @@ services:
       - bitcoind
 
   merchant_lightningd:
-    image: btcpayserver/lightning:v24.05
+    image: btcpayserver/lightning:v24.08.2
     stop_signal: SIGKILL
     restart: unless-stopped
     environment:

--- a/BTCPayServer/BTCPayServer.csproj
+++ b/BTCPayServer/BTCPayServer.csproj
@@ -41,7 +41,7 @@
     <PackageReference Include="YamlDotNet" Version="8.0.0" />
     <PackageReference Include="BIP78.Sender" Version="0.2.2" />
     <PackageReference Include="BTCPayServer.Hwi" Version="2.0.2" />
-    <PackageReference Include="BTCPayServer.Lightning.All" Version="1.6.1" />
+    <PackageReference Include="BTCPayServer.Lightning.All" Version="1.6.3" />
     <PackageReference Include="CsvHelper" Version="32.0.3" />
     <PackageReference Include="Dapper" Version="2.1.35" />
     <PackageReference Include="Fido2" Version="2.0.2" />


### PR DESCRIPTION
This fixes two bugs:
* The Eclair Client wasn't disposing resources properly, which may have caused timeout
* Recent versions of CLN had a breaking change where the error code of `pay` when a route cannot be found has been changed.

The also potentially fix the flaky `CanUseLNPayoutProcessor`, which is flaky because of a potential bug in earlier CLN version.

Do not merge now... the package referenced by Nuget seems stuck at the "Validating" state at this point.