### PR TITLE
Bumping LND to 0.18.4-beta

### DIFF
--- a/BTCPayServer.Tests/docker-compose.altcoins.yml
+++ b/BTCPayServer.Tests/docker-compose.altcoins.yml
@@ -229,7 +229,7 @@ services:
       - "5432"
 
   merchant_lnd:
-    image: btcpayserver/lnd:v0.18.3-beta
+    image: btcpayserver/lnd:v0.18.4-beta
     restart: unless-stopped
     environment:
       LND_CHAIN: "btc"
@@ -267,7 +267,7 @@ services:
       - bitcoind
 
   customer_lnd:
-    image: btcpayserver/lnd:v0.18.3-beta
+    image: btcpayserver/lnd:v0.18.4-beta
     restart: unless-stopped
     environment:
       LND_CHAIN: "btc"

--- a/BTCPayServer.Tests/docker-compose.mutinynet.yml
+++ b/BTCPayServer.Tests/docker-compose.mutinynet.yml
@@ -187,7 +187,7 @@ services:
       - "5432"
 
   merchant_lnd:
-    image: btcpayserver/lnd:v0.18.3-beta
+    image: btcpayserver/lnd:v0.18.4-beta
     restart: unless-stopped
     environment:
       LND_CHAIN: "btc"
@@ -225,7 +225,7 @@ services:
       - bitcoind
 
   customer_lnd:
-    image: btcpayserver/lnd:v0.18.3-beta
+    image: btcpayserver/lnd:v0.18.4-beta
     restart: unless-stopped
     environment:
       LND_CHAIN: "btc"

--- a/BTCPayServer.Tests/docker-compose.testnet.yml
+++ b/BTCPayServer.Tests/docker-compose.testnet.yml
@@ -177,7 +177,7 @@ services:
       - "5432"
 
   merchant_lnd:
-    image: btcpayserver/lnd:v0.18.3-beta
+    image: btcpayserver/lnd:v0.18.4-beta
     restart: unless-stopped
     environment:
       LND_CHAIN: "btc"
@@ -215,7 +215,7 @@ services:
       - bitcoind
 
   customer_lnd:
-    image: btcpayserver/lnd:v0.18.3-beta
+    image: btcpayserver/lnd:v0.18.4-beta
     restart: unless-stopped
     environment:
       LND_CHAIN: "btc"

--- a/BTCPayServer.Tests/docker-compose.yml
+++ b/BTCPayServer.Tests/docker-compose.yml
@@ -215,7 +215,7 @@ services:
       - "5432"
 
   merchant_lnd:
-    image: btcpayserver/lnd:v0.18.3-beta
+    image: btcpayserver/lnd:v0.18.4-beta
     restart: unless-stopped
     environment:
       LND_CHAIN: "btc"
@@ -253,7 +253,7 @@ services:
       - bitcoind
 
   customer_lnd:
-    image: btcpayserver/lnd:v0.18.3-beta
+    image: btcpayserver/lnd:v0.18.4-beta
     restart: unless-stopped
     environment:
       LND_CHAIN: "btc"


### PR DESCRIPTION
Updating our devenv to use LND 0.18.3

Used it in BTCPayServer.Lightning library and it's good to go, passed all the tests:
https://github.com/btcpayserver/BTCPayServer.Lightning/pull/166