### PR TITLE
Fix: No need to select the Signing Key for signing through multi sig process

### DIFF
--- a/BTCPayServer/Controllers/GreenField/GreenfieldStoreOnChainPaymentMethodsController.WalletGeneration.cs
+++ b/BTCPayServer/Controllers/GreenField/GreenfieldStoreOnChainPaymentMethodsController.WalletGeneration.cs
@@ -93,7 +93,7 @@ namespace BTCPayServer.Controllers.Greenfield
                 request.ExistingMnemonic is null ? "NBXplorerGenerated" : "ImportedSeed";
             derivationSchemeSettings.IsHotWallet = request.SavePrivateKeys;
             derivationSchemeSettings.Label = request.Label;
-            var accountSettings = derivationSchemeSettings.GetSigningAccountKeySettings();
+            var accountSettings = derivationSchemeSettings.AccountKeySettings[0];
             accountSettings.AccountKeyPath = response.AccountKeyPath.KeyPath;
             accountSettings.RootFingerprint = response.AccountKeyPath.MasterFingerprint;
             derivationSchemeSettings.AccountOriginal = response.DerivationScheme.ToString();

--- a/BTCPayServer/Controllers/GreenField/GreenfieldStoreOnChainWalletsController.cs
+++ b/BTCPayServer/Controllers/GreenField/GreenfieldStoreOnChainWalletsController.cs
@@ -582,9 +582,13 @@ namespace BTCPayServer.Controllers.Greenfield
 
             var signingKey = ExtKey.Parse(signingKeyStr, network.NBitcoinNetwork);
 
-            var signingKeySettings = derivationScheme.GetSigningAccountKeySettings();
-            signingKeySettings.RootFingerprint ??= signingKey.GetPublicKey().GetHDFingerPrint();
-            RootedKeyPath rootedKeyPath = signingKeySettings.GetRootedKeyPath();
+            var signingKeySettings = derivationScheme.GetSigningAccountKeySettings(signingKey);
+            RootedKeyPath? rootedKeyPath = signingKeySettings?.GetRootedKeyPath();
+            if (rootedKeyPath is null || signingKeySettings is null)
+            {
+                return this.CreateAPIError(503, "not-available",
+                    "The private key saved for this wallet doesn't match the derivation scheme");
+            }
             psbt.PSBT.RebaseKeyPaths(signingKeySettings.AccountKey, rootedKeyPath);
             var accountKey = signingKey.Derive(rootedKeyPath.KeyPath);
 

--- a/BTCPayServer/Controllers/UIStoresController.Onchain.cs
+++ b/BTCPayServer/Controllers/UIStoresController.Onchain.cs
@@ -320,7 +320,7 @@ public partial class UIStoresController
             derivationSchemeSettings.IsHotWallet = method == WalletSetupMethod.HotWallet;
         }
 
-        var accountSettings = derivationSchemeSettings.GetSigningAccountKeySettings();
+        var accountSettings = derivationSchemeSettings.AccountKeySettings[0];
         accountSettings.AccountKeyPath = response.AccountKeyPath.KeyPath;
         accountSettings.RootFingerprint = response.AccountKeyPath.MasterFingerprint;
         derivationSchemeSettings.AccountOriginal = response.DerivationScheme.ToString();

--- a/BTCPayServer/DerivationSchemeSettings.cs
+++ b/BTCPayServer/DerivationSchemeSettings.cs
@@ -78,16 +78,26 @@ namespace BTCPayServer
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
         public BitcoinExtPubKey ExplicitAccountKey { get; set; }
 
+#nullable enable
         public AccountKeySettings GetSigningAccountKeySettings()
         {
             return (AccountKeySettings ?? []).Single(a => a.AccountKey == SigningKey);
         }
 
-        public AccountKeySettings GetSigningAccountKeySettingsOrDefault()
+        public AccountKeySettings? GetSigningAccountKeySettings(IHDKey rootKey)
+        => GetSigningAccountKeySettings(rootKey.GetPublicKey().GetHDFingerPrint());
+
+        public AccountKeySettings? GetSigningAccountKeySettings(HDFingerprint rootFingerprint)
+        {
+            return (AccountKeySettings ?? []).Where(a => a.RootFingerprint == rootFingerprint).FirstOrDefault();
+        }
+
+
+        public AccountKeySettings? GetSigningAccountKeySettingsOrDefault()
         {
             return (AccountKeySettings ?? []).SingleOrDefault(a => a.AccountKey == SigningKey);
         }
-
+#nullable restore
         public AccountKeySettings[] AccountKeySettings { get; set; }
 
         public IEnumerable<NBXplorer.Models.PSBTRebaseKeyRules> GetPSBTRebaseKeyRules()


### PR DESCRIPTION
Fix: https://github.com/btcpayserver/btcpayserver/issues/6670

When using `Sign with Seed`, BTCPay Server will verify that the seed that has been input match the fingerprint of the `Signing key` of the wallet.

However, the selection of the `Signing Key` in the Wallet settings is only possible when `Multisig on Server` is disabled.

This PR improves the situation by making `Sign with Seed` automatically select the right signing key based on the passed seed.