### PR TITLE
Subscriptions: SubscriberDisabled webhook now includes the reason why subscriber has been disabled

### DIFF
--- a/BTCPayServer.Client/Models/WebhookSubscriptionEvent.cs
+++ b/BTCPayServer.Client/Models/WebhookSubscriptionEvent.cs
@@ -1,4 +1,7 @@
-﻿namespace BTCPayServer.Client.Models;
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
+namespace BTCPayServer.Client.Models;
 
 public class WebhookSubscriptionEvent : StoreWebhookEvent
 {
@@ -108,6 +111,12 @@ public class WebhookSubscriptionEvent : StoreWebhookEvent
 
     public class SubscriberDisabledEvent : WebhookSubscriptionEvent.SubscriberEvent
     {
+        public enum DisabledReason
+        {
+            Suspension,
+            Expired
+        }
+
         public SubscriberDisabledEvent()
         {
         }
@@ -115,6 +124,10 @@ public class WebhookSubscriptionEvent : StoreWebhookEvent
         public SubscriberDisabledEvent(string storeId) : base(SubscriberDisabled, storeId)
         {
         }
+
+        [JsonConverter(typeof(StringEnumConverter))]
+        public DisabledReason Reason { get; set; }
+        public string SuspensionReason { get; set; }
     }
 
     public class PaymentReminderEvent : WebhookSubscriptionEvent.SubscriberEvent

--- a/BTCPayServer.Tests/SubscriptionTests.cs
+++ b/BTCPayServer.Tests/SubscriptionTests.cs
@@ -714,7 +714,9 @@ public class SubscriptionTests(ITestOutputHelper testOutputHelper) : UnitTestBas
             Status = InvoiceStatus.Invalid
         });
         var disabled = await waiting;
+        Assert.Equal(SubscriptionEvent.DisabledReason.Suspension, disabled.Reason);
         Assert.True(disabled.Subscriber.IsSuspended);
+        Assert.Equal(disabled.Subscriber.SuspensionReason, disabled.SuspensionReason);
         Assert.Equal("The plan has been started by an invoice which later became invalid.", disabled.Subscriber.SuspensionReason);
 
         await s.FastReloadAsync();
@@ -771,7 +773,9 @@ public class SubscriptionTests(ITestOutputHelper testOutputHelper) : UnitTestBas
             var disabling = offering.WaitEvent<SubscriptionEvent.SubscriberDisabled>();
             await portal.GoToNextPhase();
             await portal.AssertCallToAction(PortalPMO.CallToAction.Danger, noticeTitle: "Access expired");
-            await disabling;
+            var expired = await disabling;
+            Assert.Equal(SubscriptionEvent.DisabledReason.Expired, expired.Reason);
+            Assert.Null(expired.SuspensionReason);
 
             await portal.AddCredit("19.00001");
             var addingCredit = offering.WaitEvent<SubscriptionEvent.SubscriberCredited>();

--- a/BTCPayServer/Plugins/Subscriptions/SubscriberWebhookProvider.cs
+++ b/BTCPayServer/Plugins/Subscriptions/SubscriberWebhookProvider.cs
@@ -90,10 +90,12 @@ public class SubscriberWebhookProvider : WebhookTriggerProvider<SubscriptionEven
                     CurrentPhase = Mapper.Map(sub.Phase)
                 };
 
-            case SubscriptionEvent.SubscriberDisabled:
+            case SubscriptionEvent.SubscriberDisabled disabled:
                 return new WebhookSubscriptionEvent.SubscriberDisabledEvent(storeId)
                 {
-                    Subscriber = model
+                    Subscriber = model,
+                    Reason = Map(disabled.Reason),
+                    SuspensionReason = disabled.SuspensionReason
                 };
 
             case SubscriptionEvent.PaymentReminder:
@@ -117,4 +119,12 @@ public class SubscriberWebhookProvider : WebhookTriggerProvider<SubscriptionEven
                 throw new ArgumentOutOfRangeException(nameof(evt), evt.GetType(), "Unsupported subscription event type");
         }
     }
+
+    private WebhookSubscriptionEvent.SubscriberDisabledEvent.DisabledReason Map(SubscriptionEvent.DisabledReason disabledReason)
+        => disabledReason switch
+        {
+            SubscriptionEvent.DisabledReason.Expired => WebhookSubscriptionEvent.SubscriberDisabledEvent.DisabledReason.Expired,
+            SubscriptionEvent.DisabledReason.Suspension => WebhookSubscriptionEvent.SubscriberDisabledEvent.DisabledReason.Suspension,
+            _ => throw new ArgumentOutOfRangeException(nameof(disabledReason), disabledReason, null)
+        };
 }

--- a/BTCPayServer/Plugins/Subscriptions/SubscriptionEvent.cs
+++ b/BTCPayServer/Plugins/Subscriptions/SubscriptionEvent.cs
@@ -43,8 +43,16 @@ public class SubscriptionEvent
         public override string ToString() => $"Subscriber {Subscriber.ToNiceString()} changed phase from {PreviousPhase} to {Subscriber.Phase}";
     }
 
