### PR TITLE
Feature: RBF and UX improvement to fee bumping

### DIFF
--- a/BTCPayServer.Data/Data/WalletObjectData.cs
+++ b/BTCPayServer.Data/Data/WalletObjectData.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Newtonsoft.Json.Linq;
 
 namespace BTCPayServer.Data
 {
@@ -19,6 +20,8 @@ namespace BTCPayServer.Data
             }
             public const string Label = "label";
             public const string Tx = "tx";
+            public const string CPFP = "CPFP";
+            public const string RBF = "RBF";
             public const string Payjoin = "payjoin";
             public const string Invoice = "invoice";
             public const string PaymentRequest = "payment-request";
@@ -33,24 +36,27 @@ namespace BTCPayServer.Data
         public string Type { get; set; }
         public string Id { get; set; }
         public string Data { get; set; }
-
+#nullable enable
+        public JObject? GetData() => Data is null ? null : JObject.Parse(Data);
+#nullable restore
         public List<WalletObjectLinkData> Bs { get; set; }
         public List<WalletObjectLinkData> As { get; set; }
-
-        public IEnumerable<(string type, string id, string linkdata, string objectdata)> GetLinks()
+#nullable enable
+        public IEnumerable<(string type, string id, JObject? linkdata, JObject? objectdata)> GetLinks()
         {
+            static JObject? AsJObj(string? data) => data is null ? null : JObject.Parse(data);
             if (Bs is not null)
                 foreach (var c in Bs)
                 {
-                    yield return (c.BType, c.BId, c.Data, c.B?.Data);
+                    yield return (c.BType, c.BId, AsJObj(c.Data), AsJObj(c.B?.Data));
                 }
             if (As is not null)
                 foreach (var c in As)
                 {
-                    yield return (c.AType, c.AId, c.Data, c.A?.Data);
+                    yield return (c.AType, c.AId, AsJObj(c.Data), AsJObj(c.A?.Data));
                 }
         }
-
+#nullable restore
         public IEnumerable<WalletObjectData> GetNeighbours()
         {
             if (Bs != null)

--- a/BTCPayServer.Tests/SeleniumTester.cs
+++ b/BTCPayServer.Tests/SeleniumTester.cs
@@ -679,5 +679,10 @@ retry:
                 Driver.WaitForAndClick(By.Id("page-primary"));
             }
         }
+
+        public void ClickCancel()
+        {
+            Driver.FindElement(By.Id("CancelWizard")).Click();
+        }
     }
 }

--- a/BTCPayServer.Tests/SeleniumTests.cs
+++ b/BTCPayServer.Tests/SeleniumTests.cs
@@ -10,6 +10,7 @@ using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
+using BTCPayServer.Abstractions.Form;
 using BTCPayServer.Abstractions.Models;
 using BTCPayServer.Client;
 using BTCPayServer.Client.Models;
@@ -206,6 +207,104 @@ namespace BTCPayServer.Tests
             Assert.Equal(4, new SelectElement(s.Driver.FindElement(By.Id("FormId"))).Options.Count);
         }
 
+		[Fact(Timeout = TestTimeout)]
+		public async Task CanUseBumpFee()
+        {
+            using var s = CreateSeleniumTester();
+            await s.StartAsync();
+            await s.Server.ExplorerNode.GenerateAsync(1);
+            s.RegisterNewUser(true);
+            s.CreateNewStore();
+            s.GenerateWallet(isHotWallet: true);
+
+            for (int i = 0; i < 3; i++)
+            {
+                s.CreateInvoice();
+                s.GoToInvoiceCheckout();
+                s.PayInvoice();
+                s.GoToInvoices(s.StoreId);
+            }
+            var client = await s.AsTestAccount().CreateClient();
+            var txs = (await client.ShowOnChainWalletTransactions(s.StoreId, "BTC")).Select(t => t.TransactionHash).ToArray();
+            Assert.Equal(3, txs.Length);
+
+            s.GoToWallet(navPages: WalletsNavPages.Transactions);
+            ClickBumpFee(s, txs[0]);
+
+			// Because a single transaction is selected, we should be able to select CPFP only (Because no change are available, we can't do RBF)
+			s.Driver.FindElement(By.Name("txId"));
+			Assert.Equal("true", s.Driver.FindElement(By.Id("BumpMethod")).GetAttribute("disabled"));
+			Assert.Equal("CPFP", new SelectElement(s.Driver.FindElement(By.Id("BumpMethod"))).SelectedOption.Text);
+			s.ClickCancel();
+
+			// Same but using mass action
+			SelectTransactions(s, txs[0]);
+			s.Driver.FindElement(By.Id("BumpFee")).Click();
+			s.Driver.FindElement(By.Name("txId"));
+			s.ClickCancel();
+
+			// Because two transactions are select we can only mass bump on CPFP
+			SelectTransactions(s, txs[0], txs[1]);
+			s.Driver.FindElement(By.Id("BumpFee")).Click();
+			s.Driver.ElementDoesNotExist(By.Name("txId"));
+			Assert.Equal("true", s.Driver.FindElement(By.Id("BumpMethod")).GetAttribute("disabled"));
+			Assert.Equal("CPFP", new SelectElement(s.Driver.FindElement(By.Id("BumpMethod"))).SelectedOption.Text);
+
+			var newExpectedEffectiveFeeRate = decimal.Parse(s.Driver.FindElement(By.Name("FeeSatoshiPerByte")).GetAttribute("value"), CultureInfo.InvariantCulture);
+
+			s.ClickPagePrimary();
+			s.Driver.FindElement(By.Id("BroadcastTransaction")).Click();
+			Assert.Contains("Transaction broadcasted successfully", s.FindAlertMessage().Text);
+
+			// The CPFP tag should be applied to the new tx
+			s.Driver.Navigate().Refresh();
+			s.Driver.WaitWalletTransactionsLoaded();
+			var cpfpTx = (await client.ShowOnChainWalletTransactions(s.StoreId, "BTC")).Select(t => t.TransactionHash).ToArray()[0];
+
+			// The CPFP should be RBF-able
+			Assert.DoesNotContain(cpfpTx, txs);
+			s.Driver.FindElement(By.CssSelector($"{TxRowSelector(cpfpTx)} .transaction-label[data-value=\"CPFP\"]"));
+			ClickBumpFee(s, cpfpTx);
+			Assert.Null(s.Driver.FindElement(By.Id("BumpMethod")).GetAttribute("disabled"));
+			Assert.Equal("RBF", new SelectElement(s.Driver.FindElement(By.Id("BumpMethod"))).SelectedOption.Text);
+
+			var currentEffectiveFeeRate = decimal.Parse(s.Driver.FindElement(By.Name("CurrentFeeSatoshiPerByte")).GetAttribute("value"), CultureInfo.InvariantCulture);
+
+			// We CPFP'd two transactions with a newExpectedEffectiveFeeRate of 20.0
+			// When we want to RBF the previous CPFP, the currentEffectiveFeeRate should be coherent with our ealier choice
+			Assert.Equal(newExpectedEffectiveFeeRate, currentEffectiveFeeRate, 1);
+
+			s.ClickPagePrimary();
+			s.Driver.FindElement(By.Id("BroadcastTransaction")).Click();
+
+			s.Driver.Navigate().Refresh();
+			s.Driver.WaitWalletTransactionsLoaded();
+			var rbfTx = (await client.ShowOnChainWalletTransactions(s.StoreId, "BTC")).Select(t => t.TransactionHash).ToArray()[0];
+
+			// CPFP has been replaced, so it should not be found
+			s.Driver.AssertElementNotFound(By.CssSelector(TxRowSelector(cpfpTx)));
+
+			// However, the new transaction should have copied the CPFP tag from the transaction it replaced, and have a RBF label as well.
+			s.Driver.FindElement(By.CssSelector($"{TxRowSelector(rbfTx)} .transaction-label[data-value=\"CPFP\"]"));
+			s.Driver.FindElement(By.CssSelector($"{TxRowSelector(rbfTx)} .transaction-label[data-value=\"RBF\"]"));
+		}
+		static string TxRowSelector(uint256 txId) => $".transaction-row[data-value=\"{txId}\"]";
+
+		private void SelectTransactions(SeleniumTester s, params uint256[] txs)
+        {
+			s.Driver.WaitWalletTransactionsLoaded();
+			foreach (var txId in txs)
+			{
+				s.Driver.SetCheckbox(By.CssSelector($"{TxRowSelector(txId)} .mass-action-select"), true);
+			}
+		}
+
+        private static void ClickBumpFee(SeleniumTester s, uint256 txId)
+        {
+			s.Driver.WaitWalletTransactionsLoaded();
+			s.Driver.FindElement(By.CssSelector($"{TxRowSelector(txId)} .bumpFee-btn")).Click();
+        }
+
         [Fact(Timeout = TestTimeout)]
         public async Task CanUseCPFP()
         {
@@ -225,6 +324,7 @@ namespace BTCPayServer.Tests
             // Let's CPFP from the invoices page
             s.Driver.SetCheckbox(By.CssSelector(".mass-action-select-all"), true);
             s.Driver.FindElement(By.Id("BumpFee")).Click();
+            s.ClickPagePrimary();
             s.Driver.FindElement(By.Id("BroadcastTransaction")).Click();
             s.FindAlertMessage();
             Assert.Contains($"/stores/{s.StoreId}/invoices", s.Driver.Url);
@@ -234,15 +334,21 @@ namespace BTCPayServer.Tests
             s.Driver.SetCheckbox(By.CssSelector(".mass-action-select-all"), true);
             s.Driver.FindElement(By.Id("BumpFee")).Click();
             Assert.Contains($"/stores/{s.StoreId}/invoices", s.Driver.Url);
-            Assert.Contains("any UTXO available", s.FindAlertMessage(StatusMessageModel.StatusSeverity.Error).Text);
+            Assert.Contains("No UTXOs available", s.FindAlertMessage(StatusMessageModel.StatusSeverity.Error).Text);
 
             // But we should be able to bump from the wallet's page
             s.GoToWallet(navPages: WalletsNavPages.Transactions);
             s.Driver.SetCheckbox(By.CssSelector(".mass-action-select-all"), true);
             s.Driver.FindElement(By.Id("BumpFee")).Click();
-            s.Driver.FindElement(By.Id("BroadcastTransaction")).Click();
+			s.ClickPagePrimary();
+			s.Driver.FindElement(By.Id("BroadcastTransaction")).Click();
             Assert.Contains($"/wallets/{s.WalletId}", s.Driver.Url);
             Assert.Contains("Transaction broadcasted successfully", s.FindAlertMessage().Text);
+
+			// The CPFP tag should be applied to the new tx
+			s.Driver.Navigate().Refresh();
+			s.Driver.WaitWalletTransactionsLoaded();
+			s.Driver.FindElement(By.CssSelector(".transaction-label[data-value=\"CPFP\"]"));
         }
 
         [Fact(Timeout = TestTimeout)]

