### PR TITLE
Fix: Failure to sign with Vault when a PSBT size exceeds 32KB

### DIFF
--- a/BTCPayServer.Tests/POSTests.cs
+++ b/BTCPayServer.Tests/POSTests.cs
@@ -437,7 +437,7 @@ goodies:
             {
                 Assert.Equal("3 left", await s.Page.TextContentAsync(".posItem:nth-child(3) .badge.inventory"));
             }
-            catch (Exception e)
+            catch (Exception)
             {
                 // Flaky
                 await s.TakeScreenshot("BadInventory.png");

--- a/BTCPayServer/Blazor/VaultBridge/HWIController.cs
+++ b/BTCPayServer/Blazor/VaultBridge/HWIController.cs
@@ -182,12 +182,15 @@ public abstract class HWIController : VaultController
 public class SignHWIController : HWIController
 {
     public string StoreId { get; set; }
-    public string PSBT { get; set; }
+    /// <summary>
+    /// We use byte[] to avoid wasted bytes and hitting size limits of Blazor
+    /// </summary>
+    public byte[] PSBT { get; set; }
 
     protected override async Task Run(VaultBridgeUI ui, HwiClient hwi, HwiDeviceClient device, HDFingerprint fingerprint, BTCPayNetwork network,
         CancellationToken cancellationToken)
     {
-        if (!NBitcoin.PSBT.TryParse(PSBT, network.NBitcoinNetwork, out var psbt))
+        if (!NBitcoin.PSBT.TryParse(Convert.ToBase64String(PSBT), network.NBitcoinNetwork, out var psbt))
             return;
         var store = await ui.ServiceProvider.GetRequiredService<StoreRepository>().FindStore(StoreId ?? "");
         var handlers = ui.ServiceProvider.GetRequiredService<PaymentMethodHandlerDictionary>();

--- a/BTCPayServer/HostedServices/Webhooks/InvoiceWebhookDeliveryRequest.cs
+++ b/BTCPayServer/HostedServices/Webhooks/InvoiceWebhookDeliveryRequest.cs
@@ -49,5 +49,5 @@ public class InvoiceWebhookDeliveryRequest(
     }
 
     public override string ToString()
-        => $"Webhook delivery request ({webhookEvent.Type})";
+        => $"Webhook delivery request ({WebhookEvent.Type})";
 }

--- a/BTCPayServer/Hosting/Startup.cs
+++ b/BTCPayServer/Hosting/Startup.cs
@@ -178,7 +178,13 @@ namespace BTCPayServer.Hosting
             mvcBuilder.AddRazorRuntimeCompilation();
 #endif
 
-            services.AddServerSideBlazor();
+
+            services.AddServerSideBlazor().AddHubOptions(o =>
+            {
+                // PSBT with previous transactions could become
+                // easily too big to get signed without this.
+                o.MaximumReceiveMessageSize = BlazorMaximumReceiveMessageSize;
+            });
 
             LowercaseTransformer.Register(services);
             ValidateControllerNameTransformer.Register(services);
@@ -237,6 +243,9 @@ namespace BTCPayServer.Hosting
                 });
             }
         }
+
+        public const long BlazorMaximumReceiveMessageSize = 5_000_000;
+
         public void Configure(
             IApplicationBuilder app,
             IWebHostEnvironment env,

--- a/BTCPayServer/Views/UIWallets/WalletSendVault.cshtml
+++ b/BTCPayServer/Views/UIWallets/WalletSendVault.cshtml
@@ -1,7 +1,5 @@
-@using BTCPayServer.Abstractions.TagHelpers
 @using BTCPayServer.Blazor.VaultBridge
-@using BTCPayServer.TagHelpers
-@using Microsoft.AspNetCore.Mvc.TagHelpers
+@using BTCPayServer.Hosting
 @model WalletSendVaultModel
 @{
     var walletId = Context.GetRouteValue("walletId")?.ToString() ?? "";
@@ -9,6 +7,12 @@
     Layout = "_LayoutWizard";
     ViewData.SetActivePage(WalletsNavPages.Send, StringLocalizer["Sign the transaction"], walletId);
     this.ViewData.SetBlazorAllowed(true);
+
+    // Calculate maximum PSBT size accounting for SignalR message overhead
+    var blazorMax = Startup.BlazorMaximumReceiveMessageSize;
+    var otherDataSize = 500; // Estimated overhead for other SignalR message data
+    decimal waste = 1.35m; // Base64 re-encoding overhead factor (approximately 35%)
+    long maxPSBTSize = (long)((blazorMax - otherDataSize) / waste);
 }
 
 @section Navbar {
@@ -20,18 +24,29 @@
     <p class="lead text-secondary mt-3" text-translate="true">Using BTCPay Server Vault</p>
 </header>
 
-<div class="row mt-5 mb-4">
-    <div class="col-md-8 mx-auto">
-        <component type="typeof(VaultBridgeUI)"
-                   param-Controller="@(new SignHWIController()
-                                      {
-                                          StoreId = WalletId.Parse(walletId).StoreId,
-                                          CryptoCode = WalletId.Parse(walletId).CryptoCode,
-                                          PSBT = Model.SigningContext.PSBT
-                                      })"
-                   render-mode="Server"/>
+<partial name="_StatusMessage" />
+
+@if (maxPSBTSize >= Model.SigningContext.PSBT.Length)
+{
+    <div class="row mt-5 mb-4">
+        <div class="col-md-8 mx-auto">
+            <component type="typeof(VaultBridgeUI)"
+                       param-Controller="@(new SignHWIController()
+                                         {
+                                             StoreId = WalletId.Parse(walletId).StoreId,
+                                             CryptoCode = WalletId.Parse(walletId).CryptoCode,
+                                             PSBT = Convert.FromBase64String(Model.SigningContext.PSBT)
+                                         })"
+                       render-mode="Server" />
+        </div>
     </div>
-</div>
+}
+else
+{
+    <div class="alert alert-danger my-4" role="alert">
+        <span>@StringLocalizer["PSBT too large to be signed by Vault. (Max: {0} bytes)", maxPSBTSize]</span>
+    </div>
+}
 
 <div id="body" class="my-4">
     <form id="broadcastForm" asp-action="WalletSendVault" asp-route-walletId="@walletId" method="post" style="display:none;">


### PR DESCRIPTION
Reported by @rockstardev 

More precisely, a blazor message should be less than 32KB, but due to how blazor encode the message, the actual max PSBT byte size is ~24 KB.

A PSBT can easily exceeds this size when `Include NonWitness Utxo in PSBTs` is activated.

I bumped the max blazor message size to 5MB. I believe it should be fine for most cases... if it exceeds, we now show a proper error message instead of crashing.