-    public class SubscriberDisabled(SubscriberData subscriber) : SubscriberEvent(subscriber)
+    public enum DisabledReason
     {
+        Suspension,
+        Expired
+    }
+
+    public class SubscriberDisabled(SubscriberData subscriber, DisabledReason reason, string? suspensionReason = null) : SubscriberEvent(subscriber)
+    {
+        public DisabledReason Reason { get; } = reason;
+        public string? SuspensionReason { get; } = reason is DisabledReason.Suspension ? suspensionReason : null;
         public override string ToString() => $"Subscriber {Subscriber.ToNiceString()} disabled";
     }
 

--- a/BTCPayServer/Plugins/Subscriptions/SubscriptionHostedService.cs
+++ b/BTCPayServer/Plugins/Subscriptions/SubscriptionHostedService.cs
@@ -309,7 +309,10 @@ public class SubscriptionHostedService(
                 if (newActive)
                     subCtx.AddEvent(new SubscriptionEvent.SubscriberActivated(m));
                 else
-                    subCtx.AddEvent(new SubscriptionEvent.SubscriberDisabled(m));
+                    subCtx.AddEvent(new SubscriptionEvent.SubscriberDisabled(
+                        m,
+                        m.IsSuspended ? SubscriptionEvent.DisabledReason.Suspension : SubscriptionEvent.DisabledReason.Expired,
+                        m.SuspensionReason));
             }
         }
 

--- a/BTCPayServer/Plugins/Webhooks/HostedServices/WebhookProviderHostedService.cs
+++ b/BTCPayServer/Plugins/Webhooks/HostedServices/WebhookProviderHostedService.cs
@@ -74,7 +74,7 @@ public class WebhookProviderHostedService(
     }
 
     private StoreWebhookEvent Clone(StoreWebhookEvent webhookEvent)
-    => (StoreWebhookEvent)JsonConvert.DeserializeObject(JsonConvert.SerializeObject(webhookEvent), webhookEvent.GetType(), WebhookSender.DefaultSerializerSettings)!;
+    => (StoreWebhookEvent)JsonConvert.DeserializeObject(JsonConvert.SerializeObject(webhookEvent, WebhookSender.DefaultSerializerSettings), webhookEvent.GetType(), WebhookSender.DefaultSerializerSettings)!;
 
     private async Task<StoreData?> GetStore(StoreWebhookEvent webhookEvent)
     {

--- a/BTCPayServer/wwwroot/swagger/v1/swagger.template.subscriptions.json
+++ b/BTCPayServer/wwwroot/swagger/v1/swagger.template.subscriptions.json
@@ -1577,6 +1577,39 @@
                     }
                 ]
             },
+            "WebhookSubscriberDisabledReason": {
+                "type": "string",
+                "description": "Reason why the subscriber was disabled.",
+                "enum": [
+                    "Suspension",
+                    "Expired"
+                ],
+                "example": "Suspension"
+            },
+            "WebhookSubscriberDisabledEvent": {
+                "description": "Callback sent if the `type` is `SubscriberDisabled`",
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/WebhookSubscriberEvent"
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "reason": {
+                                "$ref": "#/components/schemas/WebhookSubscriberDisabledReason",
+                                "description": "Whether the subscriber was disabled because of a suspension or expiration.",
+                                "example": "Suspension"
+                            },
+                            "suspensionReason": {
+                                "type": "string",
+                                "nullable": true,
+                                "description": "Suspension reason provided by the merchant when `reason` is `Suspension`.",
+                                "example": "Spam behavior detected."
+                            }
+                        }
+                    }
+                ]
+            },
             "WebhookPlanStartedEvent": {
                 "description": "Callback sent if the `type` is `PlanStarted`",
                 "allOf": [
@@ -1842,7 +1875,7 @@
                     "content": {
                         "application/json": {
                             "schema": {
-                                "$ref": "#/components/schemas/WebhookSubscriberEvent"
+                                "$ref": "#/components/schemas/WebhookSubscriberDisabledEvent"
                             }
                         }
                     }


### PR DESCRIPTION
Implement one of the suggestions of @ou7law007. https://github.com/btcpayserver/btcpayserver/issues/7145#issuecomment-3817443684

> Using only webhooks (e.g. SubscriberDisabled), you cannot reliably distinguish between when the subscription is suspended in the middle of the subscription period (e.g. using the UI website, or using cancel now with refund) or the subscription has actually fully ended without the user resubscribing. This is important if you're trying to work around the issue (2) by cutting of the subscriber's continuous benefit when the subscription actually ends vs when it was ended mid subscription.

A `reason` enum with value `Suspension` or `Expired` has been added to the webhook, along with `suspensionReason`.