### PR TITLE
Fix swagger invalid syntax blocking docs repo build

### DIFF
--- a/BTCPayServer/wwwroot/swagger/v1/swagger.template.pull-payments.json
+++ b/BTCPayServer/wwwroot/swagger/v1/swagger.template.pull-payments.json
@@ -1202,6 +1202,6 @@
         {
             "name": "Stores (Payouts)",
             "description": "Store pull payment payout operations"
-        },
+        }
     ]
 }


### PR DESCRIPTION
Facing a build issue in btcpayserver docs

https://github.com/btcpayserver/btcpayserver-doc/actions/runs/15728683484/job/44324438097?pr=1506

I was able to trace the issue to this syntax error


![image](https://github.com/user-attachments/assets/19e4f450-6d25-4918-a309-da063ccde259)
