### PR TITLE
Display fiat amount previews in Transaction Details page

### DIFF
--- a/BTCPayServer/Controllers/UIWalletsController.PSBT.cs
+++ b/BTCPayServer/Controllers/UIWalletsController.PSBT.cs
@@ -381,15 +381,14 @@ namespace BTCPayServer.Controllers
                 try
                 {
                     var r = await fetchRate(walletId);
-
-                    var fiatAmount = r.result.BidAsk.Center * balanceChange.ToDecimal(MoneyUnit.BTC);
-
-                    vm.FiatBalanceChange = fiatAmount.ToString("C",
-                        _currencyTable.GetNumberFormatInfo(r.currencyPair.Right, true));
+                    
                     vm.Rate = r.result.BidAsk.Center;
                     vm.FiatDivisibility = _currencyTable.GetNumberFormatInfo(r.currencyPair.Right, true)
                         .CurrencyDecimalDigits;
                     vm.Fiat = r.currencyPair.Right;
+
+                    var fiatAmount = r.result.BidAsk.Center * balanceChange.ToDecimal(MoneyUnit.BTC);
+                    vm.FiatBalanceChange = fiatAmount.ToString("N"+vm.FiatDivisibility) +" "+ vm.Fiat;
                 }
                 catch (Exception ex)
                 {

--- a/BTCPayServer/Controllers/UIWalletsController.PSBT.cs
+++ b/BTCPayServer/Controllers/UIWalletsController.PSBT.cs
@@ -377,6 +377,25 @@ namespace BTCPayServer.Controllers
                 vm.BalanceChange = ValueToString(balanceChange, network);
                 vm.CanCalculateBalance = true;
                 vm.Positive = balanceChange >= Money.Zero;
+
+                try
+                {
+                    var r = await fetchRate(walletId);
+
+                    var fiatAmount = r.result.BidAsk.Center * balanceChange.ToDecimal(MoneyUnit.BTC);
+
+                    vm.FiatBalanceChange = fiatAmount.ToString("C",
+                        _currencyTable.GetNumberFormatInfo(r.currencyPair.Right, true));
+                    vm.Rate = r.result.BidAsk.Center;
+                    vm.FiatDivisibility = _currencyTable.GetNumberFormatInfo(r.currencyPair.Right, true)
+                        .CurrencyDecimalDigits;
+                    vm.Fiat = r.currencyPair.Right;
+                }
+                catch (Exception ex)
+                {
+                    // keeping model simple
+                    // vm.RateError = ex.Message;
+                }
             }
             vm.Inputs = new List<WalletPSBTReadyViewModel.InputViewModel>();
             var inputToObjects = new Dictionary<uint, ObjectTypeId[]>();

--- a/BTCPayServer/Models/WalletViewModels/WalletPSBTReadyViewModel.cs
+++ b/BTCPayServer/Models/WalletViewModels/WalletPSBTReadyViewModel.cs
@@ -15,7 +15,7 @@ namespace BTCPayServer.Models.WalletViewModels
         {
             public bool Positive { get; set; }
             public string Destination { get; set; }
-            public string Balance { get; set; }
+            public CryptoFiatAmount Balance { get; set; }
             public IEnumerable<TransactionTagModel> Labels { get; set; } = new List<TransactionTagModel>();
         }
 
@@ -24,7 +24,7 @@ namespace BTCPayServer.Models.WalletViewModels
             public int Index { get; set; }
             public string Error { get; set; }
             public bool Positive { get; set; }
-            public string BalanceChange { get; set; }
+            public CryptoFiatAmount BalanceChange { get; set; }
             public IEnumerable<TransactionTagModel> Labels { get; set; } = new List<TransactionTagModel>();
         }
         public class AmountViewModel
@@ -34,7 +34,7 @@ namespace BTCPayServer.Models.WalletViewModels
         }
         public AmountViewModel ReplacementBalanceChange { get; set; }
         public bool HasErrors => Inputs.Count == 0 || Inputs.Any(i => !string.IsNullOrEmpty(i.Error));
-        public string BalanceChange { get; set; }
+        public CryptoFiatAmount BalanceChange { get; set; }
         public bool CanCalculateBalance { get; set; }
         public bool Positive { get; set; }
         public List<DestinationViewModel> Destinations { get; set; } = new List<DestinationViewModel>();
@@ -42,12 +42,6 @@ namespace BTCPayServer.Models.WalletViewModels
         public string FeeRate { get; set; }
         public string BackUrl { get; set; }
         public string ReturnUrl { get; set; }
