### PR TITLE
Add rate information in on chain wallet and reports

### DIFF
--- a/BTCPayServer.Client/Models/StoreBaseData.cs
+++ b/BTCPayServer.Client/Models/StoreBaseData.cs
@@ -46,6 +46,7 @@ namespace BTCPayServer.Client.Models
         public double? PaymentTolerance { get; set; }
         public bool? AnyoneCanCreateInvoice { get; set; }
         public string DefaultCurrency { get; set; }
+        public List<string> AdditionalTrackedRates { get; set; }
 
         public bool? LightningAmountInSatoshi { get; set; }
         public bool? LightningPrivateRouteHints { get; set; }

--- a/BTCPayServer.Tests/CSVInvoicesTester.cs
+++ b/BTCPayServer.Tests/CSVInvoicesTester.cs
@@ -1,0 +1,46 @@
+﻿using System.Linq;
+using Xunit;
+
+namespace BTCPayServer.Tests;
+
+internal class CSVInvoicesTester(string text) : CSVTester(text)
+{
+    string invoice = "";
+    int payment = 0;
+
+    public CSVInvoicesTester ForInvoice(string invoice)
+    {
+        this.payment = 0;
+        this.invoice = invoice;
+        return this;
+    }
+    public CSVInvoicesTester SelectPayment(int payment)
+    {
+        this.payment = payment;
+        return this;
+    }
+    public CSVInvoicesTester AssertCount(int count)
+    {
+        Assert.Equal(count, _lines
+            .Count(l => l[_indexes["InvoiceId"]] == invoice));
+        return this;
+    }
+
+    public CSVInvoicesTester AssertValues(params (string, string)[] values)
+    {
+        var payments = _lines
+            .Where(l => l[_indexes["InvoiceId"]] == invoice)
+            .ToArray();
+        var line = payments[payment];
+        foreach (var (key, value) in values)
+        {
+            Assert.Equal(value, line[_indexes[key]]);
+        }
+        return this;
+    }
+
+    public string GetPaymentId() => _lines
+        .Where(l => l[_indexes["InvoiceId"]] == invoice)
+        .Select(l => l[_indexes["PaymentId"]])
+        .FirstOrDefault();
+}

--- a/BTCPayServer.Tests/CSVTester.cs
+++ b/BTCPayServer.Tests/CSVTester.cs
@@ -1,0 +1,18 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+
+namespace BTCPayServer.Tests;
+
+public class CSVTester
+{
+    protected readonly Dictionary<string, int> _indexes;
+    protected  readonly List<string[]> _lines;
+
+    public CSVTester(string text)
+    {
+        var lines = text.Split("\r\n").ToList();
+        var headers = lines[0].Split(',');
+        _indexes = headers.Select((h,i) => (h,i)).ToDictionary(h => h.h, h => h.i);
+        _lines = lines.Skip(1).ToList().Select(l => l.Split(',')).ToList();
+    }
+}

--- a/BTCPayServer.Tests/PlaywrightTester.cs
+++ b/BTCPayServer.Tests/PlaywrightTester.cs
@@ -375,6 +375,14 @@ namespace BTCPayServer.Tests
         public async Task AddDerivationScheme(string cryptoCode = "BTC",
             string derivationScheme = "tpubD6NzVbkrYhZ4XxNXjYTcRujMc8z8734diCthtFGgDMimbG5hUsKBuSTCuUyxWL7YwP7R4A5StMTRQiZnb6vE4pdHWPgy9hbiHuVJfBMumUu-[legacy]")
         {
+            if (cryptoCode != "BTC" && derivationScheme ==
+                "tpubD6NzVbkrYhZ4XxNXjYTcRujMc8z8734diCthtFGgDMimbG5hUsKBuSTCuUyxWL7YwP7R4A5StMTRQiZnb6vE4pdHWPgy9hbiHuVJfBMumUu-[legacy]")
+            {
+                derivationScheme = new BitcoinExtPubKey("tpubD6NzVbkrYhZ4XxNXjYTcRujMc8z8734diCthtFGgDMimbG5hUsKBuSTCuUyxWL7YwP7R4A5StMTRQiZnb6vE4pdHWPgy9hbiHuVJfBMumUu", Network.RegTest)
+                    .ToNetwork(NBitcoin.Altcoins.Litecoin.Instance.Regtest)
+                    .ToString()! + "-[legacy]";
+            }
+
             if (!(await Page.ContentAsync()).Contains($"Setup {cryptoCode} Wallet"))
                 await GoToWalletSettings(cryptoCode);
 
@@ -651,6 +659,12 @@ namespace BTCPayServer.Tests
             public Task BumpFee(uint256? txId = null) => Page.ClickAsync($"{TxRowSelector(txId)} .bumpFee-btn");
             static string TxRowSelector(uint256? txId = null) => txId is null ? ".transaction-row:first-of-type"  : $".transaction-row[data-value=\"{txId}\"]";
 
+            public async Task AssertRowContains(uint256 txId, string expected)
+            {
+                var text = await Page.InnerTextAsync(TxRowSelector(txId));
+                Assert.Contains(expected.NormalizeWhitespaces(), text.NormalizeWhitespaces());
+            }
+
             public Task AssertHasLabels(string label) => AssertHasLabels(null, label);
             public async Task AssertHasLabels(uint256? txId, string label)
             {
@@ -732,6 +746,21 @@ namespace BTCPayServer.Tests
                 Assert.Equal(expected, actual);
             }
             public async Task Broadcast() => await page.ClickAsync("#BroadcastTransaction");
+        }
+
+        public async Task ClickViewReport()
+        {
+            await Page.ClickAsync("#view-report");
+            await Page.WaitForSelectorAsync("#raw-data-table");
+        }
+
+        public async Task<string> DownloadReportCSV()
+        {
+            var download = await Page.RunAndWaitForDownloadAsync(async () =>
+            {
+                await ClickPagePrimary();
+            });
+            return await new StreamReader(await download.CreateReadStreamAsync()).ReadToEndAsync();
         }
     }
 }

--- a/BTCPayServer.Tests/ServerTester.cs
+++ b/BTCPayServer.Tests/ServerTester.cs
@@ -275,5 +275,16 @@ namespace BTCPayServer.Tests
                 PayTester.Dispose();
             TestLogs.LogInformation("BTCPayTester disposed");
         }
+
+        public RPCClient GetExplorerNode(string cryptoCode) =>
+            cryptoCode == "BTC" ? ExplorerNode :
+            cryptoCode == "LTC" ? LTCExplorerNode :
+            throw new NotSupportedException();
+
+        public BTCPayNetwork GetNetwork(string cryptoCode)
+            => cryptoCode == "BTC" ? NetworkProvider.GetNetwork<BTCPayNetwork>("BTC") :
+                cryptoCode == "LTC" ? NetworkProvider.GetNetwork<BTCPayNetwork>("LTC") :
+                cryptoCode == "LBTC" ? NetworkProvider.GetNetwork<BTCPayNetwork>("LBTC") :
+                throw new NotSupportedException();
     }
 }

