### PR TITLE
Add ability for to upload screenshot to circleci artifact for Playwright tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,6 +16,12 @@ jobs:
       - run:
           command: |
             cd .circleci && ./run-tests.sh "Playwright=Playwright"
+      - run:
+          when: always
+          command: |
+            docker run --rm -v btcpayservertests_tests_datadir:/data -v /tmp/Artifacts:/host alpine sh -c "cp -r /data/. /host/"
+      - store_artifacts:
+          path: /tmp/Artifacts
   selenium_tests:
     machine:
       image: ubuntu-2004:2024.11.1

--- a/.circleci/run-tests.sh
+++ b/.circleci/run-tests.sh
@@ -10,7 +10,7 @@ n=0
 until [ "$n" -ge 10 ]
 do
    docker-compose -f "docker-compose.altcoins.yml" pull && break
-   n=$((n+1)) 
+   n=$((n+1))
    sleep 5
 done
 

--- a/BTCPayServer.Tests/POSTests.cs
+++ b/BTCPayServer.Tests/POSTests.cs
@@ -405,9 +405,7 @@ goodies:
             Assert.Contains("0,77 €", await s.Page.TextContentAsync("#PaymentDetails-TaxIncluded"));
             Assert.Contains("10,67 €", await s.Page.TextContentAsync("#PaymentDetails-TotalFiat"));
             //
-            // Pay
             await s.PayInvoice(true);
-
 
             // Receipt
             await s.Page.ClickAsync("#ReceiptLink");
@@ -435,7 +433,17 @@ goodies:
 
             // Check inventory got updated and is now 3 instead of 5
             await s.GoToUrl(posUrl);
-            Assert.Equal("3 left", await s.Page.TextContentAsync(".posItem:nth-child(3) .badge.inventory"));
+            try
+            {
+                Assert.Equal("3 left", await s.Page.TextContentAsync(".posItem:nth-child(3) .badge.inventory"));
+            }
+            catch (Exception e)
+            {
+                // Flaky
+                await s.TakeScreenshot("BadInventory.png");
+                throw;
+            }
+
 
             // Guest user can access recent transactions
             await s.GoToHome();

--- a/BTCPayServer.Tests/PlaywrightTester.cs
+++ b/BTCPayServer.Tests/PlaywrightTester.cs
@@ -566,21 +566,11 @@ namespace BTCPayServer.Tests
             }
             await Page.ClickAsync("#FakePayment");
             await Page.Locator("#CheatSuccessMessage").WaitForAsync();
-            // TODO: Fix flakyness
-            try
-            {
-                await Page.Locator("text=Payment Received").WaitForAsync();
-            }
-            catch
-            {
-                await TakeScreenshot("PayInvoice.png");
-                throw;
-            }
-
             if (mine)
             {
                 await MineBlockOnInvoiceCheckout();
             }
+            await Page.Locator("xpath=//*[text()=\"Invoice Paid\" or text()=\"Payment Received\"]").WaitForAsync();
         }
 
         /// <summary>

--- a/BTCPayServer.Tests/ServerTester.cs
+++ b/BTCPayServer.Tests/ServerTester.cs
@@ -34,6 +34,7 @@ namespace BTCPayServer.Tests
         internal ILog TestLogs;
         public ServerTester(string scope, bool newDb, ILog testLogs, ILoggerProvider loggerProvider, BTCPayNetworkProvider networkProvider)
         {
+            Scope = scope;
             LoggerProvider = loggerProvider;
             this.TestLogs = testLogs;
             _Directory = scope;
@@ -72,6 +73,8 @@ namespace BTCPayServer.Tests
             PayTester.SSHConnection = GetEnvironment("TESTS_SSHCONNECTION", "root@127.0.0.1:21622");
             PayTester.SocksEndpoint = GetEnvironment("TESTS_SOCKSENDPOINT", "localhost:9050");
         }
