### PR TITLE
UI: Allow iframe context to get defined by opener

### DIFF
--- a/BTCPayServer/Views/Shared/LayoutHeadTheme.cshtml
+++ b/BTCPayServer/Views/Shared/LayoutHeadTheme.cshtml
@@ -4,7 +4,7 @@
 
 <script>
     if (window.localStorage.getItem('btcpay-hide-sensitive-info') === 'true') { document.documentElement.setAttribute('data-hide-sensitive-info', 'true')}
-    if (window.location !== window.parent.location) { document.documentElement.setAttribute('data-within-iframe', 'true')}
+    if (window.location !== window.parent.location) { window.addEventListener('message', function(event) { try { const data = JSON.parse(event.data); if (data.context) { document.documentElement.setAttribute('data-context', data.context) } } catch {} }, false); }
 </script>
 @if (Theme.CustomTheme && Theme.CustomThemeCssUrl is not null)
 {   // new customization uses theme file id provided by upload

--- a/BTCPayServer/wwwroot/main/site.css
+++ b/BTCPayServer/wwwroot/main/site.css
@@ -28,8 +28,8 @@
 }
 
 /* Iframe context */
-[data-within-iframe] #StoreLink,
-[data-within-iframe] .store-footer {
+[data-context="btcpayapp"] #Checkout #StoreLink,
+[data-context="btcpayapp"] #Checkout .store-footer {
     display: none;
 }
 


### PR DESCRIPTION
The CSS to hide certain elements in the iframe context was introduced in #6574.

The mechanism to define the iframe context is now shifted to the opener, so that we can limit that behaviour to the mobile app.

Closes #6614.