-        
-        // fiat balance display properties
-        public string FiatBalanceChange { get; set; }
-        public decimal Rate { get; set; }
-        public int FiatDivisibility { get; set; }
-        public string Fiat { get; set; }
 
         internal void SetErrors(IList<PSBTError> errors)
         {
@@ -55,6 +49,14 @@ namespace BTCPayServer.Models.WalletViewModels
             {
                 Inputs[(int)err.InputIndex].Error = err.Message;
             }
+        }
+
+        public record CryptoFiatAmount(string CryptoAmount, string FiatAmount);
+
+        public class CryptoFiatConversionHelper
+        {
+            public decimal Rate { get; set; }
+            public string Fiat { get; set; }
         }
     }
 }

--- a/BTCPayServer/Models/WalletViewModels/WalletPSBTReadyViewModel.cs
+++ b/BTCPayServer/Models/WalletViewModels/WalletPSBTReadyViewModel.cs
@@ -42,6 +42,12 @@ namespace BTCPayServer.Models.WalletViewModels
         public string FeeRate { get; set; }
         public string BackUrl { get; set; }
         public string ReturnUrl { get; set; }
+        
+        // fiat balance display properties
+        public string FiatBalanceChange { get; set; }
+        public decimal Rate { get; set; }
+        public int FiatDivisibility { get; set; }
+        public string Fiat { get; set; }
 
         internal void SetErrors(IList<PSBTError> errors)
         {

--- a/BTCPayServer/Models/WalletViewModels/WalletPSBTReadyViewModel.cs
+++ b/BTCPayServer/Models/WalletViewModels/WalletPSBTReadyViewModel.cs
@@ -15,7 +15,7 @@ namespace BTCPayServer.Models.WalletViewModels
         {
             public bool Positive { get; set; }
             public string Destination { get; set; }
-            public CryptoFiatAmount Balance { get; set; }
+            public StringAmounts Balance { get; set; }
             public IEnumerable<TransactionTagModel> Labels { get; set; } = new List<TransactionTagModel>();
         }
 
@@ -24,7 +24,7 @@ namespace BTCPayServer.Models.WalletViewModels
             public int Index { get; set; }
             public string Error { get; set; }
             public bool Positive { get; set; }
-            public CryptoFiatAmount BalanceChange { get; set; }
+            public StringAmounts BalanceChange { get; set; }
             public IEnumerable<TransactionTagModel> Labels { get; set; } = new List<TransactionTagModel>();
         }
         public class AmountViewModel
@@ -34,7 +34,7 @@ namespace BTCPayServer.Models.WalletViewModels
         }
         public AmountViewModel ReplacementBalanceChange { get; set; }
         public bool HasErrors => Inputs.Count == 0 || Inputs.Any(i => !string.IsNullOrEmpty(i.Error));
-        public CryptoFiatAmount BalanceChange { get; set; }
+        public StringAmounts BalanceChange { get; set; }
         public bool CanCalculateBalance { get; set; }
         public bool Positive { get; set; }
         public List<DestinationViewModel> Destinations { get; set; } = new List<DestinationViewModel>();
@@ -51,12 +51,6 @@ namespace BTCPayServer.Models.WalletViewModels
             }
         }
 
-        public record CryptoFiatAmount(string CryptoAmount, string FiatAmount);
-
-        public class CryptoFiatConversionHelper
-        {
-            public decimal Rate { get; set; }
-            public string Fiat { get; set; }
-        }
+        public record StringAmounts(string CryptoAmount, string FiatAmount);
     }
 }

--- a/BTCPayServer/Views/UIWallets/_PSBTInfo.cshtml
+++ b/BTCPayServer/Views/UIWallets/_PSBTInfo.cshtml
@@ -1,11 +1,22 @@
 @model WalletPSBTReadyViewModel
 
+@functions {
+    private string ToFiatAmount(string destinationBalance)
+    {
+        var amt = Model.Rate * Decimal.Parse(destinationBalance.Replace("BTC", "").Trim());
+        return amt.ToString("N" + Model.FiatDivisibility) + " " + Model.Fiat;
+    }
+}
+
 @if (Model.CanCalculateBalance)
 {
     <p class="lead text-center text-secondary">
         <span text-translate="true">This transaction will change your balance:</span>
         <br>
-        <span class="text-@(Model.Positive ? "success" : "danger")">@Model.BalanceChange</span>
+        <span id="balance-toggle" class="text-@(Model.Positive ? "success" : "danger") cursor-pointer"
+              data-btc="@Model.BalanceChange" data-fiat="@Model.FiatBalanceChange">
+            @Model.BalanceChange (<small>@Model.FiatBalanceChange</small>)
+        </span>
     </p>
 }
 
