### PR TITLE
Fix: Migration bug on old instances (Could not cast or convert from System.String to BTCPayServer.DerivationSchemeSettings)

### DIFF
--- a/BTCPayServer/Services/MigrationSettings.cs
+++ b/BTCPayServer/Services/MigrationSettings.cs
@@ -32,6 +32,7 @@ namespace BTCPayServer.Services
         public bool MigrateAppYmlToJson { get; set; }
         public bool MigrateToStoreConfig { get; set; }
         public bool MigrateBlockExplorerLinks { get; set; }
-        public bool MigrateStoreExcludedPaymentMethods { get; internal set; }
+        public bool MigrateStoreExcludedPaymentMethods { get; set; }
+        public bool MigrateOldDerivationSchemes { get; set; }
     }
 }


### PR DESCRIPTION
Long time ago, derivation schemes could be saved as a string in the database. I forgot to migrate this.

An exception during migration would be thrown:
`Error converting value "xpub661MyMwAqR-SOMELONGID-vCzQGKJzpFc6B-[legacy]" to type 'BTCPayServer.DerivationSchemeSettings'. Path 'BTC-CHAIN', line 1, position 136.`

This fix https://github.com/btcpayserver/btcpayserver-docker/issues/966