### PR TITLE
Fix: Archived invoices shouldn't be browsable by non authenticated users 

### DIFF
--- a/BTCPayServer/Controllers/UIInvoiceController.UI.cs
+++ b/BTCPayServer/Controllers/UIInvoiceController.UI.cs
@@ -198,6 +198,9 @@ namespace BTCPayServer.Controllers
             var store = await _StoreRepository.GetStoreByInvoiceId(i.Id);
             if (store is null)
                 return NotFound();
+            
+            if (i.Archived && User.Identity?.IsAuthenticated == false)
+                return StatusCode(403);
 
             var receipt = InvoiceDataBase.ReceiptOptions.Merge(store.GetStoreBlob().ReceiptOptions, i.ReceiptOptions);
             if (receipt.Enabled is not true)


### PR DESCRIPTION
Fixes #6578. Non-authenticated users will now see the 403 Denied view when attempting to access archived invoice receipts.