### PR TITLE
(Fix): Fiat text input disappears if you remove the BTC amount 

### DIFF
--- a/BTCPayServer/wwwroot/js/wallet/WalletSend.js
+++ b/BTCPayServer/wwwroot/js/wallet/WalletSend.js
@@ -11,12 +11,9 @@
         var fiatValue = $(element).parents(".input-group").first().find(".fiat-value")
         var fiatValueInput = fiatValue.find(".fiat-value-edit-input");
         var amountValue = parseFloat($(element).val());
+        fiatValue.show();
         if (!isNaN(amountValue)) {
-            fiatValue.show();
             fiatValueInput.val((rate * amountValue).toFixed(divisibility));
-        } else {
-            fiatValue.hide();
-            fiatValueInput.val("")
         }
     }
 }


### PR DESCRIPTION
Fixes: #6744 

![image](https://github.com/user-attachments/assets/f9b29b99-23ae-4653-8504-6e503e978c8e)
