### PR TITLE
Add ability to RBF a transaction with a single output

### DIFF
--- a/BTCPayServer.Tests/Extensions.cs
+++ b/BTCPayServer.Tests/Extensions.cs
@@ -170,12 +170,6 @@ retry:
             wait.Until(d => d.WaitForElement(By.CssSelector("#WalletTransactions[data-loaded='true']")));
         }
 
-        public static async Task WaitWalletTransactionsLoaded(this IPage page)
-        {
-            await page.WaitForLoadStateAsync(LoadState.NetworkIdle);
-            await page.Locator("#WalletTransactions[data-loaded='true']").WaitForAsync(new() { State = WaitForSelectorState.Visible });
-        }
-
         public static IWebElement WaitForElement(this IWebDriver driver, By selector)
         {
             var wait = new WebDriverWait(driver, SeleniumTester.ImplicitWait);

--- a/BTCPayServer.Tests/PlaywrightTester.cs
+++ b/BTCPayServer.Tests/PlaywrightTester.cs
@@ -474,6 +474,7 @@ namespace BTCPayServer.Tests
                     goto retry;
                 }
             }
+            await Server.ExplorerNode.GenerateAsync(1);
             await Page.ReloadAsync();
             await Page.Locator("#CancelWizard").ClickAsync();
             return addressStr;
@@ -540,6 +541,24 @@ namespace BTCPayServer.Tests
             Page = page;
             await page.BringToFrontAsync();
             return new SwitchDisposable(page, old, this, closeAfter);
+        }
+
+        public async Task<SendWalletPMO> GoToWalletSend(WalletId walletId = null)
+        {
+            await GoToWallet(walletId, navPages: WalletsNavPages.Send);
+            return new(Page);
+        }
+
+        public class SendWalletPMO(IPage page)
+        {
+            public Task FillAddress(BitcoinAddress address) => page.FillAsync("[name='Outputs[0].DestinationAddress']",
+                address.ToString());
+
+            public Task SweepBalance() => page.ClickAsync("#SweepBalance");
+
+            public Task Sign() => page.ClickAsync("#SignTransaction");
+
+            public Task SetFeeRate(decimal val) => page.FillAsync("[name=\"FeeSatoshiPerByte\"]", val.ToString(CultureInfo.InvariantCulture));
         }
     }
 }

--- a/BTCPayServer.Tests/WalletTests.cs
+++ b/BTCPayServer.Tests/WalletTests.cs
@@ -2,7 +2,6 @@
 using System.Linq;
 using System.Threading.Tasks;
 using BTCPayServer.Abstractions.Models;
-using BTCPayServer.Views.Wallets;
 using NBitcoin;
 using Xunit;
 using Xunit.Abstractions;
@@ -26,8 +25,8 @@ public class WalletTests(ITestOutputHelper helper) : UnitTestBase(helper)
         var txs = (await client.ShowOnChainWalletTransactions(s.StoreId, "BTC")).Select(t => t.TransactionHash).ToArray();
         Assert.Equal(3, txs.Length);
 
-        await s.GoToWallet(navPages: WalletsNavPages.Transactions);
-        await ClickBumpFee(s, txs[0]);
+        var w = await s.GoToWalletTransactions();
+        await w.BumpFee(txs[0]);
 
         // Because a single transaction is selected, we should be able to select CPFP only (Because no change are available, we can't do RBF)
         await s.Page.Locator("[name='txId']").WaitForAsync();
@@ -36,13 +35,13 @@ public class WalletTests(ITestOutputHelper helper) : UnitTestBase(helper)
         await s.ClickCancel();
 
         // Same but using mass action
-        await SelectTransactions(s, txs[0]);
+        await w.Select(txs[0]);
         await s.Page.ClickAsync("#BumpFee");
         await s.Page.Locator("[name='txId']").WaitForAsync();
         await s.ClickCancel();
 
         // Because two transactions are select we can only mass bump on CPFP
-        await SelectTransactions(s, txs[0], txs[1]);
+        await w.Select(txs[0], txs[1]);
         await s.Page.ClickAsync("#BumpFee");
         Assert.False(await s.Page.Locator("[name='txId']").IsVisibleAsync());
         Assert.Equal("disabled", await s.Page.GetAttributeAsync("#BumpMethod", "disabled"));
