### PR TITLE
Fix: Pull payment could get stuck in Pending mode (#6259)

### DIFF
--- a/BTCPayServer/BTCPayServer.csproj
+++ b/BTCPayServer/BTCPayServer.csproj
@@ -41,7 +41,7 @@
     <PackageReference Include="YamlDotNet" Version="8.0.0" />
     <PackageReference Include="BIP78.Sender" Version="0.2.2" />
     <PackageReference Include="BTCPayServer.Hwi" Version="2.0.2" />
-    <PackageReference Include="BTCPayServer.Lightning.All" Version="1.6.6" />
+    <PackageReference Include="BTCPayServer.Lightning.All" Version="1.6.7" />
     <PackageReference Include="CsvHelper" Version="32.0.3" />
     <PackageReference Include="Dapper" Version="2.1.35" />
     <PackageReference Include="Fido2" Version="2.0.2" />


### PR DESCRIPTION
Fix #6259
Library fix: https://github.com/btcpayserver/BTCPayServer.Lightning/commit/fc53710f565988c310fc841b4b20da79f49cd28b