### PR TITLE
allow for notification email in subscription

### DIFF
--- a/BTCPayServer.Data/Data/CustomerData.cs
+++ b/BTCPayServer.Data/Data/CustomerData.cs
@@ -1,4 +1,4 @@
-﻿#nullable  enable
+#nullable  enable
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
@@ -65,6 +65,9 @@ public class CustomerData : BaseEntityData
 
     [NotMapped]
     public ContactSetter Email => new ContactSetter(this, "Email");
+
+    [NotMapped]
+    public ContactSetter NotificationEmail => new ContactSetter(this, "NotificationEmail");
 
     public void SetContact(string type, string? value)
     {

--- a/BTCPayServer.Tests/SubscriptionTests.cs
+++ b/BTCPayServer.Tests/SubscriptionTests.cs
@@ -346,6 +346,42 @@ public class SubscriptionTests(ITestOutputHelper testOutputHelper) : UnitTestBas
         await portal.AssertNoScheduledChange();
     }
 
+    [Fact]
+    [Trait("Playwright", "Playwright-2")]
+    public async Task CanUpdateNotificationEmail()
+    {
+        await using var s = CreatePlaywrightTester();
+        await s.StartAsync();
+        await s.RegisterNewUser();
+        await s.CreateNewStore();
+        await s.AddDerivationScheme();
+
+        var offering = await CreateNewSubscription(s);
+        await offering.NewSubscriber("Enterprise Plan", "enterprise@example.com", true);
+        await offering.GoToSubscribers();
+
+        await using var portal = await offering.GoToPortal("enterprise@example.com");
+
+        await portal.ClickCallToAction();
+        await s.Server.WaitForEvent<SubscriptionEvent.SubscriberCredited>(async () =>
+        {
+            await s.PayInvoice(mine: true);
+        });
+        await s.ClickCheckoutRedirect();
+        await portal.AssertNoCallToAction();
+
+        await portal.UpdateNotificationEmail("notify@example.com");
+        await s.FindAlertMessage(partialText: "Notification email updated");
+
+        var notifEmail = await s.Page.Locator("input[name='NotificationEmail']").InputValueAsync();
+        Assert.Equal("notify@example.com", notifEmail);
+
+        await portal.UpdateNotificationEmail("");
+        await s.FindAlertMessage(partialText: "Notification email updated");
+        notifEmail = await s.Page.Locator("input[name='NotificationEmail']").InputValueAsync();
+        Assert.Equal("", notifEmail);
+    }
+
     private static decimal GetUnusedPeriodValue(int usedDays, decimal planPrice, int daysInPeriod)
     {
         var unused = (daysInPeriod - usedDays) / (double)daysInPeriod;
@@ -1257,6 +1293,12 @@ public class SubscriptionTests(ITestOutputHelper testOutputHelper) : UnitTestBas
         {
             await s.Page.ClickAsync(".scheduled-change-banner button[value='cancel-scheduled-change']");
             await s.FindAlertMessage(partialText: "cancelled");
+        }
+
+        public async Task UpdateNotificationEmail(string email)
+        {
+            await s.Page.FillAsync("input[name='NotificationEmail']", email);
+            await s.Page.ClickAsync("button[value='update-notification-email']");
         }
     }
 