--- a/BTCPayServer/BTCPayServer.csproj
+++ b/BTCPayServer/BTCPayServer.csproj
@@ -112,11 +112,13 @@
 	<ItemGroup>
     <Watch Include="Views\**\*.*"></Watch>
     <Watch Remove="Views\Shared\LocalhostBrowserSupport.cshtml" />
+    <Watch Remove="Views\Shared\_BackAndReturn.cshtml" />
     <Watch Remove="Views\UIAccount\CheatPermissions.cshtml" />
     <Watch Remove="Views\UIReports\StoreReports.cshtml" />
     <Watch Remove="Views\UIServer\CreateDictionary.cshtml" />
     <Watch Remove="Views\UIServer\EditDictionary.cshtml" />
     <Watch Remove="Views\UIServer\ListDictionaries.cshtml" />
+    <Watch Remove="Views\UIWallets\WalletBumpFee.cshtml" />
     <Content Update="Views\UIApps\_ViewImports.cshtml">
       <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
       <Pack>$(IncludeRazorContentInPack)</Pack>

--- a/BTCPayServer/Controllers/GreenField/GreenfieldStoreOnChainWalletsController.cs
+++ b/BTCPayServer/Controllers/GreenField/GreenfieldStoreOnChainWalletsController.cs
@@ -790,12 +790,12 @@ namespace BTCPayServer.Controllers.Greenfield
             };
         }
 