+
+        public string Scope { get; set; }
 
         public void ActivateLangs()
         {

--- a/BTCPayServer.Tests/WalletTests.cs
+++ b/BTCPayServer.Tests/WalletTests.cs
@@ -74,6 +74,7 @@ public class WalletTests(ITestOutputHelper helper) : UnitTestBase(helper)
 
         await s.ClickPagePrimary();
         await s.Page.ClickAsync("#BroadcastTransaction");
+        await s.FindAlertMessage();
 
         await s.Page.ReloadAsync();
         var rbfTx = (await client.ShowOnChainWalletTransactions(s.StoreId, "BTC")).Select(t => t.TransactionHash).ToArray()[0];
@@ -82,17 +83,7 @@ public class WalletTests(ITestOutputHelper helper) : UnitTestBase(helper)
         await w.AssertNotFound(cpfpTx);
 
         // However, the new transaction should have copied the CPFP tag from the transaction it replaced, and have a RBF label as well.
-        try
-        {
-            await w.AssertHasLabels(rbfTx, "CPFP");
-        }
-        catch
-        {
-            // TODO: Flaky
-            await s.TakeScreenshot("AssertHasLabels-Fails.png");
-            throw;
-        }
-
+        await w.AssertHasLabels(rbfTx, "CPFP");
         await w.AssertHasLabels(rbfTx, "RBF");
 
         // Now, we sweep all the UTXOs to a single destination. This should be RBF-able. (Fee deducted on the lone UTXO)

--- a/BTCPayServer.Tests/WalletTests.cs
+++ b/BTCPayServer.Tests/WalletTests.cs
@@ -82,7 +82,17 @@ public class WalletTests(ITestOutputHelper helper) : UnitTestBase(helper)
         await w.AssertNotFound(cpfpTx);
 
         // However, the new transaction should have copied the CPFP tag from the transaction it replaced, and have a RBF label as well.
-        await w.AssertHasLabels(rbfTx, "CPFP");
+        try
+        {
+            await w.AssertHasLabels(rbfTx, "CPFP");
+        }
+        catch
+        {
+            // TODO: Flaky
+            await s.TakeScreenshot("AssertHasLabels-Fails.png");
+            throw;
+        }
+
         await w.AssertHasLabels(rbfTx, "RBF");
 
         // Now, we sweep all the UTXOs to a single destination. This should be RBF-able. (Fee deducted on the lone UTXO)

--- a/BTCPayServer.Tests/docker-compose.altcoins.yml
+++ b/BTCPayServer.Tests/docker-compose.altcoins.yml
@@ -29,6 +29,7 @@ services:
       TESTS_SSHPASSWORD: ""
       TESTS_SSHKEYFILE: ""
       TESTS_SOCKSENDPOINT: "tor:9050"
+      TESTS_ARTIFACTS_DIR: "/tmp/Artifacts"
     expose:
       - "80"
     depends_on:
@@ -44,6 +45,7 @@ services:
       - "sshd_datadir:/root/.ssh"
       - "customer_lightningd_datadir:/etc/customer_lightningd_datadir"
       - "merchant_lightningd_datadir:/etc/merchant_lightningd_datadir"
+      - "tests_datadir:/tmp/Artifacts"
 
   # The dev container is not actually used, it is just handy to run `docker-compose up dev` to start all services
   dev:
@@ -366,6 +368,7 @@ services:
           - "elementsd_liquid_datadir:/data"
 
 volumes:
+    tests_datadir:
     sshd_datadir:
     bitcoin_datadir:
     elementsd_liquid_datadir:

--- a/BTCPayServer/EventAggregator.cs
+++ b/BTCPayServer/EventAggregator.cs
@@ -87,6 +87,9 @@ namespace BTCPayServer
                 }
             }
 
+            if (Logs.Events.IsEnabled(LogLevel.Information))
+                Logs.Events.LogInformation("Event published {0}", evt);
+
             foreach (var sub in actionList)
             {
                 try

--- a/BTCPayServer/EventAggregator.cs
+++ b/BTCPayServer/EventAggregator.cs
@@ -88,7 +88,7 @@ namespace BTCPayServer
             }
 
             if (Logs.Events.IsEnabled(LogLevel.Information))
-                Logs.Events.LogInformation("Event published {0}", evt);
+                Logs.Events.LogInformation("Event published {0}", string.IsNullOrEmpty(evt?.ToString()) ? evtType.GetType().Name : evt.ToString());
 
             foreach (var sub in actionList)
             {

--- a/BTCPayServer/HostedServices/Webhooks/InvoiceWebhookDeliveryRequest.cs
+++ b/BTCPayServer/HostedServices/Webhooks/InvoiceWebhookDeliveryRequest.cs
@@ -47,4 +47,7 @@ public class InvoiceWebhookDeliveryRequest(
         res = InterpolateJsonField(res, "Invoice.Metadata", Invoice.Metadata.ToJObject());
         return res;
     }
+
+    public override string ToString()
+        => $"Webhook delivery request ({webhookEvent.Type})";
 }


### PR DESCRIPTION
Given playwright tests are flaky on CI, I added the ability to take screenshot and see then in CircleCI.
I also now logs events in Debug mode and tests so we can have better logs when debugging flaky behavior.

![image](https://github.com/user-attachments/assets/692f53c5-d253-4fe5-b163-befe9563a35b)
