### PR TITLE
UI: Fix and unify localizer usage for page titles

### DIFF
--- a/BTCPayServer/Components/StoreNumbers/Default.cshtml
+++ b/BTCPayServer/Components/StoreNumbers/Default.cshtml
@@ -24,7 +24,7 @@
     {
         <div class="store-number">
             <header>
-                <h6 text-translate="true">@ViewLocalizer["Paid invoices in the last {0} days", Model.TimeframeDays]</h6>
+                <h6>@ViewLocalizer["Paid invoices in the last {0} days", Model.TimeframeDays]</h6>
                 @if (Model.PaidInvoices > 0)
                 {
                     <a asp-controller="UIInvoice" asp-action="ListInvoices" asp-route-storeId="@Model.StoreId"  permission="@Policies.CanViewInvoices" text-translate="true">View All</a>

--- a/BTCPayServer/Views/Shared/CreateOrEditRole.cshtml
+++ b/BTCPayServer/Views/Shared/CreateOrEditRole.cshtml
@@ -12,12 +12,11 @@
         role = null;
 
     var storeId = Context.GetRouteValue("storeId") as string;
+    var title = role is null ? StringLocalizer["Create role"] : StringLocalizer["Update Role"];
     if (storeId is null)
-        ViewData.SetActivePage(ServerNavPages.Roles, role is null ? "Create role" : "Update Role");
+        ViewData.SetActivePage(ServerNavPages.Roles, title);
     else
-    {
-        ViewData.SetActivePage(StoreNavPages.Roles, role is null ? "Create role" : "Update Role");
-    }
+        ViewData.SetActivePage(StoreNavPages.Roles, title, storeId);
     var storePolicies = Policies.AllPolicies.Where(Policies.IsStorePolicy).ToArray();
 }
 
@@ -30,7 +29,7 @@
                 </li>
                 <li class="breadcrumb-item active" aria-current="page">@ViewData["Title"]</li>
             </ol>
-            <h2 text-translate="true">@ViewData["Title"]</h2>
+            <h2>@ViewData["Title"]</h2>
         </nav>
         <button id="page-primary" type="submit" class="btn btn-primary" name="command" value="Save">Save</button>
     </div>

--- a/BTCPayServer/Views/Shared/Crowdfund/UpdateCrowdfund.cshtml
+++ b/BTCPayServer/Views/Shared/Crowdfund/UpdateCrowdfund.cshtml
@@ -30,7 +30,7 @@
 
 <form method="post" enctype="multipart/form-data" permissioned="@Policies.CanModifyStoreSettings">
     <div class="sticky-header">
-        <h2 text-translate="true">@ViewData["Title"]</h2>
+        <h2>@ViewData["Title"]</h2>
         <div>
             <button id="page-primary" type="submit" class="btn btn-primary order-sm-1">Save</button>
             <a class="btn btn-secondary" asp-action="ListInvoices" asp-controller="UIInvoice" asp-route-storeId="@Model.StoreId" asp-route-searchterm="@Model.SearchTerm">Invoices</a>

--- a/BTCPayServer/Views/Shared/ListRoles.cshtml
+++ b/BTCPayServer/Views/Shared/ListRoles.cshtml
@@ -9,7 +9,7 @@
     if (string.IsNullOrEmpty(storeId))
         ViewData.SetActivePage(ServerNavPages.Roles, StringLocalizer["Roles"]);
     else
-        ViewData.SetActivePage(StoreNavPages.Roles, StringLocalizer["Roles"]);
+        ViewData.SetActivePage(StoreNavPages.Roles, StringLocalizer["Roles"], storeId);
     var permission = string.IsNullOrEmpty(storeId) ? Policies.CanModifyServerSettings : Policies.CanModifyStoreSettings;
     var nextRoleSortOrder = (string) ViewData["NextRoleSortOrder"];
     var roleSortOrder = nextRoleSortOrder switch
@@ -25,7 +25,7 @@
 }
 
 <div class="sticky-header">
-    <h2 text-translate="true">@ViewData["Title"]</h2>
+    <h2>@ViewData["Title"]</h2>
 	<a id="page-primary" class="btn btn-primary" role="button" asp-controller="@controller" asp-action="CreateOrEditRole" asp-route-role="create" asp-route-storeId="@storeId" permission="@permission">Add Role</a>
 </div>
 <partial name="_StatusMessage" />

--- a/BTCPayServer/Views/Shared/PayButton/Enable.cshtml
+++ b/BTCPayServer/Views/Shared/PayButton/Enable.cshtml
@@ -1,13 +1,12 @@
 @using BTCPayServer.TagHelpers
 @using BTCPayServer.Views.Stores
-@using Microsoft.AspNetCore.Html
 @using Microsoft.AspNetCore.Mvc.TagHelpers
 @{
-	ViewData.SetActivePage(StoreNavPages.PayButton, "Pay Button", Context.GetStoreData().Id);
+	ViewData.SetActivePage(StoreNavPages.PayButton, StringLocalizer["Pay Button"], Context.GetStoreData().Id);
 }
 
 <div class="sticky-header">
-    <h2 class="my-1" text-translate="true">@ViewData["Title"]</h2>
+    <h2 class="my-1">@ViewData["Title"]</h2>
 </div>
 
 <partial name="_StatusMessage" />

--- a/BTCPayServer/Views/Shared/PayButton/PayButton.cshtml
+++ b/BTCPayServer/Views/Shared/PayButton/PayButton.cshtml
@@ -1,10 +1,9 @@
 @using BTCPayServer.Views.Stores
-@using Microsoft.AspNetCore.Html
 @inject Security.ContentSecurityPolicies Csp
 @inject BTCPayNetworkProvider NetworkProvider
 @model BTCPayServer.Plugins.PayButton.Models.PayButtonViewModel
 @{
-    ViewData.SetActivePage(StoreNavPages.PayButton, "Pay Button", Context.GetStoreData().Id);
+    ViewData.SetActivePage(StoreNavPages.PayButton, StringLocalizer["Pay Button"], Context.GetStoreData().Id);
 	Csp.UnsafeEval();
 }
 
@@ -176,7 +175,7 @@
 }
 
 <div class="sticky-header">
-	<h2 class="my-1" text-translate="true">@ViewData["Title"]</h2>
+	<h2 class="my-1">@ViewData["Title"]</h2>
 </div>
 
 <partial name="_StatusMessage" />

--- a/BTCPayServer/Views/Shared/PointOfSale/UpdatePointOfSale.cshtml
+++ b/BTCPayServer/Views/Shared/PointOfSale/UpdatePointOfSale.cshtml
@@ -29,7 +29,7 @@
 
 <form method="post" permissioned="@Policies.CanModifyStoreSettings">
     <div class="sticky-header">
-        <h2 text-translate="true">@ViewData["Title"]</h2>
+        <h2>@ViewData["Title"]</h2>
         <div>
             <button id="page-primary" type="submit" class="btn btn-primary order-sm-1">Save</button>
             <a class="btn btn-secondary" asp-action="ListInvoices" asp-controller="UIInvoice" asp-route-storeId="@Model.StoreId" asp-route-searchterm="@Model.SearchTerm" text-translate="true">Invoices</a>

