### PR TITLE
feat(pos): add confirmation dialog for multi-store user selection in POS (#6763)

### DIFF
--- a/BTCPayServer/Plugins/PointOfSale/Models/ViewPointOfSaleViewModel.cs
+++ b/BTCPayServer/Plugins/PointOfSale/Models/ViewPointOfSaleViewModel.cs
@@ -76,7 +76,7 @@ namespace BTCPayServer.Plugins.PointOfSale.Models
         public decimal DefaultTaxRate { get; set; }
         public List<PosUserViewModel> PosUsers { get; set; } = new List<PosUserViewModel>(); // Initialize to avoid null-checks
 
-        public class PosUserViewModel
+        public partial class PosUserViewModel
         {
             public string Id { get; set; }
             public string Email { get; set; }

--- a/BTCPayServer/Plugins/PointOfSale/Models/ViewPointOfSaleViewModel.cs
+++ b/BTCPayServer/Plugins/PointOfSale/Models/ViewPointOfSaleViewModel.cs
@@ -74,5 +74,14 @@ namespace BTCPayServer.Plugins.PointOfSale.Models
         public SelectList AllCategories { get; set; }
         public string StoreId { get; set; }
         public decimal DefaultTaxRate { get; set; }
+        public List<PosUserViewModel> PosUsers { get; set; }
+    }
+
+    public class PosUserViewModel
+    {
+        public string Id { get; set; }
+        public string Email { get; set; }
+        public string Role { get; set; }
+        public bool IsMultiStoreUser { get; set; }
     }
 }

--- a/BTCPayServer/Plugins/PointOfSale/Models/ViewPointOfSaleViewModel.cs
+++ b/BTCPayServer/Plugins/PointOfSale/Models/ViewPointOfSaleViewModel.cs
@@ -69,19 +69,19 @@ namespace BTCPayServer.Plugins.PointOfSale.Models
         public string CustomTipText { get; set; }
         public int[] CustomTipPercentages { get; set; }
         public string HtmlLang { get; set; }
-        public string HtmlMetaTags{ get; set; }
+        public string HtmlMetaTags { get; set; }
         public string Description { get; set; }
         public SelectList AllCategories { get; set; }
         public string StoreId { get; set; }
         public decimal DefaultTaxRate { get; set; }
-        public List<PosUserViewModel> PosUsers { get; set; }
-    }
+        public List<PosUserViewModel> PosUsers { get; set; } = new List<PosUserViewModel>(); // Initialize to avoid null-checks
 
-    public class PosUserViewModel
-    {
-        public string Id { get; set; }
-        public string Email { get; set; }
-        public string Role { get; set; }
-        public bool IsMultiStoreUser { get; set; }
+        public class PosUserViewModel
+        {
+            public string Id { get; set; }
+            public string Email { get; set; }
+            public string Role { get; set; }
+            public bool IsMultiStoreUser { get; set; }
+        }
     }
 }

--- a/BTCPayServer/Services/Stores/StoreRepository.cs
+++ b/BTCPayServer/Services/Stores/StoreRepository.cs
@@ -763,6 +763,15 @@ retry:
             public string? DefaultPaymentMethodId { get; set; }
             public StoreBlob? Blob { get; set; }
         }
+
+        public async Task<Dictionary<string, int>> GetStoreCountsPerUserAsync()
+        {
+            using var context = _ContextFactory.CreateContext();
+            return await context.UserStore
+                .GroupBy(us => us.ApplicationUserId)
+                .Select(group => new { UserId = group.Key, StoreCount = group.Count() })
+                .ToDictionaryAsync(g => g.UserId, g => g.StoreCount);
+        }
     }
 
     public record StoreRoleId

--- a/BTCPayServer/Views/Shared/PointOfSale/Public/Static.cshtml
+++ b/BTCPayServer/Views/Shared/PointOfSale/Public/Static.cshtml
@@ -27,43 +27,26 @@
         @foreach (var user in Model.PosUsers)
         {
             <option value="@user.Id" data-multistore="@user.IsMultiStoreUser.ToString().ToLower()">
-                @user.Email (@user.Role)
+                @user.Role (@user.Id) <!-- Replace email with role or ID -->
             </option>
         }
         </select>
     </div>
 }
 
