### PR TITLE
Apply CSRF protection on all UI**Controller globally

### DIFF
--- a/BTCPayServer.Tests/UnitTest1.cs
+++ b/BTCPayServer.Tests/UnitTest1.cs
@@ -2948,7 +2948,7 @@ namespace BTCPayServer.Tests
         private async Task<StoreReportResponse> GetReport(TestAccount acc, StoreReportRequest req)
         {
             var controller = acc.GetController<UIReportsController>();
-            return (await controller.StoreReportsJson(acc.StoreId, req)).AssertType<JsonResult>()
+            return (await controller.StoreReportsJson(acc.StoreId, req)).AssertType<OkObjectResult>()
                 .Value
                 .AssertType<StoreReportResponse>();
         }

--- a/BTCPayServer/Controllers/GreenField/GreenfieldFilesController.cs
+++ b/BTCPayServer/Controllers/GreenField/GreenfieldFilesController.cs
@@ -23,7 +23,7 @@ public class GreenfieldFilesController(
     UserManager<ApplicationUser> userManager,
     IFileService fileService,
     StoredFileRepository fileRepository)
-    : Controller
+    : ControllerBase
 {
     [HttpGet("~/api/v1/files")]
     public async Task<IActionResult> GetFiles()

--- a/BTCPayServer/Controllers/GreenField/GreenfieldInvoiceController.cs
+++ b/BTCPayServer/Controllers/GreenField/GreenfieldInvoiceController.cs
@@ -33,7 +33,7 @@ namespace BTCPayServer.Controllers.Greenfield
     [ApiController]
     [Authorize(AuthenticationSchemes = AuthenticationSchemes.Greenfield)]
     [EnableCors(CorsPolicies.All)]
-    public class GreenfieldInvoiceController : Controller
+    public class GreenfieldInvoiceController : ControllerBase
     {
         private readonly UIInvoiceController _invoiceController;
         private readonly InvoiceRepository _invoiceRepository;

--- a/BTCPayServer/Controllers/GreenField/GreenfieldLightningNodeApiController.Internal.cs
+++ b/BTCPayServer/Controllers/GreenField/GreenfieldLightningNodeApiController.Internal.cs
@@ -20,21 +20,17 @@ namespace BTCPayServer.Controllers.Greenfield
     [EnableCors(CorsPolicies.All)]
     public class GreenfieldInternalLightningNodeApiController : GreenfieldLightningNodeApiController
     {
-        private readonly LightningClientFactoryService _lightningClientFactory;
         private readonly IOptions<LightningNetworkOptions> _lightningNetworkOptions;
-        private readonly PaymentMethodHandlerDictionary _handlers;
 
         public GreenfieldInternalLightningNodeApiController(
-            PoliciesSettings policiesSettings, LightningClientFactoryService lightningClientFactory,
+            PoliciesSettings policiesSettings,
             IOptions<LightningNetworkOptions> lightningNetworkOptions,
             IAuthorizationService authorizationService,
             PaymentMethodHandlerDictionary handlers,
             LightningHistogramService lnHistogramService
             ) : base(policiesSettings, authorizationService, handlers, lnHistogramService)
         {
-            _lightningClientFactory = lightningClientFactory;
             _lightningNetworkOptions = lightningNetworkOptions;
-            _handlers = handlers;
         }
 
         [Authorize(Policy = Policies.CanUseInternalLightningNode,

--- a/BTCPayServer/Controllers/GreenField/GreenfieldLightningNodeApiController.cs
+++ b/BTCPayServer/Controllers/GreenField/GreenfieldLightningNodeApiController.cs
@@ -27,7 +27,7 @@ namespace BTCPayServer.Controllers.Greenfield
         }
     }
 
-    public abstract class GreenfieldLightningNodeApiController : Controller
+    public abstract class GreenfieldLightningNodeApiController : ControllerBase
     {
         private readonly PoliciesSettings _policiesSettings;
         private readonly IAuthorizationService _authorizationService;
@@ -89,7 +89,7 @@ namespace BTCPayServer.Controllers.Greenfield
                     : null
             });
         }
-        
+
         public virtual async Task<IActionResult> GetHistogram(string cryptoCode, HistogramType? type = null, CancellationToken cancellationToken = default)
         {
             Enum.TryParse<HistogramType>(type.ToString(), true, out var histType);
@@ -361,7 +361,7 @@ namespace BTCPayServer.Controllers.Greenfield
             }
         }
         protected BTCPayNetwork GetNetwork(string cryptoCode)
