### PR TITLE
UI: Quote translated strings in JS

### DIFF
--- a/BTCPayServer/Views/Shared/CameraScanner.cshtml
+++ b/BTCPayServer/Views/Shared/CameraScanner.cshtml
@@ -255,15 +255,15 @@ function initCameraScanningApp(title, onDataSubmit, modalId, submitOnScan = fals
 					if (error.name === 'StreamApiNotSupportedError') {
 						this.noStreamApiSupport = true;
 					} else if (error.name === 'NotAllowedError') {
-						this.errorMessage = @StringLocalizer["A permission to the camera is needed to scan the QR code. Please grant the browser access and then retry."]
+						this.errorMessage = @Safe.Json(StringLocalizer["A permission to the camera is needed to scan the QR code. Please grant the browser access and then retry."])
 					} else if (error.name === 'NotFoundError') {
-						this.errorMessage = @StringLocalizer["A camera was not detected on your device."]
+						this.errorMessage = @Safe.Json(StringLocalizer["A camera was not detected on your device."])
 					} else if (error.name === 'NotSupportedError') {
-						this.errorMessage = @StringLocalizer["This page is served in non-secure context (HTTPS, localhost or file://)"]
+						this.errorMessage = @Safe.Json(StringLocalizer["This page is served in non-secure context (HTTPS, localhost or file://)"])
 					} else if (error.name === 'NotReadableError') {
-						this.errorMessage = @StringLocalizer["Could not access your camera. Is it already in use?"]
+						this.errorMessage = @Safe.Json(StringLocalizer["Could not access your camera. Is it already in use?"])
 					} else if (error.name === 'OverconstrainedError') {
-						this.errorMessage = @StringLocalizer["Constraints do not match any installed camera."]
+						this.errorMessage = @Safe.Json(StringLocalizer["Constraints do not match any installed camera."])
 					} else {
 						this.errorMessage = 'UNKNOWN ERROR: ' + error.message
 					}

--- a/BTCPayServer/Views/UIWallets/WalletSend.cshtml
+++ b/BTCPayServer/Views/UIWallets/WalletSend.cshtml
@@ -1,4 +1,3 @@
-@inject BTCPayServer.Security.ContentSecurityPolicies csp
 @using Microsoft.AspNetCore.Mvc.ModelBinding
 @using BTCPayServer.Controllers
 @using BTCPayServer.Services
@@ -12,7 +11,7 @@
 	var backUrl = Model.BackUrl != null ? $"{Model.BackUrl}?returnUrl={Model.ReturnUrl}" : null;
 	Layout = "_LayoutWizard";
 	ViewData.SetActivePage(WalletsNavPages.Send, StringLocalizer["Send {0}", Model.CryptoCode], walletId);
-	csp.Add("worker-src", "blob:");
+	Csp.Add("worker-src", "blob:");
 	Csp.UnsafeEval();
 }
 


### PR DESCRIPTION
Fixes #6370. The strings not being quoted caused a JS error, which prevented the scanning from work.