### PR TITLE
Fix: Spurious EF error on CallbackGenerator

### DIFF
--- a/BTCPayServer/Controllers/GreenField/GreenfieldUsersController.cs
+++ b/BTCPayServer/Controllers/GreenField/GreenfieldUsersController.cs
@@ -117,7 +117,7 @@ namespace BTCPayServer.Controllers.Greenfield
 
             if (user.RequiresApproval)
             {
-                var loginLink = _callbackGenerator.ForLogin(user, Request);
+                var loginLink = _callbackGenerator.ForLogin(user);
                 return await _userService.SetUserApproval(user.Id, request.Approved, loginLink)
                     ? Ok()
                     : this.CreateAPIError("invalid-state", $"User is already {(request.Approved ? "approved" : "unapproved")}");
@@ -416,8 +416,8 @@ namespace BTCPayServer.Controllers.Greenfield
             var currentUser = await _userManager.GetUserAsync(User);
             var userEvent = currentUser switch
             {
-                { } invitedBy => await UserEvent.Invited.Create(user, invitedBy, _callbackGenerator, Request, request.SendInvitationEmail is not false),
-                _ => await UserEvent.Registered.Create(user, _callbackGenerator, Request)
+                { } invitedBy => await UserEvent.Invited.Create(user, invitedBy, _callbackGenerator, request.SendInvitationEmail is not false),
+                _ => await UserEvent.Registered.Create(user, _callbackGenerator)
             };
             _eventAggregator.Publish(userEvent);
 

--- a/BTCPayServer/Controllers/UIAccountController.cs
+++ b/BTCPayServer/Controllers/UIAccountController.cs
@@ -267,7 +267,7 @@ namespace BTCPayServer.Controllers
                 {
                     RememberMe = rememberMe,
                     UserId = user.Id,
-                    LNURLEndpoint = new Uri(callbackGenerator.ForLNUrlAuth(user, r, Request))
+                    LNURLEndpoint = new Uri(callbackGenerator.ForLNUrlAuth(user, r))
                 };
             }
             return null;
@@ -573,7 +573,7 @@ namespace BTCPayServer.Controllers
                         RegisteredAdmin = true;
                     }
 
-                    eventAggregator.Publish(await UserEvent.Registered.Create(user, callbackGenerator, Request));
+                    eventAggregator.Publish(await UserEvent.Registered.Create(user, callbackGenerator));
                     RegisteredUserId = user.Id;
 
                     TempData[WellKnownTempData.SuccessMessage] = StringLocalizer["Account created."].Value;
@@ -640,7 +640,7 @@ namespace BTCPayServer.Controllers
             var result = await userManager.ConfirmEmailAsync(user, code);
             if (result.Succeeded)
             {
-                var approvalLink = callbackGenerator.ForApproval(user, Request);
+                var approvalLink = callbackGenerator.ForApproval(user);
                 eventAggregator.Publish(new UserEvent.ConfirmedEmail(user, approvalLink));
 
                 var hasPassword = await userManager.HasPasswordAsync(user);
@@ -686,7 +686,7 @@ namespace BTCPayServer.Controllers
                 {
                     return RedirectToAction(nameof(ForgotPasswordConfirmation));
                 }
-                var callbackUri = await callbackGenerator.ForPasswordReset(user, Request);
+                var callbackUri = await callbackGenerator.ForPasswordReset(user);
                 eventAggregator.Publish(new UserEvent.PasswordResetRequested(user, callbackUri));
                 return RedirectToAction(nameof(ForgotPasswordConfirmation));
             }

--- a/BTCPayServer/Controllers/UIManageController.cs
+++ b/BTCPayServer/Controllers/UIManageController.cs
@@ -219,7 +219,7 @@ namespace BTCPayServer.Controllers
                 throw new ApplicationException($"Unable to load user with ID '{_userManager.GetUserId(User)}'.");
             }
 