-            => _handlers.TryGetValue(PaymentTypes.LN.GetPaymentMethodId(cryptoCode), out var h) 
+            => _handlers.TryGetValue(PaymentTypes.LN.GetPaymentMethodId(cryptoCode), out var h)
                     && h is IHasNetwork { Network: var network }
                 ? network
                 : null;

--- a/BTCPayServer/Controllers/GreenField/GreenfieldPaymentRequestsController.cs
+++ b/BTCPayServer/Controllers/GreenField/GreenfieldPaymentRequestsController.cs
@@ -17,9 +17,6 @@ using Microsoft.AspNetCore.Cors;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
-using TwentyTwenty.Storage;
-using static System.Runtime.InteropServices.JavaScript.JSType;
-using static QRCoder.PayloadGenerator;
 using PaymentRequestData = BTCPayServer.Data.PaymentRequestData;
 
 namespace BTCPayServer.Controllers.Greenfield

--- a/BTCPayServer/Controllers/GreenField/GreenfieldPayoutProcessorsController.cs
+++ b/BTCPayServer/Controllers/GreenField/GreenfieldPayoutProcessorsController.cs
@@ -13,20 +13,13 @@ namespace BTCPayServer.Controllers.Greenfield
     [ApiController]
     [Authorize(AuthenticationSchemes = AuthenticationSchemes.Greenfield)]
     [EnableCors(CorsPolicies.All)]
