### PR TITLE
Fix: Do not allow retry of payouts if they are non interactive (Boltcards)

### DIFF
--- a/BTCPayServer/Controllers/UILNURLController.cs
+++ b/BTCPayServer/Controllers/UILNURLController.cs
@@ -192,6 +192,7 @@ namespace BTCPayServer
                 PayoutMethodId = pmi,
                 PullPaymentId = pullPaymentId,
                 StoreId = pp.StoreId,
+                NonInteractiveOnly = nonInteractiveOnly,
                 ClaimedAmount = result.MinimumAmount.ToDecimal(unit),
             });
 

--- a/BTCPayServer/Data/Payouts/PayoutBlob.cs
+++ b/BTCPayServer/Data/Payouts/PayoutBlob.cs
@@ -27,7 +27,8 @@ namespace BTCPayServer.Data
 
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
         public int? ErrorCount { get; set; }
-
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public bool NonInteractiveOnly { get; set; }
         public int IncrementErrorCount()
         {
             if (ErrorCount is { } c)

--- a/BTCPayServer/HostedServices/PullPaymentHostedService.cs
+++ b/BTCPayServer/HostedServices/PullPaymentHostedService.cs
@@ -709,11 +709,12 @@ namespace BTCPayServer.HostedServices
                     DedupId = req.ClaimRequest.Destination.Id,
                     StoreDataId = req.ClaimRequest.StoreId ?? pp?.StoreId,
                     Currency = payoutHandler.Currency,
-                    OriginalCurrency = pp?.Currency ?? payoutHandler.Currency
+                    OriginalCurrency = pp?.Currency ?? payoutHandler.Currency,
                 };
                 var payoutBlob = new PayoutBlob()
                 {
                     Destination = req.ClaimRequest.Destination.ToString(),
+                    NonInteractiveOnly = req.ClaimRequest.NonInteractiveOnly,
                     Metadata = req.ClaimRequest.Metadata ?? new JObject(),
                 };
                 payout.OriginalAmount = claimed;
@@ -1067,6 +1068,7 @@ namespace BTCPayServer.HostedServices
         public IClaimDestination Destination { get; set; }
         public string StoreId { get; set; }
         public bool? PreApprove { get; set; }
+        public bool NonInteractiveOnly { get; set; }
         public JObject Metadata { get; set; }
     }
 

--- a/BTCPayServer/PayoutProcessors/Lightning/LightningAutomatedPayoutProcessor.cs
+++ b/BTCPayServer/PayoutProcessors/Lightning/LightningAutomatedPayoutProcessor.cs
@@ -117,6 +117,9 @@ public class LightningAutomatedPayoutProcessor : BaseAutomatedPayoutProcessor<Li
                 break;
         }
 
+        if (result.Success is false && blob.NonInteractiveOnly)
+            payoutData.State = PayoutState.Cancelled;
+
         bool updateBlob = false;
 		if (result.Success is false && payoutData.State == PayoutState.AwaitingPayment)
 		{


### PR DESCRIPTION
Fix #6377

From version 2.0, a payout that fails to be sent will be automatically retried by the automated payout processor.
It can also be retried manually.

This is the desired behavior for refunds where the customer does not expect the payout to be processed immediately. And the merchant is expected to re-attempt payment manually if something goes wrong.

However, in cases where the payout is non-interactive (Boltcard payment), we expect it to either succeed immediately or be canceled, allowing the customer, rather than the merchant, to retry it manually if needed.