### PR TITLE
Fix: Payouts were incorrectly marked as canceled even after successful completion

### DIFF
--- a/BTCPayServer/Data/Payouts/LightningLike/UILightningLikePayoutController.cs
+++ b/BTCPayServer/Data/Payouts/LightningLike/UILightningLikePayoutController.cs
@@ -192,7 +192,7 @@ namespace BTCPayServer.Data.Payouts.LightningLike
             return new ResultVM
             {
                 PayoutId = payoutData.Id,
-                Result = PayResult.Error,
+                Success = false,
                 Destination = blob.Destination,
                 Message = message
             };
@@ -216,7 +216,7 @@ namespace BTCPayServer.Data.Payouts.LightningLike
         {
             public string PayoutId { get; set; }
             public string Destination { get; set; }
-            public PayResult Result { get; set; }
+            public bool? Success { get; set; }
             public string Message { get; set; }
         }
 

--- a/BTCPayServer/Views/UILightningLikePayout/LightningPayoutResult.cshtml
+++ b/BTCPayServer/Views/UILightningLikePayout/LightningPayoutResult.cshtml
@@ -8,9 +8,9 @@
 <h2 class="mt-1 mb-4" text-translate="true">@ViewData["Title"]</h2>
 @foreach (var item in Model)
 {
-    <div class="alert alert-@(item.Result == PayResult.Ok ? "success" : "danger") mb-3" role="alert">
+    <div class="alert alert-@(item.Success is true ? "success" : "danger") mb-3" role="alert">
         <h5 class="alert-heading">
-            @(item.Result == PayResult.Ok ? "Sent" : "Failed")
+            @(item.Success is true ? "Sent" : "Failed")
             @if (!string.IsNullOrEmpty(item.Message))
             {
                 <span>- @item.Message</span>


### PR DESCRIPTION
## Bug fix

Payouts were incorrectly marked as canceled even after successful completion on some Lightning implementations (NwC/Nostr and Blink).

## Explanation

Following a refactoring of Payout in 2.0, the automated Lightning payout processor would pay the BOLT11 invoice and then request the payment data via the `LightningClient`.

However, retrieving payment data could fail in certain cases. For Nostr, this occurred when a timeout happened (for example, if the connection to relays is hanging).
For Blink, it failed if the recipient was also using a Blink wallet, as the pre-image wasn't accessible through the API.

This PR ensures that a failed call to `GetPayment` will no longer result in the payout being marked as canceled after a successful payment.