### PR TITLE
Fix: Date column header isn't aligned

### DIFF
--- a/BTCPayServer/Views/UIInvoice/ListInvoices.cshtml
+++ b/BTCPayServer/Views/UIInvoice/ListInvoices.cshtml
@@ -326,9 +326,9 @@
                             <input type="checkbox" class="form-check-input mass-action-select-all" />
                         </th>
                         <th class="date-col">
-                            <div class="d-flex align-items-center gap-1">
+                            <div class="d-flex align-items-center gap-3">
                                 <span text-translate="true">Date</span>
-                                <button type="button" class="btn btn-link p-2 switch-time-format only-for-js" title="@StringLocalizer["Switch date format"]">
+                                <button type="button" class="btn btn-link p-0 switch-time-format only-for-js" title="@StringLocalizer["Switch date format"]">
                                     <vc:icon symbol="time" />
                                 </button>
                             </div>

--- a/BTCPayServer/Views/UINotifications/Index.cshtml
+++ b/BTCPayServer/Views/UINotifications/Index.cshtml
@@ -27,7 +27,7 @@
             #SearchText {
                 width: 100%;
             }
-        } 
+        }
     </style>
 }
 
@@ -124,7 +124,7 @@
                             </th>
                             <th text-translate="true">Message</th>
                             <th class="date-col">
-                                <div class="d-flex align-items-center gap-1">
+                                <div class="d-flex align-items-center gap-3">
                                     <span text-translate="true">Date</span>
                                     <button type="button" class="btn btn-link p-0 switch-time-format only-for-js" title="@StringLocalizer["Switch date format"]">
                                         <vc:icon symbol="time" />

--- a/BTCPayServer/Views/UIPaymentRequest/GetPaymentRequests.cshtml
+++ b/BTCPayServer/Views/UIPaymentRequest/GetPaymentRequests.cshtml
@@ -87,7 +87,7 @@
                 <tr>
                     <th text-translate="true">Title</th>
                     <th class="date-col">
-                        <div class="d-flex align-items-center gap-1">
+                        <div class="d-flex align-items-center gap-3">
                             <span text-translate="true">Expiry</span>
                             <button type="button" class="btn btn-link p-0 switch-time-format only-for-js" title="@StringLocalizer["Switch date format"]">
                                 <vc:icon symbol="time" />

--- a/BTCPayServer/Views/UIStorePullPayments/Payouts.cshtml
+++ b/BTCPayServer/Views/UIStorePullPayments/Payouts.cshtml
@@ -152,7 +152,7 @@
                             </th>
                         }
                         <th class="date-col">
-                            <div class="d-flex align-items-center gap-1">
+                            <div class="d-flex align-items-center gap-3">
                                 <span text-translate="true">Date</span>
                                 <button type="button" class="btn btn-link p-0 switch-time-format only-for-js" title="Switch date format">
                                     <vc:icon symbol="time" />

--- a/BTCPayServer/Views/UIStorePullPayments/PullPayments.cshtml
+++ b/BTCPayServer/Views/UIStorePullPayments/PullPayments.cshtml
@@ -87,7 +87,7 @@
             <thead>
             <tr>
                 <th scope="col" class="date-col">
-                    <div class="d-flex align-items-center gap-2">
+                    <div class="d-flex align-items-center gap-3">
                         <a asp-action="PullPayments"
                            asp-route-sortOrder="@(nextStartDateSortOrder ?? "asc")"
                            asp-route-pullPaymentState="@Model.ActiveState"
@@ -113,7 +113,7 @@
                 <tr class="mass-action-row">
                     <td class="date-col">@pp.StartDate.ToBrowserDate()</td>
                     <td>
-                        <a 
+                        <a
                             permission="@Policies.CanManagePullPayments"
                             asp-action="EditPullPayment"
                             asp-controller="UIPullPayment"

--- a/BTCPayServer/Views/UIWallets/WalletTransactions.cshtml
+++ b/BTCPayServer/Views/UIWallets/WalletTransactions.cshtml
@@ -224,9 +224,9 @@
                 <input type="checkbox" class="form-check-input mass-action-select-all" />
             </th>
             <th class="date-col">
-                <div class="d-flex align-items-center gap-1">
+                <div class="d-flex align-items-center gap-3">
                         <span text-translate="true">Date</span>
-                        <button type="button" class="btn btn-link p-2 switch-time-format only-for-js" title="@StringLocalizer["Switch date format"]">
+                        <button type="button" class="btn btn-link p-0 switch-time-format only-for-js" title="@StringLocalizer["Switch date format"]">
                             <vc:icon symbol="time" />
                         </button>
                 </div>


### PR DESCRIPTION
Fix #6907

# Before

## Wallet view

<img width="750" height="130" alt="image" src="https://github.com/user-attachments/assets/c274657b-5c18-4806-8c83-2e7857789731" />

## Invoice view

<img width="299" height="88" alt="image" src="https://github.com/user-attachments/assets/faeb9578-049d-4783-8012-0a8a81531ed7" />

# After

## Wallet view

<img width="656" height="93" alt="image" src="https://github.com/user-attachments/assets/bfded2a3-5c8b-4606-bca9-972866881eee" />

## Invoice view

<img width="315" height="98" alt="image" src="https://github.com/user-attachments/assets/d82e8e3f-3068-442e-9298-77583036e8f2" />