--- a/BTCPayServer/Controllers/GreenField/GreenfieldStoreRatesController.cs
+++ b/BTCPayServer/Controllers/GreenField/GreenfieldStoreRatesController.cs
@@ -68,7 +68,7 @@ namespace BTCPayServer.Controllers.GreenField
             var result = new List<StoreRateResult>();
             foreach (var rateTask in rateTasks)
             {
-                var rateTaskResult = rateTask.Value.Result;
+                var rateTaskResult = await rateTask.Value;
 
                 result.Add(new StoreRateResult()
                 {

--- a/BTCPayServer/Controllers/GreenField/GreenfieldStoresController.cs
+++ b/BTCPayServer/Controllers/GreenField/GreenfieldStoresController.cs
@@ -208,6 +208,7 @@ namespace BTCPayServer.Controllers.Greenfield
                 //we do not include PaymentMethodCriteria because moving the CurrencyValueJsonConverter to the Client csproj is hard and requires a refactor (#1571 & #1572)
                 NetworkFeeMode = storeBlob.NetworkFeeMode,
                 DefaultCurrency = storeBlob.DefaultCurrency,
+                AdditionalTrackedRates = (storeBlob.AdditionalTrackedRates ?? []).ToList(),
                 Receipt = InvoiceDataBase.ReceiptOptions.Merge(storeBlob.ReceiptOptions, null),
                 LightningAmountInSatoshi = storeBlob.LightningAmountInSatoshi,
                 LightningPrivateRouteHints = storeBlob.LightningPrivateRouteHints,
@@ -259,6 +260,7 @@ namespace BTCPayServer.Controllers.Greenfield
             //we do not include OnChainMinValue and LightningMaxValue because moving the CurrencyValueJsonConverter to the Client csproj is hard and requires a refactor (#1571 & #1572)
             blob.NetworkFeeMode = restModel.NetworkFeeMode.Value;
             blob.DefaultCurrency = restModel.DefaultCurrency;
+            blob.AdditionalTrackedRates = restModel.AdditionalTrackedRates?.ToArray();
             blob.ReceiptOptions = InvoiceDataBase.ReceiptOptions.Merge(restModel.Receipt, null);
             blob.LightningAmountInSatoshi = restModel.LightningAmountInSatoshi.Value;
             blob.LightningPrivateRouteHints = restModel.LightningPrivateRouteHints.Value;

--- a/BTCPayServer/Controllers/UIStoresController.Settings.cs
+++ b/BTCPayServer/Controllers/UIStoresController.Settings.cs
@@ -40,6 +40,7 @@ public partial class UIStoresController
             PaymentTolerance = storeBlob.PaymentTolerance,
             InvoiceExpiration = (int)storeBlob.InvoiceExpiration.TotalMinutes,
             DefaultCurrency = storeBlob.DefaultCurrency,
+            AdditionalTrackedRates = string.Join(',', storeBlob.AdditionalTrackedRates?.ToArray() ?? []),
             BOLT11Expiration = (long)storeBlob.RefundBOLT11Expiration.TotalDays,
             Archived = store.Archived,
             MonitoringExpiration = (int)storeBlob.MonitoringExpiration.TotalMinutes,
@@ -81,7 +82,8 @@ public partial class UIStoresController
         blob.AnyoneCanInvoice = model.AnyoneCanCreateInvoice;
         blob.NetworkFeeMode = model.NetworkFeeMode;
         blob.PaymentTolerance = model.PaymentTolerance;
-        blob.DefaultCurrency = model.DefaultCurrency;
+        blob.DefaultCurrency = model.DefaultCurrency.ToUpperInvariant().Trim();
+        blob.AdditionalTrackedRates = model.AdditionalTrackedRates?.Split(',', StringSplitOptions.RemoveEmptyEntries);
         blob.ShowRecommendedFee = model.ShowRecommendedFee;
         blob.RecommendedFeeBlockTarget = model.RecommendedFeeBlockTarget;
         blob.InvoiceExpiration = TimeSpan.FromMinutes(model.InvoiceExpiration);
@@ -174,7 +176,7 @@ public partial class UIStoresController
             storeId = CurrentStore.Id
         });
     }
-        
+
     [HttpPost("{storeId}/archive")]
     [Authorize(Policy = Policies.CanModifyStoreSettings, AuthenticationSchemes = AuthenticationSchemes.Cookie)]
     public async Task<IActionResult> ToggleArchive(string storeId)
@@ -207,7 +209,7 @@ public partial class UIStoresController
         TempData[WellKnownTempData.SuccessMessage] = "Store successfully deleted.";
         return RedirectToAction(nameof(UIHomeController.Index), "UIHome");
     }
-        
+
     [HttpGet("{storeId}/checkout")]
     public async Task<IActionResult> CheckoutAppearance()
     {
@@ -281,7 +283,7 @@ public partial class UIStoresController
                 }
             }
         }
-            
+
         var userId = GetUserId();
         if (userId is null)
             return NotFound();

--- a/BTCPayServer/Data/WalletTransactionInfo.cs
+++ b/BTCPayServer/Data/WalletTransactionInfo.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using BTCPayServer.Client.Models;
 using BTCPayServer.Services;
+using BTCPayServer.Services.Invoices;
 using BTCPayServer.Services.Labels;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -19,7 +20,7 @@ namespace BTCPayServer.Data
         }
         [JsonIgnore]
         public WalletId WalletId { get; }
-        public string Comment { get; set; } = string.Empty;
+        public string? Comment { get; set; } = string.Empty;
         [JsonIgnore]
         public List<Attachment> Attachments { get; set; } = new List<Attachment>();
 
@@ -81,6 +82,8 @@ namespace BTCPayServer.Data
                 return _LegacyLabels;
             }
         }