-        private OnChainWalletObjectData.OnChainWalletObjectLink ToModel((string type, string id, string linkdata, string objectdata) data)
+        private OnChainWalletObjectData.OnChainWalletObjectLink ToModel((string type, string id, JObject? linkdata, JObject? objectdata) data)
         {
             return new OnChainWalletObjectData.OnChainWalletObjectLink()
             {
-                LinkData = string.IsNullOrEmpty(data.linkdata) ? null : JObject.Parse(data.linkdata),
-                ObjectData = string.IsNullOrEmpty(data.objectdata) ? null : JObject.Parse(data.objectdata),
+                LinkData = data.linkdata,
+                ObjectData = data.objectdata,
                 Type = data.type,
                 Id = data.id,
             };

--- a/BTCPayServer/Controllers/UIInvoiceController.UI.cs
+++ b/BTCPayServer/Controllers/UIInvoiceController.UI.cs
@@ -663,6 +663,8 @@ namespace BTCPayServer.Controllers
                     var bumpableAddresses = await GetAddresses(btc, selectedItems);
                     var utxos = await explorer.GetUTXOsAsync(derivationScheme);
                     var bumpableUTXOs = utxos.GetUnspentUTXOs().Where(u => u.Confirmations == 0 && bumpableAddresses.Contains(u.ScriptPubKey.Hash.ToString())).ToArray();
+                    if (bumpableUTXOs.Length == 0)
+                        return NotSupported("No UTXOs available for bumping the selected invoices");
                     var parameters = new MultiValueDictionary<string, string>();
                     foreach (var utxo in bumpableUTXOs)
                     {
@@ -671,7 +673,7 @@ namespace BTCPayServer.Controllers
                     return View("PostRedirect", new PostRedirectViewModel
                     {
                         AspController = "UIWallets",
-                        AspAction = nameof(UIWalletsController.WalletCPFP),
+                        AspAction = nameof(UIWalletsController.WalletBumpFee),
                         RouteParameters = {
                             { "walletId", new WalletId(storeId, network.CryptoCode).ToString() },
                             { "returnUrl", Url.Action(nameof(ListInvoices), new { storeId }) }

--- a/BTCPayServer/Controllers/UIWalletsController.cs
+++ b/BTCPayServer/Controllers/UIWalletsController.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Net.Mime;
+using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using BTCPayServer.Abstractions.Constants;
@@ -23,6 +24,7 @@ using BTCPayServer.Payments.PayJoin;
 using BTCPayServer.Payouts;
 using BTCPayServer.Rating;
 using BTCPayServer.Services;
+using BTCPayServer.Services.Fees;
 using BTCPayServer.Services.Invoices;
 using BTCPayServer.Services.Labels;
 using BTCPayServer.Services.Rates;
@@ -30,6 +32,7 @@ using BTCPayServer.Services.Stores;
 using BTCPayServer.Services.Wallets;
 using BTCPayServer.Services.Wallets.Export;
 using Dapper;
+using ExchangeSharp.BinanceGroup;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Identity;
@@ -42,6 +45,10 @@ using NBXplorer;
 using NBXplorer.DerivationStrategy;
 using NBXplorer.Models;
 using Newtonsoft.Json;
+using static BTCPayServer.Models.WalletViewModels.WalletBumpFeeViewModel;
+using static BTCPayServer.Services.Wallets.ReplacementInfo;
+using static Microsoft.EntityFrameworkCore.DbLoggerCategory;
+using static Microsoft.EntityFrameworkCore.DbLoggerCategory.Database;
 using StoreData = BTCPayServer.Data.StoreData;
 
 namespace BTCPayServer.Controllers
@@ -143,8 +150,8 @@ namespace BTCPayServer.Controllers
             [ModelBinder(typeof(WalletIdModelBinder))] WalletId walletId,
             string transactionId)
         {
-            return View("Confirm", new ConfirmModel("Abort Pending Transaction", 
-                "Proceeding with this action will invalidate Pending Transaction and all accepted signatures.", 
+            return View("Confirm", new ConfirmModel("Abort Pending Transaction",
+                "Proceeding with this action will invalidate Pending Transaction and all accepted signatures.",
                 "Confirm Abort"));
         }
         [HttpPost("{walletId}/pending/{transactionId}/cancel")]
@@ -190,7 +197,8 @@ namespace BTCPayServer.Controllers
                 CryptoCode = network.CryptoCode,
                 SigningContext = new SigningContextModel(currentPsbt)
                 {
-                    PendingTransactionId = transactionId, PSBT = currentPsbt.ToBase64(),
+                    PendingTransactionId = transactionId,
+                    PSBT = currentPsbt.ToBase64(),
                 },
             };
             await FetchTransactionDetails(walletId, derivationSchemeSettings, vm, network);
@@ -198,6 +206,292 @@ namespace BTCPayServer.Controllers
             return View("WalletPSBTDecoded", vm);
         }
 
+        [Route("{walletId}/transactions/bump")]
+        [Route("{walletId}/transactions/{transactionId}/bump")]
+        public async Task<IActionResult> WalletBumpFee([ModelBinder(typeof(WalletIdModelBinder))]
+            [FromQuery]
+            WalletId walletId,
+            WalletBumpFeeViewModel model,
+          CancellationToken cancellationToken = default)
+        {
+            var paymentMethod = GetDerivationSchemeSettings(walletId);
+            if (paymentMethod is null)
+                return NotFound();
+            
+            var wallet = _walletProvider.GetWallet(walletId.CryptoCode);
+			var bumpable = await wallet.GetBumpableTransactions(paymentMethod.AccountDerivation, cancellationToken);
+
+            var bumpTarget = model.GetBumpTarget()
+                                // Remove from the selected targets everything that isn't bumpable
+                                .Filter(bumpable.Where(o => (o.Value.CPFP || o.Value.RBF) && o.Value.ReplacementInfo != null).Select(o => o.Key).ToHashSet());
+
+            var explorer = this.ExplorerClientProvider.GetExplorerClient(walletId.CryptoCode);
+            var txs = await GetUnconfWalletTxInfo(explorer, paymentMethod.AccountDerivation, bumpTarget.GetTransactionIds(), cancellationToken);
+
+            // Remove from the selected targets everything for which we don't have the transaction info
+            bumpTarget = bumpTarget.Filter(txs.Select(t => t.Key).ToHashSet());
+
+			model.ReturnUrl ??= Url.WalletTransactions(walletId)!;
+
+			decimal minBumpFee = 0.0m;
+            if (bumpTarget.GetSingleTransactionId() is { } txId)
+            {
+                var inf = bumpable[txId];
+                if (inf.RBF)
+                    model.BumpFeeMethods.Add(new("RBF", "RBF"));
+                if (inf.CPFP)
+                    model.BumpFeeMethods.Add(new("CPFP", "CPFP"));
+
+                // We calculate the effective fee rate using all the ancestors and descendant.
+                model.CurrentFeeSatoshiPerByte = inf.ReplacementInfo!.GetEffectiveFeeRate().SatoshiPerByte;
+                minBumpFee = inf.ReplacementInfo.CalculateNewMinFeeRate().SatoshiPerByte;
+            }
+            else if (bumpTarget.GetTransactionIds().Any())
+            {
+                model.BumpFeeMethods.Add(new("CPFP", "CPFP"));
+                // If we bump multiple transactions, we calculate the effective fee rate without
+                // taking into account descendants. This isn't super correct... but good enough for our purposes.
+                // This is because we would have the risk of double counting the fees otherwise.
+                var currentFeeRate = GetTransactionsFeeInfo(bumpTarget, txs, null).CurrentFeeRate.SatoshiPerByte;
+                model.CurrentFeeSatoshiPerByte = currentFeeRate;
+                minBumpFee = currentFeeRate + 1.0m;
+            }
+            else
+            {
+                this.TempData.SetStatusMessageModel(new StatusMessageModel()
+                {
+                    Severity = StatusMessageModel.StatusSeverity.Error,
+                    Message =
+                    bumpable switch
+                    {
+                        { Support: BumpableSupport.NotCompatible } => StringLocalizer["This version of NBXplorer is not compatible. Please update to 2.5.22 or above"],
+                        { Support: BumpableSupport.NotConfigured } => StringLocalizer["Please set NBXPlorer's PostgreSQL connection string to make this feature available."],
+                        { Support: BumpableSupport.NotSynched } => StringLocalizer["Please wait for your node to be synched"],
+                        _ => StringLocalizer["None of the selected transaction can be fee bumped"]
+                    }
+                });
+                return LocalRedirect(model.ReturnUrl);
+            }
+
+            model.IsMultiSigOnServer = paymentMethod.IsMultiSigOnServer;
+            var feeProvider = _feeRateProvider.CreateFeeProvider(wallet.Network);
+            var recommendedFees = await GetRecommendedFees(wallet.Network, _feeRateProvider);
+
+            foreach (var option in recommendedFees)
+            {
+                if (option is null)
+                    continue;
+                if (minBumpFee is decimal v && option.FeeRate < v)
+                    option.FeeRate = v;
+            }
+            
+            model.RecommendedSatoshiPerByte =
+                recommendedFees.Where(option => option != null).ToList();
+            model.FeeSatoshiPerByte ??= recommendedFees.Skip(1).FirstOrDefault()?.FeeRate;
+
+            if (HttpContext.Request.Method != HttpMethods.Post)
+            {
+                model.Command = null;
+            }
+            if (!ModelState.IsValid || model.Command is null || model.FeeSatoshiPerByte is null)
+                return View(nameof(WalletBumpFee), model);
+
+            var targetFeeRate = new FeeRate(model.FeeSatoshiPerByte.Value);
+            model.BumpMethod ??= model.BumpFeeMethods switch
+            {
+                { Count: 1 } => model.BumpFeeMethods[0].Value,
+                _ => "RBF"
+            };
+            PSBT? psbt = null;
+            SigningContextModel? signingContext = null;
+            var feeBumpUrl = Url.Action(nameof(WalletBumpFee), new { walletId, transactionId = bumpTarget.GetSingleTransactionId(), model.FeeSatoshiPerByte, model.BumpMethod, model.TransactionHashes, model.Outpoints })!;
+            if (model.BumpMethod == "CPFP")
+            {
+                var utxos = await explorer.GetUTXOsAsync(paymentMethod.AccountDerivation);
+
+                List<OutPoint> bumpableUTXOs = bumpTarget.GetMatchedOutpoints(utxos.GetUnspentUTXOs().Where(u => u.Confirmations == 0).Select(u => u.Outpoint));
+                if (bumpableUTXOs.Count == 0)
+                {
+                    TempData[WellKnownTempData.ErrorMessage] = StringLocalizer["There isn't any UTXO available to bump fee with CPFP"].Value;
+                    return LocalRedirect(model.ReturnUrl);
+                }
+
+                var createPSBT = new CreatePSBTRequest()
+				{
+					RBF = true,
+					AlwaysIncludeNonWitnessUTXO = paymentMethod.DefaultIncludeNonWitnessUtxo,
+					IncludeOnlyOutpoints = bumpableUTXOs,
+					SpendAllMatchingOutpoints = true,
+					FeePreference = new FeePreference()
+					{
+						ExplicitFee = GetTransactionsFeeInfo(bumpTarget, txs, targetFeeRate).MissingFee,
+						ExplicitFeeRate = targetFeeRate
+					}
+				};
+
+                try
+                {
+                    var psbtResponse = await explorer.CreatePSBTAsync(paymentMethod.AccountDerivation, createPSBT, cancellationToken);
+
+                    signingContext = new SigningContextModel
+                    {
+                        EnforceLowR = psbtResponse.Suggestions?.ShouldEnforceLowR,
+                        ChangeAddress = psbtResponse.ChangeAddress?.ToString(),
+                        PSBT = psbtResponse.PSBT.ToHex()
+                    };
+                    psbt = psbtResponse.PSBT;
+                }
+                catch (Exception ex)
+                {
+                    TempData[WellKnownTempData.ErrorMessage] = ex.Message;
+
+                    return LocalRedirect(model.ReturnUrl);
+                }
+            }
+            else if (model.BumpMethod == "RBF")
+            {
+                // RBF is only supported for a single tx
+                var tx = txs[bumpTarget.GetSingleTransactionId()!];
+                var changeOutput = tx.Outputs.FirstOrDefault(o => o.Feature == DerivationFeature.Change);
+                if (tx.Inputs.Count != tx.Transaction?.Inputs.Count ||
+                    changeOutput is null)
+                {
+                    this.ModelState.AddModelError(nameof(model.BumpMethod), StringLocalizer["This transaction can't be RBF'd"]);
+                    return View(nameof(WalletBumpFee), model);
+                }
+                IActionResult ChangeTooSmall(WalletBumpFeeViewModel model, Money? missing)
+                {
+                    if (missing is not null)
+                        ModelState.AddModelError(nameof(model.FeeSatoshiPerByte), StringLocalizer["The change output is too small to pay for additional fee. (Missing {0} BTC)", missing.ToDecimal(MoneyUnit.BTC)]);
+                    else
+                        ModelState.AddModelError(nameof(model.FeeSatoshiPerByte), StringLocalizer["The change output is too small to pay for additional fee."]);
+                    return View(nameof(WalletBumpFee), model);
+                }
+
+                var bumpResult = bumpable[tx.TransactionId].ReplacementInfo!.CalculateBumpResult(targetFeeRate);
+                var createPSBT = new CreatePSBTRequest()
+                {
+                    RBF = true,
+                    AlwaysIncludeNonWitnessUTXO = paymentMethod.DefaultIncludeNonWitnessUtxo,
+                    IncludeOnlyOutpoints = tx.Transaction.Inputs.Select(i => i.PrevOut).ToList(),
+                    SpendAllMatchingOutpoints = true,
+                    DisableFingerprintRandomization = true,
+                    FeePreference = new FeePreference()
+                    {
+                        ExplicitFee = bumpResult.NewTxFee
+                    },
+                    ExplicitChangeAddress = changeOutput.Address,
+                    Destinations = tx.Transaction.Outputs.AsIndexedOutputs()
+                                        .Select(o => new CreatePSBTDestination()
+                                        {
+                                            Amount = o.N == changeOutput.Index ? (Money)o.TxOut.Value - bumpResult.BumpTxFee : (Money)o.TxOut.Value,
+                                            Destination = o.TxOut.ScriptPubKey,
+                                        }).ToList()
+                };
+                var missingFundsOutput = createPSBT.Destinations.FirstOrDefault(d => d.Amount < Money.Zero);
+                if (missingFundsOutput is not null)
+                    return ChangeTooSmall(model, -missingFundsOutput.Amount);
+
+                try
+                {
+                    var psbtResponse = await explorer.CreatePSBTAsync(paymentMethod.AccountDerivation, createPSBT, cancellationToken);
+
+                    signingContext = new SigningContextModel
+                    {
+                        EnforceLowR = psbtResponse.Suggestions?.ShouldEnforceLowR,
+                        ChangeAddress = psbtResponse.ChangeAddress?.ToString(),
+                        PSBT = psbtResponse.PSBT.ToHex(),
+                        BalanceChangeFromReplacement = (-(Money)tx.BalanceChange).Satoshi
+                    };
+                    psbt = psbtResponse.PSBT;
+                }
+                catch (NBXplorerException ex) when (ex.Error.Code == "output-too-small")
+                {
+                    return ChangeTooSmall(model, null);
+                }
+                catch (NBXplorerException ex)
+                {
+                    ModelState.AddModelError(nameof(model.TransactionId), StringLocalizer["Unable to create the replacement transaction ({0})", ex.Error.Message]);
+                    return View(nameof(WalletBumpFee), model);
+                }
+            }
+
+            if (psbt is not null && signingContext is not null)
+            {
+                if (psbt.TryGetFinalizedHash(out var hash))
+                    await this.WalletRepository.EnsureWalletObject(new WalletObjectId(walletId, WalletObjectData.Types.Tx, hash.ToString()),
+                        new Newtonsoft.Json.Linq.JObject()
+                        {
+                            ["bumpFeeMethod"] = model.BumpMethod
+                        });
+                switch (model.Command)
+                {
+                    case "createpending":
+                        var pt = await _pendingTransactionService.CreatePendingTransaction(walletId.StoreId, walletId.CryptoCode, psbt);
+                        return RedirectToWalletList(walletId);
+                    default:
+                        // case "sign":
+                        return await WalletSign(walletId, new WalletPSBTViewModel()
+                        {
+                            SigningContext = signingContext,
+                            BackUrl = feeBumpUrl,
+                            ReturnUrl = model.ReturnUrl
+                        });
+                }
+            }
+
+            // Ask choice to user
+            return View(nameof(WalletBumpFee), model);
+        }
+
+        private async Task<Dictionary<uint256, TransactionInformation>> GetUnconfWalletTxInfo(ExplorerClient client, DerivationStrategyBase derivationStrategyBase, HashSet<uint256> txs, CancellationToken cancellationToken)
+        {
+			var txWalletInfo = new Dictionary<uint256, TransactionInformation>();
+            var getTransactionAsync = txs.Select(t => client.GetTransactionAsync(derivationStrategyBase, t, cancellationToken)).ToArray();
+            await Task.WhenAll(getTransactionAsync);
+            foreach (var t in getTransactionAsync)
+            {
+                var r = await t;
+                if (r is not
+					{
+						Confirmations: 0,
+						Transaction: not null
+					})
+                    continue;
+				txWalletInfo.Add(r.TransactionId, r);
+            }
+            return txWalletInfo;
+        }
+
+        private (Money MissingFee, FeeRate CurrentFeeRate) GetTransactionsFeeInfo(BumpTarget target, Dictionary<uint256, TransactionInformation> txs, FeeRate? newFeeRate)
+        {
+            Money missingFee = Money.Zero;
+            int totalSize = 0;
+            Money totalFee = Money.Zero;
+            // In theory, we should calculate using the effective fee rate of all bumped transactions.
+            // In practice, it's a bit complicated to get... meh, that's good enough.
+            foreach (var bumpedTx in target.GetTransactionIds().Select(o => txs[o]))
+            {
+                var size = bumpedTx.Metadata?.VirtualSize ?? bumpedTx.Transaction?.GetVirtualSize() ?? 200;
+                var feePaid = bumpedTx.Metadata?.Fees;
+                if (feePaid is null)
+                    // This shouldn't normally happen, as NBX indexes the fee if the transaction is in the mempool
+                    continue;
+                if (newFeeRate is not null)
+                {
+                    var expectedFeePaid = newFeeRate.GetFee(size);
+                    missingFee += Money.Max(Money.Zero, expectedFeePaid - feePaid);
+                }
+                totalSize += size;
+                totalFee += feePaid;
+            }
+            return (missingFee, new FeeRate(totalFee, totalSize));
+        }
+
+        private IActionResult RedirectToWalletList(WalletId walletId)
+        {
+            return RedirectToAction(nameof(WalletTransactions), new { walletId = walletId.ToString() });
+        }
 
         [HttpPost]
         [Route("{walletId}")]
@@ -275,7 +569,7 @@ namespace BTCPayServer.Controllers
                 ListWalletsViewModel.WalletViewModel walletVm = new ListWalletsViewModel.WalletViewModel();
                 wallets.Wallets.Add(walletVm);
                 walletVm.Balance = await wallet.Balance + " " + wallet.Wallet.Network.CryptoCode;
-                
+
 
                 walletVm.CryptoCode = wallet.Network.CryptoCode;
                 walletVm.StoreId = wallet.Store.Id;
@@ -312,9 +606,9 @@ namespace BTCPayServer.Controllers
             // We can't filter at the database level if we need to apply label filter
             var preFiltering = string.IsNullOrEmpty(labelFilter);
             var model = new ListTransactionsViewModel { Skip = skip, Count = count };
-            
+
             model.PendingTransactions = await _pendingTransactionService.GetPendingTransactions(walletId.CryptoCode, walletId.StoreId);
-            
+
             model.Labels.AddRange(
                 (await WalletRepository.GetWalletLabels(walletId))
                 .Select(c => (c.Label, c.Color, ColorPalette.Default.TextColor(c.Color))));
@@ -326,7 +620,6 @@ namespace BTCPayServer.Controllers
                 transactions = await wallet.FetchTransactionHistory(paymentMethod.AccountDerivation, preFiltering ? skip : null, preFiltering ? count : null, cancellationToken: cancellationToken);
                 walletTransactionsInfo = await WalletRepository.GetWalletTransactionsInfo(walletId, transactions.Select(t => t.TransactionId.ToString()).ToArray());
             }
-
             if (labelFilter != null)
             {
                 model.PaginationQuery = new Dictionary<string, object> { { "labelFilter", labelFilter } };
@@ -337,6 +630,7 @@ namespace BTCPayServer.Controllers
             }
             else
             {
+                var bumpable = transactions.Any(tx => tx.Confirmations == 0) ? await wallet.GetBumpableTransactions(paymentMethod.AccountDerivation, cancellationToken) : new();
                 var pmi = PaymentTypes.CHAIN.GetPaymentMethodId(walletId.CryptoCode);
                 foreach (var tx in transactions)
                 {
@@ -347,7 +641,10 @@ namespace BTCPayServer.Controllers
                     vm.Positive = tx.BalanceChange.GetValue(wallet.Network) >= 0;
                     vm.Balance = tx.BalanceChange.ShowMoney(wallet.Network);
                     vm.IsConfirmed = tx.Confirmations != 0;
-
+                    // If support isn't possible, we want the user to be able to click so he can see why it doesn't work
+                    vm.CanBumpFee =
+                        tx.Confirmations == 0 &&
+                        (bumpable.Support is not BumpableSupport.Ok || (bumpable.TryGetValue(tx.TransactionId, out var i) ? i.RBF || i.CPFP : false));
                     if (walletTransactionsInfo.TryGetValue(tx.TransactionId.ToString(), out var transactionInfo))
                     {
                         var labels = _labelService.CreateTransactionTagModels(transactionInfo, Request);
@@ -383,7 +680,8 @@ namespace BTCPayServer.Controllers
         {
             var store = GetCurrentStore();
             var data = await _walletHistogramService.GetHistogram(store, walletId, type);
-            if (data == null) return NotFound();
+            if (data == null)
+                return NotFound();
 
             return Json(data);
         }
@@ -547,30 +845,7 @@ namespace BTCPayServer.Controllers
                     }
                 };
             }
-            var feeProvider = _feeRateProvider.CreateFeeProvider(network);
-            var recommendedFees =
-                new[]
-                    {
-                        TimeSpan.FromMinutes(10.0), TimeSpan.FromMinutes(60.0), TimeSpan.FromHours(6.0),
-                        TimeSpan.FromHours(24.0),
-                    }.Select(async time =>
-                    {
-                        try
-                        {
-                            var result = await feeProvider.GetFeeRateAsync(
-                                (int)network.NBitcoinNetwork.Consensus.GetExpectedBlocksFor(time));
-                            return new WalletSendModel.FeeRateOption()
-                            {
-                                Target = time,
-                                FeeRate = result.SatoshiPerByte
-                            };
-                        }
-                        catch (Exception)
-                        {
-                            return null;
-                        }
-                    })
-                    .ToArray();
+            var recommendedFeesAsync = GetRecommendedFees(network, _feeRateProvider);
             var balance = _walletProvider.GetWallet(network).GetBalance(paymentMethod.AccountDerivation);
             model.NBXSeedAvailable = await GetSeed(walletId, network) != null;
             var Balance = await balance;
@@ -580,11 +855,11 @@ namespace BTCPayServer.Controllers
             else
                 model.ImmatureBalance = Balance.Immature.GetValue(network);
 
-            await Task.WhenAll(recommendedFees);
+            var recommendedFees = await recommendedFeesAsync;
             model.RecommendedSatoshiPerByte =
-                recommendedFees.Select(tuple => tuple.GetAwaiter().GetResult()).Where(option => option != null).ToList();
+                recommendedFees.Where(option => option != null).ToList();
 
-            model.FeeSatoshiPerByte = recommendedFees[1].GetAwaiter().GetResult()?.FeeRate;
+            model.FeeSatoshiPerByte = recommendedFees.Skip(1).FirstOrDefault()?.FeeRate;
             model.CryptoDivisibility = network.Divisibility;
             
             try
@@ -624,6 +899,33 @@ namespace BTCPayServer.Controllers
             }
 
             return new (result.BidAsk.Center, currencyPair.Right);
+        }
+
+        private static async Task<WalletSendModel.FeeRateOption?[]> GetRecommendedFees(BTCPayNetwork network, IFeeProviderFactory feeProviderFactory)
+        {
+            var feeProvider = feeProviderFactory.CreateFeeProvider(network);
+            List<WalletSendModel.FeeRateOption?> options = new();
+            foreach (var time in new[] {
+                        TimeSpan.FromMinutes(10.0), TimeSpan.FromMinutes(60.0), TimeSpan.FromHours(6.0),
+                        TimeSpan.FromHours(24.0),
+                    })
+            {
+                try
+                {
+                    var result = await feeProvider.GetFeeRateAsync(
+                        (int)network.NBitcoinNetwork.Consensus.GetExpectedBlocksFor(time));
+                    options.Add(new WalletSendModel.FeeRateOption()
+                    {
+                        Target = time,
+                        FeeRate = result.SatoshiPerByte
+                    });
+                }
+                catch (Exception)
+                {
+                    options.Add(null);
+                }
+            }
+            return options.ToArray();
         }
 
         private async Task<string?> GetSeed(WalletId walletId, BTCPayNetwork network)
@@ -943,7 +1245,7 @@ namespace BTCPayServer.Controllers
                     {
                         SigningContext = signingContext,
                         ReturnUrl = vm.ReturnUrl,
-                        BackUrl = vm.BackUrl
+                        BackUrl = this.Url.WalletSend(walletId)
                     });
                 case "analyze-psbt":
                     var name =
