### PR TITLE
Make NBXplorer service classes extensible for plugins

### DIFF
--- a/BTCPayServer/ExplorerClientProvider.cs
+++ b/BTCPayServer/ExplorerClientProvider.cs
@@ -22,6 +22,15 @@ namespace BTCPayServer
 
         readonly NBXplorerDashboard _Dashboard;
 
+        protected ExplorerClientProvider(
+            BTCPayNetworkProvider networkProviders,
+            NBXplorerDashboard dashboard)
+        {
+            Logs = new Logs();
+            _Dashboard = dashboard;
+            _NetworkProviders = networkProviders;
+        }
+
         public ExplorerClientProvider(
             IHttpClientFactory httpClientFactory,
             BTCPayNetworkProvider networkProviders,

--- a/BTCPayServer/ExplorerClientProvider.cs
+++ b/BTCPayServer/ExplorerClientProvider.cs
@@ -70,9 +70,9 @@ namespace BTCPayServer
             return explorer;
         }
 
-        readonly Dictionary<string, ExplorerClient> _Clients = new Dictionary<string, ExplorerClient>();
+        protected readonly Dictionary<string, ExplorerClient> _Clients = new Dictionary<string, ExplorerClient>();
 
-        public ExplorerClient GetExplorerClient(string cryptoCode)
+        public virtual ExplorerClient GetExplorerClient(string cryptoCode)
         {
             var network = _NetworkProviders.GetNetwork<BTCPayNetwork>(cryptoCode);
             if (network == null)
@@ -81,24 +81,24 @@ namespace BTCPayServer
             return client;
         }
 
-        public ExplorerClient GetExplorerClient(BTCPayNetworkBase network)
+        public virtual ExplorerClient GetExplorerClient(BTCPayNetworkBase network)
         {
             ArgumentNullException.ThrowIfNull(network);
             return GetExplorerClient(network.CryptoCode);
         }
 
-        public bool IsAvailable(BTCPayNetworkBase network)
+        public virtual bool IsAvailable(BTCPayNetworkBase network)
         {
             return IsAvailable(network.CryptoCode);
         }
 
-        public bool IsAvailable(string cryptoCode)
+        public virtual bool IsAvailable(string cryptoCode)
         {
             cryptoCode = cryptoCode.ToUpperInvariant();
             return _Clients.ContainsKey(cryptoCode) && _Dashboard.IsFullySynched(cryptoCode, out var unused);
         }
 
-        public BTCPayNetwork GetNetwork(string cryptoCode)
+        public virtual BTCPayNetwork GetNetwork(string cryptoCode)
         {
             var network = _NetworkProviders.GetNetwork<BTCPayNetwork>(cryptoCode);
             if (network == null)
@@ -108,7 +108,7 @@ namespace BTCPayServer
             return null;
         }
 
-        public IEnumerable<(BTCPayNetwork, ExplorerClient)> GetAll()
+        public virtual IEnumerable<(BTCPayNetwork, ExplorerClient)> GetAll()
         {
             foreach (var net in _NetworkProviders.GetAll().OfType<BTCPayNetwork>())
             {

--- a/BTCPayServer/Services/NBXplorerConnectionFactory.cs
+++ b/BTCPayServer/Services/NBXplorerConnectionFactory.cs
@@ -40,7 +40,7 @@ namespace BTCPayServer.Services
             }
         }
 
-        public async Task<DbConnection> OpenConnection()
+        public virtual async Task<DbConnection> OpenConnection()
         {
             int maxRetries = 10;
             int retries = maxRetries;

--- a/BTCPayServer/Services/Wallets/WalletHistogramService.cs
+++ b/BTCPayServer/Services/Wallets/WalletHistogramService.cs
@@ -21,7 +21,7 @@ public class WalletHistogramService
         _connectionFactory = connectionFactory;
     }
 
-    public async Task<HistogramData> GetHistogram(StoreData store, WalletId walletId, HistogramType type)
+    public virtual async Task<HistogramData> GetHistogram(StoreData store, WalletId walletId, HistogramType type)
     {
         // https://github.com/dgarage/NBXplorer/blob/master/docs/Postgres-Schema.md
         if (_connectionFactory.Available)


### PR DESCRIPTION
## Summary

- Make `ExplorerClientProvider._Clients` dictionary `protected` (was private) and all public methods `virtual`, so plugins can subclass without reflection
- Add `protected` constructor to `ExplorerClientProvider` that takes only `BTCPayNetworkProvider` + `NBXplorerDashboard`, so plugins don't need dummy `IHttpClientFactory`/`NBXplorerOptions`/`Logs` instances
- Make `WalletHistogramService.GetHistogram` `virtual`, allowing plugins to provide histogram data from alternative sources
- Make `NBXplorerConnectionFactory.OpenConnection` `virtual`, enabling plugins to override connection behavior

These are the minimal changes needed to let plugins cleanly substitute alternative blockchain backends (e.g. Electrum/Fulcrum) by subclassing instead of using reflection, `new` keyword hacks, or dummy constructor arguments.

No behavioral change — all existing code paths remain identical.

## Test plan
- [ ] Verify existing NBXplorer integration tests still pass (no behavior change)
- [ ] Confirm `ExplorerClientProvider` subclass can use protected constructor and access `_Clients`
- [ ] Confirm `WalletHistogramService` subclass can override `GetHistogram`
- [ ] Confirm `NBXplorerConnectionFactory` subclass can override `OpenConnection`