### PR TITLE
fix: Price and currency tampering via mirror fields in public forms/POS/crowdfund

### DIFF
--- a/BTCPayServer/Forms/FieldValueMirror.cs
+++ b/BTCPayServer/Forms/FieldValueMirror.cs
@@ -23,10 +23,15 @@ public class FieldValueMirror : IFormComponentProvider
     public string GetValue(Form form, Field field)
     {
         var rawValue = form.GetFieldByFullName(field.Value)?.Value;
-        if (rawValue is not null && field.AdditionalData?.TryGetValue("valuemap", out var valueMap) is true &&
-            valueMap is JObject map && map.TryGetValue(rawValue, out var mappedValue))
+        if (string.IsNullOrEmpty(rawValue))
+            return null;
+
+        if (field.AdditionalData?.TryGetValue("valuemap", out var valueMap) is true &&
+            valueMap is JObject map)
         {
-            return mappedValue.Value<string>();
+            return map.TryGetValue(rawValue, out var mappedValue)
+                ? mappedValue.Value<string>()
+                : null;
         }
 
         return rawValue;

--- a/BTCPayServer/Forms/HtmlSelectFormProvider.cs
+++ b/BTCPayServer/Forms/HtmlSelectFormProvider.cs
@@ -1,7 +1,9 @@
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
+using System.Linq;
 using BTCPayServer.Abstractions.Form;
 using Microsoft.AspNetCore.Mvc.Rendering;
+using Newtonsoft.Json.Linq;
 
 namespace BTCPayServer.Forms;
 
@@ -19,6 +21,16 @@ public class HtmlSelectFormProvider : FormComponentProviderBase
         if (field.Required)
         {
             ValidateField<RequiredAttribute>(field);
+        }
+
+        if (field.ValidationErrors.Count != 0 || string.IsNullOrEmpty(field.Value))
+            return;
+
+        var selectField = field as SelectField ?? JObject.FromObject(field).ToObject<SelectField>();
+        if (selectField?.Options != null &&
+            !selectField.Options.Any(o => string.Equals(o.Value, field.Value, System.StringComparison.Ordinal)))
+        {
+            field.ValidationErrors.Add($"{field.Label} contains an invalid option");
         }
     }
 }


### PR DESCRIPTION
## Summary

Automated security fixes for 1 findings.

## Fixes

| Title | Severity | File | Confidence | Explanation |
| --- | --- | --- | --- | --- |
| Price and currency tampering via mirror fields in public forms/POS/crowdfund | High | `BTCPayServer/Forms/FieldValueMirror.cs` | high | Two changes fix the vulnerability:  1. **FieldValueMirror.cs**: When a `valuemap` is configured on a mirror field but the raw submitted value doesn't match any entry in the map, the code now returns `null` instead of passing through the raw attacker-controlled value. This is a "fail closed" approach — if the valuemap was intended to constrain allowed values, unmapped values are rejected. Also returns `null` early for null/empty raw values.  2. **HtmlSelectFormProvider.cs**: Added server-side validation that the submitted value for a select field is actually one of the configured options. After checking the Required constraint, if there are no prior errors and the value is non-empty, it deserializes the field to a SelectField to access the Options list and verifies the submitted value matches one of them. If not, a validation error is added, which will cause the form to be rejected. |

## Caveats
- The SelectField conversion via JObject.FromObject/ToObject adds a small serialization overhead during validation, but this mirrors the existing pattern used in the view (SelectElement.cshtml) and is only executed once per select field per form submission.
- If any existing forms rely on select fields accepting values not in their options list (e.g., dynamically populated options via JavaScript that aren't in the server-side option list), those submissions would now be rejected. This is the intended security behavior but could be a breaking change for such edge cases.

## Verification Checklist

- [ ] Review the code change
- [ ] Run tests to verify no regression
- [x] Verify the vulnerability is addressed — *already verified by Cerberus Sentinel*

---
*Created by [Cerberus](https://github.com/Donjon-Cerberus) Merlin*
