### PR TITLE
feat: add paymentMethodId parameter to btcpay invoice modal

### DIFF
--- a/BTCPayServer/wwwroot/modal/btcpay.js
+++ b/BTCPayServer/wwwroot/modal/btcpay.js
@@ -40,7 +40,7 @@
     iframe.style.zIndex = '2000';
     // Removed, see https://github.com/btcpayserver/btcpayserver/issues/2139#issuecomment-768223263
     // iframe.setAttribute('allowtransparency', 'true');
-    
+
     // https://web.dev/async-clipboard/#permissions-policy-integration
     iframe.setAttribute('allow', 'clipboard-read; clipboard-write')
 
@@ -96,7 +96,7 @@
         readerAbortController.signal.onabort = () => {
             this.scanning = false;
         };
-        ndef.scan({ signal:readerAbortController.signal }).then(() => {
+        ndef.scan({ signal: readerAbortController.signal }).then(() => {
             ndef.onreading = event => {
                 const message = event.message;
                 const record = message.records[0];
@@ -116,7 +116,7 @@
             };
         }).catch(console.error);
     }
-    
+
     function receiveMessage(event) {
         if (!origin.startsWith(event.origin) || !showingInvoice) {
             return;
@@ -143,8 +143,33 @@
     function appendInvoiceFrame(invoiceId, params) {
         showingInvoice = true;
         window.document.body.appendChild(iframe);
-        var invoiceUrl = origin + '/invoice?id=' + invoiceId + '&view=modal';
-        if (params && params.animateEntrance === false) {
+
+        var paymentMethodId = null;
+        var animateEntrance = params && typeof params === 'object'
+            ? params.animateEntrance
+            : undefined;
+
+        if (typeof params === 'string') {
+            // Shorthand: btcpay.showInvoice(id, "BTC-LN")
+            paymentMethodId = params;
+        } else if (params && typeof params === 'object') {
+            paymentMethodId = params.paymentMethodId || null;
+        }
+
+        var invoiceUrl;
+        if (paymentMethodId) {
+            invoiceUrl =
+                origin +
+                '/i/' +
+                invoiceId +
+                '/' +
+                encodeURIComponent(paymentMethodId) +
+                '?view=modal';
+        } else {
+            invoiceUrl = origin + '/invoice?id=' + invoiceId + '&view=modal';
+        }
+
+        if (animateEntrance === false) {
             invoiceUrl += '&animateEntrance=false';
         }
         iframe.src = invoiceUrl;


### PR DESCRIPTION
This PR enhances the btcpay modal client to support opening specific payment methods directly

Key Changes:

* Direct Payment Method Support: Updated `btcpay.showInvoice` to accept a `paymentMethodId` in the params object.
* Shorthand Syntax: Added support for passing the payment method ID as a string directly for convenience: `btcpay.showInvoice(id, "BTC-LN")`

Fixes #7208 