### PR TITLE
Implement store templates

### DIFF
--- a/BTCPayServer.Client/Models/StoreBaseData.cs
+++ b/BTCPayServer.Client/Models/StoreBaseData.cs
@@ -17,7 +17,7 @@ namespace BTCPayServer.Client.Models
         public string Website { get; set; }
 
         public string BrandColor { get; set; }
-        public bool ApplyBrandColorToBackend { get; set; }
+        public bool? ApplyBrandColorToBackend { get; set; }
         public string LogoUrl { get; set; }
         public string CssUrl { get; set; }
         public string PaymentSoundUrl { get; set; }
@@ -26,56 +26,56 @@ namespace BTCPayServer.Client.Models
 
         [JsonConverter(typeof(TimeSpanJsonConverter.Seconds))]
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-        public TimeSpan InvoiceExpiration { get; set; } = TimeSpan.FromMinutes(15);
+        public TimeSpan? InvoiceExpiration { get; set; }
 
         [JsonConverter(typeof(TimeSpanJsonConverter.Seconds))]
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-        public TimeSpan DisplayExpirationTimer { get; set; } = TimeSpan.FromMinutes(5);
+        public TimeSpan? DisplayExpirationTimer { get; set; }
 
         [JsonConverter(typeof(TimeSpanJsonConverter.Days))]
         [JsonProperty("refundBOLT11Expiration", NullValueHandling = NullValueHandling.Ignore)]
-        public TimeSpan RefundBOLT11Expiration { get; set; } = TimeSpan.FromDays(30);
+        public TimeSpan? RefundBOLT11Expiration { get; set; }
 
         [JsonConverter(typeof(TimeSpanJsonConverter.Seconds))]
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-        public TimeSpan MonitoringExpiration { get; set; } = TimeSpan.FromMinutes(60);
+        public TimeSpan? MonitoringExpiration { get; set; }
 
         [JsonConverter(typeof(StringEnumConverter))]
-        public SpeedPolicy SpeedPolicy { get; set; }
+        public SpeedPolicy? SpeedPolicy { get; set; }
         public string LightningDescriptionTemplate { get; set; }
-        public double PaymentTolerance { get; set; } = 0;
-        public bool AnyoneCanCreateInvoice { get; set; }
+        public double? PaymentTolerance { get; set; }
+        public bool? AnyoneCanCreateInvoice { get; set; }
         public string DefaultCurrency { get; set; }
 
-        public bool LightningAmountInSatoshi { get; set; }
-        public bool LightningPrivateRouteHints { get; set; }
-        public bool OnChainWithLnInvoiceFallback { get; set; }
-        public bool LazyPaymentMethods { get; set; }
-        public bool RedirectAutomatically { get; set; }
+        public bool? LightningAmountInSatoshi { get; set; }
+        public bool? LightningPrivateRouteHints { get; set; }
+        public bool? OnChainWithLnInvoiceFallback { get; set; }
+        public bool? LazyPaymentMethods { get; set; }
+        public bool? RedirectAutomatically { get; set; }
 
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-        public bool Archived { get; set; }
+        public bool? Archived { get; set; }
 
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-        public bool ShowRecommendedFee { get; set; } = true;
+        public bool? ShowRecommendedFee { get; set; }
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-        public int RecommendedFeeBlockTarget { get; set; } = 1;
+        public int? RecommendedFeeBlockTarget { get; set; }
 
         public string DefaultPaymentMethod { get; set; }
 
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-        public string DefaultLang { get; set; } = "en";
+        public string DefaultLang { get; set; }
 
         public string HtmlTitle { get; set; }
 
         [JsonConverter(typeof(StringEnumConverter))]
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-        public NetworkFeeMode NetworkFeeMode { get; set; } = NetworkFeeMode.Never;
+        public NetworkFeeMode? NetworkFeeMode { get; set; }
 
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public List<PaymentMethodCriteriaData> PaymentMethodCriteria { get; set; }
 
-        public bool PayJoinEnabled { get; set; }
+        public bool? PayJoinEnabled { get; set; }
 
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public bool? AutoDetectLanguage { get; set; }

