### PR TITLE
Liquid fixes

### DIFF
--- a/BTCPayServer/Components/MainNav/Default.cshtml
+++ b/BTCPayServer/Components/MainNav/Default.cshtml
@@ -106,9 +106,14 @@
                                     </li>
                                     @if (ViewData.IsCategoryActive(typeof(WalletsNavPages), scheme.WalletId.ToString()) || ViewData.IsPageActive([WalletsNavPages.Settings], scheme.WalletId.ToString()) || ViewData.IsPageActive([StoreNavPages.OnchainSettings], categoryId))
                                     {
-                                        <li class="nav-item nav-item-sub">
-                                            <a id="WalletNav-Send" class="nav-link @ViewData.ActivePageClass([WalletsNavPages.Send, WalletsNavPages.PSBT], scheme.WalletId.ToString())" asp-area="" asp-controller="UIWallets" asp-action="WalletSend" asp-route-walletId="@scheme.WalletId" text-translate="true">Send</a>
-                                        </li>
+                                        @if (!scheme.ReadonlyWallet)
+                                        {  
+                                            <li class="nav-item nav-item-sub">
+                                                <a id="WalletNav-Send" class="nav-link @ViewData.ActivePageClass([WalletsNavPages.Send, WalletsNavPages.PSBT], scheme.WalletId.ToString())" asp-area="" asp-controller="UIWallets" asp-action="WalletSend" asp-route-walletId="@scheme.WalletId" text-translate="true">Send</a>
+                                            </li>
+                                        }
+
+                                      
                                         <li class="nav-item nav-item-sub">
                                             <a id="WalletNav-Receive" class="nav-link @ViewData.ActivePageClass(WalletsNavPages.Receive, scheme.WalletId.ToString())" asp-area="" asp-controller="UIWallets" asp-action="WalletReceive" asp-route-walletId="@scheme.WalletId" text-translate="true">Receive</a>
                                         </li>

--- a/BTCPayServer/Controllers/UIStoresController.Dashboard.cs
+++ b/BTCPayServer/Controllers/UIStoresController.Dashboard.cs
@@ -146,6 +146,7 @@ public partial class UIStoresController
                     Crypto = network.CryptoCode,
                     PaymentMethodId = handler.PaymentMethodId,
                     WalletSupported = network.WalletSupported,
+                    ReadonlyWallet = network.ReadonlyWallet,
                     Value = value,
                     WalletId = new WalletId(store.Id, network.CryptoCode),
                     Enabled = !excludeFilters.Match(handler.PaymentMethodId) && strategy != null,

--- a/BTCPayServer/Models/StoreViewModels/StoreDerivationScheme.cs
+++ b/BTCPayServer/Models/StoreViewModels/StoreDerivationScheme.cs
@@ -9,6 +9,7 @@ namespace BTCPayServer.Models.StoreViewModels
         public string Value { get; set; }
         public WalletId WalletId { get; set; }
         public bool WalletSupported { get; set; }
+        public bool ReadonlyWallet { get; set; }
         public bool Enabled { get; set; }
         public bool Collapsed { get; set; }
     }

--- a/BTCPayServer/Payments/PaymentMethodId.cs
+++ b/BTCPayServer/Payments/PaymentMethodId.cs
@@ -104,7 +104,6 @@ namespace BTCPayServer.Payments
             "XMR",
             "ZEC",
             "LCAD",
-            "ETB",
             "LBTC",
             "USDt",
             "MONA",

--- a/BTCPayServer/Plugins/Altcoins/AltcoinsPlugin.cs
+++ b/BTCPayServer/Plugins/Altcoins/AltcoinsPlugin.cs
@@ -1,15 +1,6 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using BTCPayServer.Abstractions.Models;
-using BTCPayServer.Hosting;
-using BTCPayServer.Logging;
-using Microsoft.AspNetCore.HttpOverrides;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
 using NBitcoin;
-using NBitcoin.Protocol;
 using NBXplorer;
 
 namespace BTCPayServer.Plugins.Altcoins
@@ -37,15 +28,12 @@ namespace BTCPayServer.Plugins.Altcoins
                 {
                     // Activating LBTC automatically activate the other liquid assets
                     InitUSDT(services, selectedChains, liquidNBX);
-                    InitETB(services, selectedChains, liquidNBX);
                     InitLCAD(services, selectedChains, liquidNBX);
                 }
                 else
                 {
                     if (selectedChains.Contains("USDT"))
                         InitUSDT(services, selectedChains, liquidNBX);
-                    if (selectedChains.Contains("ETB"))
-                        InitETB(services, selectedChains, liquidNBX);
                     if (selectedChains.Contains("LCAD"))
                         InitLCAD(services, selectedChains, liquidNBX);
                 }

--- a/BTCPayServer/Plugins/Altcoins/Liquid/AltcoinsPlugin.Liquid.cs
+++ b/BTCPayServer/Plugins/Altcoins/Liquid/AltcoinsPlugin.Liquid.cs
@@ -27,7 +27,11 @@ public partial class AltcoinsPlugin
             CryptoImagePath = "imlegacy/liquid.png",
             DefaultSettings = BTCPayDefaultSettings.GetDefaultSettings(ChainName),
             CoinType = ChainName == ChainName.Mainnet ? new KeyPath("1776'") : new KeyPath("1'"),
