### PR TITLE
Fix: Incorrect calculation for crowdfund and payment request status

### DIFF
--- a/BTCPayServer/Services/Invoices/InvoiceEntity.cs
+++ b/BTCPayServer/Services/Invoices/InvoiceEntity.cs
@@ -830,14 +830,6 @@ namespace BTCPayServer.Services.Invoices
                 Status == InvoiceStatus.Invalid;
         }
 
-        public bool IsSettled()
-        {
-            return
-                   Status == InvoiceStatus.Settled ||
-                   (Status == InvoiceStatus.Expired &&
-                    ExceptionStatus is InvoiceExceptionStatus.PaidLate or InvoiceExceptionStatus.PaidOver);
-        }
-
         public override string ToString()
         {
             return Status + ExceptionStatus switch

--- a/BTCPayServer/Services/Invoices/InvoiceRepository.cs
+++ b/BTCPayServer/Services/Invoices/InvoiceRepository.cs
@@ -70,13 +70,13 @@ namespace BTCPayServer.Services.Invoices
         public async Task<InvoiceEntity> GetInvoiceFromAddress(PaymentMethodId paymentMethodId, string address)
         {
             using var db = _applicationDbContextFactory.CreateContext();
-			var row = (await db.AddressInvoices
-			.Include(a => a.InvoiceData.Payments)
-				.Where(a => a.Address == address && a.PaymentMethodId == paymentMethodId.ToString())
-				.Select(a => a.InvoiceData)
-			.FirstOrDefaultAsync());
-			return row is null ? null : ToEntity(row);
-		}
+            var row = (await db.AddressInvoices
+            .Include(a => a.InvoiceData.Payments)
+                .Where(a => a.Address == address && a.PaymentMethodId == paymentMethodId.ToString())
+                .Select(a => a.InvoiceData)
+            .FirstOrDefaultAsync());
+            return row is null ? null : ToEntity(row);
+        }
 
         /// <summary>
         /// Returns all invoices which either:
@@ -820,6 +820,8 @@ retry:
 
         public InvoiceStatistics GetContributionsByPaymentMethodId(string currency, InvoiceEntity[] invoices, bool softcap)
         {
+            decimal totalSettledCurrency = 0.0m;
+            decimal totalProcessingCurrency = 0.0m;
             var contributions = invoices
                 .Where(p => p.Currency.Equals(currency, StringComparison.OrdinalIgnoreCase))
                 .SelectMany(p =>
@@ -828,30 +830,42 @@ retry:
                     {
                         GroupKey = p.Currency,
                         Currency = p.Currency,
-                        CurrencyValue = p.Price,
-                        Settled = p.GetInvoiceState().IsSettled()
+                        CurrencyValue = p.Price
                     };
                     contribution.Value = contribution.CurrencyValue;
 
                     // For hardcap, we count newly created invoices as part of the contributions
                     if (!softcap && p.Status == InvoiceStatus.New)
+                    {
+                        totalProcessingCurrency += contribution.CurrencyValue;
                         return new[] { contribution };
+                    }
 
+                    var markedSettled = p is
+                    {
+                        Status: InvoiceStatus.Settled,
+                        ExceptionStatus: InvoiceExceptionStatus.Marked
+                    };
                     // If the user get a donation via other mean, he can register an invoice manually for such amount
                     // then mark the invoice as complete
                     var payments = p.GetPayments(true);
-                    if (payments.Count == 0 &&
-                        p.ExceptionStatus == InvoiceExceptionStatus.Marked &&
-                        p.Status == InvoiceStatus.Settled)
+                    if (payments.Count == 0 && markedSettled)
+                    {
+                        totalSettledCurrency += contribution.CurrencyValue;
                         return new[] { contribution };
-
-                    contribution.CurrencyValue = 0m;
-                    contribution.Value = 0m;
+                    }
 
                     // If an invoice has been marked invalid, remove the contribution
-                    if (p.ExceptionStatus == InvoiceExceptionStatus.Marked &&
-                        p.Status == InvoiceStatus.Invalid)
+                    if (p is
+                        {
+                            Status: InvoiceStatus.Invalid,
+                            ExceptionStatus: InvoiceExceptionStatus.Marked
+                        })
+                    {
+                        contribution.CurrencyValue = 0m;
+                        contribution.Value = 0m;
                         return new[] { contribution };
+                    }
 
                     // Else, we just sum the payments
                     return payments
@@ -863,9 +877,22 @@ retry:
                                      Currency = pay.Currency,
                                      CurrencyValue = pay.InvoicePaidAmount.Net,
                                      Value = pay.PaidAmount.Net,
-                                     Divisibility = pay.Divisibility,
-                                     Settled = p.GetInvoiceState().IsSettled()
+                                     Divisibility = pay.Divisibility
                                  };
+
+                                 // If paid before expiration or marked settled, account the payments...
+                                 if (pay.ReceivedTime <= p.ExpirationTime || markedSettled)
+                                 {
+                                     if (pay.Status is PaymentStatus.Settled)
+                                         totalSettledCurrency += pay.InvoicePaidAmount.Net;
+                                     else if (pay.Status is PaymentStatus.Processing)
+                                         totalProcessingCurrency += pay.InvoicePaidAmount.Net;
+                                 }
+                                 else
+                                 {
+                                     paymentMethodContribution.CurrencyValue = 0m;
+                                     paymentMethodContribution.Value = 0m;
+                                 }
                                  return paymentMethodContribution;
                              })
                              .ToArray();
