### PR TITLE
Disable cold wallet creation by default

### DIFF
--- a/BTCPayServer/Controllers/GreenField/GreenfieldStoreOnChainPaymentMethodsController.WalletGeneration.cs
+++ b/BTCPayServer/Controllers/GreenField/GreenfieldStoreOnChainPaymentMethodsController.WalletGeneration.cs
@@ -43,13 +43,13 @@ namespace BTCPayServer.Controllers.Greenfield
             }
 
             var canUseHotWallet = await CanUseHotWallet();
-            if (request.SavePrivateKeys && !canUseHotWallet.HotWallet)
+            if (request.SavePrivateKeys && !canUseHotWallet.CanCreateHotWallet)
             {
                 ModelState.AddModelError(nameof(request.SavePrivateKeys),
                     "This instance forbids non-admins from having a hot wallet for your store.");
             }
 
-            if (request.ImportKeysToRPC && !canUseHotWallet.RPCImport)
+            if (request.ImportKeysToRPC && !canUseHotWallet.CanRPCImport)
             {
                 ModelState.AddModelError(nameof(request.ImportKeysToRPC),
                     "This instance forbids non-admins from having importing the wallet addresses/keys to the underlying node.");
@@ -120,7 +120,7 @@ namespace BTCPayServer.Controllers.Greenfield
             return Ok(result);
         }
 
-        private async Task<(bool HotWallet, bool RPCImport)> CanUseHotWallet()
+        private async Task<WalletCreationPermissions> CanUseHotWallet()
         {
             return await _authorizationService.CanUseHotWallet(PoliciesSettings, User);
         }

--- a/BTCPayServer/Controllers/GreenField/GreenfieldStoreOnChainWalletsController.cs
+++ b/BTCPayServer/Controllers/GreenField/GreenfieldStoreOnChainWalletsController.cs
@@ -383,7 +383,7 @@ namespace BTCPayServer.Controllers.Greenfield
             }
 
             //This API is only meant for hot wallet usage for now. We can expand later when we allow PSBT manipulation.
-            if (!(await CanUseHotWallet()).HotWallet)
+            if (!(await CanUseHotWallet()).CanCreateHotWallet)
             {
                 return this.CreateAPIError(503, "not-available",
                     $"You need to allow non-admins to use hotwallets for their stores (in /server/policies)");
@@ -802,7 +802,7 @@ namespace BTCPayServer.Controllers.Greenfield
         }
 
 
-        private async Task<(bool HotWallet, bool RPCImport)> CanUseHotWallet()
+        private async Task<WalletCreationPermissions> CanUseHotWallet()
         {
             return await _authorizationService.CanUseHotWallet(PoliciesSettings, User);
         }

--- a/BTCPayServer/Controllers/UIWalletsController.cs
+++ b/BTCPayServer/Controllers/UIWalletsController.cs
@@ -795,7 +795,7 @@ namespace BTCPayServer.Controllers
         private async Task<bool> CanUseHotWallet()
         {
             var policies = await _settingsRepository.GetSettingAsync<PoliciesSettings>();
-            return (await _authorizationService.CanUseHotWallet(policies, User)).HotWallet;
+            return (await _authorizationService.CanUseHotWallet(policies, User)).CanCreateHotWallet;
         }
 
         [HttpGet("{walletId}/send")]

--- a/BTCPayServer/Extensions/AuthorizationExtensions.cs
+++ b/BTCPayServer/Extensions/AuthorizationExtensions.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System.Security.Claims;
 using System.Threading.Tasks;
 using BTCPayServer.Abstractions.Constants;
