### PR TITLE
fix: updated `UpdateDefaultTranslations` to detect all translation strings 

### DIFF
--- a/BTCPayServer.Tests/Dockerfile
+++ b/BTCPayServer.Tests/Dockerfile
@@ -23,7 +23,7 @@ ENV SCREEN_HEIGHT 600 \
 COPY . .
 
 ARG CONFIGURATION_NAME=Release
-RUN cd BTCPayServer.Tests && dotnet build --configuration ${CONFIGURATION_NAME} /p:CI_TESTS=true /p:RazorCompileOnBuild=true
+RUN cd BTCPayServer.Tests && dotnet build --configuration ${CONFIGURATION_NAME} /p:CI_TESTS=true /p:RazorCompileOnBuild=false
 RUN dotnet tool install --global Microsoft.Playwright.CLI
 ENV PATH="$PATH:/root/.dotnet/tools"
 RUN playwright install chromium --with-deps

--- a/BTCPayServer.Tests/UtilitiesTests.cs
+++ b/BTCPayServer.Tests/UtilitiesTests.cs
@@ -303,16 +303,17 @@ namespace BTCPayServer.Tests
             {
                 await tester.StartAsync();
                 var engine = tester.PayTester.GetService<RazorProjectEngine>();
-                var solDirPath = soldir.FullName;
-                var files = soldir.EnumerateFiles("*.cshtml", SearchOption.AllDirectories)
-                    .Union(soldir.EnumerateFiles("*.razor", SearchOption.AllDirectories));
+                var btcpayDir = Path.Combine(soldir.FullName, "BTCPayServer");
+                var btcpayDirInfo = new DirectoryInfo(btcpayDir);
+                var files = btcpayDirInfo.EnumerateFiles("*.cshtml", SearchOption.AllDirectories)
+                    .Union(btcpayDirInfo.EnumerateFiles("*.razor", SearchOption.AllDirectories));
                 foreach (var file in files)
                 {
                     var filePath = file.FullName;
                     var txt = File.ReadAllText(file.FullName);
                     AddLocalizers(defaultTranslatedKeys, txt);
 
-                    filePath = filePath.Replace(Path.Combine(solDirPath, "BTCPayServer"), "/").Replace("\\", "/");
+                    filePath = filePath.Replace(btcpayDir, "").Replace("\\", "/");
                     var item = engine.FileSystem.GetItem(filePath);
 
                     var node = (DocumentIntermediateNode)engine.Process(item).Items[typeof(DocumentIntermediateNode)];

--- a/BTCPayServer.Tests/UtilitiesTests.cs
+++ b/BTCPayServer.Tests/UtilitiesTests.cs
@@ -20,6 +20,7 @@ using Microsoft.AspNetCore.Mvc.Localization;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.Language.Intermediate;
 using Microsoft.AspNetCore.Razor.TagHelpers;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.Extensions.FileSystemGlobbing;
@@ -203,6 +204,31 @@ namespace BTCPayServer.Tests
         }
 
         /// <summary>
+        /// Pre-release check to ensure UpdateDefaultTranslations has been run
+        /// </summary>
+        [Trait("PreReleaseCheck", "PreReleaseCheck")]
+        [Fact]
+        public async Task CheckDefaultTranslationsUpToDate()
+        {
+            var soldir = TestUtils.TryGetSolutionDirectoryInfo();
+            var path = Path.Combine(soldir.FullName, "BTCPayServer/Services/Translations.Default.cs");
+            var originalContent = File.ReadAllText(path);
+
+            try
+            {
+                await UpdateDefaultTranslationsCore();
+
+                // Check if file was modified
+                var newContent = File.ReadAllText(path);
+                Assert.True(originalContent == newContent, 
+                    "Default translations are out of date. Please run the UpdateDefaultTranslations test before building docker images.\n" +
+                    "You can run it with: dotnet test --filter \"FullyQualifiedName~UpdateDefaultTranslations\"");
+            }
+            finally
+            {
+                File.WriteAllText(path, originalContent);
+            }
+        }
         /// Pre-release check to ensure language packs list in ListDictionaries.cshtml is up to date
         /// </summary>
         [Trait("PreReleaseCheck", "PreReleaseCheck")]
@@ -248,6 +274,11 @@ namespace BTCPayServer.Tests
         [Fact]
         public async Task UpdateDefaultTranslations()
         {
+            await UpdateDefaultTranslationsCore();
+        }
+
+        private async Task UpdateDefaultTranslationsCore()
+        {
             var soldir = TestUtils.TryGetSolutionDirectoryInfo();
             List<string> defaultTranslatedKeys = new List<string>();
 
@@ -267,10 +298,12 @@ namespace BTCPayServer.Tests
             }
 
             // Go through all cshtml file, search for text-translate or ViewLocalizer usage
+            // Use the server's configured RazorProjectEngine to ensure tag helpers are properly discovered
             using (var tester = CreateServerTester(newDb: true))
             {
                 await tester.StartAsync();
                 var engine = tester.PayTester.GetService<RazorProjectEngine>();
+                var solDirPath = soldir.FullName;
                 var files = soldir.EnumerateFiles("*.cshtml", SearchOption.AllDirectories)
                     .Union(soldir.EnumerateFiles("*.razor", SearchOption.AllDirectories));
                 foreach (var file in files)
@@ -279,14 +312,13 @@ namespace BTCPayServer.Tests
                     var txt = File.ReadAllText(file.FullName);
                     AddLocalizers(defaultTranslatedKeys, txt);
 
-                    filePath = filePath.Replace(Path.Combine(soldir.FullName, "BTCPayServer"), "/");
+                    filePath = filePath.Replace(Path.Combine(solDirPath, "BTCPayServer"), "/").Replace("\\", "/");
                     var item = engine.FileSystem.GetItem(filePath);
 
                     var node = (DocumentIntermediateNode)engine.Process(item).Items[typeof(DocumentIntermediateNode)];
                     var w = new TranslatedKeyNodeWalker(defaultTranslatedKeys, txt);
                     w.Visit(node);
                 }
-
             }
             defaultTranslatedKeys = defaultTranslatedKeys.Select(d => d.Trim().Replace("\r\n", "\n")).Distinct().OrderBy(o => o).ToList();
             JObject obj = new JObject();

--- a/RELEASE-CHECKLIST.md
+++ b/RELEASE-CHECKLIST.md
@@ -3,7 +3,8 @@
 Things to think about when creating a new release:
 
 * Run `dotnet format` on the solution
-* Run `PullTransifexTranslations` test.
+* Run `UpdateDefaultTranslations` test (required before building docker images)
+* Run `PullTransifexTranslations` test
 * Write chanlog in CHANGELOG.md
 * Bump version in `Build/Version.csproj`
 * Ensure the commit is signed with GPG (do not merge PRs via GitHub UI)


### PR DESCRIPTION
Fixes : 

- **UtilitiesTests.cs**: Reverted to using the server’s properly configured `RazorProjectEngine` by starting a test server, ensuring all tag helpers are discovered via dependency injection.

- **Dockerfile**: Added `/p:RazorCompileOnBuild=false` so Razor isn’t precompiled in Release builds, allowing RazorProjectEngine to be available at runtime for tests.

related : #7086, https://github.com/btcpayserver/btcpayserver/issues/7085