### PR TITLE
Plugin: Add IGlobalCheckoutModelExtension

### DIFF
--- a/BTCPayServer/Controllers/UIInvoiceController.UI.cs
+++ b/BTCPayServer/Controllers/UIInvoiceController.UI.cs
@@ -936,10 +936,15 @@ namespace BTCPayServer.Controllers
             var expiration = TimeSpan.FromSeconds(model.ExpirationSeconds);
             model.TimeLeft = expiration.PrettyPrint();
 
-            if (_paymentModelExtensions.TryGetValue(paymentMethodId, out var extension) &&
-                    _handlers.TryGetValue(paymentMethodId, out var h))
+            if (_handlers.TryGetValue(paymentMethodId, out var h))
             {
-                extension.ModifyCheckoutModel(new CheckoutModelContext(model, store, storeBlob, invoice, Url, prompt, h));
+                var ctx = new CheckoutModelContext(model, store, storeBlob, invoice, Url, prompt, h);
+                if (_paymentModelExtensions.TryGetValue(paymentMethodId, out var extension))
+                {
+                    extension.ModifyCheckoutModel(ctx);
+                }
+                foreach (var global in GlobalCheckoutModelExtensions)
+                    global.ModifyCheckoutModel(ctx);
             }
             return model;
         }

--- a/BTCPayServer/Controllers/UIInvoiceController.cs
+++ b/BTCPayServer/Controllers/UIInvoiceController.cs
@@ -69,6 +69,7 @@ namespace BTCPayServer.Controllers
         private readonly UriResolver _uriResolver;
 
         public WebhookSender WebhookNotificationManager { get; }
+        public IEnumerable<IGlobalCheckoutModelExtension> GlobalCheckoutModelExtensions { get; }
         public IStringLocalizer StringLocalizer { get; }
 
         public UIInvoiceController(
@@ -99,6 +100,7 @@ namespace BTCPayServer.Controllers
             IAuthorizationService authorizationService,
             TransactionLinkProviders transactionLinkProviders,
             Dictionary<PaymentMethodId, ICheckoutModelExtension> paymentModelExtensions,
+            IEnumerable<IGlobalCheckoutModelExtension> globalCheckoutModelExtensions,
             IStringLocalizer stringLocalizer,
             PrettyNameProvider prettyName)
         {
@@ -124,6 +126,7 @@ namespace BTCPayServer.Controllers
             _authorizationService = authorizationService;
             _transactionLinkProviders = transactionLinkProviders;
             _paymentModelExtensions = paymentModelExtensions;
+            GlobalCheckoutModelExtensions = globalCheckoutModelExtensions;
             _prettyName = prettyName;
             _fileService = fileService;
             _uriResolver = uriResolver;

--- a/BTCPayServer/Payments/IGlobalCheckoutModelExtension.cs
+++ b/BTCPayServer/Payments/IGlobalCheckoutModelExtension.cs
@@ -1,0 +1,10 @@
+namespace BTCPayServer.Payments
+{
+    /// <summary>
+    /// <see cref="ModifyCheckoutModel"/> will always run when showing the checkout page
+    /// </summary>
+    public interface IGlobalCheckoutModelExtension
+    {
+        void ModifyCheckoutModel(CheckoutModelContext context);
+    }
+}


### PR DESCRIPTION
Some plugins need to modify the checkout page irrespective with the payment method selection.

See @jackstar12 PR on https://github.com/btcpayserver/btcpayserver/pull/6455.

This PR allows the injection of `IGlobalCheckoutModelExtension` by plugin to this effect.