@@ -1055,11 +1357,11 @@ namespace BTCPayServer.Controllers
             {
                 var psbt = PSBT.Parse(vm.SigningContext.PSBT, NetworkProvider.GetNetwork<BTCPayNetwork>(walletId.CryptoCode).NBitcoinNetwork);
                 var pendingTransaction = await _pendingTransactionService.CollectSignature(walletId.CryptoCode, psbt, false, CancellationToken.None);
-                
+
                 if (pendingTransaction != null)
                     return RedirectToAction(nameof(WalletTransactions), new { walletId = walletId.ToString() });
             }
-            
+
             var redirectVm = new PostRedirectViewModel
             {
                 AspController = "UIWallets",
@@ -1102,6 +1404,7 @@ namespace BTCPayServer.Controllers
                 signingContext.EnforceLowR?.ToString(CultureInfo.InvariantCulture));
             redirectVm.FormParameters.Add("SigningContext.ChangeAddress", signingContext.ChangeAddress);
             redirectVm.FormParameters.Add("SigningContext.PendingTransactionId", signingContext.PendingTransactionId);
+            redirectVm.FormParameters.Add("SigningContext.BalanceChangeFromReplacement", signingContext.BalanceChangeFromReplacement.ToString());
         }
 
         private IActionResult RedirectToWalletPSBT(WalletPSBTViewModel vm)
