### PR TITLE
Display Lightning amounts in BTC, sats and fiat / Plan B Assigment

### DIFF
--- a/BTCPayServer.Client/Models/StoreBaseData.cs
+++ b/BTCPayServer.Client/Models/StoreBaseData.cs
@@ -38,6 +38,10 @@ namespace BTCPayServer.Client.Models
 
         [JsonConverter(typeof(StringEnumConverter))]
         public SpeedPolicy SpeedPolicy { get; set; }
+
+        [JsonConverter(typeof(StringEnumConverter))]
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public LightningCurrencyDisplayMode LightningCurrencyDisplayMode { get; set; } = LightningCurrencyDisplayMode.BTC;
         public string LightningDescriptionTemplate { get; set; }
         public double PaymentTolerance { get; set; } = 0;
         public bool AnyoneCanCreateInvoice { get; set; }
@@ -104,5 +108,12 @@ namespace BTCPayServer.Client.Models
         MediumSpeed = 1,
         LowSpeed = 2,
         LowMediumSpeed = 3
+    }
+
+    public enum LightningCurrencyDisplayMode
+    {
+        BTC,
+        Satoshis,
+        Fiat
     }
 }

--- a/BTCPayServer/Controllers/UIStoresController.Settings.cs
+++ b/BTCPayServer/Controllers/UIStoresController.Settings.cs
@@ -239,6 +239,7 @@ public partial class UIStoresController
         vm.ShowPayInWalletButton = storeBlob.ShowPayInWalletButton;
         vm.ShowStoreHeader = storeBlob.ShowStoreHeader;
         vm.LightningAmountInSatoshi = storeBlob.LightningAmountInSatoshi;
+        vm.LightningCurrencyDisplayMode = storeBlob.LightningCurrencyDisplayMode;
         vm.LazyPaymentMethods = storeBlob.LazyPaymentMethods;
         vm.RedirectAutomatically = storeBlob.RedirectAutomatically;
         vm.PaymentSoundUrl = storeBlob.PaymentSoundUrl is null
@@ -373,6 +374,7 @@ public partial class UIStoresController
         blob.PlaySoundOnPayment = model.PlaySoundOnPayment;
         blob.OnChainWithLnInvoiceFallback = model.OnChainWithLnInvoiceFallback;
         blob.LightningAmountInSatoshi = model.LightningAmountInSatoshi;
+        blob.LightningCurrencyDisplayMode = model.LightningCurrencyDisplayMode;
         blob.LazyPaymentMethods = model.LazyPaymentMethods;
         blob.RedirectAutomatically = model.RedirectAutomatically;
         blob.ReceiptOptions = model.ReceiptOptions.ToDTO();

--- a/BTCPayServer/Data/StoreBlob.cs
+++ b/BTCPayServer/Data/StoreBlob.cs
@@ -37,6 +37,8 @@ namespace BTCPayServer.Data
         [JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
         public NetworkFeeMode NetworkFeeMode { get; set; }
 
+        [JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
+        public LightningCurrencyDisplayMode LightningCurrencyDisplayMode { get; set; }
         public bool LightningAmountInSatoshi { get; set; }
         public bool LightningPrivateRouteHints { get; set; }
         public bool OnChainWithLnInvoiceFallback { get; set; }

--- a/BTCPayServer/Models/StoreViewModels/CheckoutAppearanceViewModel.cs
+++ b/BTCPayServer/Models/StoreViewModels/CheckoutAppearanceViewModel.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
+using BTCPayServer.Client.Models;
 using BTCPayServer.Services;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.Rendering;
@@ -56,6 +57,9 @@ namespace BTCPayServer.Models.StoreViewModels
 
         [Display(Name = "Default language on checkout")]
         public string DefaultLang { get; set; }
+
+        [Display(Name = "Display Lightning payment amounts in:")]
+        public LightningCurrencyDisplayMode LightningCurrencyDisplayMode { get; set; }
 
         [Display(Name = "Custom sound file for successful payment")]
         public IFormFile SoundFile { get; set; }

--- a/BTCPayServer/Payments/Bitcoin/BitcoinCheckoutModelExtension.cs
+++ b/BTCPayServer/Payments/Bitcoin/BitcoinCheckoutModelExtension.cs
@@ -126,7 +126,7 @@ namespace BTCPayServer.Payments.Bitcoin
                     StringComparison.OrdinalIgnoreCase);
                 // model.InvoiceBitcoinUrlQR: bitcoin:BCRT1QXP2QA5DHN...?amount=0.00044007&lightning=LNBCRT4400...
             }
