### PR TITLE
Subscriptions: Can delete subscribers via UI and API

### DIFF
--- a/BTCPayServer.Client/BTCPayServerClient.Subscriptions.cs
+++ b/BTCPayServer.Client/BTCPayServerClient.Subscriptions.cs
@@ -41,6 +41,9 @@ public partial class BTCPayServerClient
     public async Task<SubscriberModel> GetSubscriber(string storeId, string offeringId, string customerSelector, CancellationToken token = default)
     => await SendHttpRequest<SubscriberModel>($"api/v1/stores/{storeId}/offerings/{offeringId}/subscribers/{Uri.EscapeDataString(customerSelector)}", null, HttpMethod.Get, token);
 
+    public async Task DeleteSubscriber(string storeId, string offeringId, string customerSelector, CancellationToken token = default)
+        => await SendHttpRequest($"api/v1/stores/{storeId}/offerings/{offeringId}/subscribers/{Uri.EscapeDataString(customerSelector)}", null, HttpMethod.Delete, token);
+
     public async Task<SubscriberModel> SuspendSubscriber(string storeId, string offeringId, string customerSelector, string? reason = null,
         CancellationToken token = default)
         => await SendHttpRequest<SubscriberModel>($"api/v1/stores/{storeId}/offerings/{offeringId}/subscribers/{Uri.EscapeDataString(customerSelector)}/suspend", new SuspendSubscriberRequest()

--- a/BTCPayServer.Tests/SubscriptionTests.cs
+++ b/BTCPayServer.Tests/SubscriptionTests.cs
@@ -350,7 +350,7 @@ public class SubscriptionTests(ITestOutputHelper testOutputHelper) : UnitTestBas
         Assert.Equal("can-access", offering2.Features[0].Id);
         Assert.Equal("can-access", offering.Features[0].Id);
 
-        var planCheckout = await client.CreatePlanCheckout(new CreatePlanCheckoutRequest()
+        var planCheckoutRequest = new CreatePlanCheckoutRequest()
         {
             StoreId = user.StoreId,
             OfferingId = offering.Id,
@@ -359,7 +359,8 @@ public class SubscriptionTests(ITestOutputHelper testOutputHelper) : UnitTestBas
             InvoiceMetadata = new JObject() { ["inv"] = "invtest" },
             Metadata = new JObject() { ["checkout"] = "metatest" },
             PlanId = plan.Id,
-        });
+        };
+        var planCheckout = await client.CreatePlanCheckout(planCheckoutRequest);
 
         var planCheckout2 = await client.GetPlanCheckout(planCheckout.Id);
         Assert.Equal(planCheckout.Id, planCheckout2.Id);
@@ -476,11 +477,24 @@ public class SubscriptionTests(ITestOutputHelper testOutputHelper) : UnitTestBas
         await MoveToExpiration(s, offering);
 
         // The price to renew is 10 USD, the user has 27 USD.
-        // The subscriber, should be renewed.
+        // The subscriber should be renewed.
         subscriber = await client.GetSubscriber(user.StoreId, offering.Id, planCheckout.Subscriber.Customer.Id);
         Assert.True(subscriber.IsActive);
         result = await client.GetCredit(user.StoreId, offering.Id, planCheckout.Subscriber.Customer.Id, "current");
         Assert.Equal(-5m + 2m + 30m -10m, result.Value);
+
+        // Delete a user, then recreate it. Since it is the same email, it should be attached to the same customer.
+        await client.DeleteSubscriber(user.StoreId, offering.Id, planCheckout.Subscriber.Customer.Id);
+        await AssertEx.AssertApiError(404, "subscriber-not-found", () => client.GetSubscriber(user.StoreId, offering.Id, planCheckout.Subscriber.Customer.Id));
+        var planCheckoutB = await client.CreatePlanCheckout(planCheckoutRequest);
+        planCheckoutB = await client.ProceedPlanCheckout(planCheckoutB.Id);
+        await s.WaitForEvent<SubscriptionEvent.NewSubscriber>(async () =>
+        {
+            await user.PayOnChain(planCheckoutB.InvoiceId);
+            await s.ExplorerNode.GenerateAsync(1);
+        });
+        planCheckoutB = await client.GetPlanCheckout(planCheckoutB.Id);
+        Assert.Equal(planCheckout.Subscriber.Customer.Id, planCheckoutB.Subscriber.Customer.Id);
     }
 
     private static async Task MoveToExpiration(ServerTester s, OfferingModel offering)