@@ -1372,15 +1675,11 @@ namespace BTCPayServer.Controllers
                             parameters.Add($"transactionHashes[{i}]", tx);
                             i++;
                         }
-
-                        var backUrl = Url.Action(nameof(WalletTransactions), new { walletId })!;
-                        parameters.Add("returnUrl", backUrl);
-                        parameters.Add("backUrl", backUrl);
                         return View("PostRedirect",
                             new PostRedirectViewModel
                             {
                                 AspController = "UIWallets",
-                                AspAction = nameof(WalletCPFP),
+                                AspAction = nameof(WalletBumpFee),
                                 RouteParameters = { { "walletId", walletId.ToString() } },
                                 FormParameters = parameters
                             });

--- a/BTCPayServer/GetMempoolInfoResponse.cs
+++ b/BTCPayServer/GetMempoolInfoResponse.cs
@@ -1,0 +1,11 @@
+using NBitcoin;
+
+namespace BTCPayServer
+{
+    public class GetMempoolInfoResponse
+    {
+        public FeeRate IncrementalRelayFeeRate { get; internal set; }
+        public FeeRate MempoolMinfeeRate { get; internal set; }
+        public bool? FullRBF { get; internal set; }
+    }
+}

--- a/BTCPayServer/Models/WalletViewModels/ListTransactionsViewModel.cs
+++ b/BTCPayServer/Models/WalletViewModels/ListTransactionsViewModel.cs
@@ -10,6 +10,7 @@ namespace BTCPayServer.Models.WalletViewModels
         {
             public DateTimeOffset Timestamp { get; set; }
             public bool IsConfirmed { get; set; }
+            public bool CanBumpFee { get; set; }
             public string Comment { get; set; }
             public string Id { get; set; }
             public string Link { get; set; }

--- a/BTCPayServer/Models/WalletViewModels/SigningContextModel.cs
+++ b/BTCPayServer/Models/WalletViewModels/SigningContextModel.cs
@@ -19,5 +19,6 @@ namespace BTCPayServer.Models.WalletViewModels
         public string ChangeAddress { get; set; }
 
         public string PendingTransactionId { get; set; }
+        public long BalanceChangeFromReplacement { get; set; }
     }
 }