--- a/BTCPayServer.Data/Migrations/20250501000000_storetemplate.cs
+++ b/BTCPayServer.Data/Migrations/20250501000000_storetemplate.cs
@@ -1,0 +1,45 @@
+﻿using BTCPayServer.Data;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace BTCPayServer.Migrations
+{
+    [DbContext(typeof(ApplicationDbContext))]
+    [Migration("20250501000000_storetemplate")]
+    public partial class storetemplate : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            // This migrates the old `Default Currency` settings from Server Settings to a Default Store Template.
+            migrationBuilder.Sql(
+                """
+                UPDATE "Settings"
+                SET "Value" =
+                    jsonb_set(
+                        -- remove "DefaultCurrency", create a template
+                        ("Value" - 'DefaultCurrency') || '{"DefaultStoreTemplate":{"blob":{}}}'::JSONB,
+                        -- path to insert the new nested value
+                        '{DefaultStoreTemplate,blob,defaultCurrency}',
+                        -- extract the old value of "DefaultCurrency"
+                        to_jsonb("Value"->'DefaultCurrency'),
+                        true
+                    )
+                WHERE "Id" = 'BTCPayServer.Services.PoliciesSettings'
+                  AND "Value" ? 'DefaultCurrency' AND "Value"->>'DefaultCurrency' != 'USD';
+
+                UPDATE "Settings"
+                SET "Value" = "Value" - 'DefaultCurrency'
+                WHERE "Id" = 'BTCPayServer.Services.PoliciesSettings'
+                  AND "Value" ? 'DefaultCurrency';
+                """);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+        }
+    }
+}

--- a/BTCPayServer.Rating/RateSourceInfo.cs
+++ b/BTCPayServer.Rating/RateSourceInfo.cs
@@ -5,4 +5,4 @@ public enum RateSource
     Coingecko,
     Direct
 }
-public record RateSourceInfo(string Id, string DisplayName, string Url, RateSource Source = RateSource.Direct);
+public record RateSourceInfo(string? Id, string DisplayName, string Url, RateSource Source = RateSource.Direct);

--- a/BTCPayServer.Tests/PlaywrightTests.cs
+++ b/BTCPayServer.Tests/PlaywrightTests.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
 using BTCPayServer.Abstractions.Models;
+using BTCPayServer.Client.Models;
 using BTCPayServer.Data;
 using BTCPayServer.Services;
 using BTCPayServer.Services.Invoices;
@@ -12,6 +13,7 @@ using BTCPayServer.Views.Stores;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.Playwright;
 using NBitcoin;
+using Newtonsoft.Json.Linq;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -37,7 +39,6 @@ namespace BTCPayServer.Tests
             await s.Page.Locator("a:has-text('.log')").First.ClickAsync();
             Assert.Contains("Starting listening NBXplorer", await s.Page.ContentAsync());
         }
-
 
         [Fact]
         public async Task CanUseForms()
@@ -488,6 +489,92 @@ namespace BTCPayServer.Tests
             await s.FindAlertMessage(partialText: "Email server password reset");
             Assert.DoesNotContain("Configured", await s.Page.ContentAsync());
             Assert.Contains("test_fix", await s.Page.ContentAsync());