-           
+
 
             if (amountInSats)
             {
@@ -149,6 +149,29 @@ namespace BTCPayServer.Payments.Bitcoin
                 ? null
                 : displayFormatter.Currency(rate / 100_000_000, model.InvoiceCurrency, DisplayFormatter.CurrencyFormat.Symbol);
         }
+        public static void PreparePaymentModelForAmountInFiat(CheckoutModel model, decimal rate, DisplayFormatter displayFormatter)
+        {
 
+            var fiatCulture = new CultureInfo(CultureInfo.InvariantCulture.Name)
+            {
+                NumberFormat = { NumberGroupSeparator = " " }
+            };
+
+            model.PaymentMethodCurrency = model.InvoiceCurrency;
+
+            var dueValue = (Money.Parse(model.Due).ToUnit(MoneyUnit.BTC) * rate);
+            var paidValue = (Money.Parse(model.Paid).ToUnit(MoneyUnit.BTC) * rate);
+            var orderAmountValue = (Money.Parse(model.OrderAmount).ToUnit(MoneyUnit.BTC) * rate);
+     
+            var dueFormatted =  dueValue.ToString("N", fiatCulture);
+            var paidFormatted = paidValue.ToString("N", fiatCulture);
+            var orderAmountFormatted = orderAmountValue.ToString("N", fiatCulture);
+        
+            model.Due = displayFormatter.Currency(dueValue, model.InvoiceCurrency, DisplayFormatter.CurrencyFormat.None);
+            model.Paid = displayFormatter.Currency(paidValue, model.InvoiceCurrency, DisplayFormatter.CurrencyFormat.None);
+            model.OrderAmount = displayFormatter.Currency(orderAmountValue, model.InvoiceCurrency, DisplayFormatter.CurrencyFormat.None);
+            model.Rate = displayFormatter.Currency(rate * 1, model.InvoiceCurrency, DisplayFormatter.CurrencyFormat.Code); 
+            
+        }
     }
 }

--- a/BTCPayServer/Payments/LNURLPay/LNURLCheckoutModelExtension.cs
+++ b/BTCPayServer/Payments/LNURLPay/LNURLCheckoutModelExtension.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Linq;
 using BTCPayServer.Payments.Lightning;
 using NBitcoin;
+using BTCPayServer.Client.Models;
 
 namespace BTCPayServer.Payments.LNURLPay
 {
@@ -48,9 +49,19 @@ namespace BTCPayServer.Payments.LNURLPay
             }
             context.Model.CheckoutBodyComponentName = LNCheckoutModelExtension.CheckoutBodyComponentName;
             context.Model.PeerInfo = handler.ParsePaymentPromptDetails(context.Prompt.Details).NodeInfo;
-            if (context.StoreBlob.LightningAmountInSatoshi && context.Model.PaymentMethodCurrency == "BTC")
+            if (context.Model.PaymentMethodCurrency == "BTC")
             {
-                BitcoinCheckoutModelExtension.PreparePaymentModelForAmountInSats(context.Model, context.Prompt.Rate, _displayFormatter);
+                switch (context.StoreBlob.LightningCurrencyDisplayMode)
+                {
+                    case LightningCurrencyDisplayMode.Satoshis:
+                        BitcoinCheckoutModelExtension.PreparePaymentModelForAmountInSats(context.Model, context.Prompt.Rate, _displayFormatter);
+                            break;
+                    case LightningCurrencyDisplayMode.BTC:
+                            break;
+                    case LightningCurrencyDisplayMode.Fiat:
+                        BitcoinCheckoutModelExtension.PreparePaymentModelForAmountInFiat(context.Model, context.Prompt.Rate, _displayFormatter);
+                            break;
+                }
             }
         }
     }

