### PR TITLE
Disable static web assets for tests and plugin packer

### DIFF
--- a/BTCPayServer.PluginPacker/BTCPayServer.PluginPacker.csproj
+++ b/BTCPayServer.PluginPacker/BTCPayServer.PluginPacker.csproj
@@ -15,6 +15,7 @@
       <PackageLicenseExpression>MIT</PackageLicenseExpression>
       <RepositoryUrl>https://github.com/btcpayserver/btcpayserver</RepositoryUrl>
       <RepositoryType>git</RepositoryType>
+      <StaticWebAssetsEnabled>false</StaticWebAssetsEnabled>
     </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <PublishRepositoryUrl>true</PublishRepositoryUrl>

--- a/BTCPayServer.Tests/BTCPayServer.Tests.csproj
+++ b/BTCPayServer.Tests/BTCPayServer.Tests.csproj
@@ -6,6 +6,7 @@
     <UserSecretsId>AB0AC1DD-9D26-485B-9416-56A33F268117</UserSecretsId>
     <!--https://devblogs.microsoft.com/aspnet/testing-asp-net-core-mvc-web-apps-in-memory/-->
     <PreserveCompilationContext>true</PreserveCompilationContext>
+    <StaticWebAssetsEnabled>false</StaticWebAssetsEnabled>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Should prevent build failure: https://github.com/btcpay-monero/btcpayserver-monero-plugin/actions/runs/15731876593/job/44334672902

`/usr/share/dotnet/sdk/8.0.411/Microsoft.Common.CurrentVersion.targets(5321,5): error MSB3030: Could not copy the file "/home/runner/work/btcpayserver-monero-plugin/btcpayserver-monero-plugin/submodules/btcpayserver/BTCPayServer/obj/Release/net8.0/staticwebassets.development.json" because it was not found. [/home/runner/work/btcpayserver-monero-plugin/btcpayserver-monero-plugin/submodules/btcpayserver/BTCPayServer.PluginPacker/BTCPayServer.PluginPacker.csproj]`

`/usr/share/dotnet/sdk/8.0.411/Microsoft.Common.CurrentVersion.targets(5321,5): error MSB3030: Could not copy the file "/home/runner/work/btcpayserver-monero-plugin/btcpayserver-monero-plugin/submodules/btcpayserver/BTCPayServer/obj/Release/net8.0/staticwebassets.development.json" because it was not found. [/home/runner/work/btcpayserver-monero-plugin/btcpayserver-monero-plugin/submodules/btcpayserver/BTCPayServer.Tests/BTCPayServer.Tests.csproj]`

