### PR TITLE
Throttle API calls with Basic auth

### DIFF
--- a/BTCPayServer.Tests/ApiKeysTests.cs
+++ b/BTCPayServer.Tests/ApiKeysTests.cs
@@ -48,13 +48,13 @@ namespace BTCPayServer.Tests
 
             async Task AssertNoPermission(string permission)
             {
+                await s.Page.WaitForLoadStateAsync(LoadState.DOMContentLoaded);
                 var txt = await s.Page.ContentAsync();
                 Assert.DoesNotContain(permission, txt);
             }
             async Task AssertPermission(string permission)
             {
-                var txt = await s.Page.ContentAsync();
-                Assert.Contains(permission, txt);
+                await s.Page.Locator($".text-muted:has-text('{permission}')").WaitForAsync();
             }
 
             //not an admin, so this permission should not show

--- a/BTCPayServer.Tests/AssertEx.cs
+++ b/BTCPayServer.Tests/AssertEx.cs
@@ -32,11 +32,12 @@ public class AssertEx
         var ex = await Assert.ThrowsAsync<GreenfieldAPIException>(act);
         Assert.Equal(code, ex.HttpCode);
     }
-    public static async Task AssertApiError(int httpStatus, string errorCode, Func<Task> act)
+    public static async Task<GreenfieldAPIException> AssertApiError(int httpStatus, string errorCode, Func<Task> act)
     {
         var ex = await Assert.ThrowsAsync<GreenfieldAPIException>(act);
         Assert.Equal(httpStatus, ex.HttpCode);
         Assert.Equal(errorCode, ex.APIError.Code);
+        return ex;
     }
 
     public static async Task<GreenfieldAPIException> AssertApiError(string expectedError, Func<Task> act)

--- a/BTCPayServer.Tests/BTCPayServerTester.cs
+++ b/BTCPayServer.Tests/BTCPayServerTester.cs
@@ -28,6 +28,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using NBitcoin;
 using NBXplorer;
@@ -184,6 +185,7 @@ namespace BTCPayServer.Tests
                     {
                         options.ValidateScopes = true;
                     })
+                    .UseEnvironment(HostEnvironment)
                     .UseConfiguration(conf)
                     .UseContentRoot(FindBTCPayServerDirectory())
                     .UseWebRoot(Path.Combine(FindBTCPayServerDirectory(), "wwwroot"))
@@ -344,6 +346,7 @@ namespace BTCPayServer.Tests
         public string SSHKeyFile { get; internal set; }
         public string SSHConnection { get; set; }
         public bool NoCSP { get; set; }
+        public string HostEnvironment { get; set; } = Environments.Development;
 
         public T GetController<T>(string userId = null, string storeId = null, bool isAdmin = false) where T : Controller
         {

--- a/BTCPayServer.Tests/POSTests.cs
+++ b/BTCPayServer.Tests/POSTests.cs
@@ -1063,6 +1063,7 @@ goodies:
             await s.ClickPagePrimary();
             await s.FindAlertMessage();
 
+            await s.Page.Locator("#CodeTabButton").WaitForAsync();
             await s.Page.Locator("#CodeTabButton").ScrollIntoViewIfNeededAsync();
             await s.Page.ClickAsync("#CodeTabButton");
             template = await s.Page.Locator("#TemplateConfig").InputValueAsync();
@@ -1104,6 +1105,7 @@ goodies:
             // Let's set change the root app
             await s.GoToHome();
             await s.GoToServer(ServerNavPages.Policies);
+            await s.Page.Locator("#RootAppId").WaitForAsync();
             await s.Page.Locator("#RootAppId").ScrollIntoViewIfNeededAsync();
 
             var options = await s.Page.Locator("#RootAppId option").AllTextContentsAsync();
@@ -1140,10 +1142,8 @@ goodies:
             // Let's check with domain mapping as well.
             await s.GoToUrl(prevUrl);
             await s.GoToServer(ServerNavPages.Policies);
-            await s.Page.Locator("#RootAppId").ScrollIntoViewIfNeededAsync();
             await s.Page.Locator("#RootAppId").SelectOptionAsync("");
             await s.ClickPagePrimary();
-            await s.Page.Locator("#RootAppId").ScrollIntoViewIfNeededAsync();
             await s.Page.ClickAsync("#AddDomainButton");
             await s.Page.Locator("#DomainToAppMapping_0__Domain").FillAsync(new Uri(s.Page.Url, UriKind.Absolute).DnsSafeHost);
 

--- a/BTCPayServer/Hosting/GreenfieldMiddleware.cs
+++ b/BTCPayServer/Hosting/GreenfieldMiddleware.cs
@@ -43,7 +43,9 @@ namespace BTCPayServer.Hosting
                 }
                 if (httpContext.Response.StatusCode == 401)
                 {
-                    var outputObj = new GreenfieldAPIError("unauthenticated", "Authentication is required for accessing this endpoint");
+                    httpContext.Items.TryGetValue(APIKeysAuthenticationHandler.AuthFailureReason, out var reason);
+                    var reasonStr = reason as string ?? "Authentication is required for accessing this endpoint";
+                    var outputObj = new GreenfieldAPIError("unauthenticated", reasonStr);
                     await WriteError(httpContext, outputObj);
                 }
             }


### PR DESCRIPTION
This PR achieves two things:
* Returning proper error messages when authentication fail via API Keys Auth or Basic Auth.
* Apply rate limiting to Basic-auth API authentication to mitigate brute-force attempts.

I was thinking about turning off Basic authentication by default, however, basic authentication is still needed when you create a new User via the API and need the API for creating his first API key.

This PR might throttle people using Basic Auth for normal operation. But since this isn't recommended, nobody I know use it, and we want to discourage it, I don't think this is a problem. The error message when that happen is quite explicit about using API keys instead.