@@ -874,12 +901,16 @@ retry:
                 .ToDictionary(p => p.Key, p => new InvoiceStatistics.Contribution
                 {
                     Currency = p.Select(p => p.Currency).First(),
-                    Settled = p.All(v => v.Settled),
                     Divisibility = p.Max(p => p.Divisibility),
                     Value = p.Select(v => v.Value).Sum(),
                     CurrencyValue = p.Select(v => v.CurrencyValue).Sum()
                 });
-            return new InvoiceStatistics(contributions);
+            return new InvoiceStatistics(contributions)
+            { 
+                TotalSettled = totalSettledCurrency,
+                TotalProcessing = totalProcessingCurrency,
+                Total = totalSettledCurrency + totalProcessingCurrency
+            };
         }
 
         private string GetGroupKey(PaymentEntity pay)
@@ -967,15 +998,18 @@ retry:
     {
         public InvoiceStatistics(IEnumerable<KeyValuePair<string, Contribution>> collection) : base(collection)
         {
-            TotalCurrency = Values.Select(v => v.CurrencyValue).Sum();
         }
-        public decimal TotalCurrency { get; }
+        public decimal TotalSettled { get; set; }
+        public decimal TotalProcessing { get; set; }
+        /// <summary>
+        /// <see cref="TotalSettled"/> + <see cref="TotalProcessing"/>
+        /// </summary>
+        public decimal Total { get; set; }
 
         public class Contribution
         {
             public string Currency { get; set; }
             public int Divisibility { get; set; }
-            public bool Settled { get; set; }
             public decimal Value { get; set; }
             public decimal CurrencyValue { get; set; }
             public string GroupKey { get; set; }


### PR DESCRIPTION
Fix https://github.com/btcpayserver/btcpayserver/issues/6371

In the Crowdfund app, payments for expired or invalid invoices were always recorded as Pending payments.

Additionally, there was a bug in both the Crowdfund app and the Payment Request feature, where a user could send a payment to an old invoice, and it would be included in the total for the payment request or crowdfund.

This behavior is undesirable, as the currency rate may have fluctuated since the invoice's expiration.

Instead, for crowdfund and payment requests, we will now account for every payment:
* Paid before the expiration regardless of the status (ie. even if the invoice is Invalid)
* Paid on an invoice that has been manually marked Settled. (I am not sure this is a good idea, as somebody could then pay the old invoice with an old rate, replicating the bug from 1.0. however, a merchant may expect this behavior?)

