### PR TITLE
Fix: Backend translations would sometimes fail to load during startup

### DIFF
--- a/BTCPayServer/Extensions.cs
+++ b/BTCPayServer/Extensions.cs
@@ -448,8 +448,7 @@ namespace BTCPayServer
         public static void AddSettingsAccessor<T>(this IServiceCollection services) where T : class, new()
         {
             services.TryAddSingleton<ISettingsAccessor<T>, SettingsAccessor<T>>();
-            services.AddSingleton<IHostedService>(provider => (SettingsAccessor<T>)provider.GetRequiredService<ISettingsAccessor<T>>());
-            services.AddSingleton<IStartupTask>(provider => (SettingsAccessor<T>)provider.GetRequiredService<ISettingsAccessor<T>>());
+            services.AddSingleton(new SettingsAccessorsStartupTask.Registration(typeof(T)));
             // Singletons shouldn't reference the settings directly, but ISettingsAccessor<T>, since singletons won't have refreshed values of the setting
             services.AddTransient<T>(provider => provider.GetRequiredService<ISettingsAccessor<T>>().Settings);
         }

--- a/BTCPayServer/HostedServices/SettingsAccessorsStartupTask.cs
+++ b/BTCPayServer/HostedServices/SettingsAccessorsStartupTask.cs
@@ -1,0 +1,36 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using BTCPayServer.Abstractions.Contracts;
+using BTCPayServer.Events;
+using BTCPayServer.Services;
+
+namespace BTCPayServer.HostedServices;
+
+public class SettingsAccessorsStartupTask(
+    IEnumerable<SettingsAccessorsStartupTask.Registration> registrations,
+    SettingsRepository settingsRepository,
+    EventAggregator eventAggregator,
+    IServiceProvider serviceProvider)
+: IStartupTask
+{
+    public record Registration(Type SettingType, string? KeyName = null);
+
+    public async Task ExecuteAsync(CancellationToken cancellationToken = default)
+    {
+        var settingsAccessorByTypes = registrations
+            .Select(r => (r, (SettingsAccessor)serviceProvider.GetService(typeof(ISettingsAccessor<>).MakeGenericType(r.SettingType))!))
+            .ToDictionary(k => k.r.SettingType, k => (KeyName: k.r.KeyName, Accessor: k.Item2));
+        var values = await settingsRepository.LoadAllSettings(settingsAccessorByTypes.Select(r => (r.Key, r.Value.KeyName)).ToArray());
+        foreach (var o in settingsAccessorByTypes)
+        {
+            o.Value.Accessor.SetSetting(values[o.Key]);
+            var settingsChangedType = typeof(SettingsChanged<>).MakeGenericType(o.Key);
+            // We could dispose the subscriptions explicitely when the server stop but EventAggregator dispose anyway when the service quit
+            eventAggregator.Subscribe(settingsChangedType, (s, oo) => o.Value.Accessor.SetSetting(settingsChangedType.GetProperty(nameof(SettingsChanged<object>.Settings))!.GetValue(oo)));
+        }
+    }
+}

--- a/BTCPayServer/Hosting/BTCPayServerServices.cs
+++ b/BTCPayServer/Hosting/BTCPayServerServices.cs
@@ -166,6 +166,7 @@ namespace BTCPayServer.Hosting
                 o.GetRequiredService<IOptions<BTCPayServerOptions>>().Value);
 
             services.AddStartupTask<MigrationStartupTask>();
+            services.AddStartupTask<SettingsAccessorsStartupTask>();
 
             //
             services.AddSettingsAccessor<PoliciesSettings>();


### PR DESCRIPTION
Backend translations would sometimes fail to load during startup

```
warn: BTCPayServer.Services.LocalizerService: Failed to load translations
System.InvalidOperationException: Settings BTCPayServer.Plugins.Monetization.MonetizationSettings not yet initialized
   at BTCPayServer.Services.SettingsAccessor`1.get_Settings() in /home/nicolasdorier/src/btcpayserver/BTCPayServer/Services/ISettingsAccessor.cs:line 19
   at BTCPayServer.Plugins.Monetization.MonetizationEmailTriggerTransformer.Transform(EmailTriggerViewModel viewModel) in /home/nicolasdorier/src/btcpayserver/BTCPayServer/Plugins/Monetization/MonetizationEmailTransformer.cs:line 19
   at BTCPayServer.Plugins.Emails.Views.EmailTriggerViewModels.Transform(EmailTriggerViewModel arg) in /home/nicolasdorier/src/btcpayserver/BTCPayServer/Plugins/Emails/Views/EmailTriggerViewModels.cs:line 26
   at System.Linq.Enumerable.SelectArrayIterator`2.Fill(ReadOnlySpan`1 source, Span`1 destination, Func`2 func)
   at System.Linq.Enumerable.SelectArrayIterator`2.ToList()
   at BTCPayServer.Plugins.Emails.Views.EmailTriggerViewModels.GetViewModels() in /home/nicolasdorier/src/btcpayserver/BTCPayServer/Plugins/Emails/Views/EmailTriggerViewModels.cs:line 17
   at BTCPayServer.Plugins.Emails.EmailsTranslationProvider.GetDefaultTranslations() in /home/nicolasdorier/src/btcpayserver/BTCPayServer/Plugins/Emails/EmailsTranslationProvider.cs:line 14
   at BTCPayServer.Services.LocalizerService.<>c.<GetTranslations>b__10_0(IDefaultTranslationProvider d) in /home/nicolasdorier/src/btcpayserver/BTCPayServer/Services/LocalizerService.cs:line 93
   at System.Linq.Enumerable.SelectArrayIterator`2.Fill(ReadOnlySpan`1 source, Span`1 destination, Func`2 func)
   at System.Linq.Enumerable.SelectArrayIterator`2.ToArray()
   at BTCPayServer.Services.LocalizerService.GetTranslations(String dictionaryName) in /home/nicolasdorier/src/btcpayserver/BTCPayServer/Services/LocalizerService.cs:line 93
   at BTCPayServer.Services.LocalizerService.Load() in /home/nicolasdorier/src/btcpayserver/BTCPayServer/Services/LocalizerService.cs:line 71
info: Configuration:  Root Path: /
info: Configuration:  Connection to NBXplorer's database successful, dashboard and reporting features activated.
info: Configuration:  SSH settings detected, testing connection to root@127.0.0.1 on port 21622 ...
info: PayServer:      Checking if any payment arrived on lightning while the server was offline...
info: BTCPayServer.HostedServices.DbPeriodicTask: Executing Invoice Cleanup
```


This fix refactored how `SettingsAccessor` are loaded.

Prior to this fix, it would be possible for a plugin to use a `SettingsAccessor` before it has been loaded.

It should make the boot a little bit faster, as we were querying the database for each setting accessor prior to this. But this PR is making only a single query.

This fix make sure that all the settings accessors are loaded just after migrations executed.