### PR TITLE
Fix: Images in Point of Sale Cart doesn't show on mobile

### DIFF
--- a/BTCPayServer/Plugins/PointOfSale/Views/Public/Cart.cshtml
+++ b/BTCPayServer/Plugins/PointOfSale/Views/Public/Cart.cshtml
@@ -60,7 +60,7 @@
                 <div ref="posItems" class="row row-cols row-cols-1 row-cols-sm-2 row-cols-md-3 row-cols-lg-2 row-cols-xl-3 row-cols-xxl-4 g-4" id="PosItems">
                         <div v-for="(item, index) in items" :id="'card_' + item.id" class="col posItem posItem--displayed" :class="{ 'posItem--inStock': inStock(index) }" :data-index="index" :data-search="item.search" :data-categories='item.categories ? JSON.stringify(item.categories) : null'>
                             <div class="tile card" v-on:click="addToCart(index, 1)">
-                                <div v-if="item.hasImage" class="img d-none d-sm-block">
+                                <div v-if="item.hasImage" class="img d-sm-block">
                                     <img class="card-img-top" :src="item.image" :alt="item.title" />
                                 </div>
 


### PR DESCRIPTION
Reported on mattermost

Before:

<img width="890" height="1098" alt="image" src="https://github.com/user-attachments/assets/9eed6896-702c-4ec7-aa55-b9fcbaf66009" />

After:

<img width="894" height="1088" alt="image" src="https://github.com/user-attachments/assets/50ceeaee-2bd7-4e3c-9fe5-b062ec6378fd" />
