### PR TITLE
Bugfixing interpolation on Payment Request

### DIFF
--- a/BTCPayServer/HostedServices/Webhooks/PaymentRequestWebhookDeliveryRequest.cs
+++ b/BTCPayServer/HostedServices/Webhooks/PaymentRequestWebhookDeliveryRequest.cs
@@ -37,9 +37,13 @@ public class PaymentRequestWebhookDeliveryRequest : WebhookSender.WebhookDeliver
 
     private string Interpolate(string str, Data.PaymentRequestData data)
     {
+        var id = data.Id;
+        string trimmedId = $"{id.Substring(0, 7)}...{id.Substring(id.Length - 7)}";
+        
         var blob = data.GetBlob();
-        var res = str.Replace("{PaymentRequest.Id}", _evt.Data.Id)
-            .Replace("{PaymentRequest.Price}", data.Amount.ToString(CultureInfo.InvariantCulture))
+        var res = str.Replace("{PaymentRequest.Id}", id)
+            .Replace("{PaymentRequest.TrimmedId}", trimmedId)
+            .Replace("{PaymentRequest.Amount}", data.Amount.ToString(CultureInfo.InvariantCulture))
             .Replace("{PaymentRequest.Currency}", data.Currency)
             .Replace("{PaymentRequest.Title}", blob.Title)
             .Replace("{PaymentRequest.Description}", blob.Description)

--- a/BTCPayServer/Views/UIStores/StoreEmailRulesManage.cshtml
+++ b/BTCPayServer/Views/UIStores/StoreEmailRulesManage.cshtml
@@ -89,7 +89,8 @@
                     <th text-translate="true">Request</th>
                     <td>
                         <code>{PaymentRequest.Id}</code>,
-                        <code>{PaymentRequest.Price}</code>,
+                        <code>{PaymentRequest.TrimmedId}</code>,
+                        <code>{PaymentRequest.Amount}</code>,
                         <code>{PaymentRequest.Currency}</code>,
                         <code>{PaymentRequest.Title}</code>,
                         <code>{PaymentRequest.Description}</code>,


### PR DESCRIPTION
There was a bug in `Interpolate` method that was trying to replace `Price` instead of `Amount`.

Also added `TrimmedId` property for convenience.