### PR TITLE
fix: Cross-store privilege escalation to approved pull payments/payouts in GreenfieldPullPaymentController

### DIFF
--- a/BTCPayServer/Controllers/GreenField/GreenfieldPullPaymentController.cs
+++ b/BTCPayServer/Controllers/GreenField/GreenfieldPullPaymentController.cs
@@ -89,7 +89,7 @@ namespace BTCPayServer.Controllers.Greenfield
 
             if (request.AutoApproveClaims)
             {
-                if (!(await _authorizationService.AuthorizeAsync(User, null,
+                if (!(await _authorizationService.AuthorizeAsync(User, storeId,
                         new PolicyRequirement(Policies.CanCreatePullPayments))).Succeeded)
                 {
                     return this.CreateAPIPermissionError(Policies.CanCreatePullPayments);
@@ -479,7 +479,7 @@ retry:
         {
             if (request?.Approved is true)
             {
-                if (!(await _authorizationService.AuthorizeAsync(User, null,
+                if (!(await _authorizationService.AuthorizeAsync(User, storeId,
                         new PolicyRequirement(Policies.CanCreatePullPayments))).Succeeded)
                 {
                     return this.CreateAPIPermissionError(Policies.CanCreatePullPayments);


### PR DESCRIPTION
## Summary

Automated security fixes for 1 findings.

## Fixes

| Title | Severity | File | Confidence | Explanation |
| --- | --- | --- | --- | --- |
| Cross-store privilege escalation to approved pull payments/payouts in GreenfieldPullPaymentController | High | `BTCPayServer/Controllers/GreenField/GreenfieldPullPaymentController.cs` | high | Changed `null` to `storeId` in both `AuthorizeAsync` calls (line 92 in `CreatePullPayment` and line 482 in `CreatePayoutThroughStore`) so the `CanCreatePullPayments` permission check is scoped to the target store. This prevents cross-store privilege escalation where a caller with `CanCreatePullPayments` on store A could use it to auto-approve pull payments or payouts on store B. |

## Caveats
- The fix assumes PermissionAuthorizationHandler correctly handles a string storeId resource for scoped permission checks, consistent with how other store-scoped policies work throughout the codebase.

## Verification Checklist

- [ ] Review the code change
- [ ] Run tests to verify no regression
- [x] Verify the vulnerability is addressed — *already verified by Cerberus Sentinel*

---
*Created by [Cerberus](https://github.com/Donjon-Cerberus) Merlin*