-    public class GreenfieldPayoutProcessorsController : ControllerBase
+    public class GreenfieldPayoutProcessorsController(IEnumerable<IPayoutProcessorFactory> factories) : ControllerBase
     {
-        private readonly IEnumerable<IPayoutProcessorFactory> _factories;
-
-        public GreenfieldPayoutProcessorsController(IEnumerable<IPayoutProcessorFactory> factories)
-        {
-            _factories = factories;
-        }
-
         [Authorize(AuthenticationSchemes = AuthenticationSchemes.Greenfield)]
         [HttpGet("~/api/v1/payout-processors")]
         public IActionResult GetPayoutProcessors()
         {
-            return Ok(_factories.Select(factory => new PayoutProcessorData()
+            return Ok(factories.Select(factory => new PayoutProcessorData()
             {
                 Name = factory.Processor,
                 FriendlyName = factory.FriendlyName,

--- a/BTCPayServer/Controllers/GreenField/GreenfieldReportsController.cs
+++ b/BTCPayServer/Controllers/GreenField/GreenfieldReportsController.cs
@@ -20,17 +20,12 @@ namespace BTCPayServer.Controllers.GreenField;
 [ApiController]
 [Authorize(AuthenticationSchemes = AuthenticationSchemes.Greenfield)]
 [EnableCors(CorsPolicies.All)]
-public class GreenfieldReportsController : Controller
+public class GreenfieldReportsController(
+    ApplicationDbContextFactory dbContextFactory,
+    ReportService reportService) : ControllerBase
 {
-    public GreenfieldReportsController(
-        ApplicationDbContextFactory dbContextFactory,
-        ReportService reportService)
-    {
-        DBContextFactory = dbContextFactory;
-        ReportService = reportService;
-    }
-    public ApplicationDbContextFactory DBContextFactory { get; }
-    public ReportService ReportService { get; }
+    public ApplicationDbContextFactory DBContextFactory { get; } = dbContextFactory;
+    public ReportService ReportService { get; } = reportService;
 
     public const string DefaultReport = "Invoices";
     [Authorize(Policy = Policies.CanViewReports, AuthenticationSchemes = AuthenticationSchemes.Greenfield)]
@@ -62,7 +57,7 @@ public class GreenfieldReportsController : Controller
                 From = from,
                 To = to
             };
-            return Json(result);
+            return Ok(result);
         }
 
         ModelState.AddModelError(nameof(vm.ViewName), "View doesn't exist");

--- a/BTCPayServer/Controllers/GreenField/GreenfieldServerEmailController.cs
+++ b/BTCPayServer/Controllers/GreenField/GreenfieldServerEmailController.cs
@@ -15,7 +15,7 @@ namespace BTCPayServer.Controllers.GreenField
     [ApiController]
     [Authorize(AuthenticationSchemes = AuthenticationSchemes.Greenfield)]
     [EnableCors(CorsPolicies.All)]
-    public class GreenfieldServerEmailController : Controller
+    public class GreenfieldServerEmailController : ControllerBase
     {
         private readonly EmailSenderFactory _emailSenderFactory;
         private readonly PoliciesSettings _policiesSettings;

--- a/BTCPayServer/Controllers/GreenField/GreenfieldServerInfoController.cs
+++ b/BTCPayServer/Controllers/GreenField/GreenfieldServerInfoController.cs
@@ -13,7 +13,7 @@ namespace BTCPayServer.Controllers.Greenfield
 {
     [ApiController]
     [EnableCors(CorsPolicies.All)]
-    public class GreenfieldServerInfoController : Controller
+    public class GreenfieldServerInfoController : ControllerBase
     {
         private readonly BTCPayServerEnvironment _env;
         private readonly PaymentMethodHandlerDictionary _paymentMethodHandlerDictionary;

--- a/BTCPayServer/Controllers/GreenField/GreenfieldStoreEmailController.cs
+++ b/BTCPayServer/Controllers/GreenField/GreenfieldStoreEmailController.cs
@@ -16,7 +16,7 @@ namespace BTCPayServer.Controllers.GreenField
     [ApiController]
     [Authorize(AuthenticationSchemes = AuthenticationSchemes.Greenfield)]
     [EnableCors(CorsPolicies.All)]
-    public class GreenfieldStoreEmailController : Controller
+    public class GreenfieldStoreEmailController : ControllerBase
     {
         private readonly EmailSenderFactory _emailSenderFactory;
         private readonly StoreRepository _storeRepository;

--- a/BTCPayServer/Controllers/GreenField/GreenfieldStoreOnChainWalletsController.cs
+++ b/BTCPayServer/Controllers/GreenField/GreenfieldStoreOnChainWalletsController.cs
@@ -36,7 +36,7 @@ namespace BTCPayServer.Controllers.Greenfield
     [ApiController]
     [Authorize(AuthenticationSchemes = AuthenticationSchemes.Greenfield)]
     [EnableCors(CorsPolicies.All)]
-    public class GreenfieldStoreOnChainWalletsController : Controller
+    public class GreenfieldStoreOnChainWalletsController : ControllerBase
     {
         private StoreData Store => HttpContext.GetStoreData();
 

--- a/BTCPayServer/Controllers/UIAppsController.cs
+++ b/BTCPayServer/Controllers/UIAppsController.cs
@@ -21,7 +21,6 @@ using Microsoft.Extensions.Localization;
 
 namespace BTCPayServer.Controllers
 {
-    [AutoValidateAntiforgeryToken]
     [Route("apps")]
     public partial class UIAppsController : Controller
     {

--- a/BTCPayServer/Controllers/UIErrorController.cs
+++ b/BTCPayServer/Controllers/UIErrorController.cs
@@ -4,8 +4,10 @@ using Microsoft.AspNetCore.Mvc;
 
 namespace BTCPayServer.Controllers
 {
+    [IgnoreAntiforgeryToken]
     public class UIErrorController : Controller
     {
+        public const string ErrorDetailsKey = "ERROR_DETAILS";
         [Route("/errors/{statusCode:int}")]
         public IActionResult Handle(int? statusCode = null)
         {

--- a/BTCPayServer/Controllers/UIInvoiceController.UI.cs
+++ b/BTCPayServer/Controllers/UIInvoiceController.UI.cs
@@ -1262,6 +1262,7 @@ namespace BTCPayServer.Controllers
         [Route("invoices/{invoiceId}/changestate/{newState}")]
         [Route("stores/{storeId}/invoices/{invoiceId}/changestate/{newState}")]
         [Authorize(AuthenticationSchemes = AuthenticationSchemes.Cookie, Policy = Policies.CanViewInvoices)]
+        [IgnoreAntiforgeryToken]
         public async Task<IActionResult> ChangeInvoiceState(string invoiceId, string newState)
         {
             var invoice = (await _InvoiceRepository.GetInvoices(new InvoiceQuery

--- a/BTCPayServer/Controllers/UIReportsController.cs
+++ b/BTCPayServer/Controllers/UIReportsController.cs
@@ -17,7 +17,6 @@ using Newtonsoft.Json.Linq;
 namespace BTCPayServer.Controllers;
 
 [Authorize(Policy = Policies.CanViewReports, AuthenticationSchemes = AuthenticationSchemes.Cookie)]
-[AutoValidateAntiforgeryToken]
 public partial class UIReportsController : Controller
 {
     public UIReportsController(

--- a/BTCPayServer/Controllers/UIStorePullPaymentsController.PullPayments.cs
+++ b/BTCPayServer/Controllers/UIStorePullPaymentsController.PullPayments.cs
@@ -28,7 +28,6 @@ using StoreData = BTCPayServer.Data.StoreData;
 namespace BTCPayServer.Controllers
 {
     [Authorize(Policy = Policies.CanViewPullPayments, AuthenticationSchemes = AuthenticationSchemes.Cookie)]
-    [AutoValidateAntiforgeryToken]
     public class UIStorePullPaymentsController : Controller
     {
         private readonly BTCPayNetworkProvider _btcPayNetworkProvider;

--- a/BTCPayServer/Controllers/UIStoresController.cs
+++ b/BTCPayServer/Controllers/UIStoresController.cs
@@ -29,7 +29,6 @@ namespace BTCPayServer.Controllers;
 [Route("stores")]
 [Authorize(AuthenticationSchemes = AuthenticationSchemes.Cookie)]
 [Authorize(Policy = Policies.CanViewStoreSettings, AuthenticationSchemes = AuthenticationSchemes.Cookie)]
-[AutoValidateAntiforgeryToken]
 public partial class UIStoresController : Controller
 {
     public UIStoresController(

--- a/BTCPayServer/Controllers/UIUserStoresController.cs
+++ b/BTCPayServer/Controllers/UIUserStoresController.cs
@@ -19,7 +19,6 @@ using Microsoft.Extensions.Localization;
 namespace BTCPayServer.Controllers
 {
     [Route("stores")]
-    [AutoValidateAntiforgeryToken]
     public class UIUserStoresController : Controller
     {
         private readonly StoreRepository _repo;

--- a/BTCPayServer/Controllers/UIWalletsController.cs
+++ b/BTCPayServer/Controllers/UIWalletsController.cs
@@ -50,7 +50,6 @@ namespace BTCPayServer.Controllers
 {
     [Route("wallets")]
     [Authorize(Policy = Policies.CanModifyStoreSettings, AuthenticationSchemes = AuthenticationSchemes.Cookie)]
-    [AutoValidateAntiforgeryToken]
     //16mb psbts
     [RequestFormLimits(ValueLengthLimit = FormReader.DefaultValueLengthLimit * 4)]
     public partial class UIWalletsController : Controller

--- a/BTCPayServer/Data/Payouts/LightningLike/UILightningLikePayoutController.cs
+++ b/BTCPayServer/Data/Payouts/LightningLike/UILightningLikePayoutController.cs
@@ -24,7 +24,6 @@ using Microsoft.Extensions.Options;
 namespace BTCPayServer.Data.Payouts.LightningLike
 {
     [Authorize(AuthenticationSchemes = AuthenticationSchemes.Cookie)]
-    [AutoValidateAntiforgeryToken]
     public class UILightningLikePayoutController : Controller
     {
         private readonly ApplicationDbContextFactory _applicationDbContextFactory;

--- a/BTCPayServer/Filters/UIControllerAntiforgeryTokenAttribute.cs
+++ b/BTCPayServer/Filters/UIControllerAntiforgeryTokenAttribute.cs
@@ -1,0 +1,65 @@
+#nullable enable
+using System;
+using System.Threading.Tasks;
+using BTCPayServer.Controllers;
+using Microsoft.AspNetCore.Antiforgery;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Controllers;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace BTCPayServer.Filters;
+
+public class UIControllerAntiforgeryTokenAttribute :
+    Attribute,
+    IFilterMetadata,
+    IAntiforgeryPolicy,
+    IAsyncAuthorizationFilter
+{
+    public async Task OnAuthorizationAsync(AuthorizationFilterContext context)
+    {
+        if (context.Result is AntiforgeryValidationFailedResult)
+            AddErrorDetails(context.HttpContext);
+        var antiForgery = context.HttpContext.RequestServices.GetService<IAntiforgery>();
+        if (
+            antiForgery is not null &&
+            context.IsEffectivePolicy<IAntiforgeryPolicy>(this)
+            && this.ShouldValidate(context))
+        {
+            try
+            {
+                await antiForgery.ValidateRequestAsync(context.HttpContext);
+            }
+            catch (AntiforgeryValidationException)
+            {
+                context.Result = new AntiforgeryValidationFailedResult();
+                AddErrorDetails(context.HttpContext);
+            }
+        }
+    }
+
+    private void AddErrorDetails(HttpContext context)
+    => context.Items[UIErrorController.ErrorDetailsKey] = "CSRF token validation failed.";
+
+    private bool ShouldValidate(AuthorizationFilterContext context)
+    {
+        var isUI = IsUI(context);
+        if (isUI is false)
+            return false;
+        var method = context.HttpContext.Request.Method;
+        return !HttpMethods.IsGet(method) && !HttpMethods.IsHead(method) && !HttpMethods.IsTrace(method) && !HttpMethods.IsOptions(method);
+    }
+
+    private bool? IsUI(AuthorizationFilterContext context)
+    {
+        if (context.ActionDescriptor is not ControllerActionDescriptor controllerActionDescriptor)
+            return null;
+        if (controllerActionDescriptor.ControllerName.StartsWith("UI", StringComparison.OrdinalIgnoreCase))
+            return true;
+        if (controllerActionDescriptor.ControllerName.StartsWith("Greenfield", StringComparison.OrdinalIgnoreCase))
+            return false;
+        return typeof(Controller).IsAssignableFrom(controllerActionDescriptor.ControllerTypeInfo);
+    }
+}

--- a/BTCPayServer/Hosting/Startup.cs
+++ b/BTCPayServer/Hosting/Startup.cs
@@ -157,7 +157,7 @@ namespace BTCPayServer.Hosting
             services.AddSingleton<LnurlAuthService>();
             services.AddSingleton<LightningAddressService>();
             var mvcBuilder = services.AddMvc(o =>
-             {
+                {
                  o.Filters.Add(new XFrameOptionsAttribute(XFrameOptionsAttribute.XFrameOptions.Deny));
                  o.Filters.Add(new XContentTypeOptionsAttribute("nosniff"));
                  o.Filters.Add(new XXSSProtectionAttribute());
@@ -167,6 +167,7 @@ namespace BTCPayServer.Hosting
                      o.Filters.Add(new ContentSecurityPolicyAttribute(CSPTemplate.AntiXSS));
                  o.Filters.Add(new JsonHttpExceptionFilter());
                  o.Filters.Add(new JsonObjectExceptionFilter());
+                 o.Filters.Add(new UIControllerAntiforgeryTokenAttribute());
              })
             .ConfigureApiBehaviorOptions(options =>
             {

--- a/BTCPayServer/Plugins/Crowdfund/Controllers/UICrowdfundController.cs
+++ b/BTCPayServer/Plugins/Crowdfund/Controllers/UICrowdfundController.cs
@@ -37,7 +37,6 @@ using CrowdfundResetEvery = BTCPayServer.Services.Apps.CrowdfundResetEvery;
 
 namespace BTCPayServer.Plugins.Crowdfund.Controllers
 {
-    [AutoValidateAntiforgeryToken]
     [Route("apps")]
     [Area(CrowdfundPlugin.Area)]
     public class UICrowdfundController(

--- a/BTCPayServer/Plugins/Emails/Controllers/UIServerEmailController.cs
+++ b/BTCPayServer/Plugins/Emails/Controllers/UIServerEmailController.cs
@@ -14,7 +14,6 @@ namespace BTCPayServer.Plugins.Emails.Controllers;
 [Area(EmailsPlugin.Area)]
 [Authorize(Policy = Client.Policies.CanModifyServerSettings,
     AuthenticationSchemes = AuthenticationSchemes.Cookie)]
-[AutoValidateAntiforgeryToken]
 public class UIServerEmailController(
     EmailSenderFactory emailSenderFactory,
     PoliciesSettings policiesSettings,

--- a/BTCPayServer/Plugins/Emails/Controllers/UIServerEmailRulesController.cs
+++ b/BTCPayServer/Plugins/Emails/Controllers/UIServerEmailRulesController.cs
@@ -18,7 +18,6 @@ namespace BTCPayServer.Plugins.Emails.Controllers;
 [Route("server/rules")]
 [Authorize(AuthenticationSchemes = AuthenticationSchemes.Cookie)]
 [Authorize(Policy = Policies.CanModifyServerSettings, AuthenticationSchemes = AuthenticationSchemes.Cookie)]
-[AutoValidateAntiforgeryToken]
 public class UIServerEmailRulesController(
     EmailSenderFactory emailSenderFactory,
     EmailTriggerViewModels triggers,

--- a/BTCPayServer/Plugins/Emails/Controllers/UIStoreEmailRulesController.cs
+++ b/BTCPayServer/Plugins/Emails/Controllers/UIStoreEmailRulesController.cs
@@ -19,7 +19,6 @@ namespace BTCPayServer.Plugins.Emails.Controllers;
 [Route("stores/{storeId}/emails/rules")]
 [Authorize(AuthenticationSchemes = AuthenticationSchemes.Cookie)]
 [Authorize(Policy = Policies.CanViewStoreSettings, AuthenticationSchemes = AuthenticationSchemes.Cookie)]
-[AutoValidateAntiforgeryToken]
 public class UIStoreEmailRulesController(
     EmailSenderFactory emailSenderFactory,
     LinkGenerator linkGenerator,

--- a/BTCPayServer/Plugins/Emails/Controllers/UIStoresEmailController.cs
+++ b/BTCPayServer/Plugins/Emails/Controllers/UIStoresEmailController.cs
@@ -15,7 +15,6 @@ namespace BTCPayServer.Plugins.Emails.Controllers;
 [Route("stores/{storeId}")]
 [Authorize(AuthenticationSchemes = AuthenticationSchemes.Cookie)]
 [Authorize(Policy = Policies.CanViewStoreSettings, AuthenticationSchemes = AuthenticationSchemes.Cookie)]
-[AutoValidateAntiforgeryToken]
 public class UIStoresEmailController(
     EmailSenderFactory emailSenderFactory,
     StoreRepository storeRepository,

--- a/BTCPayServer/Plugins/PayButton/Controllers/UIPayButtonController.cs
+++ b/BTCPayServer/Plugins/PayButton/Controllers/UIPayButtonController.cs
@@ -19,7 +19,6 @@ namespace BTCPayServer.Plugins.PayButton.Controllers
     [Route("stores")]
     [Authorize(AuthenticationSchemes = AuthenticationSchemes.Cookie)]
     [Authorize(Policy = Policies.CanModifyStoreSettings, AuthenticationSchemes = AuthenticationSchemes.Cookie)]
-    [AutoValidateAntiforgeryToken]
     [Area(PayButtonPlugin.Area)]
     public class UIPayButtonController(
         StoreRepository repo,

--- a/BTCPayServer/Plugins/PointOfSale/Controllers/UIPointOfSaleController.cs
+++ b/BTCPayServer/Plugins/PointOfSale/Controllers/UIPointOfSaleController.cs
@@ -44,7 +44,6 @@ using StoreData = BTCPayServer.Data.StoreData;
 
 namespace BTCPayServer.Plugins.PointOfSale.Controllers
 {
-    [AutoValidateAntiforgeryToken]
     [Route("apps")]
     public class UIPointOfSaleController : Controller
     {

--- a/BTCPayServer/Plugins/Subscriptions/Controllers/UIOfferingController.cs
+++ b/BTCPayServer/Plugins/Subscriptions/Controllers/UIOfferingController.cs
@@ -28,7 +28,6 @@ using DisplayFormatter = BTCPayServer.Services.DisplayFormatter;
 namespace BTCPayServer.Plugins.Subscriptions.Controllers;
 
 [Authorize(Policy = Policies.CanViewOfferings, AuthenticationSchemes = AuthenticationSchemes.Cookie)]
-[AutoValidateAntiforgeryToken]
 [Area(SubscriptionsPlugin.Area)]
 public partial class UIOfferingController(
     ApplicationDbContextFactory dbContextFactory,

--- a/BTCPayServer/Plugins/Subscriptions/Controllers/UIPlanCheckoutController.cs
+++ b/BTCPayServer/Plugins/Subscriptions/Controllers/UIPlanCheckoutController.cs
@@ -15,7 +15,6 @@ namespace BTCPayServer.Plugins.Subscriptions.Controllers;
 
 
 [AllowAnonymous]
-[AutoValidateAntiforgeryToken]
 [Area(SubscriptionsPlugin.Area)]
 [Route("plan-checkout/{checkoutId}")]
 public class UIPlanCheckoutController(

--- a/BTCPayServer/Plugins/Subscriptions/Controllers/UISubscriberPortalController.cs
+++ b/BTCPayServer/Plugins/Subscriptions/Controllers/UISubscriberPortalController.cs
@@ -23,7 +23,6 @@ using Microsoft.Extensions.Localization;
 namespace BTCPayServer.Plugins.Subscriptions.Controllers;
 
 [AllowAnonymous]
-[AutoValidateAntiforgeryToken]
 [Area(SubscriptionsPlugin.Area)]
 [Route("subscriber-portal/{portalSessionId}")]
 public class UISubscriberPortalController(

--- a/BTCPayServer/Plugins/Translations/Controllers/UITranslationController.cs
+++ b/BTCPayServer/Plugins/Translations/Controllers/UITranslationController.cs
@@ -17,7 +17,6 @@ namespace BTCPayServer.Plugins.Translations.Controllers;
 [Authorize(Policy = Client.Policies.CanModifyServerSettings,
     AuthenticationSchemes = AuthenticationSchemes.Cookie)]
 [Area(TranslationsPlugin.Area)]
-[AutoValidateAntiforgeryToken]
 public class UITranslationController(
     PoliciesSettings policiesSettings,
     IStringLocalizer stringLocalizer,

--- a/BTCPayServer/Plugins/Webhooks/Controllers/UIStoreWebhooksController.cs
+++ b/BTCPayServer/Plugins/Webhooks/Controllers/UIStoreWebhooksController.cs
@@ -19,7 +19,6 @@ namespace BTCPayServer.Plugins.Webhooks.Controllers;
 [Route("stores")]
 [Authorize(AuthenticationSchemes = AuthenticationSchemes.Cookie)]
 [Authorize(Policy = Policies.CanViewStoreSettings, AuthenticationSchemes = AuthenticationSchemes.Cookie)]
-[AutoValidateAntiforgeryToken]
 [Area(WebhooksPlugin.Area)]
 public class UIStoreWebhooksController(
     StoreRepository storeRepo,

--- a/BTCPayServer/Views/UIError/Handle.cshtml
+++ b/BTCPayServer/Views/UIError/Handle.cshtml
@@ -1,5 +1,6 @@
 ﻿@using System.Net
 @using System.Text.RegularExpressions
+@using BTCPayServer.Controllers
 @model int?
 @{
     Layout = "_LayoutError";
@@ -10,8 +11,13 @@
         var name = Regex.Replace(httpCode.ToString(), @"(\B[A-Z])", @" $1");
         ViewData["Title"] = $"{(int)httpCode} - {name}";
     }
+    this.Context.Items.TryGetValue(UIErrorController.ErrorDetailsKey, out var errorDetails);
 }
 
 <p class="mt-4">A generic error occurred (HTTP Code: @Model)</p>
+@if (errorDetails != null)
+{
+    <pre>@errorDetails</pre>
+}
 <p text-translate="true">Please consult the server log for more details.</p>
 <a href="/" text-translate="true">Navigate back to home</a>

--- a/BTCPayServer/Views/UIManage/Index.cshtml
+++ b/BTCPayServer/Views/UIManage/Index.cshtml
@@ -70,12 +70,12 @@
         }
         <h3 class="mt-5 mb-4" text-translate="true">Delete Account</h3>
         <div id="danger-zone">
-            <a id="delete-user" class="btn btn-outline-danger mb-5" data-confirm-input="@StringLocalizer["Delete"]" data-bs-toggle="modal" data-bs-target="#ConfirmModal" asp-action="DeleteUserPost" data-description="@StringLocalizer["This action will also delete all stores, invoices, apps and data associated with the user."]" text-translate="true">Delete Account</a>
+            <a id="delete-user" asp-action="DeleteUserPost" class="btn btn-outline-danger mb-5" data-confirm-input="@StringLocalizer["Delete"]" data-bs-toggle="modal" data-bs-target="#ConfirmModal" text-translate="true">Delete Account</a>
         </div>
     </div>
 </form>
 <partial name="_Confirm"
-         model="@(new ConfirmModel(StringLocalizer["Delete user"], StringLocalizer["The user will be permanently deleted. This action will also delete all stores, invoices, apps and data associated with your user."], StringLocalizer["Delete"], actionName: nameof(BTCPayServer.Controllers.UIManageController.DeleteUserPost)))"/>
+         model="@(new ConfirmModel(StringLocalizer["Delete user"], StringLocalizer["The user will be permanently deleted. This action will also delete all stores, invoices, apps and data associated with your user."], StringLocalizer["Delete"]))"/>
 
 @section PageFootContent {
     <partial name="_ValidationScriptsPartial"/>


### PR DESCRIPTION
In ASP.NET [CSRF protection](https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.html) can be opt-in at the Controller level with the attribute `[AutoValidateAntiforgeryTokenAttribute]`.

This PR will enforce CSRF protection globally instead, for all controllers whose name starts with `UI` or which inherits from `Controller`.
Controllers whose name starts with `Greenfield` or inherits from `ControllerBase` are not affected.

Since it may breaks plugin, I added more error details in the error page to help diagnostic. (`CSRF token validation failed.`)



<img width="1372" height="940" alt="image" src="https://github.com/user-attachments/assets/29969951-1987-48ab-a799-34477aa5cfbb" />

The only potential breaking change for plugins is if they access a POST route on UI controller via Javascript's fetch.
While I advise to just pass the CSRF token in this situation, it is also possible to opt out CSRF at the action or controller level by applying the attribute `[IgnoreAntiforgeryTokenAttribute]`.

Routes protected with `[Authorize(AuthenticationSchemes = AuthenticationSchemes.Cookie...` are normally not really vulnerable, because the authentication cookie is set to `SameSite=Lax`.

You can pass the CSRF token by passing the `RequestVerificationToken` HTTP header or `__RequestVerificationToken` forms field.