### PR TITLE
Paging improvements

### DIFF
--- a/BTCPayServer/Components/Pager/Default.cshtml
+++ b/BTCPayServer/Components/Pager/Default.cshtml
@@ -1,6 +1,5 @@
+@using System.Web
 @using BTCPayServer.TagHelpers
-@using Microsoft.AspNetCore.Http
-@using Microsoft.AspNetCore.WebUtilities
 @model BasePagingViewModel
 
 @{
@@ -88,11 +87,26 @@
         {
             // merge both, preferring the `query` properties in case of duplicate keys
             query = query.Concat(Model.PaginationQuery)
+                .Where(e => e.Value != null)
                 .GroupBy(e => e.Key)
                 .ToDictionary(g => g.Key, g => g.First().Value);
         }
 
-        return QueryHelpers.AddQueryString(ViewContext.HttpContext.Request.GetCurrentUrlWithQueryString(),
-            query.ToDictionary(kvp => kvp.Key, kvp => kvp.Value?.ToString()));
+        return ReplaceQueryParameters(query);
+    }
+    
+    string ReplaceQueryParameters(Dictionary<string, object> query)
+    {
+        var uri = new Uri(ViewContext.HttpContext.Request.GetCurrentUrlWithQueryString());
+        var queryParams = HttpUtility.ParseQueryString(uri.Query);
+        foreach (var (key, value) in query)
+        {
+            if (value != null) queryParams[key] = value?.ToString();
+        }
+        var uriBuilder = new UriBuilder(uri)
+        {
+            Query = queryParams.ToString()!
+        };
+        return uriBuilder.ToString();
     }
 }

--- a/BTCPayServer/Components/Pager/Default.cshtml
+++ b/BTCPayServer/Components/Pager/Default.cshtml
@@ -1,3 +1,6 @@
+@using BTCPayServer.TagHelpers
+@using Microsoft.AspNetCore.Http
+@using Microsoft.AspNetCore.WebUtilities
 @model BasePagingViewModel
 
 @{
@@ -89,6 +92,7 @@
                 .ToDictionary(g => g.Key, g => g.First().Value);
         }
 
-        return Url.Action(null, query);
+        return QueryHelpers.AddQueryString(ViewContext.HttpContext.Request.GetCurrentUrlWithQueryString(),
+            query.ToDictionary(kvp => kvp.Key, kvp => kvp.Value?.ToString()));
     }
 }

--- a/BTCPayServer/Components/Pager/Pager.cs
+++ b/BTCPayServer/Components/Pager/Pager.cs
@@ -1,7 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 using BTCPayServer.Models;
 using Microsoft.AspNetCore.Mvc;
 

--- a/BTCPayServer/Filters/DomainMappingConstraintAttribute.cs
+++ b/BTCPayServer/Filters/DomainMappingConstraintAttribute.cs
@@ -46,6 +46,8 @@ namespace BTCPayServer.Filters
                     var uri = new UriBuilder(req.Scheme, redirectDomain);
                     if (req.Host.Port.HasValue)
                         uri.Port = req.Host.Port.Value;
+                    if (req.QueryString.HasValue)
+                        uri.Query = req.QueryString.Value!;
                     context.RouteContext.HttpContext.Response.Redirect(uri.ToString());
                 }
                 return true;


### PR DESCRIPTION
Two things I noticed while upgrading my plugins to v2:

- The `DomainMappingConstraint` didn't append the query parameters when redirecting
- The `Pager` used the long action URL when generating the navigation URLs. This is suboptimal if a domain mapping is used, as it results in the app action URL (ugly) plus redirect (unnecessary). 