### PR TITLE
Fix: CanModifyInvoices permission should include the ability to see the lightning invoices of the store

### DIFF
--- a/BTCPayServer.Client/Permissions.cs
+++ b/BTCPayServer.Client/Permissions.cs
@@ -280,6 +280,7 @@ namespace BTCPayServer.Client
             PolicyHasChild(policyMap,Policies.CanModifyProfile, Policies.CanViewProfile);
             PolicyHasChild(policyMap,Policies.CanModifyOfferings, Policies.CanViewOfferings, Policies.CanManageSubscribers, Policies.CanCreditSubscribers);
             PolicyHasChild(policyMap,Policies.CanUseLightningNodeInStore, Policies.CanViewLightningInvoiceInStore, Policies.CanCreateLightningInvoiceInStore);
+            PolicyHasChild(policyMap,Policies.CanCreateLightningInvoiceInStore, Policies.CanViewLightningInvoiceInStore);
             PolicyHasChild(policyMap,Policies.CanManageNotificationsForUser, Policies.CanViewNotificationsForUser);
             PolicyHasChild(policyMap,Policies.CanModifyServerSettings,
                 Policies.CanUseInternalLightningNode,


### PR DESCRIPTION
Fix #6867

The permissions were not very intuitive before:
* `btcpay.store.canmodifyinvoices` couldn't view the lightning invoices. (but could create them)
* `btcpay.store.cancreatelightninginvoice` couldn't view lightning invoices.

To fix this, I changed the permission hierarchy from:

```mermaid
graph TD
    A[btcpay.store.canmodifyinvoices]
    B[btcpay.store.canuselightningnode]
    C[btcpay.store.cancreatelightninginvoice]
    D[btcpay.store.canviewlightninginvoice]

    A --> C
    B --> C
    B --> D

```

To more permissive:

```mermaid
graph TD
    A[btcpay.store.canmodifyinvoices]
    B[btcpay.store.canuselightningnode]
    C[btcpay.store.cancreatelightninginvoice]
    D[btcpay.store.canviewlightninginvoice]

    A --> C
    B --> C
    B --> D
    C --> D

```

