### PR TITLE
Simplify code

### DIFF
--- a/BTCPayServer/Blazor/VaultBridge/HWIController.cs
+++ b/BTCPayServer/Blazor/VaultBridge/HWIController.cs
@@ -260,8 +260,7 @@ public class GetXPubController : HWIController
         ui.ShowFeedback(FeedbackType.Success, ui.StringLocalizer["Public keys successfully fetched."]);
 
         var firstDepositPath = new KeyPath(0, 0);
-        var firstDepositAddr =
-            network.NBXplorerNetwork.CreateAddress(strategy, firstDepositPath, strategy.GetDerivation(firstDepositPath).ScriptPubKey);
+        var firstDepositAddr = strategy.GetDerivation(firstDepositPath).ScriptPubKey.GetDestinationAddress(network.NBitcoinNetwork);
 
         var verif = new VerifyAddress(ui)
         {

--- a/BTCPayServer/Controllers/GreenField/GreenfieldStoreOnChainPaymentMethodsController.cs
+++ b/BTCPayServer/Controllers/GreenField/GreenfieldStoreOnChainPaymentMethodsController.cs
@@ -113,7 +113,7 @@ namespace BTCPayServer.Controllers.Greenfield
             return Ok(result);
         }
 
-        private static OnChainPaymentMethodPreviewResultData GetPreviewResultData(int offset, int count, BTCPayNetwork network, DerivationStrategyBase strategy)
+        internal static OnChainPaymentMethodPreviewResultData GetPreviewResultData(int offset, int count, BTCPayNetwork network, DerivationStrategyBase strategy)
         {
             var deposit = new NBXplorer.KeyPathTemplates(null).GetKeyPathTemplate(DerivationFeature.Deposit);
             var line = strategy.GetLineFor(deposit);
@@ -122,9 +122,7 @@ namespace BTCPayServer.Controllers.Greenfield
             {
                 var derivation = line.Derive((uint)i);
                 result.Addresses.Add(
-                    new
-                        OnChainPaymentMethodPreviewResultData.
-                        OnChainPaymentMethodPreviewResultAddressItem()
+                    new()
                     {
                         KeyPath = deposit.GetKeyPath((uint)i).ToString(),
                         Address =

--- a/BTCPayServer/Controllers/GreenField/GreenfieldStoreOnChainWalletsController.cs
+++ b/BTCPayServer/Controllers/GreenField/GreenfieldStoreOnChainWalletsController.cs
@@ -360,9 +360,7 @@ namespace BTCPayServer.Controllers.Greenfield
                         Timestamp = coin.Timestamp,
                         KeyPath = coin.KeyPath,
                         Confirmations = coin.Confirmations,
-                        Address = network.NBXplorerNetwork
-                            .CreateAddress(derivationScheme.AccountDerivation, coin.KeyPath, coin.ScriptPubKey)
-                            .ToString()
+                        Address = coin.Address.ToString()
                     };
                 }).ToList()
             );

--- a/BTCPayServer/Models/StoreViewModels/DerivationSchemeViewModel.cs
+++ b/BTCPayServer/Models/StoreViewModels/DerivationSchemeViewModel.cs
@@ -11,10 +11,10 @@ namespace BTCPayServer.Models.StoreViewModels
         [Display(Name = "Derivation scheme")]
         public string DerivationScheme { get; set; }
 
-        public List<(string KeyPath, string Address, RootedKeyPath RootedKeyPath)> AddressSamples
+        public List<(string KeyPath, string Address)> AddressSamples
         {
             get; set;
-        } = new List<(string KeyPath, string Address, RootedKeyPath RootedKeyPath)>();
+        }
         public string CryptoCode { get; set; }
         public string KeyPath { get; set; }
         [Display(Name = "Root fingerprint")]


### PR DESCRIPTION
Avoid call to `network.NBXplorerNetwork.CreateAddress` which will disappear in a future version of NBXplorer.

Calling it was meant to properly constructed blinded addresses for Liquid, but in most part, NBXplorer API already provide us with the blinded address so we don't need to calculate it on our side.
For another part (for hardware wallet), we do not support Liquid, so I could just remove it.

There is only the call in `GreenfieldStoreOnChainPaymentMethodsController` that I do not manage to remove at this point.