--- a/BTCPayServer/Models/WalletViewModels/WalletBumpFeeViewModel.cs
+++ b/BTCPayServer/Models/WalletViewModels/WalletBumpFeeViewModel.cs
@@ -1,0 +1,94 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using NBitcoin;
+using static BTCPayServer.Models.WalletViewModels.WalletBumpFeeViewModel;
+
+namespace BTCPayServer.Models.WalletViewModels
+{
+    public class WalletBumpFeeViewModel
+    {
+        public string ReturnUrl { get; set; }
+        [Display(Name = "Transaction Id")]
+        public uint256 TransactionId { get; set; }
+        public List<SelectListItem> BumpFeeMethods { get; set; } = new();
+        public string[] Outpoints { get; set; }
+        public string[] TransactionHashes { get; set; }
+        public List<WalletSendModel.FeeRateOption> RecommendedSatoshiPerByte { get; set; }
+        [Display]
+        public decimal? FeeSatoshiPerByte { get; set; }
+        [Display]
+        public decimal? CurrentFeeSatoshiPerByte { get; set; }
+        public bool IsMultiSigOnServer { get; set; }
+        [Display(Name = "Fee bump method")]
+        public string BumpMethod { get; set; }
+
+        public string Command { get; set; }
+#nullable enable
+        public record BumpTarget(HashSet<OutPoint> Outpoints, HashSet<uint256> TxIds)
+        {
+
+            public uint256? GetSingleTransactionId()
+                => this switch
+                {
+                    { TxIds: { Count: 1 } ids, Outpoints: { Count: 0 } } => ids.First(),
+                    { TxIds: { Count: 0 }, Outpoints: { Count: 1 } outpoints } => outpoints.First().Hash,
+                    _ => null
+                };
+            public HashSet<uint256> GetTransactionIds()
+            => (TxIds.Concat(Outpoints.Select(o => o.Hash))).ToHashSet();
+
+            public BumpTarget Filter(HashSet<uint256> elligibleTxs)
+            => new BumpTarget(
+                    Outpoints.Where(o => elligibleTxs.Contains(o.Hash)).ToHashSet(),
+                    TxIds.Where(t => elligibleTxs.Contains(t)).ToHashSet());
+
+            public List<OutPoint> GetMatchedOutpoints(IEnumerable<OutPoint> outpoints)
+            {
+                List<OutPoint> matches = new();
+                HashSet<uint256> bumpedTxs = new();
+                foreach (var outpoint in outpoints)
+                {
+                    if (Outpoints.Contains(outpoint))
+                    {
+                        matches.Add(outpoint);
+                        bumpedTxs.Add(outpoint.Hash);
+                    }
+                    else if (TxIds.Contains(outpoint.Hash) && bumpedTxs.Add(outpoint.Hash))
+                    {
+                        matches.Add(outpoint);
+                    }
+                }
+                return matches;
+            }
+        }
+
+        public BumpTarget GetBumpTarget()
+        {
+            if (TransactionId is not null)
+                return new BumpTarget(new(), new([TransactionId]));
+            HashSet<OutPoint> outpoints = new();
+            HashSet<uint256> txids = new();
+            foreach (var o in Outpoints ?? [])
+            {
+                try
+                {
+                    outpoints.Add(OutPoint.Parse(o));
+                }
+                catch { }
+            }
+            foreach (var o in TransactionHashes ?? [])
+            {
+                try
+                {
+                    txids.Add(uint256.Parse(o));
+                }
+                catch { }
+            }
+            return new BumpTarget(outpoints, txids);
+        }
+#nullable restore
+    }
+}

--- a/BTCPayServer/Models/WalletViewModels/WalletPSBTReadyViewModel.cs
+++ b/BTCPayServer/Models/WalletViewModels/WalletPSBTReadyViewModel.cs
@@ -30,7 +30,7 @@ namespace BTCPayServer.Models.WalletViewModels
         public class AmountViewModel
         {
             public bool Positive { get; set; }
-            public string BalanceChange { get; set; }
+            public StringAmounts BalanceChange { get; set; }
         }
         public AmountViewModel ReplacementBalanceChange { get; set; }
         public bool HasErrors => Inputs.Count == 0 || Inputs.Any(i => !string.IsNullOrEmpty(i.Error));

--- a/BTCPayServer/Services/Attachment.cs
+++ b/BTCPayServer/Services/Attachment.cs
@@ -12,12 +12,13 @@ namespace BTCPayServer.Services
         public string Type { get; }
         public string Id { get; }
         public JObject? Data { get; }