--- a/BTCPayServer/Plugins/Subscriptions/Controllers/UISubscriberPortalController.cs
+++ b/BTCPayServer/Plugins/Subscriptions/Controllers/UISubscriberPortalController.cs
@@ -174,64 +174,89 @@ public class UISubscriberPortalController(
         var session = await ctx.PortalSessions.GetActiveById(portalSessionId);
         if (session is null)
             return NotFound();
-        if (command == "add-credit")
-        {
-            var value = vm.Credit?.InputAmount;
-            if (value is null || value.Value <= 0)
-                ModelState.AddModelError("Credit.InputAmount", StringLocalizer["Please enter a positive amount"]);
-            if (!ModelState.IsValid)
-                return await SubscriberPortal(portalSessionId, cancellationToken: cancellationToken);
 
-            try
-            {
-                var invoiceId = await SubsService.CreateCreditCheckout(session.Id, value);
-                if (invoiceId is not null)
+        switch (command)
+        {
+            case "add-credit":
                 {
-                    return RedirectToInvoiceCheckout(invoiceId);
+                    var value = vm.Credit?.InputAmount;
+                    if (value is null || value.Value <= 0)
+                        ModelState.AddModelError("Credit.InputAmount", StringLocalizer["Please enter a positive amount"]);
+                    if (!ModelState.IsValid)
+                        return await SubscriberPortal(portalSessionId, cancellationToken: cancellationToken);
+
+                    try
+                    {
+                        var invoiceId = await SubsService.CreateCreditCheckout(session.Id, value);
+                        if (invoiceId is not null)
+                        {
+                            return RedirectToInvoiceCheckout(invoiceId);
+                        }
+                    }
+                    catch (BitpayHttpException ex)
+                    {
+                        TempData.SetStatusMessageModel(new StatusMessageModel
+                        {
+                            Html = ex.Message.Replace("\n", "<br />", StringComparison.OrdinalIgnoreCase),
+                            Severity = StatusMessageModel.StatusSeverity.Error,
+                            AllowDismiss = true
+                        });
+                        return RedirectToPlanCheckout(portalSessionId);
+                    }
+                    break;
                 }
-            }
-            catch (BitpayHttpException ex)
-            {
-                TempData.SetStatusMessageModel(new StatusMessageModel
+
+            case "migrate":
+            case "pay":
                 {
-                    Html = ex.Message.Replace("\n", "<br />", StringComparison.OrdinalIgnoreCase),
-                    Severity = StatusMessageModel.StatusSeverity.Error,
-                    AllowDismiss = true
-                });
-                return RedirectToPlanCheckout(portalSessionId);
-            }
-        }
-        else if (command is "migrate" or "pay")
-        {
-            var onPay = command == "migrate" ? PlanCheckoutData.OnPayBehavior.HardMigration : PlanCheckoutData.OnPayBehavior.SoftMigration;
-            if (command == "migrate" && changedPlanId is null)
-            {
-                if (session.Subscriber.Plan.PlanChanges.Count == 1)
-                    changedPlanId = session.Subscriber.Plan.PlanChanges[0].PlanChangeId;
-                else
-                    return RedirectToSubscriberPortal(portalSessionId, "plans");
-            }
-            var result = await SubsService.CreatePlanMigrationCheckout(session.Id, changedPlanId, onPay, Request.GetRequestBaseUrl());
-            if (result is PlanMigrationResult.Scheduled)
-            {
-                TempData.SetStatusSuccess(StringLocalizer["Your plan will change at the end of your current billing period."]);
-                return RedirectToSubscriberPortal(portalSessionId);
-            }
-            return result is PlanMigrationResult.Checkout c
-                ? await RedirectToPlanCheckoutPayment(c.CheckoutId, cancellationToken)
-                : RedirectToSubscriberPortal(portalSessionId);
-        }
-        else if (command == "update-auto-renewal")
-        {
-            session.Subscriber.AutoRenew = !session.Subscriber.AutoRenew;
-            await ctx.SaveChangesAsync(cancellationToken);
-        }
-        else if (command == "cancel-scheduled-change")
-        {
-            session.Subscriber.NewPlanId = null;
-            session.Subscriber.NewPlan = null;
-            await ctx.SaveChangesAsync(cancellationToken);
-            TempData.SetStatusSuccess(StringLocalizer["Scheduled plan change cancelled."]);
+                    var onPay = command == "migrate" ? PlanCheckoutData.OnPayBehavior.HardMigration : PlanCheckoutData.OnPayBehavior.SoftMigration;
+                    if (command == "migrate" && changedPlanId is null)
+                    {
+                        if (session.Subscriber.Plan.PlanChanges.Count == 1)
+                            changedPlanId = session.Subscriber.Plan.PlanChanges[0].PlanChangeId;
+                        else
+                            return RedirectToSubscriberPortal(portalSessionId, "plans");
+                    }
+                    var result = await SubsService.CreatePlanMigrationCheckout(session.Id, changedPlanId, onPay, Request.GetRequestBaseUrl());
+                    if (result is PlanMigrationResult.Scheduled)
+                    {
+                        TempData.SetStatusSuccess(StringLocalizer["Your plan will change at the end of your current billing period."]);
+                        return RedirectToSubscriberPortal(portalSessionId);
+                    }
+                    return result is PlanMigrationResult.Checkout c
+                        ? await RedirectToPlanCheckoutPayment(c.CheckoutId, cancellationToken)
+                        : RedirectToSubscriberPortal(portalSessionId);
+                }
+
+            case "update-auto-renewal":
+                session.Subscriber.AutoRenew = !session.Subscriber.AutoRenew;
+                await ctx.SaveChangesAsync(cancellationToken);
+                break;
+
+            case "cancel-scheduled-change":
+                session.Subscriber.NewPlanId = null;
+                session.Subscriber.NewPlan = null;
+                await ctx.SaveChangesAsync(cancellationToken);
+                TempData.SetStatusSuccess(StringLocalizer["Scheduled plan change cancelled."]);
+                break;
+
+            case "update-notification-email":
+                {
+                    var email = vm.NotificationEmail?.Trim();
+                    if (!string.IsNullOrEmpty(email) && !email.IsValidEmail())
+                    {
+                        TempData.SetStatusMessageModel(new StatusMessageModel
+                        {
+                            Message = StringLocalizer["Please enter a valid email address."],
+                            Severity = StatusMessageModel.StatusSeverity.Error
+                        });
+                        return RedirectToSubscriberPortal(portalSessionId);
+                    }
+                    session.Subscriber.Customer.NotificationEmail.Set(string.IsNullOrEmpty(email) ? null : email);
+                    await ctx.SaveChangesAsync(cancellationToken);
+                    TempData.SetStatusSuccess(StringLocalizer["Notification email updated."]);
+                    break;
+                }
         }
         return RedirectToSubscriberPortal(portalSessionId);
     }

