### PR TITLE
fix: ensure unlisted installed plugins appear as updatable

### DIFF
--- a/BTCPayServer/Controllers/UIServerController.Plugins.cs
+++ b/BTCPayServer/Controllers/UIServerController.Plugins.cs
@@ -26,12 +26,14 @@ namespace BTCPayServer.Controllers
             {
                 availablePlugins = await pluginService.GetRemotePlugins(search);
             }
-            catch (Exception)
+            catch (Exception ex)
             {
+                var errorDetail = ex.GetBaseException().Message;
+
                 TempData.SetStatusMessageModel(new StatusMessageModel
                 {
                     Severity = StatusMessageModel.StatusSeverity.Error,
-                    Message = StringLocalizer["Remote plugins lookup failed. Try again later."].Value
+                    Message = StringLocalizer["Remote plugins lookup failed. Try again later. Error: {0}", errorDetail].Value
                 });
                 availablePlugins = Array.Empty<PluginService.AvailablePlugin>();
             }

--- a/BTCPayServer/Controllers/UIServerController.Plugins.cs
+++ b/BTCPayServer/Controllers/UIServerController.Plugins.cs
@@ -28,12 +28,10 @@ namespace BTCPayServer.Controllers
             }
             catch (Exception ex)
             {
-                var errorDetail = ex.GetBaseException().Message;
-
                 TempData.SetStatusMessageModel(new StatusMessageModel
                 {
                     Severity = StatusMessageModel.StatusSeverity.Error,
-                    Message = StringLocalizer["Remote plugins lookup failed. Try again later. Error: {0}", errorDetail].Value
+                    Message = StringLocalizer["Remote plugins lookup failed. Try again later. Error: {0}", ex.Message].Value
                 });
                 availablePlugins = Array.Empty<PluginService.AvailablePlugin>();
             }

--- a/BTCPayServer/Plugins/PluginBuilderClient.cs
+++ b/BTCPayServer/Plugins/PluginBuilderClient.cs
@@ -53,8 +53,6 @@ namespace BTCPayServer.Plugins
 
     public class PluginBuilderClient
     {
-        #nullable enable
-
         HttpClient httpClient;
         public HttpClient HttpClient => httpClient;
         private readonly ILogger<PluginBuilderClient> _logger;
@@ -99,7 +97,7 @@ namespace BTCPayServer.Plugins
                    ?? throw new InvalidOperationException();
         }
 
-        public async Task<PublishedVersion[]?> GetInstalledPluginsUpdates(
+        public async Task<PublishedVersion[]> GetInstalledPluginsUpdates(
             string btcpayVersion,
             bool includePreRelease,
             IEnumerable<InstalledPluginRequest> plugins)
@@ -123,12 +121,12 @@ namespace BTCPayServer.Plugins
             catch (HttpRequestException ex)
             {
                 _logger.LogWarning(ex, "Failed to check for plugins updates");
-                return null;
+                return Array.Empty<PublishedVersion>();
             }
             catch (JsonException ex)
             {
                 _logger.LogWarning(ex, "Failed to parse plugins updates response");
-                return null;
+                return Array.Empty<PublishedVersion>();
             }
         }
     }

--- a/BTCPayServer/Plugins/PluginBuilderClient.cs
+++ b/BTCPayServer/Plugins/PluginBuilderClient.cs
@@ -53,12 +53,12 @@ namespace BTCPayServer.Plugins
 
     public class PluginBuilderClient
     {
-        HttpClient httpClient;
-        public HttpClient HttpClient => httpClient;
+        private readonly HttpClient _httpClient;
+        public HttpClient HttpClient => _httpClient;
         private readonly ILogger<PluginBuilderClient> _logger;
         public PluginBuilderClient(HttpClient httpClient, ILogger<PluginBuilderClient> logger)
         {
-            this.httpClient = httpClient;
+            _httpClient = httpClient;
             _logger = logger;
         }
         static JsonSerializerSettings serializerSettings = new() { ContractResolver = new Newtonsoft.Json.Serialization.CamelCasePropertyNamesContractResolver() };
@@ -71,14 +71,14 @@ namespace BTCPayServer.Plugins
                 queryString += $"&searchPluginName={searchPluginName}";
             if (includeAllVersions is not null)
                 queryString += $"&includeAllVersions={includeAllVersions}";
-            var result = await httpClient.GetStringAsync($"api/v1/plugins{queryString}");
+            var result = await _httpClient.GetStringAsync($"api/v1/plugins{queryString}");
             return JsonConvert.DeserializeObject<PublishedVersion[]>(result, serializerSettings) ?? throw new InvalidOperationException();
         }
         public async Task<PublishedVersion> GetPlugin(string pluginSlug, string version)
         {
             try
             {
-                var result = await httpClient.GetStringAsync($"api/v1/plugins/{pluginSlug}/versions/{version}");
+                var result = await _httpClient.GetStringAsync($"api/v1/plugins/{pluginSlug}/versions/{version}");
                 return JsonConvert.DeserializeObject<PublishedVersion>(result, serializerSettings);
             }
             catch (HttpRequestException ex) when (ex.StatusCode == System.Net.HttpStatusCode.NotFound)
@@ -92,7 +92,7 @@ namespace BTCPayServer.Plugins
             var queryString = $"?btcpayVersion={btcpayVersion}&includePreRelease={includePreRelease}&includeAllVersions={includeAllVersions}";
             var url = $"api/v1/plugins/{identifier}{queryString}";
 
-            var result = await httpClient.GetStringAsync(url);
+            var result = await _httpClient.GetStringAsync(url);
             return JsonConvert.DeserializeObject<PublishedVersion[]>(result, serializerSettings)
                    ?? throw new InvalidOperationException();
         }
