### PR TITLE
Add All time to the Time filter,  PlanB Assignment

### DIFF
--- a/BTCPayServer/Controllers/UIInvoiceController.UI.cs
+++ b/BTCPayServer/Controllers/UIInvoiceController.UI.cs
@@ -1108,19 +1108,6 @@ namespace BTCPayServer.Controllers
             return View(model);
         }
 
-        // public IActionResult ResetFilters()
-        // {
-
-        //     string defaultStatus = "All";
-        //     string defaultDateRange = "All Time";
-
-        //     return RedirectToAction("ListInvoices", new { 
-        //         storeId = 1,
-        //         status = defaultStatus, 
-        //         dateRange = defaultDateRange
-        //     });
-        // }
-
         private InvoiceQuery GetInvoiceQuery(SearchString fs, ListAppsViewModel.ListAppViewModel[] apps, int timezoneOffset = 0)
         {
             var textSearch = fs.TextSearch;

--- a/BTCPayServer/Controllers/UIInvoiceController.UI.cs
+++ b/BTCPayServer/Controllers/UIInvoiceController.UI.cs
@@ -1046,12 +1046,8 @@ namespace BTCPayServer.Controllers
         {
             model = this.ParseListQuery(model ?? new InvoicesModel());
             var timezoneOffset = model.TimezoneOffset ?? 0;
-
-            var searchTerm = string.IsNullOrEmpty(model.SearchText)
-                ? model.SearchTerm
-                : $"{model.SearchText},{model.SearchTerm}";
+            var searchTerm = string.IsNullOrEmpty(model.SearchText) ? model.SearchTerm : $"{model.SearchText},{model.SearchTerm}";
             var fs = new SearchString(searchTerm, timezoneOffset);
-
             string? storeId = model.StoreId;
             var storeIds = new HashSet<string>();
             if (storeId is not null)
@@ -1063,12 +1059,10 @@ namespace BTCPayServer.Controllers
                 foreach (var i in l)
                     storeIds.Add(i);
             }
-
             model.Search = fs;
             model.SearchText = fs.TextCombined;
 
             var apps = await _appService.GetAllApps(GetUserId(), false, storeId);
-
             InvoiceQuery invoiceQuery = GetInvoiceQuery(fs, apps, timezoneOffset);
             invoiceQuery.StoreId = storeIds.ToArray();
             invoiceQuery.Take = model.Count;
@@ -1104,7 +1098,6 @@ namespace BTCPayServer.Controllers
                     HasRefund = invoice.Refunds.Any()
                 });
             }
-
             return View(model);
         }
 

--- a/BTCPayServer/Controllers/UIInvoiceController.UI.cs
+++ b/BTCPayServer/Controllers/UIInvoiceController.UI.cs
@@ -1046,8 +1046,12 @@ namespace BTCPayServer.Controllers
         {
             model = this.ParseListQuery(model ?? new InvoicesModel());
             var timezoneOffset = model.TimezoneOffset ?? 0;
-            var searchTerm = string.IsNullOrEmpty(model.SearchText) ? model.SearchTerm : $"{model.SearchText},{model.SearchTerm}";
+
+            var searchTerm = string.IsNullOrEmpty(model.SearchText)
+                ? model.SearchTerm
+                : $"{model.SearchText},{model.SearchTerm}";
             var fs = new SearchString(searchTerm, timezoneOffset);
+
             string? storeId = model.StoreId;
             var storeIds = new HashSet<string>();
             if (storeId is not null)
@@ -1059,10 +1063,12 @@ namespace BTCPayServer.Controllers
                 foreach (var i in l)
                     storeIds.Add(i);
             }
+
             model.Search = fs;
             model.SearchText = fs.TextCombined;
 
             var apps = await _appService.GetAllApps(GetUserId(), false, storeId);
+
             InvoiceQuery invoiceQuery = GetInvoiceQuery(fs, apps, timezoneOffset);
             invoiceQuery.StoreId = storeIds.ToArray();
             invoiceQuery.Take = model.Count;
@@ -1098,8 +1104,22 @@ namespace BTCPayServer.Controllers
                     HasRefund = invoice.Refunds.Any()
                 });
             }
+
             return View(model);
         }
+
+        // public IActionResult ResetFilters()
+        // {
+
+        //     string defaultStatus = "All";
+        //     string defaultDateRange = "All Time";
+
+        //     return RedirectToAction("ListInvoices", new { 
+        //         storeId = 1,
+        //         status = defaultStatus, 
+        //         dateRange = defaultDateRange
+        //     });
+        // }
 
         private InvoiceQuery GetInvoiceQuery(SearchString fs, ListAppsViewModel.ListAppViewModel[] apps, int timezoneOffset = 0)
         {

--- a/BTCPayServer/SearchString.cs
+++ b/BTCPayServer/SearchString.cs
@@ -158,15 +158,5 @@ namespace BTCPayServer
             return string.IsNullOrEmpty(value) ? " " : value;
         }
 
