### PR TITLE
Improve wording for setting up NBXplorer connection string

### DIFF
--- a/BTCPayServer/Components/StoreWalletBalance/Default.cshtml
+++ b/BTCPayServer/Components/StoreWalletBalance/Default.cshtml
@@ -48,9 +48,7 @@
     else
     {
         <p>
-            We would like to show you a chart of your balance.
-            Please <a href="https://github.com/dgarage/NBXplorer/blob/master/docs/Postgres-Migration.md" target="_blank" rel="noreferrer noopener">migrate to the new NBXplorer backend</a>
-            for that data to become available.
+			We would like to show you a chart of your balance. Please set <a href="https://docs.btcpayserver.org/Deployment/ManualDeploymentExtended/#3-create-a-configuration-file" target="_blank" rel="noreferrer noopener">NBXPlorer's PostgreSQL connection string</a> to make this data available.
         </p>
     }
     <script>


### PR DESCRIPTION
I also updated the link to point to the configuration settings of BTCPay Server.
The link will now point to [this doc section](https://docs.btcpayserver.org/Deployment/ManualDeploymentExtended/#3-create-a-configuration-file), which will be updated in https://github.com/btcpayserver/btcpayserver-doc/pull/1471

Before:

![image](https://github.com/user-attachments/assets/2af94e67-7f07-4028-aacb-d4d02f00298e)

After:

![image](https://github.com/user-attachments/assets/0181a2b3-d8db-4e32-b30d-60dccf0cec55)


Related to https://github.com/btcpayserver/btcpayserver-doc/pull/1471 and https://github.com/dgarage/NBXplorer/issues/500