### PR TITLE
UI: Display unconfirmed transactions with lower opacity

### DIFF
--- a/BTCPayServer/Components/StoreRecentTransactions/Default.cshtml
+++ b/BTCPayServer/Components/StoreRecentTransactions/Default.cshtml
@@ -43,7 +43,7 @@
                 <tbody>
                 @foreach (var tx in Model.Transactions)
                 {
-                    <tr>
+                    <tr class="@(tx.IsConfirmed ? "" : "opacity-50")">
                         <td>@tx.Timestamp.ToTimeAgo()</td>
                         <td>
                             <vc:truncate-center text="@tx.Id" link="@tx.Link" classes="truncate-center-id" />

--- a/BTCPayServer/Views/UIWallets/WalletTransactions.cshtml
+++ b/BTCPayServer/Views/UIWallets/WalletTransactions.cshtml
@@ -42,10 +42,6 @@
                 order: 1;
             }
         }
-
-        .unconf > * {
-            opacity: 0.5;
-        }
         
         #LoadingIndicator {
             margin-bottom: 1.5rem;

--- a/BTCPayServer/Views/UIWallets/_WalletTransactionsList.cshtml
+++ b/BTCPayServer/Views/UIWallets/_WalletTransactionsList.cshtml
@@ -6,7 +6,7 @@
 }
 @foreach (var transaction in Model.Transactions)
 {
-    <tr class="mass-action-row">
+    <tr class="mass-action-row@(transaction.IsConfirmed ? "" : " opacity-50")">
         <td class="only-for-js mass-action-select-col">
             <input name="selectedTransactions" type="checkbox" class="form-check-input mass-action-select" form="WalletActions" value="@transaction.Id" />
         </td>


### PR DESCRIPTION
Fixes a regression introduced in #6190 and also adds this display style to the dashboard list of recent transactions.