+
+        public RateBook? Rates { get; set; }
 
         public WalletTransactionInfo Merge(WalletTransactionInfo? value)
         {

--- a/BTCPayServer/HostedServices/OnChainRateTrackerHostedService.cs
+++ b/BTCPayServer/HostedServices/OnChainRateTrackerHostedService.cs
@@ -1,0 +1,81 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using BTCPayServer.Data;
+using BTCPayServer.Events;
+using BTCPayServer.Logging;
+using BTCPayServer.Rating;
+using BTCPayServer.Services;
+using BTCPayServer.Services.Rates;
+using BTCPayServer.Services.Stores;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json.Linq;
+
+namespace BTCPayServer.HostedServices;
+
+public class OnChainRateTrackerHostedService(
+    EventAggregator eventAggregator,
+    Logs logger,
+    WalletRepository walletRepository,
+    DefaultRulesCollection defaultRateRules,
+    RateFetcher rateFetcher,
+    StoreRepository storeRepository) : EventHostedServiceBase(eventAggregator, logger)
+{
+    protected override void SubscribeToEvents()
+    {
+        Subscribe<NewOnChainTransactionEvent>();
+    }
+
+    protected override async Task ProcessEvent(object evt, CancellationToken cancellationToken)
+    {
+        if (evt is NewOnChainTransactionEvent newOnChainTransactionEvent)
+            await ProcessEventCore(newOnChainTransactionEvent, cancellationToken);
+    }
+
+    private async Task ProcessEventCore(NewOnChainTransactionEvent transactionEvent, CancellationToken cancellationToken)
+    {
+        var derivation = transactionEvent.NewTransactionEvent.DerivationStrategy;
+            if (derivation is null)
+                return;
+            var now = DateTimeOffset.UtcNow;
+            // Too late
+            if ((transactionEvent.NewTransactionEvent.TransactionData.Timestamp - now).Duration() > TimeSpan.FromMinutes(10))
+                return;
+            var cryptoCode = transactionEvent.NewTransactionEvent.CryptoCode;
+
+            var stores = await storeRepository.GetStoresFromDerivation(transactionEvent.PaymentMethodId, derivation);
+            foreach (var storeId in stores)
+            {
+                var store = await storeRepository.FindStore(storeId);
+                if (store is null)
+                    continue;
+                var blob = store.GetStoreBlob();
+                var trackedCurrencies = blob.GetTrackedRates();
+                var rules = blob.GetRateRules(defaultRateRules);
+                var fetching = rateFetcher.FetchRates(
+                    trackedCurrencies
+                        .Select(t => new CurrencyPair(cryptoCode, t))
+                        .ToHashSet(), rules, new StoreIdRateContext(storeId), CancellationToken);
+                JObject rates = new();
+                foreach (var rate in fetching)
+                {
+                    var result = await rate.Value;
+                    if (result.BidAsk is { } ba)
+                        rates.Add(rate.Key.Right, ba.Center.ToString(CultureInfo.InvariantCulture));
+                }
+                if (!rates.Properties().Any())
+                    continue;
+
+                var wid = new WalletId(storeId, cryptoCode);
+                var txObject = new WalletObjectId(wid, WalletObjectData.Types.Tx, transactionEvent.NewTransactionEvent.TransactionData.TransactionHash.ToString());
+
+                await walletRepository.AddOrUpdateWalletObjectData(txObject, new WalletRepository.UpdateOperation.MergeObject(new JObject()
+                {
+                    [ "rates" ] = rates,
+                }));
+            }
+    }
+}

--- a/BTCPayServer/Hosting/BTCPayServerServices.cs
+++ b/BTCPayServer/Hosting/BTCPayServerServices.cs
@@ -435,6 +435,7 @@ o.GetRequiredService<IEnumerable<IPaymentLinkExtension>>().ToDictionary(o => o.P
             services.AddSingleton<IHostedService, AppHubStreamer>();
             services.AddSingleton<IHostedService, AppInventoryUpdaterHostedService>();
             services.AddSingleton<IHostedService, TransactionLabelMarkerHostedService>();
+            services.AddSingleton<IHostedService, OnChainRateTrackerHostedService>();
             services.AddSingleton<IHostedService, UserEventHostedService>();
             services.AddSingleton<IHostedService, DynamicDnsHostedService>();
             services.AddSingleton<PaymentRequestStreamer>();

--- a/BTCPayServer/Models/StoreViewModels/GeneralSettingsViewModel.cs
+++ b/BTCPayServer/Models/StoreViewModels/GeneralSettingsViewModel.cs
@@ -27,7 +27,7 @@ namespace BTCPayServer.Models.StoreViewModels
 
         [Display(Name = "Apply the brand color to the store's backend as well")]
         public bool ApplyBrandColorToBackend { get; set; }
-        
+
         [Display(Name = "Logo")]
         public IFormFile LogoFile { get; set; }
         public string LogoUrl { get; set; }
@@ -55,6 +55,10 @@ namespace BTCPayServer.Models.StoreViewModels
         [Display(Name = "Default currency")]
         [MaxLength(10)]
         public string DefaultCurrency { get; set; }
+
+        [Display(Name = "Additional rates to track")]
+        [MaxLength(30)]
+        public string AdditionalTrackedRates { get; set; }
 
         [Display(Name = "Minimum acceptable expiration time for BOLT11 for refunds")]
         [Range(0, 365 * 10)]

--- a/BTCPayServer/Models/WalletViewModels/ListTransactionsViewModel.cs
+++ b/BTCPayServer/Models/WalletViewModels/ListTransactionsViewModel.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using BTCPayServer.Data;
+using BTCPayServer.Services.Invoices;
 
 namespace BTCPayServer.Models.WalletViewModels
 {
@@ -17,11 +18,17 @@ namespace BTCPayServer.Models.WalletViewModels
             public bool Positive { get; set; }
             public string Balance { get; set; }
             public HashSet<TransactionTagModel> Tags { get; set; } = new();
+            public string Rate { get; set; }
+            public List<string> Rates { get; set; } = new();
+            public RateBook WalletRateBook { get; set; }
+            public RateBook InvoiceRateBook { get; set; }
+            public string InvoiceId { get; set; }
         }
         public HashSet<(string Text, string Color, string TextColor)> Labels { get; set; } = new();
         public List<TransactionViewModel> Transactions { get; set; } = new();
         public override int CurrentPageCount => Transactions.Count;
         public string CryptoCode { get; set; }
         public PendingTransaction[] PendingTransactions { get; set; }
+        public List<string> Rates { get; set; }
     }
 }

--- a/BTCPayServer/Payments/IPaymentMethodHandler.cs
+++ b/BTCPayServer/Payments/IPaymentMethodHandler.cs
@@ -308,9 +308,13 @@ namespace BTCPayServer.Payments
             // We need to fetch the rates necessary for the evaluation of the payment method criteria
             var currency = Prompt.Currency;
             if (currency is not null)