--- a/BTCPayServer/Plugins/Subscriptions/SubscriberWebhookProvider.cs
+++ b/BTCPayServer/Plugins/Subscriptions/SubscriberWebhookProvider.cs
@@ -1,4 +1,4 @@
-﻿#nullable enable
+#nullable enable
 using System;
 using System.Threading.Tasks;
 using BTCPayServer.Client.Models;
@@ -31,7 +31,7 @@ public class SubscriberWebhookProvider : WebhookTriggerProvider<SubscriptionEven
         {
             ["Phase"] = evt.Subscriber.Phase.ToString(),
             // TODO: When the subscriber can customize the email, also check it!
-            ["Email"] = evt.Subscriber.Customer.Email.Get(),
+            ["Email"] = evt.Subscriber.Customer.NotificationEmail.Get() ?? evt.Subscriber.Customer.Email.Get(),
             ["Metadata"] = JObject.Parse(evt.Subscriber.Metadata)
         };
         model["Customer"] = new JObject()

--- a/BTCPayServer/Plugins/Subscriptions/Views/UISubscriberPortal/SubscriberPortal.cshtml
+++ b/BTCPayServer/Plugins/Subscriptions/Views/UISubscriberPortal/SubscriberPortal.cshtml
@@ -397,82 +397,98 @@
         </div>
         <div class="card-body">
             <div class="row">
