### PR TITLE
Webhooks for Pending Transactions & Email Rules

### DIFF
--- a/BTCPayServer.Client/Models/WebhookEventType.cs
+++ b/BTCPayServer.Client/Models/WebhookEventType.cs
@@ -1,5 +1,6 @@
 namespace BTCPayServer.Client.Models;
 
+// TODO: This should be moved to individual Webhook Event Providers
 public static class WebhookEventType
 {
     public const string InvoiceCreated = nameof(InvoiceCreated);

--- a/BTCPayServer.Data/Data/PendingTransaction.cs
+++ b/BTCPayServer.Data/Data/PendingTransaction.cs
@@ -54,6 +54,11 @@ public class PendingTransaction: IHasBlob<PendingTransactionBlob>
     {
         public string PSBT { get; set; }
         public List<CollectedSignature> CollectedSignatures { get; set; } = new();
+
+        public int? SignaturesCollected { get; set; }
+        // for example: 3/5
+        public int? SignaturesNeeded { get; set; }
+        public int? SignaturesTotal { get; set; }
     }
 
     public class CollectedSignature

--- a/BTCPayServer.Tests/FeatureTests/MultisigTests.cs
+++ b/BTCPayServer.Tests/FeatureTests/MultisigTests.cs
@@ -123,14 +123,23 @@ public class MultisigTests : UnitTestBase
         s.Driver.FindElement(By.Id("Outputs_0__Amount")).SendKeys(amount);
         s.Driver.FindElement(By.Id("CreatePendingTransaction")).Click();
         
-        // now clicking on View to sign transaction
+        // validating the state of UI
+        Assert.Equal("0", s.Driver.FindElement(By.Id("Sigs_0__Collected")).Text);
+        Assert.Equal("2/3", s.Driver.FindElement(By.Id("Sigs_0__Scheme")).Text);
+        
+        // now proceeding to click on sign button and sign transactions
         SignPendingTransactionWithKey(s, address, derivationScheme, resp1);
+        Assert.Equal("1", s.Driver.FindElement(By.Id("Sigs_0__Collected")).Text);
+        
         SignPendingTransactionWithKey(s, address, derivationScheme, resp2);
+        Assert.Equal("2", s.Driver.FindElement(By.Id("Sigs_0__Collected")).Text);
 
-        // Broadcasting transaction and ensuring there is no longer broadcast button
+        // we should now have enough signatures to broadcast transaction
         s.Driver.WaitForElement(By.XPath("//a[text()='Broadcast']")).Click();
         s.Driver.FindElement(By.Id("BroadcastTransaction")).Click();
         Assert.Contains("Transaction broadcasted successfully", s.FindAlertMessage().Text);
+        
+        // now that we broadcast transaction, there shouldn't be broadcast button
         s.Driver.AssertElementNotFound(By.XPath("//a[text()='Broadcast']"));
         
         // Abort pending transaction flow

--- a/BTCPayServer/Controllers/UIStoresController.EmailRules.cs
+++ b/BTCPayServer/Controllers/UIStoresController.EmailRules.cs
@@ -19,6 +19,11 @@ namespace BTCPayServer.Controllers
 {
     public partial class UIStoresController
     {
+        private void setupBitcoinWalletTransactions()
+        {
+            ViewData["BitcoinWalletTransactions"] = _callbackGenerator.WalletTransactionsLink(HttpContext.GetStoreData().Id, "BTC", Request);
+        }
+        
         [HttpGet("{storeId}/emails/rules")]
         public async Task<IActionResult> StoreEmailRulesList(string storeId)
         {
@@ -44,6 +49,7 @@ namespace BTCPayServer.Controllers
         [Authorize(Policy = Policies.CanModifyStoreSettings, AuthenticationSchemes = AuthenticationSchemes.Cookie)]
         public IActionResult StoreEmailRulesCreate(string storeId)
         {
+            setupBitcoinWalletTransactions();
             return View("StoreEmailRulesManage", new StoreEmailRule());
         }
 
@@ -51,6 +57,8 @@ namespace BTCPayServer.Controllers
         [Authorize(Policy = Policies.CanModifyStoreSettings, AuthenticationSchemes = AuthenticationSchemes.Cookie)]
         public async Task<IActionResult> StoreEmailRulesCreate(string storeId, StoreEmailRule model)
         {
+            setupBitcoinWalletTransactions();
+            
             if (!ModelState.IsValid)
                 return View("StoreEmailRulesManage", model);
 
@@ -85,6 +93,8 @@ namespace BTCPayServer.Controllers
             var rules = store.GetStoreBlob().EmailRules;
             if (rules == null || ruleIndex >= rules.Count) return NotFound();
 
+            setupBitcoinWalletTransactions();
+            
             var rule = rules[ruleIndex];
             return View("StoreEmailRulesManage", rule);
         }
@@ -93,6 +103,7 @@ namespace BTCPayServer.Controllers
         [Authorize(Policy = Policies.CanModifyStoreSettings, AuthenticationSchemes = AuthenticationSchemes.Cookie)]
         public async Task<IActionResult> StoreEmailRulesEdit(string storeId, int ruleIndex, StoreEmailRule model)
         {
+            setupBitcoinWalletTransactions();
             if (!ModelState.IsValid)
                 return View("StoreEmailRulesManage", model);
 

--- a/BTCPayServer/Controllers/UIWalletsController.cs
+++ b/BTCPayServer/Controllers/UIWalletsController.cs
@@ -1356,7 +1356,7 @@ namespace BTCPayServer.Controllers
             if (vm.SigningContext.PendingTransactionId is not null)
             {
                 var psbt = PSBT.Parse(vm.SigningContext.PSBT, NetworkProvider.GetNetwork<BTCPayNetwork>(walletId.CryptoCode).NBitcoinNetwork);
-                var pendingTransaction = await _pendingTransactionService.CollectSignature(walletId.CryptoCode, psbt, false, CancellationToken.None);
+                var pendingTransaction = await _pendingTransactionService.CollectSignature(walletId.CryptoCode, psbt, CancellationToken.None);
 
                 if (pendingTransaction != null)
                     return RedirectToAction(nameof(WalletTransactions), new { walletId = walletId.ToString() });

--- a/BTCPayServer/Controllers/UIWalletsController.cs
+++ b/BTCPayServer/Controllers/UIWalletsController.cs
@@ -1356,7 +1356,7 @@ namespace BTCPayServer.Controllers
             if (vm.SigningContext.PendingTransactionId is not null)
             {
                 var psbt = PSBT.Parse(vm.SigningContext.PSBT, NetworkProvider.GetNetwork<BTCPayNetwork>(walletId.CryptoCode).NBitcoinNetwork);
-                var pendingTransaction = await _pendingTransactionService.CollectSignature(walletId.CryptoCode, psbt, CancellationToken.None);
+                var pendingTransaction = await _pendingTransactionService.CollectSignature(psbt, CancellationToken.None);
 
                 if (pendingTransaction != null)
                     return RedirectToAction(nameof(WalletTransactions), new { walletId = walletId.ToString() });

--- a/BTCPayServer/HostedServices/Webhooks/PendingTransactionDeliveryRequest.cs
+++ b/BTCPayServer/HostedServices/Webhooks/PendingTransactionDeliveryRequest.cs
@@ -1,0 +1,48 @@
+﻿using System.Globalization;
+using System.Threading.Tasks;
+using BTCPayServer.Client.Models;
+using BTCPayServer.Controllers;
+using BTCPayServer.Data;
+using BTCPayServer.Services.Invoices;
+using WebhookDeliveryData = BTCPayServer.Data.WebhookDeliveryData;
+
+namespace BTCPayServer.HostedServices.Webhooks;
+
+public class PendingTransactionDeliveryRequest(
+    PendingTransaction pendingTransaction,
+    string webhookId,
+    WebhookEvent webhookEvent,
+    WebhookDeliveryData delivery,
+    WebhookBlob webhookBlob)
+    : WebhookSender.WebhookDeliveryRequest(webhookId, webhookEvent, delivery, webhookBlob)
+{
+    public override Task<SendEmailRequest> Interpolate(SendEmailRequest req,
+        UIStoresController.StoreEmailRule storeEmailRule)
+    {
+        // if (storeEmailRule.CustomerEmail &&
+        //     MailboxAddressValidator.TryParse(Invoice.Metadata.BuyerEmail, out var bmb))
+        // {
+        //     req.Email ??= string.Empty;
+        //     req.Email += $",{bmb}";
+        // }
+
+        req.Subject = Interpolate(req.Subject);
+        req.Body = Interpolate(req.Body);
+        return Task.FromResult(req);
+    }
+
+    private string Interpolate(string str)
+    {
+        var res = str.Replace("{PendingTransaction.Id}", pendingTransaction.TransactionId);
+            // .Replace("{Invoice.StoreId}", Invoice.StoreId)
+            // .Replace("{Invoice.Price}", Invoice.Price.ToString(CultureInfo.InvariantCulture))
+            // .Replace("{Invoice.Currency}", Invoice.Currency)
+            // .Replace("{Invoice.Status}", Invoice.Status.ToString())
+            // .Replace("{Invoice.AdditionalStatus}", Invoice.ExceptionStatus.ToString())
+            // .Replace("{Invoice.OrderId}", Invoice.Metadata.OrderId);
+            
+        // res = InterpolateJsonField(res, "Invoice.Metadata", Invoice.Metadata.ToJObject());
+        return res;
+    }
+    
+}

--- a/BTCPayServer/HostedServices/Webhooks/PendingTransactionDeliveryRequest.cs
+++ b/BTCPayServer/HostedServices/Webhooks/PendingTransactionDeliveryRequest.cs
@@ -36,7 +36,11 @@ public class PendingTransactionDeliveryRequest(
 
     private string Interpolate(string str, PendingTransactionBlob blob)
     {
-        var res = str.Replace("{PendingTransaction.Id}", evt.Data.TransactionId)
+        var id = evt.Data.TransactionId;
+        string trimmedId = $"{id.Substring(0, 7)}...{id.Substring(id.Length - 7)}";
+        
+        var res = str.Replace("{PendingTransaction.Id}", id)
+            .Replace("{PendingTransaction.TrimmedId}", trimmedId)
             .Replace("{PendingTransaction.StoreId}", evt.Data.StoreId)
             .Replace("{PendingTransaction.SignaturesCollected}", blob.SignaturesCollected?.ToString())
             .Replace("{PendingTransaction.SignaturesNeeded}", blob.SignaturesNeeded?.ToString())

--- a/BTCPayServer/HostedServices/Webhooks/PendingTransactionWebhookProvider.cs
+++ b/BTCPayServer/HostedServices/Webhooks/PendingTransactionWebhookProvider.cs
@@ -23,6 +23,7 @@ public class PendingTransactionWebhookProvider : WebhookProvider<PendingTransact
     public const string PendingTransactionCreated = nameof(PendingTransactionCreated);
     public const string PendingTransactionSignatureCollected = nameof(PendingTransactionSignatureCollected);
     public const string PendingTransactionBroadcast = nameof(PendingTransactionBroadcast);
+    public const string PendingTransactionCancelled = nameof(PendingTransactionCancelled);
 
     public override Dictionary<string, string> GetSupportedWebhookTypes()
     {
@@ -30,7 +31,8 @@ public class PendingTransactionWebhookProvider : WebhookProvider<PendingTransact
         {
             {PendingTransactionCreated, "Pending Transaction - Created"},
             {PendingTransactionSignatureCollected, "Pending Transaction - Signature Collected"},
-            {PendingTransactionBroadcast, "Pending Transaction - Broadcast"}
+            {PendingTransactionBroadcast, "Pending Transaction - Broadcast"},
+            {PendingTransactionCancelled, "Pending Transaction - Cancelled"}
         };
     }
 
@@ -50,7 +52,7 @@ public class PendingTransactionWebhookProvider : WebhookProvider<PendingTransact
             webhookEvent.OriginalDeliveryId = delivery.Id;
             webhookEvent.Timestamp = delivery.Timestamp;
         }
-        return new PendingTransactionDeliveryRequest(evt.Data, webhook?.Id, webhookEvent, delivery, webhookBlob);
+        return new PendingTransactionDeliveryRequest(evt, webhook?.Id, webhookEvent, delivery, webhookBlob);
     }
 
     protected override WebhookPendingTransactionEvent GetWebhookEvent(PendingTransactionService.PendingTransactionEvent evt)
@@ -63,6 +65,8 @@ public class PendingTransactionWebhookProvider : WebhookProvider<PendingTransact
                 PendingTransactionSignatureCollected, evt.Data.StoreId),
             PendingTransactionService.PendingTransactionEvent.Broadcast => new WebhookPendingTransactionEvent(
                 PendingTransactionBroadcast, evt.Data.StoreId),
+            PendingTransactionService.PendingTransactionEvent.Cancelled => new WebhookPendingTransactionEvent(
+                PendingTransactionCancelled, evt.Data.StoreId),
             _ => null
         };
     }

--- a/BTCPayServer/HostedServices/Webhooks/PendingTransactionWebhookProvider.cs
+++ b/BTCPayServer/HostedServices/Webhooks/PendingTransactionWebhookProvider.cs
@@ -1,0 +1,92 @@
+using System;
+using System.Collections.Generic;
+using BTCPayServer.Client.Models;
+using BTCPayServer.Controllers.Greenfield;
+using BTCPayServer.Data;
+using BTCPayServer.Events;
+using BTCPayServer.Services.Invoices;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+using WebhookDeliveryData = BTCPayServer.Data.WebhookDeliveryData;
+
+namespace BTCPayServer.HostedServices.Webhooks;
+
+public class PendingTransactionWebhookProvider : WebhookProvider<PendingTransactionService.PendingTransactionEvent>
+{
+    public PendingTransactionWebhookProvider(WebhookSender webhookSender, EventAggregator eventAggregator,
+        ILogger<InvoiceWebhookProvider> logger) : base(
+        eventAggregator, logger, webhookSender)
+    {
+    }
+    
+    public const string PendingTransactionCreated = nameof(PendingTransactionCreated);
+    public const string PendingTransactionSignatureCollected = nameof(PendingTransactionSignatureCollected);
+    public const string PendingTransactionBroadcast = nameof(PendingTransactionBroadcast);
+
+    public override Dictionary<string, string> GetSupportedWebhookTypes()
+    {
+        return new Dictionary<string, string>
+        {
+            {PendingTransactionCreated, "Pending Transaction - Created"},
+            {PendingTransactionSignatureCollected, "Pending Transaction - Signature Collected"},
+            {PendingTransactionBroadcast, "Pending Transaction - Broadcast"}
+        };
+    }
+
+    protected override WebhookSender.WebhookDeliveryRequest CreateDeliveryRequest(PendingTransactionService.PendingTransactionEvent evt,
+        WebhookData webhook)
+    {
+        var webhookBlob = webhook?.GetBlob();
+
+        var webhookEvent = GetWebhookEvent(evt)!;
+        webhookEvent.StoreId = evt.Data.StoreId;
+        webhookEvent.WebhookId = webhook?.Id;
+        webhookEvent.IsRedelivery = false;
+        WebhookDeliveryData delivery = webhook is null? null:  WebhookExtensions.NewWebhookDelivery(webhook.Id);
+        if (delivery is not null)
+        {
+            webhookEvent.DeliveryId = delivery.Id;
+            webhookEvent.OriginalDeliveryId = delivery.Id;
+            webhookEvent.Timestamp = delivery.Timestamp;
+        }
+        return new PendingTransactionDeliveryRequest(evt.Data, webhook?.Id, webhookEvent, delivery, webhookBlob);
+    }
+
+    protected override WebhookPendingTransactionEvent GetWebhookEvent(PendingTransactionService.PendingTransactionEvent evt)
+    {
+        return evt.Type switch
+        {
+            PendingTransactionService.PendingTransactionEvent.Created => new WebhookPendingTransactionEvent(
+                PendingTransactionCreated, evt.Data.StoreId),
+            PendingTransactionService.PendingTransactionEvent.SignatureCollected => new WebhookPendingTransactionEvent(
+                PendingTransactionSignatureCollected, evt.Data.StoreId),
+            PendingTransactionService.PendingTransactionEvent.Broadcast => new WebhookPendingTransactionEvent(
+                PendingTransactionBroadcast, evt.Data.StoreId),
+            _ => null
+        };
+    }
+
+    public override WebhookEvent CreateTestEvent(string type, params object[] args)
+    {
+        var storeId = args[0].ToString();
+        return new WebhookInvoiceEvent(type, storeId)
+        {
+            InvoiceId = "__test__" + Guid.NewGuid() + "__test__"
+        };
+    }
+    
+    
+    public class WebhookPendingTransactionEvent : StoreWebhookEvent
+    {
+        public WebhookPendingTransactionEvent(string type, string storeId)
+        {
+            if (!type.StartsWith(PendingTransactionCreated.Replace("Created", "").ToLower(), StringComparison.InvariantCultureIgnoreCase))
+                throw new ArgumentException("Invalid event type", nameof(type));
+            Type = type;
+            StoreId = storeId;
+        }
+
+        [JsonProperty(Order = 2)] public string PendingTransactionId { get; set; }
+    }
+}

--- a/BTCPayServer/HostedServices/Webhooks/WebhookExtensions.cs
+++ b/BTCPayServer/HostedServices/Webhooks/WebhookExtensions.cs
@@ -39,6 +39,10 @@ public static class WebhookExtensions
         services.AddSingleton<PaymentRequestWebhookProvider>();
         services.AddSingleton<IWebhookProvider>(o => o.GetRequiredService<PaymentRequestWebhookProvider>());
         services.AddHostedService(o => o.GetRequiredService<PaymentRequestWebhookProvider>());
+        
+        services.AddSingleton<PendingTransactionWebhookProvider>();
+        services.AddSingleton<IWebhookProvider>(o => o.GetRequiredService<PendingTransactionWebhookProvider>());
+        services.AddHostedService(o => o.GetRequiredService<PendingTransactionWebhookProvider>());
 
         services.AddSingleton<WebhookSender>();
         services.AddSingleton<IHostedService, WebhookSender>(o => o.GetRequiredService<WebhookSender>());

--- a/BTCPayServer/Hosting/BTCPayServerServices.cs
+++ b/BTCPayServer/Hosting/BTCPayServerServices.cs
@@ -354,6 +354,7 @@ namespace BTCPayServer.Hosting
             services.TryAddSingleton<PaymentRequestRepository>();
             services.TryAddSingleton<BTCPayWalletProvider>();
             services.AddSingleton<PendingTransactionService>();
+            services.AddSingleton<IWebhookProvider>(o => o.GetRequiredService<PendingTransactionWebhookProvider>());
             services.AddScheduledTask<PendingTransactionService>(TimeSpan.FromMinutes(10));
             services.TryAddSingleton<WalletReceiveService>();
             services.AddSingleton<IHostedService>(provider => provider.GetService<WalletReceiveService>());

--- a/BTCPayServer/Hosting/BTCPayServerServices.cs
+++ b/BTCPayServer/Hosting/BTCPayServerServices.cs
@@ -354,8 +354,8 @@ namespace BTCPayServer.Hosting
             services.TryAddSingleton<PaymentRequestRepository>();
             services.TryAddSingleton<BTCPayWalletProvider>();
             services.AddSingleton<PendingTransactionService>();
-            services.AddSingleton<IWebhookProvider>(o => o.GetRequiredService<PendingTransactionWebhookProvider>());
             services.AddScheduledTask<PendingTransactionService>(TimeSpan.FromMinutes(10));
+            // PendingTransactionWebhookProvider webhooks registered in WebhookExtensions
             services.TryAddSingleton<WalletReceiveService>();
             services.AddSingleton<IHostedService>(provider => provider.GetService<WalletReceiveService>());
 

--- a/BTCPayServer/Services/CallbackGenerator.cs
+++ b/BTCPayServer/Services/CallbackGenerator.cs
@@ -80,5 +80,18 @@ namespace BTCPayServer.Services
         }
 
         private Exception Bug([CallerMemberName] string? name = null) => new InvalidOperationException($"Error generating link for {name} (Report this bug to BTCPay Server github repository)");
+
+        public string WalletTransactionsLink(string storeId, string cryptoCode, HttpRequest request)
+        {
+            var walletId = new WalletId(storeId, cryptoCode);
+            return LinkGenerator.GetUriByAction(
+                action: nameof(UIWalletsController.WalletTransactions),
+                controller: "UIWallets",
+                values: new { walletId },
+                scheme: request.Scheme,
+                host: request.Host,
+                pathBase: request.PathBase
+            ) ?? throw Bug();
+        }
     }
 }

--- a/BTCPayServer/Services/PaymentRequests/PaymentRequestRepository.cs
+++ b/BTCPayServer/Services/PaymentRequests/PaymentRequestRepository.cs
@@ -17,8 +17,6 @@ namespace BTCPayServer.Services.PaymentRequests
         public const string StatusChanged = nameof(StatusChanged);
         public PaymentRequestData Data { get; set; }
         public string Type { get; set; }
-        
-        
     }
     
     public class PaymentRequestRepository
