### PR TITLE
Fix crowdfund number formatting for non-English locales (#6863)

### DIFF
--- a/BTCPayServer/wwwroot/crowdfund/app.js
+++ b/BTCPayServer/wwwroot/crowdfund/app.js
@@ -327,9 +327,8 @@ app = new Vue({
  * @returns String formatted as a number according to current browser locale and correct fraction amount
  */
 function formatAmount(amount, divisibility) {
-    var parsedAmount = parseFloat(amount).toFixed(divisibility);
-    var [wholeAmount, fractionAmount] = parsedAmount.split('.');
-    var formattedWholeAmount = new Intl.NumberFormat().format(parseInt(wholeAmount, 10));
-
-    return formattedWholeAmount + (fractionAmount ? '.' + fractionAmount : '');
+    return new Intl.NumberFormat(undefined, {
+        minimumFractionDigits: divisibility,
+        maximumFractionDigits: divisibility
+    }).format(parseFloat(amount));
 }


### PR DESCRIPTION
Function was mixing locale-specific thousand separators with hardcoded decimal points, causing incorrect display like '7.500.00' in German. Now uses Intl.NumberFormat properly to respect user's locale settings.