-                <div class="col-md-6">
-                    <h6 class="mb-2">Payment Method</h6>
-                    <div class="d-flex justify-content-between align-items-center mb-3">
-                        <div class="d-flex align-items-center">
-                            <span class="badge bg-light text-dark border">Credit balance</span>
-                            <span
-                                class="ms-2 fw-semibold credit-balance">@creditBalance</span>
-                        </div>
-                        <button id="add-credit" class="btn btn-link p-0" type="button" data-bs-toggle="collapse" data-bs-target="#credit-input"
-                                aria-expanded="false"
-                                aria-controls="credit-input">
-                            <i class="fa fa-credit-card"></i>
-                            Add credit
-                        </button>
-                    </div>
-                    <div class="collapse" id="credit-input">
-                        <form method="post">
-                            <div class="input-group">
-                                <button type="submit" name="command" value="add-credit" class="btn btn-primary">Proceed to payment</button>
-                                <input inputmode="decimal" class="form-control" placeholder="Enter credit amount" asp-for="Credit.InputAmount" min="0"
-                                       required />
-                            </div>
-                            <span asp-validation-for="Credit.InputAmount" class="text-danger"></span>
-                        </form>
-                    </div>
-                    @if (Model.Subscriber.Plan.RecurringType is not PlanData.RecurringInterval.Lifetime)
-                    {
-                        <hr>
-                        <div class="d-flex justify-content-between credit-plan-price">
-                            <div class="text-muted">Plan price</div>
-                            <div>@DisplayFormatter.Currency(Model.Subscriber.Plan.Price, Model.Subscriber.Plan.Currency, DisplayFormatter.CurrencyFormat.Symbol)</div>
-                        </div>
-                        @if (Model.Credit.CreditApplied > 0m)
-                        {
-                            <div class="d-flex justify-content-between credit-applied">
-                                <div class="text-muted">Credit applied</div>
-                                <div class="text-success">
-                                    - @DisplayFormatter.Currency(Model.Credit.CreditApplied, Model.Credit.Currency, DisplayFormatter.CurrencyFormat.Symbol)</div>
-                            </div>
-                        }
-                        @if (Model.Credit.CreditApplied < 0m)
-                        {
-                            <div class="d-flex justify-content-between credit-past-due">
-                                <div class="text-muted">Past due</div>
-                                <div class="text-danger">
-                                    - @DisplayFormatter.Currency((-Model.Credit.CreditApplied), Model.Credit.Currency, DisplayFormatter.CurrencyFormat.Symbol)</div>
-                            </div>
-                        }
-                        <div class="d-flex justify-content-between fw-semibold credit-next-charge">
-                            <div>Next charge on @date</div>
-                            <div>@DisplayFormatter.Currency(Model.Credit.NextCharge, Model.Credit.Currency, DisplayFormatter.CurrencyFormat.Symbol)</div>
-                        </div>
-                        <form method="post" class="d-flex mt-3">
-                            <input type="hidden" name="command" value="update-auto-renewal" />
-                            <input type="checkbox" class="btcpay-toggle me-2" id="autoRenewal" asp-for="Subscriber.AutoRenew">
-                            <label class="form-check-label" for="autoRenewal">Auto renewal</label>
-                        </form>
-                    }
-                </div>
-                @if (Model.Subscriber.Plan.RecurringType is not PlanData.RecurringInterval.Lifetime)
-                {
-                    <div class="col-md-6">
-                        <h6 class="mb-2">Notification</h6>
-                        <p class="text-muted mb-0">
-                            @foreach (var identity in Model.Subscriber.Customer.CustomerIdentities)
-                            {
-                                <vc:contact type="@identity.Type" value="@identity.Value"></vc:contact>
-                            }
-                        </p>
-                        <p class="form-text mb-0">Payment reminder will be sent <span class="fw-bold">@Model.Subscriber.PaymentReminderDaysOrDefault days</span> before
-                            expiration.</p>
-                    </div>
-                }
+				<h6 class="mb-2">Payment Method</h6>
+				<div class="d-flex justify-content-between align-items-center mb-3">
+					<div class="d-flex align-items-center">
+						<span class="badge bg-light text-dark border">Credit balance</span>
+						<span class="ms-2 fw-semibold credit-balance">@creditBalance</span>
+					</div>
+					<button id="add-credit" class="btn btn-link p-0" type="button" data-bs-toggle="collapse" data-bs-target="#credit-input"
+							aria-expanded="false"
+							aria-controls="credit-input">
+						<i class="fa fa-credit-card"></i>
+						Add credit
+					</button>
+				</div>
+				<div class="collapse" id="credit-input">
+					<form method="post">
+						<div class="input-group">
+							<button type="submit" name="command" value="add-credit" class="btn btn-primary">Proceed to payment</button>
+							<input inputmode="decimal" class="form-control" placeholder="Enter credit amount" asp-for="Credit.InputAmount" min="0"
+									required />
+						</div>
+						<span asp-validation-for="Credit.InputAmount" class="text-danger"></span>
+					</form>
+				</div>
+				@if (Model.Subscriber.Plan.RecurringType is not PlanData.RecurringInterval.Lifetime)
+				{
+					<hr>
+					<div class="d-flex justify-content-between credit-plan-price">
+						<div class="text-muted">Plan price</div>
+						<div>@DisplayFormatter.Currency(Model.Subscriber.Plan.Price, Model.Subscriber.Plan.Currency, DisplayFormatter.CurrencyFormat.Symbol)</div>
+					</div>
+					@if (Model.Credit.CreditApplied > 0m)
+					{
+						<div class="d-flex justify-content-between credit-applied">
+							<div class="text-muted">Credit applied</div>
+							<div class="text-success">
+								- @DisplayFormatter.Currency(Model.Credit.CreditApplied, Model.Credit.Currency, DisplayFormatter.CurrencyFormat.Symbol)
+							</div>
+						</div>
+					}
+					@if (Model.Credit.CreditApplied < 0m)
+					{
+						<div class="d-flex justify-content-between credit-past-due">
+							<div class="text-muted">Past due</div>
+							<div class="text-danger">
+								- @DisplayFormatter.Currency((-Model.Credit.CreditApplied), Model.Credit.Currency, DisplayFormatter.CurrencyFormat.Symbol)
+							</div>
+						</div>
+					}
+					<div class="d-flex justify-content-between fw-semibold credit-next-charge">
+						<div>Next charge on @date</div>
+						<div>@DisplayFormatter.Currency(Model.Credit.NextCharge, Model.Credit.Currency, DisplayFormatter.CurrencyFormat.Symbol)</div>
+					</div>
+					<form method="post" class="d-flex mt-3">
+						<input type="hidden" name="command" value="update-auto-renewal" />
+						<input type="checkbox" class="btcpay-toggle me-2" id="autoRenewal" asp-for="Subscriber.AutoRenew">
+						<label class="form-check-label" for="autoRenewal">Auto renewal</label>
+					</form>
+				}
             </div>
         </div>
     </div>
