### PR TITLE
fix: center qr code

### DIFF
--- a/BTCPayServer/Views/Shared/ShowQR.cshtml
+++ b/BTCPayServer/Views/Shared/ShowQR.cshtml
@@ -9,8 +9,8 @@
                     </button>
                 </div>
                 <div class="modal-body pt-0">
-                    <div class="payment-box m-0">
-                        <div class="qr-container justify-content-start">
+                    <div class="payment-box">
+                        <div class="qr-container">
                             <component v-if="currentFragment" :is="currentMode.href ? 'a': 'div'" class="qr-container d-inline-block" :href="currentMode.href">
                                 <qrcode :value="currentFragment" :options="qrOptions"></qrcode>
                             </component>


### PR DESCRIPTION
closes: #6361 

example from issue now:
![image](https://github.com/user-attachments/assets/d9d0d695-8155-46d8-a0e0-c64564b1cc88)

have yet to look at the other views which use the view