### PR TITLE
Display the keypad's running total more prominently

### DIFF
--- a/BTCPayServer.Tests/POSTests.cs
+++ b/BTCPayServer.Tests/POSTests.cs
@@ -525,20 +525,20 @@ donation:
             Assert.Equal("0,56", await s.Page.TextContentAsync("#Amount"));
             Assert.True(await s.Page.IsEnabledAsync("#ModeTablist-discount"));
             Assert.True(await s.Page.IsEnabledAsync("#ModeTablist-tip"));
-            await AssertKeypadCalculation(s, "1.234,00 € + 0,56 € = 1.234,56 €");
+            await AssertKeypadCalculation(s, "1.234,00 € + 0,56 €", "1.234,56 €");
 
             // Discount: 10%
             await s.Page.ClickAsync("label[for='ModeTablist-discount']");
             await EnterKeypad(s, "10");
             Assert.Contains("0,56", await s.Page.TextContentAsync("#Amount"));
             Assert.Contains("10% discount", await s.Page.TextContentAsync("#Discount"));
-            await AssertKeypadCalculation(s, "1.234,00 € + 0,56 € - 123,46 € (10%) = 1.111,10 €");
+            await AssertKeypadCalculation(s, "1.234,00 € + 0,56 € - 123,46 € (10%)", "1.111,10 €");
 
             // Tip: 10%
             await s.Page.ClickAsync("label[for='ModeTablist-tip']");
             await s.Page.ClickAsync("#Tip-10");
             Assert.Contains("0,56", await s.Page.TextContentAsync("#Amount"));
-            await AssertKeypadCalculation(s, "1.234,00 € + 0,56 € - 123,46 € (10%) + 111,11 € (10%) = 1.222,21 €");
+            await AssertKeypadCalculation(s, "1.234,00 € + 0,56 € - 123,46 € (10%) + 111,11 € (10%)", "1.222,21 €");
 
             // Pay
             await s.Page.ClickAsync("#pay-button");
@@ -581,7 +581,7 @@ donation:
 
             await EnterKeypad(s, "123");
             Assert.Contains("1,23", await s.Page.TextContentAsync("#Amount"));
-            await AssertKeypadCalculation(s, "2 x Green Tea (1,00 €) = 2,00 € + 1 x Black Tea (1,00 €) = 1,00 € + 1,23 € + 0,42 € (10%) = 4,65 €");
+            await AssertKeypadCalculation(s, "2 x Green Tea (1,00 €) = 2,00 € + 1 x Black Tea (1,00 €) = 1,00 € + 1,23 € + 0,42 € (10%)", "4,65 €");
 
             // Pay
             await s.Page.ClickAsync("#pay-button");
@@ -632,9 +632,10 @@ donation:
             Assert.Contains("1,35 €", await s.Page.TextContentAsync("#PaymentDetails-TotalFiat"));
         }
 
-        private static async Task AssertKeypadCalculation(PlaywrightTester s, string expected)
+        private static async Task AssertKeypadCalculation(PlaywrightTester s, string expectedCalculation, string expectedTotal)
         {
-            Assert.Equal(expected.NormalizeWhitespaces(), (await s.Page.TextContentAsync("#Calculation")).NormalizeWhitespaces());
+            Assert.Equal(expectedCalculation.NormalizeWhitespaces(), (await s.Page.TextContentAsync("#Calculation")).NormalizeWhitespaces());
+            Assert.Equal(("Total: " + expectedTotal).NormalizeWhitespaces(), (await s.Page.TextContentAsync("#Total")).NormalizeWhitespaces());
         }
 
         public class AssertReceiptAssertion

--- a/BTCPayServer/Views/Shared/PointOfSale/Public/VueLight.cshtml
+++ b/BTCPayServer/Views/Shared/PointOfSale/Public/VueLight.cshtml
@@ -23,6 +23,7 @@
     <div ref="display" class="d-flex flex-column align-items-center px-4 mb-auto">
         <div class="fw-semibold text-muted" id="Currency">{{currencyCode}}</div>
         <div class="fw-bold lh-sm" ref="amount" v-bind:style="{ fontSize: `${fontSize}px` }" id="Amount">{{ formatCurrency(lastAmount, false) }}</div>
+        <div class="fw-bold lh-sm" ref="total" v-if="totalNumeric !== parseFloat(lastAmount)" v-bind:style="{ fontSize: `${fontSize/3}px` }" id="Total">Total: {{ formatCurrency(totalNumeric, true) }}</div>
         <div class="text-muted text-center mt-2" id="Calculation">{{ calculation }}</div>
     </div>
     <div id="ModeTabs" class="tab-content mb-n2" v-if="showDiscount || enableTips">

--- a/BTCPayServer/wwwroot/pos/keypad.js
+++ b/BTCPayServer/wwwroot/pos/keypad.js
@@ -48,7 +48,6 @@ document.addEventListener("DOMContentLoaded",function () {
                         calc += ` (${this.posOrder.getTaxRate()}%)`
                     }
                 }
-                calc += ` = ${this.formatCurrency(this.summary.priceTaxIncludedWithTips, true)}`
                 return calc
             }
         },


### PR DESCRIPTION
@pavlenex mentioned that our change in #6739 which moved the total out from the top number into the calculation line make it difficult for the user to see the total as before.

This PR remove the total from the calculation line, into a separate line below the current amount input.
 
The `total` line doesn't show if that is the same value as the current input.
This mean that for users not using tips, discounts, taxes, or the `+`, the would not even see it.

![image](https://github.com/user-attachments/assets/516a7591-664c-4e5a-9c1f-012c51299189)

