### PR TITLE
Reporting: Fix values for InvoiceCurrencyAmount and Rate columns

### DIFF
--- a/BTCPayServer/Services/Invoices/InvoiceEntity.cs
+++ b/BTCPayServer/Services/Invoices/InvoiceEntity.cs
@@ -326,7 +326,7 @@ namespace BTCPayServer.Services.Invoices
         }
         public bool TryGetRate(string currency, out decimal rate)
         {
-            return TryGetRate(new CurrencyPair(Currency, currency), out rate);
+            return TryGetRate(new CurrencyPair(currency, Currency), out rate);
         }
         public bool TryGetRate(CurrencyPair pair, out decimal rate)
         {

--- a/BTCPayServer/Services/Reporting/PaymentsReportProvider.cs
+++ b/BTCPayServer/Services/Reporting/PaymentsReportProvider.cs
@@ -135,8 +135,8 @@ public class PaymentsReportProvider : ReportProvider
                 values.Add(payment.PaymentMethodFee);
 
                 var prompt = invoice.GetPaymentPrompt(PaymentTypes.LNURL.GetPaymentMethodId("BTC"));
-                var consumerdLightningAddress = prompt is null || handler is not LNURLPayPaymentHandler lnurlHandler ? null : lnurlHandler.ParsePaymentPromptDetails(prompt.Details).ConsumedLightningAddress;
-                values.Add(consumerdLightningAddress);
+                var consumedLightningAddress = prompt is null || handler is not LNURLPayPaymentHandler lnurlHandler ? null : lnurlHandler.ParsePaymentPromptDetails(prompt.Details).ConsumedLightningAddress;
+                values.Add(consumedLightningAddress);
                 values.Add(invoice.Currency);
                 if (invoice.TryGetRate(payment.Currency, out var rate))
                 {


### PR DESCRIPTION
Fixes #6364, which is a regression in #5809: The arguments for `TryGetRate` were swapped — the rate calculation for the reporting is the only occurance where that method is used, hence it didn't get caught earlier.

Also fixes a typo in a variable name for the reporting.