### PR TITLE
Fix reserved addresses after wallet replacement

### DIFF
--- a/BTCPayServer.Tests/WalletTests.cs
+++ b/BTCPayServer.Tests/WalletTests.cs
@@ -515,6 +515,89 @@ public class WalletTests(ITestOutputHelper helper) : UnitTestBase(helper)
 
     [Fact]
     [Trait("Playwright", "Playwright-2")]
+    public async Task CanHideReservedAddressesFromReplacedWallet()
+    {
+        await using var s = CreatePlaywrightTester();
+        await s.StartAsync();
+        await s.RegisterNewUser(true);
+        await s.CreateNewStore();
+        var walletId = new WalletId(s.StoreId, "BTC");
+        s.WalletId = walletId;
+        var originalMnemonic = (await s.GenerateWallet()).ToString();
+
+        await s.GoToWallet(walletId, WalletsNavPages.Receive);
+
+        List<string> oldAddresses = [];
+        var currentAddress = await s.Page.GetAttributeAsync("#Address", "data-text") ?? string.Empty;
+        Assert.False(string.IsNullOrEmpty(currentAddress));
+        oldAddresses.Add(currentAddress);
+
+        for (var i = 0; i < 2; i++)
+        {
+            await s.Page.ClickAsync("button[value=generate-new-address]");
+            await TestUtils.EventuallyAsync(async () =>
+            {
+                var newAddress = await s.Page.GetAttributeAsync("#Address[data-text]", "data-text");
+                Assert.False(string.IsNullOrEmpty(newAddress));
+                Assert.NotEqual(currentAddress, newAddress);
+            });
+
+            currentAddress = await s.Page.GetAttributeAsync("#Address", "data-text") ?? string.Empty;
+            Assert.False(string.IsNullOrEmpty(currentAddress));
+            oldAddresses.Add(currentAddress);
+        }
+
+        await s.Page.ClickAsync("#reserved-addresses-button");
+        await s.Page.WaitForSelectorAsync("#reserved-addresses");
+        const string labelInputSelector = "#reserved-addresses table tbody tr .ts-control input";
+        await s.Page.WaitForSelectorAsync(labelInputSelector);
+        await s.Page.FillAsync(labelInputSelector, "old-wallet-label");
+        await s.Page.Keyboard.PressAsync("Enter");
+        await TestUtils.EventuallyAsync(async () =>
+        {
+            var text = await s.Page.InnerTextAsync("#reserved-addresses table tbody");
+            Assert.Contains("old-wallet-label", text);
+        });
+        var oldReservedAddressesPage = await s.Page.ContentAsync();
+        foreach (var oldAddress in oldAddresses)
+        {
+            Assert.Contains(oldAddress, oldReservedAddressesPage);
+        }
+
+        await s.GenerateWallet(seed: "melody lizard phrase voice unique car opinion merge degree evil swift cargo");
+        await s.GoToWallet(walletId, WalletsNavPages.Receive);
+
+        var newAddress = await s.Page.GetAttributeAsync("#Address", "data-text") ?? string.Empty;
+        Assert.False(string.IsNullOrEmpty(newAddress));
+        Assert.DoesNotContain(newAddress, oldAddresses);
+
+        await s.Page.ClickAsync("#reserved-addresses-button");
+        await s.Page.WaitForSelectorAsync("#reserved-addresses");
+
+        var replacedWalletReservedAddressesPage = await s.Page.ContentAsync();
+        Assert.Contains(newAddress, replacedWalletReservedAddressesPage);
+        Assert.DoesNotContain("old-wallet-label", replacedWalletReservedAddressesPage);
+        foreach (var oldAddress in oldAddresses)
+        {
+            Assert.DoesNotContain(oldAddress, replacedWalletReservedAddressesPage);
+        }
+
+        await s.GenerateWallet(seed: originalMnemonic);
+        await s.GoToWallet(walletId, WalletsNavPages.Receive);
+        await s.Page.ClickAsync("#reserved-addresses-button");
+        await s.Page.WaitForSelectorAsync("#reserved-addresses");
+
+        var restoredWalletReservedAddressesPage = await s.Page.ContentAsync();
+        Assert.DoesNotContain(newAddress, restoredWalletReservedAddressesPage);
+        Assert.Contains("old-wallet-label", restoredWalletReservedAddressesPage);
+        foreach (var oldAddress in oldAddresses)
+        {
+            Assert.Contains(oldAddress, restoredWalletReservedAddressesPage);
+        }
+    }
+
+    [Fact]
+    [Trait("Playwright", "Playwright-2")]
     public async Task CanUseBumpFee()
     {
         await using var s = CreatePlaywrightTester();

--- a/BTCPayServer/Controllers/UIWalletsController.cs
+++ b/BTCPayServer/Controllers/UIWalletsController.cs
@@ -1,6 +1,7 @@
 #nullable enable
 using System;
 using System.Collections.Generic;
+using System.Data.Common;
 using System.Globalization;
 using System.Linq;
 using System.Net.Mime;
@@ -804,6 +805,25 @@ namespace BTCPayServer.Controllers
                 return NotFound();
 
             var labeledAddresses = await WalletRepository.GetReservedAddressesWithDetails(walletId);
+            if (labeledAddresses.Count != 0)
+            {
+                var connectionFactory = ServiceProvider.GetRequiredService<NBXplorerConnectionFactory>();
+                if (!connectionFactory.Available)
+                {
+                    TempData[WellKnownTempData.ErrorMessage] = StringLocalizer["Reserved Addresses requires access to the NBXplorer database."].Value;
+                    return RedirectToAction(nameof(WalletReceive), new { walletId });
+                }
+
+                try
+                {
+                    labeledAddresses = await FilterReservedAddressesToCurrentDerivation(connectionFactory, walletId, paymentMethod, labeledAddresses);
+                }
+                catch (DbException)
+                {
+                    TempData[WellKnownTempData.ErrorMessage] = StringLocalizer["Reserved Addresses is temporarily unavailable because the NBXplorer database cannot be reached."].Value;
+                    return RedirectToAction(nameof(WalletReceive), new { walletId });
+                }
+            }
 
             var vm = new ReservedAddressesViewModel
             {
@@ -813,6 +833,45 @@ namespace BTCPayServer.Controllers
             };
 
             return View(vm);
+        }
+
+        private async Task<List<ReservedAddress>> FilterReservedAddressesToCurrentDerivation(
+            NBXplorerConnectionFactory connectionFactory,
+            WalletId walletId,
+            DerivationSchemeSettings paymentMethod,
+            List<ReservedAddress> labeledAddresses)
+        {
+            if (labeledAddresses.Count == 0 || paymentMethod.AccountDerivation is null)
+                return labeledAddresses;
+
+            var addresses = labeledAddresses.Select(a => a.Address).ToArray();
+            var currentWalletId = NBXplorer.Client.DBUtils.nbxv1_get_wallet_id(
+                walletId.CryptoCode,
+                paymentMethod.AccountDerivation.ToString());
+
+            await using var conn = await connectionFactory.OpenConnection();
+            var activeAddresses = (await conn.QueryAsync<string>(
+                """
+                SELECT DISTINCT searched.addr
+                FROM unnest(@addresses) AS searched(addr)
+                JOIN scripts s
+                  ON s.code = @code
+                 AND s.addr = searched.addr
+                JOIN wallets_scripts ws
+                  ON ws.code = s.code
+                 AND ws.script = s.script
+                WHERE ws.wallet_id = @walletId
+                """,
+                new
+                {
+                    addresses,
+                    code = walletId.CryptoCode,
+                    walletId = currentWalletId
+                })).ToHashSet(StringComparer.Ordinal);
+
+            return labeledAddresses
+                .Where(address => activeAddresses.Contains(address.Address))
+                .ToList();
         }
 
         private async Task SendFreeMoney(Cheater cheater, WalletId walletId, DerivationSchemeSettings paymentMethod)


### PR DESCRIPTION
Fixes #7295.

Clears persisted reserved receive address markers when an on-chain wallet is replaced or deleted, so old addresses no longer appear in Reserved Addresses.

Adds a Playwright regression test for the wallet replacement flow.
