### PR TITLE
fix: correct `<` plugin dependency implementation

### DIFF
--- a/BTCPayServer/Plugins/PluginManager.cs
+++ b/BTCPayServer/Plugins/PluginManager.cs
@@ -505,7 +505,7 @@ namespace BTCPayServer.Plugins
                     case { } xx when xx.StartsWith(">"):
                         return installed[plugin] > parsedV;
                     case { } xx when xx.StartsWith("<"):
-                        return installed[plugin] >= parsedV;
+                        return installed[plugin] < parsedV;
                     case { } xx when xx.StartsWith("^"):
                         return installed[plugin] >= parsedV && installed[plugin].Major == parsedV.Major;
                     case { } xx when xx.StartsWith("~"):


### PR DESCRIPTION
was wrongly implemented using `>=`
