### PR TITLE
UI: clarify LND seed recovery expectations

### DIFF
--- a/BTCPayServer/Services/Translations.Default.cs
+++ b/BTCPayServer/Services/Translations.Default.cs
@@ -1639,6 +1639,7 @@ namespace BTCPayServer.Services
   "The label has been successfully renamed.": "",
   "The Lightning node could not be registered.": "",
   "The LND seed backup is useful to recover on-chain funds of your LND wallet in case of a corruption of your server.": "",
+  "In some deployments (for example BTCPay Server Docker), LND may be initialized/unlocked automatically and recovery may require running the steps with an interactive shell (TTY) and temporarily disabling any automatic init/unlock behavior.": "",
   "The name of the field in the invoice's metadata.": "",
   "The name should be maximum 50 characters.": "",
   "The node is offline": "",

--- a/BTCPayServer/Views/UIServer/LndSeedBackup.cshtml
+++ b/BTCPayServer/Views/UIServer/LndSeedBackup.cshtml
@@ -1,3 +1,5 @@
+@using BTCPayServer.Configuration
+@inject BTCPayServerOptions BtcPayServerOptions
 @model LndSeedBackupViewModel
 @{
     ViewData.SetLayoutModel(new LayoutModel(nameof(ServerNavPages.Services), StringLocalizer["LND Seed Backup"])
@@ -23,7 +25,10 @@
         <div class="col-lg-8">
             <div class="form-group">
                 <p text-translate="true">The LND seed backup is useful to recover on-chain funds of your LND wallet in case of a corruption of your server.</p>
-                <p text-translate="true">In some deployments (for example BTCPay Server Docker), LND may be initialized/unlocked automatically and recovery may require running the steps with an interactive shell (TTY) and temporarily disabling any automatic init/unlock behavior.</p>
+                @if (BtcPayServerOptions.DockerDeployment)
+                {
+                    <p text-translate="true">In BTCPay Server Docker deployments, LND is initialized and unlocked automatically. Recovery requires running the steps with an interactive shell (TTY) and temporarily disabling automatic init/unlock behavior.</p>
+                }
                 <p text-translate="true">The recovering process is documented by LND on <a href="https://github.com/lightningnetwork/lnd/blob/master/docs/recovery.md" rel="noreferrer noopener">this page</a>.</p>
             </div>
             <button class="btn btn-primary @(Model.Removed ? "collapse" : "")" id="details" type="button">See confidential seed information</button>

--- a/BTCPayServer/Views/UIServer/LndSeedBackup.cshtml
+++ b/BTCPayServer/Views/UIServer/LndSeedBackup.cshtml
@@ -23,7 +23,8 @@
         <div class="col-lg-8">
             <div class="form-group">
                 <p text-translate="true">The LND seed backup is useful to recover on-chain funds of your LND wallet in case of a corruption of your server.</p>
-                <p>The recovering process is documented by LND on <a href="https://github.com/lightningnetwork/lnd/blob/master/docs/recovery.md" rel="noreferrer noopener">this page</a>.</p>
+                <p text-translate="true">In some deployments (for example BTCPay Server Docker), LND may be initialized/unlocked automatically and recovery may require running the steps with an interactive shell (TTY) and temporarily disabling any automatic init/unlock behavior.</p>
+                <p text-translate="true">The recovering process is documented by LND on <a href="https://github.com/lightningnetwork/lnd/blob/master/docs/recovery.md" rel="noreferrer noopener">this page</a>.</p>
             </div>
             <button class="btn btn-primary @(Model.Removed ? "collapse" : "")" id="details" type="button">See confidential seed information</button>
 


### PR DESCRIPTION
Fixes #5612.

Clarifies the LND Seed Backup page copy to set correct expectations for recovery steps under some deployments (e.g. BTCPay Server Docker), where LND may be initialized/unlocked automatically and recovery may require an interactive shell (TTY) and temporarily disabling automatic init/unlock.

Changes:
- Add a short clarification paragraph on the LND Seed Backup page.
- Add the new string to Translations.Default.cs for localization support.

How to verify:
- Server → Services → LND Seed Backup: confirm the new paragraph appears above the link to LND's recovery documentation.

Note: PR #6897 also touches this view for translation-related refactors; happy to rebase/adjust if it lands first.