### PR TITLE
Fix: Editing a plan subcription set the Currency back to USD

### DIFF
--- a/BTCPayServer/Plugins/Subscriptions/Controllers/UIOfferingController.cs
+++ b/BTCPayServer/Plugins/Subscriptions/Controllers/UIOfferingController.cs
@@ -490,7 +490,7 @@ public partial class UIOfferingController(
             OfferingId = offeringId,
             PlanId = planId,
             OfferingName = offering.App.Name,
-            Currency = this.HttpContext.GetStoreData().GetStoreBlob().DefaultCurrency,
+            Currency = plan?.Currency ?? this.HttpContext.GetStoreData().GetStoreBlob().DefaultCurrency,
             Price = plan?.Price ?? 0m,
             Name = plan?.Name ?? "",
             Description = plan?.Description ?? "",


### PR DESCRIPTION
Fix this

<img width="1902" height="1022" alt="Schermata del 2025-12-23 12-28-04" src="https://github.com/user-attachments/assets/2214ed73-f0bb-4999-8970-d5ddb2d6b20e" />
