### PR TITLE
Include API key - permission analysis for improved security

### DIFF
--- a/BTCPayServer.Data/ApplicationDbContext.cs
+++ b/BTCPayServer.Data/ApplicationDbContext.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations.Schema;
 using System.Linq;
 using System.Threading.Tasks;
+using BTCPayServer.Data.Data;
 using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Design;
@@ -28,6 +29,7 @@ namespace BTCPayServer.Data
         }
         public DbSet<AddressInvoiceData> AddressInvoices { get; set; }
         public DbSet<APIKeyData> ApiKeys { get; set; }
+        public DbSet<ApiKeyPermissionUsage> ApiKeyPermissionUsages { get; set; }
         public DbSet<AppData> Apps { get; set; }
         public DbSet<StoredFile> Files { get; set; }
         public DbSet<InvoiceSearchData> InvoiceSearches { get; set; }

--- a/BTCPayServer.Data/Data/ApiKeyPermissionUsage.cs
+++ b/BTCPayServer.Data/Data/ApiKeyPermissionUsage.cs
@@ -1,0 +1,15 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+
+namespace BTCPayServer.Data.Data
+{
+    public class ApiKeyPermissionUsage
+    {
+        [Key]
+        public string Id { get; set; } // Id in the format [apiKey]-[permission]
+        public string ApiKey { get; set; }
+        public string Permission { get; set; }
+        public DateTimeOffset LastUsed { get; set; }
+        public int UsageCount { get; set; }
+    }
+}

--- a/BTCPayServer.Data/Migrations/20250605063018_IncludeAPIKeyPermissionUsageTable.Designer.cs
+++ b/BTCPayServer.Data/Migrations/20250605063018_IncludeAPIKeyPermissionUsageTable.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using BTCPayServer.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace BTCPayServer.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250605063018_IncludeAPIKeyPermissionUsageTable")]
+    partial class IncludeAPIKeyPermissionUsageTable
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/BTCPayServer.Data/Migrations/20250605063018_IncludeAPIKeyPermissionUsageTable.cs
+++ b/BTCPayServer.Data/Migrations/20250605063018_IncludeAPIKeyPermissionUsageTable.cs
@@ -1,0 +1,37 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace BTCPayServer.Migrations
+{
+    /// <inheritdoc />
+    public partial class IncludeAPIKeyPermissionUsageTable : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "ApiKeyPermissionUsages",
+                columns: table => new
+                {
+                    Id = table.Column<string>(type: "text", nullable: false),
+                    ApiKey = table.Column<string>(type: "text", nullable: true),
+                    Permission = table.Column<string>(type: "text", nullable: true),
+                    LastUsed = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    UsageCount = table.Column<int>(type: "integer", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ApiKeyPermissionUsages", x => x.Id);
+                });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "ApiKeyPermissionUsages");
+        }
+    }
+}

--- a/BTCPayServer/Controllers/GreenField/LocalBTCPayServerClient.cs
+++ b/BTCPayServer/Controllers/GreenField/LocalBTCPayServerClient.cs
@@ -139,6 +139,7 @@ namespace BTCPayServer.Controllers.Greenfield
         {
             var authoverride = new AuthorizationService(new GreenfieldAuthorizationHandler(_httpContextAccessor,
                 _serviceProvider.GetService<UserManager<ApplicationUser>>(),
+                _serviceProvider.GetService<APIKeyRepository>(),
                 _serviceProvider.GetService<StoreRepository>(),
                 _serviceProvider.GetService<IPluginHookService>()));
 

--- a/BTCPayServer/Controllers/UIManageController.APIKeys.cs
+++ b/BTCPayServer/Controllers/UIManageController.APIKeys.cs
@@ -2,11 +2,9 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
-using System.Text.Encodings.Web;
 using System.Threading.Tasks;
 using BTCPayServer.Abstractions.Extensions;
 using BTCPayServer.Abstractions.Models;
-using BTCPayServer.Abstractions.Services;
 using BTCPayServer.Client;
 using BTCPayServer.Data;
 using BTCPayServer.Models;
@@ -29,6 +27,50 @@ namespace BTCPayServer.Controllers
                 {
                     UserId = new[] { _userManager.GetUserId(User) }
                 })