+        }
+
+        [Fact]
+        public async Task CanUseStoreTemplate()
+        {
+            await using var s = CreatePlaywrightTester(newDb: true);
+            await s.StartAsync();
+            await s.RegisterNewUser(true);
+            await s.CreateNewStore(preferredExchange: "Kraken");
+            var client = await s.AsTestAccount().CreateClient();
+            await client.UpdateStore(s.StoreId, new UpdateStoreRequest()
+            {
+                Name = "Can Use Store?",
+                Website = "https://test.com/",
+                CelebratePayment = false,
+                DefaultLang = "fr-FR",
+                NetworkFeeMode = NetworkFeeMode.MultiplePaymentsOnly,
+                ShowStoreHeader = false
+            });
+            await s.GoToServer();
+            await s.Page.ClickAsync("#SetTemplate");
+            await s.FindAlertMessage();
+
+            var newStore = await client.CreateStore(new ());
+            Assert.Equal("Can Use Store?", newStore.Name);
+            Assert.Equal("https://test.com/", newStore.Website);
+            Assert.False(newStore.CelebratePayment);
+            Assert.Equal("fr-FR", newStore.DefaultLang);
+            Assert.Equal(NetworkFeeMode.MultiplePaymentsOnly, newStore.NetworkFeeMode);
+            Assert.False(newStore.ShowStoreHeader);
+
+            newStore = await client.CreateStore(new (){ Name = "Yes you can also customize"});
+            Assert.Equal("Yes you can also customize", newStore.Name);
+            Assert.Equal("https://test.com/", newStore.Website);
+            Assert.False(newStore.CelebratePayment);
+            Assert.Equal("fr-FR", newStore.DefaultLang);
+            Assert.Equal(NetworkFeeMode.MultiplePaymentsOnly, newStore.NetworkFeeMode);
+            Assert.False(newStore.ShowStoreHeader);
+
+            await s.GoToUrl("/stores/create");
+            Assert.Equal("Can Use Store?" ,await s.Page.InputValueAsync("#Name"));
+            await s.Page.FillAsync("#Name", "Just changed it!");
+            await s.Page.ClickAsync("#Create");
+            await s.Page.ClickAsync("#StoreNav-General");
+            var newStoreId = await s.Page.InputValueAsync("#Id");
+            Assert.NotEqual(newStoreId, s.StoreId);
+
+            newStore = await client.GetStore(newStoreId);
+            Assert.Equal("Just changed it!", newStore.Name);
+            Assert.Equal("https://test.com/", newStore.Website);
+            Assert.False(newStore.CelebratePayment);
+            Assert.Equal("fr-FR", newStore.DefaultLang);
+            Assert.Equal(NetworkFeeMode.MultiplePaymentsOnly, newStore.NetworkFeeMode);
+            Assert.False(newStore.ShowStoreHeader);
+
+            await s.GoToServer();
+            await s.Page.ClickAsync("#ResetTemplate");
+            await s.FindAlertMessage(partialText: "Store template successfully unset");
+
+            await s.GoToUrl("/stores/create");
+            Assert.Equal("" ,await s.Page.InputValueAsync("#Name"));
+
+            newStore = await client.CreateStore(new (){ Name = "Test"});
+            Assert.Equal(TimeSpan.FromDays(30), newStore.RefundBOLT11Expiration);
+            Assert.Equal(TimeSpan.FromDays(1), newStore.MonitoringExpiration);
+            Assert.Equal(TimeSpan.FromMinutes(5), newStore.DisplayExpirationTimer);
+            Assert.Equal(TimeSpan.FromMinutes(15), newStore.InvoiceExpiration);
+
+            // What happens if the default template doesn't have all the fields?
+            var settings = s.Server.PayTester.GetService<SettingsRepository>();
+            var policies = await settings.GetSettingAsync<PoliciesSettings>() ?? new();
+            policies.DefaultStoreTemplate = new JObject()
+            {
+                ["blob"] = new JObject()
+                {
+                    ["defaultCurrency"] = "AAA"
+                }
+            };
+            await settings.UpdateSetting(policies);
+
+            newStore = await client.CreateStore(new (){ Name = "Test2"});
+            Assert.Equal("AAA", newStore.DefaultCurrency);
+            Assert.Equal(TimeSpan.FromDays(30), newStore.RefundBOLT11Expiration);
+            Assert.Equal(TimeSpan.FromDays(1), newStore.MonitoringExpiration);
+            Assert.Equal(TimeSpan.FromMinutes(5), newStore.DisplayExpirationTimer);
+            Assert.Equal(TimeSpan.FromMinutes(15), newStore.InvoiceExpiration);
         }
     }
 }

--- a/BTCPayServer.Tests/PlaywrightTests.cs
+++ b/BTCPayServer.Tests/PlaywrightTests.cs
@@ -564,13 +564,14 @@ namespace BTCPayServer.Tests
             {
                 ["blob"] = new JObject()
                 {
-                    ["defaultCurrency"] = "AAA"
+                    ["defaultCurrency"] = "AAA",
+                    ["defaultLang"] = "de-DE"
                 }
             };
             await settings.UpdateSetting(policies);
-
-            newStore = await client.CreateStore(new (){ Name = "Test2"});
+            newStore = await client.CreateStore(new() { Name = "Test2"});
             Assert.Equal("AAA", newStore.DefaultCurrency);
+            Assert.Equal("de-DE", newStore.DefaultLang);
             Assert.Equal(TimeSpan.FromDays(30), newStore.RefundBOLT11Expiration);
             Assert.Equal(TimeSpan.FromDays(1), newStore.MonitoringExpiration);
             Assert.Equal(TimeSpan.FromMinutes(5), newStore.DisplayExpirationTimer);