-        // public void ResetFilters()
-        // {
-        //     Filters.Clear();
-
-        //     TextSearch = null; 
-        //     TextFilters = null;
-
-        //     _originalString = string.Empty;
-        // }
-
     }
 }

--- a/BTCPayServer/SearchString.cs
+++ b/BTCPayServer/SearchString.cs
@@ -11,7 +11,7 @@ namespace BTCPayServer
         private const char ValueSeparator = ':';
         private static readonly string[] StripFilters = ["status", "exceptionstatus", "unusual", "includearchived", "appid", "startdate", "enddate"];
 
-        private readonly string _originalString;
+        private string _originalString;
         private readonly int _timezoneOffset;
 
         public SearchString(string str, int timezoneOffset = 0)
@@ -127,6 +127,8 @@ namespace BTCPayServer
                     return DateTimeOffset.UtcNow.AddDays(-3).AddMinutes(timezoneOffset);
                 case "-7d":
                     return DateTimeOffset.UtcNow.AddDays(-7).AddMinutes(timezoneOffset);
+                case "alltime":
+                    return null; // No filtering by date, so return null
             }
 
             // default parsing logic
@@ -155,5 +157,16 @@ namespace BTCPayServer
             var value = str.Trim().TrimStart(FilterSeparator).TrimEnd(FilterSeparator);
             return string.IsNullOrEmpty(value) ? " " : value;
         }
+
+        // public void ResetFilters()
+        // {
+        //     Filters.Clear();
+
+        //     TextSearch = null; 
+        //     TextFilters = null;
+
+        //     _originalString = string.Empty;
+        // }
+
     }
 }

--- a/BTCPayServer/SearchString.cs
+++ b/BTCPayServer/SearchString.cs
@@ -11,7 +11,7 @@ namespace BTCPayServer
         private const char ValueSeparator = ':';
         private static readonly string[] StripFilters = ["status", "exceptionstatus", "unusual", "includearchived", "appid", "startdate", "enddate"];
 
-        private string _originalString;
+        private readonly string _originalString;
         private readonly int _timezoneOffset;
 
         public SearchString(string str, int timezoneOffset = 0)

--- a/BTCPayServer/Views/UIInvoice/ListInvoices.cshtml
+++ b/BTCPayServer/Views/UIInvoice/ListInvoices.cshtml
@@ -24,6 +24,9 @@
     
     private bool HasCustomDateFilter() =>
         Model.Search.ContainsFilter("startdate") && Model.Search.ContainsFilter("enddate");
+
+    private void ResetFilters () => Model.Search.ResetFilters();
+
 }
 
 @section PageHeadContent
@@ -250,6 +253,11 @@
                 {
                     <span text-translate="true">7 Days</span>
                 }
+                else if (HasArrayFilter("startdate", "alltime")) 
+                {
+                    <span text-translate="true">All Time</span>
+                }
+
                 else
                 {
                     <span text-translate="true">Custom</span>
@@ -264,9 +272,19 @@
             <a asp-action="ListInvoices" asp-route-storeId="@Model.StoreId" asp-route-count="@Model.Count" asp-route-searchTerm="@Model.Search.Toggle("startdate", "-1d")" class="dropdown-item @(HasArrayFilter("startdate", "-1d") ? "custom-active" : "")" text-translate="true">Last 24 hours</a>
             <a asp-action="ListInvoices" asp-route-storeId="@Model.StoreId" asp-route-count="@Model.Count" asp-route-searchTerm="@Model.Search.Toggle("startdate", "-3d")" class="dropdown-item @(HasArrayFilter("startdate", "-3d") ? "custom-active" : "")" text-translate="true">Last 3 days</a>
             <a asp-action="ListInvoices" asp-route-storeId="@Model.StoreId" asp-route-count="@Model.Count" asp-route-searchTerm="@Model.Search.Toggle("startdate", "-7d")" class="dropdown-item @(HasArrayFilter("startdate", "-7d") ? "custom-active" : "")" text-translate="true">Last 7 days</a>
+            <a asp-action="ListInvoices" asp-route-storeId="@Model.StoreId" asp-route-count="@Model.Count" asp-route-searchTerm="@Model.Search.Toggle("startdate", "alltime")" class="dropdown-item @(HasArrayFilter("startdate", "alltime") ? "custom-active" : "")" text-translate="true">All Time</a>
             <button type="button" class="dropdown-item @(HasCustomDateFilter() ? "custom-active" : "")" data-bs-toggle="modal" data-bs-target="#customRangeModal" text-translate="true">Custom Range</button>
         </div>
     </div>
+
+    <button onclick="ResetFilters()">Clear All Filters</button>
+
+<script>
+    function resetFilters() {
+        statusFilterCount = 0;
+    }
+</script>
+
 </form>
 
 @if (Model.Invoices.Any())

--- a/BTCPayServer/Views/UIInvoice/ListInvoices.cshtml
+++ b/BTCPayServer/Views/UIInvoice/ListInvoices.cshtml
@@ -25,7 +25,7 @@
     private bool HasCustomDateFilter() =>
         Model.Search.ContainsFilter("startdate") && Model.Search.ContainsFilter("enddate");
 
-    private void ResetFilters () => Model.Search.ResetFilters();
+    @* private void ResetFilters () => Model.Search.ResetFilters(); *@
 
 }
 

