### PR TITLE
Fix: Denied 403 page if denied access to default store

### DIFF
--- a/BTCPayServer/Controllers/UIHomeController.cs
+++ b/BTCPayServer/Controllers/UIHomeController.cs
@@ -70,14 +70,15 @@ namespace BTCPayServer.Controllers
             {
                 var userId = SignInManager.UserManager.GetUserId(HttpContext.User);
                 var storeId = HttpContext.GetUserPrefsCookie()?.CurrentStoreId;
-                if (storeId != null)
+                if (storeId != null && userId != null)
                 {
                     // verify store exists and redirect to it
-                    var store = await _storeRepository.FindStore(storeId);
+                    var store = await _storeRepository.FindStore(storeId, userId);
                     if (store != null)
                     {
                         return RedirectToAction(nameof(UIStoresController.Index), "UIStores", new { storeId });
                     }
+                    HttpContext.DeleteUserPrefsCookie();
                 }
 
                 var stores = await _storeRepository.GetStoresByUserId(userId!);


### PR DESCRIPTION
If a user go to store A, then lose access to store A, any attempt to
browse the home page will return a 403 error.

The user would then get stuck, unable to select a new store until he
clears the cache.