@@ -23,38 +34,36 @@
         @foreach (var input in Model.Inputs)
         {
             <tr>
-                @if (input.Error != null)
-                {
-                    <td>
-                        @input.Index <span class="text-danger" title="@input.Error"><vc:icon symbol="warning"/></span>
-                    </td>
-                }
-                else
-                {
-                    <td>@input.Index</td>
-                }<td>
+                <td>@input.Index</td>
+                <td>
                     @if (input.Labels.Any())
-                       {
-                           <div class="d-flex flex-wrap gap-2 align-items-center">
-                               @foreach (var label in input.Labels)
-                               {
-                                   <div class="transaction-label" style="--label-bg:@label.Color;--label-fg:@label.TextColor">
-                                       <span>@label.Text</span>
-                                       @if (!string.IsNullOrEmpty(label.Link))
-                                       {
-                                           <a class="transaction-label-info transaction-details-icon" href="@label.Link"
-                                              target="_blank" rel="noreferrer noopener" title="@label.Tooltip" data-bs-html="true"
-                                              data-bs-toggle="tooltip" data-bs-custom-class="transaction-label-tooltip">
-                                               <vc:icon symbol="info" />
-                                           </a>
-                                       }
-                                   </div>
-                               }
-                           </div>
-                       }
+                    {
+                        <div class="d-flex flex-wrap gap-2 align-items-center">
+                            @foreach (var label in input.Labels)
+                            {
+                                <div class="transaction-label" style="--label-bg:@label.Color;--label-fg:@label.TextColor">
+                                    <span>@label.Text</span>
+                                    @if (!string.IsNullOrEmpty(label.Link))
+                                    {
+                                        <a class="transaction-label-info transaction-details-icon" href="@label.Link"
+                                           target="_blank" rel="noreferrer noopener" title="@label.Tooltip"
+                                           data-bs-html="true" data-bs-toggle="tooltip"
+                                           data-bs-custom-class="transaction-label-tooltip">
+                                            <vc:icon symbol="info"/>
+                                        </a>
+                                    }
+                                </div>
+                            }
+                        </div>
+                    }
                 </td>
-                <td class="text-end text-@(input.Positive ? "success" : "danger")">@input.BalanceChange</td>
-                
+                <td class="text-end text-@(input.Positive ? "success" : "danger")">
+                    <span class="amount-toggle cursor-pointer"
+                          data-btc="@input.BalanceChange"
+                          data-fiat="@ToFiatAmount(input.BalanceChange)">
+                        @input.BalanceChange
+                    </span>
+                </td>
             </tr>
         }
         </tbody>
@@ -87,9 +96,10 @@
                                     @if (!string.IsNullOrEmpty(label.Link))
                                     {
                                         <a class="transaction-label-info transaction-details-icon" href="@label.Link"
-                                           target="_blank" rel="noreferrer noopener" title="@label.Tooltip" data-bs-html="true"
-                                           data-bs-toggle="tooltip" data-bs-custom-class="transaction-label-tooltip">
-                                            <vc:icon symbol="info" />
+                                           target="_blank" rel="noreferrer noopener" title="@label.Tooltip"
+                                           data-bs-html="true" data-bs-toggle="tooltip"
+                                           data-bs-custom-class="transaction-label-tooltip">
+                                            <vc:icon symbol="info"/>
                                         </a>
                                     }
                                 </div>
@@ -97,7 +107,13 @@
                         </div>
                     }
                 </td>
-                <td class="text-end text-@(destination.Positive ? "success" : "danger")">@destination.Balance</td>
+                <td class="text-end text-@(destination.Positive ? "success" : "danger")">
+                    <span class="amount-toggle cursor-pointer"
+                          data-btc="@destination.Balance"
+                          data-fiat="@ToFiatAmount(destination.Balance)">
+                        @destination.Balance
+                    </span>
+                </td>
             </tr>
         }
         </tbody>
@@ -111,3 +127,36 @@
         <b>@Model.FeeRate</b>
     </p>
 }
