### PR TITLE
UI: Prevent copy to clipboard double-clicks

### DIFF
--- a/BTCPayServer/wwwroot/js/copy-to-clipboard.js
+++ b/BTCPayServer/wwwroot/js/copy-to-clipboard.js
@@ -1,4 +1,5 @@
 function confirmCopy(el, message) {
+    if (el.dataset.clipboardConfirming) return;
     const hasIcon = !!el.innerHTML.match('icon-actions-copy')
     const confirmHTML = `<span class="text-success">${message}</span>`;
     if (hasIcon) {
@@ -10,7 +11,7 @@ function confirmCopy(el, message) {
         el.style.minHeight = height + 'px';
         el.innerHTML = confirmHTML;
     }
-    el.dataset.clipboardConfirming = true;
+    el.dataset.clipboardConfirming = 'true';
     if (el.dataset.clipboardHandler) {
         clearTimeout(parseInt(el.dataset.clipboardHandler));
     }


### PR DESCRIPTION
As long as the copy confirmation is shown, it should not allow the handler to be called again.

Fixes #6632. This is also compatible with #6631, so the pull requests can be merged independent of each other.