### PR TITLE
POS: Create Invoice action optionally responds with JSON

### DIFF
--- a/BTCPayServer.Tests/AltcoinTests/AltcoinTests.cs
+++ b/BTCPayServer.Tests/AltcoinTests/AltcoinTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using System.Net.Http;
 using System.Threading.Tasks;
 using BTCPayServer.Client.Models;
 using BTCPayServer.Controllers;
@@ -801,6 +802,66 @@ g:
                 Assert.Equal(0, topupInvoice.Price);
                 Assert.Equal("new", topupInvoice.Status);
             }
+        }
+        
+        
+        [Fact]
+        [Trait("Integration", "Integration")]
+        public async Task CanUsePoSAppJsonEndpoint()
+        {
+            using var tester = CreateServerTester();
+            await tester.StartAsync();
+            var user = tester.NewAccount();
+            await user.GrantAccessAsync();
+            user.RegisterDerivationScheme("BTC");
+            var apps = user.GetController<UIAppsController>();
+            var pos = user.GetController<UIPointOfSaleController>();
+            var vm = Assert.IsType<CreateAppViewModel>(Assert.IsType<ViewResult>(apps.CreateApp(user.StoreId)).Model);
+            var appType = PointOfSaleAppType.AppType;
+            vm.AppName = "test";
+            vm.SelectedAppType = appType;
+            var redirect = Assert.IsType<RedirectResult>(apps.CreateApp(user.StoreId, vm).Result);
+            Assert.EndsWith("/settings/pos", redirect.Url);
+            var appList = Assert.IsType<ListAppsViewModel>(Assert.IsType<ViewResult>(apps.ListApps(user.StoreId).Result).Model);
+            var app = appList.Apps[0];
+            var appData = new AppData { Id = app.Id, StoreDataId = app.StoreId, Name = app.AppName, AppType = appType };
+            apps.HttpContext.SetAppData(appData);
+            pos.HttpContext.SetAppData(appData);
+            var vmpos = await pos.UpdatePointOfSale(app.Id).AssertViewModelAsync<UpdatePointOfSaleViewModel>();
+            vmpos.Title = "App POS";
+            vmpos.Currency = "EUR";
+            Assert.IsType<RedirectToActionResult>(pos.UpdatePointOfSale(app.Id, vmpos).Result);
+
+            // Failing requests
+            var (invoiceId1, error1) = await PosJsonRequest(tester, app.Id, "amount=-21&discount=10&tip=2");
+            Assert.Null(invoiceId1);
+            Assert.Equal("Negative amount is not allowed", error1);
+            var (invoiceId2, error2) = await PosJsonRequest(tester, app.Id, "amount=21&discount=-10&tip=-2");
+            Assert.Null(invoiceId2);
+            Assert.Equal("Negative tip or discount is not allowed", error2);
+
+            // Successful request
+            var (invoiceId3, error3) = await PosJsonRequest(tester, app.Id, "amount=21");
+            Assert.NotNull(invoiceId3);
+            Assert.Null(error3);
+            
+            // Check generated invoice
+            var invoices = await user.BitPay.GetInvoicesAsync();
+            var invoice = invoices.First();
+            Assert.Equal(invoiceId3, invoice.Id);
+            Assert.Equal(21.00m, invoice.Price);
+            Assert.Equal("EUR", invoice.Currency);
+        }
+
+        private async Task<(string invoiceId, string error)> PosJsonRequest(ServerTester tester, string appId, string query)
+        {
+            var uriBuilder = new UriBuilder(tester.PayTester.ServerUri) { Path = $"/apps/{appId}/pos/light", Query = query };
+            var request = new HttpRequestMessage(HttpMethod.Post, uriBuilder.Uri);
+            request.Headers.Add("Accept", "application/json");
+            var response = await tester.PayTester.HttpClient.SendAsync(request);
+            var content = await response.Content.ReadAsStringAsync();
+            var json = JObject.Parse(content);
+            return (json["invoiceId"]?.Value<string>(), json["error"]?.Value<string>());
         }
     }
 }

--- a/BTCPayServer/Plugins/PointOfSale/Controllers/UIPointOfSaleController.cs
+++ b/BTCPayServer/Plugins/PointOfSale/Controllers/UIPointOfSaleController.cs
@@ -262,8 +262,10 @@ namespace BTCPayServer.Plugins.PointOfSale.Controllers
             var store = await _appService.GetStore(app);
             var storeBlob = store.GetStoreBlob();
             var posFormId = settings.FormId;
-            var formData = await FormDataService.GetForm(posFormId);
-
+            
+            // skip forms feature for JSON requests (from the app)
+            var wantsJson = Request.Headers.Accept.FirstOrDefault()?.StartsWith("application/json") is true;
+            var formData = wantsJson ? null : await FormDataService.GetForm(posFormId);
             JObject formResponseJObject = null;
             switch (formData)
             {
@@ -411,14 +413,16 @@ namespace BTCPayServer.Plugins.PointOfSale.Controllers
                         meta.Merge(formResponseJObject);
                         entity.Metadata = InvoiceMetadata.FromJObject(meta);
                     });
+                var data = new { invoiceId = invoice.Id };
+                if (wantsJson)
+                    return Json(data);
                 if (price is 0 && storeBlob.ReceiptOptions?.Enabled is true)
-                {
-                    return RedirectToAction(nameof(UIInvoiceController.InvoiceReceipt), "UIInvoice", new { invoiceId = invoice.Id });
-                }
-                return RedirectToAction(nameof(UIInvoiceController.Checkout), "UIInvoice", new { invoiceId = invoice.Id });
+                    return RedirectToAction(nameof(UIInvoiceController.InvoiceReceipt), "UIInvoice", data);
+                return RedirectToAction(nameof(UIInvoiceController.Checkout), "UIInvoice", data);
             }
             catch (BitpayHttpException e)
             {
+                if (wantsJson) return Json(new { error = e.Message });
                 TempData.SetStatusMessageModel(new StatusMessageModel
                 {
                     Html = e.Message.Replace("\n", "<br />", StringComparison.OrdinalIgnoreCase),


### PR DESCRIPTION
We adapted this action, which is full of custom POS logic, for the app to avoid creating a separate API endpoint.