@@ -56,12 +55,12 @@ public class WalletTests(ITestOutputHelper helper) : UnitTestBase(helper)
 
         // The CPFP tag should be applied to the new tx
         var cpfpTx = (await client.ShowOnChainWalletTransactions(s.StoreId, "BTC")).Select(t => t.TransactionHash).ToArray()[0];
-        await AssertHasLabels(s, cpfpTx, "CPFP");
+        await w.AssertHasLabels(cpfpTx, "CPFP");
 
         // The CPFP should be RBF-able
         Assert.DoesNotContain(cpfpTx, txs);
 
-        await ClickBumpFee(s, cpfpTx);
+        await w.BumpFee(cpfpTx);
         Assert.Null(await s.Page.GetAttributeAsync("#BumpMethod", "disabled"));
         Assert.Equal("RBF", await s.Page.Locator("#BumpMethod option:checked").InnerTextAsync());
 
@@ -80,14 +79,13 @@ public class WalletTests(ITestOutputHelper helper) : UnitTestBase(helper)
         var rbfTx = (await client.ShowOnChainWalletTransactions(s.StoreId, "BTC")).Select(t => t.TransactionHash).ToArray()[0];
 
         // CPFP has been replaced, so it should not be found
-        Assert.False(await s.Page.Locator(TxRowSelector(cpfpTx)).IsVisibleAsync());
+        await w.AssertNotFound(cpfpTx);
 
         // However, the new transaction should have copied the CPFP tag from the transaction it replaced, and have a RBF label as well.
-        await AssertHasLabels(s, rbfTx, "CPFP");
-        await AssertHasLabels(s, rbfTx, "RBF");
+        await w.AssertHasLabels(rbfTx, "CPFP");
+        await w.AssertHasLabels(rbfTx, "RBF");
 
         // Now, we sweep all the UTXOs to a single destination. This should be RBF-able. (Fee deducted on the lone UTXO)
-        await s.GoToWallet(navPages: WalletsNavPages.Send);
         var send = await s.GoToWalletSend();
         await send.FillAddress(new Key().PubKey.GetAddress(ScriptPubKeyType.Legacy, Network.RegTest));
         await send.SweepBalance();
@@ -95,11 +93,11 @@ public class WalletTests(ITestOutputHelper helper) : UnitTestBase(helper)
         await send.Sign();
         await s.Page.ClickAsync("button[value=broadcast]");
         // Now we RBF the sweep
-        await ClickBumpFee(s);
+        await w.BumpFee();
         Assert.Equal("RBF", await s.Page.Locator("#BumpMethod").InnerTextAsync());
         await s.ClickPagePrimary();
         await s.Page.ClickAsync("#BroadcastTransaction");
-        await AssertHasLabels(s, "RBF");
+        await w.AssertHasLabels("RBF");
     }
 
     private async Task CreateInvoices(PlaywrightTester tester)
@@ -115,28 +113,6 @@ public class WalletTests(ITestOutputHelper helper) : UnitTestBase(helper)
         }
     }
 
-    private async Task AssertHasLabels(PlaywrightTester s, uint256 txId, string label)
-    {
-        await s.Page.ReloadAsync();
-        await s.Page.Locator($"{TxRowSelector(txId)} .transaction-label[data-value=\"{label}\"]").WaitForAsync();
-    }
-
-    private Task AssertHasLabels(PlaywrightTester s, string label) => AssertHasLabels(s, null, label);
-
-    static string TxRowSelector(uint256 txId) => txId is null ? ".transaction-row:first-of-type"  : $".transaction-row[data-value=\"{txId}\"]";
-
-    private async Task SelectTransactions(PlaywrightTester s, params uint256[] txs)
-    {
-        foreach (var txId in txs)
-        {
-            await s.Page.SetCheckedAsync($"{TxRowSelector(txId)} .mass-action-select", true);
-        }
-    }
-
-    private async Task ClickBumpFee(PlaywrightTester s, uint256 txId = null)
-    {
-        await s.Page.ClickAsync($"{TxRowSelector(txId)} .bumpFee-btn");
-    }
 
     [Fact]
     [Trait("Playwright", "Playwright")]
