### PR TITLE
fix(email): skip SMTP AUTH when Login and Password are empty

### DIFF
--- a/BTCPayServer/Plugins/Emails/Services/EmailSettings.cs
+++ b/BTCPayServer/Plugins/Emails/Services/EmailSettings.cs
@@ -111,8 +111,10 @@ public class EmailSettings
 #pragma warning restore CA5359 // Do Not Disable Certificate Validation
             }
             await client.ConnectAsync(Server, Port.Value, MailKit.Security.SecureSocketOptions.Auto, connectCancel.Token);
-            if ((client.Capabilities & SmtpCapabilities.Authentication) != 0)
-                await client.AuthenticateAsync(Login ?? string.Empty, Password ?? string.Empty, connectCancel.Token);
+            if ((client.Capabilities & SmtpCapabilities.Authentication) != 0
+                && !string.IsNullOrWhiteSpace(Login)
+                && !string.IsNullOrWhiteSpace(Password))
+                await client.AuthenticateAsync(Login, Password, connectCancel.Token);
         }
         catch
         {


### PR DESCRIPTION
Fixes #7267

## Problem
When SMTP is configured with a relay that uses IP-based authentication (e.g. Google Workspace email relay), BTCPay still calls `AuthenticateAsync` if the SMTP server advertises the AUTH capability, causing 535 errors.

## Fix
Skip SMTP authentication when both Login and Password fields are empty. Only authenticate when credentials are actually configured.