### PR TITLE
fix: save proof blob if payout is in progress

### DIFF
--- a/BTCPayServer/PayoutProcessors/Lightning/LightningAutomatedPayoutProcessor.cs
+++ b/BTCPayServer/PayoutProcessors/Lightning/LightningAutomatedPayoutProcessor.cs
@@ -311,11 +311,13 @@ public class LightningAutomatedPayoutProcessor : BaseAutomatedPayoutProcessor<Li
             }
             else
             {
+                // Payment will be saved as pending, the LightningPendingPayoutListener will handle settling/cancelling
                 payoutData.State = PayoutState.InProgress;
+                payoutData.SetProofBlob(proofBlob, null);
                 return new ResultVM
                 {
                     PayoutId = payoutData.Id,
-                    Result = PayResult.Unknown,
+                    Result = PayResult.Ok,
                     Destination = payoutBlob.Destination,
                     Message = "The payment has been initiated but is still in-flight."
                 };


### PR DESCRIPTION
The payout cant be tracked later otherwise and will be marked cancelled as a result. 

This fixes a regression for lightning implementations which throwed an `OperationCanceledException`, signaling that the payment will take longer to complete,  which was previously caught here https://github.com/btcpayserver/btcpayserver/blob/5ad0b128aafa5c9a49d57690a46fc7ac591dd0b2/BTCPayServer/PayoutProcessors/Lightning/LightningAutomatedPayoutProcessor.cs#L324-L338
For example, https://github.com/BoltzExchange/boltz-btcpay-plugin/blob/551aa53b1a8122fdada80951b9d65dcfe4560600/BTCPayServer.Plugins.Boltz/BoltzLightningClient.cs#L305-L308

This behaviour isnt possible anymore since the exception is caught in another try-catch block introduced in https://github.com/btcpayserver/btcpayserver/commit/cc0ea0b3f8c9bbffaebc04a6c4073c432216134f

This change allows the lightning implementation to simply return an `Unkown` result instead of having to throw an exception which makes more sense imo.