--- a/BTCPayServer/Views/UIAccount/CheatPermissions.cshtml
+++ b/BTCPayServer/Views/UIAccount/CheatPermissions.cshtml
@@ -7,11 +7,11 @@
 
 @if (Model.StoreId is not null)
 {
-	<h1 text-translate="true">@ViewLocalizer["Store: {0}", Model.StoreId]</h1>
+	<h1>@ViewLocalizer["Store: {0}", Model.StoreId]</h1>
 }
 else
 {
-	<h1 text-translate="true" text-translate="true">No scope</h1>
+	<h1 text-translate="true">No scope</h1>
 }
 
 <ul>

--- a/BTCPayServer/Views/UIAccount/SignedOut.cshtml
+++ b/BTCPayServer/Views/UIAccount/SignedOut.cshtml
@@ -1,8 +1,8 @@
 ﻿@{
-    ViewData["Title"] = "Signed out";
+    ViewData["Title"] = StringLocalizer["Signed out"];
 }
 
-<h2 text-translate="true">@ViewData["Title"]</h2>
+<h2>@ViewData["Title"]</h2>
 <p text-translate="true">
     You have successfully signed out.
 </p>

--- a/BTCPayServer/Views/UIApps/CreateApp.cshtml
+++ b/BTCPayServer/Views/UIApps/CreateApp.cshtml
@@ -1,6 +1,6 @@
 @model CreateAppViewModel
 @{
-    ViewData.SetActivePage(AppsNavPages.Create, $"Create a new {Model.AppType ?? "app"}", Model.AppType);
+    ViewData.SetActivePage(AppsNavPages.Create, StringLocalizer["Create a new {0}", Model.AppType]);
 }
 
 @section PageFootContent {
@@ -9,7 +9,7 @@
 
 <form asp-action="CreateApp" asp-route-appType="@Model.AppType">
     <div class="sticky-header">
-        <h2 text-translate="true">@ViewData["Title"]</h2>
+        <h2>@ViewData["Title"]</h2>
 		<input id="page-primary" type="submit" value="Create" class="btn btn-primary" />
     </div>
     <partial name="_StatusMessage" />

--- a/BTCPayServer/Views/UIFido2/Create.cshtml
+++ b/BTCPayServer/Views/UIFido2/Create.cshtml
@@ -12,7 +12,7 @@
             </li>
             <li class="breadcrumb-item active" aria-current="page" text-translate="true">Register Device</li>
         </ol>
-        <h2 text-translate="true">@ViewData["Title"]</h2>
+        <h2>@ViewData["Title"]</h2>
     </nav>
 </div>
 <partial name="_StatusMessage" />

--- a/BTCPayServer/Views/UIForms/FormsList.cshtml
+++ b/BTCPayServer/Views/UIForms/FormsList.cshtml
@@ -9,7 +9,7 @@
 
 <div class="sticky-header">
     <h2>
-        <span text-translate="true">@ViewData["Title"]</span>
+        <span>@ViewData["Title"]</span>
         <a href="https://docs.btcpayserver.org/Forms" target="_blank" rel="noreferrer noopener" title="@StringLocalizer["More information..."]">
             <vc:icon symbol="info" />
         </a>

--- a/BTCPayServer/Views/UIForms/Modify.cshtml
+++ b/BTCPayServer/Views/UIForms/Modify.cshtml
@@ -203,7 +203,7 @@
                 <li class="breadcrumb-item">
                     <a asp-controller="UIForms" asp-action="FormsList" asp-route-storeId="@storeId" text-translate="true">Forms</a>
                 </li>
-                <li class="breadcrumb-item active" aria-current="page" text-translate="true">@ViewData["Title"]</li>
+                <li class="breadcrumb-item active" aria-current="page">@ViewData["Title"]</li>
             </ol>
             <h2>
                 @ViewData["Title"]

--- a/BTCPayServer/Views/UIInvoice/CreateInvoice.cshtml
+++ b/BTCPayServer/Views/UIInvoice/CreateInvoice.cshtml
@@ -34,9 +34,9 @@
                 <li class="breadcrumb-item">
                     <a asp-action="ListInvoices" asp-route-storeId="@Model.StoreId" text-translate="true">Invoices</a>
                 </li>
-                <li class="breadcrumb-item active" aria-current="page" text-translate="true">@ViewData["Title"]</li>
+                <li class="breadcrumb-item active" aria-current="page">@ViewData["Title"]</li>
             </ol>
-            <h2 text-translate="true">@ViewData["Title"]</h2>
+            <h2>@ViewData["Title"]</h2>
         </nav>
 		<input id="page-primary" type="submit" value="Create" class="btn btn-primary" />
     </div>

--- a/BTCPayServer/Views/UIInvoice/Invoice.cshtml
+++ b/BTCPayServer/Views/UIInvoice/Invoice.cshtml
@@ -1,7 +1,7 @@
 @using BTCPayServer.Client
 @model InvoiceDetailsModel
 @{
-    ViewData["Title"] = $"Invoice {Model.Id}";
+    ViewData["Title"] = StringLocalizer["Invoice {0}", Model.Id];
 }
 
 @section PageHeadContent {
@@ -177,7 +177,7 @@
             </li>
             <li class="breadcrumb-item active" aria-current="page">Invoice</li>
         </ol>
-        <h2 text-translate="true">@ViewData["Title"]</h2>
+        <h2>@ViewData["Title"]</h2>
     </nav>
     <div>
         @if (Model.ShowCheckout)

--- a/BTCPayServer/Views/UIInvoice/ListInvoices.cshtml
+++ b/BTCPayServer/Views/UIInvoice/ListInvoices.cshtml
@@ -102,7 +102,7 @@
 
 <div class="sticky-header">
     <h2>
-        <span text-translate="true">@ViewData["Title"]</span>
+        <span>@ViewData["Title"]</span>
         <a href="#descriptor" data-bs-toggle="collapse">
             <vc:icon symbol="info" />
         </a>

--- a/BTCPayServer/Views/UILNURL/EditLightningAddress.cshtml
+++ b/BTCPayServer/Views/UILNURL/EditLightningAddress.cshtml
@@ -26,7 +26,7 @@
 }
 
 <div class="sticky-header">
-    <h2 text-translate="true">@ViewData["Title"]</h2>
+    <h2>@ViewData["Title"]</h2>
 	<a id="page-primary" data-bs-toggle="collapse" data-bs-target="#AddAddress" class="btn btn-primary" role="button">
         Add Address
     </a>

--- a/BTCPayServer/Views/UILNURLAuth/Create.cshtml
+++ b/BTCPayServer/Views/UILNURLAuth/Create.cshtml
@@ -9,7 +9,7 @@
     };
 }
 
-<h2 class="mb-2 mb-lg-3" text-translate="true">@ViewData["Title"]</h2>
+<h2 class="mb-2 mb-lg-3">@ViewData["Title"]</h2>
 <partial name="_StatusMessage" />
 
 <p text-translate="true">Scan the QR code with your Lightning wallet to link it to your user account.</p>

