### PR TITLE
Bump Payjoin libraries

### DIFF
--- a/BTCPayServer.Tests/PayJoinTests.cs
+++ b/BTCPayServer.Tests/PayJoinTests.cs
@@ -481,12 +481,12 @@ namespace BTCPayServer.Tests
             var request = await fakeServer.GetNextRequest();
             Assert.Equal("1", request.Request.Query["v"][0]);
             Assert.Equal(changeIndex.ToString(), request.Request.Query["additionalfeeoutputindex"][0]);
-            Assert.Equal("1146", request.Request.Query["maxadditionalfeecontribution"][0]);
+            Assert.Equal("1853", request.Request.Query["maxadditionalfeecontribution"][0]);
 
             TestLogs.LogInformation("The payjoin receiver tries to make us pay lots of fee");
             var originalPSBT = await ParsePSBT(request);
             var proposalTx = originalPSBT.GetGlobalTransaction();
-            proposalTx.Outputs[changeIndex].Value -= Money.Satoshis(1147);
+            proposalTx.Outputs[changeIndex].Value -= Money.Satoshis(1854);
             await request.Response.WriteAsync(PSBT.FromTransaction(proposalTx, Network.RegTest).ToBase64(), Encoding.UTF8);
             fakeServer.Done();
             var ex = await Assert.ThrowsAsync<PayjoinSenderException>(async () => await requesting);

--- a/BTCPayServer/BTCPayServer.csproj
+++ b/BTCPayServer/BTCPayServer.csproj
@@ -1,4 +1,4 @@
-﻿ <Project Sdk="Microsoft.NET.Sdk.Web">
+ <Project Sdk="Microsoft.NET.Sdk.Web">
   <Import Project="../Build/Version.csproj" Condition="Exists('../Build/Version.csproj')" />
   <Import Project="../Build/Common.csproj" />
 
@@ -52,7 +52,7 @@
   <ItemGroup>
     <PackageReference Include="BTCPayServer.NTag424" Version="1.0.25" />
     <PackageReference Include="YamlDotNet" Version="8.0.0" />
-    <PackageReference Include="BIP78.Sender" Version="0.2.2" />
+    <PackageReference Include="BIP78.Sender" Version="0.2.4" />
     <PackageReference Include="BTCPayServer.Hwi" Version="2.0.2" />
     <PackageReference Include="BTCPayServer.Lightning.All" Version="1.6.9" />
     <PackageReference Include="CsvHelper" Version="32.0.3" />


### PR DESCRIPTION
This update the library to integrate two payjoin BIP changes:
* [Allowing finalized proposal to have input utxo data](https://github.com/bitcoin/bips/pull/1396)
* [BIP78: Allow mixed inputs Redux](https://github.com/bitcoin/bips/pull/1605)