### PR TITLE
PoS: Unpermissioned store users can browse login links and invoices from Update PoS page

### DIFF
--- a/BTCPayServer.Abstractions/TagHelpers/PermissionedFormTagHelper.cs
+++ b/BTCPayServer.Abstractions/TagHelpers/PermissionedFormTagHelper.cs
@@ -7,6 +7,9 @@ using Microsoft.AspNetCore.Razor.TagHelpers;
 namespace BTCPayServer.Abstractions.TagHelpers;
 
 [HtmlTargetElement("form", Attributes = "[permissioned]")]
+[HtmlTargetElement("div", Attributes = "[permissioned]")]
+[HtmlTargetElement("button", Attributes = "[permissioned]")]
+[HtmlTargetElement("input", Attributes = "[permissioned]")]
 public partial class PermissionedFormTagHelper(
     IAuthorizationService authorizationService,
     IHttpContextAccessor httpContextAccessor)
@@ -24,9 +27,16 @@ public partial class PermissionedFormTagHelper(
             PermissionResource, Permissioned);
         if (!res.Succeeded)
         {
-            var content = await output.GetChildContentAsync();
-            var html = SubmitButtonRegex().Replace(content.GetContent(), "");
-            output.Content.SetHtmlContent($"<fieldset disabled>{html}</fieldset>");
+            if (context.TagName is "input" or "button")
+            {
+                output.Attributes.Add("disabled", "disabled");
+            }
+            else
+            {
+                var content = await output.GetChildContentAsync();
+                var html = SubmitButtonRegex().Replace(content.GetContent(), "");
+                output.Content.SetHtmlContent($"<fieldset disabled>{html}</fieldset>");
+            }
         }
     }
 

--- a/BTCPayServer/Plugins/Crowdfund/Views/NavExtension.cshtml
+++ b/BTCPayServer/Plugins/Crowdfund/Views/NavExtension.cshtml
@@ -20,10 +20,8 @@
     @if (apps.Any())
     {
         <li layout-menu-item="CreateApp-@appType.Type" class="nav-item" not-permission="@Policies.CanModifyStoreSettings" permission="@Policies.CanViewStoreSettings">
-            <span class="nav-link">
-                <vc:icon symbol="nav-crowdfund" />
-				<span text-translate="true">Crowdfund</span>
-            </span>
+            <vc:icon symbol="nav-crowdfund" />
+			<span text-translate="true">Crowdfund</span>
         </li>
     }
     @foreach (var app in apps)

--- a/BTCPayServer/Plugins/PointOfSale/Views/NavExtension.cshtml
+++ b/BTCPayServer/Plugins/PointOfSale/Views/NavExtension.cshtml
@@ -20,10 +20,8 @@
     @if (apps.Any())
     {
         <li layout-menu-item="CreateApp-@appType.Type" not-permission="@Policies.CanModifyStoreSettings" permission="@Policies.CanViewStoreSettings">
-            <span class="nav-link">
-                <vc:icon symbol="nav-pointofsale" />
-				<span text-translate="true">Point of Sale</span>
-            </span>
+            <vc:icon symbol="nav-pointofsale" />
+			<span text-translate="true">Point of Sale</span>
         </li>
     }
     @foreach (var app in apps)

--- a/BTCPayServer/Plugins/PointOfSale/Views/UpdatePointOfSale.cshtml
+++ b/BTCPayServer/Plugins/PointOfSale/Views/UpdatePointOfSale.cshtml
@@ -25,15 +25,15 @@
     <script src="~/pos/admin.js" asp-append-version="true"></script>
 }
 
-<form method="post" permissioned="@Policies.CanModifyStoreSettings">
+<form method="post">
     <div class="sticky-header">
         <h2>@ViewData["Title"]</h2>
         <div>
-            <button id="page-primary" type="submit" class="btn btn-primary order-sm-1" text-translate="true">Save</button>
+            <button id="page-primary" type="submit" class="btn btn-primary order-sm-1" text-translate="true" permissioned="@Policies.CanModifyStoreSettings">Save</button>
             <a class="btn btn-secondary" asp-action="ListInvoices" asp-controller="UIInvoice" asp-route-storeId="@Model.StoreId" asp-route-searchterm="@Model.SearchTerm" text-translate="true">Invoices</a>
             @if (Model.Archived)
             {
-                <button type="submit" class="btn btn-outline-secondary" name="Archived" value="False" text-translate="true">Unarchive</button>
+                <button type="submit" class="btn btn-outline-secondary" name="Archived" value="False" text-translate="true" permissioned="@Policies.CanModifyStoreSettings">Unarchive</button>
             }
             else
             {
@@ -56,7 +56,7 @@
     {
         <div asp-validation-summary="All" class="@(ViewContext.ModelState.ErrorCount.Equals(1) ? "no-marker" : "")"></div>
     }
-    <div class="row" style="max-width:540px;">
+    <div permissioned="@Policies.CanModifyStoreSettings" class="row" style="max-width:540px;">
         <div class="col-sm-6">
             <div class="form-group">
                 <label asp-for="AppName" class="form-label" data-required></label>


### PR DESCRIPTION
Those three buttons are now clickable to store users without permissions to modify the store.

<img width="2008" height="896" alt="image" src="https://github.com/user-attachments/assets/a4983794-89ff-4908-9e9a-be61d6234856" />