--- a/BTCPayServer/Views/UILightningAutomatedPayoutProcessors/Configure.cshtml
+++ b/BTCPayServer/Views/UILightningAutomatedPayoutProcessors/Configure.cshtml
@@ -16,7 +16,7 @@
                 </li>
                 <li class="breadcrumb-item active" aria-current="page">@ViewData["Title"]</li>
             </ol>
-            <h2 text-translate="true">@ViewData["Title"]</h2>
+            <h2>@ViewData["Title"]</h2>
         </nav>
 		<button id="page-primary" name="command" type="submit" class="btn btn-primary" value="Save">Save</button>
     </div>

--- a/BTCPayServer/Views/UILightningLikePayout/ConfirmLightningPayout.cshtml
+++ b/BTCPayServer/Views/UILightningLikePayout/ConfirmLightningPayout.cshtml
@@ -1,11 +1,11 @@
 @model System.Collections.Generic.List<BTCPayServer.Data.Payouts.LightningLike.UILightningLikePayoutController.ConfirmVM>
 @{
     Layout = "../Shared/_Layout.cshtml";
-    ViewData["Title"] = "Confirm Lightning Payout";
+    ViewData["Title"] = StringLocalizer["Confirm Lightning Payout"];
     var cryptoCode = Context.GetRouteValue("cryptoCode");
 }
 
-<h2 class="mt-1 mb-2" text-translate="true">@ViewData["Title"]</h2>
+<h2 class="mt-1 mb-2">@ViewData["Title"]</h2>
 <div class="row">
     <div class="col-md-12">
         <ul class="list-group list-group-flush">

--- a/BTCPayServer/Views/UILightningLikePayout/LightningPayoutResult.cshtml
+++ b/BTCPayServer/Views/UILightningLikePayout/LightningPayoutResult.cshtml
@@ -1,11 +1,10 @@
-@using BTCPayServer.Lightning
 @model System.Collections.Generic.List<BTCPayServer.Data.Payouts.LightningLike.UILightningLikePayoutController.ResultVM>
 @{
     Layout = "_Layout";
-    ViewData["Title"] = "Lightning Payout Result";
+    ViewData["Title"] = StringLocalizer["Lightning Payout Result"];
 }
 
-<h2 class="mt-1 mb-4" text-translate="true">@ViewData["Title"]</h2>
+<h2 class="mt-1 mb-4">@ViewData["Title"]</h2>
 @foreach (var item in Model)
 {
     <div class="alert alert-@(item.Success is true ? "success" : "danger") mb-3" role="alert">

--- a/BTCPayServer/Views/UIManage/APIKeys.cshtml
+++ b/BTCPayServer/Views/UIManage/APIKeys.cshtml
@@ -12,7 +12,7 @@
 }
 
 <div class="sticky-header">
-    <h2 text-translate="true">@ViewData["Title"]</h2>
+    <h2>@ViewData["Title"]</h2>
 	<a id="page-primary" class="btn btn-primary" asp-action="AddApiKey">
         Generate Key
     </a>

--- a/BTCPayServer/Views/UIManage/AddApiKey.cshtml
+++ b/BTCPayServer/Views/UIManage/AddApiKey.cshtml
@@ -3,7 +3,7 @@
 @model UIManageController.AddApiKeyViewModel
 
 @{
-    ViewData.SetActivePage(ManageNavPages.APIKeys, "Generate API Key");
+    ViewData.SetActivePage(ManageNavPages.APIKeys, StringLocalizer["Generate API Key"]);
 }
 
 @section PageHeadContent {
@@ -32,9 +32,9 @@
                 <li class="breadcrumb-item">
                     <a asp-action="APIKeys" text-translate="true">API Keys</a>
                 </li>
-                <li class="breadcrumb-item active" aria-current="page" text-translate="true">@ViewData["Title"]</li>
+                <li class="breadcrumb-item active" aria-current="page">@ViewData["Title"]</li>
             </ol>
-            <h2 text-translate="true">@ViewData["Title"]</h2>
+            <h2>@ViewData["Title"]</h2>
         </nav>
 		<button id="page-primary" type="submit" class="btn btn-primary">Generate API Key</button>
     </div>

--- a/BTCPayServer/Views/UIManage/ChangePassword.cshtml
+++ b/BTCPayServer/Views/UIManage/ChangePassword.cshtml
@@ -5,7 +5,7 @@
 
 <form method="post">
     <div class="sticky-header">
-        <h2 text-translate="true">@ViewData["Title"]</h2>
+        <h2>@ViewData["Title"]</h2>
 		<button id="page-primary" type="submit" class="btn btn-primary">Update Password</button>
     </div>
     <partial name="_StatusMessage" />

--- a/BTCPayServer/Views/UIManage/EnableAuthenticator.cshtml
+++ b/BTCPayServer/Views/UIManage/EnableAuthenticator.cshtml
@@ -13,9 +13,9 @@
             <li class="breadcrumb-item">
                 <a asp-action="TwoFactorAuthentication" text-translate="true">Two Factor Authentication</a>
             </li>
-            <li class="breadcrumb-item active" aria-current="page" text-translate="true">@ViewData["Title"]</li>
+            <li class="breadcrumb-item active" aria-current="page">@ViewData["Title"]</li>
         </ol>
-        <h2 text-translate="true">@ViewData["Title"]</h2>
+        <h2>@ViewData["Title"]</h2>
     </nav>
 </div>
 <partial name="_StatusMessage" />

--- a/BTCPayServer/Views/UIManage/GenerateRecoveryCodes.cshtml
+++ b/BTCPayServer/Views/UIManage/GenerateRecoveryCodes.cshtml
@@ -3,7 +3,7 @@
     ViewData.SetActivePage(ManageNavPages.TwoFactorAuthentication, StringLocalizer["Recovery codes"]);
 }
 
-<h2 class="mb-2 mb-lg-3" text-translate="true">@ViewData["Title"]</h2>
+<h2 class="mb-2 mb-lg-3">@ViewData["Title"]</h2>
 <partial name="_StatusMessage" />
 
 <div class="alert alert-warning" role="alert">

--- a/BTCPayServer/Views/UIManage/Index.cshtml
+++ b/BTCPayServer/Views/UIManage/Index.cshtml
@@ -10,7 +10,7 @@
 
 <form method="post" enctype="multipart/form-data">
     <div class="sticky-header">
-        <h2 text-translate="true">@ViewData["Title"]</h2>
+        <h2>@ViewData["Title"]</h2>
 		<button id="page-primary" type="submit" class="btn btn-primary">Save</button>
     </div>
     <partial name="_StatusMessage" />

--- a/BTCPayServer/Views/UIManage/LoginCodes.cshtml
+++ b/BTCPayServer/Views/UIManage/LoginCodes.cshtml
@@ -4,7 +4,7 @@
 }
 
 <div class="sticky-header">
-    <h2 text-translate="true">@ViewData["Title"]</h2>
+    <h2>@ViewData["Title"]</h2>
 </div>
 <partial name="_StatusMessage" />
 <p text-translate="true">Easily log into BTCPay Server on another device using a simple login code from an already authenticated device.</p>

