### PR TITLE
Fix: Incorrect percentage accounting of raised money in crowdfunding

### DIFF
--- a/BTCPayServer/Plugins/Crowdfund/Models/ViewCrowdfundViewModel.cs
+++ b/BTCPayServer/Plugins/Crowdfund/Models/ViewCrowdfundViewModel.cs
@@ -56,7 +56,6 @@ namespace BTCPayServer.Plugins.Crowdfund.Models
             public decimal? PendingProgressPercentage { get; set; }
             public DateTime LastUpdated { get; set; }
             public Dictionary<string, PaymentStat> PaymentStats { get; set; }
-            public Dictionary<string, PaymentStat> PendingPaymentStats { get; set; }
             public DateTime? LastResetDate { get; set; }
             public DateTime? NextResetDate { get; set; }
         }

--- a/BTCPayServer/wwwroot/crowdfund/app.js
+++ b/BTCPayServer/wwwroot/crowdfund/app.js
@@ -111,37 +111,12 @@ app = new Vue({
             return this.srvModel.targetCurrency.toUpperCase();
         },
             paymentStats: function(){
-                var result= [];                
-            var combinedStats = {};
             var keys = Object.keys(this.srvModel.info.paymentStats);
-
+            var result = [];
             for (var i = 0; i < keys.length; i++) {
-                    if(combinedStats[keys[i]]){
-                        combinedStats[keys[i]] +=this.srvModel.info.paymentStats[keys[i]];
-                    }else{
-                        combinedStats[keys[i]] =this.srvModel.info.paymentStats[keys[i]];
-                }
-            }
-
-            keys = Object.keys(this.srvModel.info.pendingPaymentStats);
-
-            for (var i = 0; i < keys.length; i++) {
-                    if(combinedStats[keys[i]]){
-                        combinedStats[keys[i]] +=this.srvModel.info.pendingPaymentStats[keys[i]];
-                    }else{
-                        combinedStats[keys[i]] =this.srvModel.info.pendingPaymentStats[keys[i]];
-                }
-            }
-
-            keys = Object.keys(combinedStats);
-
-            for (var i = 0; i < keys.length; i++) {
-                    if(!combinedStats[keys[i]]){
-                    continue;
-                }
-                var value = combinedStats[keys[i]].percent.toFixed(2) + '%';
-                    var newItem = {key:keys[i], value: value, label: combinedStats[keys[i]].label};
-                newItem.lightning = combinedStats[keys[i]].isLightning;
+                var value = this.srvModel.info.paymentStats[keys[i]].percent.toFixed(2) + '%';
+                var newItem = { key: keys[i], value: value, label: this.srvModel.info.paymentStats[keys[i]].label};
+                newItem.lightning = this.srvModel.info.paymentStats[keys[i]].isLightning;
                 result.push(newItem);
             }
 


### PR DESCRIPTION
1. The breakdown of payments in the crowdfund was giving incorrect numbers (above 100%) before.
2. Move the logic out of javascript into C#.
3. The PrettyName of the payment method would be translated with the server's custom translations rather than staying in english.

![image](https://github.com/user-attachments/assets/be0f5977-af25-46e0-b086-2b6e9a62236a)
