### PR TITLE
LND conf: enable bLIP-50: LSP Spec Transport Layer

### DIFF
--- a/BTCPayServer.Tests/docker-compose.altcoins.yml
+++ b/BTCPayServer.Tests/docker-compose.altcoins.yml
@@ -248,6 +248,7 @@ services:
         bitcoind.zmqpubrawtx=tcp://bitcoind:28333
         externalip=merchant_lnd:9735
         bitcoin.defaultchanconfs=1
+        protocol.custom-message=37913
         no-macaroons=1
         debuglevel=debug
         trickledelay=1000
@@ -286,6 +287,7 @@ services:
         bitcoind.zmqpubrawtx=tcp://bitcoind:28333
         externalip=customer_lnd:10009
         bitcoin.defaultchanconfs=1
+        protocol.custom-message=37913
         no-macaroons=1
         debuglevel=debug
         trickledelay=1000

--- a/BTCPayServer.Tests/docker-compose.mutinynet.yml
+++ b/BTCPayServer.Tests/docker-compose.mutinynet.yml
@@ -206,6 +206,7 @@ services:
         bitcoind.zmqpubrawtx=tcp://bitcoind:28333
         externalip=merchant_lnd:9735
         bitcoin.defaultchanconfs=1
+        protocol.custom-message=37913
         no-macaroons=1
         debuglevel=debug
         trickledelay=1000
@@ -244,6 +245,7 @@ services:
         bitcoind.zmqpubrawtx=tcp://bitcoind:28333
         externalip=customer_lnd:9735
         bitcoin.defaultchanconfs=1
+        protocol.custom-message=37913
         no-macaroons=1
         debuglevel=debug
         trickledelay=1000

--- a/BTCPayServer.Tests/docker-compose.testnet.yml
+++ b/BTCPayServer.Tests/docker-compose.testnet.yml
@@ -196,6 +196,7 @@ services:
         bitcoind.zmqpubrawtx=tcp://bitcoind:28333
         externalip=merchant_lnd:9735
         bitcoin.defaultchanconfs=1
+        protocol.custom-message=37913
         no-macaroons=1
         debuglevel=debug
         trickledelay=1000
@@ -234,6 +235,7 @@ services:
         bitcoind.zmqpubrawtx=tcp://bitcoind:28333
         externalip=customer_lnd:9735
         bitcoin.defaultchanconfs=1
+        protocol.custom-message=37913
         no-macaroons=1
         debuglevel=debug
         trickledelay=1000

--- a/BTCPayServer.Tests/docker-compose.yml
+++ b/BTCPayServer.Tests/docker-compose.yml
@@ -234,6 +234,7 @@ services:
         bitcoind.zmqpubrawtx=tcp://bitcoind:28333
         externalip=merchant_lnd:9735
         bitcoin.defaultchanconfs=1
+        protocol.custom-message=37913
         no-macaroons=1
         debuglevel=debug
         trickledelay=1000
@@ -272,6 +273,7 @@ services:
         bitcoind.zmqpubrawtx=tcp://bitcoind:28333
         externalip=customer_lnd:9735
         bitcoin.defaultchanconfs=1
+        protocol.custom-message=37913
         no-macaroons=1
         debuglevel=debug
         trickledelay=1000


### PR DESCRIPTION
LSPS0/bLIP-50 has recently been [merged into the bLIP spec](https://github.com/lightning/blips/blob/master/blip-0050.md). This is a communication protocol over Lightning's p2p messaging layer called BOLT8, and is used for clients to communicate with Lightning Service Providers and vice versa.

At present, LND doesn't allow applications to communicate over BOLT8 with message types higher than 32768, without building with the `dev` tag or modifying the LND configuration. LSPS0/bLIP-50 uses type 37913.

This configuration change will allow BTCPay users to interface with LSP spec-compliant services, such as ZEUS' Olympus.