### PR TITLE
Fix: Wrong manifest downloaded when installing plugin on old btcpay (Fix #6344)

### DIFF
--- a/BTCPayServer/Plugins/PluginBuilderClient.cs
+++ b/BTCPayServer/Plugins/PluginBuilderClient.cs
@@ -65,5 +65,17 @@ namespace BTCPayServer.Plugins
             var result = await httpClient.GetStringAsync($"api/v1/plugins{queryString}");
             return JsonConvert.DeserializeObject<PublishedVersion[]>(result, serializerSettings) ?? throw new InvalidOperationException();
         }
+        public async Task<PublishedVersion> GetPlugin(string pluginSlug, string version)
+        {
+            try
+            {
+                var result = await httpClient.GetStringAsync($"api/v1/plugins/{pluginSlug}/versions/{version}");
+                return JsonConvert.DeserializeObject<PublishedVersion>(result, serializerSettings);
+            }
+            catch (HttpRequestException ex) when (ex.StatusCode == System.Net.HttpStatusCode.NotFound)
+            {
+                return null;
+            }
+        }
     }
 }

--- a/BTCPayServer/Plugins/PluginService.cs
+++ b/BTCPayServer/Plugins/PluginService.cs
@@ -72,9 +72,11 @@ namespace BTCPayServer.Plugins
             var dest = _dataDirectories.Value.PluginDir;
             var filedest = Path.Join(dest, pluginIdentifier + ".btcpay");
             var filemanifestdest = Path.Join(dest, pluginIdentifier + ".json");
+            var pluginSelector = $"[{Uri.EscapeDataString(pluginIdentifier)}]";
+            version = Uri.EscapeDataString(version);
             Directory.CreateDirectory(Path.GetDirectoryName(filedest));
-            var url = $"api/v1/plugins/[{Uri.EscapeDataString(pluginIdentifier)}]/versions/{Uri.EscapeDataString(version)}/download";
-            var manifest = (await _pluginBuilderClient.GetPublishedVersions(null, true)).Select(v => v.ManifestInfo.ToObject<AvailablePlugin>()).FirstOrDefault(p => p.Identifier == pluginIdentifier);
+            var url = $"api/v1/plugins/{pluginSelector}/versions/{version}/download";
+            var manifest = (await _pluginBuilderClient.GetPlugin(pluginSelector, version))?.ManifestInfo?.ToObject<AvailablePlugin>();
             await File.WriteAllTextAsync(filemanifestdest, JsonConvert.SerializeObject(manifest, Formatting.Indented));
             using var resp2 = await _pluginBuilderClient.HttpClient.GetAsync(url);
             await using var fs = new FileStream(filedest, FileMode.Create, FileAccess.ReadWrite);


### PR DESCRIPTION
Fix #6344 

This require plugin builder 1.0.28, which I deployed. (https://github.com/btcpayserver/btcpayserver-plugin-builder/commit/354feefa3d58ef4ac09b9f0d5e5a51ee1dff9f0c)

I branched from 1.0.27 to avoid pushing the on-going changes of rockstardev.

Need to be ported to 1.13.x