### PR TITLE
feat: call all checkout model extensions

### DIFF
--- a/BTCPayServer/Controllers/UIInvoiceController.UI.cs
+++ b/BTCPayServer/Controllers/UIInvoiceController.UI.cs
@@ -936,11 +936,16 @@ namespace BTCPayServer.Controllers
             var expiration = TimeSpan.FromSeconds(model.ExpirationSeconds);
             model.TimeLeft = expiration.PrettyPrint();
 
-            if (_paymentModelExtensions.TryGetValue(paymentMethodId, out var extension) &&
-                    _handlers.TryGetValue(paymentMethodId, out var h))
+            // make sure that the selected payment method gets to make the last modifications
+            foreach (var method in model.AvailablePaymentMethods.OrderBy(a => a.PaymentMethodId == paymentMethodId ? 1 : 0))
             {
-                extension.ModifyCheckoutModel(new CheckoutModelContext(model, store, storeBlob, invoice, Url, prompt, h));
+                if (_paymentModelExtensions.TryGetValue(method.PaymentMethodId, out var extension) &&
+                        _handlers.TryGetValue(paymentMethodId, out var h))
+                {
+                    extension.ModifyCheckoutModel(new CheckoutModelContext(model, store, storeBlob, invoice, Url, prompt, h));
+                }
             }
+
             return model;
         }
 


### PR DESCRIPTION
The boltz plugin will offer a new onchain payment method which simply swaps the funds to lightning.
It should be able to work in parallel with the native onchain payment method, allowing it as a backup if boltz is offline / cant find routes to merchants ln node.

I've evaluated the following possibilities:

1. Keep the native on-chain method disabled on invoice creation and add it in code if any issues occur with the boltz method.
Hard to get such implementation working right.

2. Inject some JS through UI extensions into the fronted to hide the native method as long as the boltz method is displayed. While one could get that to work without any changes, its a pain to implement (messing with vue stuff in native js)

3. (this one)
Utilize the checkout model extension to modify the displayed payment methods. 
Problem: Right now, this only works when the boltz payment method is selected, since the `ModifyCheckoutModel` function is only called for the selected payment method.

So, this pr calls all checkout model extensions.
This should be safe for all existing implementations since they all either check the prompt details or handler type and simply return if it doesn't match their expectation.
However, there might be some plugins not doing proper checks - so I made sure that the selected payment method is always the last one modifying the checkout model.

Here's an example of how this can be used in practice:
https://github.com/BoltzExchange/boltz-btcpay-plugin/blob/boltz-payment-handlers/BTCPayServer.Plugins.Boltz/Payments/BoltzPaymentExtension.cs#L15-L28