### PR TITLE
POS: Fix throttling for unauthenticated users

### DIFF
--- a/BTCPayServer.Tests/SeleniumTests.cs
+++ b/BTCPayServer.Tests/SeleniumTests.cs
@@ -2903,6 +2903,16 @@ namespace BTCPayServer.Tests
             // Unauthenticated user can't access recent transactions
             s.GoToUrl(keypadUrl);
             s.Driver.ElementDoesNotExist(By.Id("RecentTransactionsToggle"));
+            
+            // But they can generate invoices
+            s.Driver.FindElement(By.CssSelector(".keypad [data-key='1']")).Click();
+            s.Driver.FindElement(By.CssSelector(".keypad [data-key='2']")).Click();
+            s.Driver.FindElement(By.CssSelector(".keypad [data-key='3']")).Click();
+            s.Driver.FindElement(By.Id("pay-button")).Click();
+            s.Driver.WaitUntilAvailable(By.Id("Checkout"));
+            s.Driver.FindElement(By.Id("DetailsToggle")).Click();
+            s.Driver.WaitForElement(By.Id("PaymentDetails-TotalFiat"));
+            Assert.Contains("1,23 €", s.Driver.FindElement(By.Id("PaymentDetails-TotalFiat")).Text);
         }
 
         [Fact]

--- a/BTCPayServer/Plugins/PointOfSale/Controllers/UIPointOfSaleController.cs
+++ b/BTCPayServer/Plugins/PointOfSale/Controllers/UIPointOfSaleController.cs
@@ -430,9 +430,9 @@ namespace BTCPayServer.Plugins.PointOfSale.Controllers
         }
 
         private async Task<bool> Throttle(string appId) =>
-            HttpContext.Connection is { RemoteIpAddress: { } addr }  &&
-            await _rateLimitService.Throttle(ZoneLimits.PublicInvoices, addr.ToString(), HttpContext.RequestAborted) &&
-            !(await _authorizationService.AuthorizeAsync(HttpContext.User, appId, Policies.CanViewInvoices)).Succeeded;
+            !(await _authorizationService.AuthorizeAsync(HttpContext.User, appId, Policies.CanViewInvoices)).Succeeded &&
+            HttpContext.Connection is { RemoteIpAddress: { } addr } &&
+            !await _rateLimitService.Throttle(ZoneLimits.PublicInvoices, addr.ToString(), HttpContext.RequestAborted);
 
         private JObject TryParseJObject(string posData)
         {


### PR DESCRIPTION
Fixes a regression introduced with d24adda70084f0f807d2a98d204b16b509ae2397: The negation for the `_rateLimitService.Throttle` result was removed with that commit, which lead to all unauthenticated request getting throttled. (It was correctly implemented in #6415.

Fixes btcpayserver/app#131.