### PR TITLE
Fix: strip "bitcoin:" prefix when scanning QR 

### DIFF
--- a/BTCPayServer/wwwroot/js/wallet/wallet-camera-scanner.js
+++ b/BTCPayServer/wwwroot/js/wallet/wallet-camera-scanner.js
@@ -1,11 +1,11 @@
 window.addEventListener("load", () => {
     let $input = null;
     initCameraScanningApp("Scan address or payment link", data => {
-        if (data.includes('?') || $input == null) {
+        if (data.includes(':') || $input == null) {
             document.getElementById("BIP21").value = data;
             document.getElementById("SendForm").submit();
         } else {
-            $input.value = data.includes(":") ? data.split(":")[1] : data;
+            $input.value = data;
         }
     }, "scanModal");
     document.getElementById('scanModal').addEventListener('show.bs.modal', e => {

--- a/BTCPayServer/wwwroot/js/wallet/wallet-camera-scanner.js
+++ b/BTCPayServer/wwwroot/js/wallet/wallet-camera-scanner.js
@@ -5,7 +5,7 @@ window.addEventListener("load", () => {
             document.getElementById("BIP21").value = data;
             document.getElementById("SendForm").submit();
         } else {
-            $input.value = data;
+            $input.value = data.includes(":") ? data.split(":")[1] : data;
         }
     }, "scanModal");
     document.getElementById('scanModal').addEventListener('show.bs.modal', e => {


### PR DESCRIPTION

Removing everything before the ":" when scanning from QR that contains "Bitcoin:" 

Fixes: #6665 

Manually tested to make sure it works. 