### PR TITLE
[fix] Minor visual fix of literal <br /> on the checkout preset select

### DIFF
--- a/BTCPayServer/Views/UIStores/CheckoutAppearance.cshtml
+++ b/BTCPayServer/Views/UIStores/CheckoutAppearance.cshtml
@@ -118,12 +118,12 @@
 						<div id="Presets_Online" class="btcpay-list-select-item dropdown-item">
 							<vc:icon symbol="pos-cart" />
 							<span text-translate="true">Online</span>
-							<span class="note" text-translate="true"  html-translate="true">Enhance the checkout process for online purchases.<br />This assumes the payment page will be displayed on the customer's device.</span>
+							<span class="note" text-translate="true"  html-translate="true">Enhance the checkout process for online purchases.This assumes the payment page will be displayed on the customer's device.</span>
 						</div>
 						<div id="Presets_InStore" class="btcpay-list-select-item dropdown-item">
 							<vc:icon symbol="nav-store" />
 							<span text-translate="true">In-store</span>
-							<span class="note" text-translate="true" html-translate="true">Enhance the checkout process for in-store purchases.<br />This assumes the payment page will be displayed on the merchant's device.</span>
+							<span class="note" text-translate="true" html-translate="true">Enhance the checkout process for in-store purchases.This assumes the payment page will be displayed on the merchant's device.</span>
 						</div>
 					</div>
 				</div>

--- a/BTCPayServer/Views/UIStores/CheckoutAppearance.cshtml
+++ b/BTCPayServer/Views/UIStores/CheckoutAppearance.cshtml
@@ -118,12 +118,12 @@
 						<div id="Presets_Online" class="btcpay-list-select-item dropdown-item">
 							<vc:icon symbol="pos-cart" />
 							<span text-translate="true">Online</span>
-							<span class="note" text-translate="true"  html-translate="true">Enhance the checkout process for online purchases.This assumes the payment page will be displayed on the customer's device.</span>
+							<span class="note" text-translate="true"  html-translate="true">Enhance the checkout process for online purchases. This assumes the payment page will be displayed on the customer's device.</span>
 						</div>
 						<div id="Presets_InStore" class="btcpay-list-select-item dropdown-item">
 							<vc:icon symbol="nav-store" />
 							<span text-translate="true">In-store</span>
-							<span class="note" text-translate="true" html-translate="true">Enhance the checkout process for in-store purchases.This assumes the payment page will be displayed on the merchant's device.</span>
+							<span class="note" text-translate="true" html-translate="true">Enhance the checkout process for in-store purchases. This assumes the payment page will be displayed on the merchant's device.</span>
 						</div>
 					</div>
 				</div>


### PR DESCRIPTION
This is a minor visual fix of literal `<br />` on the checkout preset select.

<img width="1111" height="192" alt="imagen" src="https://github.com/user-attachments/assets/62d727ed-582c-4ead-b523-f2b1f56a01cb" />

I decided to delete it, but if you want to keep the line break, it's best to use <br> instead of </br>. Please let me know what you prefer, and I'll make the change you need.