+
+	@if (Model.Subscriber.Plan.RecurringType is not PlanData.RecurringInterval.Lifetime)
+	{
+		<div class="card">
+			<div class="card-header">
+				<i class="fa fa-bell me-2"></i>Notification
+			</div>
+			<div class="card-body">
+				<p class="text-muted mb-3">
+					@foreach (var identity in Model.Subscriber.Customer.CustomerIdentities)
+					{
+						<vc:contact type="@identity.Type" value="@identity.Value"></vc:contact>
+					}
+				</p>
+				<form method="post" class="mb-3">
+					<label class="form-label">Notification email</label>
+					<div class="input-group">
+						<span class="input-group-text"><i class="fa fa-envelope"></i></span>
+						<input type="email" name="NotificationEmail"
+								class="form-control" value="@Model.Subscriber.Customer.NotificationEmail.Get()"
+								placeholder="@Model.Subscriber.Customer.Email.Get()" />
+						<button type="submit" name="command" value="update-notification-email" class="btn btn-outline-secondary">
+							Update
+						</button>
+					</div>
+					<small class="text-muted">Leave blank to use subscription account email for notifications.</small>
+				</form>
+				<p class="form-text mb-0">Payment reminder will be sent <span class="fw-bold">@Model.Subscriber.PaymentReminderDaysOrDefault days</span> before expiration.</p>
+			</div>
+		</div>
+	}
 
     @if (Model.Plan.PlanChanges.Any())
     {

--- a/BTCPayServer/Plugins/Subscriptions/Views/UISubscriberPortal/SubscriberPortalViewModel.cs
+++ b/BTCPayServer/Plugins/Subscriptions/Views/UISubscriberPortal/SubscriberPortalViewModel.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using BTCPayServer.Data.Subscriptions;
 using BTCPayServer.Models;
@@ -88,6 +88,8 @@ public class SubscriberPortalViewModel
     [BindingBehavior(BindingBehavior.Never)]
     [ValidateNever]
     public PlanData Plan => Data.Subscriber.Plan;
+    [ValidateNever]
+    public string NotificationEmail { get; set; }
 
     public string Anchor { get; set; }
     public string Url { get; set; }


### PR DESCRIPTION

Breaking down subscription portal improvements into smaller PR (https://github.com/btcpayserver/btcpayserver/pull/7284)

This PR allows subscribers and customers to be able to give a notification email 


<img width="2100" height="1217" alt="image" src="https://github.com/user-attachments/assets/1385ac01-0612-478c-b7fd-d5cdb771830f" />

Cc. @NicolasDorier 