### PR TITLE
Partial Resolution For Issue #6479 / Plan B Tech Assignment

### DIFF
--- a/BTCPayServer/Controllers/UIWalletsController.cs
+++ b/BTCPayServer/Controllers/UIWalletsController.cs
@@ -335,6 +335,7 @@ namespace BTCPayServer.Controllers
             }
             else
             {
+                var store = GetCurrentStore();
                 var pmi = PaymentTypes.CHAIN.GetPaymentMethodId(walletId.CryptoCode);
                 foreach (var tx in transactions)
                 {
@@ -344,6 +345,9 @@ namespace BTCPayServer.Controllers
                     vm.Timestamp = tx.SeenAt;
                     vm.Positive = tx.BalanceChange.GetValue(wallet.Network) >= 0;
                     vm.Balance = tx.BalanceChange.ShowMoney(wallet.Network);
+                    vm.Currency = store.GetStoreBlob().DefaultCurrency;
+                    var rate = await RateFetcher.FetchRate(new Rating.CurrencyPair(walletId.CryptoCode, vm.Currency), store.GetStoreBlob().GetRateRules(_defaultRules), default, cancellationToken);
+                    vm.Price = Math.Round(Decimal.Parse(vm.Balance) * rate.BidAsk.Center, 2);
                     vm.IsConfirmed = tx.Confirmations != 0;
 
                     if (walletTransactionsInfo.TryGetValue(tx.TransactionId.ToString(), out var transactionInfo))

--- a/BTCPayServer/Models/WalletViewModels/ListTransactionsViewModel.cs
+++ b/BTCPayServer/Models/WalletViewModels/ListTransactionsViewModel.cs
@@ -15,6 +15,8 @@ namespace BTCPayServer.Models.WalletViewModels
             public string Link { get; set; }
             public bool Positive { get; set; }
             public string Balance { get; set; }
+            public string Currency { get; set; }
+            public decimal Price { get; set; }
             public HashSet<TransactionTagModel> Tags { get; set; } = new();
         }
         public HashSet<(string Text, string Color, string TextColor)> Labels { get; set; } = new();

--- a/BTCPayServer/Views/UIWallets/WalletTransactions.cshtml
+++ b/BTCPayServer/Views/UIWallets/WalletTransactions.cshtml
@@ -235,6 +235,8 @@
                 <th text-translate="true" class="text-start">Label</th>
                 <th text-translate="true">Transaction</th>
                 <th text-translate="true" class="amount-col">Amount</th>
+                <th text-translate="true" class="currency-col">Currency</th>
+                <th text-translate="true" class="price-col">Price</th>
             <th></th>
         </tr>
         </thead>

--- a/BTCPayServer/Views/UIWallets/_WalletTransactionsList.cshtml
+++ b/BTCPayServer/Views/UIWallets/_WalletTransactionsList.cshtml
@@ -27,6 +27,12 @@
         <td class="amount-col">
             <span data-sensitive class="text-@(transaction.Positive ? "success" : "danger")">@transaction.Balance</span>
         </td>
+        <td class="currency-col">
+            <span text-translate="true")">@transaction.Currency</span>
+        </td>
+        <td class="price-col">
+            <span text-translate="true" )">@transaction.Price</span>
+        </td>
         <td class="text-end">
             <div class="d-inline-block">
                 <button class="btn btn-link p-0 @(!string.IsNullOrEmpty(transaction.Comment) ? "text-primary" : "text-secondary")" type="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">


### PR DESCRIPTION
Given the limited time I had to resolve the issue (I was only able to start yesterday), I present a partial solution for Issue #6479 where fiat information (Currency & Price) has been added directly to the transactions' log in the wallet screen.

![image](https://github.com/user-attachments/assets/ad5587f0-03a0-41d2-97b5-44c1641bf4ac)

This doesn't aim to completely solve the issue (for now) but it might be a good starting point. I'm willing to continue working on the solution of the issue to its completion. For now, and due to time constraints, I’m submitting this partial resolution for your reviewing.