+            });
+        }
+
+        [HttpGet("~/api-keys/{id}/view-analysis")]
+        public async Task<IActionResult> APIKeyPermissionAnalysis(string id)
+        {
+            var key = await _apiKeyRepository.GetKey(id);
+            if (key == null || key.UserId != _userManager.GetUserId(User))
+                return NotFound();
+
+            var allPermissions = key.GetBlob().Permissions;
+            var usageRecords = await _apiKeyRepository.GetAPIPermissionUsageRecords(id);
+            var usageByPermission = usageRecords.ToDictionary(u => u.Permission, u => u);
+
+            var usedPermissions = new List<PermissionUsageViewModel>();
+            var unusedPermissions = new List<string>();
+            var allPermissionVMs = new List<PermissionViewModel>();
+
+            foreach (var permission in allPermissions)
+            {
+                if (usageByPermission.TryGetValue(permission, out var usage))
+                {
+                    var usageVM = new PermissionUsageViewModel
+                    {
+                        Permission = usage.Permission,
+                        LastUsed = usage.LastUsed,
+                        UsageCount = usage.UsageCount
+                    };
+                    usedPermissions.Add(usageVM);
+                    allPermissionVMs.Add(new PermissionViewModel { Permission = permission, Usage = usageVM });
+                }
+                else
+                {
+                    unusedPermissions.Add(permission);
+                    allPermissionVMs.Add(new PermissionViewModel { Permission = permission, Usage = null });
+                }
+            }
+            return View(new ApiKeyPermissionAnalyticsViewModel
+            {
+                ApiKey = key.Id,
+                Label = key.Label,
+                UsedPermissions = usedPermissions,
+                UnusedPermissions = unusedPermissions,
+                AllPermissions = allPermissionVMs
             });
         }
 
@@ -57,13 +99,16 @@ namespace BTCPayServer.Controllers
             {
                 return NotFound();
             }
-            await _apiKeyRepository.Remove(id, _userManager.GetUserId(User));
+            var isDeleted = await _apiKeyRepository.Remove(id, _userManager.GetUserId(User));
+            if (isDeleted)
+                await _apiKeyRepository.DeleteAPIPermissionRecord(id);
+
             TempData.SetStatusMessageModel(new StatusMessageModel
             {
                 Severity = StatusMessageModel.StatusSeverity.Success,
                 Message = StringLocalizer["API Key removed"].Value
             });
-            return RedirectToAction("APIKeys");
+            return RedirectToAction(nameof(APIKeys));
         }
 
         [HttpGet]
@@ -244,7 +289,50 @@ namespace BTCPayServer.Controllers
                 Severity = StatusMessageModel.StatusSeverity.Success,
                 Html = StringLocalizer["API key generated!"].Value + $" <code class='alert-link'>{key.Id}</code>"
             });
