### PR TITLE
Revert target framework from .NET 10 to .NET 8

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,7 +10,7 @@
             "request": "launch",
             "preLaunchTask": "build",
             // If you have changed target frameworks, make sure to update the program path.
-            "program": "${workspaceFolder}/BTCPayServer/bin/Debug/net10.0/BTCPayServer.dll",
+            "program": "${workspaceFolder}/BTCPayServer/bin/Debug/net8.0/BTCPayServer.dll",
             "args": [],
             "cwd": "${workspaceFolder}/BTCPayServer",
             "stopAtEntry": false,

--- a/BTCPayServer.Abstractions/BTCPayServer.Abstractions.csproj
+++ b/BTCPayServer.Abstractions/BTCPayServer.Abstractions.csproj
@@ -32,8 +32,8 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="HtmlSanitizer" Version="9.0.892" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.4" />
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.11" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.11" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\BTCPayServer.Client\BTCPayServer.Client.csproj" />

--- a/BTCPayServer.Data/BTCPayServer.Data.csproj
+++ b/BTCPayServer.Data/BTCPayServer.Data.csproj
@@ -3,11 +3,11 @@
   <Import Project="../Build/Common.csproj" />
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.4">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.11">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="10.0.4" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.11" />
     <PackageReference Include="NBitcoin.Altcoins" Version="5.0.1" />
     <PackageReference Include="Dapper" Version="2.1.72" />
   </ItemGroup>

