### PR TITLE
Fix: adding a confirmation for the deletion of Email Rule

### DIFF
--- a/BTCPayServer.Tests/SeleniumTests.cs
+++ b/BTCPayServer.Tests/SeleniumTests.cs
@@ -906,10 +906,16 @@ namespace BTCPayServer.Tests
 
             deleteLinks[0].Click();
 
+            var confirmDelete = s.Driver.FindElement(By.XPath("//*[@id='deleteConfirmation']//button[contains(text(), 'Delete')]"));
+            confirmDelete.Click();
+
             deleteLinks = s.Driver.FindElements(By.XPath("//a[contains(text(), 'Delete')]")); // Refresh list
             Assert.True(deleteLinks.Count == 1, "Expected one delete button remaining.");
 
             deleteLinks[0].Click();
+
+            confirmDelete = s.Driver.FindElement(By.XPath("//*[@id='deleteConfirmation']//button[contains(text(), 'Delete')]"));
+            confirmDelete.Click();
 
             // Validate that there are no more rules
             Assert.Contains("There are no rules yet.", s.Driver.PageSource);

--- a/BTCPayServer.Tests/SeleniumTests.cs
+++ b/BTCPayServer.Tests/SeleniumTests.cs
@@ -899,26 +899,6 @@ namespace BTCPayServer.Tests
             // Validate that the email is updated in the list of email rules
             Assert.Contains("changedagain@gmail.com", s.Driver.PageSource);
             Assert.DoesNotContain("statuschanged@gmail.com", s.Driver.PageSource);
-
-            // Delete both email rules
-            var deleteLinks = s.Driver.FindElements(By.XPath("//a[contains(text(), 'Delete')]"));
-            Assert.True(deleteLinks.Count == 2, "Expected exactly two delete buttons but found a different number.");
-
-            deleteLinks[0].Click();
-
-            var confirmDelete = s.Driver.FindElement(By.XPath("//*[@id='deleteConfirmation']//button[contains(text(), 'Delete')]"));
-            confirmDelete.Click();
-
-            deleteLinks = s.Driver.FindElements(By.XPath("//a[contains(text(), 'Delete')]")); // Refresh list
-            Assert.True(deleteLinks.Count == 1, "Expected one delete button remaining.");
-
-            deleteLinks[0].Click();
-
-            confirmDelete = s.Driver.FindElement(By.XPath("//*[@id='deleteConfirmation']//button[contains(text(), 'Delete')]"));
-            confirmDelete.Click();
-
-            // Validate that there are no more rules
-            Assert.Contains("There are no rules yet.", s.Driver.PageSource);
         }
 
         [Fact(Timeout = TestTimeout)]

--- a/BTCPayServer.Tests/SeleniumTests.cs
+++ b/BTCPayServer.Tests/SeleniumTests.cs
@@ -866,6 +866,7 @@ namespace BTCPayServer.Tests
             s.Driver.FindElement(By.Id("SaveEmailRules")).Click();
 
             // Ensure that the rule is created
+            s.FindAlertMessage();
             Assert.DoesNotContain("There are no rules yet.", s.Driver.PageSource);
             Assert.Contains("invoicecreated@gmail.com", s.Driver.PageSource);
             Assert.Contains("Invoice {Invoice.Id} created", s.Driver.PageSource);
@@ -881,6 +882,7 @@ namespace BTCPayServer.Tests
             s.Driver.FindElement(By.Id("SaveEmailRules")).Click();
 
             // Validate the second rule is added
+            s.FindAlertMessage();
             Assert.Contains("statuschanged@gmail.com", s.Driver.PageSource);
             Assert.Contains("Status changed!", s.Driver.PageSource);
 
@@ -897,8 +899,29 @@ namespace BTCPayServer.Tests
             s.Driver.FindElement(By.Id("SaveEmailRules")).Click();
 
             // Validate that the email is updated in the list of email rules
+            s.FindAlertMessage();
             Assert.Contains("changedagain@gmail.com", s.Driver.PageSource);
             Assert.DoesNotContain("statuschanged@gmail.com", s.Driver.PageSource);
