### PR TITLE
fix: Cross-tenant payment request creation/update via forged StoreId in UIPaymentRequestController

### DIFF
--- a/BTCPayServer/Controllers/UIPaymentRequestController.cs
+++ b/BTCPayServer/Controllers/UIPaymentRequestController.cs
@@ -227,6 +227,8 @@ namespace BTCPayServer.Controllers
             var store = GetCurrentStore();
             var paymentRequest = GetCurrentPaymentRequest();
 
+            viewModel.StoreId = store.Id;
+
             if ((paymentRequest == null && !string.IsNullOrEmpty(payReqId)) ||
                 (paymentRequest != null && paymentRequest.Id != payReqId))
                 return NotFound();
@@ -243,7 +245,7 @@ namespace BTCPayServer.Controllers
                 var existingPaymentRequests = await _PaymentRequestRepository.FindPaymentRequests(
                     new PaymentRequestQuery
                     {
-                        StoreId = viewModel.StoreId,
+                        StoreId = store.Id,
                         SearchText = viewModel.ReferenceId
                     });
 
@@ -263,7 +265,7 @@ namespace BTCPayServer.Controllers
 
 
             var data = paymentRequest ?? new PaymentRequestData();
-            data.StoreDataId = viewModel.StoreId;
+            data.StoreDataId = store.Id;
             data.Archived = viewModel.Archived;
             var blob = data.GetBlob();
 


### PR DESCRIPTION
## Summary

Automated security fixes for 1 findings.

## Fixes

| Title | Severity | File | Confidence | Explanation |
| --- | --- | --- | --- | --- |
| Cross-tenant payment request creation/update via forged StoreId in UIPaymentRequestController | High | `BTCPayServer/Controllers/UIPaymentRequestController.cs` | high | The vulnerability allows cross-tenant payment request creation/update by trusting the client-supplied `viewModel.StoreId` instead of using the server-side authorized store. The fix adds `viewModel.StoreId = store.Id;` right after retrieving the store from the server-side context, ensuring the client cannot forge a different store ID. Additionally, the duplicate-reference query and `data.StoreDataId` assignment now both use `store.Id` directly instead of `viewModel.StoreId`. These are the three changes:  1. Added `viewModel.StoreId = store.Id;` after `GetCurrentStore()` to override any client-supplied value. 2. Changed duplicate-check query `StoreId = viewModel.StoreId` to `StoreId = store.Id`. 3. Changed `data.StoreDataId = viewModel.StoreId` to `data.StoreDataId = store.Id`.  Changes 2 and 3 are technically redundant after change 1, but using the authoritative `store.Id` directly is defense-in-depth and makes the code's intent clearer. |

## Caveats
- The viewModel.StoreId override makes changes 2 and 3 technically redundant, but all three are included for defense-in-depth. If viewModel.StoreId is used elsewhere (e.g., in the view for a hidden field), it will now always reflect the authorized store, which is the correct behavior.

## Verification Checklist

- [ ] Review the code change
- [ ] Run tests to verify no regression
- [x] Verify the vulnerability is addressed — *already verified by Cerberus Sentinel*

---
*Created by [Cerberus](https://github.com/Donjon-Cerberus) Merlin*
