### PR TITLE
If an On-Chain payment get replaced, log it in invoice logs rather than console

### DIFF
--- a/BTCPayServer/Payments/Bitcoin/NBXplorerListener.cs
+++ b/BTCPayServer/Payments/Bitcoin/NBXplorerListener.cs
@@ -291,7 +291,9 @@ namespace BTCPayServer.Payments.Bitcoin
                                     result.RPCCode == RPCErrorCode.RPC_TRANSACTION_REJECTED);
                         if (!accounted && payment.Accounted && tx.Confirmations != -1)
                         {
-                            Logs.PayServer.LogInformation($"{wallet.Network.CryptoCode}: The transaction {tx.TransactionHash} has been replaced.");
+                            var logs = new InvoiceLogs();
+                            logs.Write($"The transaction {tx.TransactionHash} has been replaced.", InvoiceEventData.EventSeverity.Warning);
+                            await _InvoiceRepository.AddInvoiceLogs(invoice.Id, logs);
                         }
                         if (paymentData.PayjoinInformation is PayjoinInformation pj)
                         {


### PR DESCRIPTION
We are right now logging replacement in the console rather than under the invoice logs.

![image](https://github.com/user-attachments/assets/5eac0345-e3dc-49cf-97aa-f6cd763ebb73)
