### PR TITLE
Hide payment method selector for single payment method invoices

### DIFF
--- a/BTCPayServer/Views/UIInvoice/Checkout.cshtml
+++ b/BTCPayServer/Views/UIInvoice/Checkout.cshtml
@@ -88,7 +88,7 @@
                         :show-recommended-fee="showRecommendedFee"
                         class="pb-4" />
                 </div>
-                <div v-if="displayedPaymentMethods.length > 1 || @Safe.Json(hasPaymentPlugins)" class="mt-3 mb-2">
+                <div v-if="shouldShowPaymentMethodSelector" class="mt-3 mb-2">
                     <h6 class="text-center mb-3" v-t="'pay_with'"></h6>
                     <div class="btcpay-pills d-flex flex-wrap align-items-center justify-content-center gap-2 pb-2">
                         <a v-for="crypto in displayedPaymentMethods"

--- a/BTCPayServer/wwwroot/checkout/checkout.js
+++ b/BTCPayServer/wwwroot/checkout/checkout.js
@@ -188,6 +188,20 @@ function initApp() {
             },
             displayedPaymentMethods: function () {
                 return this.srvModel?.availablePaymentMethods?.filter(pm => pm.displayed) ?? [];
+            },
+            shouldShowPaymentMethodSelector() {
+                // Hide for single payment method
+                if (this.displayedPaymentMethods.length === 1) {
+                    return false;
+                }
+                
+                // Hide when unified QR is enabled (treats BTC + Lightning as single method)
+                if (this.srvModel.onChainWithLnInvoiceFallback) {
+                    return false;
+                }
+
+                // Show for multiple payment methods without unified QR
+                return true;
             }
         },
         watch: {


### PR DESCRIPTION

## Description
- Hide 'Pay with' section when only one payment method is available
- Hide selector when unified QR is enabled (treats BTC + Lightning as single method)
- Improves UX for retail/POS by keeping QR code above the fold on small screens

**changes**

- Added `IsUnifiedQrCode` property to `CheckoutModel`
- Modified `Checkout.cshtml` to use `shouldShowPaymentMethodSelector` computed property
- Added `shouldShowPaymentMethodSelector` logic in `checkout.js`

### Before (single payment method)
<img width="419" height="705" alt="Screenshot 2025-11-07 at 9 24 36 PM" src="https://github.com/user-attachments/assets/9608ef94-0d66-49f0-a5d8-8e55e12b1bb5" />


### After (Single Payment Method)
<img width="436" height="705" alt="Screenshot 2025-11-07 at 9 23 47 PM" src="https://github.com/user-attachments/assets/faa4eb76-a552-4ccd-9497-de1f1442b26b" />

## Tested with:
-  Single payment method (BTC)
-  Multiple payment methods (BTC + LTC)
-  Unified QR enabled scenario

Solved #[#6772]