### PR TITLE
Restoring reading of PaymentHash from LightningInvoice

### DIFF
--- a/BTCPayServer/Payments/Lightning/LightningExtensions.cs
+++ b/BTCPayServer/Payments/Lightning/LightningExtensions.cs
@@ -1,12 +1,12 @@
 using BTCPayServer.Configuration;
 using BTCPayServer.Lightning;
 using BTCPayServer.Services;
+using NBitcoin;
 
 namespace BTCPayServer.Payments.Lightning
 {
     public static class LightningExtensions
     {
-
         public static bool IsConfigured(this LightningPaymentMethodConfig supportedPaymentMethod, BTCPayNetwork network, LightningNetworkOptions options)
         {
             return supportedPaymentMethod.GetExternalLightningUrl() is not null || (supportedPaymentMethod.IsInternalNode && options.InternalLightningByCryptoCode.ContainsKey(network.CryptoCode));
@@ -24,6 +24,13 @@ namespace BTCPayServer.Payments.Lightning
                     throw new PaymentMethodUnavailableException("No internal node configured");
                 return connectionString;
             }
+        }
+
+        public static uint256? GetPaymentHash(this LightningInvoice lightningInvoice, Network btcpayNetwork)
+        {
+            return lightningInvoice.PaymentHash != null ?
+                uint256.Parse(lightningInvoice.PaymentHash) :
+                BOLT11PaymentRequest.Parse(lightningInvoice.BOLT11, btcpayNetwork).PaymentHash;
         }
     }
 }

--- a/BTCPayServer/Payments/Lightning/LightningLikePaymentHandler.cs
+++ b/BTCPayServer/Payments/Lightning/LightningLikePaymentHandler.cs
@@ -128,13 +128,9 @@ namespace BTCPayServer.Payments.Lightning
             }
 
             paymentPrompt.Destination = lightningInvoice.BOLT11;
-            var paymentHash = lightningInvoice.PaymentHash != null ? 
-                uint256.Parse(lightningInvoice.PaymentHash) : 
-                BOLT11PaymentRequest.Parse(lightningInvoice.BOLT11, _Network.NBitcoinNetwork).PaymentHash;
-            
             var details = new LigthningPaymentPromptDetails
             {
-                PaymentHash = paymentHash,
+                PaymentHash = lightningInvoice.GetPaymentHash(_Network.NBitcoinNetwork),
                 Preimage = string.IsNullOrEmpty(lightningInvoice.Preimage) ? null : uint256.Parse(lightningInvoice.Preimage),
                 InvoiceId = lightningInvoice.Id,
                 NodeInfo = (await nodeInfo).FirstOrDefault()?.ToString()

--- a/BTCPayServer/Payments/Lightning/LightningLikePaymentHandler.cs
+++ b/BTCPayServer/Payments/Lightning/LightningLikePaymentHandler.cs
@@ -128,9 +128,13 @@ namespace BTCPayServer.Payments.Lightning
             }
 
             paymentPrompt.Destination = lightningInvoice.BOLT11;
+            var paymentHash = lightningInvoice.PaymentHash != null ? 
+                uint256.Parse(lightningInvoice.PaymentHash) : 
+                BOLT11PaymentRequest.Parse(lightningInvoice.BOLT11, _Network.NBitcoinNetwork).PaymentHash;
+            
             var details = new LigthningPaymentPromptDetails
             {
-                PaymentHash = BOLT11PaymentRequest.Parse(lightningInvoice.BOLT11, _Network.NBitcoinNetwork).PaymentHash,
+                PaymentHash = paymentHash,
                 Preimage = string.IsNullOrEmpty(lightningInvoice.Preimage) ? null : uint256.Parse(lightningInvoice.Preimage),
                 InvoiceId = lightningInvoice.Id,
                 NodeInfo = (await nodeInfo).FirstOrDefault()?.ToString()

--- a/BTCPayServer/Payments/Lightning/LightningListener.cs
+++ b/BTCPayServer/Payments/Lightning/LightningListener.cs
@@ -527,8 +527,7 @@ retry:
                         continue;
                     if (notification.Id == listenedInvoice.PaymentMethodDetails.InvoiceId &&
                         (notification.BOLT11 == listenedInvoice.PaymentMethod.Destination ||
-                         BOLT11PaymentRequest.Parse(notification.BOLT11, _network.NBitcoinNetwork).PaymentHash ==
-                         GetPaymentHash(listenedInvoice)))
+                        notification.GetPaymentHash(_network.NBitcoinNetwork) == GetPaymentHash(listenedInvoice)))
                     {
                         if (notification.Status == LightningInvoiceStatus.Paid &&
                             notification.PaidAt.HasValue && notification.Amount != null)
@@ -559,7 +558,8 @@ retry:
 
         private uint256? GetPaymentHash(ListenedInvoice listenedInvoice)
         {
-            return listenedInvoice.PaymentMethodDetails.PaymentHash ?? BOLT11PaymentRequest.Parse(listenedInvoice.PaymentMethod.Destination, _network.NBitcoinNetwork).PaymentHash;
+            return listenedInvoice.PaymentMethodDetails.PaymentHash ??
+                   BOLT11PaymentRequest.Parse(listenedInvoice.PaymentMethod.Destination, _network.NBitcoinNetwork).PaymentHash;
         }
 
         public DateTimeOffset? LastFullPoll { get; set; }
@@ -591,9 +591,7 @@ retry:
                 return false;
 
             var handler = _handlers[paymentMethodId];
-            var paymentHash = notification.PaymentHash != null ?
-                uint256.Parse(notification.PaymentHash) :
-                BOLT11PaymentRequest.Parse(notification.BOLT11, _network.NBitcoinNetwork).PaymentHash;
+            var paymentHash = notification.GetPaymentHash(_network.NBitcoinNetwork);
             var paymentData = new PaymentData()
             {
                 Id = paymentHash?.ToString() ?? notification.BOLT11,

--- a/BTCPayServer/Payments/Lightning/LightningListener.cs
+++ b/BTCPayServer/Payments/Lightning/LightningListener.cs
@@ -270,7 +270,6 @@ retry:
         {
             if (_InstanceListeners.TryGetValue((cryptoCode, connStr), out var instance))
             {
-                
                 instance.RemoveExpiredInvoices();
                 if (!instance.Empty)
                     instance.EnsureListening(_Cts.Token);
@@ -592,7 +591,9 @@ retry:
                 return false;
 
             var handler = _handlers[paymentMethodId];
-            var paymentHash = BOLT11PaymentRequest.Parse(notification.BOLT11, _network.NBitcoinNetwork).PaymentHash;
+            var paymentHash = notification.PaymentHash != null ?
+                uint256.Parse(notification.PaymentHash) :
+                BOLT11PaymentRequest.Parse(notification.BOLT11, _network.NBitcoinNetwork).PaymentHash;
             var paymentData = new PaymentData()
             {
                 Id = paymentHash?.ToString() ?? notification.BOLT11,


### PR DESCRIPTION
For some reason, we are no longer using PaymentHash returned during invoice creation. One of the biggest issues with this approach is that it hinders our ability to debug mainnet Lightning invoices locally.

Therefore, I have revised the logic - if PaymentHash is present - use it.

Otherwise - if PaymentHash is missing - only then do the extra parsing of BOLT11 invoice and generate PaymentHash.