+            {
                 RequiredRates.Add(currency);
+                foreach (var r in StoreBlob.AdditionalTrackedRates ?? [])
+                    OptionalRates.Add(new CurrencyPair(currency, r));
+            }
             if (currency is not null
-                 && Status is PaymentMethodContext.ContextStatus.WaitingForCreation or PaymentMethodContext.ContextStatus.WaitingForActivation)
+                && Status is PaymentMethodContext.ContextStatus.WaitingForCreation or PaymentMethodContext.ContextStatus.WaitingForActivation)
             {
                 foreach (var paymentMethodCriteria in StoreBlob.PaymentMethodCriteria
                     .Where(c => c.Value?.Currency is not null && c.PaymentMethod == PaymentMethodId))

--- a/BTCPayServer/Services/Invoices/RateBook.cs
+++ b/BTCPayServer/Services/Invoices/RateBook.cs
@@ -1,0 +1,149 @@
+﻿#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using BTCPayServer.Data;
+using BTCPayServer.Rating;
+using Newtonsoft.Json.Linq;
+
+namespace BTCPayServer.Services.Invoices;
+
+public class RateBook
+{
+    public static RateBook Parse(string rates, string defaultCurrency)
+    {
+        ArgumentNullException.ThrowIfNull(rates);
+        ArgumentNullException.ThrowIfNull(defaultCurrency);
+        if (rates == "")
+            return new(defaultCurrency, new());
+        var o = JObject.Parse(rates);
+        var ratesDict = new Dictionary<string, decimal>();
+        foreach (var property in o.Properties())
+        {
+            ratesDict.Add(property.Name, decimal.Parse(property.Value.ToString(), CultureInfo.InvariantCulture));
+        }
+        return new RateBook(defaultCurrency, ratesDict);
+    }
+
+    public RateBook()
+    {
+        Rates = new();
+    }
+    public RateBook(
+        string defaultCurrency,
+        Dictionary<string, decimal> rates
+    )
+    {
+        Rates = new(rates.Count);
+        foreach (var rate in rates)
+        {
+            if (!rate.Key.Contains('_', StringComparison.Ordinal))
+                Rates.Add(new CurrencyPair(rate.Key, defaultCurrency), rate.Value);
+            else
+                Rates.Add(CurrencyPair.Parse(rate.Key), rate.Value);
+        }
+    }
+    public Dictionary<CurrencyPair, decimal> Rates { get; }
+
+    public decimal? TryGetRate(CurrencyPair pair)
+    {
+        if (GetFastLaneRate(pair, out var tryGetRate)) return tryGetRate;
+
+        var rule = GetRateRules().GetRuleFor(pair);
+        rule.Reevaluate();
+        if (rule.BidAsk is null)
+            return null;
+        return rule.BidAsk.Bid;
+    }
+
+    private bool GetFastLaneRate(CurrencyPair pair, out decimal v)
+    {
+        ArgumentNullException.ThrowIfNull(pair);
+        if (Rates.TryGetValue(pair, out var rate)) // Fast lane
+        {
+            v = rate;
+            return true;
+        }
+        v = 0m;
+        return false;
+    }
+
+    public decimal GetRate(CurrencyPair pair)
+    {
+        if (GetFastLaneRate(pair, out var v)) return v;
+        var rule = GetRateRules().GetRuleFor(pair);
+        rule.Reevaluate();
+        if (rule.BidAsk is null)
+            throw new InvalidOperationException($"Rate rule is not evaluated ({rule.Errors.First()})");
+        return rule.BidAsk.Bid;
+    }
+
+    public bool TryGetRate(CurrencyPair pair, out decimal rate)
+    {
+        if (GetFastLaneRate(pair, out rate)) return true;
+        var rule = GetRateRules().GetRuleFor(pair);
+        rule.Reevaluate();
+        if (rule.BidAsk is null)
+        {
+            rate = 0.0m;
+            return false;
+        }
+
+        rate = rule.BidAsk.Bid;
+        return true;
+    }
+
+    public RateRules GetRateRules()
+    {
+        var builder = new StringBuilder();
+        foreach (var r in Rates)
+        {
+            builder.AppendLine($"{r.Key} = {r.Value.ToString(CultureInfo.InvariantCulture)};");
+        }
+
+        if (RateRules.TryParse(builder.ToString(), out var rules))
+            return rules;
+        throw new FormatException("Invalid rate rules");
+    }
+
+    public void AddRates(RateBook? otherBook)
+    {
+        if (otherBook is null)
+            return;
+        foreach (var rate in otherBook.Rates)
+        {
+            this.Rates.TryAdd(rate.Key, rate.Value);
+        }
+    }
+
+    public static RateBook? FromTxWalletObject(WalletObjectData txObject)
+    {
+        var rates = txObject.GetData()?["rates"] as JObject;
+        if (rates is null)
+            return null;
+        var cryptoCode = WalletId.Parse(txObject.WalletId).CryptoCode;
+        return FromJObject(rates, cryptoCode);
+    }
+
+    public static RateBook? FromJObject(JObject rates, string cryptoCode)
+    {
+        var result = new RateBook();
+        foreach (var property in rates.Properties())
+        {
+            var rate = decimal.Parse(property.Value.ToString(), CultureInfo.InvariantCulture);
+            result.Rates.TryAdd(new CurrencyPair(cryptoCode, property.Name), rate);
+        }
+        return result;
+    }
+
+    public void AddCurrencies(HashSet<string> trackedCurrencies)
+    {
+        foreach (var r in Rates)
+        {
+            trackedCurrencies.Add(r.Key.Left);
+            trackedCurrencies.Add(r.Key.Right);
+        }
+    }
+}

--- a/BTCPayServer/Services/Reporting/OnChainWalletReportProvider.cs
+++ b/BTCPayServer/Services/Reporting/OnChainWalletReportProvider.cs
@@ -1,10 +1,12 @@
 #nullable enable
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using BTCPayServer.Data;
 using BTCPayServer.Payments.Bitcoin;
+using BTCPayServer.Rating;
 using BTCPayServer.Services.Invoices;
 using BTCPayServer.Services.Stores;
 using Dapper;
@@ -12,42 +14,33 @@ using NBitcoin;
 
 namespace BTCPayServer.Services.Reporting;
 
-public class OnChainWalletReportProvider : ReportProvider
+public class OnChainWalletReportProvider(
+    NBXplorerConnectionFactory nbxplorerConnectionFactory,
+    StoreRepository storeRepository,
+    InvoiceRepository invoiceRepository,
+    PaymentMethodHandlerDictionary handlers,
+    WalletRepository walletRepository)
+    : ReportProvider
 {
-    public OnChainWalletReportProvider(
-        NBXplorerConnectionFactory NbxplorerConnectionFactory,
-        StoreRepository storeRepository,
-        PaymentMethodHandlerDictionary handlers,
-        WalletRepository walletRepository)
-    {
-        this.NbxplorerConnectionFactory = NbxplorerConnectionFactory;
-        StoreRepository = storeRepository;
-        _handlers = handlers;
-        WalletRepository = walletRepository;
-    }
-
-    private NBXplorerConnectionFactory NbxplorerConnectionFactory { get; }
-    private StoreRepository StoreRepository { get; }
-    private PaymentMethodHandlerDictionary _handlers;
-    private WalletRepository WalletRepository { get; }
     public override string Name => "Wallets";
+
     ViewDefinition CreateViewDefinition()
     {
         return new()
         {
             Fields =
             {
-                new ("Date", "datetime"),
-                new ("Crypto", "string"),
+                new("Date", "datetime"),
+                new("Crypto", "string"),
                 // For proper rendering of explorer links, Crypto should always be before tx_id
-                new ("TransactionId", "tx_id"),
-                new ("InvoiceId", "invoice_id"),
-                new ("Confirmed", "boolean"),
-                new ("BalanceChange", "amount")
+                new("TransactionId", "tx_id"),
+                new("InvoiceId", "invoice_id"),
+                new("Confirmed", "boolean"),
+                new("BalanceChange", "amount"),
             },
             Charts =
             {
-                new ()
+                new()
                 {
                     Name = "Group by Crypto",
                     Totals = { "Crypto" },
@@ -58,37 +51,39 @@ public class OnChainWalletReportProvider : ReportProvider
         };
     }
 
-    public override bool IsAvailable()
-    {
-        return NbxplorerConnectionFactory.Available;
-    }
+    public override bool IsAvailable() => nbxplorerConnectionFactory.Available;
 
     public override async Task Query(QueryContext queryContext, CancellationToken cancellation)
     {
         queryContext.ViewDefinition = CreateViewDefinition();
-        await using var conn = await NbxplorerConnectionFactory.OpenConnection();
-        var store = await StoreRepository.FindStore(queryContext.StoreId);
+        await using var conn = await nbxplorerConnectionFactory.OpenConnection();
+        var store = await storeRepository.FindStore(queryContext.StoreId);
         if (store is null)
             return;
+        Dictionary<(string CryptoCode, string TxId), RateBook> walletBooks = new();
+        HashSet<string> cryptoCodes = new();
         var interval = DateTimeOffset.UtcNow - queryContext.From;
-        foreach (var (pmi, settings) in store.GetPaymentMethodConfigs<DerivationSchemeSettings>(_handlers))
+        foreach (var (pmi, settings) in store.GetPaymentMethodConfigs<DerivationSchemeSettings>(handlers))
         {
-            var network = ((IHasNetwork)_handlers[pmi]).Network;
+            var network = ((IHasNetwork)handlers[pmi]).Network;
+            cryptoCodes.Add(network.CryptoCode);
             var walletId = new WalletId(store.Id, network.CryptoCode);
             var command = new CommandDefinition(
-            commandText:
-            "SELECT r.tx_id, r.seen_at, t.blk_id, t.blk_height, r.balance_change " +
-            "FROM get_wallets_recent(@wallet_id, @code, @asset_id, @interval, NULL, NULL) r " +
-            "JOIN txs t USING (code, tx_id) " +
-            "ORDER BY r.seen_at",
-            parameters: new
-            {
-                asset_id = GetAssetId(network),
-                wallet_id = NBXplorer.Client.DBUtils.nbxv1_get_wallet_id(network.CryptoCode, settings.AccountDerivation.ToString()),
-                code = network.CryptoCode,
-                interval
-            },
-            cancellationToken: cancellation);
+                commandText:
+                """
+                SELECT r.tx_id, r.seen_at, t.blk_id, t.blk_height, r.balance_change
+                FROM get_wallets_recent(@wallet_id, @code, @asset_id, @interval, NULL, NULL) r
+                JOIN txs t USING (code, tx_id)
+                ORDER BY r.seen_at
+                """,
+                parameters: new
+                {
+                    asset_id = GetAssetId(network),
+                    wallet_id = NBXplorer.Client.DBUtils.nbxv1_get_wallet_id(network.CryptoCode, settings.AccountDerivation.ToString()),
+                    code = network.CryptoCode,
+                    interval
+                },
+                cancellationToken: cancellation);
 
             var rows = await conn.QueryAsync(command);
             foreach (var r in rows)
@@ -105,21 +100,66 @@ public class OnChainWalletReportProvider : ReportProvider
                 values.Add((long?)r.blk_height is not null);
                 values.Add(new FormattedAmount(balanceChange, network.Divisibility).ToJObject());
             }
-            var objects = await WalletRepository.GetWalletObjects(new GetWalletObjectsQuery
+
+            var objects = await walletRepository.GetWalletObjects(new GetWalletObjectsQuery
             {
                 Ids = queryContext.Data.Select(d => (string)d[2]!).ToArray(),
                 WalletId = walletId,
-                Type = "tx"
+                Type = WalletObjectData.Types.Tx
             });
             foreach (var row in queryContext.Data)
             {
-                if (!objects.TryGetValue(new WalletObjectId(walletId, "tx", (string)row[2]!), out var txObject))
+                if (!objects.TryGetValue(new WalletObjectId(walletId, WalletObjectData.Types.Tx, (string)row[2]!), out var txObject))
                     continue;
-                var invoiceId = txObject.GetLinks().Where(t => t.type == "invoice").Select(t => t.id).FirstOrDefault();
+                var invoiceId = txObject.GetLinks().Where(t => t.type == WalletObjectData.Types.Invoice).Select(t => t.id).FirstOrDefault();
                 row[3] = invoiceId;
+                if (RateBook.FromTxWalletObject(txObject) is {} book)
+                    walletBooks.Add(GetKey(row), book);
+            }
+        }
+
+        // The currencies appearing in this report are:
+        // - The currently tracked rates of the store
+        // - The rates that were tracked at the invoices level
+        // - The rates that were tracked at the wallet level
+        var trackedCurrencies = store.GetStoreBlob().GetTrackedRates().ToHashSet();
+        var rates = await invoiceRepository.GetRatesOfInvoices(queryContext.Data.Select(r => r[3]).OfType<string>().ToHashSet());
+        foreach (var book in rates.Select(r => r.Value))
+        {
+            book.AddCurrencies(trackedCurrencies);
+        }
+        foreach (var row in queryContext.Data)
+        {
+            walletBooks.TryGetValue(GetKey(row), out var rateData);
+            rateData?.AddCurrencies(trackedCurrencies);
+        }
+        trackedCurrencies.ExceptWith(cryptoCodes);
+        foreach (var trackedCurrency in trackedCurrencies)
+        {
+            // We don't use amount here. Rounding the rates is dangerous when the price of the
+            // shitcoin is very low.
+            queryContext.ViewDefinition.Fields.Add(new($"Rate ({trackedCurrency})", "number"));
+        }
+
+        foreach (var row in queryContext.Data)
+        {
+            var k = GetKey(row);
+            walletBooks.TryGetValue(k, out var rateData);
+            var invoiceId = row[3] as string;
+            rates.TryGetValue(invoiceId ?? "", out var r);
+            r ??= new("", new());
+            r.AddRates(rateData);
+            foreach (var trackedCurrency in trackedCurrencies)
+            {
+                if (r.TryGetRate(new CurrencyPair(k.CryptoCode, trackedCurrency)) is decimal v)
+                    row.Add(v);
+                else
+                    row.Add(null);
             }
         }
     }
+
+    private (string CryptoCode, string TxId) GetKey(IList<object?> row) => ((string)row[1]!, (string)row[2]!);
 
     private string? GetAssetId(BTCPayNetwork network)
     {

--- a/BTCPayServer/Views/UIReports/StoreReports.cshtml
+++ b/BTCPayServer/Views/UIReports/StoreReports.cshtml
@@ -4,20 +4,33 @@
 @inject BTCPayServer.Security.ContentSecurityPolicies Csp
 @model StoreReportsViewModel
 @{
-	ViewData.SetActivePage(StoreNavPages.Reporting, StringLocalizer["Reporting"]);
-	Csp.UnsafeEval();
+    ViewData.SetActivePage(StoreNavPages.Reporting, StringLocalizer["Reporting"]);
+    Csp.UnsafeEval();
 }
+
 @section PageHeadContent
 {
     @* Set a height for the responsive table container to make it work with the fixed table headers.
        Details described here: thttps://uxdesign.cc/position-stuck-96c9f55d9526 *@
     <style>
-        #app .table-responsive { max-height: 80vh; }
-        #app #charts { gap: var(--btcpay-space-l) var(--btcpay-space-xxl); }
-        #app #charts article { flex: 1 1 450px; }
-        main .dropdown-menu.show { z-index: 99999; }
+        #app .table-responsive {
+            max-height: 80vh;
+        }
+
+        #app #charts {
+            gap: var(--btcpay-space-l) var(--btcpay-space-xxl);
+        }
+
+        #app #charts article {
+            flex: 1 1 450px;
+        }
+
+        main .dropdown-menu.show {
+            z-index: 99999;
+        }
     </style>
 }
+
 
 <div class="sticky-header">
     <h2>
@@ -27,40 +40,50 @@
         </a>
     </h2>
     <div>
-        <a cheat-mode="true" class="btn btn-outline-info text-nowrap" asp-action="StoreReports" asp-route-fakeData="true" asp-route-viewName="@Model.Request?.ViewName">Create fake data</a>
-		<button id="page-primary" class="btn btn-primary text-nowrap" type="button" data-action="exportCSV">Export</button>
+        <a cheat-mode="true" class="btn btn-outline-info text-nowrap" asp-action="StoreReports" asp-route-fakeData="true"
+           asp-route-viewName="@Model.Request?.ViewName">Create fake data</a>
+        <button id="page-primary" class="btn btn-primary text-nowrap" type="button" data-action="exportCSV">Export</button>
     </div>
 </div>
-<div class="d-flex flex-column flex-sm-row align-items-center gap-3 mb-l">
-	<div class="dropdown" v-pre>
-		<button id="ViewNameToggle" class="btn btn-secondary dropdown-toggle dropdown-toggle-custom-caret" type="button" data-bs-toggle="dropdown" aria-expanded="false">@Model.Request.ViewName</button>
-		<div class="dropdown-menu" aria-labelledby="ViewNameToggle">
-			@foreach (var v in Model.AvailableViews)
-			{
-				<a href="#" data-view="@v" class="available-view dropdown-item @(Model.Request.ViewName == v ? "custom-active" : "")">@v</a>
-			}
-		</div>
-	</div>
-	<div class="input-group">
-		<input id="fromDate" class="form-control flatdtpicker" type="datetime-local"
-			   data-fdtp='{ "enableTime": true, "enableSeconds": true, "dateFormat": "Y-m-d H:i:S", "time_24hr": true, "defaultHour": 0 }'
-			   placeholder="Start Date" />
-		<button type="button" class="btn btn-primary input-group-clear" title="@StringLocalizer["Clear"]">
-            <vc:icon symbol="close" />
-		</button>
-	</div>
-	<div class="input-group">
-		<input id="toDate" class="form-control flatdtpicker" type="datetime-local"
-			   data-fdtp='{ "enableTime": true, "enableSeconds": true, "dateFormat": "Y-m-d H:i:S", "time_24hr": true, "defaultHour": 0 }'
-			   placeholder="End Date" />
-		<button type="button" class="btn btn-primary input-group-clear" title="@StringLocalizer["Clear"]">
-            <vc:icon symbol="close" />
-		</button>
+<div class="row">
+    <div class="col-xl-8 col-xxl-constrain">
+        <nav id="SectionNav">
+            <div class="nav">
+                @foreach (var v in Model.AvailableViews)
+                {
+                    <a href="#" data-view="@v" class="available-view nav-link @(Model.Request.ViewName == v ? "active" : "")" role="tab">@v</a>
+                }
+            </div>
+        </nav>
+
+        <div class="d-flex gap-3">
+            <div class="form-group">
+                <label for="fromDate" class="form-label">@StringLocalizer["Start Date"]</label>
+                <input id="fromDate" name="fromDate"
+                       data-fdtp='{ "enableTime": true, "enableSeconds": true, "dateFormat": "Y-m-d H:i:S", "time_24hr": true, "defaultHour": 0 }'
+                       class="form-control flatdtpicker" placeholder="@StringLocalizer["Start Date"]" />
+            </div>
+
+            <div class="form-group">
+                <label for="toDate" class="form-label">@StringLocalizer["End Date"]</label>
+                <input id="toDate" name="toDate" class="form-control flatdtpicker"
+                       data-fdtp='{ "enableTime": true, "enableSeconds": true, "dateFormat": "Y-m-d H:i:S", "time_24hr": true, "defaultHour": 0 }'
+                       placeholder="@StringLocalizer["End Date"]" />
+            </div>
+            <div id="searchGroup" v-cloak class="form-group d-flex align-items-end">
+                <button id="searchBtn" class="btn btn-primary" :disabled="loading" type="button">
+                    <span v-if="loading" class="spinner-border spinner-border-sm me-1" role="status" style="margin-left: -6px;"></span>
+                    <span v-else class="me-1"><vc:icon symbol="actions-search" /></span>
+                    <span text-translate="true">Search</span>
+                </button>
+                <span class="text-danger invalid-feedback field-validation-error" v-if="error">{{ error }}</span>
+            </div>
+        </div>
     </div>
 </div>
 
-<div id="app" v-cloak class="w-100-fixed">
-    <div v-if="srv.charts && srv.charts.some(hasChartData)" id="charts"  class="d-flex flex-wrap mb-5">
+<div id="app" v-if="!loading" v-cloak class="w-100-fixed">
+    <div v-if="srv.charts && srv.charts.some(hasChartData)" id="charts" class="d-flex flex-wrap mb-3">
         <article v-for="chart in srv.charts" v-if="hasChartData(chart)">
             <h3>{{ chart.name }}</h3>
             <div class="table-responsive">
@@ -74,8 +97,12 @@
                     <tbody>
                     <tr v-for="(row, rowIndex) in chart.rows">
                         <td v-for="(group, groupIndex) in row.groups" :rowspan="group.rowCount">
-                            <template v-if="group.name === true"><vc:icon symbol="checkmark" css-class="text-success" /></template>
-                            <template v-else-if="group.name === false"><vc:icon symbol="cross" css-class="text-danger" /></template>
+                            <template v-if="group.name === true">
+                                <vc:icon symbol="checkmark" css-class="text-success" />
+                            </template>
+                            <template v-else-if="group.name === false">
+                                <vc:icon symbol="cross" css-class="text-danger" />
+                            </template>
                             <template v-else-if="['Settled', 'Processing', 'Invalid', 'Expired', 'New', 'Pending'].includes(group.name)">
                                 <span class="badge" :class="`badge-${group.name.toLowerCase()}`">{{ displayValue(group.name) }}</span>
                             </template>
@@ -83,8 +110,11 @@
                         </td>
                         <td v-if="row.isTotal" :colspan="row.rLevel">Total</td>
                         <td v-for="(value, columnIndex) in row.values" class="text-end">
-                            <template v-if="chart.aggregates[columnIndex] === 'BalanceChange' && (value >= 0 || typeof value === 'object' && value.d >= 0)"><span class="text-success">{{ displayValue(value) }}</span></template>
-                            <template v-else-if="chart.aggregates[columnIndex] === 'BalanceChange' && (value < 0 || typeof value === 'object' && value.d < 0)"><span class="text-danger">{{ displayValue(value) }}</span></template>
+                            <template v-if="chart.aggregates[columnIndex] === 'BalanceChange' && (value >= 0 || typeof value === 'object' && value.d >= 0)">
+                                <span class="text-success">{{ displayValue(value) }}</span></template>
+                            <template
+                                v-else-if="chart.aggregates[columnIndex] === 'BalanceChange' && (value < 0 || typeof value === 'object' && value.d < 0)">
+                                <span class="text-danger">{{ displayValue(value) }}</span></template>
                             <template v-else>{{ displayValue(value) }}</template>
                         </td>
                     </tr>
@@ -99,7 +129,7 @@
     </div>
     <article v-if="srv.result.data">
         <h3 id="raw-data">Raw data</h3>
-        <div class="table-responsive" v-if="srv.result.data.length">
+        <div id="raw-data-table" class="table-responsive" v-if="srv.result.data.length">
             <table class="table table-hover">
                 <thead class="sticky-top bg-body">
                 <tr>
@@ -127,7 +157,8 @@
                            target="_blank"
                            v-if="srv.result.fields[columnIndex].type === 'invoice_id'">{{ displayValue(value) }}</a>
                         <template v-else-if="srv.result.fields[columnIndex].type === 'tx_id'">
-                            <vc:truncate-center text="value" is-vue="true" padding="15" classes="truncate-center-id" link="getExplorerUrl(value, row[columnIndex-1])" />
+                            <vc:truncate-center text="value" is-vue="true" padding="15" classes="truncate-center-id"
+                                                link="getExplorerUrl(value, row[columnIndex-1])" />
                         </template>
                         <template
                             v-else-if="value && srv.result.fields[columnIndex].name.toLowerCase().endsWith('url')">
@@ -136,15 +167,22 @@
                             </template>
                             <template v-else>{{ displayValue(value) }}</template>
                         </template>
-                        <template v-else-if="value && ['Address'].includes(srv.result.fields[columnIndex].name)" >
+                        <template v-else-if="value && ['Address'].includes(srv.result.fields[columnIndex].name)">
                             <vc:truncate-center text="value" is-vue="true" padding="15" classes="truncate-center-id" />
                         </template>
                         <template v-else-if="srv.result.fields[columnIndex].type === 'datetime'">{{ displayDate(value) }}</template>
-                        <span v-else-if="srv.result.fields[columnIndex].type === 'boolean' && value === true"><vc:icon symbol="checkmark" css-class="text-success" /></span>
-                        <span v-else-if="srv.result.fields[columnIndex].type === 'boolean' && value === false"><vc:icon symbol="cross" css-class="text-danger"/></span>
-                        <span v-else-if="['BalanceChange'].includes(srv.result.fields[columnIndex].name) && (value >= 0 || typeof value === 'object' && value.d >= 0)" class="text-success">{{ displayValue(value) }}</span>
-                        <span v-else-if="['BalanceChange'].includes(srv.result.fields[columnIndex].name) && (value < 0 || typeof value === 'object' && value.d < 0)" class="text-danger">{{ displayValue(value) }}</span>
-                        <span v-else-if="['State'].includes(srv.result.fields[columnIndex].name)" class="badge" :class="`badge-${value.toLowerCase()}`">{{ displayValue(value) }}</span>
+                        <span v-else-if="srv.result.fields[columnIndex].type === 'boolean' && value === true"><vc:icon symbol="checkmark"
+                                                                                                                       css-class="text-success" /></span>
+                        <span v-else-if="srv.result.fields[columnIndex].type === 'boolean' && value === false"><vc:icon symbol="cross"
+                                                                                                                        css-class="text-danger" /></span>
+                        <span
+                            v-else-if="['BalanceChange'].includes(srv.result.fields[columnIndex].name) && (value >= 0 || typeof value === 'object' && value.d >= 0)"
+                            class="text-success">{{ displayValue(value) }}</span>
+                        <span
+                            v-else-if="['BalanceChange'].includes(srv.result.fields[columnIndex].name) && (value < 0 || typeof value === 'object' && value.d < 0)"
+                            class="text-danger">{{ displayValue(value) }}</span>
+                        <span v-else-if="['State'].includes(srv.result.fields[columnIndex].name)" class="badge"
+                              :class="`badge-${value.toLowerCase()}`">{{ displayValue(value) }}</span>
                         <template v-else>{{ displayValue(value) }}</template>
                     </td>
                 </tr>
@@ -155,12 +193,13 @@
     </article>
 </div>
 
+
 @section PageFootContent {
-	<script src="~/vendor/decimal.js/decimal.min.js" asp-append-version="true"></script>
-	<script src="~/vendor/FileSaver/FileSaver.min.js" asp-append-version="true"></script>
-	<script src="~/vendor/papaparse/papaparse.min.js" asp-append-version="true"></script>
-	<script src="~/vendor/vuejs/vue.min.js" asp-append-version="true"></script>
-	<script>const srv = @Safe.Json(Model);</script>
-	<script src="~/js/datatable.js" asp-append-version="true"></script>
-	<script src="~/js/store-reports.js" asp-append-version="true"></script>
+    <script src="~/vendor/decimal.js/decimal.min.js" asp-append-version="true"></script>
+    <script src="~/vendor/FileSaver/FileSaver.min.js" asp-append-version="true"></script>
+    <script src="~/vendor/papaparse/papaparse.min.js" asp-append-version="true"></script>
+    <script src="~/vendor/vuejs/vue.min.js" asp-append-version="true"></script>
+    <script>const srv = @Safe.Json(Model);</script>
+    <script src="~/js/datatable.js" asp-append-version="true"></script>
+    <script src="~/js/store-reports.js" asp-append-version="true"></script>
 }

--- a/BTCPayServer/Views/UIStores/GeneralSettings.cshtml
+++ b/BTCPayServer/Views/UIStores/GeneralSettings.cshtml
@@ -57,7 +57,7 @@
                     </div>
                 </div>
             </div>
-                
+
             <div class="form-group">
                 <div class="d-flex align-items-center justify-content-between gap-2">
                     <label asp-for="LogoFile" class="form-label"></label>
@@ -118,6 +118,12 @@
                 <label asp-for="DefaultCurrency" class="form-label"></label>
                 <input asp-for="DefaultCurrency" class="form-control w-auto" currency-selection />
                 <span asp-validation-for="DefaultCurrency" class="text-danger"></span>
+            </div>
+            <div class="form-group">
+                <label asp-for="AdditionalTrackedRates" class="form-label"></label>
+                <input asp-for="AdditionalTrackedRates" class="form-control" placeholder="@StringLocalizer["Comma-separated list of currencies (eg. USD,EUR,JPY)"]" />
+                <div class="form-text" text-translate="true">The rates of those currencies, in addition to the default currency, will be recorded when a new invoice is created. The rates will then be accessible through reports.</div>
+                <span asp-validation-for="AdditionalTrackedRates" class="text-danger"></span>
             </div>
             <div class="form-group mt-4">
                 <label asp-for="NetworkFeeMode" class="form-label"></label>

--- a/BTCPayServer/Views/UIWallets/WalletTransactions.cshtml
+++ b/BTCPayServer/Views/UIWallets/WalletTransactions.cshtml
@@ -13,6 +13,7 @@
     var cryptoCode = Context.GetRouteValue("cryptoCode")?.ToString();
     var labelFilter = Context.Request.Query["labelFilter"].ToString();
     var wallet = walletId != null ? WalletId.Parse(walletId) : new WalletId(storeId, cryptoCode);
+    storeId = wallet.StoreId;
 
     ViewData.SetActivePage(WalletsNavPages.Transactions, StringLocalizer["{0} Transactions", Model.CryptoCode], walletId);
 }