+
+            // Delete both email rules
+            var deleteLinks = s.Driver.FindElements(By.XPath("//a[contains(text(), 'Remove')]"));
+            Assert.True(deleteLinks.Count == 2, "Expected exactly two delete buttons but found a different number.");
+
+            deleteLinks[0].Click();
+            s.Driver.WaitForElement(By.Id("ConfirmInput")).SendKeys("REMOVE");
+            s.Driver.FindElement(By.Id("ConfirmContinue")).Click();
+
+            s.FindAlertMessage();
+            deleteLinks = s.Driver.FindElements(By.XPath("//a[contains(text(), 'Remove')]")); // Refresh list
+            Assert.True(deleteLinks.Count == 1, "Expected one delete button remaining.");
+
+            deleteLinks[0].Click();
+            s.Driver.WaitForElement(By.Id("ConfirmInput")).SendKeys("REMOVE");
+            s.Driver.FindElement(By.Id("ConfirmContinue")).Click();
+
+            s.FindAlertMessage();
+            // Validate that there are no more rules
+            Assert.Contains("There are no rules yet.", s.Driver.PageSource);
         }
 
         [Fact(Timeout = TestTimeout)]

--- a/BTCPayServer/Controllers/UIStoresController.EmailRules.cs
+++ b/BTCPayServer/Controllers/UIStoresController.EmailRules.cs
@@ -72,6 +72,7 @@ namespace BTCPayServer.Controllers
             store.SetStoreBlob(blob);
             await _storeRepo.UpdateStore(store);
 
+            this.TempData.SetStatusSuccess(StringLocalizer["Email rule successfully created"]);
             return RedirectToAction(nameof(StoreEmailRulesList), new { storeId });
         }
 
@@ -111,6 +112,7 @@ namespace BTCPayServer.Controllers
             store.SetStoreBlob(blob);
             await _storeRepo.UpdateStore(store);
 
+            this.TempData.SetStatusSuccess(StringLocalizer["Email rule successfully updated"]);
             return RedirectToAction(nameof(StoreEmailRulesList), new { storeId });
         }
 
@@ -128,6 +130,7 @@ namespace BTCPayServer.Controllers
             store.SetStoreBlob(blob);
             await _storeRepo.UpdateStore(store);
 
+            this.TempData.SetStatusSuccess(StringLocalizer["Email rule successfully deleted"]);
             return RedirectToAction(nameof(StoreEmailRulesList), new { storeId });
         }
 

--- a/BTCPayServer/Views/UIStores/StoreEmailRulesList.cshtml
+++ b/BTCPayServer/Views/UIStores/StoreEmailRulesList.cshtml
@@ -53,7 +53,7 @@
                     <td class="actions-col" permission="@Policies.CanModifyStoreSettings">
                         <div class="d-inline-flex align-items-center gap-3">
                             <a asp-action="StoreEmailRulesEdit" asp-route-storeId="@storeId" asp-route-ruleIndex="@rule.index">Edit</a>
-                            <a asp-action="StoreEmailRulesDelete" asp-route-storeId="@storeId" asp-route-ruleIndex="@rule.index" data-bs-toggle="modal" data-bs-target="#ConfirmModal" data-description="@StringLocalizer["This action will remove the rule with the trigger {0}.", Html.Encode(rule.value.Trigger)]" data-confirm-input="@StringLocalizer["REMOVE"]" text-translate="true">Remove</a>
+                            <a asp-action="StoreEmailRulesDelete" asp-route-storeId="@storeId" asp-route-ruleIndex="@rule.index" data-bs-toggle="modal" data-bs-target="#ConfirmModal" data-description="@ViewLocalizer["This action will remove the rule with the trigger <b>{0}</b>.", Html.Encode(rule.value.Trigger)]" data-confirm-input="@StringLocalizer["REMOVE"]" text-translate="true">Remove</a>
                         </div>
                     </td>
                 </tr>

--- a/BTCPayServer/Views/UIStores/StoreEmailRulesList.cshtml
+++ b/BTCPayServer/Views/UIStores/StoreEmailRulesList.cshtml
@@ -18,12 +18,10 @@
         </ol>
         <h2>@ViewData["Title"]</h2>
     </nav>
-    <form method="post" permission="@Policies.CanModifyStoreSettings">
-        <a id="CreateEmailRule" permission="@Policies.CanModifyStoreSettings" asp-action="StoreEmailRulesCreate" asp-route-storeId="@storeId" 
-           class="btn btn-primary" role="button">
-            Create Email Rule
-        </a>
-    </form>
+    <a id="CreateEmailRule" permission="@Policies.CanModifyStoreSettings" asp-action="StoreEmailRulesCreate" asp-route-storeId="@storeId" 
+       class="btn btn-primary" role="button">
+        Create Email Rule
+    </a>
 </div>
 
 <partial name="_StatusMessage" />

