### PR TITLE
Update wallet folder access instructions for Wasabi

### DIFF
--- a/BTCPayServer/Views/UIStores/ImportWallet/File.cshtml
+++ b/BTCPayServer/Views/UIStores/ImportWallet/File.cshtml
@@ -51,7 +51,7 @@
 	</tr>
     <tr>
         <td>Wasabi</td>
-        <td>Tools ❯ Wallet Manager ❯ Open Wallets Folder</td>
+        <td>Search ❯ &quot;wallet folder&quot;</td>
     </tr>
      <tr>
         <td class="text-nowrap">Specter Desktop</td>


### PR DESCRIPTION
Not sure what's "Tools" and "Wallet Manager" is. I suspect they don't exist.

<img width="649" height="225" alt="image" src="https://github.com/user-attachments/assets/cb71a781-4918-443a-9302-aecc0e294885" />
