### PR TITLE
Greenfield: Remove authorization requirement for app data

### DIFF
--- a/BTCPayServer/Controllers/GreenField/GreenfieldAppsController.cs
+++ b/BTCPayServer/Controllers/GreenField/GreenfieldAppsController.cs
@@ -195,30 +195,17 @@ namespace BTCPayServer.Controllers.Greenfield
         }
 
         [HttpGet("~/api/v1/apps/pos/{appId}")]
-        [Authorize(Policy = Policies.CanModifyStoreSettings, AuthenticationSchemes = AuthenticationSchemes.Greenfield)]
         public async Task<IActionResult> GetPosApp(string appId)
         {
             var app = await _appService.GetApp(appId, PointOfSaleAppType.AppType, includeArchived: true);
-            if (app == null)
-            {
-                return AppNotFound();
-            }
-
-            return Ok(ToPointOfSaleModel(app));
+            return app == null ? AppNotFound() : Ok(ToPointOfSaleModel(app));
         }
 
         [HttpGet("~/api/v1/apps/crowdfund/{appId}")]
-        [Authorize(Policy = Policies.CanModifyStoreSettings, AuthenticationSchemes = AuthenticationSchemes.Greenfield)]
         public async Task<IActionResult> GetCrowdfundApp(string appId)
         {
             var app = await _appService.GetApp(appId, CrowdfundAppType.AppType, includeArchived: true);
-            if (app == null)
-            {
-                return AppNotFound();
-            }
-
-            var model = await ToCrowdfundModel(app);
-            return Ok(model);
+            return app == null ? AppNotFound() : Ok(await ToCrowdfundModel(app));
         }
 
         [HttpDelete("~/api/v1/apps/{appId}")]

--- a/BTCPayServer/wwwroot/swagger/v1/swagger.template.apps.json
+++ b/BTCPayServer/wwwroot/swagger/v1/swagger.template.apps.json
@@ -135,15 +135,7 @@
                     "404": {
                         "description": "POS app with specified ID was not found"
                     }
-                },
-                "security": [
-                    {
-                        "API_Key": [
-                            "btcpay.store.canmodifystoresettings"
-                        ],
-                        "Basic": []
-                    }
-                ]
+                }
             }
         },
         "/api/v1/apps/crowdfund/{appId}": {
@@ -174,15 +166,7 @@
                     "404": {
                         "description": "Crowdfund app with specified ID was not found"
                     }
-                },
-                "security": [
-                    {
-                        "API_Key": [
-                            "btcpay.store.canmodifystoresettings"
-                        ],
-                        "Basic": []
-                    }
-                ]
+                }
             }
         },
         "/api/v1/stores/{storeId}/apps/crowdfund": {


### PR DESCRIPTION
As discussed with @NicolasDorier on Mattermost: Right now only store owners can access the app data, which doesn't contain sensitive info or something beyond what one would see as a regular customer. The app would need a way to access the data for roles other than `Owner` as well, e.g. `Employee`.