### PR TITLE
Fix: Disable zero amount invoices in PoS doesn't show for Keypad

### DIFF
--- a/BTCPayServer/Views/Shared/PointOfSale/UpdatePointOfSale.cshtml
+++ b/BTCPayServer/Views/Shared/PointOfSale/UpdatePointOfSale.cshtml
@@ -122,6 +122,10 @@
                     <select asp-for="FormId" class="form-select w-auto" asp-items="@checkoutFormOptions"></select>
                     <span asp-validation-for="FormId" class="text-danger"></span>
                 </div>
+                <div class="form-group d-flex align-items-center">
+                    <input asp-for="DisableZeroAmountInvoice" type="checkbox" class="btcpay-toggle me-3"/>
+                    <label asp-for="DisableZeroAmountInvoice" class="form-check-label"></label>
+                </div>
             </fieldset>
             <fieldset id="keypad-display" class="mt-2">
                 <legend class="h5 mb-3 fw-semibold" text-translate="true">Keypad</legend>
@@ -202,10 +206,6 @@
                         <input asp-for="CustomButtonText" class="form-control" required />
                         <span asp-validation-for="CustomButtonText" class="text-danger"></span>
                     </div>
-                </div>
-                <div class="form-group d-flex align-items-center">
-                    <input asp-for="DisableZeroAmountInvoice" type="checkbox" class="btcpay-toggle me-3"/>
-                    <label asp-for="DisableZeroAmountInvoice" class="form-check-label"></label>
                 </div>
             </fieldset>
         </div>


### PR DESCRIPTION
When selecting "Keypad" view for the PoS, the option to disable the creation of zero amount invoices disappear.

As workaround, one have to switch "Point of Sale Style" to some other option, activate "Disable zero amount invoices" and get back to the original "Point of Sale Style".

To fix this issue, this PR move the field to the "Checkout" field set of the form instead of "Custom Payments".