-            return RedirectToAction("APIKeys");
+            return RedirectToAction(nameof(APIKeys));
+        }
+
+        [HttpGet("~/api-keys/{id}/edit")]
+        public async Task<IActionResult> EditAPIKey(string id)
+        {
+            var key = await _apiKeyRepository.GetKey(id);
+            if (key == null || key.UserId != _userManager.GetUserId(User))
+            {
+                return NotFound();
+            }
+            var viewModel = new EditApiKeyViewModel { Label = key.Label, Id = key.Id };
+            await SetViewModelValues(viewModel);
+            var existingPermissions = key.GetBlob().Permissions;
+
+            foreach (var permissionItem in viewModel.PermissionValues)
+            {
+                var permissionKey = permissionItem.StoreMode == AddApiKeyViewModel.ApiKeyStoreMode.Specific ? $"{permissionItem.Permission}:" : permissionItem.Permission;
+
+                permissionItem.Value = existingPermissions.Contains(permissionKey) || existingPermissions.Any(p => p.StartsWith($"{permissionItem.Permission}:"));
+                if (permissionItem.Value && permissionItem.StoreMode == AddApiKeyViewModel.ApiKeyStoreMode.Specific)
+                {
+                    var storeSpecificPermissions = existingPermissions.Where(p => p.StartsWith($"{permissionItem.Permission}:")).ToList();
+                    if (storeSpecificPermissions.Any())
+                    {
+                        permissionItem.SpecificStores = storeSpecificPermissions.Select(p => p.Substring(p.IndexOf(':') + 1)).ToList();
+                    }
+                }
+            }
+            return View(viewModel);
+        }
+
+        [HttpPost("~/api-keys/{id}/edit")]
+        public async Task<IActionResult> UpdateApiKey(string id, EditApiKeyViewModel viewModel)
+        {
+            await SetViewModelValues(viewModel);
+            var permissions = GetPermissionsFromViewModel(viewModel).Select(p => p.ToString()).Distinct().ToArray();
+            await _apiKeyRepository.UpdateKey(id, permissions, viewModel.Label, _userManager.GetUserId(User));
+            TempData.SetStatusMessageModel(new StatusMessageModel
+            {
+                Severity = StatusMessageModel.StatusSeverity.Success,
+                Message = "API key updated successfully"
+            });
+            return RedirectToAction(nameof(APIKeys));
         }
 
         private async Task<APIKeyData> CheckForMatchingApiKey(IEnumerable<Permission> requestedPermissions, AuthorizeApiKeysViewModel vm)
@@ -491,6 +579,11 @@ namespace BTCPayServer.Controllers
             return viewModel;
         }
 
+        public class EditApiKeyViewModel : AddApiKeyViewModel
+        {
+            public string Id { get; set; }
+        }
+
         public class AddApiKeyViewModel
         {
             public string Label { get; set; }
@@ -599,6 +692,29 @@ namespace BTCPayServer.Controllers
         public class ApiKeysViewModel
         {
             public List<APIKeyData> ApiKeyDatas { get; set; }
+        }
+
+        public class ApiKeyPermissionAnalyticsViewModel
+        {
+            public string ApiKey { get; set; }
+            public string Label { get; set; }
+            public List<PermissionUsageViewModel> UsedPermissions { get; set; } = new();
+            public List<string> UnusedPermissions { get; set; } = new();
+            public List<PermissionViewModel> AllPermissions { get; set; } = new();
+            public int TotalPermissions => AllPermissions.Count;
+        }
+
+        public class PermissionUsageViewModel
+        {
+            public string Permission { get; set; }
+            public DateTimeOffset LastUsed { get; set; }
+            public int UsageCount { get; set; }
+            public int DaysAgo => (int)(DateTimeOffset.UtcNow - LastUsed).TotalDays;
+        }
+        public class PermissionViewModel
+        {
+            public string Permission { get; set; }
+            public PermissionUsageViewModel Usage { get; set; }
         }
     }
 }

--- a/BTCPayServer/Security/GreenField/GreenFieldAuthorizationHandler.cs
+++ b/BTCPayServer/Security/GreenField/GreenFieldAuthorizationHandler.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Security.Claims;
 using System.Threading.Tasks;
@@ -8,6 +9,7 @@ using BTCPayServer.Services.Stores;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
 using StoreData = BTCPayServer.Data.StoreData;
 
 namespace BTCPayServer.Security.Greenfield
@@ -17,16 +19,19 @@ namespace BTCPayServer.Security.Greenfield
         private readonly IHttpContextAccessor _httpContextAccessor;
         private readonly UserManager<ApplicationUser> _userManager;
         private readonly StoreRepository _storeRepository;