--- a/BTCPayServer/Views/UIStores/StoreEmailRulesList.cshtml
+++ b/BTCPayServer/Views/UIStores/StoreEmailRulesList.cshtml
@@ -1,3 +1,4 @@
+@using BTCPayServer.Abstractions.Models
 @using BTCPayServer.Client
 @using BTCPayServer.TagHelpers
 @using Microsoft.AspNetCore.Mvc.TagHelpers
@@ -17,34 +18,18 @@
         </ol>
         <h2>@ViewData["Title"]</h2>
     </nav>
-    <a id="CreateEmailRule" permission="@Policies.CanModifyStoreSettings" asp-action="StoreEmailRulesCreate" asp-route-storeId="@storeId" 
-       class="btn btn-primary" role="button">
-        Create Email Rule
-    </a>
+    <form method="post" permission="@Policies.CanModifyStoreSettings">
+        <a id="CreateEmailRule" permission="@Policies.CanModifyStoreSettings" asp-action="StoreEmailRulesCreate" asp-route-storeId="@storeId" 
+           class="btn btn-primary" role="button">
+            Create Email Rule
+        </a>
+    </form>
 </div>
 
 <partial name="_StatusMessage" />
 <p text-translate="true">
     Email rules allow BTCPay Server to send customized emails from your store based on events.
 </p>
-
-<div id="overlay" style="display: none; position: fixed; top: 0; left: 0;
-    width: 100vw; height: 100vh; background-color: rgba(0,0,0,0.5);
-    z-index: 9998;"></div>
-
-<div id="deleteConfirmation" class="modal-content" style="display: none;position: fixed; top: 50%; left: 50%;
-    transform: translate(-50%, -50%); background-color: black; color: white; padding: 20px;
-    border-radius: 8px; box-shadow: 0 4px 10px rgba(0,0,0,0.3); z-index: 9999; width: 500px;">
-    <div class="modal-header"><h4 class="modal-title">Delete rule</h4></div><br />
-    <p style="margin-bottom: 20px;">This rule will be deleted. Are you sure?</p>
-    <br />
-    <div style="display: flex; justify-content: flex-end; gap: 10px;">
-        <button onclick="cancelDelete()" class="btn btn-secondary only-for-js">Cancel</button>
-        <button onclick="confirmDelete()" class="btn btn-danger">Delete</button>
-    </div>
-</div>
-
-<button onclick="showConfirmation()" style="display: none;">Delete Item</button>
 
 @if (Model.Any())
 {
@@ -56,7 +41,7 @@
                 <th>Customer Email</th>
                 <th>To</th>
                 <th>Subject</th>
-                <th>Actions</th>
+                <th class="actions-col" permission="@Policies.CanModifyStoreSettings"></th>
             </tr>
             </thead>
             <tbody>
@@ -67,12 +52,11 @@
                     <td>@(rule.value.CustomerEmail ? "Yes" : "No")</td>
                     <td>@rule.value.To</td>
                     <td>@rule.value.Subject</td>
-                    <td>
-                        <a asp-action="StoreEmailRulesEdit" asp-route-storeId="@storeId" asp-route-ruleIndex="@rule.index">Edit</a>
-                        -
-                        <form id="deleteRule" asp-action="StoreEmailRulesDelete" asp-route-storeId="@storeId" asp-route-ruleIndex="@rule.index" method="post" style="display:inline;">
-                            <a href="#" class="text-danger" onclick="event.preventDefault(); showConfirmation();">Delete</a>
-                        </form>
+                    <td class="actions-col" permission="@Policies.CanModifyStoreSettings">
+                        <div class="d-inline-flex align-items-center gap-3">
+                            <a asp-action="StoreEmailRulesEdit" asp-route-storeId="@storeId" asp-route-ruleIndex="@rule.index">Edit</a>
+                            <a asp-action="StoreEmailRulesDelete" asp-route-storeId="@storeId" asp-route-ruleIndex="@rule.index" data-bs-toggle="modal" data-bs-target="#ConfirmModal" data-description="@StringLocalizer["This action will remove the rule with the trigger {0}.", Html.Encode(rule.value.Trigger)]" data-confirm-input="@StringLocalizer["REMOVE"]" text-translate="true">Remove</a>
+                        </div>
                     </td>
                 </tr>
             }
@@ -87,24 +71,4 @@ else
     </p>
 }
 
