### PR TITLE
Add Subscriber.Metadata as email placeholder, fix Offering.Metadata and Customer.Metadata placeholder

### DIFF
--- a/BTCPayServer/Plugins/Subscriptions/SubscriberWebhookProvider.cs
+++ b/BTCPayServer/Plugins/Subscriptions/SubscriberWebhookProvider.cs
@@ -25,19 +25,20 @@ public class SubscriberWebhookProvider : WebhookTriggerProvider<SubscriptionEven
             ["Name"] = evt.Subscriber.Offering.App.Name,
             ["Id"] = evt.Subscriber.Offering.Id,
             ["AppId"] = evt.Subscriber.Offering.AppId,
-            ["Metadata"] = evt.Subscriber.Offering.Metadata,
+            ["Metadata"] = JObject.Parse(evt.Subscriber.Offering.Metadata),
         };
         model["Subscriber"] = new JObject()
         {
             ["Phase"] = evt.Subscriber.Phase.ToString(),
             // TODO: When the subscriber can customize the email, also check it!
-            ["Email"] = evt.Subscriber.Customer.Email.Get()
+            ["Email"] = evt.Subscriber.Customer.Email.Get(),
+            ["Metadata"] = JObject.Parse(evt.Subscriber.Metadata)
         };
         model["Customer"] = new JObject()
         {
             ["ExternalRef"] = evt.Subscriber.Customer.ExternalRef ?? "",
             ["Name"] = evt.Subscriber.Customer.Name,
-            ["Metadata"] = evt.Subscriber.Customer.Metadata
+            ["Metadata"] = JObject.Parse(evt.Subscriber.Customer.Metadata)
         };
         return model;
     }

--- a/BTCPayServer/Plugins/Subscriptions/SubscriptionsPlugin.cs
+++ b/BTCPayServer/Plugins/Subscriptions/SubscriptionsPlugin.cs
@@ -82,6 +82,7 @@ public class SubscriptionsPlugin : BaseBTCPayServerPlugin
             new("{Offering.Metadata}*", "Offering metadata"),
             new("{Subscriber.Phase}", "Subscriber phase (Trial, Normal, Grace, Expired)"),
             new("{Subscriber.Email}", "Subscriber email"),
+            new("{Subscriber.Metadata}*", "Subscriber metadata"),
             new("{Customer.ExternalRef}", "Customer external reference"),
             new("{Customer.Name}", "Customer name"),
             new("{Customer.Metadata}*", "Customer metadata")

--- a/Changelog.md
+++ b/Changelog.md
@@ -603,18 +603,20 @@ If you are using Boltcards, we advise you to update to this release.
 
 ### Bug fixes
 
-* LNUrl payouts failing due to amount restriction wouldn't be immediately cancelled (#6061) @Kukks
+* Fix: Offering and Customer metadata email placeholders couldn't be used (#7150) @NicolasDorier
+* LNUrl payouts failing due to amount restriction wouldn't be immediately canceled (#6061) @Kukks
 * Fix row ordering and display issues in reporting (#6065 #6087, 597e2b0e) @NicolasDorier @dennisreimann
 * Parse Timespan strings in the API properly (#6012) @dennisreimann
-* "Return to Store" link in invoice receipt should return to the redirectUrl (#6079) @dennisreimann
+* "Return to Store" link in the invoice receipt should return to the redirectUrl (#6079) @dennisreimann
 * Fix crash caused by custom explorer links in some conditions (#6077 #6078) @dennisreimann
 * Fix: Can't save email settings on store level (#6076 #6080) @dennisreimann
 * Reports: Fix dropdown z-index @dennisreimann
-* Shopify: Properly cancel an order when BTCPay invoice expires, and restock the inventory (#6104 #6107 #6108) @NicolasDorier
+* Shopify: Properly cancel an order when BTCPay invoice expires and restock the inventory (#6104 #6107 #6108) @NicolasDorier
 * Shopify: Generate BTCPay invoice as soon as the payment page in shopify opens (#6105) @NicolasDorier
 
 ### Improvements
 
+* Add subscriber's metadata to email placeholders (#7150) @NicolasDorier
 * Checkout: Display item description if present (#6082) @dennisreimann
 * Disable plugins if they crash the Dashboard page (#6099) @NicolasDorier
 * Hide empty values in the receipts (#6079) @dennisreimann
@@ -624,7 +626,7 @@ If you are using Boltcards, we advise you to update to this release.
 
 ### Bug fixes
 
-* Fix potential crash on receipt print page (#6045) @dennisreimann
+* Fix a potential crash on the receipt print page (#6045) @dennisreimann
 * Fix invoice paid for topping up a pull payment didn't top up. @NicolasDorier
 * Pull payment: Enable CORS for LNURL request (#6044) @dennisreimann
 


### PR DESCRIPTION
1. `Subscriber.Metadata` was not in the placeholder list of subscriber email templates.
2. `Offering.Metadata` and `Customer.Metadata` were exposed as string rather than `JObject`.