### PR TITLE
Plugins: Add a way for LightningClient to be more customizable (Fix #6467)

### DIFF
--- a/BTCPayServer/Payments/Lightning/IExtendedLightningClient.cs
+++ b/BTCPayServer/Payments/Lightning/IExtendedLightningClient.cs
@@ -1,0 +1,25 @@
+#nullable enable
+using System;
+using System.ComponentModel.DataAnnotations;
+using System.Threading.Tasks;
+using BTCPayServer.Lightning;
+
+namespace BTCPayServer.Payments.Lightning
+{
+    public interface IExtendedLightningClient : ILightningClient
+    {
+        /// <summary>
+        /// Used to validate the client configuration
+        /// </summary>
+        /// <returns></returns>
+        public Task<ValidationResult> Validate();
+        /// <summary>
+        /// The display name of this client (ie. LND (REST), Eclair, LNDhub)
+        /// </summary>
+        public string? DisplayName { get; }
+        /// <summary>
+        /// The server URI of this client (ie. http://localhost:8080)
+        /// </summary>
+        public Uri? ServerUri { get; }
+    }
+}

--- a/BTCPayServer/Payments/Lightning/LightningListener.cs
+++ b/BTCPayServer/Payments/Lightning/LightningListener.cs
@@ -500,27 +500,20 @@ retry:
         public CancellationTokenSource? StopListeningCancellationTokenSource;
         async Task Listen(CancellationToken cancellation)
         {
-            Uri? uri = null;
-            string? logUrl = null;
+            string? uri = null;
             try
             {
                 var lightningClient = _lightningClientFactory.Create(ConnectionString, _network);
                 if(lightningClient is null)
                     return;
-                uri = lightningClient.GetServerUri();
-                logUrl = uri switch
-                {
-                    null when LightningConnectionStringHelper.ExtractValues(ConnectionString, out var type) is not null => type,
-                    null => string.Empty,
-                    _ => string.IsNullOrEmpty(uri.UserInfo) ? uri.ToString() : uri.ToString().Replace(uri.UserInfo, "***")
-                };
-                Logs.PayServer.LogInformation("{CryptoCode} (Lightning): Start listening {Uri}", _network.CryptoCode, logUrl);
+                uri = lightningClient.GetServerUri(ConnectionString)?.RemoveUserInfo() ?? "";
+                Logs.PayServer.LogInformation("{CryptoCode} (Lightning): Start listening {Uri}", _network.CryptoCode, uri);
                 using var session = await lightningClient.Listen(cancellation);
                 // Just in case the payment arrived after our last poll but before we listened.
                 await PollAllListenedInvoices(cancellation);
                 if (_ErrorAlreadyLogged)
                 {
-                    Logs.PayServer.LogInformation("{CryptoCode} (Lightning): Could reconnect successfully to {Uri}", _network.CryptoCode, logUrl);
+                    Logs.PayServer.LogInformation("{CryptoCode} (Lightning): Could reconnect successfully to {Uri}", _network.CryptoCode, uri);
                 }
                 _ErrorAlreadyLogged = false;
                 while (!_ListenedInvoices.IsEmpty)
@@ -552,12 +545,12 @@ retry:
             catch (Exception ex) when (!cancellation.IsCancellationRequested && !_ErrorAlreadyLogged)
             {
                 _ErrorAlreadyLogged = true;
-                Logs.PayServer.LogError(ex, "{CryptoCode} (Lightning): Error while contacting {Uri}", _network.CryptoCode, logUrl);
-                Logs.PayServer.LogInformation("{CryptoCode} (Lightning): Stop listening {Uri}", _network.CryptoCode, logUrl);
+                Logs.PayServer.LogError(ex, "{CryptoCode} (Lightning): Error while contacting {Uri}", _network.CryptoCode, uri);
+                Logs.PayServer.LogInformation("{CryptoCode} (Lightning): Stop listening {Uri}", _network.CryptoCode, uri);
             }
             catch (OperationCanceledException) when (cancellation.IsCancellationRequested) { }
             if (_ListenedInvoices.IsEmpty)
-                Logs.PayServer.LogInformation("{CryptoCode} (Lightning): No more invoice to listen on {Uri}, releasing the connection", _network.CryptoCode, logUrl);
+                Logs.PayServer.LogInformation("{CryptoCode} (Lightning): No more invoice to listen on {Uri}, releasing the connection", _network.CryptoCode, uri);
         }
 
         private uint256? GetPaymentHash(ListenedInvoice listenedInvoice)

--- a/BTCPayServer/Views/UIStores/Lightning.cshtml
+++ b/BTCPayServer/Views/UIStores/Lightning.cshtml
@@ -19,8 +19,8 @@
                 @try
                 {
                     var client = LightningClientFactoryService.Create(Model.ConnectionString, NetworkProvider.GetNetwork<BTCPayNetwork>(Model.CryptoCode));
-                    <span>@client.GetDisplayName()</span>
-                    var uri = client.GetServerUri();
+					<span>@client.GetDisplayName(Model.ConnectionString)</span>
+					var uri = client.GetServerUri(Model.ConnectionString);
                     if (uri is not null)
                     {
                         <span>(@uri.Host)</span>

--- a/BTCPayServer/Views/UIStores/LightningSettings.cshtml
+++ b/BTCPayServer/Views/UIStores/LightningSettings.cshtml
@@ -23,8 +23,8 @@
                             @try
                             {
                                 var client = LightningClientFactoryService.Create(Model.ConnectionString, NetworkProvider.GetNetwork<BTCPayNetwork>(Model.CryptoCode));
-                                <span>@client.GetDisplayName()</span>
-                                var uri = client.GetServerUri();
+								<span>@client.GetDisplayName(Model.ConnectionString)</span>
+								var uri = client.GetServerUri(Model.ConnectionString);
                                 if (uri is not null)
                                 {
                                     <span>(@uri.Host)</span>


### PR DESCRIPTION
## Problem

I have seen several plugins (@Kukks  with NwC and @rockstardev with Strike I believe), with network calls in `ILightningClientFactory.Create`.

This is really bad, because:
1. This method is called often.
2. Using synchronous calls over asynchronous call means that if there is too many concurrent calls, we will end up in an undebuggable deadlock.



## Solution

This PR adds a new interface `IExtendedLightningClient`, which plugin can override instead of `ILightningClient`.
It has two properties `DisplayName` and `ServerUri`, which allows the plugin to decide what to show as ServerUri or DisplayName in the UI. Both properties being optional.

On top of this, I added an async `Validate` which returns a `ValidationResult`.
This method can be used for the plugin to validate a connection string that has been passed by the user, and output human readable error message.

## Additional fix

This PR also fix https://github.com/btcpayserver/btcpayserver/issues/6467. It doesn't call the `ExtractValues` from the lightning library, and instead called the one from BTCPayServer which doesn't through any exception.

Ping @jackstar12, I don't know but this may also be useful for Boltz.