-<!-- Hidden input to sync dropdown value -->
-<input type="hidden" name="userId" id="formUserId" value="" />
+<!-- Global hidden input -->
+<input type="hidden" name="userId" value="" />
 
 <script>
 document.getElementById('userDropdown')?.addEventListener('change', function(e) {
     var selectedOption = e.target.options[e.target.selectedIndex];
-    document.getElementById('formUserId').value = selectedOption.value; // Sync hidden input value
+    document.querySelector('input[name="userId"]').value = selectedOption.value; // Sync hidden input value
     if (selectedOption.dataset.multistore === "true") {
         if (!window.confirm("Are you sure you want to generate a QR code for a user who has access to multiple stores?")) {
             e.target.selectedIndex = 0;
-            document.getElementById('formUserId').value = ""; // Reset hidden input value
+            document.querySelector('input[name="userId"]').value = ""; // Reset hidden input value
         }
     }
-});
-</script>
-
-<script>
-const userDropdown = document.getElementById('userDropdown');
-document.querySelectorAll('form').forEach(form => {
-    form.addEventListener('submit', function() {
-        // find or create the hidden input
-        let input = form.querySelector('input[name="userId"]');
-        if (!input) {
-            input = document.createElement('input');
-            input.type = 'hidden';
-            input.name = 'userId';
-            form.appendChild(input);
-        }
-        input.value = userDropdown.value;
-    });
 });
 </script>
 