--- a/BTCPayServer/Views/UIManage/NotificationSettings.cshtml
+++ b/BTCPayServer/Views/UIManage/NotificationSettings.cshtml
@@ -10,9 +10,9 @@
                 <li class="breadcrumb-item">
                     <a asp-controller="UINotifications" asp-action="Index" text-translate="true">Notifications</a>
                 </li>
-                <li class="breadcrumb-item active" aria-current="page" text-translate="true">@ViewData["Title"]</li>
+                <li class="breadcrumb-item active" aria-current="page">@ViewData["Title"]</li>
             </ol>
-            <h2 text-translate="true">@ViewData["Title"]</h2>
+            <h2>@ViewData["Title"]</h2>
         </nav>
 		<button id="page-primary" type="submit" class="btn btn-primary" name="command" value="update">Save</button>
     </div>

--- a/BTCPayServer/Views/UIManage/SetPassword.cshtml
+++ b/BTCPayServer/Views/UIManage/SetPassword.cshtml
@@ -5,7 +5,7 @@
 
 <form method="post">
     <div class="sticky-header">
-        <h2 text-translate="true">@ViewData["Title"]</h2>
+        <h2>@ViewData["Title"]</h2>
 		<button id="page-primary" type="submit" class="btn btn-primary">Set Password</button>
     </div>
     <partial name="_StatusMessage" />

--- a/BTCPayServer/Views/UIManage/TwoFactorAuthentication.cshtml
+++ b/BTCPayServer/Views/UIManage/TwoFactorAuthentication.cshtml
@@ -4,7 +4,7 @@
     ViewData.SetActivePage(ManageNavPages.TwoFactorAuthentication, StringLocalizer["Two-Factor Authentication"]);
 }
 <div class="sticky-header">
-	<h2 class="my-1" text-translate="true">@ViewData["Title"]</h2>
+	<h2 class="my-1">@ViewData["Title"]</h2>
 </div>
 <partial name="_StatusMessage" />
 <div class="row">

--- a/BTCPayServer/Views/UINotifications/Index.cshtml
+++ b/BTCPayServer/Views/UINotifications/Index.cshtml
@@ -32,7 +32,7 @@
 }
 
 <div class="sticky-header">
-	<h2 class="my-1" text-translate="true">@ViewData["Title"]</h2>
+	<h2 class="my-1">@ViewData["Title"]</h2>
     <a id="NotificationSettings" asp-controller="UIManage" asp-action="NotificationSettings" class="btn btn-secondary d-flex align-items-center">
         <vc:icon symbol="nav-store-settings" />
     </a>

--- a/BTCPayServer/Views/UIOnChainAutomatedPayoutProcessors/Configure.cshtml
+++ b/BTCPayServer/Views/UIOnChainAutomatedPayoutProcessors/Configure.cshtml
@@ -15,9 +15,9 @@
                 <li class="breadcrumb-item">
                     <a asp-controller="UIPayoutProcessors" asp-action="ConfigureStorePayoutProcessors" asp-route-storeId="@storeId" text-translate="true">Payout Processors</a>
                 </li>
-                <li class="breadcrumb-item active" aria-current="page" text-translate="true">@ViewData["Title"]</li>
+                <li class="breadcrumb-item active" aria-current="page">@ViewData["Title"]</li>
             </ol>
-            <h2 text-translate="true">@ViewData["Title"]</h2>
+            <h2>@ViewData["Title"]</h2>
         </nav>
 		<button id="page-primary" name="command" type="submit" class="btn btn-primary" value="Save" text-translate="true">Save</button>
     </div>

--- a/BTCPayServer/Views/UIPaymentRequest/EditPaymentRequest.cshtml
+++ b/BTCPayServer/Views/UIPaymentRequest/EditPaymentRequest.cshtml
@@ -30,7 +30,7 @@
                 </li>
                 <li class="breadcrumb-item active" aria-current="page">@ViewData["Title"]</li>
             </ol>
-            <h2 text-translate="true">@ViewData["Title"]</h2>
+            <h2>@ViewData["Title"]</h2>
         </nav>
         <div>
             @if (string.IsNullOrEmpty(Model.Id))

--- a/BTCPayServer/Views/UIPayoutProcessors/ConfigureStorePayoutProcessors.cshtml
+++ b/BTCPayServer/Views/UIPayoutProcessors/ConfigureStorePayoutProcessors.cshtml
@@ -8,7 +8,7 @@
     ViewData.SetActivePage(StoreNavPages.PayoutProcessors, StringLocalizer["Payout Processors"], storeId);
 }
 <div class="sticky-header">
-	<h2 class="my-1" text-translate="true">@ViewData["Title"]</h2>
+	<h2 class="my-1">@ViewData["Title"]</h2>
 </div>
 
 <partial name="_StatusMessage" />

--- a/BTCPayServer/Views/UIPullPayment/EditPullPayment.cshtml
+++ b/BTCPayServer/Views/UIPullPayment/EditPullPayment.cshtml
@@ -21,9 +21,9 @@
                 <li class="breadcrumb-item">
                     <a asp-controller="UIStorePullPayments" asp-action="PullPayments" asp-route-storeId="@storeId" text-translate="true">Pull Payments</a>
                 </li>
-                <li class="breadcrumb-item active" aria-current="page" text-translate="true">@ViewData["Title"]</li>
+                <li class="breadcrumb-item active" aria-current="page">@ViewData["Title"]</li>
             </ol>
-            <h2 text-translate="true">@ViewData["Title"]</h2>
+            <h2>@ViewData["Title"]</h2>
         </nav>
         <div>
             @if (string.IsNullOrEmpty(Model.Id))

--- a/BTCPayServer/Views/UIServer/Branding.cshtml
+++ b/BTCPayServer/Views/UIServer/Branding.cshtml
@@ -15,7 +15,7 @@
 
 <form method="post" enctype="multipart/form-data">
     <div class="sticky-header">
-		<h2 text-translate="true">@ViewData["Title"]</h2>
+		<h2>@ViewData["Title"]</h2>
 		<button id="page-primary" type="submit" class="btn btn-primary" name="command" value="Save">Save</button>
     </div>
     <partial name="_StatusMessage" />

--- a/BTCPayServer/Views/UIServer/CLightningRestServices.cshtml
+++ b/BTCPayServer/Views/UIServer/CLightningRestServices.cshtml
@@ -11,7 +11,7 @@
             </li>
             <li class="breadcrumb-item active" aria-current="page">@ViewData["Title"]</li>
         </ol>
-        <h2 text-translate="true">@ViewData["Title"]</h2>
+        <h2>@ViewData["Title"]</h2>
     </nav>
 </div>
 <partial name="_StatusMessage" />

--- a/BTCPayServer/Views/UIServer/ConfiguratorService.cshtml
+++ b/BTCPayServer/Views/UIServer/ConfiguratorService.cshtml
@@ -10,9 +10,9 @@
             <li class="breadcrumb-item">
                 <a asp-action="Services" text-translate="true">Services</a>
             </li>
-            <li class="breadcrumb-item active" aria-current="page" text-translate="true">@ViewData["Title"]</li>
+            <li class="breadcrumb-item active" aria-current="page">@ViewData["Title"]</li>
         </ol>