--- a/BTCPayServer/Payments/Lightning/LNCheckoutModelExtension.cs
+++ b/BTCPayServer/Payments/Lightning/LNCheckoutModelExtension.cs
@@ -7,6 +7,7 @@ using Org.BouncyCastle.Crypto.Modes.Gcm;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Extensions.Localization;
+using BTCPayServer.Client.Models;
 
 namespace BTCPayServer.Payments.Lightning
 {
@@ -51,10 +52,21 @@ namespace BTCPayServer.Payments.Lightning
             if (context.Model.InvoiceBitcoinUrl is not null)
                 context.Model.InvoiceBitcoinUrlQR = $"lightning:{context.Model.InvoiceBitcoinUrl.ToUpperInvariant()?.Substring("LIGHTNING:".Length)}";
             context.Model.PeerInfo = handler.ParsePaymentPromptDetails(paymentPrompt.Details).NodeInfo;
-            if (context.StoreBlob.LightningAmountInSatoshi && Network.IsBTC)
-            {
-                BitcoinCheckoutModelExtension.PreparePaymentModelForAmountInSats(context.Model, paymentPrompt.Rate, _displayFormatter);
-            }
+            if (Network.IsBTC && context.Model.InvoiceCurrency != "BTC")
+            {         
+                switch (context.StoreBlob.LightningCurrencyDisplayMode)
+                {
+                    case LightningCurrencyDisplayMode.Satoshis:
+                        BitcoinCheckoutModelExtension.PreparePaymentModelForAmountInSats(context.Model, context.Prompt.Rate, _displayFormatter);
+                            break;
+                    case LightningCurrencyDisplayMode.BTC:
+                            break;
+                    case LightningCurrencyDisplayMode.Fiat:
+                        BitcoinCheckoutModelExtension.PreparePaymentModelForAmountInFiat(context.Model, context.Prompt.Rate, _displayFormatter);
+                            break;
+                }
+           }
         }
     }
 }
+

--- a/BTCPayServer/Services/DisplayFormatter.cs
+++ b/BTCPayServer/Services/DisplayFormatter.cs
@@ -42,6 +42,9 @@ public class DisplayFormatter
             provider = (NumberFormatInfo)provider.Clone();
             provider.CurrencyDecimalDigits = div;
         }
+        provider.CurrencyGroupSeparator = " ";
+        provider.NumberGroupSeparator = " ";
+
         var formatted = value.ToString("C", provider);
 
         // Ensure we are not using the symbol for BTC — we made that design choice consciously.

--- a/BTCPayServer/Views/UIInvoice/Checkout.cshtml
+++ b/BTCPayServer/Views/UIInvoice/Checkout.cshtml
@@ -60,7 +60,7 @@
                     }
                     else
                     {
-                        <h2 id="AmountDue" v-text="`${srvModel.due} ${srvModel.paymentMethodCurrency}`" :data-clipboard="asNumber(srvModel.due)" data-clipboard-hover :data-amount-due="srvModel.due">@Model.Due @Model.PaymentMethodCurrency</h2>
+						<h2 id="AmountDue" v-text="`${srvModel.due} ${srvModel.paymentMethodCurrency}`" :data-clipboard="asNumber(srvModel.due)" data-clipboard-hover :data-amount-due="srvModel.due">@Model.Due @Model.PaymentMethodCurrency</h2>
                     }
                 </div>
                 <div id="PaymentInfo" class="info mt-3 mb-2" v-collapsible="showInfo">
