### PR TITLE
Dashboard: Fix missing data in Lightning Balance component

### DIFF
--- a/BTCPayServer/Components/StoreLightningBalance/Default.cshtml
+++ b/BTCPayServer/Components/StoreLightningBalance/Default.cshtml
@@ -152,13 +152,10 @@
                 </div>
             }
         </div>
-        @if (Model.Series != null)
-        {
-            <div class="ct-chart"></div>
-            <template>
-                @Safe.Json(Model)
-            </template>
-        }
+        <div class="ct-chart"></div>
+        <template>
+            @Safe.Json(Model)
+        </template>
     }
     else
     {

--- a/BTCPayServer/Views/UIStores/Dashboard.cshtml
+++ b/BTCPayServer/Views/UIStores/Dashboard.cshtml
@@ -41,11 +41,15 @@
             async fetchRate(currencyPair) {
                 const storeId = @Safe.Json(Context.GetRouteValue("storeId"));
                 const pathBase = @Safe.Json(Context.Request.PathBase);
-                const response = await fetch(`${pathBase}/api/rates?storeId=${storeId}&currencyPairs=${currencyPair}`);
-                const json = await response.json();
-                const rate = json[0] && json[0].rate;
-                if (rate) return rate;
-                else console.warn(`Fetching rate for ${currencyPair} failed.`);
+                try {
+                    const response = await fetch(`${pathBase}/api/rates?storeId=${storeId}&currencyPairs=${currencyPair}`);
+                    const json = await response.json();
+                    const rate = json[0] && json[0].rate;
+                    if (rate) return rate;
+                    else console.warn(`Fetching rate for ${currencyPair} failed.`);
+                } catch (e) {
+                    console.error(`Fetching rate for ${currencyPair} failed: ${e}`);
+                }
             }
         };
     </script>


### PR DESCRIPTION
I wasn't able to reproduce the problem, but this most likely fixes #6480 and #6458.

If there's no series data, the `template` (containing the other relevant data as well) wasn't present. This is now fixed so that later rquests can also show and update the graph. Also added proper error handling for the rate fetch request.