@@ -9,6 +10,7 @@ using Microsoft.AspNetCore.Authorization;
 
 namespace BTCPayServer
 {
+    public record WalletCreationPermissions(bool CanCreateHotWallet, bool CanCreateColdWallet, bool CanRPCImport);
     public static class AuthorizationExtensions
     {
         public static async Task<bool> CanModifyStore(this IAuthorizationService authorizationService, ClaimsPrincipal user)
@@ -16,24 +18,26 @@ namespace BTCPayServer
             return (await authorizationService.AuthorizeAsync(user, null,
                                 new PolicyRequirement(Policies.CanModifyStoreSettings))).Succeeded;
         }
-        public static async Task<(bool HotWallet, bool RPCImport)> CanUseHotWallet(
+        public static async Task<WalletCreationPermissions> CanUseHotWallet(
             this IAuthorizationService authorizationService,
-            PoliciesSettings policiesSettings,
+            PoliciesSettings? policiesSettings,
             ClaimsPrincipal user)
         {
-            if (!user.Identity.IsAuthenticated)
-                return (false, false);
+            if (user.Identity?.IsAuthenticated is not true)
+                return new(false, false, false);
             var claimUser = user.Identity as ClaimsIdentity;
             if (claimUser is null)
-                return (false, false);
+                return new(false, false, false);
 
             bool isAdmin = false;
             if (claimUser.AuthenticationType == AuthenticationSchemes.Cookie)
                 isAdmin = user.IsInRole(Roles.ServerAdmin);
             else if (claimUser.AuthenticationType == GreenfieldConstants.AuthenticationType)
                 isAdmin = (await authorizationService.AuthorizeAsync(user, Policies.CanModifyServerSettings)).Succeeded;
-            return isAdmin ? (true, true) :
-                   (policiesSettings?.AllowHotWalletForAll is true, policiesSettings?.AllowHotWalletRPCImportForAll is true);
+            return isAdmin ? new(true, true, true) :
+                   new(policiesSettings?.AllowHotWalletForAll is true,
+                   policiesSettings?.AllowCreateColdWalletForAll is true,
+                   policiesSettings?.AllowHotWalletRPCImportForAll is true);
         }
     }
 }

--- a/BTCPayServer/Models/StoreViewModels/DerivationSchemeViewModel.cs
+++ b/BTCPayServer/Models/StoreViewModels/DerivationSchemeViewModel.cs
@@ -35,6 +35,8 @@ namespace BTCPayServer.Models.StoreViewModels
         public BTCPayNetwork Network { get; set; }
         [Display(Name = "Can use hot wallet")]
         public bool CanUseHotWallet { get; set; }
+        [Display(Name = "Can create a new cold wallet")]
+        public bool CanCreateNewColdWallet { get; set; }
         [Display(Name = "Can use RPC import")]
         public bool CanUseRPCImport { get; set; }
         public bool SupportSegwit { get; set; }

--- a/BTCPayServer/Models/StoreViewModels/WalletSetupViewModel.cs
+++ b/BTCPayServer/Models/StoreViewModels/WalletSetupViewModel.cs
@@ -1,3 +1,6 @@
+using System;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
+
 namespace BTCPayServer.Models.StoreViewModels
 {
     public enum WalletSetupMethod
@@ -34,5 +37,21 @@ namespace BTCPayServer.Models.StoreViewModels
                 WalletSetupMethod.WatchOnly => "GenerateWallet",
                 _ => "SetupWallet"
             };
+
+        internal void SetPermission(WalletCreationPermissions perm)
+        {
+            this.CanCreateNewColdWallet = perm.CanCreateColdWallet;
+            this.CanUseHotWallet = perm.CanCreateHotWallet;
+            this.CanUseRPCImport = perm.CanRPCImport;
+        }
+        public void SetViewData(ViewDataDictionary ViewData)
+        {
+            ViewData.Add(nameof(CanUseHotWallet), CanUseHotWallet);
+            ViewData.Add(nameof(CanCreateNewColdWallet), CanCreateNewColdWallet);
+            ViewData.Add(nameof(CanUseRPCImport), CanUseRPCImport);
+            ViewData.Add(nameof(SupportSegwit), SupportSegwit);
+            ViewData.Add(nameof(SupportTaproot), SupportTaproot);
+            ViewData.Add(nameof(Method), Method);
+        }
     }
 }

--- a/BTCPayServer/Services/PoliciesSettings.cs
+++ b/BTCPayServer/Services/PoliciesSettings.cs
@@ -52,6 +52,8 @@ namespace BTCPayServer.Services
 
         [Display(Name = "Non-admins can create Hot Wallets for their Store")]
         public bool AllowHotWalletForAll { get; set; }
+        [Display(Name = "Non-admins can create Cold Wallets for their Store")]
+        public bool AllowCreateColdWalletForAll { get; set; }
 
         [Display(Name = "Non-admins can import Hot Wallets for their Store")]
         public bool AllowHotWalletRPCImportForAll { get; set; }

--- a/BTCPayServer/Views/UIServer/Policies.cshtml
+++ b/BTCPayServer/Views/UIServer/Policies.cshtml
@@ -120,6 +120,13 @@
                             </div>
                         </div>
                     </div>
+					<div class="d-flex my-3">
+						<input asp-for="AllowCreateColdWalletForAll" type="checkbox" class="btcpay-toggle me-3" />
+						<div>
+							<label asp-for="AllowCreateColdWalletForAll" class="form-check-label"></label>
+							<span asp-validation-for="AllowCreateColdWalletForAll" class="text-danger"></span>
+						</div>
+					</div>
                     <div class="d-flex my-3">
                         <input asp-for="AllowHotWalletRPCImportForAll" type="checkbox" class="btcpay-toggle me-3"/>
                         <div>