-        <h2 text-translate="true">@ViewData["Title"]</h2>
+        <h2>@ViewData["Title"]</h2>
     </nav>
 </div>
 <partial name="_StatusMessage" />

--- a/BTCPayServer/Views/UIServer/CreateDictionary.cshtml
+++ b/BTCPayServer/Views/UIServer/CreateDictionary.cshtml
@@ -9,9 +9,9 @@
 				<li class="breadcrumb-item">
 					<a asp-action="ListDictionaries" text-translate="true">Dictionaries</a>
 				</li>
-				<li class="breadcrumb-item active" aria-current="page" text-translate="true">@ViewData["Title"]</li>
+				<li class="breadcrumb-item active" aria-current="page">@ViewData["Title"]</li>
 			</ol>
-			<h2 text-translate="true">@ViewData["Title"]</h2>
+			<h2>@ViewData["Title"]</h2>
 		</nav>
 		<input id="page-primary" type="submit" value="Create" class="btn btn-primary" />
 	</div>

--- a/BTCPayServer/Views/UIServer/CreateTemporaryFileUrl.cshtml
+++ b/BTCPayServer/Views/UIServer/CreateTemporaryFileUrl.cshtml
@@ -6,7 +6,7 @@
 
 <form method="post">
     <div class="sticky-header">
-        <h2 text-translate="true">@ViewData["Title"]</h2>
+        <h2>@ViewData["Title"]</h2>
 		<button id="page-primary" type="submit" class="btn btn-primary" name="command" value="Generate" text-translate="true">Generate</button>
     </div>
     <partial name="_StatusMessage" />

--- a/BTCPayServer/Views/UIServer/CreateUser.cshtml
+++ b/BTCPayServer/Views/UIServer/CreateUser.cshtml
@@ -13,9 +13,9 @@
                 <li class="breadcrumb-item">
                     <a asp-action="ListUsers" text-translate="true">Users</a>
                 </li>
-                <li class="breadcrumb-item active" aria-current="page" text-translate="true">@ViewData["Title"]</li>
+                <li class="breadcrumb-item active" aria-current="page">@ViewData["Title"]</li>
             </ol>
-            <h2 text-translate="true">@ViewData["Title"]</h2>
+            <h2>@ViewData["Title"]</h2>
         </nav>
 		<button id="page-primary" type="submit" class="btn btn-primary" name="command" value="Save">Create Account</button>
     </div>

--- a/BTCPayServer/Views/UIServer/DynamicDnsServices.cshtml
+++ b/BTCPayServer/Views/UIServer/DynamicDnsServices.cshtml
@@ -9,10 +9,10 @@
             <li class="breadcrumb-item">
                 <a asp-action="Services" text-translate="true">Services</a>
             </li>
-            <li class="breadcrumb-item active" aria-current="page" text-translate="true">@ViewData["Title"]</li>
+            <li class="breadcrumb-item active" aria-current="page">@ViewData["Title"]</li>
         </ol>
         <h2>
-            <span text-translate="true">@ViewData["Title"]</span>
+            <span>@ViewData["Title"]</span>
             <small>
                 <a href="https://docs.btcpayserver.org/Apps/" target="_blank" rel="noreferrer noopener" title="@StringLocalizer["More information..."]">
                     <vc:icon symbol="info" />

--- a/BTCPayServer/Views/UIServer/EditAmazonS3StorageProvider.cshtml
+++ b/BTCPayServer/Views/UIServer/EditAmazonS3StorageProvider.cshtml
@@ -14,7 +14,7 @@
             </li>
             <li class="breadcrumb-item active" aria-current="page" text-translate="true">Provider</li>
         </ol>
-        <h2 text-translate="true">@ViewData["Title"]</h2>
+        <h2>@ViewData["Title"]</h2>
     </nav>
 </div>
 <partial name="_StatusMessage" />

--- a/BTCPayServer/Views/UIServer/EditAzureBlobStorageStorageProvider.cshtml
+++ b/BTCPayServer/Views/UIServer/EditAzureBlobStorageStorageProvider.cshtml
@@ -14,7 +14,7 @@
             </li>
             <li class="breadcrumb-item active" aria-current="page" text-translate="true">Provider</li>
         </ol>
-        <h2 text-translate="true">@ViewData["Title"]</h2>
+        <h2>@ViewData["Title"]</h2>
     </nav>
 </div>
 <partial name="_StatusMessage" />

--- a/BTCPayServer/Views/UIServer/EditDictionary.cshtml
+++ b/BTCPayServer/Views/UIServer/EditDictionary.cshtml
@@ -1,4 +1,3 @@
-@using BTCPayServer.Abstractions.Models
 @model EditDictionaryViewModel
 @{
 	ViewData.SetActivePage(ServerNavPages.Translations);

--- a/BTCPayServer/Views/UIServer/EditFileSystemStorageProvider.cshtml
+++ b/BTCPayServer/Views/UIServer/EditFileSystemStorageProvider.cshtml
@@ -14,7 +14,7 @@
             </li>
             <li class="breadcrumb-item active" aria-current="page" text-translate="true">Provider</li>
         </ol>
-        <h2 text-translate="true">@ViewData["Title"]</h2>
+        <h2>@ViewData["Title"]</h2>
     </nav>
 </div>
 <partial name="_StatusMessage" />

--- a/BTCPayServer/Views/UIServer/EditGoogleCloudStorageStorageProvider.cshtml
+++ b/BTCPayServer/Views/UIServer/EditGoogleCloudStorageStorageProvider.cshtml
@@ -14,7 +14,7 @@
             </li>
             <li class="breadcrumb-item active" aria-current="page" text-translate="true">Provider</li>
         </ol>
-        <h2 text-translate="true">@ViewData["Title"]</h2>
+        <h2>@ViewData["Title"]</h2>
     </nav>
 </div>
 <partial name="_StatusMessage" />

--- a/BTCPayServer/Views/UIServer/Emails.cshtml
+++ b/BTCPayServer/Views/UIServer/Emails.cshtml
@@ -5,7 +5,7 @@
 
 <form method="post" autocomplete="off">
     <div class="sticky-header">
-        <h2 text-translate="true">@ViewData["Title"]</h2>
+        <h2>@ViewData["Title"]</h2>
 		<button id="page-primary" type="submit" class="btn btn-primary" name="command" value="Save">Save</button>
     </div>
     <partial name="_StatusMessage" />

--- a/BTCPayServer/Views/UIServer/Files.cshtml
+++ b/BTCPayServer/Views/UIServer/Files.cshtml
@@ -4,7 +4,7 @@
 }
 
 <div class="sticky-header">
-	<h2 class="my-1" text-translate="true">@ViewData["Title"]</h2>
+	<h2 class="my-1">@ViewData["Title"]</h2>
     <a asp-action="storage" asp-route-forceChoice="true" asp-route-returnurl="@ViewData["ReturnUrl"]" class="btn btn-secondary d-flex align-items-center">
         <vc:icon symbol="settings" />
     </a>

--- a/BTCPayServer/Views/UIServer/LightningChargeServices.cshtml
+++ b/BTCPayServer/Views/UIServer/LightningChargeServices.cshtml
@@ -9,9 +9,9 @@
             <li class="breadcrumb-item">
                 <a asp-action="Services" text-translate="true">Services</a>
             </li>
