### PR TITLE
Store: Fix missing invitation email when adding new user

### DIFF
--- a/BTCPayServer/Controllers/UIStoresController.Users.cs
+++ b/BTCPayServer/Controllers/UIStoresController.Users.cs
@@ -70,6 +70,7 @@ public partial class UIStoresController
                     Kind = UserRegisteredEventKind.Invite,
                     User = user,
                     InvitedByUser = currentUser,
+                    SendInvitationEmail = true,
                     CallbackUrlGenerated = tcs
                 });
                     

--- a/BTCPayServer/Events/UserRegisteredEvent.cs
+++ b/BTCPayServer/Events/UserRegisteredEvent.cs
@@ -11,7 +11,7 @@ public class UserRegisteredEvent
     public UserRegisteredEventKind Kind { get; set; } = UserRegisteredEventKind.Registration;
     public Uri RequestUri { get; set; }
     public ApplicationUser InvitedByUser { get; set; }
-    public bool SendInvitationEmail { get; set; }
+    public bool SendInvitationEmail { get; set; } = true;
     public TaskCompletionSource<Uri> CallbackUrlGenerated;
 }
 


### PR DESCRIPTION
Fixes #6369, a regression introduced with #6188: Sending invite emails required a flag to be set, which defaulted to false. This fixes the code to explicitely set the flag and also defaults it to true (sending an invite email unless declared otherwise).