@@ -119,7 +102,7 @@ document.querySelectorAll('form').forEach(form => {
                     {
                         <form method="post" asp-action="ViewPointOfSale" asp-route-appId="@Model.AppId" asp-antiforgery="false" autocomplete="off">
                             <input type="hidden" name="choiceKey" value="@item.Id" />
-                            <input type="hidden" name="userId" id="formUserId" value="" /> <!-- Hidden input added -->
+                            <input type="hidden" name="userId" value="" /> <!-- Removed id -->
                             @if (item.PriceType == AppItemPriceType.Minimum)
                             {
                                 <div class="input-group mb-2">
@@ -144,7 +127,7 @@ document.querySelectorAll('form').forEach(form => {
                 </div>
                 <div class="card-footer bg-transparent border-0 pb-3">
                     <form method="post" asp-action="ViewPointOfSale" asp-route-appId="@Model.AppId" asp-antiforgery="false" autocomplete="off">
-                        <input type="hidden" name="userId" id="formUserId" value="" /> <!-- Hidden input added -->
+                        <input type="hidden" name="userId" value="" /> <!-- Removed id -->
                         <div class="input-group mb-2">
                             <span class="input-group-text">@Model.CurrencySymbol</span>
                             <input class="form-control" type="number" min="0" step="@Model.Step" name="amount" placeholder="@StringLocalizer["Amount"]" required>

--- a/BTCPayServer/Views/Shared/PointOfSale/Public/Static.cshtml
+++ b/BTCPayServer/Views/Shared/PointOfSale/Public/Static.cshtml
@@ -18,99 +18,144 @@
 
 <div id="PosStatic" class="public-page-wrap">
     <partial name="_StoreHeader" model="(string.IsNullOrEmpty(Model.Title) ? Model.StoreName : Model.Title, Model.StoreBranding)" />
-    <main>
-        <partial name="_StatusMessage" />
-        @if (!string.IsNullOrEmpty(Model.Description))
+    <main> 
+        @if (Model.PosUsers != null && Model.PosUsers.Any())
+{
+    <div class="mb-3">
+        <label for="userDropdown" class="form-label">Select User</label>
+        <select id="userDropdown" name="userId" class="form-select">
+        @foreach (var user in Model.PosUsers)
         {
-            <div class="lead">@Safe.Raw(Model.Description)</div>
+            <option value="@user.Id" data-multistore="@user.IsMultiStoreUser.ToString().ToLower()">
+                @user.Email (@user.Role)
+            </option>
         }
-        <div class="row row-cols row-cols-1 row-cols-sm-2 row-cols-md-3 row-cols-lg-4 g-4" id="PosItems">
-            @for (var x = 0; x < Model.Items.Length; x++)
-            {
-                var item = Model.Items[x];
-                var formatted = GetItemPriceFormatted(item);
-                var inStock = item.Inventory is null or > 0;
-                var buttonText = string.IsNullOrEmpty(item.BuyButtonText)
-                    ? item.PriceType == AppItemPriceType.Topup ? Model.CustomButtonText : Model.ButtonText
-                    : item.BuyButtonText;
-                buttonText = buttonText.Replace("{0}", formatted).Replace("{Price}", formatted);
+        </select>
+    </div>
+}
 
-                <div id="card_@item.Id" class="col posItem posItem--displayed@(x == 0 ? " posItem--first" : null)@(x == Model.Items.Length - 1 && !Model.ShowCustomAmount ? " posItem--last" : null)">
-                    <div class="tile card" data-id="@x">
-                        @if (!string.IsNullOrWhiteSpace(item.Image))
+<!-- Hidden input to sync dropdown value -->
+<input type="hidden" name="userId" id="formUserId" value="" />
+
+<script>
+document.getElementById('userDropdown')?.addEventListener('change', function(e) {
+    var selectedOption = e.target.options[e.target.selectedIndex];
+    document.getElementById('formUserId').value = selectedOption.value; // Sync hidden input value
+    if (selectedOption.dataset.multistore === "true") {
+        if (!window.confirm("Are you sure you want to generate a QR code for a user who has access to multiple stores?")) {
+            e.target.selectedIndex = 0;
+            document.getElementById('formUserId').value = ""; // Reset hidden input value
+        }
+    }
+});
+</script>
+
+<script>
+const userDropdown = document.getElementById('userDropdown');
+document.querySelectorAll('form').forEach(form => {
+    form.addEventListener('submit', function() {
+        // find or create the hidden input
+        let input = form.querySelector('input[name="userId"]');
+        if (!input) {
+            input = document.createElement('input');
+            input.type = 'hidden';
+            input.name = 'userId';
+            form.appendChild(input);
+        }
+        input.value = userDropdown.value;
+    });
+});
+</script>
+
+<div class="row row-cols row-cols-1 row-cols-sm-2 row-cols-md-3 row-cols-lg-4 g-4" id="PosItems">
+    @for (var x = 0; x < Model.Items.Length; x++)
+    {
+        var item = Model.Items[x];
+        var formatted = GetItemPriceFormatted(item);
+        var inStock = item.Inventory is null or > 0;
+        var buttonText = string.IsNullOrEmpty(item.BuyButtonText)
+            ? item.PriceType == AppItemPriceType.Topup ? Model.CustomButtonText : Model.ButtonText
+            : item.BuyButtonText;
+        buttonText = buttonText.Replace("{0}", formatted).Replace("{Price}", formatted);
+
+        <div class="col posItem posItem--displayed@(x == 0 ? " posItem--first" : null)@(x == Model.Items.Length - 1 && !Model.ShowCustomAmount ? " posItem--last" : null)">
+            <div class="tile card" data-id="@x">
+                @if (!string.IsNullOrWhiteSpace(item.Image))
+                {
+                    <img class="card-img-top" src="@item.Image" alt="@Safe.Raw(item.Title)" asp-append-version="true">
+                }
+                <div class="card-body d-flex flex-column gap-2 mb-auto">
+                    <h5 class="card-title m-0">@Safe.Raw(item.Title)</h5>
+                    <div class="d-flex gap-2 align-items-center">
+                        @if (item.PriceType == AppItemPriceType.Topup || item.Price == 0)
                         {
-                            <img class="card-img-top" src="@item.Image" alt="@Safe.Raw(item.Title)" asp-append-version="true">
+                            <span class="fw-semibold badge text-bg-info">@Safe.Raw(char.ToUpper(formatted[0]) + formatted[1..])</span>
                         }
-                        <div class="card-body d-flex flex-column gap-2 mb-auto">
-                            <h5 class="card-title m-0">@Safe.Raw(item.Title)</h5>
-                            <div class="d-flex gap-2 align-items-center">
-                                @if (item.PriceType == AppItemPriceType.Topup || item.Price == 0)
+                        else
+                        {
+                            <span class="fw-semibold">@Safe.Raw(formatted)</span>
+                        }
+                        @if (item.Inventory.HasValue)
+                        {
+                            <span class="badge text-bg-warning">
+                                @if (item.Inventory > 0)
                                 {
-                                    <span class="fw-semibold badge text-bg-info">@Safe.Raw(char.ToUpper(formatted[0]) + formatted[1..])</span>
+                                    <span>@ViewLocalizer["{0} left", item.Inventory.ToString()]</span>
                                 }
                                 else
                                 {
-                                    <span class="fw-semibold">@Safe.Raw(formatted)</span>
+                                    <span text-translate="true">Sold out</span>
                                 }
-                                @if (item.Inventory.HasValue)
-                                {
-                                    <span class="badge text-bg-warning">
-                                        @if (item.Inventory > 0)
-                                        {
-                                            <span>@ViewLocalizer["{0} left", item.Inventory.ToString()]</span>
-                                        }
-                                        else
-                                        {
-                                            <span text-translate="true">Sold out</span>
-                                        }
-                                    </span>
-                                }
-                            </div>
-                            @if (!string.IsNullOrWhiteSpace(item.Description))
-                            {
-                                <p class="card-text">@Safe.Raw(item.Description)</p>
-                            }
-                        </div>
-                        <div class="card-footer">
-                            @if (inStock)
-                            {
-                                <form method="post" asp-action="ViewPointOfSale" asp-route-appId="@Model.AppId" asp-antiforgery="false" autocomplete="off">
-                                    <input type="hidden" name="choiceKey" value="@item.Id" />
-                                    @if (item.PriceType == AppItemPriceType.Minimum)
-                                    {
-                                        <div class="input-group mb-2">
-                                            <span class="input-group-text">@Model.CurrencySymbol</span>
-                                            <input class="form-control" type="number" min="@(item.Price ?? 0)" step="@Model.Step" name="amount" placeholder="@StringLocalizer["Amount"]" value="@item.Price" required>
-                                        </div>
-                                    }
-                                    <button class="btn btn-primary w-100" type="submit">@Safe.Raw(buttonText)</button>
-                                </form>
-                            }
-                        </div>
+                            </span>
+                        }
                     </div>
+                    @if (!string.IsNullOrWhiteSpace(item.Description))
+                    {
+                        <p class="card-text">@Safe.Raw(item.Description)</p>
+                    }
                 </div>
-            }
-            @if (Model.ShowCustomAmount)
-            {
-                <div id="card_custom_amount" class="col posItem posItem--displayed posItem--last@(Model.Items.Length == 0 ? " posItem--first" : null)">
-                    <div class="card h-100 px-0">
-                        <div class="card-body p-3 d-flex flex-column gap-2 mb-auto">
-                            <h5 class="card-title" text-translate="true">Custom Amount</h5>
-                            <p class="card-text" text-translate="true">Create invoice to pay custom amount</p>
-                        </div>
-                        <div class="card-footer bg-transparent border-0 pb-3">
-                            <form method="post" asp-action="ViewPointOfSale" asp-route-appId="@Model.AppId" asp-antiforgery="false" autocomplete="off">
+                <div class="card-footer">
+                    @if (inStock)
+                    {
+                        <form method="post" asp-action="ViewPointOfSale" asp-route-appId="@Model.AppId" asp-antiforgery="false" autocomplete="off">
+                            <input type="hidden" name="choiceKey" value="@item.Id" />
+                            <input type="hidden" name="userId" id="formUserId" value="" /> <!-- Hidden input added -->
+                            @if (item.PriceType == AppItemPriceType.Minimum)
+                            {
                                 <div class="input-group mb-2">
                                     <span class="input-group-text">@Model.CurrencySymbol</span>
-                                    <input class="form-control" type="number" min="0" step="@Model.Step" name="amount" placeholder="@StringLocalizer["Amount"]" required>
+                                    <input class="form-control" type="number" min="@(item.Price ?? 0)" step="@Model.Step" name="amount" placeholder="@StringLocalizer["Amount"]" value="@item.Price" required>
                                 </div>
-                                <button class="btn btn-primary w-100" type="submit">@Safe.Raw(Model.CustomButtonText ?? Model.ButtonText)</button>
-                            </form>
-                        </div>
-                    </div>
+                            }
+                            <button class="btn btn-primary w-100" type="submit">@Safe.Raw(buttonText)</button>
+                        </form>
+                    }
                 </div>
-            }
+            </div>
         </div>
+    }
+    @if (Model.ShowCustomAmount)
+    {
+        <div class="col posItem posItem--displayed posItem--last@(Model.Items.Length == 0 ? " posItem--first" : null)">
+            <div class="card h-100 px-0">
+                <div class="card-body p-3 d-flex flex-column gap-2 mb-auto">
+                    <h5 class="card-title" text-translate="true">Custom Amount</h5>
+                    <p class="card-text" text-translate="true">Create invoice to pay custom amount</p>
+                </div>
+                <div class="card-footer bg-transparent border-0 pb-3">
+                    <form method="post" asp-action="ViewPointOfSale" asp-route-appId="@Model.AppId" asp-antiforgery="false" autocomplete="off">
+                        <input type="hidden" name="userId" id="formUserId" value="" /> <!-- Hidden input added -->
+                        <div class="input-group mb-2">
+                            <span class="input-group-text">@Model.CurrencySymbol</span>
+                            <input class="form-control" type="number" min="0" step="@Model.Step" name="amount" placeholder="@StringLocalizer["Amount"]" required>
+                        </div>
+                        <button class="btn btn-primary w-100" type="submit">@Safe.Raw(Model.CustomButtonText ?? Model.ButtonText)</button>
+                    </form>
+                </div>
+            </div>
+        </div>
+    }
+</div>
     </main>
     <footer class="store-footer">
         <a class="store-powered-by" href="https://btcpayserver.org" target="_blank" rel="noreferrer noopener">

--- a/BTCPayServer/Views/Shared/PointOfSale/Public/Static.cshtml
+++ b/BTCPayServer/Views/Shared/PointOfSale/Public/Static.cshtml
@@ -27,7 +27,7 @@
         @foreach (var user in Model.PosUsers)
         {
             <option value="@user.Id" data-multistore="@user.IsMultiStoreUser.ToString().ToLower()">
-                @user.Role (@user.Id) <!-- Replace email with role or ID -->
+                @user.Role (@user.Id) 
             </option>
         }
         </select>
@@ -102,7 +102,7 @@ document.getElementById('userDropdown')?.addEventListener('change', function(e) 
                     {
                         <form method="post" asp-action="ViewPointOfSale" asp-route-appId="@Model.AppId" asp-antiforgery="false" autocomplete="off">
                             <input type="hidden" name="choiceKey" value="@item.Id" />
-                            <input type="hidden" name="userId" value="" /> <!-- Removed id -->
+                            <input type="hidden" name="userId" value="" /> 
                             @if (item.PriceType == AppItemPriceType.Minimum)
                             {
                                 <div class="input-group mb-2">
@@ -127,7 +127,7 @@ document.getElementById('userDropdown')?.addEventListener('change', function(e) 
                 </div>
                 <div class="card-footer bg-transparent border-0 pb-3">
                     <form method="post" asp-action="ViewPointOfSale" asp-route-appId="@Model.AppId" asp-antiforgery="false" autocomplete="off">
-                        <input type="hidden" name="userId" value="" /> <!-- Removed id -->
+                        <input type="hidden" name="userId" value="" /> 
                         <div class="input-group mb-2">
                             <span class="input-group-text">@Model.CurrencySymbol</span>
                             <input class="form-control" type="number" min="0" step="@Model.Step" name="amount" placeholder="@StringLocalizer["Amount"]" required>


### PR DESCRIPTION
- Adds a confirmation dialog when a multi-store user is selected in the POS.
- Ensures users are aware of and confirm multi-store selection before proceeding with an order.
- Passes the selected userId to the backend for accurate order attribution.
- Updates the POS controller to accept and process the userId field.
- (Closes #6763)