@@ -111,7 +111,7 @@ namespace BTCPayServer.Plugins
 
             try
             {
-                using var resp = await httpClient.PostAsync($"api/v1/plugins/updates{queryString}", content);
+                using var resp = await _httpClient.PostAsync($"api/v1/plugins/updates{queryString}", content);
                 resp.EnsureSuccessStatusCode();
 
                 var body = await resp.Content.ReadAsStringAsync();

--- a/BTCPayServer/Plugins/PluginBuilderClient.cs
+++ b/BTCPayServer/Plugins/PluginBuilderClient.cs
@@ -66,9 +66,9 @@ namespace BTCPayServer.Plugins
         {
             var queryString = $"?includePreRelease={includePreRelease}";
             if (btcpayVersion is not null)
-                queryString += $"&btcpayVersion={btcpayVersion}";
+                queryString += $"&btcpayVersion={Uri.EscapeDataString(btcpayVersion)}";
             if (searchPluginName is not null)
-                queryString += $"&searchPluginName={searchPluginName}";
+                queryString += $"&searchPluginName={Uri.EscapeDataString(searchPluginName)}";
             if (includeAllVersions is not null)
                 queryString += $"&includeAllVersions={includeAllVersions}";
             var result = await _httpClient.GetStringAsync($"api/v1/plugins{queryString}");
@@ -126,6 +126,11 @@ namespace BTCPayServer.Plugins
             catch (JsonException ex)
             {
                 _logger.LogWarning(ex, "Failed to parse plugins updates response");
+                return Array.Empty<PublishedVersion>();
+            }
+            catch (TaskCanceledException ex)
+            {
+                _logger.LogWarning(ex, "Timeout while checking plugins updates");
                 return Array.Empty<PublishedVersion>();
             }
         }

--- a/BTCPayServer/Plugins/PluginBuilderClient.cs
+++ b/BTCPayServer/Plugins/PluginBuilderClient.cs
@@ -125,6 +125,11 @@ namespace BTCPayServer.Plugins
                 _logger.LogWarning(ex, "Failed to check for plugins updates");
                 return null;
             }
+            catch (JsonException ex)
+            {
+                _logger.LogWarning(ex, "Failed to parse plugins updates response");
+                return null;
+            }
         }
     }
 }

--- a/BTCPayServer/Plugins/PluginService.cs
+++ b/BTCPayServer/Plugins/PluginService.cs
@@ -55,9 +55,11 @@ namespace BTCPayServer.Plugins
             return pluginManifest.Version;
         }
 
+        private string GetShortBtcpayVersion() => Env.Version.TrimStart('v').Split('+')[0];
+
         public async Task<AvailablePlugin[]> GetRemotePlugins(string searchPluginName)
         {
-            string btcpayVersion = Env.Version.TrimStart('v').Split('+')[0];
+            string btcpayVersion = GetShortBtcpayVersion();
             var versions = await _pluginBuilderClient.GetPublishedVersions(
                 btcpayVersion, _policiesSettings.PluginPreReleases, searchPluginName);
 
@@ -140,7 +142,7 @@ namespace BTCPayServer.Plugins
         {
             if (version is null)
             {
-                string btcpayVersion = Env.Version.TrimStart('v').Split('+')[0];
+                string btcpayVersion = GetShortBtcpayVersion();
                 var versions = await _pluginBuilderClient.GetPluginVersionsForDownload(pluginIdentifier,
                     btcpayVersion, _policiesSettings.PluginPreReleases, includeAllVersions: true);
                 var potentialVersions = versions

--- a/BTCPayServer/Plugins/PluginService.cs
+++ b/BTCPayServer/Plugins/PluginService.cs
@@ -100,7 +100,7 @@ namespace BTCPayServer.Plugins
         {
             if (publishedVersion.ManifestInfo is null)
             {
-                _logger.LogWarning("ManifestInfo missing for published version {Version}", publishedVersion.ToString());
+                _logger.LogWarning("Skipping published plugin with missing ManifestInfo (BuildId: {BuildId}, ProjectSlug: {ProjectSlug})", publishedVersion.BuildId, publishedVersion.ProjectSlug);
                 return null;
             }
 
@@ -112,13 +112,13 @@ namespace BTCPayServer.Plugins
             }
             catch (JsonException ex)
             {
-                _logger.LogWarning(ex, "Failed to parse manifest for published version {Version}", publishedVersion.ToString());
+                _logger.LogWarning(ex, "Failed to parse ManifestInfo (BuildId: {BuildId}, ProjectSlug: {ProjectSlug})", publishedVersion.BuildId, publishedVersion.ProjectSlug);
                 return null;
             }
 
             if (availablePlugin is null)
             {
-                _logger.LogWarning("ManifestInfo missing for published version {Version}", publishedVersion.ToString());
+                _logger.LogWarning("Failed to deserialize ManifestInfo to AvailablePlugin (BuildId: {BuildId}, ProjectSlug: {ProjectSlug})", publishedVersion.BuildId, publishedVersion.ProjectSlug);
                 return null;
             }
 


### PR DESCRIPTION
This PR ensure installed but unlisted plugins are detected as updatable by skipping core installed plugins and adding logic in GetUpdatesForUnlistedInstalledAsync

Fixes #6893 

https://github.com/user-attachments/assets/6c712a14-b8fe-4069-86cf-ecd2ccc8506a
