### PR TITLE
Fix: It shouldn't be possible to create an invoice when all store users are disabled

### DIFF
--- a/BTCPayServer.Data/ApplicationDbContextExtensions.Users.cs
+++ b/BTCPayServer.Data/ApplicationDbContextExtensions.Users.cs
@@ -1,0 +1,68 @@
+using System.Threading.Tasks;
+using Dapper;
+using Microsoft.EntityFrameworkCore;
+
+namespace BTCPayServer.Data;
+
+public static partial class ApplicationDbContextExtensions
+{
+    /// <summary>
+    /// StoreBlob.NoActiveUser is set up to `true` if users have a store where there are
+    /// no active users
+    /// </summary>
+    /// <param name="dbSet"></param>
+    /// <param name="userIds"></param>
+    public static Task UpdateStoreNoActiveUserForUsers(this DbSet<ApplicationUser> dbSet, string[] userIds)
+    {
+        DynamicParameters parameters = new();
+        parameters.Add("userIds", userIds);
+        return dbSet.UpdateStoreNoActiveUserCore("""
+                                                       SELECT DISTINCT us."StoreDataId" AS store_id
+                                                       FROM unnest(@userIds::text[]) AS u("UserId")
+                                                       JOIN "UserStore" us ON us."ApplicationUserId" = u."UserId"
+                                                       """, parameters);
+    }
+
+    public static Task UpdateStoreNoActiveUserForStores(this DbSet<ApplicationUser> dbSet, string[] storeIds)
+    {
+        DynamicParameters parameters = new();
+        parameters.Add("stores", storeIds);
+        return dbSet.UpdateStoreNoActiveUserCore("""
+                                                       SELECT DISTINCT store_id
+                                                       FROM unnest(@stores::text[]) AS u(store_id)
+                                                       """, parameters);
+    }
+
+    public static Task UpdateStoreNoActiveUserCore(this DbSet<ApplicationUser> dbSet, string selectStoresSql, DynamicParameters parameters)
+    => dbSet.GetDbConnection()
+        .ExecuteAsync(GetUpdateStoreNoActiveUserQuery(selectStoresSql), parameters);
+
+    internal static string GetUpdateStoreNoActiveUserQuery(string selectStoresSql)
+        => $$"""
+             WITH
+             -- Select all the stores belonging to the userIds
+             stores AS (
+                 {{selectStoresSql}}
+             ),
+             -- Count all active users of the store
+             active_users AS (
+                 SELECT s."Id",
+                        COUNT(u."Id") FILTER (WHERE u."LockoutEnd" IS NULL OR u."LockoutEnd" <= NOW()) AS active_users
+                 FROM stores st
+                 JOIN "Stores" s ON s."Id" = st.store_id
+                 LEFT JOIN "UserStore" us ON us."StoreDataId" = s."Id"
+                 LEFT JOIN "AspNetUsers" u ON u."Id" = us."ApplicationUserId"
+                 GROUP BY s."Id"
+             ),
+             -- If the total is 0, then the store should have noActiveUser set to true
+             expected_disabled AS (
+                 SELECT s."Id", COALESCE(s."StoreBlob"->'noActiveUser' = 'true'::JSONB, false) current_value, t.active_users = 0 expected_value FROM active_users t
+                 JOIN "Stores" s ON s."Id" = t."Id"
+             )
+             -- Update only the stores not having expected values.
+             UPDATE "Stores" s
+             SET "StoreBlob" = jsonb_set("StoreBlob", '{noActiveUser}', to_jsonb(ed.expected_value))
+             FROM expected_disabled ed
+             WHERE s."Id" = ed."Id" AND ed.expected_value <> ed.current_value;
+             """;
+}

--- a/BTCPayServer.Data/Migrations/20260112034124_disable_orphan_stores.cs
+++ b/BTCPayServer.Data/Migrations/20260112034124_disable_orphan_stores.cs
@@ -1,0 +1,15 @@
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace BTCPayServer.Data.Migrations;
+
+
+[DbContext(typeof(ApplicationDbContext))]
+[Migration("20260112034124_disable_orphan_stores")]
+public class disable_orphan_stores  : Migration
+{
+    protected override void Up(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.Sql(ApplicationDbContextExtensions.GetUpdateStoreNoActiveUserQuery("SELECT DISTINCT \"Id\" store_id FROM \"Stores\""));
+    }
+}

--- a/BTCPayServer.Tests/PlaywrightTests.cs
+++ b/BTCPayServer.Tests/PlaywrightTests.cs
@@ -2026,6 +2026,7 @@ namespace BTCPayServer.Tests
             await s.Page.ClickAsync("#InProgress-mark-awaiting-payment");
             await s.Page.ClickAsync("#AwaitingPayment-view");
 
+            await s.Page.WaitForLoadStateAsync(LoadState.DOMContentLoaded);
             var pageContent = await s.Page.ContentAsync();
             Assert.Contains("PP1", pageContent);
         }

--- a/BTCPayServer.Tests/UnitTest1.cs
+++ b/BTCPayServer.Tests/UnitTest1.cs
@@ -77,6 +77,7 @@ using RatesViewModel = BTCPayServer.Models.StoreViewModels.RatesViewModel;
 using Microsoft.Extensions.Caching.Memory;
 using PosViewType = BTCPayServer.Client.Models.PosViewType;
 using BTCPayServer.Plugins.Emails.Controllers;
+using BTCPayServer.Services.Stores;
 using BTCPayServer.Views.Stores;
 using Microsoft.Playwright;
 using MimeKit;
