### PR TITLE
Remove support for importing keys to RPC

### DIFF
--- a/BTCPayServer.Client/Models/GenerateOnChainWalletRequest.cs
+++ b/BTCPayServer.Client/Models/GenerateOnChainWalletRequest.cs
@@ -23,7 +23,6 @@ namespace BTCPayServer.Client
         [JsonConverter(typeof(StringEnumConverter))]
         public NBitcoin.ScriptPubKeyType ScriptPubKeyType { get; set; } = ScriptPubKeyType.Segwit;
         public string Passphrase { get; set; }
-        public bool ImportKeysToRPC { get; set; }
         public bool SavePrivateKeys { get; set; }
     }
     public class GenerateOnChainWalletResponse : GenericPaymentMethodData

--- a/BTCPayServer.Tests/GreenfieldAPITests.cs
+++ b/BTCPayServer.Tests/GreenfieldAPITests.cs
@@ -2446,12 +2446,11 @@ namespace BTCPayServer.Tests
                 await viewOnlyClient.GenerateOnChainWallet(store.Id, "BTC", new GenerateOnChainWalletRequest() { });
             });
 
-            await AssertValidationError(new[] { "SavePrivateKeys", "ImportKeysToRPC" }, async () =>
+            await AssertValidationError(new[] { "SavePrivateKeys" }, async () =>
               {
                   await client2.GenerateOnChainWallet(user2.StoreId, "BTC", new GenerateOnChainWalletRequest()
                   {
-                      SavePrivateKeys = true,
-                      ImportKeysToRPC = true
+                      SavePrivateKeys = true
                   });
               });
 

--- a/BTCPayServer.Tests/PayJoinTests.cs
+++ b/BTCPayServer.Tests/PayJoinTests.cs
@@ -247,11 +247,11 @@ namespace BTCPayServer.Tests
             await s.StartAsync();
             await s.RegisterNewUser(true);
             var receiver = await s.CreateNewStore();
-            await s.GenerateWallet("BTC", "", true, true);
+            await s.GenerateWallet("BTC", "", true);
             var receiverWalletId = new WalletId(receiver.storeId, "BTC");
 
             var sender = await s.CreateNewStore();
-            await s.GenerateWallet("BTC", "", true, true);
+            await s.GenerateWallet("BTC", "", true);
             var senderWalletId = new WalletId(sender.storeId, "BTC");
 
             await s.Server.ExplorerNode.GenerateAsync(1);
@@ -315,7 +315,7 @@ namespace BTCPayServer.Tests
             {
                 var cryptoCode = "BTC";
                 var receiver = await s.CreateNewStore();
-                await s.GenerateWallet(cryptoCode, "", true, true, format);
+                await s.GenerateWallet(cryptoCode, "", true, format);
                 var receiverWalletId = new WalletId(receiver.storeId, cryptoCode);
 
                 //payjoin is enabled by default.
@@ -328,7 +328,7 @@ namespace BTCPayServer.Tests
                 await Expect(s.Page.Locator("#PayJoinEnabled")).ToBeCheckedAsync();
 
                 var sender = await s.CreateNewStore();
-                await s.GenerateWallet(cryptoCode, "", true, true, format);
+                await s.GenerateWallet(cryptoCode, "", true, format);
                 var senderWalletId = new WalletId(sender.storeId, cryptoCode);
                 await s.Server.ExplorerNode.GenerateAsync(1);
                 await s.FundStoreWallet(senderWalletId);

--- a/BTCPayServer.Tests/PlaywrightTester.cs
+++ b/BTCPayServer.Tests/PlaywrightTester.cs
@@ -264,7 +264,7 @@ namespace BTCPayServer.Tests
             return (name, storeId);
         }
 
-        public async Task<Mnemonic> GenerateWallet(string cryptoCode = "BTC", string seed = "", bool? importkeys = null, bool isHotWallet = false,
+        public async Task<Mnemonic> GenerateWallet(string cryptoCode = "BTC", string seed = "", bool isHotWallet = false,
             ScriptPubKeyType format = ScriptPubKeyType.Segwit)
         {
             var isImport = !string.IsNullOrEmpty(seed);
@@ -298,8 +298,6 @@ namespace BTCPayServer.Tests
 
             await Page.SelectOptionAsync("#ScriptPubKeyType", new SelectOptionValue { Value = format.ToString() });
             await Page.ClickAsync("#AdvancedSettingsButton");
-            if (importkeys is bool v)
-                await Page.Locator("#ImportKeysToRPC").SetCheckedAsync(v);
             await Page.ClickAsync("#Continue");
 
             if (isImport)

--- a/BTCPayServer.Tests/PullPaymentsTests.cs
+++ b/BTCPayServer.Tests/PullPaymentsTests.cs
@@ -48,7 +48,7 @@ public class PullPaymentsTests(ITestOutputHelper helper) : UnitTestBase(helper)
         await s.Server.EnsureChannelsSetup();
         await s.RegisterNewUser(true);
         await s.CreateNewStore();
-        await s.GenerateWallet("BTC", "", true, true);
+        await s.GenerateWallet("BTC", "", true);
 
         await s.Server.ExplorerNode.GenerateAsync(1);
         await s.FundStoreWallet(denomination: 50.0m);
@@ -155,7 +155,7 @@ public class PullPaymentsTests(ITestOutputHelper helper) : UnitTestBase(helper)
         //offline/external payout test
 
         await s.CreateNewStore();
-        await s.GenerateWallet("BTC", "", true, true);
+        await s.GenerateWallet("BTC", "", true);
         await s.GoToStore(s.StoreId, StoreNavPages.PullPayments);
 
         await s.ClickPagePrimary();
@@ -214,7 +214,7 @@ public class PullPaymentsTests(ITestOutputHelper helper) : UnitTestBase(helper)
         await s.AddLightningNode();
 
         //Currently an onchain wallet is required to use the Lightning payouts feature…
-        await s.GenerateWallet("BTC", "", true, true);
+        await s.GenerateWallet("BTC", "", true);
         await s.GoToStore(newStore.storeId, StoreNavPages.PullPayments);
         await s.ClickPagePrimary();
 
@@ -1021,7 +1021,7 @@ public class PullPaymentsTests(ITestOutputHelper helper) : UnitTestBase(helper)
         await s.StartAsync();
         await s.RegisterNewUser(true);
         await s.CreateNewStore();
-        await s.GenerateWallet("BTC", "", true, true);
+        await s.GenerateWallet("BTC", "", true);
         await s.Server.ExplorerNode.GenerateAsync(1);
         await s.FundStoreWallet(denomination: 50.0m);
 

--- a/BTCPayServer.Tests/TestAccount.cs
+++ b/BTCPayServer.Tests/TestAccount.cs
@@ -177,7 +177,7 @@ namespace BTCPayServer.Tests
         }
 
         public async Task<WalletId> RegisterDerivationSchemeAsync(string cryptoCode, ScriptPubKeyType segwit = ScriptPubKeyType.Legacy,
-            bool importKeysToNBX = false, bool importsKeysToBitcoinCore = false)
+            bool importKeysToNBX = false)
         {
             if (StoreId is null)
                 await CreateStoreAsync();
@@ -188,7 +188,6 @@ namespace BTCPayServer.Tests
             {
                 ScriptPubKeyType = segwit,
                 SavePrivateKeys = importKeysToNBX,
-                ImportKeysToRPC = importsKeysToBitcoinCore
             };
 
             await store.GenerateWallet(StoreId, cryptoCode, WalletSetupMethod.HotWallet, generateRequest);

--- a/BTCPayServer.Tests/WalletTests.cs
+++ b/BTCPayServer.Tests/WalletTests.cs
@@ -31,7 +31,7 @@ public class WalletTests(ITestOutputHelper helper) : UnitTestBase(helper)
         await s.StartAsync();
         await s.RegisterNewUser(true);
         (_, string storeId) = await s.CreateNewStore();
-        await s.GenerateWallet("BTC", "", false, true);
+        await s.GenerateWallet("BTC", "", false);
         var walletId = new WalletId(storeId, "BTC");
 
         await s.GoToWallet(walletId, WalletsNavPages.Receive);
@@ -242,7 +242,7 @@ public class WalletTests(ITestOutputHelper helper) : UnitTestBase(helper)
         await wt.AssertHasLabels("label2");
 
         //change the wallet and ensure old address is not there and generating a new one does not result in the prev one
-        await s.GenerateWallet(importkeys: true, isHotWallet: true);
+        await s.GenerateWallet(isHotWallet: true);
         await s.GoToWallet(null, WalletsNavPages.Receive);
         await s.Page.ClickAsync("button[value=generate-new-address]");
         var newAddr = await s.Page.Locator("#Address").GetAttributeAsync("data-text");
@@ -258,7 +258,7 @@ public class WalletTests(ITestOutputHelper helper) : UnitTestBase(helper)
             await s.Server.ExplorerNode.GetAddressInfoAsync(BitcoinAddress.Create(address, Network.RegTest));
         Assert.False(result.IsWatchOnly);
         await s.GoToStore(storeId);
-        var mnemonic = await s.GenerateWallet(cryptoCode, "", true, true);
+        var mnemonic = await s.GenerateWallet(cryptoCode, "", true);
 
         //let's import and save private keys
         invoiceId = await s.CreateInvoice(storeId);
@@ -715,7 +715,7 @@ public class WalletTests(ITestOutputHelper helper) : UnitTestBase(helper)
         await s.StartAsync();
         await s.RegisterNewUser(true);
         var (_, storeId) = await s.CreateNewStore();
-        await s.GenerateWallet("BTC", "", false, true);
+        await s.GenerateWallet("BTC", "", true);
         var walletId = new WalletId(storeId, "BTC");
         await s.GoToWallet(walletId, WalletsNavPages.Receive);
         var addressStr = await s.Page.Locator("#Address").GetAttributeAsync("data-text");

--- a/BTCPayServer/Controllers/GreenField/GreenfieldStoreOnChainPaymentMethodsController.WalletGeneration.cs
+++ b/BTCPayServer/Controllers/GreenField/GreenfieldStoreOnChainPaymentMethodsController.WalletGeneration.cs
@@ -49,12 +49,6 @@ namespace BTCPayServer.Controllers.Greenfield
                     "This instance forbids non-admins from having a hot wallet for your store.");
             }
 