@@ -42,7 +43,7 @@
                 order: 1;
             }
         }
-        
+
         #LoadingIndicator {
             margin-bottom: 1.5rem;
         }
@@ -59,24 +60,24 @@
         const $list = document.getElementById('WalletTransactionsList');
         const $dropdowns = document.getElementById('Dropdowns');
         const $indicator = document.getElementById('LoadingIndicator');
-        
+
         delegate('click', '#GoToTop', () => {
             window.scrollTo({ top: 0, behavior: 'smooth' });
         });
-        
+
         if ($actions && $actions.offsetTop - window.innerHeight > 0) {
             document.getElementById('GoToTop').classList.remove('d-none');
         }
-        
+
         const count = @Safe.Json(Model.Count);
         const skipInitial = @Safe.Json(Model.Skip);
 		const loadMoreUrl = @Safe.Json(Url.Action("WalletTransactions", new {walletId, labelFilter, skip = Model.Skip, count = Model.Count, loadTransactions = true}));
 		// The next time we load transactions, skip will become 0
         let skip = @Safe.Json(Model.Skip) - count;
-        
+
         async function loadMoreTransactions() {
             $indicator.classList.remove('d-none');
-            
+
             const skipNext = skip + count;
             const url = loadMoreUrl.replace(`skip=${skipInitial}`, `skip=${skipNext}`)
             const response = await fetch(url, {
@@ -85,13 +86,13 @@
                     'X-Requested-With': 'XMLHttpRequest'
                 }
             });
