### PR TITLE
Fix: Deleting a webhook could timeout

### DIFF
--- a/BTCPayServer.Data/Migrations/20260126093615_wh_delivery_time.cs
+++ b/BTCPayServer.Data/Migrations/20260126093615_wh_delivery_time.cs
@@ -20,11 +20,12 @@ namespace BTCPayServer.Migrations
                                  -- noinspection SqlWithoutWhere
                                  UPDATE "WebhookDeliveries" SET "DeliveryTime" = "Timestamp";
                                  """);
-        }
 
-        /// <inheritdoc />
-        protected override void Down(MigrationBuilder migrationBuilder)
-        {
+            // When we delete a webhook, in cascade to webhook delivery, then to invoice webhook delivery.
+            // If we don't have an index there, the deletion of a webhook may time out.
+            migrationBuilder.Sql("""
+                                 CREATE INDEX IF NOT EXISTS "IX_InvoiceWebhookDeliveries_DeliveryId" ON "InvoiceWebhookDeliveries" ("DeliveryId");
+                                 """);
         }
     }
 }

--- a/Changelog.md
+++ b/Changelog.md
@@ -6,9 +6,12 @@
 
 * Set LUNO as the default exchange for ZAR currency @NicolasDorier
 * Add a `deliveryTime` property to webhook deliveries in the API and UI (#7140) @NicolasDorier
+* Add subscriber's metadata to email placeholders (#7150) @NicolasDorier
 
 ### Fixes
 
+* Fix: Deleting webhooks could time out (#7151) @NicolasDorier
+* Fix: Offering and Customer metadata email placeholders couldn't be used (#7150) @NicolasDorier
 * Subscribers with enough credits were receiving payment reminder emails and not being automatically renewed (#7108) @NicolasDorier
 * Fix scan-qrcode icon alignment (#7116) @Psycarlo
 * Public node info page no longer lists local network IPs (#7131 #7028) @NicolasDorier
@@ -603,7 +606,6 @@ If you are using Boltcards, we advise you to update to this release.
 
 ### Bug fixes
 
-* Fix: Offering and Customer metadata email placeholders couldn't be used (#7150) @NicolasDorier
 * LNUrl payouts failing due to amount restriction wouldn't be immediately canceled (#6061) @Kukks
 * Fix row ordering and display issues in reporting (#6065 #6087, 597e2b0e) @NicolasDorier @dennisreimann
 * Parse Timespan strings in the API properly (#6012) @dennisreimann
@@ -616,7 +618,6 @@ If you are using Boltcards, we advise you to update to this release.
 
 ### Improvements
 
-* Add subscriber's metadata to email placeholders (#7150) @NicolasDorier
 * Checkout: Display item description if present (#6082) @dennisreimann
 * Disable plugins if they crash the Dashboard page (#6099) @NicolasDorier
 * Hide empty values in the receipts (#6079) @dennisreimann


### PR DESCRIPTION
A user reported that he was unable to delete a webhook with this error in the logs.

```
2026-01-26 23:41:43.910 +00:00 [ERR] Failed executing DbCommand (30,043ms) [Parameters=[@p0='?'], CommandType='"Text"', CommandTimeout='30']
DELETE FROM "Webhooks"
WHERE "Id" = @p0;
2026-01-26 23:42:13.957 +00:00 [ERR] Failed executing DbCommand (30,012ms) [Parameters=[@p0='?'], CommandType='"Text"', CommandTimeout='30']
DELETE FROM "Webhooks"
WHERE "Id" = @p0;
2026-01-26 23:42:44.990 +00:00 [ERR] Failed executing DbCommand (30,019ms) [Parameters=[@p0='?'], CommandType='"Text"', CommandTimeout='30']
DELETE FROM "Webhooks"
```

I could reproduce on webhooks with as little as 1000 deliveries.
Without index, the cascade delete would cause a full table scan, causing timeout.

No index (Deleting only 1000 out of 33000 delieveries  takes 20 seconds)
```
                                                                                        QUERY PLAN
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Delete on "WebhookDeliveries" wd  (cost=0.84..3027.06 rows=1000 width=52) (actual time=29.344..29.346 rows=0 loops=1)
   ->  Nested Loop  (cost=0.84..3027.06 rows=1000 width=52) (actual time=3.577..26.567 rows=1000 loops=1)
         ->  Subquery Scan on b  (cost=0.42..717.06 rows=1000 width=68) (actual time=3.522..10.564 rows=1000 loops=1)
               ->  Limit  (cost=0.42..707.06 rows=1000 width=22) (actual time=3.494..9.938 rows=1000 loops=1)
                     ->  Index Scan using "IX_WebhookDeliveries_WebhookId" on "WebhookDeliveries"  (cost=0.42..23907.49 rows=33832 width=22) (actual time=3.492..9.739 rows=1000 loops=1)
                           Index Cond: ("WebhookId" = 'TmdypcbUfgfBMHXWA6hDko'::text)
         ->  Index Scan using "PK_WebhookDeliveries" on "WebhookDeliveries" wd  (cost=0.42..2.31 rows=1 width=28) (actual time=0.015..0.015 rows=1 loops=1000)
               Index Cond: ("Id" = b."Id")
 Planning Time: 0.627 ms
 Trigger for constraint FK_InvoiceWebhookDeliveries_WebhookDeliveries_DeliveryId: time=19068.047 calls=1000
 Execution Time: 19098.527 ms
(11 rows)
```

With index (Deleting the 33000 deliveries of the webhook takes 5 seconds)
```
                                                           QUERY PLAN
---------------------------------------------------------------------------------------------------------------------------------
 Delete on "Webhooks"  (cost=0.28..2.30 rows=1 width=6) (actual time=3.568..3.569 rows=0 loops=1)
   ->  Index Scan using "PK_Webhooks" on "Webhooks"  (cost=0.28..2.30 rows=1 width=6) (actual time=3.486..3.488 rows=1 loops=1)
         Index Cond: (("Id")::text = 'TmdypcbUfgfBMHXWA6hDko'::text)
 Planning Time: 0.400 ms
 Trigger for constraint FK_StoreWebhooks_Webhooks_WebhookId on Webhooks: time=4.834 calls=1
 Trigger for constraint FK_WebhookDeliveries_Webhooks_WebhookId on Webhooks: time=4370.603 calls=1
 Trigger for constraint FK_InvoiceWebhookDeliveries_WebhookDeliveries_DeliveryId on WebhookDeliveries: time=1477.979 calls=33128
 Execution Time: 5861.724 ms
(8 rows)

```

The `no index` query was also more complicated, as it wasn't taking advantage of CASCADE deletes.