### PR TITLE
Fix: Incorrect enabled value for v1/stores/{storeId}/payment-methods/{paymentMethod}

### DIFF
--- a/BTCPayServer/Controllers/GreenField/GreenfieldStorePaymentMethodsController.cs
+++ b/BTCPayServer/Controllers/GreenField/GreenfieldStorePaymentMethodsController.cs
@@ -15,6 +15,7 @@ using StoreData = BTCPayServer.Data.StoreData;
 using BTCPayServer.ModelBinders;
 using BTCPayServer.Payments;
 using BTCPayServer.Services.Stores;
+using System;
 
 namespace BTCPayServer.Controllers.Greenfield
 {
@@ -102,9 +103,9 @@ namespace BTCPayServer.Controllers.Greenfield
                     if (ctx.StripUnknownProperties)
                         config = JToken.FromObject(handler.ParsePaymentMethodConfig(config), handler.Serializer);
                 }
-                catch
+                catch (Exception ex)
                 {
-                    ModelState.AddModelError(nameof(config), "Invalid configuration");
+                    ModelState.AddModelError(nameof(config), $"Invalid configuration ({ex.Message})");
                     return this.CreateValidationError(ModelState);
                 }
                 Store.SetPaymentMethodConfig(paymentMethodId, config);
@@ -151,7 +152,7 @@ namespace BTCPayServer.Controllers.Greenfield
                     method => new GenericPaymentMethodData()
                     {
                         PaymentMethodId = method.Key.ToString(),
-                        Enabled = onlyEnabled.GetValueOrDefault(!excludedPaymentMethods.Match(method.Key)),
+                        Enabled = !excludedPaymentMethods.Match(method.Key),
                         Config = includeConfig is true ? JToken.FromObject(method.Value, _handlers[method.Key].Serializer.ForAPI()) : null
                     }).ToArray());
         }

--- a/BTCPayServer/Controllers/UIStoresController.Onchain.cs
+++ b/BTCPayServer/Controllers/UIStoresController.Onchain.cs
@@ -408,6 +408,7 @@ public partial class UIStoresController
         var client = _explorerProvider.GetExplorerClient(network);
 
         var handler = _handlers.GetBitcoinHandler(cryptoCode);
+
         var vm = new WalletSettingsViewModel
         {
             StoreId = storeId,
@@ -417,18 +418,18 @@ public partial class UIStoresController
             Network = network,
             IsHotWallet = derivation.IsHotWallet,
             Source = derivation.Source,
-            RootFingerprint = derivation.GetSigningAccountKeySettings().RootFingerprint.ToString(),
-            DerivationScheme = derivation.AccountDerivation.ToString(),
+            RootFingerprint = derivation.GetSigningAccountKeySettingsOrDefault()?.RootFingerprint.ToString(),
+            DerivationScheme = derivation.AccountDerivation?.ToString(),
             DerivationSchemeInput = derivation.AccountOriginal,
-            KeyPath = derivation.GetSigningAccountKeySettings().AccountKeyPath?.ToString(),
+            KeyPath = derivation.GetSigningAccountKeySettingsOrDefault()?.AccountKeyPath?.ToString(),
             UriScheme = network.NBitcoinNetwork.UriScheme,
             Label = derivation.Label,
-            SelectedSigningKey = derivation.SigningKey.ToString(),
+            SelectedSigningKey = derivation.SigningKey?.ToString(),
             NBXSeedAvailable = derivation.IsHotWallet &&
                                canUseHotWallet &&
                                !string.IsNullOrEmpty(await client.GetMetadataAsync<string>(derivation.AccountDerivation,
                                    WellknownMetadataKeys.MasterHDKey)),
-            AccountKeys = derivation.AccountKeySettings
+            AccountKeys = (derivation.AccountKeySettings ?? [])
                 .Select(e => new WalletSettingsAccountKeyViewModel
                 {
                     AccountKey = e.AccountKey.ToString(),
@@ -441,7 +442,7 @@ public partial class UIStoresController
             CanUseHotWallet = canUseHotWallet,
             CanUseRPCImport = rpcImport,
             StoreName = store.StoreName,
-            CanSetupMultiSig = derivation.AccountKeySettings.Length > 1,
+            CanSetupMultiSig = (derivation.AccountKeySettings ?? []).Length > 1,
             IsMultiSigOnServer = derivation.IsMultiSigOnServer,
             DefaultIncludeNonWitnessUtxo = derivation.DefaultIncludeNonWitnessUtxo
         };

--- a/BTCPayServer/DerivationSchemeSettings.cs
+++ b/BTCPayServer/DerivationSchemeSettings.cs
@@ -80,7 +80,12 @@ namespace BTCPayServer
 
         public AccountKeySettings GetSigningAccountKeySettings()
         {
-            return AccountKeySettings.Single(a => a.AccountKey == SigningKey);
+            return (AccountKeySettings ?? []).Single(a => a.AccountKey == SigningKey);
+        }
+
+        public AccountKeySettings GetSigningAccountKeySettingsOrDefault()
+        {
+            return (AccountKeySettings ?? []).SingleOrDefault(a => a.AccountKey == SigningKey);
         }
 
         public AccountKeySettings[] AccountKeySettings { get; set; }

--- a/BTCPayServer/wwwroot/swagger/v1/swagger.template.stores-payment-methods.json
+++ b/BTCPayServer/wwwroot/swagger/v1/swagger.template.stores-payment-methods.json
@@ -3,7 +3,7 @@
         "/api/v1/stores/{storeId}/payment-methods": {
             "get": {
                 "tags": [
-                    "Store Payment Methods"
+                    "Store (Payment Methods)"
                 ],
                 "summary": "Get store payment methods",
                 "description": "View information about the stores' configured payment methods",
@@ -79,7 +79,7 @@
         "/api/v1/stores/{storeId}/payment-methods/{paymentMethodId}": {
             "get": {
                 "tags": [
-                    "Store Payment Methods"
+                    "Store (Payment Methods)"
                 ],
                 "summary": "Get store payment method",
                 "description": "View information about the stores' configured payment method",
@@ -144,7 +144,7 @@
             },
             "put": {
                 "tags": [
-                    "Store Payment Methods"
+                    "Store (Payment Methods)"
                 ],
                 "summary": "Update store's payment method",
                 "description": "Update information about the stores' configured payment method",
@@ -209,7 +209,7 @@
             },
             "delete": {
                 "tags": [
-                    "Store Payment Methods"
+                    "Store (Payment Methods)"
                 ],
                 "summary": "Delete store's payment method",
                 "description": "Delete information about the stores' configured payment method",
@@ -369,7 +369,7 @@
     },
     "tags": [
         {
-            "name": "Store Payment Methods",
+            "name": "Store (Payment Methods)",
             "description": "Store Payment Methods operations"
         }
     ]


### PR DESCRIPTION
As I was trying to fix https://github.com/btcpayserver/btcpayserver/issues/6530

I noticed that the config documented in our swagger wasn't actually supported...
This add support for it.

Also, the fix a bug on `v1/stores/{storeId}/payment-methods/{paymentMethod}` returning wrong value for the `enabled` attribute if `onlyEnabled` query parameter was used.