### PR TITLE
Refactor: Add UIExtensionsRegistry

### DIFF
--- a/BTCPayServer/Components/UiExtensionPoint/UIExtensionPoint.cs
+++ b/BTCPayServer/Components/UiExtensionPoint/UIExtensionPoint.cs
@@ -2,27 +2,18 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using BTCPayServer.Abstractions.Contracts;
+using BTCPayServer.Services;
 using Microsoft.AspNetCore.Mvc;
 
 namespace BTCPayServer.Components.UIExtensionPoint
 {
-    public class UiExtensionPoint : ViewComponent
+    public class UiExtensionPoint(UIExtensionsRegistry uiExtensions) : ViewComponent
     {
-        private readonly IEnumerable<IUIExtension> _uiExtensions;
-
-        public UiExtensionPoint(IEnumerable<IUIExtension> uiExtensions)
-        {
-            _uiExtensions = uiExtensions;
-        }
-
         public IViewComponentResult Invoke(string location, object model)
         {
             return View(new UiExtensionPointViewModel()
             {
-                Partials = _uiExtensions
-                    .Where(extension =>
-                        extension.Location.Equals(location, StringComparison.InvariantCultureIgnoreCase))
-                    .Select(extension => extension.Partial).ToArray(),
+                Partials = uiExtensions.ExtensionsByLocation[location].Select(c => c.Partial).ToArray(),
                 Model = model
             });
         }

--- a/BTCPayServer/Hosting/BTCPayServerServices.cs
+++ b/BTCPayServer/Hosting/BTCPayServerServices.cs
@@ -94,6 +94,7 @@ namespace BTCPayServer.Hosting
             services.TryAddSingleton<ViewLocalizer>();
             services.TryAddSingleton<IStringLocalizer>(o => o.GetRequiredService<IStringLocalizerFactory>().Create("",""));
             services.TryAddSingleton<DelayedTaskScheduler>();
+            services.TryAddSingleton<UIExtensionsRegistry>();
 
             services.AddSingleton<MvcNewtonsoftJsonOptions>(o => o.GetRequiredService<IOptions<MvcNewtonsoftJsonOptions>>().Value);
             services.AddSingleton<JsonSerializerSettings>(o => o.GetRequiredService<IOptions<MvcNewtonsoftJsonOptions>>().Value.SerializerSettings);

--- a/BTCPayServer/Services/UIExtensionsRegistry.cs
+++ b/BTCPayServer/Services/UIExtensionsRegistry.cs
@@ -1,0 +1,17 @@
+#nullable enable
+using System.Collections.Generic;
+using System.Linq;
+using BTCPayServer.Abstractions.Contracts;
+using BTCPayServer.Abstractions.Services;
+
+namespace BTCPayServer.Services;
+
+public class UIExtensionsRegistry
+{
+    public UIExtensionsRegistry(IEnumerable<IUIExtension> uiExtensions)
+    {
+        ExtensionsByLocation = uiExtensions.OfType<UIExtension>().ToLookup(o => o.Location);
+    }
+
+    public ILookup<string, UIExtension> ExtensionsByLocation { get; }
+}


### PR DESCRIPTION
The component UIExtensionPoint was injecting IEnumerable<IUIExtension>
and then filtering on those.
As the number of IUIExtension grows, this operation grows at O(n).

Now we use UIExtensionsRegistry instead which use lookups. O(1)