-
-        public Attachment(string type, string? id = null, JObject? data = null)
+        public JObject? LinkData { get; }
+        public Attachment(string type, string? id = null, JObject? data = null, JObject? linkData = null)
         {
             Type = type;
             Id = id ?? string.Empty;
             Data = data;
+            LinkData = linkData;
         }
         public static Attachment Payjoin()
         {

--- a/BTCPayServer/Services/Labels/LabelService.cs
+++ b/BTCPayServer/Services/Labels/LabelService.cs
@@ -8,6 +8,7 @@ using BTCPayServer.Models.WalletViewModels;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
+using NBitcoin;
 using Newtonsoft.Json.Linq;
 
 namespace BTCPayServer.Services.Labels;
@@ -91,6 +92,20 @@ public class LabelService
                 model.Link = string.IsNullOrEmpty(tag.Id)
                         ? null
                         : _linkGenerator.InvoiceLink(tag.Id, req.Scheme, req.Host, req.PathBase);
+            }
+            else if (tag.Type == WalletObjectData.Types.RBF)
+            {
+                var txs = ((tag.LinkData?["txs"] as JArray)?.Select(e => e.ToString()) ?? []).ToHashSet();
+                var txsStr = string.Join(", ", txs);
+                model.Tooltip = $"This is transaction is replacing the following transactions: {txsStr}";
+                model.Link = "#";
+            }
+            else if (tag.Type == WalletObjectData.Types.CPFP)
+            {
+                var txs = ((tag.LinkData?["outpoints"] as JArray)?.Select(e => OutPoint.Parse(e.ToString()).Hash) ?? []).ToHashSet();
+                var txsStr = string.Join(", ", txs);
+                model.Tooltip = $"This is transaction is paying for fee for the following transactions: {txsStr}";
+                model.Link = "#";
             }
             else if (tag.Type == WalletObjectData.Types.PaymentRequest)
             {

--- a/BTCPayServer/Services/Wallets/BTCPayWalletProvider.cs
+++ b/BTCPayServer/Services/Wallets/BTCPayWalletProvider.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using BTCPayServer.HostedServices;
 using BTCPayServer.Logging;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Options;
@@ -21,6 +22,7 @@ namespace BTCPayServer.Services.Wallets
                                     BTCPayNetworkProvider networkProvider,
                                     NBXplorerConnectionFactory nbxplorerConnectionFactory,
                                     WalletRepository walletRepository,
+                                    NBXplorerDashboard dashboard,
                                     Logs logs)
         {
             ArgumentNullException.ThrowIfNull(client);
@@ -35,7 +37,7 @@ namespace BTCPayServer.Services.Wallets
                 var explorerClient = _Client.GetExplorerClient(network.CryptoCode);
                 if (explorerClient == null)
                     continue;
-                _Wallets.Add(network.CryptoCode.ToUpperInvariant(), new BTCPayWallet(explorerClient, new MemoryCache(_Options), network, WalletRepository, dbContextFactory, nbxplorerConnectionFactory, Logs));
+                _Wallets.Add(network.CryptoCode.ToUpperInvariant(), new BTCPayWallet(explorerClient, new MemoryCache(_Options), network, WalletRepository, dashboard, dbContextFactory, nbxplorerConnectionFactory, Logs));
             }
         }
 

--- a/BTCPayServer/Views/UIWallets/SigningContext.cshtml
+++ b/BTCPayServer/Views/UIWallets/SigningContext.cshtml
@@ -1,4 +1,4 @@
-﻿@model BTCPayServer.Models.WalletViewModels.SigningContextModel
+@model BTCPayServer.Models.WalletViewModels.SigningContextModel
 
 @if (Model != null)
 {
@@ -8,4 +8,5 @@
     <input type="hidden" asp-for="EnforceLowR" value="@Model.EnforceLowR" />
     <input type="hidden" asp-for="ChangeAddress"  value="@Model.ChangeAddress" />
     <input type="hidden" asp-for="PendingTransactionId"  value="@Model.PendingTransactionId" />
+	<input type="hidden" asp-for="BalanceChangeFromReplacement" value="@Model.BalanceChangeFromReplacement" />
 }

--- a/BTCPayServer/Views/UIWallets/WalletBumpFee.cshtml
+++ b/BTCPayServer/Views/UIWallets/WalletBumpFee.cshtml
@@ -1,0 +1,156 @@
+@using Microsoft.AspNetCore.Mvc.ModelBinding
+@using BTCPayServer.Controllers
+@using BTCPayServer.Services
+@using BTCPayServer.Components.LabelManager
+@model WalletBumpFeeViewModel
+@{
+	var walletId = Context.GetRouteValue("walletId").ToString();
+	var cancelUrl = this.Model.ReturnUrl ?? Url.Action(nameof(UIWalletsController.WalletTransactions), new { walletId });
+	Layout = "_LayoutWizard";
+	ViewData.SetActivePage(WalletsNavPages.Send, StringLocalizer["Bump fee"], walletId);
+}
+
+@section Navbar {
+	<a href="@Url.EnsureLocal(cancelUrl, Context.Request)" id="CancelWizard" class="cancel">
+		<vc:icon symbol="cross" />
+	</a>
+}
+
+@section PageHeadContent
+{
+	<style>
+		.crypto-fee-link {
+			padding-left: 1rem;
+			padding-right: 1rem;
+		}
+
+		.btn-group > .crypto-fee-link:last-of-type {
+			border-top-right-radius: .2rem !important;
+			border-bottom-right-radius: .2rem !important;
+		}
+
+		.buttons .btn {
+			flex: 1 0 45%;
+		}
+	</style>
+}
+
+@section PageFootContent
+{
+	<script src="~/vendor/vuejs/vue.min.js" asp-append-version="true"></script>
+	<script src="~/vendor/ur-registry/urlib.min.js" asp-append-version="true"></script>
+	<script src="~/vendor/vue-qrcode-reader/VueQrcodeReader.umd.min.js" asp-append-version="true"></script>
+	<script src="~/js/wallet/wallet-camera-scanner.js" asp-append-version="true"></script>
+	<script src="~/js/wallet/WalletSend.js" asp-append-version="true"></script>
+}
+
+<partial name="CameraScanner" />
+
+<header class="text-center">
+	<h1>@ViewData["Title"]</h1>
+</header>
+
+<form method="post" asp-action="WalletBumpFee" asp-route-walletId="@walletId" asp-route-transactionId="@Model.TransactionId" class="my-5" id="SendForm">
+	<input type="hidden" asp-for="ReturnUrl" />
+
+	@if (Model.TransactionHashes is not null)
+	{
+		for (int i = 0; i < Model.TransactionHashes.Length; i++)
+		{
+			<input type="hidden" asp-for="TransactionHashes[i]" />
+		}
+	}
+	@if (Model.Outpoints is not null)
+	{
+		for (int i = 0; i < Model.Outpoints.Length; i++)
+		{
+			<input type="hidden" asp-for="Outpoints[i]" />
+		}
+	}
+	@if (!ViewContext.ModelState.IsValid)
+	{
+		<ul class="text-danger">
+			@foreach (var errors in ViewData.ModelState.Where(pair => pair.Key == string.Empty && pair.Value.ValidationState == ModelValidationState.Invalid))
+			{
+				foreach (var error in errors.Value.Errors)
+				{
+					<li>@error.ErrorMessage</li>
+				}
+			}
+		</ul>
+	}
+	@if (Model.GetBumpTarget().GetSingleTransactionId() is { } txId)
+	{
+		<div class="list-group list-group-flush">
+			<div>
+				<label asp-for="TransactionId" class="form-label"></label>
+				<input name="txId" value="@txId" readonly class="form-control" disabled />
+				<span asp-validation-for="TransactionId" class="text-danger"></span>
+			</div>
+		</div>
+	}
+	@if (Model.CurrentFeeSatoshiPerByte is not null)
+	{
+		<div class="d-flex flex-wrap gap-3 my-4">
+			<div>
+				<label asp-for="CurrentFeeSatoshiPerByte" class="form-label">
+					<span text-translate="true">Current effective fee rate</span>
+					<span class="text-secondary">(sat/vB)</span>
+				</label>
+				<input asp-for="CurrentFeeSatoshiPerByte" type="number" min="0" step="any" readonly class="form-control" disabled style="max-width:14ch;" />
+			</div>
+		</div>
+	}
+	<div class="d-flex flex-wrap gap-3 my-4">
+		<div>
+			<label asp-for="FeeSatoshiPerByte" class="form-label">
+				<span text-translate="true">New effective fee rate</span>
+				<span class="text-secondary">(sat/vB)</span>
+			</label>
+			<input asp-for="FeeSatoshiPerByte" type="number" inputmode="numeric" min="0" step="any" class="form-control" style="max-width:14ch;" />
+			<span asp-validation-for="FeeSatoshiPerByte" class="text-danger"></span>
+			<span id="FeeRate-Error" class="text-danger"></span>
+		</div>
+		@if (Model.RecommendedSatoshiPerByte.Any())
+		{
+			<div>
+				<div class="form-label text-secondary" text-translate="true">Confirm in the next …</div>
+				<div class="btn-group btn-group-toggle feerate-options" role="group" data-bs-toggle="buttons">
+					@for (var index = 0; index < Model.RecommendedSatoshiPerByte.Count; index++)
+					{
+						var feeRateOption = Model.RecommendedSatoshiPerByte[index];
+						<button type="button" class="btn btn-sm btn-secondary crypto-fee-link" value="@feeRateOption.FeeRate" data-bs-toggle="tooltip" title="@feeRateOption.FeeRate sat/b">
+							@feeRateOption.Target.TimeString()
+						</button>
+						<input type="hidden" asp-for="RecommendedSatoshiPerByte[index].Target" />
+						<input type="hidden" asp-for="RecommendedSatoshiPerByte[index].FeeRate" />
+					}
+				</div>
+			</div>
+		}
+	</div>
+	<div class="d-flex flex-wrap gap-3 my-4">
+		<div>
+			<div class="form-group">
+				<label asp-for="BumpMethod" class="form-label"></label>
+				<select asp-for="BumpMethod" asp-items="@Model.BumpFeeMethods"
+				disabled="@(Model.BumpFeeMethods.Count == 1)"
+				class="form-select w-auto"></select>
+			</div>
+		</div>
+	</div>
+
+
+	<div class="d-grid d-sm-flex flex-wrap gap-3 buttons">
+		@Html.HiddenFor(a => a.IsMultiSigOnServer)
+		@if (Model.IsMultiSigOnServer)
+		{
+			<button type="submit" id="page-primary" name="command" value="createpending" class="btn btn-primary">Create pending transaction</button>
+		}
+		else
+		{
+			<button type="submit" id="page-primary" name="command" value="sign" class="btn btn-primary" text-translate="true">Sign transaction</button>
+		}
+	</div>
+
+</form>

