### PR TITLE
refactor: use `PaymentHash` instead of `Id` when checking pending ln payout

### DIFF
--- a/BTCPayServer/Payments/Lightning/LightningPendingPayoutListener.cs
+++ b/BTCPayServer/Payments/Lightning/LightningPendingPayoutListener.cs
@@ -98,7 +98,7 @@ public class LightningPendingPayoutListener : BaseAsyncService
 					try
 					{
 						if (proof is not null)
-							payment = await client.GetPayment(proof.Id, CancellationToken);
+							payment = await client.GetPayment(proof.PaymentHash, CancellationToken);
 					}
 					catch
 					{


### PR DESCRIPTION
Does the same, but the `GetPayment` call explicitly wants a payment hash, which is clearer this way (thought there might be a bug here when I first read the code)
