### PR TITLE
Include payment method to get invoices api

### DIFF
--- a/BTCPayServer.Client/BTCPayServerClient.Invoices.cs
+++ b/BTCPayServer.Client/BTCPayServerClient.Invoices.cs
@@ -11,7 +11,7 @@ namespace BTCPayServer.Client;
 
 public partial class BTCPayServerClient
 {
-    public virtual async Task<IEnumerable<InvoiceData>> GetInvoices(string storeId, string[] orderId = null,
+    public virtual async Task<IEnumerable<InvoiceDataWithPaymentMethods>> GetInvoices(string storeId, string[] orderId = null,
         InvoiceStatus[] status = null,
         DateTimeOffset? startDate = null,
         DateTimeOffset? endDate = null,
@@ -37,7 +37,7 @@ public partial class BTCPayServerClient
         if (take != null)
             queryPayload.Add(nameof(take), take);
 
-        return await SendHttpRequest<IEnumerable<InvoiceData>>($"api/v1/stores/{storeId}/invoices", queryPayload, HttpMethod.Get, token);
+        return await SendHttpRequest<IEnumerable<InvoiceDataWithPaymentMethods>>($"api/v1/stores/{storeId}/invoices", queryPayload, HttpMethod.Get, token);
     }
 
     public virtual async Task<InvoiceData> GetInvoice(string storeId, string invoiceId,

--- a/BTCPayServer.Client/Models/InvoiceData.cs
+++ b/BTCPayServer.Client/Models/InvoiceData.cs
@@ -110,6 +110,12 @@ namespace BTCPayServer.Client.Models
         public InvoiceStatus[] AvailableStatusesForManualMarking { get; set; }
         public bool Archived { get; set; }
     }
+
+    public class InvoiceDataWithPaymentMethods : InvoiceData
+    {
+        public InvoicePaymentMethodDataModel[] PaymentMethods { get; set; }
+    }
+
     public enum InvoiceStatus
     {
         New,

--- a/BTCPayServer.Tests/GreenfieldAPITests.cs
+++ b/BTCPayServer.Tests/GreenfieldAPITests.cs
@@ -2569,11 +2569,13 @@ namespace BTCPayServer.Tests
 
             Assert.NotNull(invoices);
             Assert.Single(invoices);
+            Assert.NotNull(invoices.First().PaymentMethods);
             Assert.Equal(newInvoice.Id, invoices.First().Id);
 
             invoices = await viewOnly.GetInvoices(user.StoreId, textSearch: "Banana");
             Assert.NotNull(invoices);
             Assert.Single(invoices);
+            Assert.NotNull(invoices.First().PaymentMethods);
             Assert.Equal(newInvoice.Id, invoices.First().Id);
 
             invoices = await viewOnly.GetInvoices(user.StoreId, textSearch: "apples");
@@ -2586,6 +2588,7 @@ namespace BTCPayServer.Tests
                 endDate: DateTimeOffset.Now.AddHours(1));
 
             Assert.NotNull(invoicesFiltered);
+            Assert.NotNull(invoicesFiltered.First().PaymentMethods);
             Assert.Single(invoicesFiltered);
             Assert.Equal(newInvoice.Id, invoicesFiltered.First().Id);
 

--- a/BTCPayServer/Controllers/GreenField/LocalBTCPayServerClient.cs
+++ b/BTCPayServer/Controllers/GreenField/LocalBTCPayServerClient.cs
@@ -823,7 +823,7 @@ namespace BTCPayServer.Controllers.Greenfield
             HandleActionResult(await GetController<GreenfieldStoresController>().DeleteStoreLogo(storeId));
         }
 
-        public override async Task<IEnumerable<InvoiceData>> GetInvoices(string storeId, string[] orderId = null,
+        public override async Task<IEnumerable<InvoiceDataWithPaymentMethods>> GetInvoices(string storeId, string[] orderId = null,
             InvoiceStatus[] status = null,
             DateTimeOffset? startDate = null,
             DateTimeOffset? endDate = null,
@@ -834,7 +834,7 @@ namespace BTCPayServer.Controllers.Greenfield
             CancellationToken token = default
         )
         {
-            return GetFromActionResult<IEnumerable<InvoiceData>>(
+            return GetFromActionResult<IEnumerable<InvoiceDataWithPaymentMethods>>(
                 await GetController<GreenfieldInvoiceController>().GetInvoices(storeId, orderId,
                     status?.Select(invoiceStatus => invoiceStatus.ToString())?.ToArray(), startDate,
                     endDate, textSearch, includeArchived, skip, take));

--- a/BTCPayServer/wwwroot/swagger/v1/swagger.template.invoices.json
+++ b/BTCPayServer/wwwroot/swagger/v1/swagger.template.invoices.json
@@ -674,7 +674,22 @@
             "InvoiceDataList": {
                 "type": "array",
                 "items": {
-                    "$ref": "#/components/schemas/InvoiceData"
+                    "allOf": [
+                        {
+                            "type": "object",
+                            "properties": {
+                                "PaymentMethods": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/InvoicePaymentMethodDataModel"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "$ref": "#/components/schemas/InvoiceData"
+                        }
+                    ]
                 }
             },
             "MarkInvoiceStatusRequest": {


### PR DESCRIPTION
Resolves #2394 

Include payment method information to Get all Invoices. So users dont have to call multiple invoices to retrieve payment type data. 