@@ -166,16 +142,18 @@ public class WalletTests(ITestOutputHelper helper) : UnitTestBase(helper)
         Assert.Contains($"/stores/{s.StoreId}/invoices", s.Page.Url);
         await s.FindAlertMessage(StatusMessageModel.StatusSeverity.Error, partialText: "No UTXOs available");
 
-        // But we should be able to bump from the wallet's page
-        await s.GoToWallet(navPages: WalletsNavPages.Transactions);
-        await s.Page.SetCheckedAsync(".mass-action-select-all", true);
-        await s.Page.ClickAsync("#BumpFee");
-        await s.ClickPagePrimary();
-        await s.Page.ClickAsync("#BroadcastTransaction");
-        Assert.Contains($"/wallets/{s.WalletId}", s.Page.Url);
-        await s.FindAlertMessage(partialText: "Transaction broadcasted successfully");
+        for (int i = 0; i < 5; i++)
+        {
+            var txs = await s.GoToWalletTransactions();
+            await txs.SelectAll();
+            await txs.BumpFeeSelected();
+            await s.ClickPagePrimary();
+            await s.Page.ClickAsync("#BroadcastTransaction");
+            Assert.Contains($"/wallets/{s.WalletId}", s.Page.Url);
+            await s.FindAlertMessage(partialText: "Transaction broadcasted successfully");
 
-        // The CPFP tag should be applied to the new tx
-        await AssertHasLabels(s, "CPFP");
+            // The CPFP tag should be applied to the new tx
+            await txs.AssertHasLabels("CPFP");
+        }
     }
 }

