### PR TITLE
Add ability to move a payout from InProgress to AwaitingPayment

### DIFF
--- a/BTCPayServer/Views/UIPayoutProcessors/ConfigureStorePayoutProcessors.cshtml
+++ b/BTCPayServer/Views/UIPayoutProcessors/ConfigureStorePayoutProcessors.cshtml
@@ -39,11 +39,11 @@
                             <td class="actions-col" permission="@Policies.CanModifyStoreSettings">
                                 @if (conf.Value is null)
                                 {
-                                    <a href="@processorsView.Factory.ConfigureLink(storeId, conf.Key, Context.Request)" text-translate="true">Configure</a>
+                                    <a id="Configure-@conf.Key" href="@processorsView.Factory.ConfigureLink(storeId, conf.Key, Context.Request)" text-translate="true">Configure</a>
                                 }
                                 else
                                 {
-                                    <a href="@processorsView.Factory.ConfigureLink(storeId, conf.Key, Context.Request)" text-translate="true">Modify</a>
+                                    <a id="Configure-@conf.Key" href="@processorsView.Factory.ConfigureLink(storeId, conf.Key, Context.Request)" text-translate="true">Modify</a>
                                     
                                     @if (await processorsView.Factory.CanRemove())
                                     {

--- a/BTCPayServer/Views/UIStorePullPayments/Payouts.cshtml
+++ b/BTCPayServer/Views/UIStorePullPayments/Payouts.cshtml
@@ -33,6 +33,9 @@
             stateActions.Add(("cancel", StringLocalizer["Cancel"]));
             stateActions.Add(("mark-paid", StringLocalizer["Mark as already paid"]));
             break;
+		case PayoutState.InProgress:
+			stateActions.Add(("mark-awaiting-payment", StringLocalizer["Mark as awaiting payment"]));
+			break;
     }
 }
 


### PR DESCRIPTION
A bug has been reported at https://github.com/btcpayserver/btcpayserver/issues/6540, which may result in a loss of funds in the hot wallet if the merchant is using Payouts and automated payout processors.

While I have not been able to reproduce the issue, the user reported that a payout would transition to the `InProgress` state and then revert to the `AwaitingPayment` state. When the payout's transaction would confirm again, it would transition to `Completed`. However, the user and payout processor, may become confused by the return to `AwaitingPayment` and attempt additional payments.

Previously, the only way the transition from `InProgress` to `AwaitingPayment` could happen was if a payout's transaction failed to re-broadcast. Although I couldn't reproduce it, it appears this user can.

This PR completely removes the code that would transition a payout from `InProgress` to `AwaitingPayment` for on-chain payouts. Additionally, it allows the user to manually change the state from `InProgress` to `AwaitingPayment` if they manually observe that a transaction cannot be confirmed.