+
+<script>
+    document.addEventListener("DOMContentLoaded", function () {
+        const balanceElement = document.getElementById("balance-toggle");
+        const amounts = document.querySelectorAll(".amount-toggle");
+
+        let showFiat = false;
+
+        function updateAllAmounts() {
+            amounts.forEach(el => {
+                const btcAmount = el.getAttribute("data-btc");
+                const fiatAmount = el.getAttribute("data-fiat");
+                el.innerText = showFiat ? fiatAmount : btcAmount;
+            });
+        }
+
+        // Toggle all amounts when clicking balance header
+        balanceElement.addEventListener("click", function () {
+            showFiat = !showFiat;
+            updateAllAmounts();
+        });
+
+        // Toggle individual amounts
+        amounts.forEach(el => {
+            el.addEventListener("click", function (event) {
+                event.stopPropagation();
+                const btcAmount = el.getAttribute("data-btc");
+                const fiatAmount = el.getAttribute("data-fiat");
+                el.innerText = el.innerText === btcAmount ? fiatAmount : btcAmount;
+            });
+        });
+    });
+</script>

--- a/BTCPayServer/Views/UIWallets/_PSBTInfo.cshtml
+++ b/BTCPayServer/Views/UIWallets/_PSBTInfo.cshtml
@@ -1,31 +1,16 @@
-@using BTCPayServer.Services
 @model WalletPSBTReadyViewModel
-@inject DisplayFormatter Formatter
-@functions {
-    private string ToFiatAmount(string destinationBalance)
-    {
-        if (string.IsNullOrWhiteSpace(destinationBalance))
-            return destinationBalance; // Fallback for null/empty input
-        var parts = destinationBalance.Split(' ', StringSplitOptions.RemoveEmptyEntries);
-        if (parts.Length == 0)
-            return destinationBalance; // Fallback for malformed input
-        if (!decimal.TryParse(parts[0], System.Globalization.NumberStyles.Any, 
-                System.Globalization.CultureInfo.InvariantCulture, out var balanceAmount))
-            return destinationBalance; // Fallback for non-numeric values
-
-        var amt = Model.Rate * balanceAmount;
-        return Formatter.Currency(amt, Model.Fiat);
-    }
-}
 
 @if (Model.CanCalculateBalance)
 {
     <p class="lead text-center text-secondary">
         <span text-translate="true">This transaction will change your balance:</span>
         <br>
-        <span id="balance-toggle" class="text-@(Model.Positive ? "success" : "danger") cursor-pointer"
-              data-btc="@Model.BalanceChange" data-fiat="@Model.FiatBalanceChange">
-            @Model.BalanceChange (<small style="text-decoration: underline dotted;">@Model.FiatBalanceChange</small>)
+        <span id="balance-toggle" class="text-@(Model.Positive ? "success" : "danger") cursor-pointer">
+            @Model.BalanceChange.CryptoAmount
+            @if (Model.BalanceChange.FiatAmount != null)
+            {
+                <small style="text-decoration: underline dotted;">(@Model.BalanceChange.FiatAmount)</small>
+            }
         </span>
     </p>
 }
@@ -76,9 +61,9 @@
                 </td>
                 <td class="text-end text-@(input.Positive ? "success" : "danger")">
                     <span class="amount-toggle cursor-pointer"
-                          data-btc="@input.BalanceChange"
-                          data-fiat="@ToFiatAmount(input.BalanceChange)">
-                        @input.BalanceChange
+                          data-btc="@input.BalanceChange.CryptoAmount"
+                          data-fiat="@input.BalanceChange.FiatAmount">
+                        @input.BalanceChange.CryptoAmount
                     </span>
                 </td>
             </tr>
@@ -126,9 +111,9 @@
                 </td>
                 <td class="text-end text-@(destination.Positive ? "success" : "danger")">
                     <span class="amount-toggle cursor-pointer"
-                          data-btc="@destination.Balance"
-                          data-fiat="@ToFiatAmount(destination.Balance)">
-                        @destination.Balance
+                          data-btc="@destination.Balance.CryptoAmount"
+                          data-fiat="@destination.Balance.FiatAmount">
+                        @destination.Balance.CryptoAmount
                     </span>
                 </td>
             </tr>
@@ -152,18 +137,22 @@
 
         let showFiat = false;
 