--- a/BTCPayServer/Views/UIInvoice/ListInvoices.cshtml
+++ b/BTCPayServer/Views/UIInvoice/ListInvoices.cshtml
@@ -24,9 +24,6 @@
     
     private bool HasCustomDateFilter() =>
         Model.Search.ContainsFilter("startdate") && Model.Search.ContainsFilter("enddate");
-
-    @* private void ResetFilters () => Model.Search.ResetFilters(); *@
-
 }
 
 @section PageHeadContent
@@ -276,15 +273,6 @@
             <button type="button" class="dropdown-item @(HasCustomDateFilter() ? "custom-active" : "")" data-bs-toggle="modal" data-bs-target="#customRangeModal" text-translate="true">Custom Range</button>
         </div>
     </div>
-
-    <button onclick="ResetFilters()">Clear All Filters</button>
-
-<script>
-    function resetFilters() {
-        statusFilterCount = 0;
-    }
-</script>
-
 </form>
 
 @if (Model.Invoices.Any())

--- a/BTCPayServer/Views/UIInvoice/ListInvoices.cshtml
+++ b/BTCPayServer/Views/UIInvoice/ListInvoices.cshtml
@@ -269,7 +269,7 @@
             <a asp-action="ListInvoices" asp-route-storeId="@Model.StoreId" asp-route-count="@Model.Count" asp-route-searchTerm="@Model.Search.Toggle("startdate", "-1d")" class="dropdown-item @(HasArrayFilter("startdate", "-1d") ? "custom-active" : "")" text-translate="true">Last 24 hours</a>
             <a asp-action="ListInvoices" asp-route-storeId="@Model.StoreId" asp-route-count="@Model.Count" asp-route-searchTerm="@Model.Search.Toggle("startdate", "-3d")" class="dropdown-item @(HasArrayFilter("startdate", "-3d") ? "custom-active" : "")" text-translate="true">Last 3 days</a>
             <a asp-action="ListInvoices" asp-route-storeId="@Model.StoreId" asp-route-count="@Model.Count" asp-route-searchTerm="@Model.Search.Toggle("startdate", "-7d")" class="dropdown-item @(HasArrayFilter("startdate", "-7d") ? "custom-active" : "")" text-translate="true">Last 7 days</a>
-            <a asp-action="ListInvoices" asp-route-storeId="@Model.StoreId" asp-route-count="@Model.Count" asp-route-searchTerm="@Model.Search.Toggle("startdate", "alltime")" class="dropdown-item @(HasArrayFilter("startdate", "alltime") ? "custom-active" : "")" text-translate="true">All Time</a>
+			<a asp-action="ListInvoices" asp-route-storeId="@Model.StoreId" asp-route-count="@Model.Count" asp-route-searchTerm="@Model.Search.Toggle("startdate", "alltime")" class="dropdown-item @(HasArrayFilter("startdate", "alltime") || !Model.Search.ContainsFilter("startdate") ? "custom-active" : "")" text-translate="true">All Time</a>
             <button type="button" class="dropdown-item @(HasCustomDateFilter() ? "custom-active" : "")" data-bs-toggle="modal" data-bs-target="#customRangeModal" text-translate="true">Custom Range</button>
         </div>
     </div>


### PR DESCRIPTION
Improved filter iteration #5156:  

- [x] All Time should be added to the Time filter, it's the default, but you can't return back to it after an option has been selected

Work in progress: Clear All funtionality

<img width="1305" alt="Screenshot 2024-12-20 at 12 02 53 PM" src="https://github.com/user-attachments/assets/ae537011-49d3-4825-9a20-c65498dae61b" />

All Time filter implementation is completed, Clear all funtionality is still in progress and could be a good starting point, due to time constraints I am submitting this work in progress, I am willing to continue working on it to contribute to the project.