@@ -254,37 +254,38 @@
         <dl>
             <div v-if="orderAmount > 0" id="PaymentDetails-TotalPrice" key="TotalPrice">
                 <dt v-t="'total_price'"></dt>
-                <dd :data-clipboard="asNumber(srvModel.orderAmount)" data-clipboard-hover="start">{{srvModel.orderAmount}} {{ srvModel.paymentMethodCurrency }}</dd>
+				<dd :data-clipboard="asNumber(srvModel.orderAmount)" data-clipboard-hover="start">{{srvModel.orderAmount}} {{ srvModel.paymentMethodCurrency }}</dd>
             </div>
-            <div v-if="orderAmount > 0 && srvModel.orderAmountFiat" id="PaymentDetails-TotalFiat" key="TotalFiat">
-                <dt v-t="'total_fiat'"></dt>
-                <dd :data-clipboard="asNumber(srvModel.orderAmountFiat)" data-clipboard-hover="start">{{srvModel.orderAmountFiat}}</dd>
+			<div v-if="orderAmount > 0 && srvModel.orderAmountFiat && srvModel.paymentMethodCurrency === 'sats' || srvModel.paymentMethodCurrency === 'BTC'" id="PaymentDetails-TotalFiat" key="TotalFiat">               
+				<dt v-t="'total_fiat'"></dt>
+				<dd :data-clipboard="asNumber(srvModel.orderAmountFiat)" data-clipboard-hover="start">{{srvModel.orderAmountFiat}}</dd>
             </div>
             <div v-if="srvModel.rate && srvModel.paymentMethodCurrency" id="PaymentDetails-ExchangeRate" key="ExchangeRate">
                 <dt v-t="'exchange_rate'"></dt>
-                <dd :data-clipboard="asNumber(srvModel.rate)" data-clipboard-hover="start">
-                    <template v-if="srvModel.paymentMethodCurrency === 'sats'">1 sat = {{ srvModel.rate }}</template>
-                    <template v-else>1 {{ srvModel.paymentMethodCurrency }} = {{ srvModel.rate }}</template>
-                </dd>
+				<dd :data-clipboard="asNumber(srvModel.rate)" data-clipboard-hover="start">
+				<template v-if="srvModel.paymentMethodCurrency === 'sats'">1 sat = {{ srvModel.rate }}</template>
+				<template v-else-if="srvModel.paymentMethodCurrency === 'BTC'">1 {{ srvModel.paymentMethodCurrency }} = {{ srvModel.rate }}</template>
+				<template v-else>1 BTC = {{ srvModel.rate }}</template>
+				</dd>
             </div>
             <div v-if="srvModel.networkFee" id="PaymentDetails-NetworkCost" key="NetworkCost">
                 <dt v-t="'network_cost'"></dt>
-                <dd :data-clipboard="asNumber(srvModel.networkFee)" data-clipboard-hover="start">
+				<dd :data-clipboard="asNumber(srvModel.networkFee)" data-clipboard-hover="start">
                     <div v-if="srvModel.txCountForFee > 0" v-t="{ path: 'tx_count', args: { count: srvModel.txCount } }"></div>
                     <div v-text="`${srvModel.networkFee} ${srvModel.paymentMethodCurrency}`"></div>
                 </dd>
             </div>
             <div v-if="paid > 0" id="PaymentDetails-AmountPaid" key="AmountPaid">
                 <dt v-t="'amount_paid'"></dt>
-                <dd :data-clipboard="asNumber(srvModel.paid)" data-clipboard-hover="start" v-text="`${srvModel.paid} ${srvModel.paymentMethodCurrency}`"></dd>
+				<dd :data-clipboard="asNumber(srvModel.paid)" data-clipboard-hover="start" v-text="`${srvModel.paid} ${srvModel.paymentMethodCurrency}`"></dd>
             </div>
             <div v-if="due > 0" id="PaymentDetails-AmountDue" key="AmountDue">
                 <dt v-t="'amount_due'"></dt>