-        function updateAllAmounts() {
+        // Toggle all amounts when clicking balance header
+        balanceElement.addEventListener("click", function () {
+            // Check if all elements have a non-empty data-fiat
+            const allHaveValidFiat = Array.from(amounts).every(el => {
+                const fiatAmount = el.getAttribute("data-fiat");
+                return fiatAmount !== null && fiatAmount.trim() !== "";
+            });
+
+            if (!allHaveValidFiat) return; // If any is missing or empty, do nothing
+
+            showFiat = !showFiat;
             amounts.forEach(el => {
                 const btcAmount = el.getAttribute("data-btc");
                 const fiatAmount = el.getAttribute("data-fiat");
                 el.innerText = showFiat ? fiatAmount : btcAmount;
             });
-        }
-
-        // Toggle all amounts when clicking balance header
-        balanceElement.addEventListener("click", function () {
-            showFiat = !showFiat;
-            updateAllAmounts();
         });
 
         // Toggle individual amounts
@@ -172,8 +161,12 @@
                 event.stopPropagation();
                 const btcAmount = el.getAttribute("data-btc");
                 const fiatAmount = el.getAttribute("data-fiat");
-                el.innerText = el.innerText === btcAmount ? fiatAmount : btcAmount;
+                if (fiatAmount !== null && fiatAmount.trim() !== "") {
+                    el.innerText = el.innerText === btcAmount ? fiatAmount : btcAmount;
+                }
             });
         });
     });
 </script>
+
+

