### PR TITLE
Better error message on invalid PSBT in Sign with Seed

### DIFF
--- a/BTCPayServer/Controllers/UIWalletsController.cs
+++ b/BTCPayServer/Controllers/UIWalletsController.cs
@@ -1290,6 +1290,9 @@ namespace BTCPayServer.Controllers
                 ChangeAddress = psbtResponse.ChangeAddress?.ToString(),
                 PSBT = psbt.ToHex()
             };
+
+            if (!psbt.IsReadyToSign() && command == "sign")
+                command = "analyze-psbt";
             switch (command)
             {
                 case "createpending":


### PR DESCRIPTION
Improve troubleshooting experience for error such as https://github.com/btcpayserver/btcpayserver/issues/6838#issuecomment-3294497428

In the issue, we were creating a PSBT that can't be signed. (Missing non witness UTXO in the PSBT for a legacy address)

The user was sent to the `WalletSeed` page with a cryptic message `PSBT is not ready to be signed`.

The first PR will add additional details as to why some inputs can't be signed in the same page.


The second PR will send the user to the `WalletPSBTDecoded` page instead of `WalletSeed`.
This way, he can see proper error message for inputs concerned, and have the ability to export the PSBT for troubleshooting.

Coming back to #6838 , they would instead properly see the error on specific input: `A NonWitnessUtxo is required but hasn't been provided`