### PR TITLE
Disallow calling InvoiceEntity.UpdateTotals() on incomplete invoices

### DIFF
--- a/BTCPayServer/Services/Invoices/InvoiceEntity.cs
+++ b/BTCPayServer/Services/Invoices/InvoiceEntity.cs
@@ -412,6 +412,8 @@ namespace BTCPayServer.Services.Invoices
 
         public void UpdateTotals()
         {
+            if (DisableAccounting)
+                throw new InvalidOperationException("Accounting disabled, impossible to call UpdateTotals");
             PaidAmount = new Amounts()
             {
                 Currency = Currency
@@ -781,6 +783,8 @@ namespace BTCPayServer.Services.Invoices
         /// </summary>
         [JsonIgnore]
         public decimal NetSettled { get; private set; }
+        [JsonIgnore]
+        public bool DisableAccounting { get; set; }
     }
 
     public enum InvoiceStatusLegacy

--- a/BTCPayServer/Services/Invoices/InvoiceRepository.cs
+++ b/BTCPayServer/Services/Invoices/InvoiceRepository.cs
@@ -151,7 +151,11 @@ namespace BTCPayServer.Services.Invoices
                     var paymentData = jobj.ToObject<PaymentData>();
                     invoiceData.Payments.Add(paymentData);
                 }
-                invoices.Add(ToEntity(invoiceData));
+                var entity = ToEntity(invoiceData);
+                // Disable accounting, as we don't have all the payments...
+                // only those related to this paymentMethodId
+                entity.DisableAccounting = true;
+                invoices.Add(entity);
             }
             return invoices.ToArray();
         }


### PR DESCRIPTION
When using `GetMonitoredInvoices` we don't have all the payments. So we shouldn't call `UpdateTotals`.
I am wondering if it's worth it for `GetMonitoredInvoices` to only returns the payments related to the PaymentId... It's less data, but returning all the payments would avoid this issue.