-            
+
             if (response.ok) {
                 const html = await response.text();
                 const responseEmpty = html.trim() === '';
                 $list.insertAdjacentHTML('beforeend', html);
                 skip = skipNext;
-                
+
                 if (responseEmpty) {
                     // in case the response html was empty, remove the observer and stop loading
                     observer.unobserve($actions);
@@ -105,19 +106,19 @@
                     }
                 }
             }
-            
+
             $indicator.classList.add('d-none');
             formatDateTimes(document.querySelector('#WalletTransactions .switch-time-format').dataset.mode);
             initLabelManagers();
         }
-        
+
 		const observer = new IntersectionObserver(async entries => {
             const { isIntersecting } = entries[0];
             if (isIntersecting) {
                 await loadMoreTransactions();
             }
         }, { rootMargin: '128px' });
-        
+
         // the actions div marks the end of the list table
         observer.observe($actions);
     </script>
@@ -156,7 +157,19 @@
             </ul>
         </div>
     }
+
     <div class="dropdown d-inline-flex align-items-center gap-3 ms-auto" id="Export">
+        <a
+            id="view-report"
+            permission="@Policies.CanViewReports"
+            asp-controller="UIReports"
+            asp-action="StoreReports"
+            asp-route-storeId="@storeId"
+            asp-route-viewName="Wallets"
+            class="btn btn-secondary">
+            <vc:icon symbol="nav-reporting" />
+            <span text-translate="true">Reporting</span>
+        </a>
         <button class="btn btn-secondary dropdown-toggle" type="button" id="ExportDropdownToggle" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false" text-translate="true">
             Export
         </button>
