### PR TITLE
chore: add rider .run folder to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -266,6 +266,7 @@ paket-files/
 # JetBrains Rider
 .idea/
 *.sln.iml
+.run
 
 # CodeRush
 .cr/


### PR DESCRIPTION
custom run configurations in rider are stored inside .run folder
