### PR TITLE
Fix: Subscriber without enough credits would receive reminder email and not be renewed

### DIFF
--- a/BTCPayServer.Data/Data/Subscriptions/SubscriberData.cs
+++ b/BTCPayServer.Data/Data/Subscriptions/SubscriberData.cs
@@ -130,16 +130,16 @@ public class SubscriberData : BaseEntityData
     [NotMapped]
     public bool CanStartNextPlan => CanStartNextPlanEx(false);
 
-    public bool CanStartNextPlanEx(bool newSubscriber) => this is
+    public bool CanStartNextPlanEx(bool newSubscriber, PhaseTypes? phase = null) => this is
     {
-        Phase: not PhaseTypes.Normal,
         NextPlan:
         {
             Status: Data.Subscriptions.PlanData.PlanStatus.Active
         },
         IsSuspended: false
     }
-    // If we stay on the same plan, check that the next plan is renwable
+    && (phase ?? Phase) is not PhaseTypes.Normal
+    // If we stay on the same plan, check that the next plan is renewable
     && (newSubscriber || this.PlanId != this.NextPlan.Id || this.IsNextPlanRenewable);
 
     [NotMapped]


### PR DESCRIPTION
> Hi, I’d like to ask about the auto renew behavior in Subscriptions. On the 15th, all my users who had an active subscription until the 15th and enough credit for the following months had their subscriptions switched to Expired (auto reneval is on) in and had to be manually reactivated. At the same time, they received an “insufficient credit” email even though they had enough balance. I’m using an email rule set to remind 5 days before expiration. I’m not sure if I’m describing this clearly enough, but I’d like to know if this can be reproduced on your side or if it might be a configuration issue on my end. Thanks.