### PR TITLE
Feat: Alert user if Lightning Node lacks inbound capacity. 

### DIFF
--- a/BTCPayServer/Components/Liquidity/Default.cshtml
+++ b/BTCPayServer/Components/Liquidity/Default.cshtml
@@ -1,0 +1,60 @@
+@model BTCPayServer.Components.Liquidity.LiquidityViewModel
+@using BTCPayServer.Lightning
+
+@if (Model.HasLiquidityReport && Model.LiquidityReport != null)
+{
+    var status = Model.LiquidityReport.LiquidityStatus.ToString();
+    var activeInbound = Model.LiquidityReport.ActiveInboundSatoshis;
+    var pendingInbound = Model.LiquidityReport.PendingInboundSatoshis;
+
+    <div class="mt-4 mb-4 p-3 bg-light rounded" id="liquidity-component">
+        <div class="card">
+            <div class="card-header d-flex justify-content-between align-items-center">
+                <span class="h4 mb-0">BTC Lightning Inbound Payment Capacity</span>
+
+                @{
+                    var badgeClass = status switch
+                    {
+                        "Good" => "bg-success",
+                        "Pending" => "badge-unusual",
+                        "Bad" => "bg-danger",
+                        _ => "bg-secondary"
+                    };
+                }
+                <span class="badge @badgeClass px-3 py-2">@status</span>
+            </div>
+
+            <!-- Center all body content -->
+            <div class="card-body text-center">
+                @if (status == "Good")
+                {
+                    <p class="card-text">
+                        <strong>Active Inbound Capacity:</strong>
+                        <span class="text-success">@activeInbound</span>
+                    </p>
+                }
+                else if (status == "Pending")
+                {
+                    <p class="card-text">
+                        <strong>Pending Inbound Capacity:</strong>
+                        <span class="text-warning">@pendingInbound</span>
+                    </p>
+                    <p class="card-text small text-muted">
+                        Your node has pending channels that, once confirmed, will provide sufficient inbound capacity.
+                    </p>
+                }
+                else if (status == "Bad")
+                {
+                    <p class="card-text fs-5 fw-bold">
+                        Warning: To receive Lightning payments you need a channel with inbound capacity
+                    </p>
+                    <p class="card-text">
+                        Get a channel from a Lightning Service Provider to start receiving payments.
+                    </p>
+                    <a href="~/server/plugins?search=lsps-1" class="btn btn-primary mt-2 mb-2">Get Inbound Capacity</a>
+                }
+                <p class="card-text small mt-2 text-muted">@Model.Message</p>
+            </div>
+        </div>
+    </div>
+}