@@ -175,7 +188,7 @@
         <table class="table table-hover ">
             <thead>
                 <th>Id</th>
-                <th>State</th> 
+                <th>State</th>
                 <th>Signatures</th>
                 <th>Scheme</th>
                 <th>Actions</th>
@@ -190,10 +203,10 @@
                     <td><span id="Sigs_@(index)__Collected">@ptblob?.SignaturesCollected</span></td>
                     <td><span id="Sigs_@(index)__Scheme">@ptblob?.SignaturesNeeded/@ptblob?.SignaturesTotal</span></td>
                     <td>
-                        <a asp-action="ViewPendingTransaction" asp-route-walletId="@walletId" 
+                        <a asp-action="ViewPendingTransaction" asp-route-walletId="@walletId"
                            asp-route-pendingTransactionId="@pendingTransaction.Id">@(pendingTransaction.State == PendingTransactionState.Signed ? "Broadcast" : "View")</a>
                         -
-                        <a asp-action="CancelPendingTransaction" asp-route-walletId="@walletId" 
+                        <a asp-action="CancelPendingTransaction" asp-route-walletId="@walletId"
                            asp-route-pendingTransactionId="@pendingTransaction.Id">Abort</a>
                     </td>
                 </tr>
@@ -221,6 +234,10 @@
             <th text-translate="true" style="min-width:125px">Label</th>
             <th text-translate="true">Transaction</th>
             <th text-translate="true" class="amount-col">Amount</th>
+            @foreach (var rate in Model.Rates)
+            {
+                <th class="rate-col"><span text-translate="true">Rate</span>&nbsp;<span>(@rate)</span></th>
+            }
             <th></th>
         </tr>
         </thead>
@@ -230,7 +247,7 @@
                 <input type="checkbox" class="form-check-input mass-action-select-all" />
             </th>
             <th colspan="5">
-                <div class="d-flex flex-wrap align-items-center justify-content-between gap-3">
+                <div class="d-flex flex-wrap align-items-center gap-3">
                     <div>
                         <strong class="mass-action-selected-count">0</strong>
                             <span text-translate="true">selected</span>
