### PR TITLE
Fix: Avoid uncaught exception caused by RateRules.GetRuleFor()

### DIFF
--- a/BTCPayServer.Rating/RateRules.cs
+++ b/BTCPayServer.Rating/RateRules.cs
@@ -165,7 +165,7 @@ namespace BTCPayServer.Rating
         public RateRule GetRuleFor(CurrencyPair currencyPair)
         {
             if (currencyPair.Left == "X" || currencyPair.Right == "X")
-                throw new ArgumentException(paramName: nameof(currencyPair), message: "Invalid X currency");
+                return new RateRule(this, currencyPair, CreateExpression($"ERR_INVALID_CURRENCY_PAIR({currencyPair})"));
             if (currencyPair.Left == currencyPair.Right)
                 return new RateRule(this, currencyPair, CreateExpression("1.0"));
             var candidate = FindBestCandidate(currencyPair);

--- a/BTCPayServer.Tests/FastTests.cs
+++ b/BTCPayServer.Tests/FastTests.cs
@@ -1811,7 +1811,12 @@ bc1qfzu57kgu5jthl934f9xrdzzx8mmemx7gn07tf0grnvz504j6kzusu2v0ku
             rule.Reevaluate();
             Assert.True(!rule.HasError);
             Assert.Equal(1.1m, rule.BidAsk.Ask);
+            // Check invalid currency pair (GetRule for should not contains X)
+            rule = rules.GetRuleFor(new CurrencyPair("DOGE", "X"));
+            rule.Reevaluate();
+            Assert.True(rule.HasError);
         }
+
 
         [Fact]
         public void CanSerializeExchangeRatesCache()


### PR DESCRIPTION
I have noticed this uncaught exception in my logs.

```
fail: Microsoft.AspNetCore.Diagnostics.ExceptionHandlerMiddleware: An unhandled exception has occurred while executing the request.
System.ArgumentException: Invalid X currency (Parameter 'currencyPair')
   at BTCPayServer.Rating.RateRules.GetRuleFor(CurrencyPair currencyPair) in /source/BTCPayServer.Rating/RateRules.cs:line 168
   at BTCPayServer.Services.Rates.RateFetcher.<FetchRates>g__SetQuery|8_0(RateRules rateRules, <>c__DisplayClass8_0&) in /source/BTCPayServer.Rating/Services/RateFetcher.cs:line 68
   at BTCPayServer.Services.Rates.RateFetcher.FetchRates(HashSet`1 pairs, RateRulesCollection rules, IRateContext context, CancellationToken cancellationToken) in /source/BTCPayServer.Rating/Services/RateFetcher.cs:line 71
   at BTCPayServer.Services.Rates.RateFetcher.FetchRates(HashSet`1 pairs, RateRules rules, IRateContext context, CancellationToken cancellationToken) in /source/BTCPayServer.Rating/Services/RateFetcher.cs:line 45
   at BTCPayServer.Controllers.UIStoresController.Rates(RatesViewModel model, String command, String storeId, CancellationToken cancellationToken) in /source/BTCPayServer/Controllers/UIStoresController.Rates.cs:line 127
   at Microsoft.AspNetCore.Mvc.Infrastructure.ActionMethodExecutor.TaskOfIActionResultExecutor.Execute(ActionContext actionContext, IActionResultTypeMapper mapper, ObjectMethodExecutor executor, Object controller, Object[] arguments)
   at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.<InvokeActionMethodAsync>g__Awaited|12_0(ControllerActionInvoker invoker, ValueTask`1 actionResultValueTask)
   at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.<InvokeNextActionFilterAsync>g__Awaited|10_0(ControllerActionInvoker invoker, Task lastTask, State next, Scope scope, Object state, Boolean isCompleted)
   at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.Rethrow(ActionExecutedContextSealed context)
   at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.Next(State& next, Scope& scope, Object& state, Boolean& isCompleted)
   at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.InvokeInnerFilterAsync()
--- End of stack trace from previous location ---
   at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeNextExceptionFilterAsync>g__Awaited|26_0(ResourceInvoker invoker, Task lastTask, State next, Scope scope, Object state, Boolean isCompleted)
   at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.Rethrow(ExceptionContextSealed context)
   at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.Next(State& next, Scope& scope, Object& state, Boolean& isCompleted)
   at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.InvokeNextResourceFilter()
--- End of stack trace from previous location ---
   at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.Rethrow(ResourceExecutedContextSealed context)
   at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.Next(State& next, Scope& scope, Object& state, Boolean& isCompleted)
   at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.InvokeFilterPipelineAsync()
--- End of stack trace from previous location ---
   at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeAsync>g__Awaited|17_0(ResourceInvoker invoker, Task task, IDisposable scope)
   at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeAsync>g__Awaited|17_0(ResourceInvoker invoker, Task task, IDisposable scope)
   at Microsoft.AspNetCore.Session.SessionMiddleware.Invoke(HttpContext context)
   at Microsoft.AspNetCore.Session.SessionMiddleware.Invoke(HttpContext context)
   at Microsoft.AspNetCore.Authorization.AuthorizationMiddleware.Invoke(HttpContext context)
   at Microsoft.AspNetCore.Authentication.AuthenticationMiddleware.Invoke(HttpContext context)
   at BTCPayServer.Hosting.BTCPayMiddleware.Invoke(HttpContext httpContext) in /source/BTCPayServer/Hosting/BTCpayMiddleware.cs:line 97
   at BTCPayServer.Hosting.GreenfieldMiddleware.Invoke(HttpContext httpContext) in /source/BTCPayServer/Hosting/GreenfieldMiddleware.cs:line 30
```

It turns out that `RateRules.GetRuleFor` callers aren't expecting exceptions to be thrown, which was the case if a currency passed to it had `X`.
This PR will instead create a rules that will fail when evaluated, as those are properly handled.

I do not think there is any user facing error to this.