### PR TITLE
Fix: In the UI, the prefilled email set when creating a new subscriber was ignored

### DIFF
--- a/BTCPayServer/Plugins/Subscriptions/Controllers/UIOfferingController.cs
+++ b/BTCPayServer/Plugins/Subscriptions/Controllers/UIOfferingController.cs
@@ -69,7 +69,11 @@ public partial class UIOfferingController(
         };
 
         if (prefilledEmail != null && prefilledEmail.IsValidEmail())
+        {
+            checkoutData.NewSubscriberEmail = prefilledEmail;
             checkoutData.InvoiceMetadata = new InvoiceMetadata() { BuyerEmail = prefilledEmail }.ToJObject().ToString();
+        }
+
         ctx.PlanCheckouts.Add(checkoutData);
         await ctx.SaveChangesAsync();
         return RedirectToPlanCheckout(checkoutData.Id);


### PR DESCRIPTION
The email set in this field was ignored.

<img width="1088" height="868" alt="image" src="https://github.com/user-attachments/assets/1a555ac8-c321-4365-a301-77a0e056f5ce" />