-            if (request.ImportKeysToRPC && !canUseHotWallet.CanRPCImport)
-            {
-                ModelState.AddModelError(nameof(request.ImportKeysToRPC),
-                    "This instance forbids non-admins from having importing the wallet addresses/keys to the underlying node.");
-            }
-
             if (!ModelState.IsValid)
             {
                 return this.CreateValidationError(ModelState);
@@ -72,7 +66,6 @@ namespace BTCPayServer.Controllers.Greenfield
                     WordCount = request.WordCount,
                     ScriptPubKeyType = request.ScriptPubKeyType,
                     Passphrase = request.Passphrase,
-                    ImportKeysToRPC = request.ImportKeysToRPC,
                     SavePrivateKeys = request.SavePrivateKeys,
                 });
                 if (response == null)
@@ -105,7 +98,7 @@ namespace BTCPayServer.Controllers.Greenfield
                 derivationSchemeSettings);
             store.SetStoreBlob(storeBlob);
             await _storeRepository.UpdateStore(store);
-            
+
             var result = new GenerateOnChainWalletResponse()
             {
                 Enabled = !storeBlob.IsExcluded(paymentMethodId),

--- a/BTCPayServer/Controllers/UIStoresController.Onchain.cs
+++ b/BTCPayServer/Controllers/UIStoresController.Onchain.cs
@@ -253,7 +253,6 @@ public partial class UIStoresController
 
         var perm = await CanUseHotWallet();
         if ((!perm.CanCreateHotWallet && request.SavePrivateKeys) ||
-            (!perm.CanRPCImport && request.ImportKeysToRPC) ||
             (!perm.CanCreateColdWallet && !request.SavePrivateKeys))
         {
             return NotFound();
@@ -429,7 +428,6 @@ public partial class UIStoresController
             PayJoinEnabled = storeBlob.PayJoinEnabled,
             CanUsePayJoin = perm.CanCreateHotWallet && network.SupportPayJoin && derivation.IsHotWallet,
             CanUseHotWallet = perm.CanCreateHotWallet,
-            CanUseRPCImport = perm.CanRPCImport,
             StoreName = store.StoreName,
             CanSetupMultiSig = (derivation.AccountKeySettings ?? []).Length > 1,
             IsMultiSigOnServer = derivation.IsMultiSigOnServer,

--- a/BTCPayServer/Extensions/AuthorizationExtensions.cs
+++ b/BTCPayServer/Extensions/AuthorizationExtensions.cs
@@ -10,7 +10,7 @@ using Microsoft.AspNetCore.Authorization;
 
 namespace BTCPayServer
 {
-    public record WalletCreationPermissions(bool CanCreateHotWallet, bool CanCreateColdWallet, bool CanRPCImport);
+    public record WalletCreationPermissions(bool CanCreateHotWallet, bool CanCreateColdWallet);
     public static class AuthorizationExtensions
     {
         public static async Task<bool> CanModifyStore(this IAuthorizationService authorizationService, ClaimsPrincipal user)
@@ -24,20 +24,19 @@ namespace BTCPayServer
             ClaimsPrincipal user)
         {
             if (user.Identity?.IsAuthenticated is not true)
-                return new(false, false, false);
+                return new(false, false);
             var claimUser = user.Identity as ClaimsIdentity;
             if (claimUser is null)
-                return new(false, false, false);
+                return new(false, false);
 
             bool isAdmin = false;
             if (claimUser.AuthenticationType == AuthenticationSchemes.Cookie)
                 isAdmin = user.IsInRole(Roles.ServerAdmin);
             else if (claimUser.AuthenticationType == GreenfieldConstants.AuthenticationType)
                 isAdmin = (await authorizationService.AuthorizeAsync(user, Policies.CanModifyServerSettings)).Succeeded;
-            return isAdmin ? new(true, true, true) :
+            return isAdmin ? new(true, true) :
                    new(policiesSettings?.AllowHotWalletForAll is true,
-                   policiesSettings?.AllowCreateColdWalletForAll is true,
-                   policiesSettings?.AllowHotWalletRPCImportForAll is true);
+                   policiesSettings?.AllowCreateColdWalletForAll is true);
         }
     }
 }

