### PR TITLE
UI: Fix mising navigation links for store managers

### DIFF
--- a/BTCPayServer.Tests/SeleniumTester.cs
+++ b/BTCPayServer.Tests/SeleniumTester.cs
@@ -643,7 +643,15 @@ retry:
             GoToUrl(url);
             Assert.DoesNotMatch("404 - Page not found</h", Driver.PageSource);
             if (shouldHaveAccess)
+            {
                 Assert.DoesNotMatch("- Denied</h", Driver.PageSource);
+                // check associated link is active if present
+                var sidebarLink = Driver.FindElements(By.CssSelector($"#mainNav a[href=\"{url}\"]")).FirstOrDefault();
+                if (sidebarLink != null)
+                {
+                    Assert.Contains("active", sidebarLink.GetAttribute("class"));
+                }
+            }
             else
                 Assert.Contains("- Denied</h", Driver.PageSource);
         }

--- a/BTCPayServer.Tests/SeleniumTests.cs
+++ b/BTCPayServer.Tests/SeleniumTests.cs
@@ -3783,7 +3783,7 @@ retry:
             (_, string posId) = s.CreateApp("PointOfSale");
             (_, string crowdfundId) = s.CreateApp("Crowdfund");
             
-            string GetStorePath(string subPath) => $"/stores/{storeId}/{subPath}";
+            string GetStorePath(string subPath) => $"/stores/{storeId}" + (string.IsNullOrEmpty(subPath) ? "" : $"/{subPath}");
 
             // Owner access
             s.AssertPageAccess(true, GetStorePath(""));

--- a/BTCPayServer/Components/MainNav/Default.cshtml
+++ b/BTCPayServer/Components/MainNav/Default.cshtml
@@ -45,31 +45,31 @@
                             </li>
                             @if (ViewData.IsPageActive([StoreNavPages.General, StoreNavPages.Rates, StoreNavPages.CheckoutAppearance, StoreNavPages.Tokens, StoreNavPages.Users, StoreNavPages.Roles, StoreNavPages.Webhooks, StoreNavPages.PayoutProcessors, StoreNavPages.Emails, StoreNavPages.Forms]))
                             {
-                                <li class="nav-item nav-item-sub" permission="@Policies.CanModifyStoreSettings">
+                                <li class="nav-item nav-item-sub" permission="@Policies.CanViewStoreSettings">
                                     <a id="StoreNav-@(nameof(StoreNavPages.Rates))" class="nav-link @ViewData.ActivePageClass(StoreNavPages.Rates)" asp-controller="UIStores" asp-action="Rates" asp-route-storeId="@Model.Store.Id" text-translate="true">Rates</a>
                                 </li>
-                                <li class="nav-item nav-item-sub" permission="@Policies.CanModifyStoreSettings">
+                                <li class="nav-item nav-item-sub" permission="@Policies.CanViewStoreSettings">
                                     <a id="StoreNav-@(nameof(StoreNavPages.CheckoutAppearance))" class="nav-link @ViewData.ActivePageClass(StoreNavPages.CheckoutAppearance)" asp-controller="UIStores" asp-action="CheckoutAppearance" asp-route-storeId="@Model.Store.Id" text-translate="true">Checkout Appearance</a>
                                 </li>
-                                <li class="nav-item nav-item-sub" permission="@Policies.CanModifyStoreSettings">
+                                <li class="nav-item nav-item-sub" permission="@Policies.CanViewStoreSettings">
                                     <a id="StoreNav-@(nameof(StoreNavPages.Tokens))" class="nav-link @ViewData.ActivePageClass(StoreNavPages.Tokens)" asp-controller="UIStores" asp-action="ListTokens" asp-route-storeId="@Model.Store.Id" text-translate="true">Access Tokens</a>
                                 </li>
-                                <li class="nav-item nav-item-sub" permission="@Policies.CanModifyStoreSettings">
+                                <li class="nav-item nav-item-sub" permission="@Policies.CanViewStoreSettings">
                                     <a id="StoreNav-@(nameof(StoreNavPages.Users))" class="nav-link @ViewData.ActivePageClass(StoreNavPages.Users)" asp-controller="UIStores" asp-action="StoreUsers" asp-route-storeId="@Model.Store.Id" text-translate="true">Users</a>
                                 </li>
-                                <li class="nav-item nav-item-sub" permission="@Policies.CanModifyStoreSettings">
+                                <li class="nav-item nav-item-sub" permission="@Policies.CanViewStoreSettings">
                                     <a id="StoreNav-@(nameof(StoreNavPages.Roles))" class="nav-link @ViewData.ActivePageClass(StoreNavPages.Roles)" asp-controller="UIStores" asp-action="ListRoles" asp-route-storeId="@Model.Store.Id" text-translate="true">Roles</a>
                                 </li>
-                                <li class="nav-item nav-item-sub" permission="@Policies.CanModifyStoreSettings">
+                                <li class="nav-item nav-item-sub" permission="@Policies.CanViewStoreSettings">
                                     <a id="StoreNav-@(nameof(StoreNavPages.Webhooks))" class="nav-link @ViewData.ActivePageClass(StoreNavPages.Webhooks)" asp-controller="UIStores" asp-action="Webhooks" asp-route-storeId="@Model.Store.Id" text-translate="true">Webhooks</a>
                                 </li>
-                                <li class="nav-item nav-item-sub" permission="@Policies.CanModifyStoreSettings">
+                                <li class="nav-item nav-item-sub" permission="@Policies.CanViewStoreSettings">
                                     <a id="StoreNav-@(nameof(StoreNavPages.PayoutProcessors))" class="nav-link @ViewData.ActivePageClass(StoreNavPages.PayoutProcessors)" asp-controller="UIPayoutProcessors" asp-action="ConfigureStorePayoutProcessors" asp-route-storeId="@Model.Store.Id" text-translate="true">Payout Processors</a>
                                 </li>
-                                <li class="nav-item nav-item-sub" permission="@Policies.CanModifyStoreSettings">
+                                <li class="nav-item nav-item-sub" permission="@Policies.CanViewStoreSettings">
                                     <a id="StoreNav-@(nameof(StoreNavPages.Emails))" class="nav-link @ViewData.ActivePageClass(StoreNavPages.Emails)" asp-controller="UIStores" asp-action="StoreEmailSettings" asp-route-storeId="@Model.Store.Id" text-translate="true">Emails</a>
                                 </li>
-                                <li class="nav-item nav-item-sub" permission="@Policies.CanModifyStoreSettings">
+                                <li class="nav-item nav-item-sub" permission="@Policies.CanViewStoreSettings">
                                     <a id="StoreNav-@(nameof(StoreNavPages.Forms))" class="nav-link @ViewData.ActivePageClass(StoreNavPages.Forms)" asp-controller="UIForms" asp-action="FormsList" asp-route-storeId="@Model.Store.Id" text-translate="true">Forms</a>
                                 </li>
                             }


### PR DESCRIPTION
As reported by @pavlenex, the store settings links were missing for users with the `Manager` role.