### PR TITLE
Include get subscribers API

### DIFF
--- a/BTCPayServer/Plugins/Subscriptions/Controllers/GreenfieldOfferingController.cs
+++ b/BTCPayServer/Plugins/Subscriptions/Controllers/GreenfieldOfferingController.cs
@@ -286,6 +286,17 @@ namespace BTCPayServer.Plugins.Subscriptions.Controllers
             return Ok(Mapper.MapToSubscriberModel(subscriber));
         }
 
+        [HttpGet("~/api/v1/stores/{storeId}/offerings/{offeringId}/subscribers")]
+        public async Task<IActionResult> GetSubscribers(string storeId, string offeringId)
+        {
+            var offering = await ctx.Offerings.GetOfferingData(offeringId, storeId: storeId, fetchPlanFeatures: true);
+            if (offering is null)
+                return OfferingNotFound();
+
+            var subscribers = await ctx.Subscribers.IncludeAll().Where(s => s.OfferingId == offeringId).ToListAsync();
+            return Ok(subscribers.Select(Mapper.MapToSubscriberModel));
+        }
+
         [Authorize(AuthenticationSchemes = AuthenticationSchemes.Greenfield, Policy = SubscriptionsPolicies.CanManageSubscribers)]
         [HttpDelete("~/api/v1/stores/{storeId}/offerings/{offeringId}/subscribers/{customerSelector}")]
         public async Task<IActionResult> DeleteSubscriber(string storeId, string offeringId,

--- a/BTCPayServer/wwwroot/swagger/v1/swagger.template.subscriptions.json
+++ b/BTCPayServer/wwwroot/swagger/v1/swagger.template.subscriptions.json
@@ -327,6 +327,50 @@
                 }
             }
         },
+        "/api/v1/stores/{storeId}/offerings/{offeringId}/subscribers": {
+            "get": {
+                "summary": "Get all subscribers",
+                "description": "Retrieves all subscribers for a specific offering.",
+                "operationId": "GetSubscribers",
+                "tags": [
+                    "Subscriptions"
+                ],
+                "security": [
+                    {
+                        "API_Key": [
+                            "btcpay.store.canviewofferings"
+                        ],
+                        "Basic": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/StoreId"
+                    },
+                    {
+                        "$ref": "#/components/parameters/OfferingId"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Subscribers retrieved successfully.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/SubscriberModel"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Offering not found."
+                    }
+                }
+            }
+        },
         "/api/v1/stores/{storeId}/offerings/{offeringId}/subscribers/{customerSelector}": {
             "get": {
                 "summary": "Get a subscriber",


### PR DESCRIPTION

Breaking down subscription portal improvements into smaller PR (https://github.com/btcpayserver/btcpayserver/pull/7284)

This PR adds GET subscribers (API)

<img width="2650" height="975" alt="image" src="https://github.com/user-attachments/assets/128d3639-5733-4e61-a143-fb1442b12541" />

<img width="2647" height="1330" alt="image" src="https://github.com/user-attachments/assets/6b744ea1-3167-4dcd-9190-1364c14110fe" />


Cc. @NicolasDorier 