### PR TITLE
Fix: Label persistence on transactions and coin selection bug

### DIFF
--- a/BTCPayServer.Tests/PlaywrightTests.cs
+++ b/BTCPayServer.Tests/PlaywrightTests.cs
@@ -985,6 +985,16 @@ namespace BTCPayServer.Tests
             var bob = new Key().PubKey.Hash.GetAddress(Network.RegTest);
             await ws.FillAddress(bob);
             await ws.FillAmount(1);
+
+            // Add labels to the transaction output
+            await TestUtils.EventuallyAsync(async () =>
+            {
+                await s.Page.ClickAsync("div.label-manager input");
+                await s.Page.FillAsync("div.label-manager input", "tx-label");
+                await s.Page.Keyboard.PressAsync("Enter");
+                await s.Page.WaitForSelectorAsync("[data-value='tx-label']");
+            });
+
             await ws.Sign();
             // Back button should lead back to the previous page inside the send wizard
             var backUrl = await s.Page.Locator("#GoBack").GetAttributeAsync("href");
@@ -998,6 +1008,8 @@ namespace BTCPayServer.Tests
             await wb.AssertSending(bob, 1.0m);
             await wb.Broadcast();
             Assert.Equal(walletTransactionUri.ToString(), s.Page.Url);
+            // Assert that the added label is associated with the transaction
+            await wt.AssertHasLabels("tx-label");
 
             await s.Page.ClickAsync($"#StoreNav-Wallet{cryptoCode}");
             await s.Page.ClickAsync("#WalletNav-Send");

--- a/BTCPayServer/Views/UIWallets/CoinSelection.cshtml
+++ b/BTCPayServer/Views/UIWallets/CoinSelection.cshtml
@@ -319,7 +319,8 @@ document.addEventListener("DOMContentLoaded", function () {
                     res = res.filter(i => i !== item.outpoint);
                 }
 
-                $("select option").each(function () {
+                // Do NOT use $("select option") or you'll break other selects like output labels
+                $("select[name='SelectedInputs'] option").each(function () {
                     var selected = res.indexOf($(this).attr("value")) !== -1;
                     $(this).attr("selected", selected ? "selected" : null);
                 });


### PR DESCRIPTION
Fixes a bug in Coin Selection where clear the output labels, turns out the logic was touching all selects on the page instead of just the input selection.

Added test to ensure label tx persistence, and was going to add a test for coin selection bug, but Abi is already working on Coin Selection in #6861, so I’ll leave it for now.

Resolves: #6883 #6676

https://github.com/user-attachments/assets/dd181e11-23bf-4c75-8171-c08dcf752a4c