### PR TITLE
Notifications: Add icon for plugin updates

### DIFF
--- a/BTCPayServer/Blazor/NotificationsDropDown.razor
+++ b/BTCPayServer/Blazor/NotificationsDropDown.razor
@@ -156,6 +156,7 @@
             "inviteaccepted" => "notifications-account",
 			"newuserrequiresapproval" => "notifications-account",
             "newversion" => "notifications-new-version",
+            "pluginupdate" => "notifications-new-version",
 			_ => "note"
 		};
 	}


### PR DESCRIPTION
Re-uses the general new version icon for plugin updates. Closes #6647.