### PR TITLE
Fix: Payments getting undetected on LND when the node restarted

### DIFF
--- a/BTCPayServer/BTCPayServer.csproj
+++ b/BTCPayServer/BTCPayServer.csproj
@@ -59,7 +59,7 @@
     <PackageReference Include="YamlDotNet" Version="8.0.0" />
     <PackageReference Include="BIP78.Sender" Version="0.2.5" />
     <PackageReference Include="BTCPayServer.Hwi" Version="2.0.6" />
-    <PackageReference Include="BTCPayServer.Lightning.All" Version="1.6.11" />
+    <PackageReference Include="BTCPayServer.Lightning.All" Version="1.6.13" />
     <PackageReference Include="CsvHelper" Version="32.0.3" />
     <PackageReference Include="Fido2" Version="3.0.1" />
     <PackageReference Include="Fido2.AspNet" Version="3.0.1" />

--- a/BTCPayServer/Payments/Lightning/LightningListener.cs
+++ b/BTCPayServer/Payments/Lightning/LightningListener.cs
@@ -527,6 +527,7 @@ namespace BTCPayServer.Payments.Lightning
                 var lightningClient = _lightningClientFactory.Create(ConnectionString, _network);
                 if (lightningClient is null)
                     return;
+                ListenLogs(lightningClient);
                 uri = lightningClient.GetServerUri(ConnectionString)?.RemoveUserInfo() ?? "";
                 Logs.PayServer.LogInformation("{CryptoCode} (Lightning): Start listening {Uri}", _network.CryptoCode, uri);
                 using var session = await lightningClient.Listen(cancellation);
@@ -576,6 +577,14 @@ namespace BTCPayServer.Payments.Lightning
             if (_ListenedInvoices.IsEmpty)
                 Logs.PayServer.LogInformation("{CryptoCode} (Lightning): No more invoice to listen on {Uri}, releasing the connection", _network.CryptoCode,
                     uri);
+        }
+
+        private void ListenLogs(ILightningClient lightningClient)
+        {
+            if (lightningClient is BTCPayServer.Lightning.LND.LndClient lnd)
+            {
+                lnd.Log = msg => Logs.PayServer.LogWarning(msg);
+            }
         }
 
         private uint256? GetPaymentHash(ListenedInvoice listenedInvoice)


### PR DESCRIPTION
If LND was being restarted or crashed while BTCPay Server was listening LND for new payment, the payments would stop being detected until BTCPay Server restart. On top of this, the listener would enter in an infinite loop resulting in CPU at 100%.

Related PR https://github.com/btcpayserver/BTCPayServer.Lightning/pull/174