### PR TITLE
fix: truncate center css for icons

### DIFF
--- a/BTCPayServer/wwwroot/main/site.css
+++ b/BTCPayServer/wwwroot/main/site.css
@@ -1073,7 +1073,7 @@ input.ts-wrapper.form-control:not(.ts-hidden-accessible,.ts-inline) {
     padding-right: 3px;
 }
 
-.truncate-center.form-control-plaintext button.btn .icon {
+.truncate-center.form-control-plaintext .icon {
     --icon-size: 1.25em;
 }
 


### PR DESCRIPTION
currently, the info icon used for displaying a link is way too big since its not matched by the current css.

before:
![image](https://github.com/user-attachments/assets/60a9b7c8-5b53-40b6-8c8a-09470dc16e14)

now:
![image](https://github.com/user-attachments/assets/82a1c7f7-ad9f-453b-bd76-c61054c0618a)

