### PR TITLE
Server Settings: Add stores overview for admin

### DIFF
--- a/BTCPayServer/Components/MainNav/Default.cshtml
+++ b/BTCPayServer/Components/MainNav/Default.cshtml
@@ -304,6 +304,9 @@
                     <a asp-controller="UIServer" id="SectionNav-@ServerNavPages.Roles" class="nav-link @ViewData.ActivePageClass(ServerNavPages.Roles)" asp-action="ListRoles" text-translate="true">Roles</a>
                 </li>
                 <li class="nav-item nav-item-sub" permission="@Policies.CanModifyServerSettings">
+                    <a asp-controller="UIServer" id="SectionNav-@ServerNavPages.Stores" class="nav-link @ViewData.ActivePageClass(ServerNavPages.Stores)" asp-action="ListStores" text-translate="true">Stores</a>
+                </li>
+                <li class="nav-item nav-item-sub" permission="@Policies.CanModifyServerSettings">
                     <a asp-controller="UIServer" id="SectionNav-@ServerNavPages.Emails" class="nav-link @ViewData.ActivePageClass(ServerNavPages.Emails)" asp-action="Emails" text-translate="true">Email</a>
                 </li>
                 <li class="nav-item nav-item-sub" permission="@Policies.CanModifyServerSettings">

--- a/BTCPayServer/Components/StoreSelector/Default.cshtml
+++ b/BTCPayServer/Components/StoreSelector/Default.cshtml
@@ -1,7 +1,9 @@
+@using BTCPayServer.Client
 @using BTCPayServer.Components.MainLogo
 @using BTCPayServer.Services
 @using BTCPayServer.Views.Server
 @using BTCPayServer.Views.Stores
+@using Microsoft.AspNetCore.Mvc.TagHelpers
 @inject BTCPayServerEnvironment Env
 @model BTCPayServer.Components.StoreSelector.StoreSelectorViewModel
 @functions {
@@ -64,10 +66,6 @@ else
                     <li><hr class="dropdown-divider"></li>
                     <li><a asp-controller="UIUserStores" asp-action="ListStores" asp-route-archived="true" class="dropdown-item @ViewData.ActivePageClass(StoreNavPages.Index)" id="StoreSelectorArchived">@(Model.ArchivedCount == 1 ? StringLocalizer["{0} Archived Store", Model.ArchivedCount] : StringLocalizer["{0} Archived Stores", Model.ArchivedCount])</a></li>
                 }
-                @*
-                <li permission="@Policies.CanModifyServerSettings"><hr class="dropdown-divider"></li>
-                <li permission="@Policies.CanModifyServerSettings"><a asp-controller="UIServer" asp-action="ListStores" class="dropdown-item @ViewData.ActivePageClass(ServerNavPages.Stores)" id="StoreSelectorAdminStores" text-translate="true">Admin Store Overview</a></li>
-                *@
             </ul>
         </div>
     </div>

--- a/BTCPayServer/Components/StoreSelector/Default.cshtml
+++ b/BTCPayServer/Components/StoreSelector/Default.cshtml
@@ -1,9 +1,7 @@
-@using BTCPayServer.Client
 @using BTCPayServer.Components.MainLogo
 @using BTCPayServer.Services
 @using BTCPayServer.Views.Server
 @using BTCPayServer.Views.Stores