-            <li class="breadcrumb-item active" aria-current="page" text-translate="true">@ViewData["Title"]</li>
+            <li class="breadcrumb-item active" aria-current="page">@ViewData["Title"]</li>
         </ol>
-        <h2 text-translate="true">@ViewData["Title"]</h2>
+        <h2>@ViewData["Title"]</h2>
     </nav>
 </div>
 <partial name="_StatusMessage" />

--- a/BTCPayServer/Views/UIServer/ListDictionaries.cshtml
+++ b/BTCPayServer/Views/UIServer/ListDictionaries.cshtml
@@ -1,11 +1,11 @@
 @using BTCPayServer.Abstractions.Models
 @model ListDictionariesViewModel
 @{
-    ViewData.SetActivePage(ServerNavPages.Translations, "Dictionaries");
+    ViewData.SetActivePage(ServerNavPages.Translations, StringLocalizer["Dictionaries"]);
 }
 
 <div class="sticky-header">
-	<h2 text-translate="true">@ViewData["Title"]</h2>
+	<h2>@ViewData["Title"]</h2>
 	<a id="page-primary" asp-action="CreateDictionary" class="btn btn-primary" role="button">
 		Create
 	</a>

--- a/BTCPayServer/Views/UIServer/ListStores.cshtml
+++ b/BTCPayServer/Views/UIServer/ListStores.cshtml
@@ -4,7 +4,7 @@
     ViewData.SetActivePage(ServerNavPages.Stores, StringLocalizer["Store Overview"]);
 }
 <div class="sticky-header">
-	<h2 class="my-1" text-translate="true">@ViewData["Title"]</h2>
+	<h2 class="my-1">@ViewData["Title"]</h2>
 </div>
 <partial name="_StatusMessage" />
 

--- a/BTCPayServer/Views/UIServer/ListUsers.cshtml
+++ b/BTCPayServer/Views/UIServer/ListUsers.cshtml
@@ -29,7 +29,7 @@
 }
 
 <div class="sticky-header">
-    <h2 text-translate="true">@ViewData["Title"]</h2>
+    <h2>@ViewData["Title"]</h2>
 	<a id="page-primary" asp-action="CreateUser" class="btn btn-primary" role="button">
         Add User
     </a>

--- a/BTCPayServer/Views/UIServer/LndSeedBackup.cshtml
+++ b/BTCPayServer/Views/UIServer/LndSeedBackup.cshtml
@@ -10,9 +10,9 @@
             <li class="breadcrumb-item">
                 <a asp-action="Services" text-translate="true">Services</a>
             </li>
-            <li class="breadcrumb-item active" aria-current="page" text-translate="true">@ViewData["Title"]</li>
+            <li class="breadcrumb-item active" aria-current="page">@ViewData["Title"]</li>
         </ol>
-        <h2 text-translate="true">@ViewData["Title"]</h2>
+        <h2>@ViewData["Title"]</h2>
     </nav>
 </div>
 <partial name="_StatusMessage" />

--- a/BTCPayServer/Views/UIServer/LndServices.cshtml
+++ b/BTCPayServer/Views/UIServer/LndServices.cshtml
@@ -9,9 +9,9 @@
             <li class="breadcrumb-item">
                 <a asp-action="Services" text-translate="true">Services</a>
             </li>
-            <li class="breadcrumb-item active" aria-current="page" text-translate="true">@ViewData["Title"]</li>
+            <li class="breadcrumb-item active" aria-current="page">@ViewData["Title"]</li>
         </ol>
-        <h2 text-translate="true">@ViewData["Title"]</h2>
+        <h2>@ViewData["Title"]</h2>
     </nav>
 </div>
 <partial name="_StatusMessage" />

--- a/BTCPayServer/Views/UIServer/Logs.cshtml
+++ b/BTCPayServer/Views/UIServer/Logs.cshtml
@@ -4,7 +4,7 @@
 }
 
 <div class="sticky-header">
-	<h2 class="my-1" text-translate="true">@ViewData["Title"]</h2>
+	<h2 class="my-1">@ViewData["Title"]</h2>
 </div>
 <partial name="_StatusMessage" />
 

--- a/BTCPayServer/Views/UIServer/Maintenance.cshtml
+++ b/BTCPayServer/Views/UIServer/Maintenance.cshtml
@@ -7,7 +7,7 @@
 }
 
 <div class="sticky-header">
-	<h2 class="my-1" text-translate="true">@ViewData["Title"]</h2>
+	<h2 class="my-1">@ViewData["Title"]</h2>
 </div>
 <partial name="_StatusMessage" />
 

--- a/BTCPayServer/Views/UIServer/Policies.cshtml
+++ b/BTCPayServer/Views/UIServer/Policies.cshtml
@@ -4,7 +4,7 @@
 @inject EmailSenderFactory EmailSenderFactory
 @inject TransactionLinkProviders TransactionLinkProviders
 @{
-    ViewData.SetActivePage(ServerNavPages.Policies);
+    ViewData.SetActivePage(ServerNavPages.Policies, StringLocalizer["Policies"]);
     var linkProviders = TransactionLinkProviders.ToArray();
 }
 
@@ -20,7 +20,7 @@
 
 <form method="post">
     <div class="sticky-header">
-        <h2 text-translate="true">@ViewData["Title"]</h2>
+        <h2>@ViewData["Title"]</h2>
 		<button id="page-primary" type="submit" class="btn btn-primary" name="command" value="Save">Save</button>
     </div>
     <partial name="_StatusMessage" />

--- a/BTCPayServer/Views/UIServer/ResetUserPassword.cshtml
+++ b/BTCPayServer/Views/UIServer/ResetUserPassword.cshtml
@@ -1,6 +1,6 @@
 @model BTCPayServer.Controllers.ResetUserPasswordFromAdmin
 @{
-    ViewData.SetActivePage(ServerNavPages.Users, "Reset Password");
+    ViewData.SetActivePage(ServerNavPages.Users, StringLocalizer["Reset Password"]);
 }
 
 <form method="post" asp-action="ResetUserPassword">
@@ -10,9 +10,9 @@
                 <li class="breadcrumb-item">
                     <a asp-action="ListUsers" text-translate="true">Users</a>
                 </li>
-                <li class="breadcrumb-item active" aria-current="page" text-translate="true">@ViewData["Title"]</li>
+                <li class="breadcrumb-item active" aria-current="page">@ViewData["Title"]</li>
             </ol>
-            <h2 text-translate="true">@ViewData["Title"]</h2>
+            <h2>@ViewData["Title"]</h2>
         </nav>
 		<button id="page-primary" type="submit" class="btn btn-primary" name="command" value="Save">Reset Password</button>
     </div>

--- a/BTCPayServer/Views/UIServer/SSHService.cshtml
+++ b/BTCPayServer/Views/UIServer/SSHService.cshtml
@@ -10,9 +10,9 @@
             <li class="breadcrumb-item">
                 <a asp-action="Services" text-translate="true">Services</a>
             </li>