@@ -217,9 +218,10 @@ namespace BTCPayServer.Tests
 
             var client = await user.CreateClient();
             await client.RemoveStore(user.StoreId);
-            tester.Stores.Clear();
-            arbValue = await settingsRepo.GetSettingAsync<string>(user.StoreId, "arbitrary");
-            Assert.Null(arbValue);
+
+            var store = await tester.PayTester.GetService<StoreRepository>()
+                .FindStore(user.StoreId);
+            Assert.True(store?.GetStoreBlob().NoActiveUser);
         }
         class TestData
         {

--- a/BTCPayServer/Controllers/UIInvoiceController.cs
+++ b/BTCPayServer/Controllers/UIInvoiceController.cs
@@ -213,6 +213,8 @@ namespace BTCPayServer.Controllers
             InvoiceLogs logs = new InvoiceLogs();
             logs.Write("Creation of invoice starting", InvoiceEventData.EventSeverity.Info);
             var storeBlob = store.GetStoreBlob();
+            if (storeBlob.NoActiveUser)
+                throw new BitpayHttpException(400, "Invoice creation is disabled for this store (No active user)");
             if (string.IsNullOrEmpty(entity.Currency))
                 entity.Currency = storeBlob.DefaultCurrency;
             entity.Currency = entity.Currency.Trim().ToUpperInvariant();

--- a/BTCPayServer/Data/StoreBlob.cs
+++ b/BTCPayServer/Data/StoreBlob.cs
@@ -302,6 +302,8 @@ namespace BTCPayServer.Data
             }
         }
 
+        public bool NoActiveUser { get; set; }
+
         private string NormalizeCurrency(string v) =>
             v is null ? null :
             Regex.Replace(v.ToUpperInvariant(), "[^A-Z]", "").Trim() is { Length: > 0 } normalized ? normalized : null;

--- a/BTCPayServer/Plugins/Monetization/MonetizationHostedService.cs
+++ b/BTCPayServer/Plugins/Monetization/MonetizationHostedService.cs
@@ -145,7 +145,9 @@ public class MonetizationHostedService(
         var user = await userManager.FindByIdAsync(userId ?? "");
         if (user is not null &&
             await userService.SetDisabled(user.Id, !activated) is not UserService.SetDisabledResult.Error)
+        {
             EventAggregator.Publish(new MonetizationLockoutUpdated([(user.Id, !activated)]));
+        }
     }
 
     private async Task AttachUserIdToSubscriber(string id, SubscriptionEvent.NewSubscriber newSub)
@@ -339,6 +341,8 @@ public class MonetizationHostedService(
                 disabledUsers.Add(update.UserId);
             else
                 disabledUsers.Remove(update.UserId);
+
+        await ctx.Users.UpdateStoreNoActiveUserForUsers(updated.Select(u => u.UserId).ToArray());
         EventAggregator.Publish(new MonetizationLockoutUpdated(updated));
     }
 

--- a/BTCPayServer/Services/Stores/StoreRepository.cs
+++ b/BTCPayServer/Services/Stores/StoreRepository.cs
@@ -314,6 +314,7 @@ namespace BTCPayServer.Services.Stores
             try
             {
                 await ctx.SaveChangesAsync();
+                await ctx.Users.UpdateStoreNoActiveUserForStores([storeId]);
                 _eventAggregator.Publish(new StoreUserEvent.Added(storeId, userId, roleId.Id));
                 return true;
             }
@@ -410,20 +411,6 @@ namespace BTCPayServer.Services.Stores
                 store.ApplicationUserId != userId);
         }
 
-        private async Task DeleteStoreIfOrphan(string storeId)
-        {
-            await using var ctx = _ContextFactory.CreateContext();
-            if (!await ctx.UserStore.Where(u => u.StoreDataId == storeId && u.StoreRole.Permissions.Contains(Policies.CanModifyStoreSettings)).AnyAsync())
-            {
-                var store = await ctx.Stores.FindAsync(storeId);
-                if (store != null)
-                {
-                    ctx.Stores.Remove(store);
-                    await ctx.SaveChangesAsync();
-                    _eventAggregator.Publish(new StoreEvent.Removed(store));
-                }
-            }
-        }
         public async Task CreateStore(string ownerId, StoreData storeData, StoreRoleId? roleId = null)
         {
             if (!string.IsNullOrEmpty(storeData.Id))
@@ -587,8 +574,8 @@ namespace BTCPayServer.Services.Stores
                     return;
                 ctx.UserStore.Remove(storeUser);
                 await ctx.SaveChangesAsync();
+                await ctx.Users.UpdateStoreNoActiveUserForStores([storeId]);
             }
-            await DeleteStoreIfOrphan(storeId);
         }
 
         public async Task UpdateStore(StoreData store)

--- a/BTCPayServer/Services/UserService.cs
+++ b/BTCPayServer/Services/UserService.cs
@@ -221,6 +221,13 @@ namespace BTCPayServer.Services
             {
                 _disabledUsers.Remove(userId);
             }
+
+            if (res.Succeeded)
+            {
+                await using var ctx = _applicationDbContextFactory.CreateContext();
+                await ctx.Users.UpdateStoreNoActiveUserForUsers([userId]);
+            }
+
             return res.Succeeded ? new SetDisabledResult.Success() : new SetDisabledResult.Error(res.Errors.ToArray());
         }
 


### PR DESCRIPTION
Reported by @golyalpha

When a user of the server has been disabled, it would still be possible to use the public apps (such as Point of Sales) to create invoices.

This PR will disable invoice creation from any store which doesn't have any enabled user.