### PR TITLE
Add tip and subtotal to report

### DIFF
--- a/BTCPayServer/Services/Invoices/PosAppData.cs
+++ b/BTCPayServer/Services/Invoices/PosAppData.cs
@@ -19,6 +19,17 @@ public class PosAppData
         }
         return null;
     }
+    public static PosAppData TryParse(JObject posData)
+    {
+        try
+        {
+            return posData.ToObject<PosAppData>();
+        }
+        catch
+        {
+        }
+        return null;
+    }
 
     [JsonProperty(PropertyName = "cart")]
     public PosAppCartItem[] Cart { get; set; }

--- a/BTCPayServer/Services/Reporting/LegacyInvoiceExportReportProvider.cs
+++ b/BTCPayServer/Services/Reporting/LegacyInvoiceExportReportProvider.cs
@@ -49,6 +49,8 @@ public class LegacyInvoiceExportReportProvider : ReportProvider
                 new("InvoiceDue", "number"),
                 new("InvoicePrice", "number"),
                 new("InvoiceTaxIncluded", "number"),
+                new("InvoiceTip", "number"),
+                new("InvoiceSubtotal", "number"),
                 new("InvoiceItemCode", "text"),
                 new("InvoiceItemDesc", "text"),
                 new("InvoiceFullStatus", "text"),
@@ -93,6 +95,17 @@ public class LegacyInvoiceExportReportProvider : ReportProvider
                     data.Add(Math.Round(invoiceDue, currency.NumberDecimalDigits));
                     data.Add(invoiceEntity.Price);
                     data.Add(invoiceEntity.Metadata.TaxIncluded ?? 0.0m);
+                    if (invoiceEntity.Metadata.PosData != null &&
+                        PosAppData.TryParse(invoiceEntity.Metadata.PosData) is { } posData)
+                    {
+                        data.Add(posData.Tip);
+                        data.Add(posData.Subtotal);
+                    }
+                    else
+                    {
+                        data.Add(0m);
+                        data.Add(0m);
+                    }
                     data.Add(invoiceEntity.Metadata.ItemCode);
                     data.Add(invoiceEntity.Metadata.ItemDesc);
                     data.Add(invoiceEntity.GetInvoiceState().ToString());
@@ -128,6 +141,8 @@ public class LegacyInvoiceExportReportProvider : ReportProvider
                 data.Add(Math.Round(invoiceDue, currency.NumberDecimalDigits)); // InvoiceDue
                 data.Add(invoiceEntity.Price);
                 data.Add(invoiceEntity.Metadata.TaxIncluded ?? 0.0m);
+                data.Add(0m); // Tip
+                data.Add(0m); // Subtotal
                 data.Add(invoiceEntity.Metadata.ItemCode);
                 data.Add(invoiceEntity.Metadata.ItemDesc);
                 data.Add(invoiceEntity.GetInvoiceState().ToString());


### PR DESCRIPTION
Ping @rockstardev is it what you need?

I want to re-iterate something for people using the Legacy report:
** They should not just add up the `Invoice*` columns, because if an invoice has two payment, they will sum up twice the tip or tax. **

I know everybody like the legacy invoice export, but I am pretty sure everybody is using it incorrectly and are just summing columns that would be counted several time if an invoice has several payments.