### PR TITLE
UI: Allow text break in labels to avoid horizontal scrolling

### DIFF
--- a/BTCPayServer/wwwroot/main/site.css
+++ b/BTCPayServer/wwwroot/main/site.css
@@ -942,6 +942,7 @@ input.ts-wrapper.form-control:not(.ts-hidden-accessible,.ts-inline) {
     margin: 0;
     padding: 1px var(--btcpay-space-s);
     text-align: left;
+    word-break: break-word;
 }
 
 .transaction-label a {


### PR DESCRIPTION
Fixes a horizontal scrolling issue on the mobile Wallet Transactions list, which was reported by @kukks.

There still might be another issue, because in [kukks' video](https://photos.google.com/share/AF1QipNEphjJZtrLJiaYdwW9NdgCTyoOVAooaZTkqsPkB7-aOBgZxxilqyesJZVhiBb_WA/photo/AF1QipMG_PV9OvhCDl-ByJ-W5Pot-HQY5Yro3rturZpB?key=QkhqeTgwOGxQRkxfWUFQZE5PaFQweXRmcW5IZU9R) the navigation bar was also extended beyond the viewport, but I wasn't able to reproduce that. Might be Edge specific as well.

## Before

![before](https://github.com/user-attachments/assets/5c0d545b-1f7e-47ee-8dfc-390094ecaef9)

## After

![after](https://github.com/user-attachments/assets/5906fc7f-9e64-4efd-aac0-f650c16601f9)