@@ -61,7 +59,6 @@ namespace BTCPayServer.Services.PaymentRequests
 
         public async Task<bool?> ArchivePaymentRequest(string id, bool toggle = false)
         {
-            
             await using var context = _ContextFactory.CreateContext();
             var pr = await context.PaymentRequests.FindAsync(id);
             if(pr == null)

--- a/BTCPayServer/Views/UIStores/StoreEmailRulesManage.cshtml
+++ b/BTCPayServer/Views/UIStores/StoreEmailRulesManage.cshtml
@@ -1,16 +1,13 @@
 @using BTCPayServer.HostedServices.Webhooks
 @using Microsoft.AspNetCore.Mvc.TagHelpers
 @model BTCPayServer.Controllers.UIStoresController.StoreEmailRule
-@inject Microsoft.AspNetCore.Http.IHttpContextAccessor context;
 @inject WebhookSender WebhookSender
 
 @{
     var storeId = Context.GetStoreData().Id;
     bool isEdit = Model.Trigger != null;
     ViewData.SetActivePage(StoreNavPages.Emails, StringLocalizer[isEdit ? "Edit Email Rule" : "Create Email Rule"], storeId);
-    var expectedScheme = context.HttpContext?.Request.Scheme;
-    var expectedHost = context.HttpContext?.Request.Host.ToString().ToLower();
-    var hostRoot = $"{expectedScheme}://{expectedHost}";
+    var bitcoinWalletTransactions = ViewData["BitcoinWalletTransactions"]?.ToString() ?? "";
 }
 
 @section PageHeadContent {
@@ -162,22 +159,22 @@
                 },
                 @PendingTransactionWebhookProvider.PendingTransactionCreated : {
                     subject: 'Pending Transaction {PendingTransaction.TrimmedId} Created',
-                    body: 'Review the transaction {PendingTransaction.Id} and sign it on: @hostRoot/wallets/S-{PendingTransaction.StoreId}-BTC/transactions'
+                    body: 'Review the transaction {PendingTransaction.Id} and sign it on: @bitcoinWalletTransactions'
                 },
                 @PendingTransactionWebhookProvider.PendingTransactionSignatureCollected : {
                     subject: 'Signature Collected for Pending Transaction {PendingTransaction.TrimmedId}',
                     body: 'So far {PendingTransaction.SignaturesCollected} signatures collected out of {PendingTransaction.SignaturesNeeded} signatures needed. ' +
-                        'Review the transaction and sign it on: @hostRoot/wallets/S-{PendingTransaction.StoreId}-BTC/transactions'
+                        'Review the transaction and sign it on: @bitcoinWalletTransactions'
                 },
                 @PendingTransactionWebhookProvider.PendingTransactionBroadcast : {
                     subject: 'Transaction {PendingTransaction.TrimmedId} has been Broadcast',
                     body: 'Transaction is visible in mempool on: https://mempool.space/tx/{PendingTransaction.Id}. ' +
-                        'Review the transaction: @hostRoot/wallets/S-{PendingTransaction.StoreId}-BTC/transactions'
+                        'Review the transaction: @bitcoinWalletTransactions'
                 },
                 @PendingTransactionWebhookProvider.PendingTransactionCancelled : {
                     subject: 'Pending Transaction {PendingTransaction.TrimmedId} Cancelled',
                     body: 'Transaction {PendingTransaction.Id} is cancelled and signatures are no longer being collected. ' +
-                        'Review the wallet: @hostRoot/wallets/S-{PendingTransaction.StoreId}-BTC/transactions'
+                        'Review the wallet: @bitcoinWalletTransactions'
                 },
             };
 