-            var callbackUrl = await _callbackGenerator.ForEmailConfirmation(user, Request);
+            var callbackUrl = await _callbackGenerator.ForEmailConfirmation(user);
             _eventAggregator.Publish(new UserEvent.ConfirmationEmailRequested(user, callbackUrl));
             TempData[WellKnownTempData.SuccessMessage] = StringLocalizer["Verification email sent. Please check your email."].Value;
             return RedirectToAction(nameof(Index));

--- a/BTCPayServer/Controllers/UIStoresController.Users.cs
+++ b/BTCPayServer/Controllers/UIStoresController.Users.cs
@@ -74,7 +74,7 @@ public partial class UIStoresController
                     (await _userManager.CreateAsync(user)) is { Succeeded: true })
                 {
                     var invitationEmail = await _emailSenderFactory.IsComplete();
-                    var evt = await UserEvent.Invited.Create(user!, currentUser, _callbackGenerator, Request, invitationEmail);
+                    var evt = await UserEvent.Invited.Create(user!, currentUser, _callbackGenerator, invitationEmail);
                     _eventAggregator.Publish(evt);
                     inviteInfo = invitationEmail
                         ? StringLocalizer["An invitation email has been sent.<br/>You may alternatively share this link with them: <a class='alert-link' href='{0}'>{0}</a>", evt.InvitationLink]

--- a/BTCPayServer/Events/UserEvent.cs
+++ b/BTCPayServer/Events/UserEvent.cs
@@ -30,10 +30,10 @@ public class UserEvent(ApplicationUser user)
     {
         public string ApprovalLink { get; } = approvalLink;
 		public string ConfirmationEmailLink { get; set; } = confirmationEmail;
-		public static async Task<Registered> Create(ApplicationUser user, CallbackGenerator callbackGenerator, HttpRequest request)
+		public static async Task<Registered> Create(ApplicationUser user, CallbackGenerator callbackGenerator)
 		{
-			var approvalLink = callbackGenerator.ForApproval(user, request);
-			var confirmationEmail = await callbackGenerator.ForEmailConfirmation(user, request);
+			var approvalLink = callbackGenerator.ForApproval(user);
+			var confirmationEmail = await callbackGenerator.ForEmailConfirmation(user);
 			return new Registered(user, approvalLink, confirmationEmail);
 		}
 	}
@@ -43,11 +43,11 @@ public class UserEvent(ApplicationUser user)
         public ApplicationUser InvitedByUser { get; } = invitedBy;
         public string InvitationLink { get; } = invitationLink;
 
-        public static async Task<Invited> Create(ApplicationUser user, ApplicationUser currentUser, CallbackGenerator callbackGenerator, HttpRequest request, bool sendEmail)
+        public static async Task<Invited> Create(ApplicationUser user, ApplicationUser currentUser, CallbackGenerator callbackGenerator, bool sendEmail)
         {
-			var invitationLink = await callbackGenerator.ForInvitation(user, request);
-			var approvalLink = callbackGenerator.ForApproval(user, request);
-			var confirmationEmail = await callbackGenerator.ForEmailConfirmation(user, request);
+			var invitationLink = await callbackGenerator.ForInvitation(user);
+			var approvalLink = callbackGenerator.ForApproval(user);
+			var confirmationEmail = await callbackGenerator.ForEmailConfirmation(user);
 			return new Invited(user, currentUser, invitationLink, approvalLink, confirmationEmail)
             {
                 SendInvitationEmail = sendEmail

--- a/BTCPayServer/Hosting/BTCPayServerServices.cs
+++ b/BTCPayServer/Hosting/BTCPayServerServices.cs
@@ -87,7 +87,7 @@ namespace BTCPayServer.Hosting
         }
         public static IServiceCollection AddBTCPayServer(this IServiceCollection services, IConfiguration configuration, Logs logs)
         {
-            services.TryAddSingleton<CallbackGenerator>();
+            services.TryAddScoped<CallbackGenerator>();
             services.TryAddSingleton<IStringLocalizerFactory, LocalizerFactory>();
             services.TryAddSingleton<IHtmlLocalizerFactory, LocalizerFactory>();
             services.TryAddSingleton<LocalizerService>();

--- a/BTCPayServer/Services/UserService.cs
+++ b/BTCPayServer/Services/UserService.cs
@@ -90,7 +90,7 @@ namespace BTCPayServer.Services
                     ? null
                     : await uriResolver.Resolve(request.GetAbsoluteRootUri(), UnresolvedUri.Create(blob.ImageUrl)),
                 InvitationUrl = string.IsNullOrEmpty(blob.InvitationToken) ? null
-                    : callbackGenerator.ForInvitation(data.Id, blob.InvitationToken, request)
+                    : callbackGenerator.ForInvitation(data.Id, blob.InvitationToken)
             };
         }
 

--- a/BTCPayServer/Views/UIPaymentRequest/GetPaymentRequests.cshtml
+++ b/BTCPayServer/Views/UIPaymentRequest/GetPaymentRequests.cshtml
@@ -123,7 +123,7 @@
                             <div class="d-inline-flex align-items-center gap-3">
                                 <a asp-action="ViewPaymentRequest" asp-route-payReqId="@item.Id" id="PaymentRequest-@item.Id" target="_blank" text-translate="true">View</a>
                                 <button type="button" class="btn btn-link p-0 clipboard-button"
-                                        data-clipboard="@CallbackGenerator.PaymentRequestByIdLink(item.Id, this.Context.Request)"
+                                        data-clipboard="@CallbackGenerator.PaymentRequestByIdLink(item.Id)"
                                         title="Copy Link">
                                     <vc:icon symbol="actions-copy" />
                                 </button>


### PR DESCRIPTION
In one of the integration test, I discovered a test that suddenly failed with this stacktrace.

```
at Microsoft.EntityFrameworkCore.Query.Internal.SingleQueryingEnumerable`1.AsyncEnumerator.MoveNextAsync()
 11/14/2025 09:05:53 +00:00 :Events:   Trigger event 'SRV-InvitePending'
 11/14/2025 09:05:53 +00:00 :Configuration:   Should have sent email, but email settings are not configured
 11/14/2025 09:05:53 +00:00 :Microsoft.AspNetCore.Diagnostics.ExceptionHandlerMiddleware:   An unhandled exception has occurred while executing the request.
 System.InvalidOperationException: A second operation was started on this context instance before a previous operation completed. This is usually caused by different threads concurrently using the same instance of DbContext. For more information on how to avoid threading issues with DbContext, see https://go.microsoft.com/fwlink/?linkid=2097913.
    at Microsoft.EntityFrameworkCore.Query.Internal.SingleQueryingEnumerable`1.AsyncEnumerator.MoveNextAsync()
    at Microsoft.EntityFrameworkCore.Query.ShapedQueryCompilingExpressionVisitor.SingleOrDefaultAsync[TSource](IAsyncEnumerable`1 asyncEnumerable, CancellationToken cancellationToken)
    at Microsoft.EntityFrameworkCore.Query.ShapedQueryCompilingExpressionVisitor.SingleOrDefaultAsync[TSource](IAsyncEnumerable`1 asyncEnumerable, CancellationToken cancellationToken)
    at BTCPayServer.UserManagerExtensions.SetInvitationTokenAsync[TUser](UserManager`1 userManager, String userId, String token) in /source/BTCPayServer/UserManagerExtensions.cs:line 43
    at BTCPayServer.UserManagerExtensions.GenerateInvitationTokenAsync[TUser](UserManager`1 userManager, String userId) in /source/BTCPayServer/UserManagerExtensions.cs:line 27
```

The reason was that `CallbackGenerator` was a singleton, but the `UserManager` was injected into it.
Upon investigation, the UserManager is a scoped service, so it shouldn't be injected. It is using a single Entity DbContext, and a DbContext can't be used concurrently.
This error was caused when two requests attempted to use the `CallbackGenerator` at the same time.

I suspect we are using the UserManager in more singletons, so this is something we should solve long term.

Because CallbackGenerator is now a scoped service, it has access to the HttpContextAccessor, so we don't have to pass the `HttpContext` explicitely to it anymore.
This simplify the codes of clients a little bit.