+        private readonly APIKeyRepository _apiKeyRepository;
         private readonly IPluginHookService _pluginHookService;
 
         public LocalGreenfieldAuthorizationHandler(IHttpContextAccessor httpContextAccessor,
             UserManager<ApplicationUser> userManager,
+            APIKeyRepository apiKeyRepository,
             StoreRepository storeRepository,
             IPluginHookService pluginHookService)
         {
             _httpContextAccessor = httpContextAccessor;
             _userManager = userManager;
             _storeRepository = storeRepository;
+            _apiKeyRepository = apiKeyRepository;
             _pluginHookService = pluginHookService;
         }
         protected override Task HandleRequirementAsync(AuthorizationHandlerContext context, PolicyRequirement requirement)
@@ -38,7 +43,7 @@ namespace BTCPayServer.Security.Greenfield
                     $"{GreenfieldConstants.AuthenticationType}"));
                 var newContext = new AuthorizationHandlerContext(context.Requirements, newUser, null);
                 return new GreenfieldAuthorizationHandler(
-                    _httpContextAccessor, _userManager, _storeRepository, _pluginHookService).HandleAsync(newContext);
+                    _httpContextAccessor, _userManager, _apiKeyRepository, _storeRepository, _pluginHookService).HandleAsync(newContext);
             }
 
             var succeed = context.User.Identity.AuthenticationType == $"Local{GreenfieldConstants.AuthenticationType}";
@@ -56,16 +61,19 @@ namespace BTCPayServer.Security.Greenfield
         private readonly HttpContext _httpContext;
         private readonly UserManager<ApplicationUser> _userManager;
         private readonly StoreRepository _storeRepository;
+        private readonly APIKeyRepository _apiKeyRepository;
         private readonly IPluginHookService _pluginHookService;
 
         public GreenfieldAuthorizationHandler(IHttpContextAccessor httpContextAccessor,
             UserManager<ApplicationUser> userManager,
+            APIKeyRepository apiKeyRepository,
             StoreRepository storeRepository,
             IPluginHookService pluginHookService)
         {
             _httpContext = httpContextAccessor.HttpContext;
             _userManager = userManager;
             _storeRepository = storeRepository;
+            _apiKeyRepository = apiKeyRepository;
             _pluginHookService = pluginHookService;
         }
 
@@ -147,6 +155,10 @@ namespace BTCPayServer.Security.Greenfield
 
             if (success)
             {
+                if (_httpContext.GetAPIKey(out var apiKey))
+                {
+                    await _apiKeyRepository.RecordPermissionUsage(apiKey, requirement.Policy);
+                }
                 context.Succeed(requirement);
             }
             _httpContext.Items[RequestedPermissionKey] = policy;

