### PR TITLE
Do not use razor runtime compilation when views have been compiled on build

### DIFF
--- a/BTCPayServer.Tests/BTCPayServer.Tests.csproj
+++ b/BTCPayServer.Tests/BTCPayServer.Tests.csproj
@@ -41,6 +41,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="Newtonsoft.Json.Schema" Version="3.0.15" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="8.0.11" />
     <PackageReference Include="Selenium.Support" Version="4.1.1" />
     <PackageReference Include="Selenium.WebDriver" Version="4.22.0" />
 	<PackageReference Include="Selenium.WebDriver.ChromeDriver" Version="128.0.6613.11900" />

--- a/BTCPayServer/BTCPayServer.csproj
+++ b/BTCPayServer/BTCPayServer.csproj
@@ -8,6 +8,19 @@
     <RunAnalyzersDuringLiveAnalysis>False</RunAnalyzersDuringLiveAnalysis>
     <RunAnalyzersDuringBuild>False</RunAnalyzersDuringBuild>
   </PropertyGroup>
+   
+   <!-- Pre-compiling views should only be done for Release builds without dotnet watch or design time build .-->
+   <!-- Runtime compiling is only useful for debugging with hot reload of the views -->
+   <PropertyGroup Condition="'$(RazorCompileOnBuild)'=='' AND ('$(Configuration)' == 'Debug' OR '$(DotNetWatchBuild)' == 'true' OR '$(DesignTimeBuild)' == 'true')">
+     <RazorCompileOnBuild>false</RazorCompileOnBuild>
+   </PropertyGroup>
+   <PropertyGroup Condition="'$(RazorCompileOnBuild)'==''">
+     <RazorCompileOnBuild>true</RazorCompileOnBuild>
+   </PropertyGroup>
+   <PropertyGroup Condition="'$(RazorCompileOnBuild)' == 'true'">
+     <DefineConstants>$(DefineConstants);RAZOR_COMPILE_ON_BUILD</DefineConstants>
+   </PropertyGroup>
+
    <ItemGroup>
      <AssemblyAttribute Condition="'$(GitCommit)' != ''" Include="BTCPayServer.GitCommitAttribute">
        <_Parameter1>$(GitCommit)</_Parameter1>
@@ -68,7 +81,7 @@
     <PackageReference Include="TwentyTwenty.Storage.Azure" Version="2.12.1" />
     <PackageReference Include="TwentyTwenty.Storage.Google" Version="2.12.1" />
     <PackageReference Include="TwentyTwenty.Storage.Local" Version="2.12.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="8.0.11" />
+    <PackageReference Condition="'$(RazorCompileOnBuild)' == 'false'" Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="8.0.11" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.11" />
   </ItemGroup>
 

--- a/BTCPayServer/Hosting/Startup.cs
+++ b/BTCPayServer/Hosting/Startup.cs
@@ -141,7 +141,7 @@ namespace BTCPayServer.Hosting
             services.AddSingleton<UserLoginCodeService>();
             services.AddSingleton<LnurlAuthService>();
             services.AddSingleton<LightningAddressService>();
-            services.AddMvc(o =>
+            var mvcBuilder = services.AddMvc(o =>
              {
                  o.Filters.Add(new XFrameOptionsAttribute(XFrameOptionsAttribute.XFrameOptions.Deny));
                  o.Filters.Add(new XContentTypeOptionsAttribute("nosniff"));
@@ -167,10 +167,13 @@ namespace BTCPayServer.Hosting
                 o.PageViewLocationFormats.Add("/{0}.cshtml");
             })
             .AddNewtonsoftJson()
-            .AddRazorRuntimeCompilation()
             .AddPlugins(services, Configuration, LoggerFactory, bootstrapServiceProvider)
             .AddDataAnnotationsLocalization()
             .AddControllersAsServices();
+
+#if !RAZOR_COMPILE_ON_BUILD
+            mvcBuilder.AddRazorRuntimeCompilation();
+#endif
 
             services.AddServerSideBlazor();
 

--- a/Build/Common.csproj
+++ b/Build/Common.csproj
@@ -12,8 +12,4 @@
     <Configurations>Debug;Release</Configurations>
     <Platforms>AnyCPU</Platforms>
   </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)' == 'Debug' And '$(RazorCompileOnBuild)' != 'true' And '$(DotNetWatchBuild)' != 'true' And '$(DesignTimeBuild)' != 'true'">
-    <RazorCompileOnBuild>false</RazorCompileOnBuild>
-  </PropertyGroup>
 </Project>


### PR DESCRIPTION
If we use `AddRazorRuntimeCompilation`, then navigating to a view will trigger runtime compilation even if the views have been already pre-compiled on build.

This means that the tests are slower, because all the views get rebuild a test run, resulting in memory leaks between tests which eventually crash the VM from 8.0.4.