-                <dd :data-clipboard="asNumber(srvModel.due)" data-clipboard-hover="start" v-text="`${srvModel.due} ${srvModel.paymentMethodCurrency}`"></dd>
+				<dd :data-clipboard="asNumber(srvModel.due)" data-clipboard-hover="start" v-text="`${srvModel.due} ${srvModel.paymentMethodCurrency}`"></dd>
             </div>
             <div v-if="showRecommendedFee" id="PaymentDetails-RecommendedFee" key="RecommendedFee">
                 <dt v-t="'recommended_fee'"></dt>
-                <dd :data-clipboard="asNumber(srvModel.feeRate)" data-clipboard-hover="start" v-t="{ path: 'fee_rate', args: { feeRate: srvModel.feeRate } }"></dd>
+				<dd :data-clipboard="asNumber(srvModel.feeRate)" data-clipboard-hover="start" v-t="{ path: 'fee_rate', args: { feeRate: srvModel.feeRate } }"></dd>
             </div>
         </dl>
     </script>

--- a/BTCPayServer/Views/UIStores/CheckoutAppearance.cshtml
+++ b/BTCPayServer/Views/UIStores/CheckoutAppearance.cshtml
@@ -195,10 +195,6 @@
                     <vc:icon symbol="info" />
                 </a>
             </div>
-            <div class="d-flex my-3">
-                <input asp-for="LightningAmountInSatoshi" type="checkbox" class="btcpay-toggle me-3" />
-                <label asp-for="LightningAmountInSatoshi" class="form-check-label"></label>
-            </div>
             <div class="form-group d-flex align-items-center">
                 <input asp-for="AutoDetectLanguage" type="checkbox" class="btcpay-toggle me-3" />
                 <div>
@@ -210,6 +206,14 @@
                 <label asp-for="DefaultLang" class="form-label"></label>
                 <select asp-for="DefaultLang" asp-items="Model.Languages" class="form-select w-auto"></select>
             </div>
+			<div class="form-group">
+				<label asp-for="LightningCurrencyDisplayMode" class="form-label"></label>
+				<select asp-for="LightningCurrencyDisplayMode" class="form-select w-auto">
+					<option value="BTC" text-translate="true">BTC</option>
+					<option value="Satoshis" text-translate="true">Satoshis</option>
+					<option value="Fiat" text-translate="true">Fiat</option>
+				</select>
+			</div>
             <div class="form-group">
                 <label asp-for="HtmlTitle" class="form-label"></label>
                 <input asp-for="HtmlTitle" class="form-control" />

--- a/BTCPayServer/Views/UIStores/LightningSettings.cshtml
+++ b/BTCPayServer/Views/UIStores/LightningSettings.cshtml
@@ -60,10 +60,6 @@
                 <div class="text-start">
                     <h3 class="mt-5 mb-3" text-translate="true">Payment</h3>
                     <div class="form-check my-3">
-                        <input asp-for="LightningAmountInSatoshi" type="checkbox" class="form-check-input"/>
-                        <label asp-for="LightningAmountInSatoshi" class="form-check-label"></label>
-                    </div>
-                    <div class="form-check my-3">
                         <input asp-for="LightningPrivateRouteHints" type="checkbox" class="form-check-input"/>
                         <label asp-for="LightningPrivateRouteHints" class="form-check-label"></label>
                     </div>


### PR DESCRIPTION
Addressing issue #6205. Adds the option to choose whether lightning invoices will be displayed in BTC, sats or fiat currency (replacing the existing one for sats).

Things to review:
* Decide the format in which fiat currency should be displayed, using symbols broke the “show more details” function so I decided for the moment to leave all information in code format.
* I modified the DisplayFormatter function to standardize the separation between groups of digits because in some cases (in USD with the comma, for example) the clipboard only got the numbers up to the comma.

Thanks in advance for the feedback.