--- a/BTCPayServer/Views/UIManage/APIKeyPermissionAnalysis.cshtml
+++ b/BTCPayServer/Views/UIManage/APIKeyPermissionAnalysis.cshtml
@@ -1,0 +1,253 @@
+@using BTCPayServer.Client
+@model BTCPayServer.Controllers.UIManageController.ApiKeyPermissionAnalyticsViewModel
+@{
+	ViewData.SetActivePage(ManageNavPages.APIKeys, $"{Model.Label} - API key analysis");
+}
+
+@section PageHeadContent {
+	<style>
+		.nav-tabs .nav-link.active {
+		color: #212529 !important;
+		}
+	</style>
+}
+
+<div class="sticky-header">
+	<h2>@ViewData["Title"]</h2>
+	<div>
+		<a id="page-primary" class="btn btn-primary" asp-action="EditAPIKey" asp-route-id="@Model.ApiKey">Edit API Key</a>
+		<a id="page-primary" class="btn btn-secondary" asp-action="APIKeys">Go Back</a>
+	</div>
+</div>
+
+<div class="row mb-4">
+	<div class="col-md-4">
+		<div class="card text-center">
+			<div class="card-body">
+				<h5 class="card-title text-primary">@Model.TotalPermissions</h5>
+				<p class="card-text">Total Permissions</p>
+			</div>
+		</div>
+	</div>
+	<div class="col-md-4">
+		<div class="card text-center">
+			<div class="card-body">
+				<h5 class="card-title text-success">@Model.UsedPermissions.Count</h5>
+				<p class="card-text">Used Permissions</p>
+			</div>
+		</div>
+	</div>
+	<div class="col-md-4">
+		<div class="card text-center">
+			<div class="card-body">
+				<h5 class="card-title text-warning">@Model.UnusedPermissions.Count</h5>
+				<p class="card-text">Unused Permissions</p>
+			</div>
+		</div>
+	</div>
+</div>
+
+
+<div class="row">
+	<div class="col-12">
+		<div class="card">
+			<div class="card-header">
+				<ul class="nav nav-tabs card-header-tabs" id="permissionTabs" role="tablist">
+					<li class="nav-item" role="presentation">
+						<button class="nav-link active" id="all-tab" data-bs-toggle="tab" data-bs-target="#all-permissions" type="button" role="tab">
+							All Permissions (@Model.TotalPermissions)
+						</button>
+					</li>
+					<li class="nav-item" role="presentation">
+						<button class="nav-link" id="used-tab" data-bs-toggle="tab" data-bs-target="#used-permissions" type="button" role="tab">
+							Used Permissions (@Model.UsedPermissions.Count)
+						</button>
+					</li>
+					<li class="nav-item" role="presentation">
+						<button class="nav-link" id="unused-tab" data-bs-toggle="tab" data-bs-target="#unused-permissions" type="button" role="tab">
+							Unused Permissions (@Model.UnusedPermissions.Count)
+						</button>
+					</li>
+				</ul>
+			</div>
+			<div class="card-body">
+				<div class="tab-content" id="permissionTabContent">
+					<div class="tab-pane fade show active" id="all-permissions" role="tabpanel">
+						@if (Model.AllPermissions.Any())
+						{
+							<div class="table-responsive">
+								<table class="table table-hover">
+									<thead class="table-light">
+										<tr>
+											<th>Permission</th>
+											<th>Usage Count</th>
+											<th>Last Used</th>
+											<th>Status</th>
+										</tr>
+									</thead>
+									<tbody>
+										@foreach (var permission in Model.AllPermissions.OrderBy(p => p.Permission))
+										{
+											var usage = Model.UsedPermissions.FirstOrDefault(u => u.Permission == permission.Permission);
+											var isUsed = usage != null;
+											var isStale = isUsed && (DateTimeOffset.UtcNow - usage.LastUsed).TotalDays > 100;
+
+											<tr class="@(isUsed ? (isStale ? "table-warning" : "") : "table-light")">
+												<td>
+													<code>@permission.Permission</code>
+												</td>
+												<td>
+													@if (isUsed)
+													{
+														<span class="badge bg-secondary">@usage.UsageCount.ToString("N0")</span>
+													}
+													else
+													{
+														<span class="text-muted">-</span>
+													}
+												</td>
+												<td>
+													@if (isUsed)
+													{
+														<span class="text-muted">@usage.LastUsed.ToString("MMM dd, yyyy HH:mm")</span>
+														<br>
+														<small class="text-muted">(@usage.DaysAgo days ago)</small>
+													}
+													else
+													{
+														<span class="text-muted">Never</span>
+													}
+												</td>
+												<td>
+													@if (!isUsed)
+													{
+														<span class="badge bg-secondary">Never Used</span>
+													}
+													else if (isStale)
+													{
+														<span class="badge bg-warning">Stale</span>
+													}
+													else
+													{
+														<span class="badge bg-info">Active</span>
+													}
+												</td>
+											</tr>
+										}
+									</tbody>
+								</table>
+							</div>
+						}
+						else
+						{
+							<div class="text-center py-5">
+								<h5 class="mt-3">No Permission Usage Recorded</h5>
+							</div>
+						}
+					</div>
+
+					<div class="tab-pane fade" id="used-permissions" role="tabpanel">
+						@if (Model.UsedPermissions.Any())
+						{
+							<div class="table-responsive">
+								<table class="table table-hover">
+									<thead class="table-light">
+										<tr>
+											<th>Permission</th>
+											<th>Usage Count</th>
+											<th>Last Used</th>
+											<th>Status</th>
+										</tr>
+									</thead>
+									<tbody>
+										@foreach (var permission in Model.UsedPermissions.OrderByDescending(p => p.LastUsed))
+										{
+											var isStale = (DateTimeOffset.UtcNow - permission.LastUsed).TotalDays > 100;
+											<tr class="@(isStale ? "table-warning" : "")">
+												<td>
+													<code>@permission.Permission</code>
+												</td>
+												<td>
+													<span class="badge bg-secondary">@permission.UsageCount.ToString("N0")</span>
+												</td>
+												<td>
+													<span class="text-muted">@permission.LastUsed.ToString("MMM dd, yyyy HH:mm")</span>
+													<br>
+													<small class="text-muted">(@permission.DaysAgo days ago)</small>
+												</td>
+												<td>
+													@if (isStale)
+													{
+														<span class="badge bg-warning">Stale (100+ days)</span>
+													}
+													else
+													{
+														<span class="badge bg-info">Active</span>
+													}
+												</td>
+											</tr>
+										}
+									</tbody>
+								</table>
+							</div>
+						}
+						else
+						{
+							<div class="text-center py-5">
+								<h5 class="mt-3">No Permission Usage Recorded</h5>
+							</div>
+						}
+					</div>
+
+					<div class="tab-pane fade" id="unused-permissions" role="tabpanel">
+						@if (Model.UnusedPermissions.Any())
+						{
+							<div class="alert alert-warning" role="alert">
+								<i class="bi bi-exclamation-triangle"></i>
+								<strong>Security Recommendation:</strong> Consider removing unused permissions to reduce security risk.
+							</div>
+
+							<div class="table-responsive">
+								<table class="table table-hover">
+									<thead class="table-light">
+										<tr>
+											<th>Permission</th>
+											<th>Status</th>
+										</tr>
+									</thead>
+									<tbody>
+										@foreach (var permission in Model.UnusedPermissions.OrderBy(p => p))
+										{
+											<tr>
+												<td>
+													<code>@permission</code>
+												</td>
+												<td>
+													<span class="badge bg-secondary">Never Used</span>
+												</td>
+											</tr>
+										}
+									</tbody>
+								</table>
+							</div>
+						}
+						else
+						{
+							<div class="text-center py-5">
+								<i class="bi bi-shield-check text-success" style="font-size: 3rem;"></i>
+								@if (Model.TotalPermissions > 0)
+								{
+									<h5 class="mt-3 text-success">No unused permission!</h5>
+								}
+								else
+								{
+									<h5 class="mt-3">No Permission Usage Recorded</h5>
+								}
+							</div>
+						}
+					</div>
+				</div>
+			</div>
+		</div>
+	</div>
+</div>