-            <li class="breadcrumb-item active" aria-current="page" text-translate="true">@ViewData["Title"]</li>
+            <li class="breadcrumb-item active" aria-current="page">@ViewData["Title"]</li>
         </ol>
-        <h2 text-translate="true">@ViewData["Title"]</h2>
+        <h2>@ViewData["Title"]</h2>
     </nav>
 </div>
 <partial name="_StatusMessage" />

--- a/BTCPayServer/Views/UIServer/Services.cshtml
+++ b/BTCPayServer/Views/UIServer/Services.cshtml
@@ -4,7 +4,7 @@
 }
 
 <div class="sticky-header">
-	<h2 class="my-1" text-translate="true">@ViewData["Title"]</h2>
+	<h2 class="my-1">@ViewData["Title"]</h2>
 </div>
 <partial name="_StatusMessage" />
 

--- a/BTCPayServer/Views/UIServer/Storage.cshtml
+++ b/BTCPayServer/Views/UIServer/Storage.cshtml
@@ -10,9 +10,9 @@
                 <li class="breadcrumb-item">
                     <a asp-action="Files" text-translate="true">Files</a>
                 </li>
-                <li class="breadcrumb-item active" aria-current="page" text-translate="true">@ViewData["Title"]</li>
+                <li class="breadcrumb-item active" aria-current="page">@ViewData["Title"]</li>
             </ol>
-            <h2 text-translate="true">@ViewData["Title"]</h2>
+            <h2>@ViewData["Title"]</h2>
         </nav>         
         <button id="page-primary" type="submit" class="btn btn-primary" name="command" value="Save" text-translate="true">Next</button>
     </div>

--- a/BTCPayServer/Views/UIServer/User.cshtml
+++ b/BTCPayServer/Views/UIServer/User.cshtml
@@ -16,7 +16,7 @@
                 </li>
                 <li class="breadcrumb-item active" aria-current="page" text-translate="true">User</li>
             </ol>
-            <h2 text-translate="true">@ViewData["Title"]</h2>
+            <h2>@ViewData["Title"]</h2>
         </nav>
 		<button id="page-primary" name="command" type="submit" class="btn btn-primary" value="Save" text-translate="true">Save</button>
     </div>

--- a/BTCPayServer/Views/UIStorePullPayments/NewPullPayment.cshtml
+++ b/BTCPayServer/Views/UIStorePullPayments/NewPullPayment.cshtml
@@ -22,9 +22,9 @@
                 <li class="breadcrumb-item">
                     <a asp-action="PullPayments" asp-route-storeId="@storeId" text-translate="true">Pull Payments</a>
                 </li>
-                <li class="breadcrumb-item active" aria-current="page" text-translate="true">@ViewData["Title"]</li>
+                <li class="breadcrumb-item active" aria-current="page">@ViewData["Title"]</li>
             </ol>
-            <h2 text-translate="true">@ViewData["Title"]</h2>
+            <h2>@ViewData["Title"]</h2>
         </nav>
 		<input id="page-primary" type="submit" value="Create" class="btn btn-primary"/>
     </div>

--- a/BTCPayServer/Views/UIStores/CheckoutAppearance.cshtml
+++ b/BTCPayServer/Views/UIStores/CheckoutAppearance.cshtml
@@ -66,7 +66,7 @@
 
 <form method="post" enctype="multipart/form-data" permissioned="@Policies.CanModifyStoreSettings">
     <div class="sticky-header">
-        <h2 text-translate="true">@ViewData["Title"]</h2>
+        <h2>@ViewData["Title"]</h2>
 		<button id="page-primary" type="submit" class="btn btn-primary">Save</button>
     </div>
     <partial name="_StatusMessage" />

--- a/BTCPayServer/Views/UIStores/CreateToken.cshtml
+++ b/BTCPayServer/Views/UIStores/CreateToken.cshtml
@@ -15,14 +15,14 @@
                     <li class="breadcrumb-item">
                         <a asp-action="ListTokens" asp-route-storeId="@store.Id" text-translate="true">Access Tokens</a>
                     </li>
-                    <li class="breadcrumb-item active" aria-current="page" text-translate="true">@ViewData["Title"]</li>
+                    <li class="breadcrumb-item active" aria-current="page">@ViewData["Title"]</li>
                 </ol>
-                <h2 text-translate="true">@ViewData["Title"]</h2>
+                <h2>@ViewData["Title"]</h2>
             </nav>
         }
         else
         {
-            <h2 text-translate="true">@ViewData["Title"]</h2>
+            <h2>@ViewData["Title"]</h2>
         }
         <input id="page-primary" type="submit" value="Request Pairing" class="btn btn-primary" />
     </div>

--- a/BTCPayServer/Views/UIStores/Lightning.cshtml
+++ b/BTCPayServer/Views/UIStores/Lightning.cshtml
@@ -7,7 +7,7 @@
     ViewData.SetActivePage(StoreNavPages.Lightning, StringLocalizer["{0} Lightning", Model.CryptoCode], $"{Context.GetStoreData().Id}-{Model.CryptoCode}");
 }
 
-<h2 class="mb-2 mb-lg-3" text-translate="true">@ViewData["Title"]</h2>
+<h2 class="mb-2 mb-lg-3">@ViewData["Title"]</h2>
 <partial name="_StatusMessage" />
 <div class="mb-5">
     <div class="mb-3">

--- a/BTCPayServer/Views/UIStores/LightningSettings.cshtml
+++ b/BTCPayServer/Views/UIStores/LightningSettings.cshtml
@@ -8,7 +8,7 @@
 
 <form method="post">
     <div class="sticky-header">
-        <h2 text-translate="true">@ViewData["Title"]</h2>
+        <h2>@ViewData["Title"]</h2>
 		<button id="page-primary" name="command" type="submit" value="save" class="btn btn-primary">Save</button>
     </div>
     <partial name="_StatusMessage" />

--- a/BTCPayServer/Views/UIStores/ListTokens.cshtml
+++ b/BTCPayServer/Views/UIStores/ListTokens.cshtml
@@ -34,7 +34,7 @@
         </p>
         
         <div class="d-flex align-items-center justify-content-between mt-5 mb-3">
-            <h3 class="mb-0" text-translate="true">@ViewData["Title"]</h3>
+            <h3 class="mb-0">@ViewData["Title"]</h3>
             <a id="CreateNewToken" asp-action="CreateToken" class="btn btn-primary" role="button" asp-route-storeId="@Context.GetRouteValue("storeId")" permission="@Policies.CanModifyStoreSettings" text-translate="true">
                 Create Token
             </a>

--- a/BTCPayServer/Views/UIStores/ModifyWebhook.cshtml
+++ b/BTCPayServer/Views/UIStores/ModifyWebhook.cshtml
@@ -22,7 +22,7 @@
                 </li>
                 <li class="breadcrumb-item active" aria-current="page">@ViewData["Title"]</li>
             </ol>
