### PR TITLE
fix: scan-qrcode icon alignment

### DIFF
--- a/BTCPayServer/Views/UIWallets/WalletSend.cshtml
+++ b/BTCPayServer/Views/UIWallets/WalletSend.cshtml
@@ -31,6 +31,9 @@
         .buttons .btn {
             flex: 1 0 45%;
         }
+        #scanqrcode .icon {
+            margin-left: 0;
+        }
     </style>
     <link href="~/vendor/tom-select/tom-select.bootstrap5.min.css" asp-append-version="true" rel="stylesheet">
     <script src="~/vendor/tom-select/tom-select.complete.min.js" asp-append-version="true"></script>
@@ -95,7 +98,7 @@
                     </div>
                     <div class="input-group">
                         <input asp-for="Outputs[index].DestinationAddress" class="form-control font-monospace flex-grow-1" autocomplete="off" autofocus="@(index == Model.Outputs.Count - 1 ? "autofocus" : null)"/>
-                        <button type="button" id="scanqrcode" class="btn btn-secondary px-3 only-for-js" data-bs-toggle="modal" data-bs-target="#scanModal" title="@StringLocalizer["Scan with camera"]" data-index="@index">
+                        <button type="button" id="scanqrcode" class="btn btn-secondary px-3 d-flex align-items-center justify-content-center only-for-js" data-bs-toggle="modal" data-bs-target="#scanModal" title="@StringLocalizer["Scan with camera"]" data-index="@index">
                             <vc:icon symbol="scan-qr" />
                         </button>
                     </div>


### PR DESCRIPTION
### In this Pull Request

- Fix scan qrcode icon alignment on send page

**Before**

<img width="1315" height="467" alt="before" src="https://github.com/user-attachments/assets/090471a1-0646-488f-8657-a2ffbf2626d3" />

**After**

<img width="1299" height="472" alt="after" src="https://github.com/user-attachments/assets/167fe3d1-05ab-49b0-b131-430908ad056d" />
