### PR TITLE
fix: IDOR in NewSubscriber allows creating checkouts for plans from other stores/offerings

### DIFF
--- a/BTCPayServer/Plugins/Subscriptions/Controllers/UIOfferingController.cs
+++ b/BTCPayServer/Plugins/Subscriptions/Controllers/UIOfferingController.cs
@@ -51,7 +51,7 @@ public partial class UIOfferingController(
         string? prefilledEmail = null)
     {
         await using var ctx = DbContextFactory.CreateContext();
-        var plan = await ctx.Plans.GetPlanFromId(planId);
+        var plan = await ctx.Plans.GetPlanFromId(planId, offeringId, storeId);
         if (plan is null)
             return NotFound();
 


### PR DESCRIPTION
## Summary

Automated security fixes for 1 findings.

## Fixes

| Title | Severity | File | Confidence | Explanation |
| --- | --- | --- | --- | --- |
| IDOR in NewSubscriber allows creating checkouts for plans from other stores/offerings | High | `BTCPayServer/Plugins/Subscriptions/Controllers/UIOfferingController.cs` | high | The vulnerability is an IDOR where `NewSubscriber` calls `GetPlanFromId(planId)` without constraining the lookup to the current store/offering from the route. This allows a store owner to create checkouts for plans belonging to other stores/offerings. The fix adds `offeringId` and `storeId` parameters to the `GetPlanFromId` call on line 54, making it `GetPlanFromId(planId, offeringId, storeId)`. This is consistent with how all other endpoints in the same controller (DeletePlan, AddPlan) already call this method with the same scoping parameters. The `GetPlanFromId` method already supports these optional parameters. |

## Verification Checklist

- [ ] Review the code change
- [ ] Run tests to verify no regression
- [x] Verify the vulnerability is addressed — *already verified by Cerberus Sentinel*

---
*Created by [Cerberus](https://github.com/Donjon-Cerberus) Merlin*