--- a/BTCPayServer/Models/StoreViewModels/DerivationSchemeViewModel.cs
+++ b/BTCPayServer/Models/StoreViewModels/DerivationSchemeViewModel.cs
@@ -34,8 +34,6 @@ namespace BTCPayServer.Models.StoreViewModels
         public bool CanUseHotWallet { get; set; }
         [Display(Name = "Can create a new cold wallet")]
         public bool CanCreateNewColdWallet { get; set; }
-        [Display(Name = "Can use RPC import")]
-        public bool CanUseRPCImport { get; set; }
         public bool SupportSegwit { get; set; }
         public bool SupportTaproot { get; set; }
         public RootedKeyPath GetAccountKeypath()

--- a/BTCPayServer/Models/StoreViewModels/WalletSetupViewModel.cs
+++ b/BTCPayServer/Models/StoreViewModels/WalletSetupViewModel.cs
@@ -41,13 +41,11 @@ namespace BTCPayServer.Models.StoreViewModels
         {
             this.CanCreateNewColdWallet = perm.CanCreateColdWallet;
             this.CanUseHotWallet = perm.CanCreateHotWallet;
-            this.CanUseRPCImport = perm.CanRPCImport;
         }
         public void SetViewData(ViewDataDictionary ViewData)
         {
             ViewData.Add(nameof(CanUseHotWallet), CanUseHotWallet);
             ViewData.Add(nameof(CanCreateNewColdWallet), CanCreateNewColdWallet);
-            ViewData.Add(nameof(CanUseRPCImport), CanUseRPCImport);
             ViewData.Add(nameof(SupportSegwit), SupportSegwit);
             ViewData.Add(nameof(SupportTaproot), SupportTaproot);
             ViewData.Add(nameof(Method), Method);

--- a/BTCPayServer/Services/PoliciesSettings.cs
+++ b/BTCPayServer/Services/PoliciesSettings.cs
@@ -55,9 +55,6 @@ namespace BTCPayServer.Services
         [Display(Name = "Non-admins can create Cold Wallets for their Store")]
         public bool AllowCreateColdWalletForAll { get; set; }
 
-        [Display(Name = "Non-admins can import Hot Wallets for their Store")]
-        public bool AllowHotWalletRPCImportForAll { get; set; }
-
         [Display(Name = "Check releases on GitHub and notify when new BTCPay Server version is available")]
         public bool CheckForNewVersions { get; set; }
 

--- a/BTCPayServer/Views/UIServer/Policies.cshtml
+++ b/BTCPayServer/Views/UIServer/Policies.cshtml
@@ -134,17 +134,6 @@
 							<span asp-validation-for="AllowCreateColdWalletForAll" class="text-danger"></span>
 						</div>
 					</div>
-                    <div class="d-flex my-3">
-                        <input asp-for="AllowHotWalletRPCImportForAll" type="checkbox" class="btcpay-toggle me-3"/>
-                        <div>
-                            <label asp-for="AllowHotWalletRPCImportForAll" class="form-check-label"></label>
-                            <span asp-validation-for="AllowHotWalletRPCImportForAll" class="text-danger"></span>
-                            <div class="info-note mt-2 text-warning" role="alert">
-                                <vc:icon symbol="warning"/>
-                                <span text-translate="true">Caution: Enabling this option, may simplify the onboarding and spending for third-parties but carries liabilities and security risks associated to storing private keys of third parties on a server.</span>
-                            </div>
-                        </div>
-                    </div>
                 </div>
 
                 <div class="mb-5">

--- a/BTCPayServer/Views/UIStores/_GenerateWalletForm.cshtml
+++ b/BTCPayServer/Views/UIStores/_GenerateWalletForm.cshtml
@@ -6,7 +6,6 @@
     var isImport = method is WalletSetupMethod.Seed;
     var isHotWallet = method is WalletSetupMethod.HotWallet;
     var canUseHotWallet = ViewData["CanUseHotWallet"] is true;
-    var canUseRpcImport = ViewData["CanUseRPCImport"] is true;
 }
 
 @if (!User.IsInRole(Roles.ServerAdmin))
