### PR TITLE
The truncate center component in vue would not properly display the content

### DIFF
--- a/BTCPayServer/Components/TruncateCenter/Default.cshtml
+++ b/BTCPayServer/Components/TruncateCenter/Default.cshtml
@@ -15,7 +15,7 @@
             }
             else
             {
-                <span class="truncate-center-start" v-text="@(Model.Text).slice(0, @(Model.Padding)) + @(Model.Text).length > 2 * @(Model.Padding) ? '…' : ''"></span>
+                <span class="truncate-center-start" v-text="@(Model.Text).length > 2 * @(Model.Padding) ? @(Model.Text).slice(0, @(Model.Padding)) + '…' : ''"></span>
             }
             <span class="truncate-center-end" v-text="@(Model.Text).slice(-@(Model.Padding))" v-if="@(Model.Text).length > 2 * @(Model.Padding)"></span>
         </span>


### PR DESCRIPTION
Before for the transaction id `6dcd61e590c3d67e0d701cd5c97a3b47e838a0b4f2a7a327d9d52dbd193da54f`

<img width="1219" height="254" alt="image" src="https://github.com/user-attachments/assets/4bddf15a-b932-4282-a086-c12466d2f2f1" />

Now

<img width="1548" height="217" alt="image" src="https://github.com/user-attachments/assets/b5c7346b-c1a0-4f88-9e0f-97c1ccc34257" />