--- a/BTCPayServer/Views/UIStores/StoreEmailRulesManage.cshtml
+++ b/BTCPayServer/Views/UIStores/StoreEmailRulesManage.cshtml
@@ -1,12 +1,16 @@
 @using BTCPayServer.HostedServices.Webhooks
 @using Microsoft.AspNetCore.Mvc.TagHelpers
 @model BTCPayServer.Controllers.UIStoresController.StoreEmailRule
+@inject Microsoft.AspNetCore.Http.IHttpContextAccessor context;
 @inject WebhookSender WebhookSender
 
 @{
     var storeId = Context.GetStoreData().Id;
     bool isEdit = Model.Trigger != null;
     ViewData.SetActivePage(StoreNavPages.Emails, StringLocalizer[isEdit ? "Edit Email Rule" : "Create Email Rule"], storeId);
+    var expectedScheme = context.HttpContext?.Request.Scheme;
+    var expectedHost = context.HttpContext?.Request.Host.ToString().ToLower();
+    var hostRoot = $"{expectedScheme}://{expectedHost}";
 }
 
 @section PageHeadContent {
@@ -104,6 +108,16 @@
                         <code>{Payout.Metadata}*</code>
                     </td>
                 </tr>
+                <tr>
+                    <th text-translate="true">Pending Transaction</th>
+                    <td>
+                        <code>{PendingTransaction.Id}</code>,
+                        <code>{PendingTransaction.StoreId}</code>,
+                        <code>{PendingTransaction.SignaturesCollected}</code>,
+                        <code>{PendingTransaction.SignaturesNeeded}</code>,
+                        <code>{PendingTransaction.SignaturesTotal}</code>
+                    </td>
+                </tr>
                 <tr><td colspan="2">* These fields are JSON objects. You can access properties within them using <a href="https://www.newtonsoft.com/json/help/html/SelectToken.htm#SelectTokenJSONPath" rel="noreferrer noopener" target="_blank">this syntax</a>. One example is <code>{Invoice.Metadata.itemCode}</code></td></tr>
             </table>
         </div>
@@ -144,6 +158,25 @@
                 InvoicePaymentSettled: {
                     subject: 'Invoice {Invoice.Id} payment settled',
                     body: 'Invoice {Invoice.Id} (Order Id: {Invoice.OrderId}) payment settled.'
+                },
+                @PendingTransactionWebhookProvider.PendingTransactionCreated : {
+                    subject: 'Pending Transaction {PendingTransaction.Id} Created',
+                    body: 'Review the transaction and sign it on: @hostRoot/wallets/S-{PendingTransaction.StoreId}-BTC/transactions'
+                },
+                @PendingTransactionWebhookProvider.PendingTransactionSignatureCollected : {
+                    subject: 'Signature Collected for Pending Transaction {PendingTransaction.Id}',
+                    body: 'So far {PendingTransaction.SignaturesCollected} signatures collected out of {PendingTransaction.SignaturesNeeded} signatures needed. ' +
+                        'Review the transaction and sign it on: @hostRoot/wallets/S-{PendingTransaction.StoreId}-BTC/transactions'
+                },
+                @PendingTransactionWebhookProvider.PendingTransactionBroadcast : {
+                    subject: 'Transaction {PendingTransaction.Id} has been Broadcast',
+                    body: 'Transaction is visible in mempool on: https://mempool.space/tx/{PendingTransaction.Id}. ' +
+                        'Review the transaction: @hostRoot/wallets/S-{PendingTransaction.StoreId}-BTC/transactions'
+                },
+                @PendingTransactionWebhookProvider.PendingTransactionCancelled : {
+                    subject: 'Pending Transaction {PendingTransaction.Id} Cancelled',
+                    body: 'Transaction {PendingTransaction.Id} is cancelled and signatures are no longer being collected. ' +
+                        'Review the wallet: @hostRoot/wallets/S-{PendingTransaction.StoreId}-BTC/transactions'
                 },
             };
 