-<script>
-    function showConfirmation() {
-         document.getElementById('overlay').style.display = 'block';
-         document.getElementById('deleteConfirmation').style.display = 'block';
-     }
-
-     function cancelDelete() {
-         document.getElementById('overlay').style.display = 'none';
-         document.getElementById('deleteConfirmation').style.display = 'none';
-     }
-
-     function confirmDelete() {
-         document.getElementById('deleteRule').submit();
-     }
-
-     document.addEventListener('keydown', function(event) {
-        if (event.key === 'Escape') {
-            cancelDelete();
-        }
-    });
-</script>
+<partial name="_Confirm" model="@(new ConfirmModel(StringLocalizer["Remove email rule"], StringLocalizer["This action will remove this rule. Are you sure?"], StringLocalizer["Delete"]))" permission="@Policies.CanModifyStoreSettings" />

--- a/BTCPayServer/Views/UIStores/StoreEmailRulesList.cshtml
+++ b/BTCPayServer/Views/UIStores/StoreEmailRulesList.cshtml
@@ -28,6 +28,24 @@
     Email rules allow BTCPay Server to send customized emails from your store based on events.
 </p>
 
+<div id="overlay" style="display: none; position: fixed; top: 0; left: 0;
+    width: 100vw; height: 100vh; background-color: rgba(0,0,0,0.5);
+    z-index: 9998;"></div>
+
+<div id="deleteConfirmation" class="modal-content" style="display: none;position: fixed; top: 50%; left: 50%;
+    transform: translate(-50%, -50%); background-color: black; color: white; padding: 20px;
+    border-radius: 8px; box-shadow: 0 4px 10px rgba(0,0,0,0.3); z-index: 9999; width: 500px;">
+    <div class="modal-header"><h4 class="modal-title">Delete rule</h4></div><br />
+    <p style="margin-bottom: 20px;">This rule will be deleted. Are you sure?</p>
+    <br />
+    <div style="display: flex; justify-content: flex-end; gap: 10px;">
+        <button onclick="cancelDelete()" class="btn btn-secondary only-for-js">Cancel</button>
+        <button onclick="confirmDelete()" class="btn btn-danger">Delete</button>
+    </div>
+</div>
+
+<button onclick="showConfirmation()" style="display: none;">Delete Item</button>
+
 @if (Model.Any())
 {
     <div class="table-responsive">
@@ -52,8 +70,8 @@
                     <td>
                         <a asp-action="StoreEmailRulesEdit" asp-route-storeId="@storeId" asp-route-ruleIndex="@rule.index">Edit</a>
                         -
-                        <form asp-action="StoreEmailRulesDelete" asp-route-storeId="@storeId" asp-route-ruleIndex="@rule.index" method="post" style="display:inline;">
-                            <a href="#" class="text-danger" onclick="event.preventDefault(); this.closest('form').submit();">Delete</a>
+                        <form id="deleteRule" asp-action="StoreEmailRulesDelete" asp-route-storeId="@storeId" asp-route-ruleIndex="@rule.index" method="post" style="display:inline;">
+                            <a href="#" class="text-danger" onclick="event.preventDefault(); showConfirmation();">Delete</a>
                         </form>
                     </td>
                 </tr>
@@ -68,3 +86,25 @@ else
         There are no rules yet.
     </p>
 }
+
+<script>
+    function showConfirmation() {
+         document.getElementById('overlay').style.display = 'block';
+         document.getElementById('deleteConfirmation').style.display = 'block';
+     }
+
+     function cancelDelete() {
+         document.getElementById('overlay').style.display = 'none';
+         document.getElementById('deleteConfirmation').style.display = 'none';
+     }
+
+     function confirmDelete() {
+         document.getElementById('deleteRule').submit();
+     }
+
+     document.addEventListener('keydown', function(event) {
+        if (event.key === 'Escape') {
+            cancelDelete();
+        }
+    });
+</script>


### PR DESCRIPTION
Fix: https://github.com/btcpayserver/btcpayserver/issues/6662

Added a confirmation modal screen for the deletion of an Email Rule. 

It was also added a template for how we could call the confirmation screen using JavaScript without refreshing the page.

Finally, a UX way to close the modal was added, pressing ESC.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added success messages when creating, editing, or deleting email rules, providing clearer feedback to users.
	- Introduced a confirmation dialog for removing email rules, requiring users to type "REMOVE" before deletion.

- **Improvements**
	- Enhanced the email rules management interface with updated action buttons and permission-based visibility.
	- Improved reliability and feedback handling for email rule operations in automated tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->