--- a/BTCPayServer/Views/UIWallets/_PSBTInfo.cshtml
+++ b/BTCPayServer/Views/UIWallets/_PSBTInfo.cshtml
@@ -14,7 +14,30 @@
         </span>
     </p>
 }
-
+@if (Model.ReplacementBalanceChange is not null)
+{
+    <div id="replacements">
+        <h4 class="mb-n3" text-translate="true">Replacements</h4>
+        <table class="table">
+            <thead>
+                <tr>
+                    <th text-translate="true" class="text-end">Amount</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr>
+                    <td class="text-end text-@(Model.ReplacementBalanceChange.Positive ? "success" : "danger")">
+						<span class="amount-toggle cursor-pointer"
+							  data-btc="@Model.ReplacementBalanceChange.BalanceChange.CryptoAmount"
+							  data-fiat="@Model.ReplacementBalanceChange.BalanceChange.FiatAmount">
+							@Model.ReplacementBalanceChange.BalanceChange.CryptoAmount
+						</span>
+					</td>
+                </tr>
+            </tbody>
+        </table>
+    </div>
+}
 <div id="inputs">
     <h4 class="mb-n3" text-translate="true">Inputs</h4>
     <table class="table">

--- a/BTCPayServer/Views/UIWallets/_WalletTransactionsList.cshtml
+++ b/BTCPayServer/Views/UIWallets/_WalletTransactionsList.cshtml
@@ -6,14 +6,14 @@
 }
 @foreach (var transaction in Model.Transactions)
 {
-    <tr class="mass-action-row">
-        <td class="only-for-js mass-action-select-col">
+    <tr class="mass-action-row transaction-row" data-value="@transaction.Id">
+        <td class="align-middle only-for-js mass-action-select-col">
             <input name="selectedTransactions" type="checkbox" class="form-check-input mass-action-select" form="WalletActions" value="@transaction.Id" />
         </td>
-        <td class="date-col">
+        <td class="align-middle date-col">
             @transaction.Timestamp.ToBrowserDate()
         </td>
-        <td class="text-start">
+        <td class="align-middle text-start">
             <vc:label-manager
                 wallet-object-id="new WalletObjectId(WalletId.Parse(walletId), WalletObjectData.Types.Tx, transaction.Id)"
                 selected-labels="transaction.Tags.Select(t => t.Text).ToArray()"
@@ -24,11 +24,18 @@
         <td>
             <vc:truncate-center text="@transaction.Id" link="@transaction.Link" classes="truncate-center-id" />
         </td>
-        <td class="amount-col">
+        <td class="align-middle amount-col">
             <span data-sensitive class="text-@(transaction.Positive ? "success" : "danger")@(transaction.IsConfirmed ? "" : " opacity-50")">@transaction.Balance</span>
         </td>
-        <td class="text-end">
-            <div class="d-inline-block">
+        <td class="align-middle text-end">
+            <div class="d-inline-flex gap-3 align-items-center">
+				@if (transaction.CanBumpFee)
+				{
+					<a asp-action="WalletBumpFee" asp-route-walletId="@Context.GetRouteValue("walletId")" asp-route-transactionId="@transaction.Id" class="btn btn-link p-0 bumpFee-btn">
+						<vc:icon symbol="actions-send" />
+						<span text-translate="true">Bump fee</span>
+					</a>
+				}
                 <button class="btn btn-link p-0 @(!string.IsNullOrEmpty(transaction.Comment) ? "text-primary" : "text-secondary")" type="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                     <vc:icon symbol="actions-comment" />
                 </button>


### PR DESCRIPTION
# Feature: RBF and UX improvement to fee bumping

The PR requires users who wants fee bumping (CPFP and RBF) capabilities need to update NBXplorer to `2.5.22` or above.

RBF is available to every transaction which:
1. The transaction has one of the store's change address
2. All the inputs of the transactions are from the store's wallet
3. The transaction is still in the mempool
4. The transaction doesn't have descendants (none of its output is spent)
5. Using NBXplorer `2.5.22` or above.

While it is possible to fee bump multiple transaction with CPFP, it is not supported at this moment with RBF.

# UX

The wallet transaction list is now showing a RBF link for transaction eligible to fee bumping (either CPFP or RBF).

![image](https://github.com/user-attachments/assets/eae1a42e-fc07-4c9e-aad1-0108dcb22318)

Once clicked, the following UI show up, prompting the user to choose the expected effective fee rate and to select the fee bump method (RBF or CPFP, the default is RBF if available).

![image](https://github.com/user-attachments/assets/6d69608a-908c-4480-8418-53fcf40b46d2)

Click on `Signing transaction` and then start the same signing process as the `Wallet Send` screen.

Note that the effective fee rate is not necessarily related to the transaction's fee rate. The effective fee rate takes into account the descendants and ancestors (ie. the package) of unconfirmed transactions of the bumped transaction.

For example, if there is a chain of transactions `A` with a fee rate of `100 sat/vbyte` and `B` with a fee rate of `10 sat/vbyte`, both of the same size, then the current fee rate is `55.0 sat/vbyte`. The minimum bump possible is `1 sat/vbyte` (in other words, to `56.0 sat/vbyte`). To bump the package fee to `56.0`, the fee rate of `B` should increase to `12 sat/vbyte` (and not to `56.0` or `11 sat/vbyte`, as someone might wrongly expect).

We are showing the total cost of the operation in the PSBT Ready screen, in the case of RBF, we take into consideration the transaction being cancelled.

![image](https://github.com/user-attachments/assets/c2eb3176-3ba7-4a58-9d91-c964f3f05850)

Lastly, fee-bumping transactions are assigned labels as a reminder.
For example, below:

1. The merchant received payment for an invoice (`4dde...`).
2. It took too long, so the merchant decided to use CPFP (`3e90...`).
3. Since `3e90...` was also delayed, the merchant decided to replace it via RBF with a new transaction, `d2bb....`.

First, you'll notice that `3e90...` is no longer visible because it has been replaced. However, you can see that it was replaced by hovering over the RBF tag for more information.

Second, `d2bb...` has two tags: `RBF` and `CPFP`. This is because when a transaction replaces another, it inherits the tags of the replaced transaction. In this case, `3e90...` had the CPFP label but was replaced via `RBF` by `d2bb...`. Since `d2bb...` inherits the `CPFP` label, it now has both `CPFP` and `RBF` labels.

![image](https://github.com/user-attachments/assets/dd3a5dce-d7d9-420b-b60d-f824ce71c7ec)

# Mass actions

The mass action for bumping fees on the invoice list and wallet transaction list has been modified. Previously, it created a CPFP transaction.

Now, it redirects to the bump fee flow explained above.

Supersede https://github.com/btcpayserver/btcpayserver/pull/6083
Close #5578

