### PR TITLE
Fix: The lightning symbol was missing in the payment stats

### DIFF
--- a/BTCPayServer/PayoutProcessors/Lightning/LightningAutomatedPayoutProcessor.cs
+++ b/BTCPayServer/PayoutProcessors/Lightning/LightningAutomatedPayoutProcessor.cs
@@ -225,6 +225,10 @@ public class LightningAutomatedPayoutProcessor : BaseAutomatedPayoutProcessor<Li
         var proofBlob = new PayoutLightningBlob { PaymentHash = bolt11PaymentRequest.PaymentHash.ToString() };
         string errorReason = null;
         string preimage = null;
+        // If success:
+        // * Is null, we don't know the status. The payout should become pending. (LightningPendingPayoutListener will monitor the situation)
+        // * Is true, we knew the transfer was done. The payout should be completed.
+        // * Is false, we knew it didn't happen. The payout can be retried.
         bool? success = null;
         LightMoney amountSent = null;
 

--- a/BTCPayServer/Plugins/Crowdfund/CrowdfundPlugin.cs
+++ b/BTCPayServer/Plugins/Crowdfund/CrowdfundPlugin.cs
@@ -251,7 +251,9 @@ namespace BTCPayServer.Plugins.Crowdfund
                         .Select(s => s.Value.CurrencyValue).Sum();
             foreach (var kv in allStats
                                     .GroupBy(k => k.Key, k => k.Value)
-                                    .Select(g => (g.Key, CurrencyValue: g.Sum(s => s.CurrencyValue))))
+                                    .Select(g => (g.Key,
+                                                 PaymentCurrency: g.Select(s => s.Currency).First(),
+                                                 CurrencyValue: g.Sum(s => s.CurrencyValue))))
             {
                 var pmi = PaymentMethodId.Parse(kv.Key);
                 r.TryAdd(kv.Key, new PaymentStat()
@@ -259,7 +261,7 @@ namespace BTCPayServer.Plugins.Crowdfund
                     Label = _prettyNameProvider.PrettyName(pmi),
                     Percent = (kv.CurrencyValue / total) * 100.0m,
                     // Note that the LNURL will have the same LN
-                    IsLightning = pmi == PaymentTypes.LN.GetPaymentMethodId(kv.Key)
+                    IsLightning = pmi == PaymentTypes.LN.GetPaymentMethodId(kv.PaymentCurrency)
                 });
             }
             return r;

--- a/BTCPayServer/Services/Invoices/InvoiceRepository.cs
+++ b/BTCPayServer/Services/Invoices/InvoiceRepository.cs
@@ -873,7 +873,7 @@ retry:
                 .GroupBy(p => p.GroupKey)
                 .ToDictionary(p => p.Key, p => new InvoiceStatistics.Contribution
                 {
-                    Currency = p.Key,
+                    Currency = p.Select(p => p.Currency).First(),
                     Settled = p.All(v => v.Settled),
                     Divisibility = p.Max(p => p.Divisibility),
                     Value = p.Select(v => v.Value).Sum(),


### PR DESCRIPTION
Missing bolt:

Before:

![image](https://github.com/user-attachments/assets/b1628df1-17c2-4a9a-af40-b684edfdf4c1)


After:

![image](https://github.com/user-attachments/assets/f305963e-2584-44e7-a6a8-6a3061853ad8)
