### PR TITLE
Fix clipboard copy for fiat amounts and other numeric values

### DIFF
--- a/BTCPayServer/wwwroot/checkout/checkout.js
+++ b/BTCPayServer/wwwroot/checkout/checkout.js
@@ -57,7 +57,27 @@ function updateLanguage(lang) {
 }
 
 function asNumber(val) {
-    return val && parseFloat(val.toString().replace(/\s/g, '')); // e.g. sats are formatted with spaces: 1 000 000
+    if (!val) return null;
+    let str = val.toString();
+    
+    // Remove leading non-numeric characters (e.g. currency symbols like $, €, £)
+    str = str.replace(/^[^\d-]+/, '');
+    
+    // Detect decimal separator: the last occurrence of . or , is the decimal separator
+    // Everything before it is thousands separators
+    const lastComma = str.lastIndexOf(',');
+    const lastDot = str.lastIndexOf('.');
+    
+    if (lastComma > lastDot) {
+        // European format: 91.121,60 - comma is decimal, dots/spaces are thousands
+        str = str.replace(/[\s.]/g, '').replace(',', '.');
+    } else {
+        // US/UK format: 91,121.60 - dot is decimal, commas/spaces are thousands
+        str = str.replace(/[\s,]/g, '');
+    }
+    
+    const num = parseFloat(str);
+    return isNaN(num) ? null : num;
 }
 
 Vue.use(VueI18next);


### PR DESCRIPTION
Convert asNumber() results to strings using optional chaining and toString() to fix clipboard copy functionality. Previously, numeric values were being copied as 'NaN' because data-clipboard attribute expected strings.

Fixes #6933