--- a/BTCPayServer/Views/UIStores/GenerateWallet.cshtml
+++ b/BTCPayServer/Views/UIStores/GenerateWallet.cshtml
@@ -1,14 +1,10 @@
 @model WalletSetupViewModel
 @{
-    var isHotWallet = Model.Method == WalletSetupMethod.HotWallet;
-    var title = isHotWallet ? StringLocalizer["Create {0} Hot Wallet", Model.CryptoCode] : StringLocalizer["Create {0} Watch-Only Wallet", Model.CryptoCode];
-    Layout = "_LayoutWalletSetup";
-    ViewData.SetActivePage(StoreNavPages.OnchainSettings, title, $"{Context.GetStoreData().Id}-{Model.CryptoCode}");
-    ViewData.Add(nameof(Model.CanUseHotWallet), Model.CanUseHotWallet);
-    ViewData.Add(nameof(Model.CanUseRPCImport), Model.CanUseRPCImport);
-    ViewData.Add(nameof(Model.SupportSegwit), Model.SupportSegwit);
-    ViewData.Add(nameof(Model.SupportTaproot), Model.SupportTaproot);
-    ViewData.Add(nameof(Model.Method), Model.Method);
+	var isHotWallet = Model.Method == WalletSetupMethod.HotWallet;
+	var title = isHotWallet ? StringLocalizer["Create {0} Hot Wallet", Model.CryptoCode] : StringLocalizer["Create {0} Watch-Only Wallet", Model.CryptoCode];
+	Layout = "_LayoutWalletSetup";
+	ViewData.SetActivePage(StoreNavPages.OnchainSettings, title, $"{Context.GetStoreData().Id}-{Model.CryptoCode}");
+	Model.SetViewData(ViewData);
 }
 
 @section Navbar {

--- a/BTCPayServer/Views/UIStores/GenerateWalletOptions.cshtml
+++ b/BTCPayServer/Views/UIStores/GenerateWalletOptions.cshtml
@@ -8,56 +8,71 @@
 }
 
 @section Navbar {
-    <a asp-controller="UIStores" asp-action="SetupWallet" asp-route-storeId="@Model.StoreId" asp-route-cryptoCode="@Model.CryptoCode">
-        <vc:icon symbol="back" />
-    </a>
+	<a asp-controller="UIStores" asp-action="SetupWallet" asp-route-storeId="@Model.StoreId" asp-route-cryptoCode="@Model.CryptoCode">
+		<vc:icon symbol="back" />
+	</a>
 }
 
 <h1 class="text-center" text-translate="true">Choose your wallet option</h1>
 
 <div class="list-group mt-5">
-    @if (Model.CanUseHotWallet)
-    {
-        <a asp-controller="UIStores" asp-action="GenerateWallet" asp-route-storeId="@Model.StoreId" asp-route-cryptoCode="@Model.CryptoCode" asp-route-method="@WalletSetupMethod.HotWallet.ToString()" id="GenerateHotwalletLink" class="list-group-item list-group-item-action">
-            <div class="image">
-                <vc:icon symbol="wallet-hot"/>
-            </div>
-            <div class="content">
+	@if (Model.CanUseHotWallet)
+	{
+		<a asp-controller="UIStores" asp-action="GenerateWallet" asp-route-storeId="@Model.StoreId" asp-route-cryptoCode="@Model.CryptoCode" asp-route-method="@WalletSetupMethod.HotWallet.ToString()" id="GenerateHotwalletLink" class="list-group-item list-group-item-action">
+			<div class="image">
+				<vc:icon symbol="wallet-hot"/>
+			</div>
+			<div class="content">
 				<h4 text-translate="true">Hot wallet</h4>
 				<p class="mb-0 text-secondary" text-translate="true">
-                    Wallet's private key is stored on the server. Spending the funds you received is convenient. To minimize the risk of theft, regularly withdraw funds to a different wallet.
-                </p>
-            </div>
-            <vc:icon symbol="caret-right"/>
-        </a>
-    }
-    else
-    {
-        <div class="list-group-item text-muted">
-            <div class="image">
-                <vc:icon symbol="wallet-hot"/>
-            </div>
-            <div class="content">
+					Wallet's private key is stored on the server. Spending the funds you received is convenient. To minimize the risk of theft, regularly withdraw funds to a different wallet.
+				</p>
+			</div>
+			<vc:icon symbol="caret-right"/>
+		</a>
+	}
+	else
+	{
+		<div class="list-group-item text-muted">
+			<div class="image">
+				<vc:icon symbol="wallet-hot"/>
+			</div>
+			<div class="content">
 				<h4 text-translate="true">Hot wallet</h4>
 				<p class="mb-0" text-translate="true">Please note that creating a hot wallet is not supported by this instance for non administrators.</p>
-            </div>
-        </div>
-    }
+			</div>
+		</div>
+	}
 </div>
 
 <div class="list-group mt-4">