--- a/BTCPayServer.Tests/UnitTest1.cs
+++ b/BTCPayServer.Tests/UnitTest1.cs
@@ -1449,7 +1449,8 @@ namespace BTCPayServer.Tests
 
                 var script = await tester.Page.InputValueAsync($"#{source}_Script");
                 var defaultScript = await tester.Page.GetAttributeAsync($"#{source}_DefaultScript", "data-defaultScript");
-                Assert.Equal(script, defaultScript);
+                Assert.Contains("X_JPY = bitbank(X_JPY);", defaultScript);
+                Assert.Contains("X_TRY = btcturk(X_TRY);", defaultScript);
 
                 await Test("BTC_JPY");
                 rules = await tester.Page.Locator(".testresult .testresult_rule").AllAsync();

--- a/BTCPayServer/Controllers/UIServerController.cs
+++ b/BTCPayServer/Controllers/UIServerController.cs
@@ -374,7 +374,7 @@ namespace BTCPayServer.Controllers
                 else
                 {
                     await _StoreRepository.SetDefaultStoreTemplate(storeId, GetUserId());
-                    this.TempData.SetStatusSuccess(StringLocalizer["Store template created from this store"]);
+                    this.TempData.SetStatusSuccess(StringLocalizer["Store template created from store '{0}'. New stores will inherit these settings.", HttpContext.GetStoreData().StoreName]);
                 }
                 return RedirectToAction(nameof(Policies));
             }

--- a/BTCPayServer/Controllers/UIServerController.cs
+++ b/BTCPayServer/Controllers/UIServerController.cs
@@ -178,7 +178,7 @@ namespace BTCPayServer.Controllers
             }
             if (!ModelState.IsValid)
                 return View(vm);