--- a/BTCPayServer/Components/Liquidity/Liquidity.cs
+++ b/BTCPayServer/Components/Liquidity/Liquidity.cs
@@ -1,0 +1,101 @@
+#nullable enable
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using BTCPayServer.Lightning;
+using BTCPayServer.Lightning.CLightning;
+using BTCPayServer.Lightning.JsonConverters;
+using Newtonsoft.Json;
+
+namespace BTCPayServer.Components.Liquidity
+{
+    /// <summary>
+    /// Overall inbound-liquidity health.
+    /// </summary>
+    public enum LiquidityStatus
+    {
+        Good,
+        Pending,
+        Bad
+    }
+
+    /// <summary>
+    /// DTO returned when liquidity could be analysed.
+    /// </summary>
+    public class LiquidityReport
+    {
+        public LiquidityStatus LiquidityStatus { get; set; }
+
+        [JsonConverter(typeof(LightMoneyJsonConverter))]
+        public LightMoney ActiveInboundSatoshis { get; set; } = LightMoney.Zero;
+
+        [JsonConverter(typeof(LightMoneyJsonConverter))]
+        public LightMoney PendingInboundSatoshis { get; set; } = LightMoney.Zero;
+    }
+
+    /// <summary>
+    /// Helper for checking Core-Lightning inbound liquidity.
+    /// </summary>
+    public static class Liquidity
+    {
+        private static readonly LightMoney DefaultThreshold = LightMoney.Satoshis(250_000);
+
+        /// <summary>
+        /// Returns <c>null</c> when the supplied node is not Core-Lightning or
+        /// if an error occurs; otherwise returns a populated <see cref="LiquidityReport"/>.
+        /// </summary>
+        public static async Task<LiquidityReport?> CheckAsync(
+            ILightningClient client,
+            LightMoney? threshold = null,
+            CancellationToken token = default)
+        {
+            // This check is specific to CLN because it's the only implementation
+            // where ListChannels returns pending channels.
+            if (client is not CLightningClient)
+            {
+                return null;
+            }
+
+            var min = threshold ?? DefaultThreshold;
+
+            try
+            {
+                var channels = await client.ListChannels(token);
+
+                if (channels is null)
+                {
+                    return null;
+                }
+
+                // inbound capacity = total – local
+                LightMoney activeInbound = channels.Where(c => c.IsActive)
+                                                    .Aggregate(LightMoney.Zero,
+                                                               (s, ch) => s + (ch.Capacity - ch.LocalBalance));
+
+                LightMoney pendingInbound = channels.Where(c => !c.IsActive)
+                                                     .Aggregate(LightMoney.Zero,
+                                                                (s, ch) => s + (ch.Capacity - ch.LocalBalance));
+
+                var status = LiquidityStatus.Bad;
+                if (activeInbound >= min)
+                    status = LiquidityStatus.Good;
+                else if (pendingInbound >= min)
+                    status = LiquidityStatus.Pending;
+
+                var report = new LiquidityReport
+                {
+                    LiquidityStatus = status,
+                    ActiveInboundSatoshis = activeInbound,
+                    PendingInboundSatoshis = pendingInbound
+                };
+                return report;
+            }
+            catch (Exception)
+            {
+                // Return null instead of re-throwing to allow the UI to handle it gracefully.
+                return null;
+            }
+        }
+    }
+}

