### PR TITLE
Add tooltip and link to pull-payment tags in wallet's transaction list

### DIFF
--- a/BTCPayServer/Extensions/UrlHelperExtensions.cs
+++ b/BTCPayServer/Extensions/UrlHelperExtensions.cs
@@ -62,6 +62,15 @@ namespace Microsoft.AspNetCore.Mvc
                 scheme, host, pathbase);
         }
 
+        public static string PullPaymentLink(this LinkGenerator urlHelper, string pullPaymentId, string scheme, HostString host, string pathbase)
+        {
+            return urlHelper.GetUriByAction(
+                action: nameof(UIPullPaymentController.ViewPullPayment),
+                controller: "UIPullPayment",
+                values: new { pullPaymentId },
+                scheme, host, pathbase);
+        }
+
         public static string CheckoutLink(this LinkGenerator urlHelper, string invoiceId, string scheme, HostString host, string pathbase)
         {
             return urlHelper.GetUriByAction(

--- a/BTCPayServer/Services/Labels/LabelService.cs
+++ b/BTCPayServer/Services/Labels/LabelService.cs
@@ -115,6 +115,11 @@ public class LabelService
                     model.Tooltip = $"This UTXO was exposed through a PayJoin proposal";
                 }
             }
+            else if (tag.Type == WalletObjectData.Types.PullPayment)
+            {
+                model.Tooltip = $"Received through a pull payment {tag.Id}";
+                model.Link = _linkGenerator.PullPaymentLink(tag.Id, req.Scheme, req.Host, req.PathBase);
+            }
             else if (tag.Type == WalletObjectData.Types.Payjoin)
             {
                 model.Tooltip = $"This UTXO was part of a PayJoin transaction.";


### PR DESCRIPTION
Small UX improvement for the transaction list so we can click to go to the pull payment.

Before
![image](https://github.com/user-attachments/assets/20e3ab02-387f-42e0-9f74-1b70a30ecf40)

After
![image](https://github.com/user-attachments/assets/8ded22e6-e101-4a79-9f22-3a0c72f80ea7)