-            
+
             if (command == "changedomain")
             {
                 if (string.IsNullOrWhiteSpace(vm.DNSDomain))
@@ -351,6 +351,34 @@ namespace BTCPayServer.Controllers
         {
             await UpdateViewBag();
 
+            if (command == "ResetTemplate")
+            {
+                ModelState.Clear();
+                await _StoreRepository.SetDefaultStoreTemplate(null);
+                this.TempData.SetStatusSuccess(StringLocalizer["Store template successfully unset"]);
+                return RedirectToAction(nameof(Policies));
+            }
+
+            if (command == "SetTemplate")
+            {
+                ModelState.Clear();
+                var storeId = this.HttpContext.GetStoreData()?.Id;
+                if (storeId is null)
+                {
+                    this.TempData.SetStatusMessageModel(new()
+                    {
+                        Severity = StatusMessageModel.StatusSeverity.Error,
+                        Message = StringLocalizer["You need to select a store first"]
+                    });
+                }
+                else
+                {
+                    await _StoreRepository.SetDefaultStoreTemplate(storeId, GetUserId());
+                    this.TempData.SetStatusSuccess(StringLocalizer["Store template created from this store"]);
+                }
+                return RedirectToAction(nameof(Policies));
+            }
+
             if (command == "add-domain")
             {
                 ModelState.Clear();
@@ -398,7 +426,7 @@ namespace BTCPayServer.Controllers
                     domainToAppMappingItem.AppType = apps[domainToAppMappingItem.AppId];
                 }
             }
-            
+
 
             await _SettingsRepository.UpdateSetting(settings);
             _ = _transactionLinkProviders.RefreshTransactionLinkTemplates();
@@ -1044,7 +1072,7 @@ namespace BTCPayServer.Controllers
         {
             var server = await _SettingsRepository.GetSettingAsync<ServerSettings>() ?? new ServerSettings();
             var theme = await _SettingsRepository.GetSettingAsync<ThemeSettings>() ?? new ThemeSettings();
-            
+
             var vm = new BrandingViewModel
             {
                 ServerName = server.ServerName,
@@ -1073,13 +1101,13 @@ namespace BTCPayServer.Controllers
 
             vm.LogoUrl = await _uriResolver.Resolve(this.Request.GetAbsoluteRootUri(), theme.LogoUrl);
             vm.CustomThemeCssUrl = await _uriResolver.Resolve(this.Request.GetAbsoluteRootUri(), theme.CustomThemeCssUrl);
-            
+
             if (server.ServerName != vm.ServerName)
             {
                 server.ServerName = vm.ServerName;
                 settingsChanged = true;
             }
-            
+
             if (server.ContactUrl != vm.ContactUrl)
             {
                 server.ContactUrl = !string.IsNullOrWhiteSpace(vm.ContactUrl)
@@ -1087,7 +1115,7 @@ namespace BTCPayServer.Controllers
                     : null;
                 settingsChanged = true;
             }
-            
+
             if (settingsChanged)
             {
                 await _SettingsRepository.UpdateSetting(server);
@@ -1255,7 +1283,7 @@ namespace BTCPayServer.Controllers
                 TempData[WellKnownTempData.SuccessMessage] = StringLocalizer["Email server password reset"].Value;
                 return RedirectToAction(nameof(Emails));
             }
-            
+
             // save if user provided valid email; this will also clear settings if no model.Settings.From
             if (model.Settings.From is not null && !MailboxAddressValidator.IsMailboxAddress(model.Settings.From))
             {
@@ -1265,7 +1293,7 @@ namespace BTCPayServer.Controllers
             var oldSettings = await _emailSenderFactory.GetSettings() ?? new EmailSettings();
             if (!string.IsNullOrEmpty(oldSettings.Password))
                 model.Settings.Password = oldSettings.Password;
-            
+
             await _SettingsRepository.UpdateSetting(model.Settings);
             TempData[WellKnownTempData.SuccessMessage] = StringLocalizer["Email settings saved"].Value;
             return RedirectToAction(nameof(Emails));

--- a/BTCPayServer/Controllers/UIUserStoresController.cs
+++ b/BTCPayServer/Controllers/UIUserStoresController.cs
@@ -24,7 +24,6 @@ namespace BTCPayServer.Controllers
     {
         private readonly StoreRepository _repo;
         private readonly IStringLocalizer StringLocalizer;
-        private readonly SettingsRepository _settingsRepository;
         private readonly UserManager<ApplicationUser> _userManager;
         private readonly DefaultRulesCollection _defaultRules;
         private readonly RateFetcher _rateFactory;
@@ -35,15 +34,13 @@ namespace BTCPayServer.Controllers
 			DefaultRulesCollection defaultRules,
             StoreRepository storeRepository,
             IStringLocalizer stringLocalizer,
-            RateFetcher rateFactory,
-            SettingsRepository settingsRepository)
+            RateFetcher rateFactory)
         {
             _repo = storeRepository;
             StringLocalizer = stringLocalizer;
             _userManager = userManager;
             _defaultRules = defaultRules;
             _rateFactory = rateFactory;
-            _settingsRepository = settingsRepository;
         }
 
         [HttpGet]
@@ -79,6 +76,7 @@ namespace BTCPayServer.Controllers
                 IsFirstStore = !(stores.Any() || skipWizard),
                 DefaultCurrency = blob.DefaultCurrency,
                 Exchanges = GetExchangesSelectList(blob.DefaultCurrency, null),
+                CanEditPreferredExchange = blob.GetRateSettings(false)?.RateScripting is not true,
                 PreferredExchange = blob.GetRateSettings(false)?.PreferredExchange
             };
 

--- a/BTCPayServer/Controllers/UIUserStoresController.cs
+++ b/BTCPayServer/Controllers/UIUserStoresController.cs
@@ -94,7 +94,7 @@ namespace BTCPayServer.Controllers
                 var stores = await _repo.GetStoresByUserId(GetUserId());
                 vm.IsFirstStore = !stores.Any();
                 var template = await _repo.GetDefaultStoreTemplate();
-                var defaultCurrency = template?.GetStoreBlob()?.DefaultCurrency ?? StoreBlob.StandardDefaultCurrency;
+                var defaultCurrency = template.GetStoreBlob().DefaultCurrency ?? StoreBlob.StandardDefaultCurrency;
                 vm.Exchanges = GetExchangesSelectList(defaultCurrency, null);
                 return View(vm);
             }

--- a/BTCPayServer/Data/StoreDataExtensions.cs
+++ b/BTCPayServer/Data/StoreDataExtensions.cs
@@ -45,8 +45,6 @@ namespace BTCPayServer.Data
         {
             storeData.DefaultCrypto = defaultPaymentId?.ToString();
         }
-#pragma warning restore CS0618
-
 
         public static StoreBlob GetStoreBlob(this StoreData storeData)
         {
@@ -57,7 +55,7 @@ namespace BTCPayServer.Data
             result.PaymentMethodCriteria.RemoveAll(criteria => criteria?.PaymentMethod is null);
             return result;
         }
-
+#pragma warning restore CS0618
         public static bool AnyPaymentMethodAvailable(this StoreData storeData, PaymentMethodHandlerDictionary handlers)
         {
             return storeData.GetPaymentMethodConfigs(handlers, true).Any();

--- a/BTCPayServer/Models/StoreViewModels/CreateStoreViewModel.cs
+++ b/BTCPayServer/Models/StoreViewModels/CreateStoreViewModel.cs
@@ -6,7 +6,7 @@ namespace BTCPayServer.Models.StoreViewModels
     public class CreateStoreViewModel
     {
         public bool IsFirstStore { get; set; }
-        
+
         [Required]
         [MaxLength(50)]
         [MinLength(1)]
@@ -22,5 +22,6 @@ namespace BTCPayServer.Models.StoreViewModels
         public string PreferredExchange { get; set; }
 
         public SelectList Exchanges { get; set; }
+        public bool CanEditPreferredExchange { get; set; }
     }
 }

--- a/BTCPayServer/Models/StoreViewModels/RatesViewModel.cs
+++ b/BTCPayServer/Models/StoreViewModels/RatesViewModel.cs
@@ -11,18 +11,23 @@ namespace BTCPayServer.Models.StoreViewModels
         public class Source
         {
             public bool ShowScripting { get; set; }
+
             [Display(Name = "Rate Rules")]
             [MaxLength(2000)]
             public string Script { get; set; }
+
             public string DefaultScript { get; set; }
+
             [Display(Name = "Preferred Price Source")]
             public string PreferredExchange { get; set; }
+
             public SelectList Exchanges { get; set; }
             public string RateSource { get; set; }
             public string PreferredResolvedExchange { get; set; }
             public bool IsFallback { get; set; }
             public ConfirmModel ScriptingConfirm { get; set; }
         }
+
         public class TestResultViewModel
         {
             public string CurrencyPair { get; set; }
@@ -35,8 +40,9 @@ namespace BTCPayServer.Models.StoreViewModels
 
         public Source PrimarySource { get; set; }
         public Source FallbackSource { get; set; }
+
         [Display(Name = "Enable fallback rates")]
-        public bool HasFallback {get; set; }
+        public bool HasFallback { get; set; }
 
         public string ScriptTest { get; set; }
         public string DefaultCurrencyPairs { get; set; }
@@ -45,6 +51,7 @@ namespace BTCPayServer.Models.StoreViewModels
         [Display(Name = "Add Exchange Rate Spread")]
         [Range(0.0, 100.0)]
         public double Spread { get; set; }
+
         public IEnumerable<RateSourceInfo> AvailableExchanges { get; set; }
     }
 }