-    <a asp-controller="UIStores" asp-action="GenerateWallet" asp-route-storeId="@Model.StoreId" asp-route-cryptoCode="@Model.CryptoCode" asp-route-method="@WalletSetupMethod.WatchOnly.ToString()" id="GenerateWatchonlyLink" class="list-group-item list-group-item-action">
-        <div class="image">
-            <vc:icon symbol="wallet-watchonly"/>
-        </div>
-        <div class="content">
-			<h4 text-translate="true">Watch-only wallet</h4>
-			<p class="mb-0 text-secondary" text-translate="true">
-                Wallet's private key is erased from the server. Higher security. To spend, you have to manually input the private key or import it into an external wallet.
-            </p>
-        </div>
-        <vc:icon symbol="caret-right" />
-    </a>
+	@if (Model.CanCreateNewColdWallet)
+	{
+		<a asp-controller="UIStores" asp-action="GenerateWallet" asp-route-storeId="@Model.StoreId" asp-route-cryptoCode="@Model.CryptoCode" asp-route-method="@WalletSetupMethod.WatchOnly.ToString()" id="GenerateWatchonlyLink" class="list-group-item list-group-item-action">
+			<div class="image">
+				<vc:icon symbol="wallet-watchonly"/>
+			</div>
+			<div class="content">
+				<h4 text-translate="true">Watch-only wallet</h4>
+				<p class="mb-0 text-secondary" text-translate="true">
+					Wallet's private key is erased from the server. Higher security. To spend, you have to manually input the private key or import it into an external wallet.
+				</p>
+			</div>
+			<vc:icon symbol="caret-right" />
+		</a>
+	}
+	else
+	{
+		<div class="list-group-item text-muted">
+			<div class="image">
+				<vc:icon symbol="wallet-watchonly" />
+			</div>
+			<div class="content">
+				<h4 text-translate="true">Watch-only wallet</h4>
+				<p class="mb-0" text-translate="true">Please note that this instance does not support creating a new cold wallet for non-administrators. However, you can import one from other wallet software.</p>
+			</div>
+		</div>		
+	}
 </div>
 
 

--- a/BTCPayServer/Views/UIStores/ImportWallet/Seed.cshtml
+++ b/BTCPayServer/Views/UIStores/ImportWallet/Seed.cshtml
@@ -18,12 +18,7 @@
 <div class="my-5">
     @if (Model.CanUseHotWallet)
     {
-        ViewData.Add(nameof(Model.CanUseHotWallet), Model.CanUseHotWallet);
-        ViewData.Add(nameof(Model.CanUseRPCImport), Model.CanUseRPCImport);
-        ViewData.Add(nameof(Model.SupportSegwit), Model.SupportSegwit);
-        ViewData.Add(nameof(Model.SupportTaproot), Model.SupportTaproot);
-        ViewData.Add(nameof(Model.Method), Model.Method);
-
+		Model.SetViewData(ViewData);
         <partial name="_GenerateWalletForm" model="Model.SetupRequest" />
     }
     else


### PR DESCRIPTION
## Motivation

By default, users on a third-party BTCPay Server can create a cold wallet. However, most inexperienced users forget to back up the seed during creation, receive funds, and then become unable to access their money, eventually seeking help in our support channel. Sadly, we can't do anything for those users as the seed aren't saved by the server for cold wallets.

Even for experienced users, this feature has limited benefits. Spending requires copying and pasting the seed into another software or directly into BTCPay to sign the transaction, which results in a terrible user experience. Instead, an experienced user should generate the seed in another wallet software rather than in BTCPay Server.

## Implementation

**By default**, non-admin users will not be able to create wallets via the UI. This setting can be changed in the server's policies.

![image](https://github.com/user-attachments/assets/740d6dbf-dc0f-490a-a33e-fa2956003bc6)

The user will see the option disabled in the setup wizard.

![image](https://github.com/user-attachments/assets/87cf8714-a8f6-4a37-bc36-917146607983)

While we could completely remove a step in the on-chain wallet creation wizard when both Hot Wallet and Cold Wallet creation are disabled for the user, I decided to keep it to allow for feature discovery. This way, the user can see that the option is disabled by the administrator and may choose to request access.

Admins can still create cold wallets regardless of the server policy settings.

Fix https://github.com/btcpayserver/btcpayserver/issues/5798