--- a/BTCPayServer/Components/Liquidity/LiquidityViewComponent.cs
+++ b/BTCPayServer/Components/Liquidity/LiquidityViewComponent.cs
@@ -1,0 +1,128 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using BTCPayServer.Lightning;
+using BTCPayServer.Services;
+using BTCPayServer.Services.Stores;
+using BTCPayServer.Data;
+using BTCPayServer.Payments;
+using BTCPayServer.Payments.Lightning;
+using BTCPayServer.Configuration;
+using BTCPayServer.Services.Invoices;
+using Microsoft.Extensions.Options;
+using NBitcoin;
+
+
+namespace BTCPayServer.Components.Liquidity
+{
+    /// <summary>
+    /// ViewComponent that displays Lightning Network inbound liquidity information.
+    /// Currently only supports Core Lightning (CLN) nodes.
+    /// </summary>
+    public class LiquidityViewComponent : ViewComponent
+    {
+        private readonly StoreRepository _storeRepository;
+        private readonly LightningClientFactoryService _lightningClientFactory;
+        private readonly BTCPayNetworkProvider _networkProvider;
+        private readonly PaymentMethodHandlerDictionary _handlers;
+        private readonly IOptions<LightningNetworkOptions> _lightningNetworkOptions;
+
+        public LiquidityViewComponent(
+            StoreRepository storeRepository,
+            LightningClientFactoryService lightningClientFactory,
+            BTCPayNetworkProvider networkProvider,
+            PaymentMethodHandlerDictionary handlers,
+            IOptions<LightningNetworkOptions> lightningNetworkOptions)
+        {
+            _storeRepository = storeRepository;
+            _lightningClientFactory = lightningClientFactory;
+            _networkProvider = networkProvider;
+            _handlers = handlers;
+            _lightningNetworkOptions = lightningNetworkOptions;
+        }
+
+        public async Task<IViewComponentResult> InvokeAsync(string storeId)
+        {
+            var viewModel = new LiquidityViewModel();
+            if (string.IsNullOrEmpty(storeId))
+            {
+                return View(viewModel);
+            }
+            try
+            {
+                var store = await _storeRepository.FindStore(storeId);
+                if (store == null)
+                {
+                    return View(viewModel);
+                }
+
+                var client = GetLightningClient(store);
+                if (client == null)
+                {
+                    viewModel.Message = "Could not connect to Lightning node";
+                    return View(viewModel);
+                }
+
+                var liquidityReport = await Liquidity.CheckAsync(client);
+                if (liquidityReport != null)
+                {
+                    viewModel.HasLiquidityReport = true;
+                    viewModel.LiquidityReport = liquidityReport;
+                    viewModel.Message = "Liquidity information is available for your Core Lightning node";
+                }
+                else
+                {
+                    viewModel.Message = "Liquidity information is only available for Core Lightning nodes";
+                }
+            }
+            catch (Exception)
+            {
+                viewModel.Message = "Error retrieving liquidity information";
+            }
+
+            return View(viewModel);
+        }
+
+        private ILightningClient? GetLightningClient(StoreData store)
+        {
+            try
+            {
+                var network = _networkProvider.GetNetwork<BTCPayNetwork>("BTC");
+                if (network == null)
+                {
+                    return null;
+                }
+
+                var paymentMethodId = PaymentTypes.LN.GetPaymentMethodId(network.CryptoCode);
+                if (_handlers.TryGet(paymentMethodId) is not LightningLikePaymentHandler)
+                {
+                    return null;
+                }
+
+                var paymentMethodDetails = store.GetPaymentMethodConfig<LightningPaymentMethodConfig>(paymentMethodId, _handlers);
+                if (paymentMethodDetails == null)
+                {
+                    return null;
+                }
+
+                if (string.IsNullOrEmpty(paymentMethodDetails.ConnectionString))
+                {
+                    return _lightningNetworkOptions.Value.InternalLightningByCryptoCode.TryGetValue(network.CryptoCode, out var internalClient)
+                        ? internalClient
+                        : null;
+                }
+
+                return _lightningClientFactory.Create(paymentMethodDetails.ConnectionString, network);
+            }
+            catch (Exception)
+            {
+                return null;
+            }
+        }
+    }
+}

--- a/BTCPayServer/Components/Liquidity/LiquidityViewModel.cs
+++ b/BTCPayServer/Components/Liquidity/LiquidityViewModel.cs
@@ -1,0 +1,11 @@
+#nullable enable
+
+namespace BTCPayServer.Components.Liquidity
+{
+    public class LiquidityViewModel
+    {
+        public bool HasLiquidityReport { get; set; }
+        public LiquidityReport? LiquidityReport { get; set; }
+        public string? Message { get; set; }
+    }
+}

--- a/BTCPayServer/Views/UIStores/Lightning.cshtml
+++ b/BTCPayServer/Views/UIStores/Lightning.cshtml
@@ -44,7 +44,7 @@
             Public Node Info
         </a>
     </div>
-
+<vc:liquidity store-id="@Model.StoreId" />
     @if (Model.Services != null && Model.Services.Any())
     {
         <div permission="@Policies.CanModifyServerSettings" class="mt-5">


### PR DESCRIPTION
This pull request relies on changes to `BTCPayserver.Lightning`, shown in this PR: https://github.com/btcpayserver/BTCPayServer.Lightning/pull/172

`BTCPayServer.Lightning` now creates a `LiquidityReport` for a backing Core Lightning node, which allows us to show useful alerts to the user on the Lightning page:

<img width="622" alt="no-inbound-capacity" src="https://github.com/user-attachments/assets/3e155eaf-70bb-472f-818a-93527ee2e528" />
<img width="744" alt="pending-capacity" src="https://github.com/user-attachments/assets/d0195197-ed3f-445f-88be-76e8e72c17d2" />
<img width="1101" alt="good-inbound-capacity" src="https://github.com/user-attachments/assets/e59295aa-79b5-4077-a0de-05bfdccc69c0" />