--- a/BTCPayServer/Services/PoliciesSettings.cs
+++ b/BTCPayServer/Services/PoliciesSettings.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
+using BTCPayServer.Data;
 using BTCPayServer.JsonConverters;
 using BTCPayServer.Payments;
 using BTCPayServer.Validation;
@@ -17,7 +18,7 @@ namespace BTCPayServer.Services
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.Populate)]
         [Display(Name = "Disable public user registration")]
         public bool LockSubscription { get; set; }
-        
+
         [JsonIgnore]
         [Display(Name = "Enable public user registration")]
         public bool EnableRegistration
@@ -38,7 +39,7 @@ namespace BTCPayServer.Services
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.Populate)]
         [Display(Name = "Discourage search engines from indexing this site")]
         public bool DiscourageSearchEngines { get; set; }
-        
+
         [JsonIgnore]
         [Display(Name = "Search engines can index this site")]
         public bool AllowSearchEngines
@@ -63,10 +64,10 @@ namespace BTCPayServer.Services
 
         [Display(Name = "Disable stores from using the server's email settings as backup")]
         public bool DisableStoresToUseServerEmailSettings { get; set; }
-        
+
         [Display(Name = "Non-admins cannot access the User Creation API Endpoint")]
         public bool DisableNonAdminCreateUserApi { get; set; }
-        
+
         [JsonIgnore]
         [Display(Name = "Non-admins can access the User Creation API Endpoint")]
         public bool EnableNonAdminCreateUserApi
@@ -82,8 +83,6 @@ namespace BTCPayServer.Services
 
         [Display(Name = "Show plugins in pre-release")]
         public bool PluginPreReleases { get; set; }
