### PR TITLE
Fix: Disable cookie access when a user is disabled

### DIFF
--- a/BTCPayServer.Tests/PlaywrightTests.cs
+++ b/BTCPayServer.Tests/PlaywrightTests.cs
@@ -220,6 +220,7 @@ namespace BTCPayServer.Tests
             await s.GoToHome();
             await s.GoToServer(ServerNavPages.Users);
 
+
             // Manage user password reset
             await s.Page.Locator("#SearchTerm").ClearAsync();
             await s.Page.FillAsync("#SearchTerm", user.RegisterDetails.Email);
@@ -233,6 +234,12 @@ namespace BTCPayServer.Tests
             await s.ClickPagePrimary();
             await s.FindAlertMessage(partialText: "Password successfully set");
 
+            var userPage = await s.Browser.NewPageAsync();
+            await using (await s.SwitchPage(userPage, false))
+            {
+                await s.GoToLogin();
+                await s.LogIn(user.Email, user.Password);
+            }
             // Manage user status (disable and enable)
             // Disable user
             await s.Page.Locator("#SearchTerm").ClearAsync();
@@ -244,6 +251,13 @@ namespace BTCPayServer.Tests
             await s.Page.ClickAsync("#UsersList tr.user-overview-row:first-child .disable-user");
             await s.Page.ClickAsync("#ConfirmContinue");
             await s.FindAlertMessage(partialText: "User disabled");
+
+            await using (await s.SwitchPage(userPage, false))
+            {
+                await s.Page.ReloadAsync();
+                await s.FindAlertMessage(StatusMessageModel.StatusSeverity.Warning, partialText: "Your user account is currently disabled");
+            }
+
             //Enable user
             await s.Page.Locator("#SearchTerm").ClearAsync();
             await s.Page.FillAsync("#SearchTerm", user.RegisterDetails.Email);
@@ -254,6 +268,14 @@ namespace BTCPayServer.Tests
             await s.Page.ClickAsync("#UsersList tr.user-overview-row:first-child .enable-user");
             await s.Page.ClickAsync("#ConfirmContinue");
             await s.FindAlertMessage(partialText: "User enabled");
+
+            await using (await s.SwitchPage(userPage))
+            {
+                // Can log again
+                await s.LogIn(user.Email, "Password@1!");
+                await s.CreateNewStore();
+                await s.Logout();
+            }
 
             // Manage user details (edit)
             await s.Page.Locator("#SearchTerm").ClearAsync();

--- a/BTCPayServer/Hosting/Startup.cs
+++ b/BTCPayServer/Hosting/Startup.cs
@@ -13,6 +13,7 @@ using BTCPayServer.Logging;
 using BTCPayServer.PaymentRequest;
 using BTCPayServer.Plugins;
 using BTCPayServer.Security;
+using BTCPayServer.Services;
 using BTCPayServer.Services.Apps;
 using BTCPayServer.Storage;
 using Fido2NetLib;
@@ -87,6 +88,9 @@ namespace BTCPayServer.Hosting
             services.AddDataProtection()
                 .SetApplicationName("BTCPay Server")
                 .PersistKeysToFileSystem(new DirectoryInfo(new DataDirectories().Configure(Configuration).DataDir));
+
+            services.AddScoped<ISecurityStampValidator, BTCPayServerSecurityStampValidator>();
+            services.AddSingleton<BTCPayServerSecurityStampValidator.DisabledUsers>();
             services.AddIdentity<ApplicationUser, IdentityRole>()
                 .AddEntityFrameworkStores<ApplicationDbContext>()
                 .AddDefaultTokenProviders()

--- a/BTCPayServer/Services/BTCPayServerSecurityStampValidator.cs
+++ b/BTCPayServer/Services/BTCPayServerSecurityStampValidator.cs
@@ -1,0 +1,66 @@
+#nullable enable
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using BTCPayServer.Data;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace BTCPayServer.Services;
+
+public class BTCPayServerSecurityStampValidator(
+    IOptions<SecurityStampValidatorOptions> options,
+    SignInManager<ApplicationUser> signInManager,
+    ILoggerFactory logger,
+    UserManager<ApplicationUser> userManager,
+    BTCPayServerSecurityStampValidator.DisabledUsers disabledUsers)
+    : SecurityStampValidator<ApplicationUser>(options, signInManager, logger)
+{
+    public class DisabledUsers
+    {
+        ConcurrentDictionary<string, DateTimeOffset> _DisabledUsers = new ConcurrentDictionary<string, DateTimeOffset>();
+        public bool HasAny => !_DisabledUsers.IsEmpty;
+
+        public void Add(string user)
+        {
+            _DisabledUsers.TryAdd(user, DateTimeOffset.UtcNow);
+        }
+
+        public void Remove(string user)
+        {
+            _DisabledUsers.TryRemove(user, out _);
+        }
+
+        public bool Contains(string id) => _DisabledUsers.ContainsKey(id);
+
+        public void Cleanup(TimeSpan validationInterval)
+        {
+            if (_DisabledUsers.IsEmpty)
+                return;
+            var now = DateTimeOffset.UtcNow;
+            foreach (var kv in _DisabledUsers)
+            {
+                if (now - kv.Value > validationInterval)
+                    Remove(kv.Key);
+            }
+        }
+    }
+
+    public override async Task ValidateAsync(CookieValidatePrincipalContext context)
+    {
+        if (disabledUsers.HasAny &&
+            context.Principal is not null &&
+            userManager.GetUserId(context.Principal) is string id &&
+            disabledUsers.Contains(id))
+        {
+            context.Properties.IssuedUtc = null;
+        }
+        disabledUsers.Cleanup(Options.ValidationInterval);
+        await base.ValidateAsync(context);
+    }
+}


### PR DESCRIPTION
Fix: When a user was disabled, any logged session would still continue to work indefinitely.

When `UserService.ToggleUser` disables a user, it needs to call `UpdateSecurityStampAsync` to invalidate any current  `AuthenticationTicket`.

However, by default, ASP.NET only check the security stamps once every `ValidationInterval` (we set that to 5min)

I replaced the default implementation of `ISecurityStampValidator` with our own version which will  cause immediate verification of security stamp if a user is in the in-memory list of `DisabledUsers`.

This mean that as expected, disabled users will be logged out immediately.