### PR TITLE
BTCpayServerTester.WaitIsFullySynched should not wait only NBX

### DIFF
--- a/BTCPayServer.Tests/BTCPayServerTester.cs
+++ b/BTCPayServer.Tests/BTCPayServerTester.cs
@@ -8,6 +8,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using BTCPayServer.Abstractions.Constants;
+using BTCPayServer.Abstractions.Contracts;
 using BTCPayServer.Configuration;
 using BTCPayServer.HostedServices;
 using BTCPayServer.Hosting;
@@ -260,8 +261,8 @@ namespace BTCPayServer.Tests
 
         private async Task WaitIsFullySynched(CancellationToken cancellationToken)
         {
-            var dashBoard = GetService<NBXplorerDashboard>();
-            while (!dashBoard.IsFullySynched())
+            var o = GetService<IEnumerable<ISyncSummaryProvider>>().ToArray();
+            while (!o.All(d => d.AllAvailable()))
             {
                 await Task.Delay(10, cancellationToken).ConfigureAwait(false);
             }


### PR DESCRIPTION
Reported by @napoly 

@napoly had trouble running tests because the tester wasn't waiting for monero to be ready in the plugin's tests.

This PR makes sure we do not wait only NBXPlorer.