-        [Display(Name = "Select the Default Currency during Store Creation")]
-        public string DefaultCurrency { get; set; }
 
         public bool DisableSSHService { get; set; }
 
@@ -97,9 +96,12 @@ namespace BTCPayServer.Services
         public List<DomainToAppMappingItem> DomainToAppMapping { get; set; } = new List<DomainToAppMappingItem>();
         [Display(Name = "Enable experimental features")]
         public bool Experimental { get; set; }
-        
+
         [Display(Name = "Default role for users on a new store")]
         public string DefaultRole { get; set; }
+
+        [Display(Name = "Default store template")]
+        public JObject DefaultStoreTemplate { get; set; }
 
         public class BlockExplorerOverrideItem
         {

--- a/BTCPayServer/Views/UIServer/Policies.cshtml
+++ b/BTCPayServer/Views/UIServer/Policies.cshtml
@@ -89,7 +89,7 @@
                         </div>
                     </div>
                 </div>
-                
+
                 <div class="mb-5">
                     <h4 class="mb-3" text-translate="true">Users</h4>
                     <div class="d-flex my-3">
@@ -173,7 +173,7 @@
                             </div>
                         </div>
                     }
-                    @* 
+                    @*
 					    Let's uncomment this when we have new experimental features.
 					    <div class="d-flex align-items-center my-3">
                         <input asp-for="Experimental" type="checkbox" class="btcpay-toggle me-3" />
@@ -202,8 +202,22 @@
 
                 <h4 class="mt-5" text-translate="true">Customization</h4>
                 <div class="form-group mb-3">
-                    <label asp-for="DefaultCurrency" class="form-label"></label>
-                    <input asp-for="DefaultCurrency" placeholder="@StoreBlob.StandardDefaultCurrency" class="form-control" currency-selection />
+                    <label asp-for="DefaultStoreTemplate" class="form-label"></label>
+                    @if (Model.DefaultStoreTemplate is null)
+                    {
+                        <div class="input-group">
+                            <input value="@StringLocalizer["Not configured"]" type="text" readonly class="form-control"/>
+                            <button type="submit" class="btn btn-primary" name="command" value="SetTemplate" id="SetTemplate" text-translate="true">Create template from selected store</button>
+                        </div>
+                    }
+                    else
+                    {
+                        <div class="input-group">
+                            <input value="@StringLocalizer["Configured"]" type="text" readonly class="form-control"/>
+                            <button type="submit" class="btn btn-primary" name="command" value="SetTemplate" id="SetTemplate" text-translate="true">Replace template from selected store</button>
+                            <button type="submit" class="btn btn-danger" name="command" value="ResetTemplate" id="ResetTemplate" text-translate="true">Remove store template</button>
+                        </div>
+                    }
                 </div>
                 <div class="form-group mb-5">
                     <label asp-for="RootAppId" class="form-label"></label>
@@ -290,7 +304,7 @@
         for (let element of document.getElementsByClassName("collapse-on-js")){
             if (element.classList.contains("show")){
                 element.classList.remove("show");
-            }    
+            }
         }
     </script>
 }

--- a/BTCPayServer/Views/UIServer/Policies.cshtml
+++ b/BTCPayServer/Views/UIServer/Policies.cshtml
@@ -218,6 +218,7 @@
                             <button type="submit" class="btn btn-danger" name="command" value="ResetTemplate" id="ResetTemplate" text-translate="true">Remove store template</button>
                         </div>
                     }
+                    <div class="form-text" text-translate="true">The store template sets defaults for all new stores. It includes rates settings, default invoice settings, checkout display settings but excludes sensitive data like access tokens, payment method settings, webhooks.</div>
                 </div>
                 <div class="form-group mb-5">
                     <label asp-for="RootAppId" class="form-label"></label>

--- a/BTCPayServer/Views/UIUserStores/_CreateStoreForm.cshtml
+++ b/BTCPayServer/Views/UIUserStores/_CreateStoreForm.cshtml
@@ -1,6 +1,7 @@
 @model BTCPayServer.Models.StoreViewModels.CreateStoreViewModel
 
 <form asp-action="CreateStore">