--- a/BTCPayServer/HostedServices/TransactionLabelMarkerHostedService.cs
+++ b/BTCPayServer/HostedServices/TransactionLabelMarkerHostedService.cs
@@ -92,24 +92,20 @@ namespace BTCPayServer.HostedServices
                             {
                                 if (transactionEvent.NewTransactionEvent.Replacing is not null)
                                 {
-
                                     foreach (var replaced in transactionEvent.NewTransactionEvent.Replacing)
                                     {
                                         var replacedwoId = new WalletObjectId(wid,
                                               WalletObjectData.Types.Tx, replaced.ToString());
                                         var replacedo = await _walletRepository.GetWalletObject(replacedwoId);
                                         var replacedLinks = replacedo?.GetLinks().Where(t => t.type != WalletObjectData.Types.Tx) ?? [];
-                                        if (replacedLinks.Count() != 0)
+                                        var rbf = new WalletObjectId(wid, WalletObjectData.Types.RBF, "");
+                                        var label = WalletRepository.CreateLabel(rbf);
+                                        newObjs.Add(label.ObjectData);
+                                        links.Add(WalletRepository.NewWalletObjectLinkData(txWalletObject, label.Id));
+                                        links.Add(WalletRepository.NewWalletObjectLinkData(txWalletObject, rbf, new JObject()
                                         {
-                                            var rbf = new WalletObjectId(wid, WalletObjectData.Types.RBF, "");
-                                            var label = WalletRepository.CreateLabel(rbf);
-                                            newObjs.Add(label.ObjectData);
-                                            links.Add(WalletRepository.NewWalletObjectLinkData(txWalletObject, label.Id));
-                                            links.Add(WalletRepository.NewWalletObjectLinkData(txWalletObject, rbf, new JObject()
-                                            {
-                                                ["txs"] = JArray.FromObject(new[] { replaced.ToString() })
-                                            }));
-                                        }
+                                            ["txs"] = JArray.FromObject(new[] { replaced.ToString() })
+                                        }));
                                         foreach (var link in replacedLinks)
                                         {
                                             links.Add(WalletRepository.NewWalletObjectLinkData(new WalletObjectId(walletObjectDatas.Key, link.type, link.id), txWalletObject, link.linkdata));

--- a/BTCPayServer/Payments/Bitcoin/NBXplorerListener.cs
+++ b/BTCPayServer/Payments/Bitcoin/NBXplorerListener.cs
@@ -155,10 +155,7 @@ namespace BTCPayServer.Payments.Bitcoin
                                 if (evt.DerivationStrategy != null)
                                 {
                                     wallet.InvalidateCache(evt.DerivationStrategy);
-                                    var validOutputs = network.GetValidOutputs(evt).ToList();
-                                    if (!validOutputs.Any())
-                                        break;
-                                    foreach (var output in validOutputs)
+                                    foreach (var output in network.GetValidOutputs(evt))
                                     {
                                         if (!output.matchedOutput.Value.IsCompatible(network))
                                             continue;

--- a/BTCPayServer/Services/Fees/NBxplorerFeeProvider.cs
+++ b/BTCPayServer/Services/Fees/NBxplorerFeeProvider.cs
@@ -10,7 +10,7 @@ namespace BTCPayServer.Services.Fees
     {
         public async Task<FeeRate> GetFeeRateAsync(int blockTarget = 20)
         {
-                return (await ExplorerClient.GetFeeRateAsync(blockTarget).ConfigureAwait(false)).FeeRate;
+            return (await ExplorerClient.GetFeeRateAsync(blockTarget).ConfigureAwait(false)).FeeRate;
         }
     }
 }

--- a/BTCPayServer/Views/UIWallets/WalletBumpFee.cshtml
+++ b/BTCPayServer/Views/UIWallets/WalletBumpFee.cshtml
@@ -67,18 +67,10 @@
 			<input type="hidden" asp-for="Outpoints[i]" />
 		}
 	}
-	@if (!ViewContext.ModelState.IsValid)
-	{
-		<ul class="text-danger">
-			@foreach (var errors in ViewData.ModelState.Where(pair => pair.Key == string.Empty && pair.Value.ValidationState == ModelValidationState.Invalid))
-			{
-				foreach (var error in errors.Value.Errors)
-				{
-					<li>@error.ErrorMessage</li>
-				}
-			}
-		</ul>
-	}
+    @if (!ViewContext.ModelState.IsValid)
+    {
+        <div asp-validation-summary="All"></div>
+    }
 	@if (Model.GetBumpTarget().GetSingleTransactionId() is { } txId)
 	{
 		<div class="list-group list-group-flush">

--- a/BTCPayServer/Views/UIWallets/WalletSend.cshtml
+++ b/BTCPayServer/Views/UIWallets/WalletSend.cshtml
@@ -127,7 +127,7 @@
                     </div>
                     <div class="form-text crypto-info">
                         <span text-translate="true">Your available balance is</span>
-                        <button type="button" class="crypto-balance-link btn btn-link p-0 align-baseline">@Model.CurrentBalance</button> <span>@Model.CryptoCode</span>.
+                        <button id="SweepBalance" type="button" class="crypto-balance-link btn btn-link p-0 align-baseline">@Model.CurrentBalance</button> <span>@Model.CryptoCode</span>.
                         @if (Model.ImmatureBalance > 0)
                         {
                             <span><br>@StringLocalizer["Note: {0} are still immature and require additional confirmations.", $"{Model.ImmatureBalance} {Model.CryptoCode}"]</span>
@@ -205,7 +205,7 @@
                     <input asp-for="AlwaysIncludeNonWitnessUTXO" class="btcpay-toggle me-3"/>
                     <label asp-for="AlwaysIncludeNonWitnessUTXO" class="form-check-label"></label>
                 </div>
-                
+
                 @if (!string.IsNullOrEmpty(Model.PayJoinBIP21))
                 {
                     <div class="d-flex mb-3">

--- a/btcpayserver.sln.DotSettings
+++ b/btcpayserver.sln.DotSettings
@@ -5,6 +5,7 @@
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=LNURL/@EntryIndexedValue">LNURL</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=NB/@EntryIndexedValue">NBX</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=NBXplorer/@EntryIndexedValue">NBXplorer</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=PMO/@EntryIndexedValue">PMO</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=POS/@EntryIndexedValue">POS</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=PSBT/@EntryIndexedValue">PSBT</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=SSH/@EntryIndexedValue">SSH</s:String>


### PR DESCRIPTION
This PR accomplish four things:

1. **Feature:** Enable RBF for single-output transactions (e.g., sweeping to an exchange without change).
2. **Fix:** Fee bumping wizard errors were not reliably displayed.
3. **Fix:** RBF label was inconsistently applied to replacement transactions.
4. **Fix:** Crash due to missing validation when effective fee rate was below the minimum threshold during RBF fee bump.