### PR TITLE
PoS: Can disable zero amount invoices

### DIFF
--- a/BTCPayServer/Plugins/PointOfSale/Controllers/UIPointOfSaleController.cs
+++ b/BTCPayServer/Plugins/PointOfSale/Controllers/UIPointOfSaleController.cs
@@ -330,6 +330,9 @@ namespace BTCPayServer.Plugins.PointOfSale.Controllers
                           selectedChoices.Any(c => c.PriceType == AppItemPriceType.Topup);
 
             var receiptData = PosReceiptData.Create(isTopup, selectedChoices, jposData, order, summary, settings.Currency, _displayFormatter);
+            if (!isTopup && summary.PriceTaxIncludedWithTips <= 0m && settings.DisableZeroAmountInvoice is true)
+                return Error(StringLocalizer["Zero amount invoices are disabled"].Value);
+
             try
             {
                 var invoice = await _invoiceController.CreateInvoiceCoreRaw(new CreateInvoiceRequest
@@ -566,6 +569,7 @@ namespace BTCPayServer.Plugins.PointOfSale.Controllers
                 Description = settings.Description,
                 NotificationUrl = settings.NotificationUrl,
                 RedirectUrl = settings.RedirectUrl,
+                DisableZeroAmountInvoice = settings.DisableZeroAmountInvoice is true,
                 SearchTerm = app.TagAllInvoices ? $"storeid:{app.StoreDataId}" : $"appid:{app.Id}",
                 RedirectAutomatically = settings.RedirectAutomatically.HasValue ? settings.RedirectAutomatically.Value ? "true" : "false" : "",
                 FormId = settings.FormId
@@ -661,6 +665,7 @@ namespace BTCPayServer.Plugins.PointOfSale.Controllers
                 HtmlLang = vm.HtmlLang,
                 HtmlMetaTags = _safe.RawMeta(vm.HtmlMetaTags, out bool wasHtmlModified),
                 Description = vm.Description,
+                DisableZeroAmountInvoice = vm.DisableZeroAmountInvoice,
                 RedirectAutomatically = string.IsNullOrEmpty(vm.RedirectAutomatically) ? null : bool.Parse(vm.RedirectAutomatically),
                 FormId = vm.FormId
             };

--- a/BTCPayServer/Plugins/PointOfSale/Models/UpdatePointOfSaleViewModel.cs
+++ b/BTCPayServer/Plugins/PointOfSale/Models/UpdatePointOfSaleViewModel.cs
@@ -101,5 +101,8 @@ namespace BTCPayServer.Plugins.PointOfSale.Models
         public string FormId { get; set; }
 
         public bool Archived { get; set; }
+
+        [Display(Name = "Disable zero amount invoices")]
+        public bool DisableZeroAmountInvoice { get; set; }
     }
 }

--- a/BTCPayServer/Services/Apps/PointOfSaleSettings.cs
+++ b/BTCPayServer/Services/Apps/PointOfSaleSettings.cs
@@ -108,5 +108,6 @@ namespace BTCPayServer.Services.Apps
         public string NotificationUrl { get; set; }
         public string RedirectUrl { get; set; }
         public bool? RedirectAutomatically { get; set; }
+        public bool? DisableZeroAmountInvoice { get; set; }
     }
 }

--- a/BTCPayServer/Views/Shared/PointOfSale/UpdatePointOfSale.cshtml
+++ b/BTCPayServer/Views/Shared/PointOfSale/UpdatePointOfSale.cshtml
@@ -203,6 +203,10 @@
                         <span asp-validation-for="CustomButtonText" class="text-danger"></span>
                     </div>
                 </div>
+                <div class="form-group d-flex align-items-center">
+                    <input asp-for="DisableZeroAmountInvoice" type="checkbox" class="btcpay-toggle me-3"/>
+                    <label asp-for="DisableZeroAmountInvoice" class="form-check-label"></label>
+                </div>
             </fieldset>
         </div>
     </div>


### PR DESCRIPTION
Fix #7035 

We discussed about whether such settings should be in the store settings instead.
But we couldn't really come with example of such problem in other context than the PoS.

We can always add this in the store settings if we want later on, in such case, we would replace the checkbox with a select which can be set to `Inherit the store's settings`.

Added a settings in PoS settings:
<img width="1804" height="710" alt="image" src="https://github.com/user-attachments/assets/7fee65ed-edb8-4187-bc80-bc55b43025ef" />


Error message in PoS:
<img width="2162" height="1406" alt="image" src="https://github.com/user-attachments/assets/f5f6e25c-cae0-4a3f-bbb3-06b0ab7ed03c" />

WIth Keypad:
<img width="980" height="1386" alt="image" src="https://github.com/user-attachments/assets/c9b41ff4-6e81-4006-abe9-be396e98e1fb" />

