### PR TITLE
Fix: Payment reminders not send to subscribers

### DIFF
--- a/BTCPayServer.Data/Migrations/20251231034124_subs_payment_reminder.cs
+++ b/BTCPayServer.Data/Migrations/20251231034124_subs_payment_reminder.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using BTCPayServer.Data;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace BTCPayServer.Migrations
+{
+    [DbContext(typeof(ApplicationDbContext))]
+    [Migration("20251231034124_subs_payment_reminder")]
+    public partial class subs_payment_reminder : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql("DROP INDEX IF EXISTS \"IX_PaymentRequests_Title\";");
+
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "reminder_date",
+                table: "subs_subscribers",
+                type: "timestamp with time zone",
+                nullable: true);
+
+            migrationBuilder.Sql("""
+                                 UPDATE subs_subscribers
+                                 SET reminder_date = COALESCE(period_end, trial_end) - INTERVAL '3 days'
+                                 WHERE COALESCE(period_end, trial_end) IS NOT NULL
+                                 """);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "reminder_date",
+                table: "subs_subscribers");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PaymentRequests_Title",
+                table: "PaymentRequests",
+                column: "Title");
+        }
+    }
+}

--- a/BTCPayServer.Data/Migrations/ApplicationDbContextModelSnapshot.cs
+++ b/BTCPayServer.Data/Migrations/ApplicationDbContextModelSnapshot.cs
@@ -713,8 +713,6 @@ namespace BTCPayServer.Migrations
 
                     b.HasIndex("StoreDataId");
 
-                    b.HasIndex("Title");
-
                     b.ToTable("PaymentRequests");
                 });
 
@@ -1585,6 +1583,10 @@ namespace BTCPayServer.Migrations
                     b.Property<string>("ProcessingInvoiceId")
                         .HasColumnType("text")
                         .HasColumnName("processing_invoice_id");
+
+                    b.Property<DateTimeOffset?>("ReminderDate")
+                        .HasColumnType("timestamp with time zone")
+                        .HasColumnName("reminder_date");
 
                     b.Property<string>("SuspensionReason")
                         .HasColumnType("text")

--- a/BTCPayServer.Tests/SubscriptionTests.cs
+++ b/BTCPayServer.Tests/SubscriptionTests.cs
@@ -837,7 +837,7 @@ public class SubscriptionTests(ITestOutputHelper testOutputHelper) : UnitTestBas
 
         public async Task<T> WaitEvent<T>()
         {
-            using var cts = new CancellationTokenSource(7000);
+            using var cts = new CancellationTokenSource(15_000);
             var eventAggregator = s.Server.PayTester.GetService<EventAggregator>();
             return await eventAggregator.WaitNext<T>(cts.Token);
         }

--- a/BTCPayServer/Plugins/Subscriptions/Controllers/UISubscriberPortalController.cs
+++ b/BTCPayServer/Plugins/Subscriptions/Controllers/UISubscriberPortalController.cs
@@ -235,7 +235,7 @@ public class UISubscriberPortalController(
 
 
         var selector = new SubscriptionHostedService.MemberSelector.Single(portal.SubscriberId);
-        if (command == "reminder" && portal.Subscriber.GetReminderDate() is { } reminderDate)
+        if (command == "reminder" && portal.Subscriber.ReminderDate is { } reminderDate)
         {
             await SubsService.MoveTime(selector, reminderDate - DateTimeOffset.UtcNow);
             TempData.SetStatusSuccess("Moved to reminder");

--- a/BTCPayServer/Plugins/Subscriptions/SubscriptionHostedService.cs
+++ b/BTCPayServer/Plugins/Subscriptions/SubscriptionHostedService.cs
@@ -126,6 +126,8 @@ public class SubscriptionHostedService(
                     member.TrialEnd -= move.Period;
                 if (member.GracePeriodEnd is not null)
                     member.GracePeriodEnd -= move.Period;
+                if (member.ReminderDate is not null)
+                    member.ReminderDate -= move.Period;
                 member.PlanStarted -= move.Period;
             }
 
@@ -221,10 +223,10 @@ public class SubscriptionHostedService(
         {
             public override IQueryable<SubscriberData> Where(IQueryable<SubscriberData> query)
                 => From is null
-                    ? query.Where(q => (q.PeriodEnd < To || q.GracePeriodEnd < To || q.TrialEnd < To))
+                    ? query.Where(q => (q.PeriodEnd < To || q.GracePeriodEnd < To || q.TrialEnd < To || q.ReminderDate < To))
                     : query.Where(q =>
                         (q.PeriodEnd >= From && q.PeriodEnd < To) || (q.GracePeriodEnd >= From && q.GracePeriodEnd < To) ||
-                        (q.TrialEnd >= From && q.TrialEnd < To));
+                        (q.TrialEnd >= From && q.TrialEnd < To) || (q.ReminderDate >= From && q.ReminderDate < To));
         }
 
         public abstract IQueryable<SubscriberData> Where(IQueryable<SubscriberData> query);
@@ -288,7 +290,7 @@ public class SubscriptionHostedService(
                 }
             }
 
-            var needReminder = m.GetReminderDate() <= now &&
+            var needReminder = m.ReminderDate <= now &&
                                !m.PaymentReminded &&
                                m.MissingCredit() >= 0m;
             if (needReminder)

--- a/BTCPayServer/Plugins/Subscriptions/Views/UISubscriberPortal/SubscriberPortal.cshtml
+++ b/BTCPayServer/Plugins/Subscriptions/Views/UISubscriberPortal/SubscriberPortal.cshtml
@@ -218,7 +218,7 @@
         <div class="d-flex align-items-center gap-3">
             @if (Model.Subscriber.TestAccount)
             {
-                @if (Model.Subscriber.GetReminderDate() is var o && DateTimeOffset.UtcNow < o)
+                @if (DateTimeOffset.UtcNow < Model.Subscriber.ReminderDate)
                 {
                     <form id="MoveToReminder"
                           asp-action="MoveTime"
@@ -357,8 +357,7 @@
             <partial name="NextAction" model="@("btn btn-info", Model.Subscriber)" />
         </div>
     }
-    else if (Model.Subscriber.GetReminderDate() is { } reminderDate2 &&
-             reminderDate2 < DateTimeOffset.UtcNow &&
+    else if (Model.Subscriber.ReminderDate < DateTimeOffset.UtcNow &&
              !Model.Subscriber.IsNextPlanRenewable)
     {
         <div class="alert-translucent alert-warning">
@@ -372,8 +371,7 @@
             <partial name="NextAction" model="@("btn btn-warning", Model.Subscriber)" />
         </div>
     }
-    else if (Model.Subscriber.GetReminderDate() is { } reminderDate &&
-             reminderDate < DateTimeOffset.UtcNow &&
+    else if (Model.Subscriber.ReminderDate < DateTimeOffset.UtcNow &&
              Model.Subscriber.MissingCredit() != 0)
     {
         @if (daysRemaining == 0)


### PR DESCRIPTION
Fix #7055

Emails for payment reminders were not being sent properly.
This issue is not reproductible via Test accounts.

It was due to our polling logic (every 5 minutes), which wouldn't detect that a subscriber needs an update.