### PR TITLE
Allow qr-code login expiry after a day

### DIFF
--- a/BTCPayServer/Controllers/UIAccountController.cs
+++ b/BTCPayServer/Controllers/UIAccountController.cs
@@ -141,10 +141,13 @@ namespace BTCPayServer.Controllers
                 }
 
                 _logger.LogInformation("User {Email} logged in with a login code", user!.Email);
+                var now = DateTimeOffset.UtcNow;
                 var authProperties = new AuthenticationProperties
                 {
+                    IssuedUtc = now,
+                    AllowRefresh = false,
                     IsPersistent = true,
-                    ExpiresUtc = DateTimeOffset.UtcNow.AddHours(24)
+                    ExpiresUtc = now.AddDays(1)
                 };
                 await signInManager.SignInAsync(user, authProperties, "LoginCode");
                 return RedirectToLocal(returnUrl);

--- a/BTCPayServer/Controllers/UIAccountController.cs
+++ b/BTCPayServer/Controllers/UIAccountController.cs
@@ -141,7 +141,12 @@ namespace BTCPayServer.Controllers
                 }
 
                 _logger.LogInformation("User {Email} logged in with a login code", user!.Email);
-                await signInManager.SignInAsync(user, false, "LoginCode");
+                var authProperties = new AuthenticationProperties
+                {
+                    IsPersistent = true,
+                    ExpiresUtc = DateTimeOffset.UtcNow.AddHours(24)
+                };
+                await signInManager.SignInAsync(user, authProperties, "LoginCode");
                 return RedirectToLocal(returnUrl);
             }
             return await Login(returnUrl);


### PR DESCRIPTION
Resolves #6801 

Extending login code to be persistent up to a day