### PR TITLE
Plugins: Convert relative to absolute path when loading a plugin

### DIFF
--- a/BTCPayServer/Plugins/PluginManager.cs
+++ b/BTCPayServer/Plugins/PluginManager.cs
@@ -125,10 +125,19 @@ namespace BTCPayServer.Plugins
             {
                 // Formatted either as "<PLUGIN_IDENTIFIER>::<PathToDll>" or "<PathToDll>"
                 var idx = plugin.IndexOf("::");
+                var filePath = plugin;
                 if (idx != -1)
-                    pluginsToLoad.Add((plugin[0..idx], plugin[(idx + 1)..]));
+                {
+                    filePath = plugin[(idx + 1)..];
+                    filePath = Path.GetFullPath(filePath);
+                    pluginsToLoad.Add((plugin[0..idx], filePath));
+                }
                 else
-                    pluginsToLoad.Add((Path.GetFileNameWithoutExtension(plugin), plugin));
+                {
+                    filePath = Path.GetFullPath(filePath);
+
+                    pluginsToLoad.Add((Path.GetFileNameWithoutExtension(plugin), filePath));
+                }
             }
 #endif
 


### PR DESCRIPTION
Avoids having to provide absolute paths, which differ across machines. We use this for the app to [reference the app plugin](https://github.com/btcpayserver/btcpayserver/blob/mobile-working-branch/BTCPayServer/Properties/launchSettings.json#L7) in the launch settings.