--- a/BTCPayServer/Views/UIManage/APIKeys.cshtml
+++ b/BTCPayServer/Views/UIManage/APIKeys.cshtml
@@ -77,9 +77,13 @@
                             </td>
                             <td>
                                 <div class="d-flex align-items-center justify-content-end gap-1">
+									<a asp-action="EditAPIKey" asp-route-id="@keyData.Id" asp-controller="UIManage" text-translate="true">Edit</a>
+									<span>-</span>
                                     <a asp-action="DeleteAPIKey" asp-route-id="@keyData.Id" asp-controller="UIManage" data-bs-toggle="modal" data-bs-target="#ConfirmModal" data-description="Any application using the API key <strong>@Html.Encode(keyData.Label ?? keyData.Id)</strong> will immediately lose access." data-confirm-input="DELETE" text-translate="true">Delete</a>
                                     <span>-</span>
                                     <button type="button" class="btn btn-link only-for-js p-0" data-qr="@index" text-translate="true">Show QR</button>
+									<span>-</span>
+									<a asp-action="APIKeyPermissionAnalysis" asp-route-id="@keyData.Id" asp-controller="UIManage" text-translate="true">View Usage</a>
                                 </div>
                             </td>
                         </tr>

--- a/BTCPayServer/Views/UIManage/EditApiKey.cshtml
+++ b/BTCPayServer/Views/UIManage/EditApiKey.cshtml
@@ -1,0 +1,148 @@
+@using BTCPayServer.Client
+@using BTCPayServer.Controllers
+@model UIManageController.EditApiKeyViewModel
+
+@{
+    ViewData.SetActivePage(ManageNavPages.APIKeys, "Update API Key");
+}
+
+@section PageHeadContent {
+    <style>
+        .remove-btn { font-size: 1.5rem; border-radius: 0; }
+        .remove-btn:hover { background-color: #CCCCCC; }
+    </style>
+}
+
+@section PageFootContent {
+    <partial name="_ValidationScriptsPartial"/>
+    <script>
+        delegate('click', `form button[value*=':']`, function (e) {
+            const { form, value } = e.target
+            const [action] = form.getAttribute('action').split('#')
+            const anchor = value.replace(/:.*/, '')
+            form.setAttribute('action', `${action}#${anchor}`)
+        })
+    </script>
+}
+
+<form method="post" asp-action="UpdateApiKey" asp-route-id="@Model.Id" id="Permissions">
+    <div class="sticky-header">
+        <nav aria-label="breadcrumb">
+            <ol class="breadcrumb">
+                <li class="breadcrumb-item">
+                    <a asp-action="APIKeys" text-translate="true">API Keys</a>
+                </li>
+                <li class="breadcrumb-item active" aria-current="page">@ViewData["Title"]</li>
+            </ol>
+            <h2>@ViewData["Title"]</h2>
+        </nav>
+		<button id="page-primary" type="submit" class="btn btn-primary">Update API Key</button>
+    </div>
+    <div class="row">
+        <div class="col-xl-10 col-xxl-constrain">
+            @if (!ViewContext.ModelState.IsValid)
+            {
+                <div asp-validation-summary="All"></div>
+            }
+            <div class="form-group">
+                <label asp-for="Label" class="form-label"></label>
+                <input asp-for="Label" class="form-control"/>
+                <span asp-validation-for="Label" class="text-danger"></span>
+            </div>
+        
+            <h5 class="mt-4 mb-3">Permissions</h5>
+            <div class="list-group mb-4">
+                @for (int i = 0; i < Model.PermissionValues.Count; i++)
+                {
+                    @if (Model.PermissionValues[i].Forbidden)
+                    {
+                        <input type="hidden" asp-for="PermissionValues[i].Value" value="false" />
+                    }
+                    else
+                    {
+                        <div class="list-group-item py-3">
+                            <input type="hidden" asp-for="PermissionValues[i].Permission" />
+                            @if (Policies.IsStorePolicy(Model.PermissionValues[i].Permission))
+                            {
+                                <input type="hidden" asp-for="PermissionValues[i].StoreMode" value="@Model.PermissionValues[i].StoreMode" />
+                                @if (Model.PermissionValues[i].StoreMode == UIManageController.AddApiKeyViewModel.ApiKeyStoreMode.AllStores)
+                                {
+                                    <div class="form-check mb-0">
+                                        <input id="@Model.PermissionValues[i].Permission" type="checkbox" asp-for="PermissionValues[i].Value" class="form-check-input ms-n4"/>
+                                        <label for="@Model.PermissionValues[i].Permission" class="h5 form-check-label me-2 mb-1">
+                                            <span class="me-lg-1">@Model.PermissionValues[i].Title</span>
+                                            <small class="text-muted text-break d-block my-2 d-lg-inline-block my-lg-0">@Model.PermissionValues[i].Permission</small>
+                                        </label>
+                                        <div>
+                                            <span asp-validation-for="PermissionValues[i].Value" class="text-danger"></span>
+                                            <div class="text-muted">@Model.PermissionValues[i].Description</div>
+                                            @if (Model.Stores.Any())
+                                            {
+                                                <button type="submit" class="btn btn-link p-0" name="command" value="@($"{Model.PermissionValues[i].Permission}:change-store-mode")">Select specific stores</button>
+                                            }
+                                        </div>
+                                    </div>
+                                }
+                                else
+                                {
+                                    <h5 class="mb-1" id="@Model.PermissionValues[i].Permission">
+                                        <span class="me-lg-1">@Model.PermissionValues[i].Title</span>
+                                        <small class="text-muted text-break d-block my-2 d-lg-inline-block my-lg-0">@Model.PermissionValues[i].Permission</small>
+                                    </h5>
+                                    <div class="text-muted">@Model.PermissionValues[i].Description</div>
+                                    <button type="submit" class="btn btn-link p-0" name="command" value="@($"{Model.PermissionValues[i].Permission}:change-store-mode")">Give permission to all stores instead</button>
+        
+                                    @if (!Model.Stores.Any())
+                                    {
+                                        <p class="info-note text-warning mt-2 mb-0">
+                                            <vc:icon symbol="warning"/>
+                                            You currently have no stores configured.
+                                        </p>
+                                    }
+                                    @for (var index = 0; index < Model.PermissionValues[i].SpecificStores.Count; index++)
+                                    {
+                                        <div class="input-group my-3">
+                                            @if (Model.PermissionValues[i].SpecificStores[index] == null)
+                                            {
+                                                <select asp-for="PermissionValues[i].SpecificStores[index]" class="form-select w-auto flex-grow-0" asp-items="@(new SelectList(Model.Stores.Where(data => !Model.PermissionValues[i].SpecificStores.Contains(data.Id)), nameof(StoreData.Id), nameof(StoreData.StoreName)))"></select>
+                                            }
+                                            else
+                                            {
+                                                var store = Model.Stores.SingleOrDefault(data => data.Id == Model.PermissionValues[i].SpecificStores[index]);
+                                                <select asp-for="PermissionValues[i].SpecificStores[index]" class="form-select w-auto flex-grow-0" asp-items="@(new SelectList(new[] {store}, nameof(StoreData.Id), nameof(StoreData.StoreName), store.Id))"></select>
+                                            }
+                                            <span asp-validation-for="PermissionValues[i].SpecificStores[index]" class="text-danger"></span>
+                                            <button type="submit" title="@StringLocalizer["Remove Store Permission"]" name="command" value="@($"{Model.PermissionValues[i].Permission}:remove-store:{index}")" class="btn btn-danger">
+                                                Remove
+                                            </button>
+                                        </div>
+                                    }
+                                    @if (Model.PermissionValues[i].SpecificStores.Count < Model.Stores.Length)
+                                    {
+                                        <div class="mt-3">
+                                            <button type="submit" name="command" value="@($"{Model.PermissionValues[i].Permission}:add-store")" class="btn btn-secondary">Add another store</button>
+                                        </div>
+                                    }
+                                }
+                            }
+                            else
+                            {
+                                <div class="form-check mb-0">
+                                    <input id="@Model.PermissionValues[i].Permission" type="checkbox" asp-for="PermissionValues[i].Value" class="form-check-input ms-n4" />
+                                    <label for="@Model.PermissionValues[i].Permission" class="h5 form-check-label me-2 mb-1">
+                                        <span class="me-lg-1">@Model.PermissionValues[i].Title</span>
+                                        <small class="text-muted text-break d-block my-2 d-lg-inline-block my-lg-0">@Model.PermissionValues[i].Permission</small>
+                                    </label>
+                                    <div>
+                                        <span asp-validation-for="PermissionValues[i].Value" class="text-danger"></span>
+                                        <span class="text-muted">@Model.PermissionValues[i].Description</span>
+                                    </div>
+                                </div>  
+                            }
+                        </div>
+                    }
+                }
+            </div>
+        </div>
+    </div>
+</form>


### PR DESCRIPTION
Resolves #3196 

Includes API key analysis showing permissions in API keys which are being used.. together with the last time they were used. 

Analysis also shows unused permissions in API key.. admin/users can then remove unused permissions from API key.

This PR also includes an edit endpoint so that key permissions can be added or removed from a particular api key without having to delete.

![apikey_analysis](https://github.com/user-attachments/assets/075cfdd7-95cd-4364-a959-ae567c41a550)