-@using Microsoft.AspNetCore.Mvc.TagHelpers
 @inject BTCPayServerEnvironment Env
 @model BTCPayServer.Components.StoreSelector.StoreSelectorViewModel
 @functions {

--- a/BTCPayServer/Controllers/UIServerController.cs
+++ b/BTCPayServer/Controllers/UIServerController.cs
@@ -135,7 +135,7 @@ namespace BTCPayServer.Controllers
         {
             model = this.ParseListQuery(model ?? new ListStoresViewModel());
 
-            var query = new StoreQuery { SearchTerm = model.SearchTerm };
+            var query = new StoreQuery { SearchTerm = model.SearchTerm, Skip = model.Skip, Count = model.Count };
             var sortDesc = false;
             if (sortOrder != null)
             {

--- a/BTCPayServer/Extensions/ControllerBaseExtensions.cs
+++ b/BTCPayServer/Extensions/ControllerBaseExtensions.cs
@@ -4,6 +4,7 @@ using BTCPayServer.Models;
 using BTCPayServer.Models.InvoicingModels;
 using BTCPayServer.Models.PaymentRequestViewModels;
 using BTCPayServer.Models.ServerViewModels;
+using BTCPayServer.Models.StoreViewModels;
 using BTCPayServer.Models.WalletViewModels;
 using Microsoft.AspNetCore.Mvc;
 using Newtonsoft.Json;
@@ -20,6 +21,8 @@ namespace BTCPayServer
                 prop = typeof(UserPrefsCookie).GetProperty(nameof(UserPrefsCookie.InvoicesQuery));
             else if (model is ListPaymentRequestsViewModel)
                 prop = typeof(UserPrefsCookie).GetProperty(nameof(UserPrefsCookie.PaymentRequestsQuery));
+            else if (model is ListStoresViewModel)
+                prop = typeof(UserPrefsCookie).GetProperty(nameof(UserPrefsCookie.StoresQuery));
             else if (model is UsersViewModel)
                 prop = typeof(UserPrefsCookie).GetProperty(nameof(UserPrefsCookie.UsersQuery));
             else if (model is PayoutsModel)

--- a/BTCPayServer/Extensions/UserPrefsCookie.cs
+++ b/BTCPayServer/Extensions/UserPrefsCookie.cs
@@ -4,6 +4,7 @@ namespace BTCPayServer
     {
         public ListQueryDataHolder InvoicesQuery { get; set; }
         public ListQueryDataHolder PaymentRequestsQuery { get; set; }
+        public ListQueryDataHolder StoresQuery { get; set; }
         public ListQueryDataHolder UsersQuery { get; set; }
         public ListQueryDataHolder PayoutsQuery { get; set; }
         public ListQueryDataHolder PullPaymentsQuery { get; set; }

--- a/BTCPayServer/Models/StoreViewModels/ListStoresViewModel.cs
+++ b/BTCPayServer/Models/StoreViewModels/ListStoresViewModel.cs
@@ -3,7 +3,7 @@ using BTCPayServer.Data;
 
 namespace BTCPayServer.Models.StoreViewModels;
 
-public class ListStoresViewModel
+public class ListStoresViewModel : BasePagingViewModel
 {
     public class StoreViewModel
     {
@@ -15,4 +15,5 @@ public class ListStoresViewModel
 
     public List<StoreViewModel> Stores { get; set; } = new ();
     public bool Archived { get; set; }
+    public override int CurrentPageCount => Stores.Count;
 }

--- a/BTCPayServer/Services/Stores/StoreRepository.cs
+++ b/BTCPayServer/Services/Stores/StoreRepository.cs
@@ -240,8 +240,10 @@ namespace BTCPayServer.Services.Stores
             await using var ctx = _ContextFactory.CreateContext();
             var queryable = ctx.Stores
                 .Where(s => (query.StoreId == null || query.StoreId.Contains(s.Id)) &&
-                    (string.IsNullOrEmpty(query.SearchTerm) || s.StoreName.Contains(query.SearchTerm)))
-                .Include(data => data.UserStores)
+                            (string.IsNullOrEmpty(query.SearchTerm) || s.StoreName.Contains(query.SearchTerm)));
+            if (query.Skip.HasValue) queryable = queryable.Skip(query.Skip.Value);
+            if (query.Count.HasValue) queryable = queryable.Take(query.Count.Value);
+            queryable = queryable.Include(data => data.UserStores)
                 .ThenInclude(data => data.StoreRole)
                 .Include(data => data.UserStores)
                 .ThenInclude(data => data.ApplicationUser);
@@ -770,6 +772,8 @@ retry:
     {
         public string[]? StoreId { get; set; }
         public string? SearchTerm { get; set; }
+        public int? Skip { get; set; }
+        public int? Count { get; set; }
     }
 
     public record StoreRoleId

--- a/BTCPayServer/Views/UIServer/ListStores.cshtml
+++ b/BTCPayServer/Views/UIServer/ListStores.cshtml
@@ -92,6 +92,8 @@
             </tbody>
         </table>
     </div>
+
+    <vc:pager view-model="Model"></vc:pager>
 }
 else
 {

--- a/BTCPayServer/Views/UIServer/ListStores.cshtml
+++ b/BTCPayServer/Views/UIServer/ListStores.cshtml
@@ -31,6 +31,8 @@
                     <a
                         asp-action="ListStores"
                         asp-route-sortOrder="@(nextStoreNameSortOrder ?? "asc")"
+                        asp-route-skip="@Model.Skip"
+                        asp-route-count="@Model.Count"
                         class="text-nowrap"
                         title="@(nextStoreNameSortOrder == "desc" ? sortByAsc : sortByDesc)"
                     >
@@ -92,7 +94,6 @@
             </tbody>
         </table>
     </div>
-
     <vc:pager view-model="Model"></vc:pager>
 }
 else

--- a/BTCPayServer/Views/UIServer/ListStores.cshtml
+++ b/BTCPayServer/Views/UIServer/ListStores.cshtml
@@ -1,23 +1,47 @@
 @model BTCPayServer.Models.StoreViewModels.ListStoresViewModel
 @{
     Layout = "_Layout";
-    ViewData.SetActivePage(ServerNavPages.Stores, StringLocalizer["Store Overview"]);
+    ViewData.SetActivePage(ServerNavPages.Stores, StringLocalizer["Stores"]);
+    var nextStoreNameSortOrder = (string)ViewData["nextStoreNameSortOrder"];
+    var storeNameSortOrder = nextStoreNameSortOrder switch
+    {
+        "asc" => "desc",
+        "desc" => "asc",
+        _ => null
+    };
+    const string sortByDesc = "Sort by email descending...";
+    const string sortByAsc = "Sort by email ascending...";
 }
 <div class="sticky-header">
 	<h2 class="my-1">@ViewData["Title"]</h2>
 </div>
 <partial name="_StatusMessage" />
 
+<form asp-action="ListStores" asp-route-sortOrder="@(storeNameSortOrder)" style="max-width:640px" method="get">
+    <input asp-for="SearchTerm" class="form-control" placeholder="@StringLocalizer["Search by name..."]" />
+</form>
+
 @if (Model.Stores.Any())
 {
-    <table class="table table-hover">
-        <thead>
+    <div class="table-responsive">
+        <table class="table table-hover">
+            <thead>
             <tr>
-                <th text-translate="true">Store</th>
+                <th>
+                    <a
+                        asp-action="ListStores"
+                        asp-route-sortOrder="@(nextStoreNameSortOrder ?? "asc")"
+                        class="text-nowrap"
+                        title="@(nextStoreNameSortOrder == "desc" ? sortByAsc : sortByDesc)"
+                    >
+                        <span text-translate="true">Store</span>
+                        <vc:icon symbol="actions-sort-alpha-@(storeNameSortOrder ?? nextStoreNameSortOrder ?? "desc")" />
+                    </a>
+                </th>
                 <th text-translate="true">Users</th>
             </tr>
-        </thead>
-        <tbody>
+            </thead>
+            <tbody>
             @foreach (var store in Model.Stores)
             {
                 var detailsId = $"store_details_{store.StoreId}";
@@ -65,8 +89,9 @@
                     </td>
                 </tr>
             }
-        </tbody>
-    </table>
+            </tbody>
+        </table>
+    </div>
 }
 else
 {


### PR DESCRIPTION
Works towards #5676. 

For store management capabilities (like requested in #5868) we currently face the following hurdle: Right now [admins only have store view permissions](https://github.com/btcpayserver/btcpayserver/blob/master/BTCPayServer/Security/CookieAuthorizationHandler.cs#L45). Granting admins `CanModifyStoreSettings` would also grant them access to change wallet settings. So we'd have to differentiate at least wallet and store permissions.

![stores](https://github.com/user-attachments/assets/b5382f4d-f68a-4d46-8058-1a1f37dffd58)
