### PR TITLE
Lightning Address: Display validation messages on failed creation

### DIFF
--- a/BTCPayServer/Views/UILNURL/EditLightningAddress.cshtml
+++ b/BTCPayServer/Views/UILNURL/EditLightningAddress.cshtml
@@ -46,7 +46,7 @@
 <form asp-action="EditLightningAddress" method="post">
     @{
         var showAddForm = !ViewContext.ViewData.ModelState.IsValid || !string.IsNullOrEmpty(Model.Add?.Username) || Model.Add?.Max != null || Model.Add?.Min != null || !string.IsNullOrEmpty(Model.Add?.CurrencyCode);
-        var showAdvancedOptions = !string.IsNullOrEmpty(Model.Add?.CurrencyCode) || Model.Add?.Min != null || Model.Add?.Max != null;
+        var showAdvancedOptions = !string.IsNullOrEmpty(Model.Add?.CurrencyCode) || !string.IsNullOrEmpty(Model.Add?.InvoiceMetadata) || Model.Add?.Min != null || Model.Add?.Max != null;
      }
     
     <div class="collapse @(showAddForm ? "show": "")" id="AddAddress">


### PR DESCRIPTION
Fixes #6590. The problem was that the validation messages for the Advanced Settings fields were hidden. 

![grafik](https://github.com/user-attachments/assets/0c85b295-98e9-41cf-9fc8-3e6ff623ea39)
