### PR TITLE
Fix: Periodic tasks would sometimes stop firing

### DIFF
--- a/BTCPayServer.Tests/docker-compose.altcoins.yml
+++ b/BTCPayServer.Tests/docker-compose.altcoins.yml
@@ -99,7 +99,7 @@ services:
       custom:
 
   nbxplorer:
-    image: nicolasdorier/nbxplorer:2.5.28
+    image: nicolasdorier/nbxplorer:2.5.29
     restart: unless-stopped
     ports:
       - "32838:32838"

--- a/BTCPayServer.Tests/docker-compose.mutinynet.yml
+++ b/BTCPayServer.Tests/docker-compose.mutinynet.yml
@@ -62,7 +62,7 @@ services:
       custom:
 
   nbxplorer:
-    image: nicolasdorier/nbxplorer:2.5.28
+    image: nicolasdorier/nbxplorer:2.5.29
     restart: unless-stopped
     ports:
       - "32838:32838"

--- a/BTCPayServer.Tests/docker-compose.testnet.yml
+++ b/BTCPayServer.Tests/docker-compose.testnet.yml
@@ -57,7 +57,7 @@ services:
       custom:
 
   nbxplorer:
-    image: nicolasdorier/nbxplorer:2.5.28
+    image: nicolasdorier/nbxplorer:2.5.29
     restart: unless-stopped
     ports:
       - "32838:32838"

--- a/BTCPayServer.Tests/docker-compose.yml
+++ b/BTCPayServer.Tests/docker-compose.yml
@@ -95,7 +95,7 @@ services:
       custom:
 
   nbxplorer:
-    image: nicolasdorier/nbxplorer:2.5.28
+    image: nicolasdorier/nbxplorer:2.5.29
     restart: unless-stopped
     ports:
       - "32838:32838"

--- a/BTCPayServer/HostedServices/ScheduledTask.cs
+++ b/BTCPayServer/HostedServices/ScheduledTask.cs
@@ -11,6 +11,5 @@ namespace BTCPayServer.HostedServices
         }
         public Type PeriodicTaskType { get; set; }
         public TimeSpan Every { get; set; } = TimeSpan.FromMinutes(5.0);
-        public DateTimeOffset NextScheduled { get; set; } = DateTimeOffset.UtcNow;
     }
 }


### PR DESCRIPTION
The bug on https://github.com/btcpayserver/btcpayserver/issues/6884 was caused by NBXplorer.
I fixed it on NBXplorer (https://github.com/dgarage/NBXplorer/commit/939a575c5181870e2eff01c0fbe7306cfe029c01) and released `2.5.29`.

We were seeing RBF'd transactions in the wallet transaction list, when those should disappear.

The issue was that timers in dotnet are a little bit imprecise and may fire a few milli second in advance.
When this happen, the job would be queued, then the loop would pick it up, see it is too early, skip it and wait again.

The issue is that then `var timeToWait = job.NextScheduled - DateTimeOffset.UtcNow;` could, by pure timing chance, be then equal to 0. Which is then interpreted by `Task.Delay` as an infinite waiting time...

We were using the same implementation in BTCPay Server, so we had this bug here too, but we never noticed.