--- a/BTCPayServer/Views/UIStores/StoreEmailRulesManage.cshtml
+++ b/BTCPayServer/Views/UIStores/StoreEmailRulesManage.cshtml
@@ -112,6 +112,7 @@
                     <th text-translate="true">Pending Transaction</th>
                     <td>
                         <code>{PendingTransaction.Id}</code>,
+                        <code>{PendingTransaction.TrimmedId}</code>,
                         <code>{PendingTransaction.StoreId}</code>,
                         <code>{PendingTransaction.SignaturesCollected}</code>,
                         <code>{PendingTransaction.SignaturesNeeded}</code>,
@@ -160,21 +161,21 @@
                     body: 'Invoice {Invoice.Id} (Order Id: {Invoice.OrderId}) payment settled.'
                 },
                 @PendingTransactionWebhookProvider.PendingTransactionCreated : {
-                    subject: 'Pending Transaction {PendingTransaction.Id} Created',
-                    body: 'Review the transaction and sign it on: @hostRoot/wallets/S-{PendingTransaction.StoreId}-BTC/transactions'
+                    subject: 'Pending Transaction {PendingTransaction.TrimmedId} Created',
+                    body: 'Review the transaction {PendingTransaction.Id} and sign it on: @hostRoot/wallets/S-{PendingTransaction.StoreId}-BTC/transactions'
                 },
                 @PendingTransactionWebhookProvider.PendingTransactionSignatureCollected : {
-                    subject: 'Signature Collected for Pending Transaction {PendingTransaction.Id}',
+                    subject: 'Signature Collected for Pending Transaction {PendingTransaction.TrimmedId}',
                     body: 'So far {PendingTransaction.SignaturesCollected} signatures collected out of {PendingTransaction.SignaturesNeeded} signatures needed. ' +
                         'Review the transaction and sign it on: @hostRoot/wallets/S-{PendingTransaction.StoreId}-BTC/transactions'
                 },
                 @PendingTransactionWebhookProvider.PendingTransactionBroadcast : {
-                    subject: 'Transaction {PendingTransaction.Id} has been Broadcast',
+                    subject: 'Transaction {PendingTransaction.TrimmedId} has been Broadcast',
                     body: 'Transaction is visible in mempool on: https://mempool.space/tx/{PendingTransaction.Id}. ' +
                         'Review the transaction: @hostRoot/wallets/S-{PendingTransaction.StoreId}-BTC/transactions'
                 },
                 @PendingTransactionWebhookProvider.PendingTransactionCancelled : {
-                    subject: 'Pending Transaction {PendingTransaction.Id} Cancelled',
+                    subject: 'Pending Transaction {PendingTransaction.TrimmedId} Cancelled',
                     body: 'Transaction {PendingTransaction.Id} is cancelled and signatures are no longer being collected. ' +
                         'Review the wallet: @hostRoot/wallets/S-{PendingTransaction.StoreId}-BTC/transactions'
                 },

