### PR TITLE
refactor: replace GetPublishedVersions with GetPluginVersionsForDownload in installation flow

### DIFF
--- a/BTCPayServer/Plugins/PluginBuilderClient.cs
+++ b/BTCPayServer/Plugins/PluginBuilderClient.cs
@@ -55,15 +55,13 @@ namespace BTCPayServer.Plugins
             this.httpClient = httpClient;
         }
         static JsonSerializerSettings serializerSettings = new() { ContractResolver = new Newtonsoft.Json.Serialization.CamelCasePropertyNamesContractResolver() };
-        public async Task<PublishedVersion[]> GetPublishedVersions(string btcpayVersion, bool includePreRelease, string searchPluginName = null, string searchPluginIdentifier = null, bool? includeAllVersions = null)
+        public async Task<PublishedVersion[]> GetPublishedVersions(string btcpayVersion, bool includePreRelease, string searchPluginName = null, bool? includeAllVersions = null)
         {
             var queryString = $"?includePreRelease={includePreRelease}";
             if (btcpayVersion is not null)
                 queryString += $"&btcpayVersion={btcpayVersion}";
             if (searchPluginName is not null)
                 queryString += $"&searchPluginName={searchPluginName}";
-            if (searchPluginIdentifier is not null)
-                queryString += $"&searchPluginIdentifier={searchPluginIdentifier}";
             if (includeAllVersions is not null)
                 queryString += $"&includeAllVersions={includeAllVersions}";
             var result = await httpClient.GetStringAsync($"api/v1/plugins{queryString}");
@@ -80,6 +78,16 @@ namespace BTCPayServer.Plugins
             {
                 return null;
             }
+        }
+
+        public async Task<PublishedVersion[]> GetPluginVersionsForDownload(string identifier, string btcpayVersion, bool includePreRelease = false, bool includeAllVersions = false)
+        {
+            var queryString = $"?btcpayVersion={btcpayVersion}&includePreRelease={includePreRelease}&includeAllVersions={includeAllVersions}";
+            var url = $"api/v1/plugins/{identifier}{queryString}";
+
+            var result = await httpClient.GetStringAsync(url);
+            return JsonConvert.DeserializeObject<PublishedVersion[]>(result, serializerSettings)
+                   ?? throw new InvalidOperationException();
         }
     }
 }

--- a/BTCPayServer/Plugins/PluginService.cs
+++ b/BTCPayServer/Plugins/PluginService.cs
@@ -75,8 +75,8 @@ namespace BTCPayServer.Plugins
             if (version is null)
             {
                 string btcpayVersion = Env.Version.TrimStart('v').Split('+')[0];
-                var versions = await _pluginBuilderClient.GetPublishedVersions(
-                    btcpayVersion, _policiesSettings.PluginPreReleases, searchPluginIdentifier: pluginIdentifier, includeAllVersions: true);
+                var versions = await _pluginBuilderClient.GetPluginVersionsForDownload(pluginIdentifier,
+                    btcpayVersion, _policiesSettings.PluginPreReleases, includeAllVersions: true);
                 var potentialVersions = versions
                     .Select(v => v.ManifestInfo?.ToObject<AvailablePlugin>())
                     .Where(v => v is not null)


### PR DESCRIPTION
This PR replaces the use of GetPublishedVersions in the plugin installation flow with the new more specific GetPluginVersionsForDownload method.

Depends on: https://github.com/btcpayserver/btcpayserver-plugin-builder/pull/59
Resolves: #6848
