### PR TITLE
Improve tooltip for Bitcoin wallet labels to display  Title of Payment Request Instead of ID

### DIFF
--- a/BTCPayServer/Services/Labels/LabelService.cs
+++ b/BTCPayServer/Services/Labels/LabelService.cs
@@ -109,7 +109,8 @@ public class LabelService
             }
             else if (tag.Type == WalletObjectData.Types.PaymentRequest)
             {
-                model.Tooltip = $"Received through a payment request {tag.Id}";
+                var paymentRequest = await _paymentRequestService.GetPaymentRequest(tag.Id);
+                model.Tooltip = !string.IsNullOrEmpty(paymentRequest?.Blob?.Title) ? $"Received through: {paymentRequest.Blob.Title}" : $"Received through payment request: {tag.Id}";
                 model.Link = _linkGenerator.PaymentRequestLink(tag.Id, req.Scheme, req.Host, req.PathBase);
             }
             else if (tag.Type == WalletObjectData.Types.App)


### PR DESCRIPTION
- Fixes  #6667 
- The changes ensure the tooltip displays the Title of the Payment Request for better readability.  
- The `GetPaymentRequest` function in `PaymentRequestService` fetches a `PaymentRequestData object` from the database using the `tag.Id` because `LabelService` operates primarily on transaction metadata, which only includes the `tag.Id` (the unique identifier of the Payment Request) but not the full details like the Title.
- I have fetch the paymentRequest?.Blob?.Title because the Title provides meaningful context about the transaction. However, it might be null if the Payment Request has no Title set, the data is incomplete, or the request ID is invalid/missing. In such cases, we fall back to displaying the tag.Id, which is always present as a unique identifier. This ensures the tooltip remains functional even when the Title is unavailable. 

File where i implemented this changes :
https://github.com/btcpayserver/btcpayserver/blob/1b762cc9cfaa89dd89099e34f0ec1a271bc34b31/BTCPayServer/Services/Labels/LabelService.cs#L110-L114

Thank you! 🌻 