@@ -558,7 +572,7 @@ public class SubscriptionTests(ITestOutputHelper testOutputHelper) : UnitTestBas
         await portal.AssertCallToAction(PortalPMO.CallToAction.Warning, noticeTitle: "Upgrade needed in 3 days");
         await portal.ClickCallToAction();
 
-        await s.Server.WaitForEvent<Events.SubscriptionEvent.PlanStarted>(async () =>
+        await s.Server.WaitForEvent<SubscriptionEvent.PlanStarted>(async () =>
         {
             await s.PayInvoice();
         });
@@ -627,7 +641,7 @@ public class SubscriptionTests(ITestOutputHelper testOutputHelper) : UnitTestBas
         var invoiceId = invoice.Id;
         Assert.Equal("basic2@example.com", invoice.Metadata["buyerEmail"]?.ToString());
 
-        var waiting = offering.WaitEvent<SubscriptionEvent.SubscriberEvent.SubscriberDisabled>();
+        var waiting = offering.WaitEvent<SubscriptionEvent.SubscriberDisabled>();
         await api.MarkInvoiceStatus(storeId, invoiceId, new()
         {
             Status = InvoiceStatus.Invalid
@@ -650,7 +664,7 @@ public class SubscriptionTests(ITestOutputHelper testOutputHelper) : UnitTestBas
             await suspendedPortal.AssertCallToAction(PortalPMO.CallToAction.Danger, noticeTitle: "Access suspended");
         }
 
-        var activating = offering.WaitEvent<SubscriptionEvent.SubscriberEvent.SubscriberActivated>();
+        var activating = offering.WaitEvent<SubscriptionEvent.SubscriberActivated>();
         await s.Server.GetExplorerNode("BTC").EnsureGenerateAsync(1);
         var activated = await activating;
         Assert.Equal("basic@example.com", activated.Subscriber.Customer.GetPrimaryIdentity());
@@ -668,7 +682,7 @@ public class SubscriptionTests(ITestOutputHelper testOutputHelper) : UnitTestBas
         {
             await portal.AssertCallToAction(PortalPMO.CallToAction.Info);
             await portal.ClickCallToAction();
-            var changingPhase = offering.WaitEvent<SubscriptionEvent.SubscriberEvent.SubscriberPhaseChanged>();
+            var changingPhase = offering.WaitEvent<SubscriptionEvent.SubscriberPhaseChanged>();
             await s.PayInvoice(mine: true, clickRedirect: true);
             var changeEvent = await changingPhase;
             Assert.Equal(
@@ -678,7 +692,7 @@ public class SubscriptionTests(ITestOutputHelper testOutputHelper) : UnitTestBas
 
             await portal.AssertNoCallToAction();
 
-            var sendingPaymentReminder = offering.WaitEvent<SubscriptionEvent.SubscriberEvent.PaymentReminder>();
+            var sendingPaymentReminder = offering.WaitEvent<SubscriptionEvent.PaymentReminder>();
             await portal.GoToReminder();
             await sendingPaymentReminder;
 
@@ -687,13 +701,13 @@ public class SubscriptionTests(ITestOutputHelper testOutputHelper) : UnitTestBas
 
             await portal.AssertCallToAction(PortalPMO.CallToAction.Danger, noticeTitle: "Payment due");
 
-            var disabling = offering.WaitEvent<SubscriptionEvent.SubscriberEvent.SubscriberDisabled>();
+            var disabling = offering.WaitEvent<SubscriptionEvent.SubscriberDisabled>();
             await portal.GoToNextPhase();
             await portal.AssertCallToAction(PortalPMO.CallToAction.Danger, noticeTitle: "Access expired");
             await disabling;
 
             await portal.AddCredit("19.00001");
-            var addingCredit = offering.WaitEvent<SubscriptionEvent.SubscriberEvent.SubscriberCredited>();
+            var addingCredit = offering.WaitEvent<SubscriptionEvent.SubscriberCredited>();
             await s.PayInvoice(mine: true, clickRedirect: true);
             var addedCredit = await addingCredit;
             Assert.Equal((19.0m, 19.0m), (addedCredit.Amount, addedCredit.Total));
@@ -701,7 +715,7 @@ public class SubscriptionTests(ITestOutputHelper testOutputHelper) : UnitTestBas
             await s.Page.ReloadAsync();
             await portal.AssertCredit("$299.00", "-$19.00", "$280.00");
 
-            addingCredit = offering.WaitEvent<SubscriptionEvent.SubscriberEvent.SubscriberCredited>();
+            addingCredit = offering.WaitEvent<SubscriptionEvent.SubscriberCredited>();
             await portal.ClickCallToAction();
             await s.PayInvoice(mine: true, clickRedirect: true);
             addedCredit = await addingCredit;
@@ -739,7 +753,7 @@ public class SubscriptionTests(ITestOutputHelper testOutputHelper) : UnitTestBas
             await portal.GoToReminder();
             await portal.AssertCallToAction(PortalPMO.CallToAction.Warning, noticeTitle: "Payment due in 3 days");
             await portal.ClickCallToAction();
-            await s.Server.WaitForEvent<Events.SubscriptionEvent.SubscriberCredited>(async () =>
+            await s.Server.WaitForEvent<SubscriptionEvent.SubscriberCredited>(async () =>
             {
                 await s.PayInvoice(mine: true);
             });
@@ -753,6 +767,12 @@ public class SubscriptionTests(ITestOutputHelper testOutputHelper) : UnitTestBas
         periodicTask.Now = DateTimeOffset.UtcNow.AddMonths(7);
         Assert.NotEqual(0, await periodicTask.RunScript("Portal Session Cleanup"));
         Assert.NotEqual(0, await periodicTask.RunScript("Checkout Session Cleanup"));
+
+        // Can delete a subscriber?
+        await offering.GoToSubscribers();
+        await offering.AssertHasSubscriber("enterprise@example.com");
+        await offering.DeleteSubscriber("enterprise@example.com");
+        await offering.AssertHasNotSubscriber("enterprise@example.com");
     }
 
     public class OfferingPMO(PlaywrightTester s)
@@ -799,6 +819,13 @@ public class SubscriptionTests(ITestOutputHelper testOutputHelper) : UnitTestBas
 
         public Task GoToMails()
             => s.Page.GetByRole(AriaRole.Link, new() { Name = "Mails" }).ClickAsync();
+
+        public async Task DeleteSubscriber(string subscriberEmail)
+        {
+            await s.Page.ClickAsync(SubscriberRowSelector(subscriberEmail) + " .remove-subscriber-link");
+            await s.ConfirmDeleteModal();
+            await s.FindAlertMessage(partialText: "deleted");
+        }
 
         public enum ActiveState
         {

--- a/BTCPayServer/Plugins/Subscriptions/Controllers/GreenfieldOfferingController.cs
+++ b/BTCPayServer/Plugins/Subscriptions/Controllers/GreenfieldOfferingController.cs
@@ -170,6 +170,20 @@ namespace BTCPayServer.Plugins.Subscriptions.Controllers
         }
 
         [Authorize(AuthenticationSchemes = AuthenticationSchemes.Greenfield, Policy = SubscriptionsPolicies.CanManageSubscribers)]
+        [HttpDelete("~/api/v1/stores/{storeId}/offerings/{offeringId}/subscribers/{customerSelector}")]
+        public async Task<IActionResult> DeleteSubscriber(string storeId, string offeringId,
+            [ModelBinder<CustomerSelectorModelBinder>]
+            CustomerSelector customerSelector)
+        {
+            var subscriber = await ctx.Subscribers.GetBySelector(offeringId, customerSelector, storeId);
+            if (subscriber is null)
+                return SubscriberNotFound();
+            ctx.Subscribers.Remove(subscriber);
+            await ctx.SaveChangesAsync();
+            return NoContent();
+        }
+
+        [Authorize(AuthenticationSchemes = AuthenticationSchemes.Greenfield, Policy = SubscriptionsPolicies.CanManageSubscribers)]
         [HttpGet("~/api/v1/stores/{storeId}/offerings/{offeringId}/subscribers/{customerSelector}/credits/{currency}")]
         public async Task<IActionResult> GetCredit(string storeId, string offeringId,
             [ModelBinder<CustomerSelectorModelBinder>]

--- a/BTCPayServer/Plugins/Subscriptions/Controllers/UIOfferingController.cs
+++ b/BTCPayServer/Plugins/Subscriptions/Controllers/UIOfferingController.cs
@@ -32,6 +32,7 @@ public partial class UIOfferingController(
     ApplicationDbContextFactory dbContextFactory,
     IStringLocalizer stringLocalizer,
     LinkGenerator linkGenerator,
+    IAuthorizationService authorizationService,
     EventAggregator eventAggregator,
     SubscriptionHostedService subsService,
     AppService appService,
@@ -98,7 +99,6 @@ public partial class UIOfferingController(
         => displayFormatter.Currency(req?.Amount ?? 0m, req?.Currency ?? "USD", DisplayFormatter.CurrencyFormat.CodeAndSymbol);
 
     [HttpPost("stores/{storeId}/offerings/{offeringId}/Subscribers")]
-    [Authorize(Policy = SubscriptionsPolicies.CanModifyOfferings, AuthenticationSchemes = AuthenticationSchemes.Cookie)]
     public async Task<IActionResult> SubscriberSuspend(string storeId, string offeringId, string customerId, string? command = null,
         string? suspensionReason = null, decimal? amount = null, string? description = null)
     {
@@ -106,6 +106,14 @@ public partial class UIOfferingController(
         var sub = await ctx.Subscribers.GetByCustomerId(customerId, offeringId: offeringId, storeId: storeId);
         if (sub is null)
             return NotFound();
+        var permission = command switch
+        {
+            "credit" or "charge" => SubscriptionsPolicies.CanCreditSubscribers,
+            _ => SubscriptionsPolicies.CanManageSubscribers
+        };
+        if (!(await authorizationService.AuthorizeAsync(User, storeId, permission)).Succeeded)
+            return Forbid();
+
         var subName = sub.Customer.GetPrimaryIdentity() ?? sub.CustomerId;
         if (command is "unsuspend" or "suspend")
         {
@@ -125,6 +133,12 @@ public partial class UIOfferingController(
             sub.TestAccount = !sub.TestAccount;
             await ctx.SaveChangesAsync();
             TempData.SetStatusSuccess(StringLocalizer["Subscriber {0} is now {1}", subName, sub.TestAccount ? "test" : "live"]);
+        }
+        else if (command is "delete")
+        {
+            ctx.Subscribers.Remove(sub);
+            await ctx.SaveChangesAsync();
+            TempData.SetStatusSuccess(StringLocalizer["Subscriber {0} deleted", subName]);
         }
         else if (command is "credit" or "charge" && amount is > 0)
         {
@@ -613,7 +627,7 @@ public partial class UIOfferingController(
     }
 
     [HttpGet("stores/{storeId}/offerings/{offeringId}/subscribers/{customerId}/create-portal")]
-    [Authorize(Policy = SubscriptionsPolicies.CanModifyOfferings, AuthenticationSchemes = AuthenticationSchemes.Cookie)]
+    [Authorize(Policy = SubscriptionsPolicies.CanManageSubscribers, AuthenticationSchemes = AuthenticationSchemes.Cookie)]
     public async Task<IActionResult> CreatePortalSession(string storeId, string offeringId, string customerId)
     {
         await using var ctx = DbContextFactory.CreateContext();

--- a/BTCPayServer/Plugins/Subscriptions/Views/Components/SubscriberStatus/Default.cshtml
+++ b/BTCPayServer/Plugins/Subscriptions/Views/Components/SubscriberStatus/Default.cshtml
@@ -1,5 +1,7 @@
-﻿@model (bool, SubscriberData)
-
+﻿@using BTCPayServer.Plugins.Subscriptions
+@using Microsoft.AspNetCore.Authorization
+@model (bool, SubscriberData)
+@inject IAuthorizationService AuthorizationService
 @{
     var subscriber = Model.Item2;
     var canSuspend = Model.Item1;
@@ -9,6 +11,8 @@
         { IsActive: false, IsSuspended: true } => (StringLocalizer["Suspended"], "danger", true),
         _ => (StringLocalizer["Inactive"], "danger", subscriber.IsSuspended)
     };
+    if (canSuspend)
+        canSuspend = (await AuthorizationService.AuthorizeAsync(User, subscriber.Customer.StoreId, SubscriptionsPolicies.CanManageSubscribers)).Succeeded;
     hasDropdown = hasDropdown && canSuspend;
 }
 <span class="subscriber-status badge badge-translucent rounded-pill text-bg-@badge">

--- a/BTCPayServer/Plugins/Subscriptions/Views/NavExtension.cshtml
+++ b/BTCPayServer/Plugins/Subscriptions/Views/NavExtension.cshtml
@@ -18,8 +18,8 @@
     </li>
     @if (apps.Any())
     {
-        <li layout-menu-item="@nameof(SubscriptionsPlugin)" not-permission="@SubscriptionsPolicies.CanModifyOfferings" permission="@Policies.CanViewStoreSettings">
-            <span class="nav-link">
+        <li class="nav-item" not-permission="@SubscriptionsPolicies.CanModifyOfferings" permission="@SubscriptionsPolicies.CanViewOfferings">
+            <span layout-menu-item="@nameof(SubscriptionsPlugin)">
                 <vc:icon symbol="nav-reporting" />
                 <span text-translate="true">Subscriptions</span>
             </span>
@@ -28,14 +28,8 @@
     @foreach (var app in apps)
     {
         var offeringId = app.Data.GetSettings<SubscriptionsAppType.AppConfig>().OfferingId ?? "";
-
         <li class="nav-item nav-item-sub" permission="@SubscriptionsPolicies.CanViewOfferings">
             <a layout-menu-item="@nameof(SubscriptionsPlugin)-@offeringId" asp-area="Subscriptions" asp-controller="UIOffering" asp-action="Offering" asp-route-storeId="@Model.Store.Id" asp-route-offeringId="@offeringId" asp-route-section="Plans">
-                <span>@app.AppName</span>
-            </a>
-        </li>
-        <li class="nav-item nav-item-sub" not-permission="@SubscriptionsPolicies.CanViewOfferings">
-            <a layout-menu-item="@nameof(SubscriptionsPlugin)-@offeringId" asp-area="Subscriptions" asp-controller="UIOffering" asp-action="Offering" asp-route-storeId="@Model.Store.Id" asp-route-offeringId="@offeringId" asp-route-section="Plans" class="nav-link">
                 <span>@app.AppName</span>
             </a>
         </li>

--- a/BTCPayServer/Plugins/Subscriptions/Views/UIOffering/Offering.cshtml
+++ b/BTCPayServer/Plugins/Subscriptions/Views/UIOffering/Offering.cshtml
@@ -29,7 +29,7 @@
 <div class="sticky-header">
     <h2>@ViewData["Title"]</h2>
     <div>
-        <a class="btn btn-secondary" asp-action="ConfigureOffering" asp-route-storeId="@storeId" asp-route-offeringId="@offeringId" text-translate="true">Configure</a>
+        <a class="btn btn-secondary" asp-action="ConfigureOffering" asp-route-storeId="@storeId" asp-route-offeringId="@offeringId" permission="@SubscriptionsPolicies.CanModifyOfferings" text-translate="true">Configure</a>
     </div>
 </div>
 
@@ -147,7 +147,8 @@
                                     <a class="edit-plan" asp-action="AddPlan"
                                        asp-route-storeId="@storeId"
                                        asp-route-offeringId="@offeringId"
-                                       asp-route-planId="@p.Data.Id">Edit</a>
+                                       asp-route-planId="@p.Data.Id"
+                                       permission="@SubscriptionsPolicies.CanModifyOfferings">Edit</a>
                                     <a
                                         asp-action="DeletePlan"
                                         asp-route-storeId="@storeId"
@@ -155,7 +156,8 @@
                                         asp-route-planId="@p.Data.Id"
                                         data-bs-toggle="modal" data-bs-target="#ConfirmModal"
                                         data-description="@ViewLocalizer["This action will remove the plan <b>{0}</b>.", Html.Encode(p.Data.Name)]"
-                                        data-confirm-input="@StringLocalizer["Delete"]" text-translate="true">Remove</a>
+                                        data-confirm-input="@StringLocalizer["Delete"]" text-translate="true"
+                                        permission="@SubscriptionsPolicies.CanModifyOfferings">Remove</a>
                                 </div>
                             </td>
                         </tr>
@@ -170,7 +172,7 @@
                 </tbody>
             </table>
         </div>
-        <partial name="_Confirm" model="@(new ConfirmModel(StringLocalizer["Remove plan"], StringLocalizer["This action will remove this plan. Are you sure?"], StringLocalizer["Delete"]))" permission="@Policies.CanModifyStoreSettings" />
+        <partial name="_Confirm" model="@(new ConfirmModel(StringLocalizer["Remove plan"], StringLocalizer["This action will remove this plan. Are you sure?"], StringLocalizer["Delete"]))" />
     }
     else if (Model.Section == SubscriptionSection.Subscribers)
     {
@@ -217,11 +219,11 @@
                             data-currency="@subscriber.Data.Plan.Currency"
                             data-current-credit-value="@subscriber.Data.GetCredit()">
                             <td class="fw-semibold text-nowrap d-flex align-items-center subscriber-email-col">
-                                <form method="post" asp-antiforgery="true" class="me-2">
-                                    @if (subscriber.Data.TestAccount)
-                                    {
-                                        <span class="badge badge-translucent rounded-pill text-bg-info">Test</span>
-                                    }
+                                @if (subscriber.Data.TestAccount)
+                                {
+                                    <span class="badge badge-translucent rounded-pill text-bg-info">Test</span>
+                                }
+                                <form method="post" asp-antiforgery="true" class="me-2" permission="@SubscriptionsPolicies.CanManageSubscribers">
                                     <span class="dropdown-toggle" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                                         @subscriber.Data.Customer.Email.Get()
                                     </span>
@@ -239,9 +241,10 @@
                                         </button>
                                     </div>
                                 </form>
+                                <span class="me-2" not-permission="@SubscriptionsPolicies.CanManageSubscribers">@subscriber.Data.Customer.Email.Get()</span>
                             </td>
                             <td class="fw-semibold text-nowrap subscriber-credit-col">
-                                <span>
+                                <span permission="@SubscriptionsPolicies.CanCreditSubscribers">
                                     <span class="dropdown-toggle" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                                         <span>@DisplayFormatter.Currency(subscriber.Data.GetCredit(), subscriber.Data.Plan.Currency, DisplayFormatter.CurrencyFormat.CodeAndSymbol)</span>
                                     </span>
@@ -265,6 +268,9 @@
                                             Charge
                                         </a>
                                     </div>
+                                </span>
+                                <span not-permission="@SubscriptionsPolicies.CanCreditSubscribers">
+                                    @DisplayFormatter.Currency(subscriber.Data.GetCredit(), subscriber.Data.Plan.Currency, DisplayFormatter.CurrencyFormat.CodeAndSymbol)
                                 </span>
                             </td>
                             <td class="text-nowrap">@subscriber.Data.Plan.Name</td>
@@ -291,7 +297,20 @@
                             <td>
                                 <div class="d-inline-flex align-items-center gap-3">
                                     <a asp-action="CreatePortalSession" asp-route-storeId="@storeId" asp-route-offeringId="@subscriber.Data.OfferingId"
-                                       asp-route-customerId="@subscriber.Data.CustomerId" class="portal-link" target="_blank">View Portal</a>
+                                        permission="@SubscriptionsPolicies.CanManageSubscribers"
+                                        asp-route-customerId="@subscriber.Data.CustomerId" class="portal-link" target="_blank">View Portal</a>
+                                    <a asp-action="SubscriberSuspend"
+                                       asp-route-storeId="@storeId"
+                                       asp-route-offeringId="@offeringId"
+                                       asp-route-customerId="@subscriber.Data.CustomerId"
+                                       asp-route-command="delete"
+                                       class="remove-subscriber-link"
+                                       data-bs-toggle="modal"
+                                       data-bs-target="#ConfirmModal"
+                                       data-description="@ViewLocalizer["This action will remove the subscriber <b>{0}</b>.", Html.Encode(subscriber.Data.Customer.Email.Get())]"
+                                       data-confirm-input="@StringLocalizer["Delete"]"
+                                       permission="@SubscriptionsPolicies.CanManageSubscribers"
+                                       text-translate="true">Remove</a>
                                 </div>
                             </td>
                         </tr>
@@ -310,8 +329,9 @@
                 }
                 </tbody>
             </table>
-        </div>
-    }
+         </div>
+        <partial name="_Confirm" model="@(new ConfirmModel(StringLocalizer["Remove subscriber"], StringLocalizer["This action will remove this subscriber. Are you sure?"], StringLocalizer["Delete"]))" />
+     }
     else if (Model.Section == SubscriptionSection.Mails)
     {
         <form asp-antiforgery="true" method="post">

--- a/BTCPayServer/wwwroot/swagger/v1/swagger.template.subscriptions.json
+++ b/BTCPayServer/wwwroot/swagger/v1/swagger.template.subscriptions.json
@@ -260,6 +260,41 @@
                         "description": "Subscriber not found."
                     }
                 }
+            },
+            "delete": {
+                "summary": "Delete a subscriber",
+                "description": "Deletes a subscriber for a specific offering by customer selector.",
+                "operationId": "DeleteSubscriber",
+                "tags": [
+                    "Subscriptions"
+                ],
+                "security": [
+                    {
+                        "API_Key": [
+                            "btcpay.store.canmanagesubscribers"
+                        ],
+                        "Basic": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/StoreId"
+                    },
+                    {
+                        "$ref": "#/components/parameters/OfferingId"
+                    },
+                    {
+                        "$ref": "#/components/parameters/CustomerSelector"
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "Subscriber deleted successfully."
+                    },
+                    "404": {
+                        "description": "Subscriber not found."
+                    }
+                }
             }
         },
         "/api/v1/stores/{storeId}/offerings/{offeringId}/subscribers/{customerSelector}/credits/{currency}": {
@@ -1954,4 +1989,3 @@
         }
     ]
 }
-


### PR DESCRIPTION
Fix https://github.com/btcpayserver/btcpayserver/issues/7206

This add subscriber deletion to both API and UI.
Note that this doesn't delete the customer object, so recreating the subscriber will attach it to the customer of the same email.

<img width="832" height="624" alt="image" src="https://github.com/user-attachments/assets/50e42677-c834-4001-bd8a-4afda7a2eed0" />


I have also improved the UI when a user only has subscriber management permission.