--- a/BTCPayServer/Views/UIWallets/WalletTransactions.cshtml
+++ b/BTCPayServer/Views/UIWallets/WalletTransactions.cshtml
@@ -176,21 +176,25 @@
             <thead>
                 <th>Id</th>
                 <th>State</th> 
-                <th>Signature count</th>
+                <th>Signatures</th>
+                <th>Scheme</th>
                 <th>Actions</th>
             </thead>
-            @foreach (var pendingTransaction in Model.PendingTransactions)
+            @for (var index = 0; index < Model.PendingTransactions.Length; index++)
             {
+                var pendingTransaction = Model.PendingTransactions[index];
+                var ptblob = @pendingTransaction.GetBlob();
                 <tr>
                     <td>@pendingTransaction.TransactionId</td>
                     <td>@pendingTransaction.State</td>
-                    <td>@pendingTransaction.GetBlob().CollectedSignatures.Count</td>
+                    <td><span id="Sigs_@(index)__Collected">@ptblob?.SignaturesCollected</span></td>
+                    <td><span id="Sigs_@(index)__Scheme">@ptblob?.SignaturesNeeded/@ptblob?.SignaturesTotal</span></td>
                     <td>
-                        <a asp-action="ViewPendingTransaction" asp-route-walletId="@walletId" asp-route-transactionId="@pendingTransaction.TransactionId"
-                        >@(pendingTransaction.State == PendingTransactionState.Signed ? "Broadcast" : "View")</a>
+                        <a asp-action="ViewPendingTransaction" asp-route-walletId="@walletId" 
+                           asp-route-transactionId="@pendingTransaction.TransactionId">@(pendingTransaction.State == PendingTransactionState.Signed ? "Broadcast" : "View")</a>
                         -
-                        <a asp-action="CancelPendingTransaction" 
-                           asp-route-walletId="@walletId" asp-route-transactionId="@pendingTransaction.TransactionId">Abort</a>
+                        <a asp-action="CancelPendingTransaction" asp-route-walletId="@walletId" 
+                           asp-route-transactionId="@pendingTransaction.TransactionId">Abort</a>
                     </td>
                 </tr>
             }


### PR DESCRIPTION
This pull request (PR) builds upon #6629 and completes Pending Transaction functionality. It enables participants in a multisig to receive email notifications for:

- Creation of a pending transaction
- Collection of signatures
- Broadcasting of the transaction
- Cancellation of the pending transaction

Here is a video demonstrating the changes in action:

https://github.com/user-attachments/assets/19431a2a-e84e-4561-a513-617091f15e81

Additionally, I've made some improvements to the user interface and added properties in the blob related to the signature scheme and signature collection.