### PR TITLE
Fix: Pay button shouldn't throw exception if currency isn't specificied (#6324)

### DIFF
--- a/BTCPayServer/Plugins/PayButton/Models/PayButtonViewModel.cs
+++ b/BTCPayServer/Plugins/PayButton/Models/PayButtonViewModel.cs
@@ -13,7 +13,6 @@ namespace BTCPayServer.Plugins.PayButton.Models
         [ModelBinder(BinderType = typeof(InvariantDecimalModelBinder))]
         public decimal? Price { get; set; }
         public string InvoiceId { get; set; }
-        [Required]
         public string Currency { get; set; }
         public string DefaultPaymentMethod { get; set; }
         public PaymentMethodOptionViewModel.Format[] PaymentMethods { get; set; }


### PR DESCRIPTION
Fix #6324

If currency isn't specified, it just fallback to the store's default.