@@ -83,17 +82,17 @@
                             </a>
                         </p>
                     </div>
-                </label>                 
+                </label>
             </div>
         }
     }
-    
+
     <div class="mb-4">
         <button class="d-inline-flex align-items-center btn btn-link text-primary fw-semibold p-0" type="button" id="AdvancedSettingsButton" data-bs-toggle="collapse" data-bs-target="#AdvancedSettings" aria-expanded="false" aria-controls="AdvancedSettings">
             <vc:icon symbol="caret-down"/>
             <span class="ms-1" text-translate="true">Advanced settings</span>
         </button>
-        <div id="AdvancedSettings" class="collapse @(string.IsNullOrEmpty(Model.Passphrase) && !Model.ImportKeysToRPC ? "" : "show")">
+        <div id="AdvancedSettings" class="collapse @(string.IsNullOrEmpty(Model.Passphrase) ? "" : "show")">
             <div class="pt-3">
                 @if (isImport) // hide account option when creating a wallet
                 {
@@ -113,26 +112,6 @@
                     <input type="text" name="passphrase_conf" id="passphrase_conf" class="form-control"/>
                     <span class="text-danger field-validation-valid" id="passphrase_conf_validation"></span>
                 </div>
-
-                @if (canUseRpcImport)
-                {
-                    <div class="form-group mt-4">
-                        <label class="d-flex align-items-center">
-                            <input type="checkbox" asp-for="ImportKeysToRPC" class="btcpay-toggle me-3"/>
-                            <div>
-                                <label asp-for="ImportKeysToRPC" class="form-check-label" text-translate="true">Import keys to RPC</label>
-                                <span asp-validation-for="ImportKeysToRPC" class="text-danger"></span>
-                                <p class="text-muted pt-2 mb-0">
-                                    <span text-translate="true">Each address generated will be imported into the node wallet and you can view your balance through the node.</span>
-                                    @if (isImport || isHotWallet)
-                                    {
-                                        <span text-translate="true">When this is enabled for a hot wallet, you are also able to use the node wallet to spend.</span>
-                                    }
-                                </p>
-                            </div>
-                        </label>
-                    </div>
-                }
             </div>
         </div>
     </div>

--- a/BTCPayServer/wwwroot/swagger/v1/swagger.template.stores-wallet.on-chain.json
+++ b/BTCPayServer/wwwroot/swagger/v1/swagger.template.stores-wallet.on-chain.json
@@ -924,11 +924,6 @@
                         "default": false,
                         "description": "Whether to store the seed inside BTCPay Server to enable some additional services. IF `false` AND `existingMnemonic` IS NOT SPECIFIED, BE SURE TO SECURELY STORE THE SEED IN THE RESPONSE!"
                     },
-                    "importKeysToRPC": {
-                        "type": "boolean",
-                        "default": false,
-                        "description": "Whether to import all addresses generated via BTCPay Server into the underlying node wallet. (Private keys will also be imported if `savePrivateKeys` is set to true."
-                    },
                     "wordList": {
                         "type": "string",
                         "description": "If `existingMnemonic` is not set, a mnemonic is generated using the specified wordList.",


### PR DESCRIPTION
This feature is barely used, not understood by most users, while requiring quite heavy maintenance on my part in NBXplorer.

I will keep the support on NBXplorer to make it harder to break people who were using it, but I will stop investing handling corner cases.

<img width="1162" height="958" alt="image" src="https://github.com/user-attachments/assets/e403938c-2423-498b-9bcc-964d4e2f14d2" />
