### PR TITLE
fix: hide claim section for archived pull-payments (#7154)

### DIFF
--- a/BTCPayServer/Views/UIPullPayment/ViewPullPayment.cshtml
+++ b/BTCPayServer/Views/UIPullPayment/ViewPullPayment.cshtml
@@ -33,7 +33,7 @@
 </head>
 <body class="min-vh-100">
     <div id="app" class="d-flex flex-column min-vh-100 pb-l">
-        @if (Model.IsPending)
+        @if (Model.IsPending && !Model.Archived)
         {
             <nav class="btcpay-header navbar sticky-top py-3 py-lg-4 d-print-none">
                 <div class="container gap-3">


### PR DESCRIPTION
Prevents showing the claim button for archived pull-payments