### PR TITLE
Bumping LND to 0.19.3-beta-1

### DIFF
--- a/BTCPayServer.Tests/docker-compose.mutinynet.yml
+++ b/BTCPayServer.Tests/docker-compose.mutinynet.yml
@@ -179,7 +179,7 @@ services:
       - "postgres_test_datadir:/var/lib/postgresql"
 
   merchant_lnd:
-    image: btcpayserver/lnd:v0.19.3-beta
+    image: btcpayserver/lnd:v0.19.3-beta-1
     restart: unless-stopped
     environment:
       LND_CHAIN: "btc"
@@ -217,7 +217,7 @@ services:
       - bitcoind
 
   customer_lnd:
-    image: btcpayserver/lnd:v0.19.3-beta
+    image: btcpayserver/lnd:v0.19.3-beta-1
     restart: unless-stopped
     environment:
       LND_CHAIN: "btc"

--- a/BTCPayServer.Tests/docker-compose.testnet.yml
+++ b/BTCPayServer.Tests/docker-compose.testnet.yml
@@ -169,7 +169,7 @@ services:
       - "postgres_test_datadir:/var/lib/postgresql"
 
   merchant_lnd:
-    image: btcpayserver/lnd:v0.19.3-beta
+    image: btcpayserver/lnd:v0.19.3-beta-1
     restart: unless-stopped
     environment:
       LND_CHAIN: "btc"
@@ -207,7 +207,7 @@ services:
       - bitcoind
 
   customer_lnd:
-    image: btcpayserver/lnd:v0.19.3-beta
+    image: btcpayserver/lnd:v0.19.3-beta-1
     restart: unless-stopped
     environment:
       LND_CHAIN: "btc"


### PR DESCRIPTION
Docker image: https://hub.docker.com/repository/docker/btcpayserver/lnd/tags/v0.19.3-beta-1
Tag: https://github.com/btcpayserver/lnd/releases/tag/basedon-v0.19.3-beta-1
BTCPayServer.Lightning: https://github.com/btcpayserver/BTCPayServer.Lightning/pull/177 (merged, tests passing)