### PR TITLE
Fixing clipboard NaN problem on checkout

### DIFF
--- a/BTCPayServer/Views/UIInvoice/Checkout.cshtml
+++ b/BTCPayServer/Views/UIInvoice/Checkout.cshtml
@@ -255,7 +255,7 @@
             </div>
             <div v-if="orderAmount > 0 && srvModel.orderAmountFiat" id="PaymentDetails-TotalFiat" key="TotalFiat">
                 <dt v-t="'total_fiat'"></dt>
-                <dd id="total_fiat" class="clipboard-button clipboard-button-hover" :data-clipboard="asNumber(srvModel.orderAmountFiat)" data-clipboard-hover="start">{{srvModel.orderAmountFiat}}</dd>
+                <dd id="total_fiat" class="clipboard-button clipboard-button-hover" :data-clipboard="srvModel.orderAmountFiat" data-clipboard-hover="start">{{srvModel.orderAmountFiat}}</dd>
             </div>
              <div v-if="srvModel.taxIncluded.value > 0 && srvModel.taxIncluded.formatted" id="PaymentDetails-TaxIncluded" key="TaxIncluded">
                 <dt v-t="'tax_included'"></dt>
@@ -263,7 +263,7 @@
             </div>
             <div v-if="srvModel.rate && srvModel.paymentMethodCurrency" id="PaymentDetails-ExchangeRate" key="ExchangeRate">
                 <dt v-t="'exchange_rate'"></dt>
-                <dd class="clipboard-button clipboard-button-hover" :data-clipboard="asNumber(srvModel.rate)" data-clipboard-hover="start">
+                <dd class="clipboard-button clipboard-button-hover" :data-clipboard="srvModel.rate" data-clipboard-hover="start">
                     <template v-if="srvModel.paymentMethodCurrency === 'sats'">1 sat = {{ srvModel.rate }}</template>
                     <template v-else>1 {{ srvModel.paymentMethodCurrency }} = {{ srvModel.rate }}</template>
                 </dd>


### PR DESCRIPTION
Fixes: #6933

As discussed in the previous pull request (https://github.com/btcpayserver/btcpayserver/pull/7011#issuecomment-3644951159), the best way to address this issue for now is by copying the strings for the fiat amount and exchange rate. Here’s a video demonstration of the code in action:

https://github.com/user-attachments/assets/7e5d969f-3b27-43ff-8614-86ece54f52e8

We cannot eliminate the `asNumber` function since it is utilized by other methods in `checkout.js`. Therefore, we’re making minimal changes in this pull request to resolve the issue with NaN.