@@ -265,6 +282,6 @@
 
 <p class="mt-4 mb-0">
     @ViewLocalizer["If BTCPay Server shows you an invalid balance, {0}.<br />If some transactions appear in BTCPay Server, but are missing in another wallet, {1}.",
-        Html.ActionLink(StringLocalizer["rescan your wallet"], "WalletRescan", "UIWallets", new { walletId = Context.GetRouteValue("walletId") }), 
+        Html.ActionLink(StringLocalizer["rescan your wallet"], "WalletRescan", "UIWallets", new { walletId = Context.GetRouteValue("walletId") }),
         new HtmlString($"<a href=\"https://docs.btcpayserver.org/FAQ/Wallet/#missing-payments-in-my-software-or-hardware-wallet\" target=\"_blank\" rel=\"noreferrer noopener\">{StringLocalizer["follow these instructions"]}</a>")]
 </p>

--- a/BTCPayServer/Views/UIWallets/_WalletTransactionsList.cshtml
+++ b/BTCPayServer/Views/UIWallets/_WalletTransactionsList.cshtml
@@ -27,6 +27,12 @@
         <td class="align-middle amount-col">
             <span data-sensitive class="text-@(transaction.Positive ? "success" : "danger")@(transaction.IsConfirmed ? "" : " opacity-50")">@transaction.Balance</span>
         </td>
+        @foreach (var rate in transaction.Rates)
+        {
+            <td class="align-middle rate-col">
+                <span>@rate</span>
+            </td>
+        }
         <td class="align-middle text-end">
             <div class="d-inline-flex gap-3 align-items-center">
 				@if (transaction.CanBumpFee)

--- a/BTCPayServer/wwwroot/main/site.css
+++ b/BTCPayServer/wwwroot/main/site.css
@@ -378,7 +378,7 @@ h2 .icon.icon-info {
 .widget {
     --widget-padding: var(--btcpay-space-m);
     --widget-chart-width: 100vw;
-    
+
     border: 1px solid var(--btcpay-body-border-light);
     border-radius: var(--btcpay-border-radius-l);
     padding: var(--widget-padding);
@@ -546,7 +546,7 @@ h2 .icon.icon-info {
     .widget.store-lightning-services .services-list .service {
         --service-width: 3rem;
     }
-    
+
     .widget .store-number {
         flex: 0 1 100%;
     }
@@ -598,7 +598,7 @@ h2 .icon.icon-info {
         grid-column-start: 9;
         grid-column-end: 13;
     }
-    
+
     .widget.store-numbers {
         flex-direction: column;
         justify-content: start;
@@ -650,7 +650,7 @@ h2 .icon.icon-info {
 .btcpay-list-select-item {
     display: flex;
     flex-wrap: wrap;
-    flex: 1 1 45%; 
+    flex: 1 1 45%;
     align-items: center;
     padding: .75rem var(--btcpay-space-s);
     cursor: pointer;
@@ -697,7 +697,7 @@ input:checked + label.btcpay-list-select-item {
         --wrap-max-width: none;
         --wrap-padding-vertical: var(--btcpay-space-l);
         --wrap-padding-horizontal: var(--btcpay-space-m);
-        
+
         display: flex;
         flex-direction: column;
         gap: 1.5rem;
@@ -705,7 +705,7 @@ input:checked + label.btcpay-list-select-item {
         margin: 0 auto;
         padding: var(--wrap-padding-vertical) var(--wrap-padding-horizontal);
     }
-    
+
     /* gradually try to set better but less supported values and units */
     .min-vh-100,
     .public-page-wrap {
@@ -808,7 +808,7 @@ a.store-powered-by:hover .logo-brand-dark {
     --icon-size: 64px;
     --icon-border-size: var(--btcpay-space-xs);
     --icon-border-color: var(--btcpay-white);
-    
+
     max-width: 320px;
     min-width: var(--qr-size);
     margin: 0 auto;
@@ -1090,7 +1090,7 @@ input.ts-wrapper.form-control:not(.ts-hidden-accessible,.ts-inline) {
         border-radius: var(--btcpay-border-radius-l);
         padding: var(--btcpay-space-xs) var(--btcpay-space-s);
     }
-    
+
     .truncate-center-text {
         color: transparent;
         position: absolute;
@@ -1161,6 +1161,15 @@ input.ts-wrapper.form-control:not(.ts-hidden-accessible,.ts-inline) {
 .blazor-status .btn-close .icon {
     --icon-size: .75rem;
 }
+
+.btn .icon {
+    --icon-size: 1.25rem;
+    vertical-align: text-bottom;
+    /*Without this the icon + text are in the middle,*/
+    /*but the visual balance is off, and it doesn't feel center*/
+    margin-left: calc(var(--icon-size) / -2);
+}
+
 .btn.btn-lg .icon {
     --icon-size: 1.75rem;
 }
@@ -1170,6 +1179,10 @@ input.ts-wrapper.form-control:not(.ts-hidden-accessible,.ts-inline) {
     min-width: 8rem;
 }
 .amount-col {
+    text-align: right;
+    white-space: nowrap;
+}
+.rate-col {
     text-align: right;
     white-space: nowrap;
 }

--- a/BTCPayServer/wwwroot/swagger/v1/swagger.template.stores.json
+++ b/BTCPayServer/wwwroot/swagger/v1/swagger.template.stores.json
@@ -507,6 +507,15 @@
                         "default": "USD",
                         "example": "USD"
                     },
+                    "additionalTrackedRates": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "description": "Additional rates to track.\nThe rates of those currencies, in addition to the default currency, will be recorded when a new invoice is created. The rates will then be accessible through reports.",
+                        "default": [],
+                        "example": ["JPY", "EUR"]
+                    },
                     "invoiceExpiration": {
                         "default": 900,
                         "minimum": 60,


### PR DESCRIPTION
## Motivation

Currently, we only show the exchange rate between the payment currency and the invoice currency. For example, if a USD invoice is paid with BTC, the merchant can see the BTC/USD rate.

However, there are many other contexts where merchants would benefit from seeing exchange rate information—for example, in the wallet transaction list (where a transaction may or may not be related to an invoice), and in reports.

Additionally, in some cases, a merchant may need to know the rate of more than one currency. For instance, when sending funds to contributors of the BTCPay Server Foundation, contributors upload USD- or EUR-denominated invoices, payments are made in BTC, but tax calculations require the JPY rate. In such cases, the store should be able to track not only the exchange rate for the invoice currency, but also for JPY.

This PR adds a new option to specify additional tracked currencies for a store.

### Configure the additional tracked currency in the store settings

In the example of the BTCPay Server Foundation, we would fill this new option with `JPY`.

<img width="870" height="308" alt="image" src="https://github.com/user-attachments/assets/41db5689-14a8-448d-87f7-b973430a543a" />


### Rate information in the wallet transaction list

Rate information now appears in the wallet transaction list.

<img width="1103" height="370" alt="image" src="https://github.com/user-attachments/assets/f4239fb9-c77c-4ce2-b0ab-830c3a32fed1" />

### Rate information in the Wallet report

<img width="1182" height="667" alt="image" src="https://github.com/user-attachments/assets/86c17f45-1ec8-4e07-ba21-e0b016dc6a1e" />

### Rate information in the Invoice report

I decided against truncating the rate, as it may have significant repercussion on accounting if the price of a crypto unit is very small.

<img width="1858" height="383" alt="image" src="https://github.com/user-attachments/assets/8a64a93d-c18a-40a2-84c8-77ecfab4e2ee" />

### Easily go to Wallet report from the wallet transactions list

Similar to what we did in #6835, I added a `Reporting` button.

<img width="1086" height="309" alt="image" src="https://github.com/user-attachments/assets/6e5151d3-2734-4bfd-bbf1-55d9f9f36375" />


## Implementation details

There are two types of rates:
* Wallet Rates: Which is the rates recorded when we detect a transaction for a wallet.
* Invoice Rates: The rates recorded at the creation of an invoice.

For the "Wallets" report and in wallet transactions list, we are mixing both. When two values conflict, the invoice rate is chosen.

If the tracking of additionally tracked currency fails at invoice creation time, the invoice will still properly generate, and the data will be missing.