### PR TITLE
fix: pass current offset to log route

### DIFF
--- a/BTCPayServer/Views/UIServer/Logs.cshtml
+++ b/BTCPayServer/Views/UIServer/Logs.cshtml
@@ -12,7 +12,7 @@
     @foreach (var file in Model.LogFiles)
     {
         <li>
-            <a asp-action="LogsView" asp-route-file="@file.Name">@file.Name</a>
+            <a asp-action="LogsView" asp-route-file="@file.Name" asp-route-offset="@Model.LogFileOffset">@file.Name</a>
         </li>
     }
 </ul>


### PR DESCRIPTION
the current offset is lost otherwise and will cause a 404 if it was greater than 0