--- a/BTCPayServer.Data/Migrations/ApplicationDbContextModelSnapshot.cs
+++ b/BTCPayServer.Data/Migrations/ApplicationDbContextModelSnapshot.cs
@@ -18,7 +18,7 @@ namespace BTCPayServer.Migrations
         {
 #pragma warning disable 612, 618
             modelBuilder
-                .HasAnnotation("ProductVersion", "10.0.1")
+                .HasAnnotation("ProductVersion", "8.0.11")
                 .HasAnnotation("Relational:MaxIdentifierLength", 63);
 
             NpgsqlModelBuilderExtensions.UseIdentityByDefaultColumns(modelBuilder);
@@ -302,7 +302,7 @@ namespace BTCPayServer.Migrations
                         .HasColumnName("additional_data")
                         .HasDefaultValueSql("'{}'::jsonb");
 
-                    b.PrimitiveCollection<string[]>("BCC")
+                    b.Property<string[]>("BCC")
                         .IsRequired()
                         .HasColumnType("text[]")
                         .HasColumnName("bcc");
@@ -312,7 +312,7 @@ namespace BTCPayServer.Migrations
                         .HasColumnType("text")
                         .HasColumnName("body");
 
-                    b.PrimitiveCollection<string[]>("CC")
+                    b.Property<string[]>("CC")
                         .IsRequired()
                         .HasColumnType("text[]")
                         .HasColumnName("cc");
@@ -347,7 +347,7 @@ namespace BTCPayServer.Migrations
                         .HasColumnType("text")
                         .HasColumnName("subject");
 
-                    b.PrimitiveCollection<string[]>("To")
+                    b.Property<string[]>("To")
                         .IsRequired()
                         .HasColumnType("text[]")
                         .HasColumnName("to");
@@ -839,7 +839,7 @@ namespace BTCPayServer.Migrations
                     b.Property<DateTimeOffset?>("Expiry")
                         .HasColumnType("timestamp with time zone");
 
-                    b.PrimitiveCollection<string[]>("OutpointsUsed")
+                    b.Property<string[]>("OutpointsUsed")
                         .HasColumnType("text[]");
 
                     b.Property<int>("State")
@@ -1045,7 +1045,7 @@ namespace BTCPayServer.Migrations
                     b.Property<string>("Id")
                         .HasColumnType("text");
 
-                    b.PrimitiveCollection<List<string>>("Permissions")
+                    b.Property<List<string>>("Permissions")
                         .HasColumnType("text[]");
 
                     b.Property<string>("Role")

--- a/BTCPayServer.PluginPacker/BTCPayServer.PluginPacker.csproj
+++ b/BTCPayServer.PluginPacker/BTCPayServer.PluginPacker.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
       <OutputType>Exe</OutputType>
-      <TargetFramework>net10.0</TargetFramework>
+      <TargetFramework>net8.0</TargetFramework>
       <Version>1.0.0.0</Version>
       <PackAsTool>true</PackAsTool>
       <ToolCommandName>btcpay-plugin</ToolCommandName>

--- a/BTCPayServer.Rating/BTCPayServer.Rating.csproj
+++ b/BTCPayServer.Rating/BTCPayServer.Rating.csproj
@@ -4,10 +4,11 @@
 
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.3.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.10.0" />
     <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="6.0.0" />
     <PackageReference Include="NBitcoin" Version="9.0.5" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
+    <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="DigitalRuby.ExchangeSharp" Version="1.2.1" />
   </ItemGroup>
 

--- a/BTCPayServer.Tests/BTCPayServer.Tests.csproj
+++ b/BTCPayServer.Tests/BTCPayServer.Tests.csproj
@@ -40,10 +40,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="Microsoft.Playwright" Version="1.57.0" />
     <PackageReference Include="Newtonsoft.Json.Schema" Version="4.0.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="10.0.4" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="8.0.11" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>

--- a/BTCPayServer.Tests/Dockerfile
+++ b/BTCPayServer.Tests/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:10.0.200-noble AS builder
+FROM mcr.microsoft.com/dotnet/sdk:8.0.404-bookworm-slim AS builder
 
 RUN apt-get update && apt-get install -y --no-install-recommends chromium-driver \
     && rm -rf /var/lib/apt/lists/*

--- a/BTCPayServer/BTCPayServer.csproj
+++ b/BTCPayServer/BTCPayServer.csproj
@@ -45,22 +45,24 @@
     <PackageReference Include="LNURL" Version="0.0.36" />
     <PackageReference Include="MailKit" Version="4.15.1" />
     <PackageReference Include="QRCoder" Version="1.7.0" />
+    <PackageReference Include="System.IO.Pipelines" Version="8.0.0" />
     <PackageReference Include="NBitpayClient" Version="1.0.0.39" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="NicolasDorier.CommandLine" Version="2.0.0" />
     <PackageReference Include="NicolasDorier.CommandLine.Configuration" Version="2.0.0" />
     <PackageReference Include="NicolasDorier.RateLimits" Version="1.2.3" />
-    <PackageReference Include="Serilog" Version="4.3.0" />
-    <PackageReference Include="Serilog.AspNetCore" Version="10.0.0" />
-    <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
+    <PackageReference Include="Serilog" Version="3.1.1" />
+    <PackageReference Include="Serilog.AspNetCore" Version="8.0.0" />
+    <PackageReference Include="Serilog.Sinks.File" Version="5.0.1-dev-00968" />
     <PackageReference Include="SSH.NET" Version="2025.1.0" />
     <PackageReference Include="TwentyTwenty.Storage" Version="2.26.1" />
     <PackageReference Include="TwentyTwenty.Storage.Amazon" Version="2.26.1" />
     <PackageReference Include="TwentyTwenty.Storage.Azure" Version="2.26.1" />
     <PackageReference Include="TwentyTwenty.Storage.Google" Version="2.26.1" />
     <PackageReference Include="TwentyTwenty.Storage.Local" Version="2.26.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.4" />
-    <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Version="10.0.4" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.11" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Version="8.0.11" />
   </ItemGroup>
 
 	<ItemGroup>

--- a/BTCPayServer/Hosting/Startup.cs
+++ b/BTCPayServer/Hosting/Startup.cs
@@ -321,7 +321,7 @@ namespace BTCPayServer.Hosting
             {
                 ForwardedHeaders = ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto
             };
-            forwardingOptions.KnownIPNetworks.Clear();
+            forwardingOptions.KnownNetworks.Clear();
             forwardingOptions.KnownProxies.Clear();
             forwardingOptions.ForwardedHeaders = ForwardedHeaders.All;
             app.UseForwardedHeaders(forwardingOptions);

--- a/Build/Common.csproj
+++ b/Build/Common.csproj
@@ -1,6 +1,7 @@
 <Project>
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework Condition="'$(TargetFrameworkOverride)' != ''">$(TargetFrameworkOverride)</TargetFramework>
 	<NoWarn>$(NoWarn),NU1701,CA1816,CA1308,CA1810,CA2208,CA1303,CA2000,CA2016,CA1835,CA2249,CA9998,CA1704;CS8981</NoWarn>
     <LangVersion>12.0</LangVersion>
     <EnableNETAnalyzers>True</EnableNETAnalyzers>

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:10.0.200-noble AS builder
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:8.0.404-bookworm-slim AS builder
 ENV DOTNET_CLI_TELEMETRY_OPTOUT=1
 WORKDIR /source
 COPY nuget.config nuget.config
@@ -21,7 +21,7 @@ ARG CONFIGURATION_NAME=Release
 ARG GIT_COMMIT
 RUN cd BTCPayServer && dotnet publish -p:GitCommit=${GIT_COMMIT} --output /app/ --configuration ${CONFIGURATION_NAME}
 
-FROM mcr.microsoft.com/dotnet/aspnet:10.0.4-noble
+FROM mcr.microsoft.com/dotnet/aspnet:8.0.18-bookworm-slim
 
 RUN apt-get update && apt-get install -y --no-install-recommends iproute2 openssh-client ca-certificates \
     && rm -rf /var/lib/apt/lists/*

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ To begin developing locally, visit our [local development guide](https://docs.bt
 
 While the documentation advises using docker-compose, you may want to build BTCPay Server yourself.
 
-First, install .NET SDK v10.0 as specified by the [Microsoft website](https://dotnet.microsoft.com/download/dotnet/10.0).
+First, install .NET SDK v8.0 as specified by the [Microsoft website](https://dotnet.microsoft.com/download/dotnet/8.0).
 
 On Powershell:
 


### PR DESCRIPTION
## Summary
- Minimal revert of the .NET 10 migration back to .NET 8, touching only what's technically required for compatibility (13 files)
- Downgrades .NET-tied NuGet packages (EF Core, ASP.NET, Serilog, Test SDK, CodeAnalysis) to 8.x versions
- Reverts Docker base images from Ubuntu Noble (.NET 10) to Debian Bookworm (.NET 8)
- Fixes ASP.NET Core 10 API rename (`KnownIPNetworks` → `KnownNetworks`) and EF Core 9+ `PrimitiveCollection` → `Property`
- Keeps `Host.CreateDefaultBuilder`/`IHost` pattern and non-.NET-tied package versions as-is (they work on .NET 8)

## Test plan
- [ ] `dotnet restore` resolves all packages
- [ ] `dotnet build` compiles with 0 errors
- [ ] `dotnet test` passes
- [ ] Docker build succeeds
- [ ] Server boots and runs correctly