### PR TITLE
Checkout: Add support link to footer

### DIFF
--- a/BTCPayServer.Tests/CheckoutUITests.cs
+++ b/BTCPayServer.Tests/CheckoutUITests.cs
@@ -65,6 +65,11 @@ namespace BTCPayServer.Tests
             Assert.Equal($"bitcoin:{address}", clipboard);
             Assert.Equal($"bitcoin:{address.ToUpperInvariant()}", qrValue);
             s.Driver.ElementDoesNotExist(By.Id("Lightning_BTC-CHAIN"));
+            
+            // Contact option
+            var contactLink = s.Driver.FindElement(By.Id("ContactLink"));
+            Assert.Equal("Contact us", contactLink.Text);
+            Assert.Matches(supportUrl.Replace("{InvoiceId}", invoiceId), contactLink.GetAttribute("href"));
 
             // Details should show exchange rate
             s.Driver.ToggleCollapse("PaymentDetails");
@@ -138,7 +143,6 @@ namespace BTCPayServer.Tests
                 Assert.Contains("resubmit a payment", expiredSection.Text);
                 Assert.DoesNotContain("This invoice expired with partial payment", expiredSection.Text);
             });
-            Assert.True(s.Driver.ElementDoesNotExist(By.Id("ContactLink")));
             Assert.True(s.Driver.ElementDoesNotExist(By.Id("ReceiptLink")));
             Assert.Equal(storeUrl, s.Driver.FindElement(By.Id("StoreLink")).GetAttribute("href"));
 
@@ -172,9 +176,6 @@ namespace BTCPayServer.Tests
                 Assert.Contains("This invoice expired with partial payment", expiredSection.Text);
                 Assert.DoesNotContain("resubmit a payment", expiredSection.Text);
             });
-            var contactLink = s.Driver.FindElement(By.Id("ContactLink"));
-            Assert.Equal("Contact us", contactLink.Text);
-            Assert.Matches(supportUrl.Replace("{InvoiceId}", invoiceId), contactLink.GetAttribute("href"));
             Assert.True(s.Driver.ElementDoesNotExist(By.Id("ReceiptLink")));
             Assert.Equal(storeUrl, s.Driver.FindElement(By.Id("StoreLink")).GetAttribute("href"));
 
@@ -243,7 +244,6 @@ namespace BTCPayServer.Tests
             });
             s.Driver.FindElement(By.Id("confetti"));
             s.Driver.FindElement(By.Id("ReceiptLink"));
-            Assert.True(s.Driver.ElementDoesNotExist(By.Id("ContactLink")));
             Assert.Equal(storeUrl, s.Driver.FindElement(By.Id("StoreLink")).GetAttribute("href"));
 
             // BIP21

--- a/BTCPayServer/Views/UIInvoice/Checkout.cshtml
+++ b/BTCPayServer/Views/UIInvoice/Checkout.cshtml
@@ -222,7 +222,6 @@
                         <p class="text-center mt-3" v-html="replaceNewlines($t(isPaidPartial ? 'invoice_paidpartial_body' : 'invoice_expired_body', { storeName: srvModel.storeName, minutes: srvModel.maxTimeMinutes }))"></p>
                     </div>
                     <div class="buttons" v-if="(isPaidPartial && srvModel.storeSupportUrl) || storeLink || isModal">
-                        <a v-if="isPaidPartial && srvModel.storeSupportUrl" class="btn btn-primary rounded-pill w-100" :href="srvModel.storeSupportUrl" v-t="'contact_us'" id="ContactLink"></a>
                         <a v-if="storeLink" class="btn btn-primary rounded-pill w-100" :href="storeLink" :target="isModal ? '_top' : null" v-html="$t('return_to_store', { storeName: srvModel.storeName })" id="StoreLink"></a>
                         <button v-else-if="isModal" class="btn btn-primary rounded-pill w-100" v-on:click="close" v-t="'Close'"></button>
                     </div>
@@ -234,6 +233,7 @@
             <checkout-cheating invoice-id="@Model.InvoiceId" :due="due" :is-settled="isSettled" :is-processing="isProcessing" :payment-method-id="pmId" :crypto-code="srvModel.paymentMethodCurrency"></checkout-cheating>
         }
         <footer class="store-footer">
+            <a v-if="srvModel.storeSupportUrl" class="mb-4" :href="srvModel.storeSupportUrl" v-t="'contact_us'" id="ContactLink"></a>
             <a class="store-powered-by" href="https://btcpayserver.org" target="_blank" rel="noreferrer noopener">
                 {{$t("powered_by")}} <partial name="_StoreFooterLogo" />
             </a>

--- a/BTCPayServer/Views/UIStores/CheckoutAppearance.cshtml
+++ b/BTCPayServer/Views/UIStores/CheckoutAppearance.cshtml
@@ -219,7 +219,7 @@
                 <label asp-for="SupportUrl" class="form-label"></label>
                 <input asp-for="SupportUrl" class="form-control" />
                 <span asp-validation-for="SupportUrl" class="text-danger"></span>
-                <div class="form-text" html-translate="true">For support requests related to partially paid invoices. A "Contact Us" button with this link will be shown on the invoice expired page. Can contain the placeholders <code>{OrderId}</code> and <code>{InvoiceId}</code>. Can be any valid URI, such as a website, email, and Nostr.</div>
+                <div class="form-text" html-translate="true">A "Contact Us" button with this link will be shown on the checkout page. Can contain the placeholders <code>{OrderId}</code> and <code>{InvoiceId}</code>. Can be any valid URI, such as a website, email, and Nostr.</div>
             </div>
             <div class="d-flex my-3">
                 <input asp-for="LazyPaymentMethods" type="checkbox" class="btcpay-toggle me-3" />


### PR DESCRIPTION
Generalizes the display of the support URL: Adds the "Contact Us" link to the checkout footer instead of just showing it on the "Invoice Expired" view. Closes #6495.

![contact-us](https://github.com/user-attachments/assets/55e512f2-886e-4d1c-ab17-b3e9dd44f39b)