-            SupportRBF = true
+            SupportRBF = true,
+            SupportLightning = false,
+            SupportPayJoin = false,
+            VaultSupported = false,
+            ReadonlyWallet = true
         }.SetDefaultElectrumMapping(ChainName);
 
         var blockExplorerLink = ChainName == ChainName.Mainnet ? "https://liquid.network/tx/{0}" : "https://liquid.network/testnet/tx/{0}";

--- a/BTCPayServer/Plugins/Altcoins/Liquid/AltcoinsPlugin.LiquidAssets.cs
+++ b/BTCPayServer/Plugins/Altcoins/Liquid/AltcoinsPlugin.LiquidAssets.cs
@@ -30,10 +30,13 @@ public partial class AltcoinsPlugin
             DefaultSettings = BTCPayDefaultSettings.GetDefaultSettings(ChainName),
             CoinType = ChainName == ChainName.Mainnet ? new KeyPath("1776'") : new KeyPath("1'"),
             SupportRBF = true,
-            SupportLightning = false
+            SupportLightning = false,
+            SupportPayJoin = false,
+            VaultSupported = false,
+            ReadonlyWallet = true
         }.SetDefaultElectrumMapping(ChainName);
         services.AddBTCPayNetwork(network)
-                .AddTransactionLinkProvider(PaymentTypes.CHAIN.GetPaymentMethodId(nbxplorerNetwork.CryptoCode), new DefaultTransactionLinkProvider(LiquidBlockExplorer));
+                .AddTransactionLinkProvider(PaymentTypes.CHAIN.GetPaymentMethodId("USDt"), new DefaultTransactionLinkProvider(LiquidBlockExplorer));
         services.AddCurrencyData(new CurrencyData()
         {
             Code = "USDt",
@@ -42,35 +45,6 @@ public partial class AltcoinsPlugin
             Symbol = null,
             Crypto = true
         });
-        selectedChains.Add("LBTC");
-    }
-
-    private void InitETB(IServiceCollection services, SelectedChains selectedChains, NBXplorer.NBXplorerNetwork nbxplorerNetwork)
-    {
-        var network = new ElementsBTCPayNetwork()
-        {
-            CryptoCode = "ETB",
-            NetworkCryptoCode = "LBTC",
-            ShowSyncSummary = false,
-            DefaultRateRules = new[]
-                    {
-
-                    "ETB_X = ETB_BTC * BTC_X",
-                    "ETB_BTC = bitpay(ETB_BTC)"
-                },
-            Divisibility = 2,
-            AssetId = new uint256("aa775044c32a7df391902b3659f46dfe004ccb2644ce2ddc7dba31e889391caf"),
-            DisplayName = "Ethiopian Birr",
-            NBXplorerNetwork = nbxplorerNetwork,
-            CryptoImagePath = "imlegacy/etb.png",
-            DefaultSettings = BTCPayDefaultSettings.GetDefaultSettings(ChainName),
-            CoinType = ChainName == ChainName.Mainnet ? new KeyPath("1776'") : new KeyPath("1'"),
-            SupportRBF = true,
-            SupportLightning = false
-        }.SetDefaultElectrumMapping(ChainName);
-
-        services.AddBTCPayNetwork(network)
-                .AddTransactionLinkProvider(PaymentTypes.CHAIN.GetPaymentMethodId(nbxplorerNetwork.CryptoCode), new DefaultTransactionLinkProvider(LiquidBlockExplorer));
         selectedChains.Add("LBTC");
     }
 
@@ -95,11 +69,14 @@ public partial class AltcoinsPlugin
             CryptoImagePath = "imlegacy/lcad.png",
             DefaultSettings = BTCPayDefaultSettings.GetDefaultSettings(ChainName),
             CoinType = ChainName == ChainName.Mainnet ? new KeyPath("1776'") : new KeyPath("1'"),
-            SupportRBF = true,
-            SupportLightning = false
+            SupportRBF = true,            
+            SupportLightning = false,
+            SupportPayJoin = false,
+            VaultSupported = false,
+            ReadonlyWallet = true
         }.SetDefaultElectrumMapping(ChainName);
         services.AddBTCPayNetwork(network)
-                .AddTransactionLinkProvider(PaymentTypes.CHAIN.GetPaymentMethodId(nbxplorerNetwork.CryptoCode), new DefaultTransactionLinkProvider(LiquidBlockExplorer));
+                .AddTransactionLinkProvider(PaymentTypes.CHAIN.GetPaymentMethodId("LCAD"), new DefaultTransactionLinkProvider(LiquidBlockExplorer));
         selectedChains.Add("LBTC");
     }
 


### PR DESCRIPTION
make sure link provider is per payment method of liquid assets. Also remove ETB as it has been unused. Also hide the send button as it is not supported thrrough BTCPay