### PR TITLE
Add missing 'Close' translation to checkout locales

### DIFF
--- a/BTCPayServer/wwwroot/locales/checkout/en.json
+++ b/BTCPayServer/wwwroot/locales/checkout/en.json
@@ -36,6 +36,7 @@
   "invoice_expired_body": "An invoice is only valid for {{minutes}} minutes.\n\nReturn to {{storeName}} if you would like to resubmit a payment.",
   "invoice_paidpartial_body": "An invoice is only valid for {{minutes}} minutes.\n\nThis invoice expired with partial payment. Please contact us, so that we can fulfill your order.",
   "view_receipt": "View receipt",
+  "Close": "Close",
   "return_to_store": "Return to {{storeName}}",
   "contact_us": "Contact us",
   "copy": "Copy",

--- a/BTCPayServer/wwwroot/locales/checkout/pt-BR.json
+++ b/BTCPayServer/wwwroot/locales/checkout/pt-BR.json
@@ -30,6 +30,7 @@
   "invoice_expired": "Fatura Expirada.",
   "invoice_expired_body": "Uma fatura é válida por apenas {{minutes}} minutos. Retorne a {{storeName}} se desejar reenviar o pagamento.",
   "view_receipt": "Ver recibo",
+  "Close": "Fechar",
   "return_to_store": "Voltar para {{storeName}}",
   "copy": "Copiar",
   "copy_confirm": "Copiado",


### PR DESCRIPTION
Added the 'Close' key to the English and Brazilian Portuguese checkout locale files.