### PR TITLE
fix: Broken Access Control: Private form access and invoice creation on other stores via unscoped authorization check

### DIFF
--- a/BTCPayServer/Forms/UIFormsController.cs
+++ b/BTCPayServer/Forms/UIFormsController.cs
@@ -154,7 +154,7 @@ public class UIFormsController : Controller
         }
 
         if (!formData.Public &&
-            !(await _authorizationService.AuthorizeAsync(User, Policies.CanViewStoreSettings)).Succeeded)
+            !(await _authorizationService.AuthorizeAsync(User, formData.StoreId, Policies.CanViewStoreSettings)).Succeeded)
         {
             return NotFound();
         }
@@ -192,7 +192,7 @@ public class UIFormsController : Controller
         }
 
         if (!formData.Public &&
-            !(await _authorizationService.AuthorizeAsync(User, Policies.CanViewStoreSettings)).Succeeded)
+            !(await _authorizationService.AuthorizeAsync(User, formData.StoreId, Policies.CanViewStoreSettings)).Succeeded)
         {
             return NotFound();
         }


### PR DESCRIPTION
## Summary

Automated security fixes for 1 findings.

## Fixes

| Title | Severity | File | Confidence | Explanation |
| --- | --- | --- | --- | --- |
| Broken Access Control: Private form access and invoice creation on other stores via unscoped authorization check | High | `BTCPayServer/Forms/UIFormsController.cs` | high | The vulnerability is that `AuthorizeAsync(User, Policies.CanViewStoreSettings)` in both `ViewPublicForm` and `SubmitForm` does not scope the authorization check to the form's owning store. This allows a user who has `CanViewStoreSettings` on any store to access private forms and create invoices on other stores. The fix passes `formData.StoreId` as the resource parameter to `AuthorizeAsync`, ensuring the check is scoped to the correct store. This matches the established pattern used throughout the codebase (e.g., in UIInvoiceController, GreenfieldInvoiceController, etc.). |

## Verification Checklist

- [ ] Review the code change
- [ ] Run tests to verify no regression
- [x] Verify the vulnerability is addressed — *already verified by Cerberus Sentinel*

---
*Created by [Cerberus](https://github.com/Donjon-Cerberus) Merlin*
