### PR TITLE
Remove automated payout proc intervals at the store level

### DIFF
--- a/BTCPayServer.Client/Models/LightningAutomatedPayoutSettings.cs
+++ b/BTCPayServer.Client/Models/LightningAutomatedPayoutSettings.cs
@@ -8,9 +8,6 @@ public class LightningAutomatedPayoutSettings
 {
     public string PayoutMethodId { get; set; }
 
-    [JsonConverter(typeof(TimeSpanJsonConverter.Seconds))]
-    public TimeSpan IntervalSeconds { get; set; }
-
     [JsonProperty(DefaultValueHandling = DefaultValueHandling.Populate)]
     public bool  ProcessNewPayoutsInstantly { get; set; }
     

--- a/BTCPayServer.Client/Models/OnChainAutomatedPayoutSettings.cs
+++ b/BTCPayServer.Client/Models/OnChainAutomatedPayoutSettings.cs
@@ -7,10 +7,6 @@ namespace BTCPayServer.Client.Models;
 public class OnChainAutomatedPayoutSettings
 {
     public string PayoutMethodId { get; set; }
-
-    [JsonConverter(typeof(TimeSpanJsonConverter.Seconds))]
-    public TimeSpan IntervalSeconds { get; set; }
-
     public int? FeeBlockTarget { get; set; }
     [JsonProperty(DefaultValueHandling = DefaultValueHandling.Populate)]
     public decimal Threshold { get; set; }

--- a/BTCPayServer.Data/Data/PayoutProcessorData.cs
+++ b/BTCPayServer.Data/Data/PayoutProcessorData.cs
@@ -7,7 +7,6 @@ namespace BTCPayServer.Data;
 
 public class AutomatedPayoutBlob
 {
-    public TimeSpan Interval { get; set; } = TimeSpan.FromHours(1);
     public bool ProcessNewPayoutsInstantly { get; set; }
 }
 public class PayoutProcessorData : IHasBlobUntyped

--- a/BTCPayServer.Tests/GreenfieldAPITests.cs
+++ b/BTCPayServer.Tests/GreenfieldAPITests.cs
@@ -4241,8 +4241,7 @@ namespace BTCPayServer.Tests
             Assert.Equal(payout.Metadata.ToString(), new JObject().ToString()); //empty
             Assert.Empty(await adminClient.GetStoreLightningAutomatedPayoutProcessors(admin.StoreId, "BTC_LightningNetwork"));
             await adminClient.UpdateStoreLightningAutomatedPayoutProcessors(admin.StoreId, "BTC_LightningNetwork",
-                new LightningAutomatedPayoutSettings() { IntervalSeconds = TimeSpan.FromSeconds(600) });
-            Assert.Equal(600, Assert.Single(await adminClient.GetStoreLightningAutomatedPayoutProcessors(admin.StoreId, "BTC_LightningNetwork")).IntervalSeconds.TotalSeconds);
+                new LightningAutomatedPayoutSettings());
             await TestUtils.EventuallyAsync(async () =>
             {
                 var payoutC =
@@ -4397,8 +4396,8 @@ namespace BTCPayServer.Tests
             Assert.Empty(await adminClient.GetPayoutProcessors(admin.StoreId));
 
             await adminClient.UpdateStoreOnChainAutomatedPayoutProcessors(admin.StoreId, "BTC",
-                new OnChainAutomatedPayoutSettings() { IntervalSeconds = TimeSpan.FromSeconds(3600) });
-            Assert.Equal(3600, Assert.Single(await adminClient.GetStoreOnChainAutomatedPayoutProcessors(admin.StoreId, "BTC")).IntervalSeconds.TotalSeconds);
+                new OnChainAutomatedPayoutSettings());
+            Assert.Single(await adminClient.GetStoreOnChainAutomatedPayoutProcessors(admin.StoreId, "BTC"));
 
             var tpGen = Assert.Single(await adminClient.GetPayoutProcessors(admin.StoreId));
             Assert.Equal("BTC-CHAIN", Assert.Single(tpGen.PayoutMethods));
@@ -4424,8 +4423,8 @@ namespace BTCPayServer.Tests
                 Assert.Equal(3, payouts.Length);
             });
             await adminClient.UpdateStoreOnChainAutomatedPayoutProcessors(admin.StoreId, "BTC",
-                new OnChainAutomatedPayoutSettings() { IntervalSeconds = TimeSpan.FromSeconds(600), FeeBlockTarget = 1000 });
-            Assert.Equal(600, Assert.Single(await adminClient.GetStoreOnChainAutomatedPayoutProcessors(admin.StoreId, "BTC")).IntervalSeconds.TotalSeconds);
+                new OnChainAutomatedPayoutSettings() { FeeBlockTarget = 1000 });
+            Assert.Single(await adminClient.GetStoreOnChainAutomatedPayoutProcessors(admin.StoreId, "BTC"));
 
             await TestUtils.EventuallyAsync(async () =>
             {
@@ -4455,8 +4454,6 @@ namespace BTCPayServer.Tests
             Assert.Equal(0m, settings.Threshold);
 
             //let's use the ProcessNewPayoutsInstantly so that it will trigger instantly
-
-            settings.IntervalSeconds = TimeSpan.FromDays(1);
             settings.ProcessNewPayoutsInstantly = true;
 
             await tester.WaitForEvent<NewOnChainTransactionEvent>(async () =>

--- a/BTCPayServer.Tests/SeleniumTests.cs
+++ b/BTCPayServer.Tests/SeleniumTests.cs
@@ -2492,8 +2492,7 @@ namespace BTCPayServer.Tests
 			var account = await s.AsTestAccount().CreateClient();
 			await account.UpdateStoreLightningAutomatedPayoutProcessors(s.StoreId, "BTC-LN", new()
 			{
-				ProcessNewPayoutsInstantly = true,
-				IntervalSeconds = TimeSpan.FromSeconds(60)
+				ProcessNewPayoutsInstantly = true
 			});
 			// Now it should process to complete
 			await TestUtils.EventuallyAsync(async () =>

--- a/BTCPayServer/Controllers/GreenField/GreenfieldStoreAutomatedLightningPayoutProcessorsController.cs
+++ b/BTCPayServer/Controllers/GreenField/GreenfieldStoreAutomatedLightningPayoutProcessorsController.cs
@@ -58,7 +58,6 @@ namespace BTCPayServer.Controllers.Greenfield
             return new LightningAutomatedPayoutSettings()
             {
                 PayoutMethodId = data.PayoutMethodId,
-                IntervalSeconds = blob.Interval,
                 ProcessNewPayoutsInstantly = blob.ProcessNewPayoutsInstantly
             };
         }
@@ -66,7 +65,6 @@ namespace BTCPayServer.Controllers.Greenfield
         private static LightningAutomatedPayoutBlob FromModel(LightningAutomatedPayoutSettings data)
         {
             return new LightningAutomatedPayoutBlob() { 
-                Interval = data.IntervalSeconds, 
                 ProcessNewPayoutsInstantly = data.ProcessNewPayoutsInstantly
             };
         }
@@ -76,7 +74,6 @@ namespace BTCPayServer.Controllers.Greenfield
         public async Task<IActionResult> UpdateStoreLightningAutomatedPayoutProcessor(
             string storeId, string payoutMethodId, LightningAutomatedPayoutSettings request)
         {
-            AutomatedPayoutConstants.ValidateInterval(ModelState, request.IntervalSeconds, nameof(request.IntervalSeconds));
             if (!ModelState.IsValid)
                 return this.CreateValidationError(ModelState);
             var pmi = PayoutMethodId.Parse(payoutMethodId);

--- a/BTCPayServer/Controllers/GreenField/GreenfieldStoreAutomatedOnChainPayoutProcessorsController.cs
+++ b/BTCPayServer/Controllers/GreenField/GreenfieldStoreAutomatedOnChainPayoutProcessorsController.cs
@@ -60,7 +60,6 @@ namespace BTCPayServer.Controllers.Greenfield
             {
                 FeeBlockTarget = blob.FeeTargetBlock,
                 PayoutMethodId = data.PayoutMethodId,
-                IntervalSeconds = blob.Interval,
                 Threshold = blob.Threshold,
                 ProcessNewPayoutsInstantly = blob.ProcessNewPayoutsInstantly
             };
@@ -71,7 +70,6 @@ namespace BTCPayServer.Controllers.Greenfield
             return new OnChainAutomatedPayoutBlob()
             {
                 FeeTargetBlock = data.FeeBlockTarget ?? 1,
-                Interval = data.IntervalSeconds,
                 Threshold = data.Threshold,
                 ProcessNewPayoutsInstantly = data.ProcessNewPayoutsInstantly
             };
@@ -82,7 +80,6 @@ namespace BTCPayServer.Controllers.Greenfield
         public async Task<IActionResult> UpdateStoreOnchainAutomatedPayoutProcessor(
             string storeId, string paymentMethod, OnChainAutomatedPayoutSettings request)
         {
-            AutomatedPayoutConstants.ValidateInterval(ModelState, request.IntervalSeconds, nameof(request.IntervalSeconds));
             if (request.FeeBlockTarget is int t && (t < 1 || t > 1000))
                 ModelState.AddModelError(nameof(request.FeeBlockTarget), "The feeBlockTarget should be between 1 and 1000");
             if (!ModelState.IsValid)

--- a/BTCPayServer/Controllers/UILNURLController.cs
+++ b/BTCPayServer/Controllers/UILNURLController.cs
@@ -179,7 +179,6 @@ namespace BTCPayServer
                 return BadRequest(new LNUrlStatusResponse { Status = "ERROR", Reason = "Payment cancelled: The payer must activate the lightning automated payment process and must check \"Process approved payouts instantly\"." });
             }
 
-			var interval = processorBlob?.Interval.TotalMinutes;
 			var autoApprove = pp.GetBlob().AutoApproveClaims;
             if (nonInteractiveOnly && !autoApprove)
             {
@@ -232,9 +231,9 @@ namespace BTCPayServer
 				}
 				else
 				{
-					var message = interval switch
+					var message = processorBlob switch
 					{
-						double intervalMinutes => $"The payment will be sent after {intervalMinutes} minutes.",
+						{ } => "The payment will be sent later.",
 						null => "The sender needs to send the payment manually. (Or activate the lightning automated payment processor)"
 					};
 					return Ok(new LNUrlStatusResponse

--- a/BTCPayServer/Data/Payouts/PayoutExtensions.cs
+++ b/BTCPayServer/Data/Payouts/PayoutExtensions.cs
@@ -45,7 +45,7 @@ namespace BTCPayServer.Data
 
         public static PayoutBlob GetBlob(this PayoutData data, BTCPayNetworkJsonSerializerSettings serializers)
         {
-            var result =  JsonConvert.DeserializeObject<PayoutBlob>(data.Blob, serializers.GetSerializer(data.GetPayoutMethodId()));
+            var result =  JsonConvert.DeserializeObject<PayoutBlob>(data.Blob, serializers?.GetSerializer(data.GetPayoutMethodId()));
             result.Metadata ??= new JObject();
             return result;
         }

--- a/BTCPayServer/PayoutProcessors/BaseAutomatedPayoutProcessor.cs
+++ b/BTCPayServer/PayoutProcessors/BaseAutomatedPayoutProcessor.cs
@@ -1,9 +1,11 @@
 #nullable  enable
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Amazon;
 using BTCPayServer.Abstractions.Contracts;
 using BTCPayServer.Client.Models;
 using BTCPayServer.Data;
@@ -14,29 +16,13 @@ using BTCPayServer.Services.Invoices;
 using BTCPayServer.Services.Stores;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.Extensions.Logging;
+using static BTCPayServer.PayoutProcessors.PayoutProcessorService;
 using PayoutData = BTCPayServer.Data.PayoutData;
 using PayoutProcessorData = BTCPayServer.Data.PayoutProcessorData;
 
 namespace BTCPayServer.PayoutProcessors;
 
-public class AutomatedPayoutConstants
-{
-    public const double MinIntervalMinutes = 1.0;
-    public const double DefaultIntervalMinutes = 60.0;
-    public const double MaxIntervalMinutes = 24 * 60; //1 day
-    public static void ValidateInterval(ModelStateDictionary modelState, TimeSpan timeSpan, string parameterName)
-    {
-        if (timeSpan < TimeSpan.FromMinutes(AutomatedPayoutConstants.MinIntervalMinutes))
-        {
-            modelState.AddModelError(parameterName, $"The minimum interval is {MinIntervalMinutes * 60} seconds");
-        }
-        if (timeSpan > TimeSpan.FromMinutes(AutomatedPayoutConstants.MaxIntervalMinutes))
-        {
-            modelState.AddModelError(parameterName, $"The maximum interval is {MaxIntervalMinutes * 60} seconds");
-        }
-    }
-}
-public abstract class BaseAutomatedPayoutProcessor<T> : BaseAsyncService where T : AutomatedPayoutBlob, new()
+public abstract class BaseAutomatedPayoutProcessor<T> : EventHostedServiceBase where T : AutomatedPayoutBlob, new()
 {
     protected readonly StoreRepository _storeRepository;
     protected readonly PayoutProcessorData PayoutProcessorSettings;
@@ -45,7 +31,6 @@ public abstract class BaseAutomatedPayoutProcessor<T> : BaseAsyncService where T
     protected readonly PayoutMethodId PayoutMethodId;
     protected readonly PaymentMethodId PaymentMethodId;
     private readonly IPluginHookService _pluginHookService;
-    protected readonly EventAggregator _eventAggregator;
 
     protected BaseAutomatedPayoutProcessor(
         PaymentMethodId paymentMethodId,
@@ -55,7 +40,7 @@ public abstract class BaseAutomatedPayoutProcessor<T> : BaseAsyncService where T
         ApplicationDbContextFactory applicationDbContextFactory,
         PaymentMethodHandlerDictionary paymentHandlers,
         IPluginHookService pluginHookService,
-        EventAggregator eventAggregator) : base(logger.CreateLogger($"{payoutProcessorSettings.Processor}:{payoutProcessorSettings.StoreId}:{payoutProcessorSettings.PayoutMethodId}"))
+        EventAggregator eventAggregator) : base(eventAggregator, logger.CreateLogger($"{payoutProcessorSettings.Processor}:{payoutProcessorSettings.StoreId}:{payoutProcessorSettings.PayoutMethodId}"))
     {
         PaymentMethodId = paymentMethodId;
         _storeRepository = storeRepository;
@@ -64,37 +49,17 @@ public abstract class BaseAutomatedPayoutProcessor<T> : BaseAsyncService where T
         _applicationDbContextFactory = applicationDbContextFactory;
         _paymentHandlers = paymentHandlers;
         _pluginHookService = pluginHookService;
-        _eventAggregator = eventAggregator;
-        this.NoLogsOnExit = true;
     }
 
-    internal override Task[] InitializeTasks()
+    protected override void SubscribeToEvents()
     {
-        _subscription = _eventAggregator.SubscribeAsync<PayoutEvent>(OnPayoutEvent);
-        return new[] { CreateLoopTask(Act) };
-    }
-    
-
-    public override Task StopAsync(CancellationToken cancellationToken)
-    {
-        _subscription?.Dispose();
-        return base.StopAsync(cancellationToken);
-    }
-
-    private Task OnPayoutEvent(PayoutEvent arg)
-    {
-        if (arg.Type == PayoutEvent.PayoutEventType.Approved && 
-            PayoutProcessorSettings.StoreId == arg.Payout.StoreDataId &&
-            arg.Payout.GetPayoutMethodId() == PayoutMethodId &&
-            GetBlob(PayoutProcessorSettings).ProcessNewPayoutsInstantly)
-        {
-            SkipInterval();
-        }
-        return Task.CompletedTask;
+        this.Subscribe<PayoutEvent>();
+        this.Subscribe<PayoutProcessorService.AwaitingPayoutsEvent>();
+        this.Subscribe<PayoutProcessorService.PollProcessorEvent>();
     }
 
     protected virtual Task Process(object paymentMethodConfig, List<PayoutData> payouts) =>
-        throw  new NotImplementedException();
+        throw new NotImplementedException();
 
     protected virtual async Task<bool> ProcessShouldSave(object paymentMethodConfig, List<PayoutData> payouts)
     {
@@ -102,37 +67,67 @@ public abstract class BaseAutomatedPayoutProcessor<T> : BaseAsyncService where T
         return true;
     }
 
-	private async Task Act()
+    protected override async Task ProcessEvent(object evt, CancellationToken cancellationToken)
     {
+        PullPaymentHostedService.PayoutQuery query = new PullPaymentHostedService.PayoutQuery()
+        {
+            States = new[] { PayoutState.AwaitingPayment },
+            PayoutMethods = new[] { PayoutProcessorSettings.PayoutMethodId },
+            Processor = PayoutProcessorSettings.Processor,
+            Stores = new[] { PayoutProcessorSettings.StoreId }
+        };
+        List<PayoutData> payouts = new();
+        if (evt is PayoutEvent pe)
+        {
+            if (!ProcessInstantly(pe))
+                return;
+            payouts.Add(pe.Payout);
+        }
+        else if (evt is PayoutProcessorService.AwaitingPayoutsEvent ape)
+        {
+            if (!ape.PayoutsByStoreId.TryGetValue(PayoutProcessorSettings.StoreId, out var p))
+                return;
+            payouts = p;
+        }
+        else if (evt is PayoutProcessorService.PollProcessorEvent poll)
+        {
+            if (poll.ProcessorId != PayoutProcessorSettings.Id)
+                return;
+            await using var context = _applicationDbContextFactory.CreateContext();
+            payouts = await PullPaymentHostedService.GetPayouts(
+            new PullPaymentHostedService.PayoutQuery()
+            {
+                States = new[] { PayoutState.AwaitingPayment },
+                PayoutMethods = new[] { PayoutProcessorSettings.PayoutMethodId },
+                Processor = PayoutProcessorSettings.Processor,
+                Stores = new[] { PayoutProcessorSettings.StoreId }
+            }, context, CancellationToken);
+        }
+        payouts = payouts
+            .Where(p => p.GetBlob(null).DisabledProcessors?.Contains(PayoutProcessorSettings.Processor) is not true)
+            .ToList();
+        if (payouts.Count == 0)
+            return;
         var store = await _storeRepository.FindStore(PayoutProcessorSettings.StoreId);
         var paymentMethod = store?.GetPaymentMethodConfig(PaymentMethodId, _paymentHandlers, true);
-
         var blob = GetBlob(PayoutProcessorSettings);
         if (paymentMethod is not null)
         {
             await using var context = _applicationDbContextFactory.CreateContext();
-            var payouts = await PullPaymentHostedService.GetPayouts(
-                new PullPaymentHostedService.PayoutQuery()
-                {
-                    States = new[] { PayoutState.AwaitingPayment },
-                    PayoutMethods = new[] { PayoutProcessorSettings.PayoutMethodId },
-					Processor = PayoutProcessorSettings.Processor,
-					Stores = new[] {PayoutProcessorSettings.StoreId}
-                }, context, CancellationToken);
+            foreach (var payout in payouts)
+                context.Payouts.Attach(payout);
 
             await _pluginHookService.ApplyAction("before-automated-payout-processing",
                 new BeforePayoutActionData(store, PayoutProcessorSettings, payouts));
             if (payouts.Any())
             {
-                Logs.PayServer.LogInformation(
-                    $"{payouts.Count} found to process. Starting (and after will sleep for {blob.Interval})");
                 if (await ProcessShouldSave(paymentMethod, payouts))
                 {
                     await context.SaveChangesAsync();
-                
+
                     foreach (var payoutData in payouts.Where(payoutData => payoutData.State != PayoutState.AwaitingPayment))
                     {
-						_eventAggregator.Publish(new PayoutEvent(PayoutEvent.PayoutEventType.Updated, payoutData));
+                        EventAggregator.Publish(new PayoutEvent(PayoutEvent.PayoutEventType.Updated, payoutData));
                     }
                 }
 
@@ -142,35 +137,13 @@ public abstract class BaseAutomatedPayoutProcessor<T> : BaseAsyncService where T
             await _pluginHookService.ApplyAction("after-automated-payout-processing",
                 new AfterPayoutActionData(store, PayoutProcessorSettings, payouts));
         }
-
-        // Clip interval
-        if (blob.Interval < TimeSpan.FromMinutes(AutomatedPayoutConstants.MinIntervalMinutes))
-            blob.Interval = TimeSpan.FromMinutes(AutomatedPayoutConstants.MinIntervalMinutes);
-        if (blob.Interval > TimeSpan.FromMinutes(AutomatedPayoutConstants.MaxIntervalMinutes))
-            blob.Interval = TimeSpan.FromMinutes(AutomatedPayoutConstants.MaxIntervalMinutes);
-        try
-        {
-            using var cts = CancellationTokenSource.CreateLinkedTokenSource(CancellationToken, _timerCTs.Token);
-            await Task.Delay(blob.Interval, cts.Token);
-        }
-        catch (TaskCanceledException)
-        {
-        }
     }
 
-    private CancellationTokenSource _timerCTs = new CancellationTokenSource();
-    private IEventAggregatorSubscription? _subscription;
-
-    private readonly object _intervalLock = new object();
-
-    public void SkipInterval()
-    {
-        lock (_intervalLock)
-        {
-            _timerCTs.Cancel();
-            _timerCTs = new CancellationTokenSource();
-        }
-    }
+    private bool ProcessInstantly(PayoutEvent evt) =>
+        evt is { Type: PayoutEvent.PayoutEventType.Approved } pe
+                && PayoutProcessorSettings.StoreId == pe.Payout.StoreDataId
+                && pe.Payout.GetPayoutMethodId() == PayoutMethodId
+                && GetBlob(PayoutProcessorSettings).ProcessNewPayoutsInstantly;
 
     public static T GetBlob(PayoutProcessorData payoutProcesserSettings)
     {

--- a/BTCPayServer/PayoutProcessors/Lightning/UILightningAutomatedPayoutProcessorsController.cs
+++ b/BTCPayServer/PayoutProcessors/Lightning/UILightningAutomatedPayoutProcessorsController.cs
@@ -128,20 +128,15 @@ public class UILightningAutomatedPayoutProcessorsController : Controller
 
         public LightningTransferViewModel(LightningAutomatedPayoutBlob blob)
         {
-            IntervalMinutes = blob.Interval.TotalMinutes;
             ProcessNewPayoutsInstantly = blob.ProcessNewPayoutsInstantly;
         }
         [Display(Name = "Process approved payouts instantly")]
         public bool ProcessNewPayoutsInstantly { get; set; }
 
-        [Range(AutomatedPayoutConstants.MinIntervalMinutes, AutomatedPayoutConstants.MaxIntervalMinutes)]
-        public double IntervalMinutes { get; set; }
-
         public LightningAutomatedPayoutBlob ToBlob()
         {
             return new LightningAutomatedPayoutBlob {
                 ProcessNewPayoutsInstantly = ProcessNewPayoutsInstantly,
-                Interval = TimeSpan.FromMinutes(IntervalMinutes), 
             };
         }
     }

--- a/BTCPayServer/PayoutProcessors/OnChain/OnChainAutomatedPayoutProcessor.cs
+++ b/BTCPayServer/PayoutProcessors/OnChain/OnChainAutomatedPayoutProcessor.cs
@@ -184,7 +184,7 @@ namespace BTCPayServer.PayoutProcessors.OnChain
                     TaskCompletionSource<bool> tcs = new();
                     var cts = new CancellationTokenSource();
                     cts.CancelAfter(TimeSpan.FromSeconds(20));
-                    var task = _eventAggregator.WaitNext<NewOnChainTransactionEvent>(
+                    var task = EventAggregator.WaitNext<NewOnChainTransactionEvent>(
                         e => e.NewTransactionEvent.TransactionData.TransactionHash == txHash,
                         cts.Token);
                     var broadcastResult = await explorerClient.BroadcastAsync(workingTx, cts.Token);

--- a/BTCPayServer/PayoutProcessors/OnChain/UIOnChainAutomatedPayoutProcessorsController.cs
+++ b/BTCPayServer/PayoutProcessors/OnChain/UIOnChainAutomatedPayoutProcessorsController.cs
@@ -140,7 +140,6 @@ public class UIOnChainAutomatedPayoutProcessorsController : Controller
         public OnChainTransferViewModel(OnChainAutomatedPayoutBlob blob)
         {
             ProcessNewPayoutsInstantly = blob.ProcessNewPayoutsInstantly;
-            IntervalMinutes = blob.Interval.TotalMinutes;
             FeeTargetBlock = blob.FeeTargetBlock;
             Threshold = blob.Threshold;
         }
@@ -152,16 +151,12 @@ public class UIOnChainAutomatedPayoutProcessorsController : Controller
         public int FeeTargetBlock { get; set; }
         public decimal Threshold { get; set; }
 
-        [Range(AutomatedPayoutConstants.MinIntervalMinutes, AutomatedPayoutConstants.MaxIntervalMinutes)]
-        public double IntervalMinutes { get; set; }
-
         public OnChainAutomatedPayoutBlob ToBlob()
         {
             return new OnChainAutomatedPayoutBlob
             {
                 ProcessNewPayoutsInstantly = ProcessNewPayoutsInstantly,
                 FeeTargetBlock = FeeTargetBlock,
-                Interval = TimeSpan.FromMinutes(IntervalMinutes),
                 Threshold = Threshold
             };
         }

--- a/BTCPayServer/PayoutProcessors/PayoutProcessorsExtensions.cs
+++ b/BTCPayServer/PayoutProcessors/PayoutProcessorsExtensions.cs
@@ -1,3 +1,4 @@
+using System;
 using BTCPayServer.Data;
 using BTCPayServer.Payments;
 using BTCPayServer.PayoutProcessors.Lightning;
@@ -17,6 +18,7 @@ public static class PayoutProcessorsExtensions
         serviceCollection.AddSingleton<IPayoutProcessorFactory>(provider => provider.GetRequiredService<LightningAutomatedPayoutSenderFactory>());
         serviceCollection.AddSingleton<PayoutProcessorService>();
         serviceCollection.AddHostedService(s => s.GetRequiredService<PayoutProcessorService>());
+        serviceCollection.AddScheduledTask<PayoutProcessorService>(TimeSpan.FromHours(1));
     }
 
     public static PayoutMethodId GetPayoutMethodId(this PayoutProcessorData data)

--- a/BTCPayServer/Views/UILightningAutomatedPayoutProcessors/Configure.cshtml
+++ b/BTCPayServer/Views/UILightningAutomatedPayoutProcessors/Configure.cshtml
@@ -33,14 +33,6 @@
                 <label asp-for="ProcessNewPayoutsInstantly" class="form-check-label"></label>
                 <span asp-validation-for="ProcessNewPayoutsInstantly" class="text-danger"></span>
             </div>
-            <div class="form-group">
-                <label asp-for="IntervalMinutes" class="form-label" data-required text-translate="true">Interval</label>
-                <div class="input-group">
-                    <input asp-for="IntervalMinutes" class="form-control" inputmode="numeric" style="max-width:12ch;">
-                    <span class="input-group-text" text-translate="true">minutes</span>
-                    <span asp-validation-for="IntervalMinutes" class="text-danger"></span>
-                </div>
-            </div>
         </div>
     </div>
 </form>

--- a/BTCPayServer/Views/UIOnChainAutomatedPayoutProcessors/Configure.cshtml
+++ b/BTCPayServer/Views/UIOnChainAutomatedPayoutProcessors/Configure.cshtml
@@ -35,14 +35,6 @@
                 <span asp-validation-for="ProcessNewPayoutsInstantly" class="text-danger"></span>
             </div>
             <div class="form-group">
-                <label asp-for="IntervalMinutes" class="form-label" data-required text-translate="true">Interval</label>
-                <div class="input-group">
-                    <input asp-for="IntervalMinutes" class="form-control" inputmode="numeric" style="max-width:12ch;">
-                    <span class="input-group-text" text-translate="true">minutes</span>
-                    <span asp-validation-for="IntervalMinutes" class="text-danger"></span>
-                </div>
-            </div>
-            <div class="form-group">
                 <label asp-for="FeeTargetBlock" class="form-label" data-required text-translate="true">Fee block target</label>
                 <div class="input-group">
                     <input asp-for="FeeTargetBlock" class="form-control" min="1" inputmode="numeric" style="max-width:12ch;">

--- a/BTCPayServer/wwwroot/swagger/v1/swagger.template.payout-processors.json
+++ b/BTCPayServer/wwwroot/swagger/v1/swagger.template.payout-processors.json
@@ -545,14 +545,6 @@
                 "type": "object",
                 "additionalProperties": false,
                 "properties": {
-                    "intervalSeconds": {
-                        "description": "How often should the processor run",
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/TimeSpanSeconds"
-                            }
-                        ]
-                    },
                     "cancelPayoutAfterFailures": {
                         "description": "How many failures should the processor tolerate before cancelling the payout",
                         "type": "number",
@@ -571,14 +563,6 @@
                 "properties": {
                     "payoutMethodId": {
                         "$ref": "#/components/schemas/PayoutMethodId"
-                    },
-                    "intervalSeconds": {
-                        "description": "How often should the processor run",
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/TimeSpanSeconds"
-                            }
-                        ]
                     },
                     "cancelPayoutAfterFailures": {
                         "description": "How many failures should the processor tolerate before cancelling the payout",
@@ -600,14 +584,6 @@
                         "type": "number",
                         "description": "How many blocks should the fee rate calculation target to confirm in. Set to 1 if not provided",
                         "nullable": true
-                    },
-                    "intervalSeconds": {
-                        "description": "How often should the processor run",
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/TimeSpanSeconds"
-                            }
-                        ]
                     },
                     "threshold": {
                         "type": "string",
@@ -633,14 +609,6 @@
                     "feeTargetBlock": {
                         "type": "number",
                         "description": "How many blocks should the fee rate calculation target to confirm in."
-                    },
-                    "intervalSeconds": {
-                        "description": "How often should the processor run",
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/TimeSpanSeconds"
-                            }
-                        ]
                     },
                     "threshold": {
                         "type": "string",


### PR DESCRIPTION
Previously, it was possible to setup the store to run the payout processor at every interval.

However, this create issues for servers with lots of stores as when the server starts, all stores start their processor and all processors hit the database at the same time. This create database exception when the server starts, and once every hour. (as the default is once every hours, and users rarely change this)

Instead, this PR will create a single database call for all stores with pending payouts when the server starts and once every hours.

EDIT: I think giving up with this PR, I believe it is possible to avoid the issue while letting users selecting their favorite interval.