### PR TITLE
Include XPubs in PSBTs for multi sig

### DIFF
--- a/BTCPayServer/Controllers/GreenField/GreenfieldStoreOnChainWalletsController.cs
+++ b/BTCPayServer/Controllers/GreenField/GreenfieldStoreOnChainWalletsController.cs
@@ -540,7 +540,7 @@ namespace BTCPayServer.Controllers.Greenfield
                     {
                         SelectedInputs = request.SelectedInputs?.Select(point => point.ToString()),
                         Outputs = outputs,
-                        AlwaysIncludeNonWitnessUTXO = true,
+                        AlwaysIncludeNonWitnessUTXO = derivationScheme.DefaultIncludeNonWitnessUtxo,
                         InputSelection = request.SelectedInputs?.Any() is true,
                         FeeSatoshiPerByte = request.FeeRate?.SatoshiPerByte,
                         NoChange = request.NoChange

--- a/BTCPayServer/Controllers/UIWalletsController.cs
+++ b/BTCPayServer/Controllers/UIWalletsController.cs
@@ -316,6 +316,7 @@ namespace BTCPayServer.Controllers
 				{
 					RBF = true,
 					AlwaysIncludeNonWitnessUTXO = paymentMethod.DefaultIncludeNonWitnessUtxo,
+                    IncludeGlobalXPub = paymentMethod.IsMultiSigOnServer,
 					IncludeOnlyOutpoints = bumpableUTXOs,
 					SpendAllMatchingOutpoints = true,
 					FeePreference = new FeePreference()
@@ -369,6 +370,7 @@ namespace BTCPayServer.Controllers
                 {
                     RBF = true,
                     AlwaysIncludeNonWitnessUTXO = paymentMethod.DefaultIncludeNonWitnessUtxo,
+                    IncludeGlobalXPub = paymentMethod.IsMultiSigOnServer,
                     IncludeOnlyOutpoints = tx.Transaction.Inputs.Select(i => i.PrevOut).ToList(),
                     SpendAllMatchingOutpoints = true,
                     DisableFingerprintRandomization = true,
@@ -1329,6 +1331,7 @@ namespace BTCPayServer.Controllers
         public async Task<IActionResult> WalletSendVault([ModelBinder(typeof(WalletIdModelBinder))] WalletId walletId,
             WalletSendVaultModel model)
         {
+            TempData.SetStatusSuccess(StringLocalizer["Transaction successfully signed"].Value);
             return await RedirectToWalletPSBTReady(walletId, new WalletPSBTReadyViewModel
             {
                 SigningContext = model.SigningContext,

--- a/BTCPayServer/Extensions.cs
+++ b/BTCPayServer/Extensions.cs
@@ -85,8 +85,8 @@ namespace BTCPayServer
         {
             return Encoding.UTF8.GetString(protector.Unprotect(Convert.FromBase64String(str)));
         }
-        
-        
+
+
         /// <summary>
         /// Outputs a serializer which will serialize default and null members.
         /// This is useful for discovering the API.
@@ -554,7 +554,8 @@ namespace BTCPayServer
             {
                 PSBT = psbt,
                 DerivationScheme = derivationSchemeSettings.AccountDerivation,
-                AlwaysIncludeNonWitnessUTXO = true
+                AlwaysIncludeNonWitnessUTXO = true,
+                IncludeGlobalXPub = derivationSchemeSettings.IsMultiSigOnServer
             });
             if (result == null)
                 return null;
@@ -638,7 +639,7 @@ namespace BTCPayServer
             var h = (BitcoinLikePaymentHandler)handlers[pmi];
             return h;
         }
-        public static BTCPayNetwork? TryGetNetwork<TId, THandler>(this HandlersDictionary<TId, THandler> handlers, TId id) 
+        public static BTCPayNetwork? TryGetNetwork<TId, THandler>(this HandlersDictionary<TId, THandler> handlers, TId id)
                                                                            where THandler : IHandler<TId>
                                                                            where TId : notnull
         {

--- a/BTCPayServer/Services/Translations.Default.cs
+++ b/BTCPayServer/Services/Translations.Default.cs
@@ -1610,6 +1610,7 @@ namespace BTCPayServer.Services
   "Transaction fee rate:": "",
   "Transaction Id": "",
   "Transaction signed successfully, proceeding to review...": "",
+  "Transaction successfully signed": "",
   "transactions": "",
   "Translations": "",
   "Translations are formatted as JSON; for example, <b>{0}</b> translates <b>{1}</b> to <b>{2}</b>.": "",

--- a/btcpayserver.sln.DotSettings
+++ b/btcpayserver.sln.DotSettings
@@ -1,4 +1,5 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=HWI/@EntryIndexedValue">HWI</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=LNURL/@EntryIndexedValue">LNURL</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=NB/@EntryIndexedValue">NBX</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=NBXplorer/@EntryIndexedValue">NBXplorer</s:String>


### PR DESCRIPTION
When using multisig, include xpubs in the PSBT so wallets like Coldcard works without requiring prior xpub registration.

If you see `Coldcard Error: XPUBs in PSBT do not match any existing wallet (BadArgument)`, then the problem is that you used another multisig wallet with colcard with another key before.

You can can delete the previous wallet in `Settings->Multi sig Wallets` then delete.