+    <input type="hidden" asp-for="CanEditPreferredExchange"/>
     @if (!ViewContext.ModelState.IsValid)
     {
         <div asp-validation-summary="ModelOnly"></div>
@@ -15,13 +16,16 @@
         <input asp-for="DefaultCurrency" class="form-control w-300px" currency-selection />
         <span asp-validation-for="DefaultCurrency" class="text-danger"></span>
     </div>
-    <div class="form-group">
-        <label asp-for="PreferredExchange" class="form-label" data-required></label>
-        <select asp-for="PreferredExchange" asp-items="Model.Exchanges" class="form-select w-300px"></select>
-        <div class="form-text mt-2 only-for-js" text-translate="true">The recommended price source gets chosen based on the default currency.</div>
-        <span asp-validation-for="PreferredExchange" class="text-danger"></span>
-    </div>
+    @if (Model.CanEditPreferredExchange)
+    {
+        <div class="form-group">
+            <label asp-for="PreferredExchange" class="form-label" data-required></label>
+            <select asp-for="PreferredExchange" asp-items="Model.Exchanges" class="form-select w-300px"></select>
+            <div class="form-text mt-2 only-for-js" text-translate="true">The recommended price source gets chosen based on the default currency.</div>
+            <span asp-validation-for="PreferredExchange" class="text-danger"></span>
+        </div>
+    }
     <div class="form-group mt-4">
-		<input type="submit" value="Create Store" class="btn btn-primary @(Model.IsFirstStore ? "w-100" : null)" id="Create" />
+        <input type="submit" value="Create Store" class="btn btn-primary @(Model.IsFirstStore ? "w-100" : null)" id="Create" />
     </div>
 </form>

--- a/BTCPayServer/wwwroot/swagger/v1/swagger.template.stores.json
+++ b/BTCPayServer/wwwroot/swagger/v1/swagger.template.stores.json
@@ -45,7 +45,7 @@
                     "Stores"
                 ],
                 "summary": "Create a new store",
-                "description": "Create a new store",
+                "description": "Create a new store (default values can be different if the server settings use a default store template)",
                 "requestBody": {
                     "x-name": "request",
                     "content": {
@@ -143,7 +143,7 @@
                         "$ref": "#/components/parameters/StoreId"
                     }
                 ],
-                "description": "Update the specified store",
+                "description": "Update the specified store (default values can be different if the server settings use a default store template)",
                 "requestBody": {
                     "x-name": "request",
                     "content": {
@@ -541,7 +541,7 @@
                         ]
                     },
                     "monitoringExpiration": {
-                        "default": 3600,
+                        "default": 86400,
                         "minimum": 600,
                         "maximum": 2073600,
                         "description": "The time after which an invoice which has been paid but not confirmed will be considered invalid. The value will be rounded down to a minute.",


### PR DESCRIPTION
## Motivation

Ambassadors who onboard local merchants often want new stores to be preconfigured based on local conditions—for example, with their preferred exchange, language, currency, timezone, retail mode, etc.

This PR introduces the ability to define a **default template store** in the `Server Settings`. When a new store is created, its default settings are set from this template instead of the usual USD-centric defaults.

## UX

First, the ambassador sets up a **model store** in BTCPay Server with the desired default settings, including checkout experience and rate sources.

Then, the ambassador makes sure the store is selected in the top left dropdown.

![image](https://github.com/user-attachments/assets/c6596b12-7e05-447d-bf90-fa102e0decad)

Then, under `Server Settings`, they click `Create template from selected store`:

![image](https://github.com/user-attachments/assets/a05efdd6-ec1b-4b16-b974-fd6832c5fbb4)


This action creates a template based on the selected store’s settings. Future stores will use this template as their default configuration.

Once set, the ambassador has the option to either reset it, or replace it:

![image](https://github.com/user-attachments/assets/e70a5213-b33b-4a52-8e82-eb62e8f74ec9)

## Migration

Since the `Default Currency` settings isn't useful anymore, I removed it from the `Server Settings`.

Users who had a `Default Currency` in the server settings different from `USD` are migrated to a template with the same currency.

## Notes

Once the template is created, it becomes independent of the original model store. Any future changes to the model store will not affect the template.

A templates doesn't include any access token, webhooks, emails, payout processors, payment method settings, roles and users of the model store.

Related to https://github.com/btcpayserver/btcpayserver/discussions/2685

#2685 is discussing about removing completely the create store page. I think this is a good follow up in a future PR.
I am adding later an option `Automatically create store for new users` in `Server Settings`: If the default name is already set, there isn't anything to ask to the user for creating a new store.