### PR TITLE
Fix time icon spacing in wallet transactions header

### DIFF
--- a/BTCPayServer/Views/UIWallets/WalletTransactions.cshtml
+++ b/BTCPayServer/Views/UIWallets/WalletTransactions.cshtml
@@ -226,7 +226,7 @@
             <th class="date-col">
                 <div class="d-flex align-items-center gap-1">
                         <span text-translate="true">Date</span>
-                        <button type="button" class="btn btn-link p-0 switch-time-format only-for-js" title="@StringLocalizer["Switch date format"]">
+                        <button type="button" class="btn btn-link p-2 switch-time-format only-for-js" title="@StringLocalizer["Switch date format"]">
                             <vc:icon symbol="time" />
                         </button>
                 </div>


### PR DESCRIPTION
Increase padding from p-0 to p-2 for better visual spacing between Date text and time format toggle icon.

Fixes #6874