### PR TITLE
fix: Missing plan validation in CreatePlanMigrationCheckout allows migration to arbitrary plans

### DIFF
--- a/BTCPayServer/Plugins/Subscriptions/SubscriptionHostedService.cs
+++ b/BTCPayServer/Plugins/Subscriptions/SubscriptionHostedService.cs
@@ -641,9 +641,22 @@ public class SubscriptionHostedService(
     {
         await using var ctx = applicationDbContextFactory.CreateContext();
         var portal = await ctx.PortalSessions.GetActiveById(portalSessionId);
-        var plan = planId is null ? null : await ctx.Plans.GetPlanFromId(planId);
         if (portal is null)
             return null;
+
+        PlanData? plan = null;
+        if (planId is not null)
+        {
+            plan = await ctx.Plans.GetPlanFromId(planId, portal.Subscriber.OfferingId);
+            if (plan is null)
+                return null;
+
+            var isAllowedChange = portal.Subscriber.Plan.PlanChanges
+                .Any(pc => pc.PlanId == portal.Subscriber.PlanId && pc.PlanChangeId == planId);
+            if (!isAllowedChange)
+                return null;
+        }
+
         var checkout = new PlanCheckoutData(portal.Subscriber, plan)
         {
             SuccessRedirectUrl = linkGenerator.SubscriberPortalLink(portalSessionId, requestBaseUrl),


### PR DESCRIPTION
## Summary

Automated security fixes for 1 findings.

## Fixes

| Title | Severity | File | Confidence | Explanation |
| --- | --- | --- | --- | --- |
| Missing plan validation in CreatePlanMigrationCheckout allows migration to arbitrary plans | High | `BTCPayServer/Plugins/Subscriptions/SubscriptionHostedService.cs` | high | The vulnerability allows a subscriber to migrate to any arbitrary plan by supplying any planId to CreatePlanMigrationCheckout, since no validation was performed on whether the plan belongs to the same offering or is an allowed plan change target.  The fix adds two validations when planId is not null: 1. Passes `portal.Subscriber.OfferingId` to `GetPlanFromId` to ensure the target plan belongs to the same offering as the subscriber's current plan. 2. Checks that the target planId exists in the subscriber's current plan's `PlanChanges` collection (which is already loaded via the `IncludeAll()` query in `GetActiveById`), ensuring only explicitly allowed plan changes are permitted.  The portal check is also moved before the plan lookup to avoid unnecessary DB queries when the portal session is invalid. |

## Caveats
- The PlanChanges collection is already eager-loaded via IncludeAll() on portal sessions, so using the in-memory check is safe and avoids an extra DB query. If the loading behavior changes in the future, this check would need to be updated to query the DB directly.
- When planId is null, no plan validation occurs - this preserves existing behavior where null planId is allowed (e.g., for cancellation flows).

## Verification Checklist

- [ ] Review the code change
- [ ] Run tests to verify no regression
- [x] Verify the vulnerability is addressed — *already verified by Cerberus Sentinel*

---
*Created by [Cerberus](https://github.com/Donjon-Cerberus) Merlin*