--- a/BTCPayServer/Views/UIWallets/_PSBTInfo.cshtml
+++ b/BTCPayServer/Views/UIWallets/_PSBTInfo.cshtml
@@ -34,7 +34,14 @@
         @foreach (var input in Model.Inputs)
         {
             <tr>
-                <td>@input.Index</td>
+                @if (input.Error != null)
+                {
+                    <td>@input.Index <span class="text-danger" title="@input.Error"><vc:icon symbol="warning"/></span></td>
+                }
+                else
+                {
+                    <td>@input.Index</td>
+                }
                 <td>
                     @if (input.Labels.Any())
                     {
@@ -49,7 +56,7 @@
                                            target="_blank" rel="noreferrer noopener" title="@label.Tooltip"
                                            data-bs-html="true" data-bs-toggle="tooltip"
                                            data-bs-custom-class="transaction-label-tooltip">
-                                            <vc:icon symbol="info"/>
+                                            <vc:icon symbol="info" />
                                         </a>
                                     }
                                 </div>

--- a/BTCPayServer/Views/UIWallets/_PSBTInfo.cshtml
+++ b/BTCPayServer/Views/UIWallets/_PSBTInfo.cshtml
@@ -1,10 +1,20 @@
+@using BTCPayServer.Services
 @model WalletPSBTReadyViewModel
-
+@inject DisplayFormatter Formatter
 @functions {
     private string ToFiatAmount(string destinationBalance)
     {
-        var amt = Model.Rate * Decimal.Parse(destinationBalance.Replace("BTC", "").Trim());
-        return amt.ToString("N" + Model.FiatDivisibility) + " " + Model.Fiat;
+        if (string.IsNullOrWhiteSpace(destinationBalance))
+            return destinationBalance; // Fallback for null/empty input
+        var parts = destinationBalance.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+        if (parts.Length == 0)
+            return destinationBalance; // Fallback for malformed input
+        if (!decimal.TryParse(parts[0], System.Globalization.NumberStyles.AllowDecimalPoint, 
+                System.Globalization.CultureInfo.InvariantCulture, out var balanceAmount))
+            return destinationBalance; // Fallback for non-numeric values
+
+        var amt = Model.Rate * balanceAmount;
+        return Formatter.Currency(amt, Model.Fiat);
     }
 }
 

--- a/BTCPayServer/Views/UIWallets/_PSBTInfo.cshtml
+++ b/BTCPayServer/Views/UIWallets/_PSBTInfo.cshtml
@@ -9,7 +9,7 @@
         var parts = destinationBalance.Split(' ', StringSplitOptions.RemoveEmptyEntries);
         if (parts.Length == 0)
             return destinationBalance; // Fallback for malformed input
-        if (!decimal.TryParse(parts[0], System.Globalization.NumberStyles.AllowDecimalPoint, 
+        if (!decimal.TryParse(parts[0], System.Globalization.NumberStyles.Any, 
                 System.Globalization.CultureInfo.InvariantCulture, out var balanceAmount))
             return destinationBalance; // Fallback for non-numeric values
 
@@ -25,7 +25,7 @@
         <br>
         <span id="balance-toggle" class="text-@(Model.Positive ? "success" : "danger") cursor-pointer"
               data-btc="@Model.BalanceChange" data-fiat="@Model.FiatBalanceChange">
-            @Model.BalanceChange (<small>@Model.FiatBalanceChange</small>)
+            @Model.BalanceChange (<small style="text-decoration: underline dotted;">@Model.FiatBalanceChange</small>)
         </span>
     </p>
 }

--- a/BTCPayServer/Views/UIWallets/_PSBTInfo.cshtml
+++ b/BTCPayServer/Views/UIWallets/_PSBTInfo.cshtml
@@ -34,24 +34,24 @@
                     <td>@input.Index</td>
                 }<td>
                     @if (input.Labels.Any())
-                                           {
-                                               <div class="d-flex flex-wrap gap-2 align-items-center">
-                                                   @foreach (var label in input.Labels)
-                                                   {
-                                                       <div class="transaction-label" style="--label-bg:@label.Color;--label-fg:@label.TextColor">
-                                                           <span>@label.Text</span>
-                                                           @if (!string.IsNullOrEmpty(label.Link))
-                                                           {
-                                                               <a class="transaction-label-info transaction-details-icon" href="@label.Link"
-                                                                  target="_blank" rel="noreferrer noopener" title="@label.Tooltip" data-bs-html="true"
-                                                                  data-bs-toggle="tooltip" data-bs-custom-class="transaction-label-tooltip">
-                                                                   <vc:icon symbol="info" />
-                                                               </a>
-                                                           }
-                                                       </div>
-                                                   }
-                                               </div>
-                                           }
+                       {
+                           <div class="d-flex flex-wrap gap-2 align-items-center">
+                               @foreach (var label in input.Labels)
+                               {
+                                   <div class="transaction-label" style="--label-bg:@label.Color;--label-fg:@label.TextColor">
+                                       <span>@label.Text</span>
+                                       @if (!string.IsNullOrEmpty(label.Link))
+                                       {
+                                           <a class="transaction-label-info transaction-details-icon" href="@label.Link"
+                                              target="_blank" rel="noreferrer noopener" title="@label.Tooltip" data-bs-html="true"
+                                              data-bs-toggle="tooltip" data-bs-custom-class="transaction-label-tooltip">
+                                               <vc:icon symbol="info" />
+                                           </a>
+                                       }
+                                   </div>
+                               }
+                           </div>
+                       }
                 </td>
                 <td class="text-end text-@(input.Positive ? "success" : "danger")">@input.BalanceChange</td>
                 
@@ -77,28 +77,27 @@
             <tr>
                 <td class="text-break">@destination.Destination</td>
                 <td>
-                  @if (destination.Labels.Any())
-                                        {
-                                            <div class="d-flex flex-wrap gap-2 align-items-center">
-                                                @foreach (var label in destination.Labels)
-                                                {
-                                                    <div class="transaction-label" style="--label-bg:@label.Color;--label-fg:@label.TextColor">
-                                                        <span>@label.Text</span>
-                                                        @if (!string.IsNullOrEmpty(label.Link))
-                                                        {
-                                                            <a class="transaction-label-info transaction-details-icon" href="@label.Link"
-                                                               target="_blank" rel="noreferrer noopener" title="@label.Tooltip" data-bs-html="true"
-                                                               data-bs-toggle="tooltip" data-bs-custom-class="transaction-label-tooltip">
-                                                                <vc:icon symbol="info" />
-                                                            </a>
-                                                        }
-                                                    </div>
-                                                }
-                                            </div>
-                                        }
+                    @if (destination.Labels.Any())
+                    {
+                        <div class="d-flex flex-wrap gap-2 align-items-center">
+                            @foreach (var label in destination.Labels)
+                            {
+                                <div class="transaction-label" style="--label-bg:@label.Color;--label-fg:@label.TextColor">
+                                    <span>@label.Text</span>
+                                    @if (!string.IsNullOrEmpty(label.Link))
+                                    {
+                                        <a class="transaction-label-info transaction-details-icon" href="@label.Link"
+                                           target="_blank" rel="noreferrer noopener" title="@label.Tooltip" data-bs-html="true"
+                                           data-bs-toggle="tooltip" data-bs-custom-class="transaction-label-tooltip">
+                                            <vc:icon symbol="info" />
+                                        </a>
+                                    }
+                                </div>
+                            }
+                        </div>
+                    }
                 </td>
                 <td class="text-end text-@(destination.Positive ? "success" : "danger")">@destination.Balance</td>
-
             </tr>
         }
         </tbody>


### PR DESCRIPTION
Resolves: #6607

This will be useful now that we have pending transactions and fiat amount can significantly change between when transaction is created versus signed and broadcasted.

https://github.com/user-attachments/assets/66078691-5aeb-49f4-a725-fd49e47e078a

