### PR TITLE
Fix: Should never show payment method selector if there's only a single payment method, even with plugins

### DIFF
--- a/BTCPayServer.Tests/CheckoutUITests.cs
+++ b/BTCPayServer.Tests/CheckoutUITests.cs
@@ -65,7 +65,7 @@ namespace BTCPayServer.Tests
             Assert.Equal($"bitcoin:{address}", clipboard);
             Assert.Equal($"bitcoin:{address.ToUpperInvariant()}", qrValue);
             s.Driver.ElementDoesNotExist(By.Id("Lightning_BTC-CHAIN"));
-            
+
             // Contact option
             var contactLink = s.Driver.FindElement(By.Id("ContactLink"));
             Assert.Equal("Contact us", contactLink.Text);
@@ -156,7 +156,7 @@ namespace BTCPayServer.Tests
             await s.Server.ExplorerNode.SendToAddressAsync(BitcoinAddress.Create(address, Network.RegTest),
                 Money.Parse(amountFraction));
             await s.Server.ExplorerNode.GenerateAsync(1);
-            
+
             expirySeconds = s.Driver.FindElement(By.Id("ExpirySeconds"));
             expirySeconds.Clear();
             expirySeconds.SendKeys("3");
@@ -201,7 +201,7 @@ namespace BTCPayServer.Tests
             await Task.Delay(200);
             s.Driver.FindElement(By.Id("test-payment-amount")).Clear();
             s.Driver.FindElement(By.Id("test-payment-amount")).SendKeys("0.00001");
-            
+
             // Fake Pay
             TestUtils.Eventually(() =>
             {
@@ -256,7 +256,8 @@ namespace BTCPayServer.Tests
 
             invoiceId = s.CreateInvoice();
             s.GoToInvoiceCheckout(invoiceId);
-            Assert.Empty(s.Driver.FindElements(By.CssSelector(".payment-method")));
+            void AssertNoPaymentMethods() => Assert.False(s.Driver.FindElement(By.CssSelector(".payment-method")).Displayed);
+            AssertNoPaymentMethods();
             Assert.Contains("BTC", s.Driver.FindElement(By.Id("AmountDue")).Text);
             qrValue = s.Driver.FindElement(By.CssSelector(".qr-container")).GetAttribute("data-qr-value");
             clipboard = s.Driver.FindElement(By.CssSelector(".qr-container")).GetAttribute("data-clipboard");
@@ -302,7 +303,7 @@ namespace BTCPayServer.Tests
             s.GoToHome();
             invoiceId = s.CreateInvoice(defaultPaymentMethod: "BTC-LN");
             s.GoToInvoiceCheckout(invoiceId);
-            Assert.Empty(s.Driver.FindElements(By.CssSelector(".payment-method")));
+            AssertNoPaymentMethods();
             payUrl = s.Driver.FindElement(By.Id("PayInWallet")).GetAttribute("href");
             Assert.StartsWith("bitcoin:", payUrl);
             Assert.Contains("&lightning=lnbcrt", payUrl);
@@ -323,7 +324,7 @@ namespace BTCPayServer.Tests
             // BIP21 with top-up invoice
             invoiceId = s.CreateInvoice(amount: null);
             s.GoToInvoiceCheckout(invoiceId);
-            Assert.Empty(s.Driver.FindElements(By.CssSelector(".payment-method")));
+            AssertNoPaymentMethods();
             qrValue = s.Driver.FindElement(By.CssSelector(".qr-container")).GetAttribute("data-qr-value");
             clipboard = s.Driver.FindElement(By.CssSelector(".qr-container")).GetAttribute("data-clipboard");
             payUrl = s.Driver.FindElement(By.Id("PayInWallet")).GetAttribute("href");
@@ -401,7 +402,7 @@ namespace BTCPayServer.Tests
             s.GoToHome();
             invoiceId = s.CreateInvoice(defaultPaymentMethod: "BTC-LN");
             s.GoToInvoiceCheckout(invoiceId);
-            Assert.Empty(s.Driver.FindElements(By.CssSelector(".payment-method")));
+            AssertNoPaymentMethods();
             payUrl = s.Driver.FindElement(By.Id("PayInWallet")).GetAttribute("href");
             Assert.StartsWith("bitcoin:", payUrl);
             Assert.Contains("&lightning=lnbcrt", payUrl);

--- a/BTCPayServer/Views/UIInvoice/Checkout.cshtml
+++ b/BTCPayServer/Views/UIInvoice/Checkout.cshtml
@@ -2,7 +2,6 @@
 @using BTCPayServer.Abstractions.Contracts
 @inject LanguageService LangService
 @inject BTCPayServerEnvironment Env
-@inject IEnumerable<IUIExtension> UiExtensions
 @inject BTCPayServer.Security.ContentSecurityPolicies Csp
 @model CheckoutModel
 @{
@@ -10,7 +9,6 @@
 	ViewData["Title"] = Model.HtmlTitle;
     ViewData["StoreBranding"] = Model.StoreBranding;
 	Csp.UnsafeEval();
-	var hasPaymentPlugins = UiExtensions.Any(extension => extension.Location == "checkout-payment-method");
 }
 @functions {
     private string ToJsValue(object value)
@@ -88,7 +86,7 @@
                         :show-recommended-fee="showRecommendedFee"
                         class="pb-4" />
                 </div>
-                <div v-if="displayedPaymentMethods.length > 1 || @Safe.Json(hasPaymentPlugins)" class="mt-3 mb-2">
+                <div class="mt-3 mb-2 payment-methods-wrapper">
                     <h6 class="text-center mb-3" v-t="'pay_with'"></h6>
                     <div class="btcpay-pills d-flex flex-wrap align-items-center justify-content-center gap-2 pb-2">
                         <a v-for="crypto in displayedPaymentMethods"

--- a/BTCPayServer/wwwroot/checkout/checkout.css
+++ b/BTCPayServer/wwwroot/checkout/checkout.css
@@ -117,6 +117,13 @@ section dl > div dd {
 #payment .btcpay-pills .btcpay-pill {
     padding: var(--btcpay-space-xs) var(--btcpay-space-m);
 }
+
+/* Do not show payments methods selector if there is only one */
+#payment .payment-methods-wrapper:not(:has(.btcpay-pills>*:nth-child(2)))
+{
+    display: none;
+}
+
 #form > form,
 #result > div {
     display: flex;


### PR DESCRIPTION
Fix #6772

This replaces #6980 which triggered a regression (#7053)
