### PR TITLE
Fix: Monero Payments in mempool not detected if accountIndex != 0 (Fix #6430)

### DIFF
--- a/BTCPayServer/Plugins/Altcoins/Monero/RPC/Models/GetTransferByTransactionIdRequest.cs
+++ b/BTCPayServer/Plugins/Altcoins/Monero/RPC/Models/GetTransferByTransactionIdRequest.cs
@@ -6,6 +6,6 @@ namespace BTCPayServer.Services.Altcoins.Monero.RPC.Models
     {
         [JsonProperty("txid")] public string TransactionId { get; set; }
 
-        [JsonProperty("account_index")] public long AccountIndex { get; set; }
+        [JsonProperty("account_index", DefaultValueHandling = DefaultValueHandling.Ignore)] public long? AccountIndex { get; set; }
     }
 }

--- a/BTCPayServer/Services/Altcoins/Monero/Services/MoneroListener.cs
+++ b/BTCPayServer/Services/Altcoins/Monero/Services/MoneroListener.cs
@@ -234,10 +234,7 @@ namespace BTCPayServer.Services.Altcoins.Monero.Services
         private async Task OnTransactionUpdated(string cryptoCode, string transactionHash)
         {
             var paymentMethodId = PaymentTypes.CHAIN.GetPaymentMethodId(cryptoCode);
-            var transfer = await _moneroRpcProvider.WalletRpcClients[cryptoCode]
-                .SendCommandAsync<GetTransferByTransactionIdRequest, GetTransferByTransactionIdResponse>(
-                    "get_transfer_by_txid",
-                    new GetTransferByTransactionIdRequest() { TransactionId = transactionHash });
+            var transfer = await GetTransferByTxId(cryptoCode, transactionHash, this.CancellationToken);
 
             var paymentsToUpdate = new List<(PaymentEntity Payment, InvoiceEntity invoice)>();
 
@@ -272,6 +269,49 @@ namespace BTCPayServer.Services.Altcoins.Monero.Services
                         _eventAggregator.Publish(new Events.InvoiceNeedUpdateEvent(valueTuples.Key.Id));
                     }
                 }
+            }
+        }
+
+        private async Task<GetTransferByTransactionIdResponse> GetTransferByTxId(string cryptoCode,
+            string transactionHash, CancellationToken cancellationToken)
+        {
+            var accounts = await _moneroRpcProvider.WalletRpcClients[cryptoCode].SendCommandAsync<GetAccountsRequest, GetAccountsResponse>("get_accounts", new GetAccountsRequest(), cancellationToken);
+            var accountIndexes = accounts
+                .SubaddressAccounts
+                .Select(a => new long?(a.AccountIndex))
+                .ToList();
+            if (accountIndexes.Count is 0)
+                accountIndexes.Add(null);
+            var req = accountIndexes
+                .Select(i => GetTransferByTxId(cryptoCode, transactionHash, i))
+                .ToArray();
+            foreach (var task in req)
+            {
+                var result = await task;
+                if (result != null)
+                    return result;
+            }
+
+            return null;
+        }
+
+        private async Task<GetTransferByTransactionIdResponse> GetTransferByTxId(string cryptoCode, string transactionHash, long? accountIndex)
+        {
+            try
+            {
+                var result = await _moneroRpcProvider.WalletRpcClients[cryptoCode]
+                    .SendCommandAsync<GetTransferByTransactionIdRequest, GetTransferByTransactionIdResponse>(
+                        "get_transfer_by_txid",
+                        new GetTransferByTransactionIdRequest()
+                        {
+                            TransactionId = transactionHash,
+                            AccountIndex = accountIndex
+                        });
+                return result;
+            }
+            catch (JsonRpcClient.JsonRpcApiException e)
+            {
+                return null;
             }
         }
 


### PR DESCRIPTION
Fix #6430

A breaking change in `monero-wallet-rpc`'s `get_transfer_by_txid` made the use of the parameter `account_index` mandatory if the account index of the user isn't 0.

This PR fix it by calling `get_transfer_by_txid` on every accounts in the wallet, and returning the first one not returning null.
This could be more easy if only `monero-wallet-rpc --tx-notify` was including the accountIndex in the notification.