### PR TITLE
Fix: Invalid currency pair (FARTCOIN_USDC) may show in the logs when using kraken rate provider

### DIFF
--- a/BTCPayServer.Rating/CurrencyPair.cs
+++ b/BTCPayServer.Rating/CurrencyPair.cs
@@ -38,8 +38,6 @@ namespace BTCPayServer.Rating
             ArgumentNullException.ThrowIfNull(str);
             value = null;
             str = str.Trim();
-            if (str.Length > 12)
-                return false;
             var splitted = str.Split(new[] { '_', '-' }, StringSplitOptions.RemoveEmptyEntries);
             if (splitted.Length == 2)
             {

--- a/BTCPayServer.Tests/GreenfieldAPITests.cs
+++ b/BTCPayServer.Tests/GreenfieldAPITests.cs
@@ -20,6 +20,7 @@ using BTCPayServer.PayoutProcessors;
 using BTCPayServer.PayoutProcessors.Lightning;
 using BTCPayServer.Plugins.PointOfSale.Controllers;
 using BTCPayServer.Plugins.PointOfSale.Models;
+using BTCPayServer.Rating;
 using BTCPayServer.Services;
 using BTCPayServer.Services.Apps;
 using BTCPayServer.Services.Invoices;
@@ -4824,9 +4825,9 @@ clientBasic.UpdateStoreRateConfiguration(user.StoreId, new StoreRateConfiguratio
 clientBasic.UpdateStoreRateConfiguration(user.StoreId, new StoreRateConfiguration() { IsCustomScript = false, PreferredSource = "coingeckoOOO", Spread = -1m }));
 
             await AssertValidationError(new[] { "currencyPair" }, () =>
-clientBasic.PreviewUpdateStoreRateConfiguration(user.StoreId, new StoreRateConfiguration() { IsCustomScript = false, PreferredSource = "coingecko" }, new[] { "BTC_USD_USD_BTC" }));
+clientBasic.PreviewUpdateStoreRateConfiguration(user.StoreId, new StoreRateConfiguration() { IsCustomScript = false, PreferredSource = "coingecko" }, new[] { "BTCUSDUSDBTC" }));
             await AssertValidationError(new[] { "PreferredSource", "currencyPair" }, () =>
-clientBasic.PreviewUpdateStoreRateConfiguration(user.StoreId, new StoreRateConfiguration() { IsCustomScript = false, PreferredSource = "coingeckoOOO" }, new[] { "BTC_USD_USD_BTC" }));
+clientBasic.PreviewUpdateStoreRateConfiguration(user.StoreId, new StoreRateConfiguration() { IsCustomScript = false, PreferredSource = "coingeckoOOO" }, new[] { "BTCUSDUSDBTC" }));
         }
     }
 }


### PR DESCRIPTION
This error would show in the log, but nothing else would really be impacted.