-            <h2 text-translate="true">@ViewData["Title"]</h2>
+            <h2>@ViewData["Title"]</h2>
         </nav>
         @if (Model.IsNew)
         {

--- a/BTCPayServer/Views/UIStores/Rates.cshtml
+++ b/BTCPayServer/Views/UIStores/Rates.cshtml
@@ -9,7 +9,7 @@
 
 <form method="post" permissioned="@Policies.CanModifyStoreSettings">
     <div class="sticky-header">
-        <h2 text-translate="true">@ViewData["Title"]</h2>
+        <h2>@ViewData["Title"]</h2>
 		<button id="page-primary" name="command" type="submit" class="btn btn-primary" value="Save">Save</button>
     </div>
     <partial name="_StatusMessage" />

--- a/BTCPayServer/Views/UIStores/RequestPairing.cshtml
+++ b/BTCPayServer/Views/UIStores/RequestPairing.cshtml
@@ -30,12 +30,12 @@
                     </li>
                     <li class="breadcrumb-item active" aria-current="page">@ViewData["Title"]</li>
                 </ol>
-                <h2 text-translate="true">@ViewData["Title"]</h2>
+                <h2>@ViewData["Title"]</h2>
             </nav>
         }
         else
         {
-            <h2 text-translate="true">@ViewData["Title"]</h2>
+            <h2>@ViewData["Title"]</h2>
         }
 		<button id="page-primary" type="submit" class="btn btn-primary mt-3" title="@StringLocalizer["Approve this pairing demand"]">Approve</button>
     </div>

--- a/BTCPayServer/Views/UIStores/StoreEmails.cshtml
+++ b/BTCPayServer/Views/UIStores/StoreEmails.cshtml
@@ -21,9 +21,9 @@
                 <li class="breadcrumb-item">
                     <a asp-action="StoreEmailSettings" asp-route-storeId="@storeId" text-translate="true">Emails</a>
                 </li>
-                <li class="breadcrumb-item active" aria-current="page" text-translate="true">@ViewData["Title"]</li>
+                <li class="breadcrumb-item active" aria-current="page">@ViewData["Title"]</li>
             </ol>
-            <h2 text-translate="true">@ViewData["Title"]</h2>
+            <h2>@ViewData["Title"]</h2>
         </nav>
         <div permission="@Policies.CanModifyStoreSettings">
             @if (Model.Rules.Any())

--- a/BTCPayServer/Views/UIStores/StoreUsers.cshtml
+++ b/BTCPayServer/Views/UIStores/StoreUsers.cshtml
@@ -19,7 +19,7 @@
         }
     </style>
 }
-<h2 class="mb-2 mb-lg-3" text-translate="true">@ViewData["Title"]</h2>
+<h2 class="mb-2 mb-lg-3">@ViewData["Title"]</h2>
 <partial name="_StatusMessage" />
 <div class="row">
     <div class="col-xxl-constrain col-xl-8">

--- a/BTCPayServer/Views/UIStores/TestWebhook.cshtml
+++ b/BTCPayServer/Views/UIStores/TestWebhook.cshtml
@@ -6,7 +6,7 @@
 }
 <form method="post">
     <div class="sticky-header">
-        <h2 text-translate="true">@ViewData["Title"]</h2>
+        <h2>@ViewData["Title"]</h2>
 		<button id="page-primary" type="submit" class="btn btn-primary mt-3" text-translate="true">Send test webhook</button>
     </div>
     <partial name="_StatusMessage" />

--- a/BTCPayServer/Views/UIStores/WalletSettings.cshtml
+++ b/BTCPayServer/Views/UIStores/WalletSettings.cshtml
@@ -18,7 +18,7 @@
 }
 
 <div class="sticky-header">
-    <h2 text-translate="true">@ViewData["Title"]</h2>
+    <h2>@ViewData["Title"]</h2>
     <div>
         <div class="dropdown">
             <button class="btn btn-secondary dropdown-toggle"

--- a/BTCPayServer/Views/UIStores/Webhooks.cshtml
+++ b/BTCPayServer/Views/UIStores/Webhooks.cshtml
@@ -7,7 +7,7 @@
 }
 
 <div class="sticky-header">
-    <h2 text-translate="true">@ViewData["Title"]</h2>
+    <h2>@ViewData["Title"]</h2>
 	<a id="page-primary" asp-action="NewWebhook" class="btn btn-primary" role="button" asp-route-storeId="@Context.GetRouteValue("storeId")" permission="@Policies.CanModifyStoreSettings">
         Create Webhook
     </a>

--- a/BTCPayServer/Views/UIUserStores/CreateStore.cshtml
+++ b/BTCPayServer/Views/UIUserStores/CreateStore.cshtml
@@ -53,7 +53,7 @@
 }
 else
 {
-	<h2 class="mb-2 mb-lg-3" text-translate="true">@ViewData["Title"]</h2>
+	<h2 class="mb-2 mb-lg-3">@ViewData["Title"]</h2>
     <partial name="_StatusMessage" />
     <div class="row">
         <div class="col-xl-8 col-xxl-constrain">

--- a/BTCPayServer/Views/UIUserStores/ListStores.cshtml
+++ b/BTCPayServer/Views/UIUserStores/ListStores.cshtml
@@ -4,7 +4,7 @@
     ViewData.SetActivePage(StoreNavPages.Index, Model.Archived ? StringLocalizer["Archived Stores"] : StringLocalizer["Stores"]);
 }
 
-<h2 class="mb-2 mb-lg-3" text-translate="true">@ViewData["Title"]</h2>
+<h2 class="mb-2 mb-lg-3">@ViewData["Title"]</h2>
 <partial name="_StatusMessage" />
 @if (Model.Stores.Any())
 {

--- a/BTCPayServer/Views/UIWallets/WalletLabels.cshtml
+++ b/BTCPayServer/Views/UIWallets/WalletLabels.cshtml
@@ -11,7 +11,7 @@
     </script>
 }
 
-<h2 class="mb-2 mb-lg-3" text-translate="true">@ViewData["Title"]</h2>
+<h2 class="mb-2 mb-lg-3">@ViewData["Title"]</h2>
 <partial name="_StatusMessage" />
 
 @if (Model.Labels.Any())

--- a/BTCPayServer/Views/UIWallets/WalletPSBTCombine.cshtml
+++ b/BTCPayServer/Views/UIWallets/WalletPSBTCombine.cshtml
@@ -12,7 +12,7 @@
 }
 
 <header class="text-center">
-    <h1 text-translate="true">@ViewData["Title"]</h1>
+    <h1>@ViewData["Title"]</h1>
 </header>
 
 <form class="form-group" method="post" asp-action="WalletPSBTCombine" asp-route-walletId="@Context.GetRouteValue("walletId")" enctype="multipart/form-data">

--- a/BTCPayServer/Views/UIWallets/WalletPSBTDecoded.cshtml
+++ b/BTCPayServer/Views/UIWallets/WalletPSBTDecoded.cshtml
@@ -81,7 +81,7 @@
 }
 
 <header class="text-center mb-3">
-    <h1 text-translate="true">@ViewData["Title"]</h1>
+    <h1>@ViewData["Title"]</h1>
 </header>
 
 <partial name="_PSBTInfo" model="Model" />


### PR DESCRIPTION
Issue was caused by duplicate translation through a combination of `StringLocalizer` and `text-translate="true"` usage. Fixes #6622.