### PR TITLE
Greenfield: Users API fixes

### DIFF
--- a/BTCPayServer.Tests/GreenfieldAPITests.cs
+++ b/BTCPayServer.Tests/GreenfieldAPITests.cs
@@ -999,7 +999,7 @@ namespace BTCPayServer.Tests
             Assert.Contains("ServerAdmin", admin.Roles);
             Assert.NotNull(admin.Created);
             Assert.True((DateTimeOffset.Now - admin.Created).Value.Seconds < 10);
-
+            
             // Creating a new user without proper creds is now impossible (unauthorized) 
             // Because if registration are locked and that an admin exists, we don't accept unauthenticated connection
             var ex = await AssertAPIError("unauthenticated",
@@ -1051,7 +1051,14 @@ namespace BTCPayServer.Tests
                 Password = "afewfoiewiou",
                 IsAdministrator = true
             });
+            
+            // Create user without password
+            await adminClient.CreateUser(new CreateApplicationUserRequest
+            {
+                Email = "nopassword@gmail.com"
+            });
 
+            // Regular user
             var user1Acc = tester.NewAccount();
             user1Acc.UserId = user1.Id;
             user1Acc.IsAdmin = false;

--- a/BTCPayServer/Controllers/GreenField/GreenfieldUsersController.cs
+++ b/BTCPayServer/Controllers/GreenField/GreenfieldUsersController.cs
@@ -112,14 +112,13 @@ namespace BTCPayServer.Controllers.Greenfield
                 return this.UserNotFound();
             }
 
-            var success = false;
             if (user.RequiresApproval)
             {
-                success = await _userService.SetUserApproval(user.Id, request.Approved, Request.GetAbsoluteRootUri());
+                return await _userService.SetUserApproval(user.Id, request.Approved, Request.GetAbsoluteRootUri())
+                    ? Ok()
+                    : this.CreateAPIError("invalid-state", $"User is already {(request.Approved ? "approved" : "unapproved")}");
             }
-
-            return success ? Ok() : this.CreateAPIError("invalid-state",
-                $"{(request.Approved ? "Approving" : "Unapproving")} user failed");
+            return this.CreateAPIError("invalid-state", $"{(request.Approved ? "Approving" : "Unapproving")} user failed: No approval required");
         }
 
         [Authorize(Policy = Policies.CanViewUsers, AuthenticationSchemes = AuthenticationSchemes.Greenfield)]


### PR DESCRIPTION
Two improvemnts for the user endpoints:

- User creation without password was crashing before. 
- More precise error message for user approval toggling

Closes #6406.