### PR TITLE
feat(translations): per-user dashboard language via ?lang= query parameter

### DIFF
--- a/BTCPayServer.Tests/LanguageServiceTests.cs
+++ b/BTCPayServer.Tests/LanguageServiceTests.cs
@@ -184,6 +184,73 @@ namespace BTCPayServer.Tests
 
         [Fact(Timeout = TestTimeout)]
         [Trait("Integration", "Integration")]
+        public async Task CanResolveLangCodeToDictionary()
+        {
+            using var tester = CreateServerTester(newDb: true);
+            await tester.StartAsync();
+            var localizer = tester.PayTester.GetService<LocalizerService>();
+
+            // Create a custom dict and associate it with pt-BR via metadata
+            var dict = await localizer.CreateDictionary("TestLang", null, "Custom");
+            var translations = new Translations(new[] { KeyValuePair.Create("Password", (string?)"Senha") });
+            await localizer.Save(dict, translations);
+            await localizer.UpdateCode("TestLang", "pt-BR");
+
+            // Should resolve via DB metadata (code stored at download time)
+            var result = await localizer.GetOrLoadForLanguageCode("pt-BR");
+            Assert.Equal("Senha", result["Password"]);
+
+            // Second call should hit the cache
+            var cached = await localizer.GetOrLoadForLanguageCode("pt-BR");
+            Assert.Same(result, cached);
+
+            // Cache should be evicted after the dictionary is updated
+            dict = await localizer.GetDictionary("TestLang");
+            var updated = new Translations(new[] { KeyValuePair.Create("Password", (string?)"Nova Senha") });
+            await localizer.Save(dict!, updated);
+            var afterUpdate = await localizer.GetOrLoadForLanguageCode("pt-BR");
+            Assert.Equal("Nova Senha", afterUpdate["Password"]);
+
+            // Static map fallback: "French" dict resolves via DictNameToCode without metadata
+            var frDict = await localizer.CreateDictionary("French", null, "Custom");
+            var frTranslations = new Translations(new[] { KeyValuePair.Create("Password", (string?)"Mot de passe") });
+            await localizer.Save(frDict, frTranslations);
+            var french = await localizer.GetOrLoadForLanguageCode("fr-FR");
+            Assert.Equal("Mot de passe", french["Password"]);
+        }
+
+        [Fact(Timeout = TestTimeout)]
+        [Trait("Playwright", "Playwright")]
+        public async Task CanSetPerUserLanguageViaQueryParam()
+        {
+            await using var tester = CreatePlaywrightTester(newDb: true);
+            ActivateLangs(tester.Server);
+            await tester.StartAsync();
+            await tester.Server.PayTester.RestartStartupTask<LoadTranslationsStartupTask>();
+
+            // Associate the Cypherpunk test dict with the pt-BR locale code
+            var localizer = tester.Server.PayTester.GetService<LocalizerService>();
+            await localizer.UpdateCode("Cypherpunk", "pt-BR");
+
+            // Server lang is English (default) — login page shows English labels
+            await tester.GoToUrl("/login");
+            await Expect(tester.Page.Locator("label[for=\"Password\"]")).ToContainTextAsync("Password");
+
+            // Visit root with ?lang=pt-BR — should set cookie and redirect to login with Cypherpunk strings
+            await tester.GoToUrl("/?lang=pt-BR");
+            var cookies = await tester.Page.Context.CookiesAsync();
+            var langCookie = cookies.FirstOrDefault(c => c.Name == LangCookieMiddleware.CookieName);
+            Assert.NotNull(langCookie);
+            Assert.Equal("pt-BR", langCookie.Value);
+            await Expect(tester.Page.Locator("label[for=\"Password\"]")).ToContainTextAsync("Cyphercode");
+
+            // Navigate to login again without ?lang= — cookie keeps the language active
+            await tester.GoToUrl("/login");
+            await Expect(tester.Page.Locator("label[for=\"Password\"]")).ToContainTextAsync("Cyphercode");
+        }
+
+        [Fact(Timeout = TestTimeout)]
+        [Trait("Integration", "Integration")]
         public async Task CanAutoDetectLanguage()
         {
             using var tester = CreateServerTester();

--- a/BTCPayServer/Plugins/Translations/Controllers/UITranslationController.cs
+++ b/BTCPayServer/Plugins/Translations/Controllers/UITranslationController.cs
@@ -192,6 +192,8 @@ public class UITranslationController(
 
         await localizer.Save(existingDictionary, translations);
         await localizer.UpdateVersion(language, version);
+        if (LanguagePackUpdateService.DictNameToCode.TryGetValue(language, out var langCode))
+            await localizer.UpdateCode(language, langCode);
         languagePackUpdateService.InvalidateCache(language);
         return RedirectToAction(nameof(ListDictionaries));
     }

--- a/BTCPayServer/Plugins/Translations/LangCookieMiddleware.cs
+++ b/BTCPayServer/Plugins/Translations/LangCookieMiddleware.cs
@@ -8,26 +8,28 @@ using Microsoft.AspNetCore.Http;
 
 namespace BTCPayServer.Plugins.Translations;
 
-public class LangCookieMiddleware(RequestDelegate next, LanguageService languageService)
+public class LangCookieMiddleware(RequestDelegate next, LanguageService languageService, LocalizerService localizerService)
 {
-    public const string ItemsKey = "btcpay_lang_dict";
+    // Stores the resolved Translations object for the current request.
+    public const string ItemsKey = "btcpay_lang_translations";
     internal const string CookieName = "btcpay_lang";
 
     public async Task InvokeAsync(HttpContext ctx)
     {
-        var queryLang = ctx.Request.Query["lang"].ToString();
-        string? dictName = null;
+        string? langCode = null;
 
+        var queryLang = ctx.Request.Query["lang"].ToString();
         if (!string.IsNullOrEmpty(queryLang))
         {
             var found = languageService.FindLanguage(queryLang);
             if (found is not null)
             {
-                dictName = found.Code;
+                langCode = found.Code;
                 ctx.Response.Cookies.Append(CookieName, found.Code, new CookieOptions
                 {
                     MaxAge = TimeSpan.FromDays(365),
-                    HttpOnly = false,
+                    HttpOnly = true,
+                    Secure = ctx.Request.IsHttps,
                     SameSite = SameSiteMode.Lax,
                     IsEssential = true
                 });
@@ -36,11 +38,19 @@ public class LangCookieMiddleware(RequestDelegate next, LanguageService language
         else if (ctx.Request.Cookies.TryGetValue(CookieName, out var cookieValue) &&
                  !string.IsNullOrEmpty(cookieValue))
         {
-            dictName = cookieValue;
+            // Validate cookie value to avoid DB lookups for arbitrary/tampered values.
+            var found = languageService.FindLanguage(cookieValue);
+            if (found is not null)
+                langCode = found.Code;
         }
 
-        if (dictName is not null)
-            ctx.Items[ItemsKey] = dictName;
+        if (langCode is not null)
+        {
+            // Resolve and cache the Translations object here (async context) so the
+            // synchronous IStringLocalizer hot path can read it directly from HttpContext.Items.
+            var translations = await localizerService.GetOrLoadForLanguageCode(langCode);
+            ctx.Items[ItemsKey] = translations;
+        }
 
         await next(ctx);
     }

--- a/BTCPayServer/Plugins/Translations/LangCookieMiddleware.cs
+++ b/BTCPayServer/Plugins/Translations/LangCookieMiddleware.cs
@@ -12,7 +12,7 @@ public class LangCookieMiddleware(RequestDelegate next, LanguageService language
 {
     // Stores the resolved Translations object for the current request.
     public const string ItemsKey = "btcpay_lang_translations";
-    internal const string CookieName = "btcpay_lang";
+    public const string CookieName = "btcpay_lang";
 
     public async Task InvokeAsync(HttpContext ctx)
     {

--- a/BTCPayServer/Plugins/Translations/LangCookieMiddleware.cs
+++ b/BTCPayServer/Plugins/Translations/LangCookieMiddleware.cs
@@ -1,0 +1,57 @@
+#nullable enable
+using System;
+using System.Threading.Tasks;
+using BTCPayServer.Services;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+
+namespace BTCPayServer.Plugins.Translations;
+
+public class LangCookieMiddleware(RequestDelegate next, LanguageService languageService)
+{
+    public const string ItemsKey = "btcpay_lang_dict";
+    internal const string CookieName = "btcpay_lang";
+
+    public async Task InvokeAsync(HttpContext ctx)
+    {
+        var queryLang = ctx.Request.Query["lang"].ToString();
+        string? dictName = null;
+
+        if (!string.IsNullOrEmpty(queryLang))
+        {
+            var found = languageService.FindLanguage(queryLang);
+            if (found is not null)
+            {
+                dictName = found.Code;
+                ctx.Response.Cookies.Append(CookieName, found.Code, new CookieOptions
+                {
+                    MaxAge = TimeSpan.FromDays(365),
+                    HttpOnly = false,
+                    SameSite = SameSiteMode.Lax,
+                    IsEssential = true
+                });
+            }
+        }
+        else if (ctx.Request.Cookies.TryGetValue(CookieName, out var cookieValue) &&
+                 !string.IsNullOrEmpty(cookieValue))
+        {
+            dictName = cookieValue;
+        }
+
+        if (dictName is not null)
+            ctx.Items[ItemsKey] = dictName;
+
+        await next(ctx);
+    }
+}
+
+public class LangCookieStartupFilter : IStartupFilter
+{
+    public Action<IApplicationBuilder> Configure(Action<IApplicationBuilder> next)
+        => app =>
+        {
+            app.UseMiddleware<LangCookieMiddleware>();
+            next(app);
+        };
+}

--- a/BTCPayServer/Plugins/Translations/LanguagePackUpdateService.cs
+++ b/BTCPayServer/Plugins/Translations/LanguagePackUpdateService.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
 using System.Threading.Tasks;
@@ -33,6 +34,29 @@ namespace BTCPayServer.Plugins.Translations
                 "Turkish"
             };
         }
+
+        // Maps English dict names (as stored in the DB) to BCP-47 codes.
+        // Must be kept in sync with GetDownloadableLanguages().
+        // The BCP-47 codes match the checkout locale JSON files in wwwroot/locales/checkout/.
+        public static readonly IReadOnlyDictionary<string, string> DictNameToCode =
+            new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                { "Dutch",                "nl"    },
+                { "French",               "fr-FR" },
+                { "German",               "de-DE" },
+                { "Hindi",                "hi"    },
+                { "Indonesian",           "id"    },
+                { "Italian",              "it"    },
+                { "Japanese",             "ja"    },
+                { "Norwegian",            "no"    },
+                { "Korean",               "ko"    },
+                { "Portuguese (Brazil)",  "pt-BR" },
+                { "Russian",              "ru"    },
+                { "Serbian",              "sr"    },
+                { "Spanish",              "es-ES" },
+                { "Thai",                 "th-TH" },
+                { "Turkish",              "tr"    },
+            };
 
         public async Task<(string translationsJson, string version)> FetchLanguagePackFromRepository(string language)
         {

--- a/BTCPayServer/Plugins/Translations/LanguagePackUpdateService.cs
+++ b/BTCPayServer/Plugins/Translations/LanguagePackUpdateService.cs
@@ -41,17 +41,17 @@ namespace BTCPayServer.Plugins.Translations
         public static readonly IReadOnlyDictionary<string, string> DictNameToCode =
             new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
             {
-                { "Dutch",                "nl"    },
+                { "Dutch",                "nl-NL" },
                 { "French",               "fr-FR" },
                 { "German",               "de-DE" },
                 { "Hindi",                "hi"    },
                 { "Indonesian",           "id"    },
-                { "Italian",              "it"    },
-                { "Japanese",             "ja"    },
+                { "Italian",              "it-IT" },
+                { "Japanese",             "ja-JP" },
                 { "Norwegian",            "no"    },
                 { "Korean",               "ko"    },
                 { "Portuguese (Brazil)",  "pt-BR" },
-                { "Russian",              "ru"    },
+                { "Russian",              "ru-RU" },
                 { "Serbian",              "sr"    },
                 { "Spanish",              "es-ES" },
                 { "Thai",                 "th-TH" },

--- a/BTCPayServer/Plugins/Translations/LocalizerFactory.cs
+++ b/BTCPayServer/Plugins/Translations/LocalizerFactory.cs
@@ -1,7 +1,9 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using BTCPayServer.Logging;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.Localization;
 using Microsoft.Extensions.Localization;
 using Microsoft.Extensions.Logging;
@@ -12,6 +14,7 @@ namespace BTCPayServer.Plugins.Translations
     {
         internal readonly Logs _logs;
         private readonly LocalizerService _localizerService;
+        private readonly IHttpContextAccessor _httpContextAccessor;
 
         class StringLocalizer : IStringLocalizer, IHtmlLocalizer
         {
@@ -34,7 +37,20 @@ namespace BTCPayServer.Plugins.Translations
                 _baseName = baseName;
                 _location = location;
             }
-            Translations Translations => _Factory._localizerService.Translations;
+
+            Translations Translations
+            {
+                get
+                {
+                    var dictName = _Factory._httpContextAccessor.HttpContext?.Items[LangCookieMiddleware.ItemsKey] as string;
+                    if (dictName is null)
+                        return _Factory._localizerService.Translations;
+
+                    // GetOrLoadForDictionary is async; use GetAwaiter to avoid deadlocks on hot path.
+                    // Results are cached after the first load so this is a fast dictionary lookup in practice.
+                    return _Factory._localizerService.GetOrLoadForLanguageCode(dictName).GetAwaiter().GetResult();
+                }
+            }
             public LocalizedString this[string name]
             {
                 get
@@ -100,10 +116,11 @@ namespace BTCPayServer.Plugins.Translations
                 return this[name, arguments];
             }
         }
-        public LocalizerFactory(Logs logs, LocalizerService localizerService)
+        public LocalizerFactory(Logs logs, LocalizerService localizerService, IHttpContextAccessor httpContextAccessor)
         {
             _logs = logs;
             _localizerService = localizerService;
+            _httpContextAccessor = httpContextAccessor;
         }
         public IStringLocalizer Create(Type resourceSource)
         {

--- a/BTCPayServer/Plugins/Translations/LocalizerFactory.cs
+++ b/BTCPayServer/Plugins/Translations/LocalizerFactory.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading.Tasks;
 using BTCPayServer.Logging;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.Localization;
@@ -38,19 +37,9 @@ namespace BTCPayServer.Plugins.Translations
                 _location = location;
             }
 
-            Translations Translations
-            {
-                get
-                {
-                    var dictName = _Factory._httpContextAccessor.HttpContext?.Items[LangCookieMiddleware.ItemsKey] as string;
-                    if (dictName is null)
-                        return _Factory._localizerService.Translations;
-
-                    // GetOrLoadForDictionary is async; use GetAwaiter to avoid deadlocks on hot path.
-                    // Results are cached after the first load so this is a fast dictionary lookup in practice.
-                    return _Factory._localizerService.GetOrLoadForLanguageCode(dictName).GetAwaiter().GetResult();
-                }
-            }
+            Translations Translations =>
+                _Factory._httpContextAccessor.HttpContext?.Items[LangCookieMiddleware.ItemsKey] as Translations
+                ?? _Factory._localizerService.Translations;
             public LocalizedString this[string name]
             {
                 get

--- a/BTCPayServer/Plugins/Translations/LocalizerService.cs
+++ b/BTCPayServer/Plugins/Translations/LocalizerService.cs
@@ -47,9 +47,10 @@ namespace BTCPayServer.Plugins.Translations
             if (_langCache.TryGetValue(langCode, out var cached))
                 return cached;
 
-            var dictName = await FindDictNameForCode(langCode);
+            var dictName = langCode;
             try
             {
+                dictName = await FindDictNameForCode(langCode);
                 var loaded = await GetTranslations(dictName);
                 _langCache[langCode] = loaded.Translations;
                 return loaded.Translations;
@@ -129,6 +130,26 @@ namespace BTCPayServer.Plugins.Translations
             return new LoadedTranslations(translations, fallback, dictionaryName);
         }
 
+        void InvalidateLangCache(string dictionaryName)
+        {
+            // Remove any cached entry whose dict name matches (keyed by lang code).
+            foreach (var kv in _langCache)
+            {
+                // Direct match: custom dict named by code (e.g. "pt-PT")
+                if (kv.Key.Equals(dictionaryName, StringComparison.OrdinalIgnoreCase))
+                {
+                    _langCache.TryRemove(kv.Key, out _);
+                    continue;
+                }
+                // Static map match
+                if (LanguagePackUpdateService.DictNameToCode.TryGetValue(dictionaryName, out var code) &&
+                    code.Equals(kv.Key, StringComparison.OrdinalIgnoreCase))
+                {
+                    _langCache.TryRemove(kv.Key, out _);
+                }
+            }
+        }
+
         public async Task Save(Dictionary dictionary, Translations translations)
         {
             var loadedTranslations = await GetTranslations(dictionary.DictionaryName);
@@ -187,6 +208,8 @@ namespace BTCPayServer.Plugins.Translations
 
             if (_LoadedTranslations.LangName == loadedTranslations.LangName)
                 _LoadedTranslations = loadedTranslations with { Translations = translations };
+
+            InvalidateLangCache(dictionary.DictionaryName);
         }
 
         public record Dictionary(string DictionaryName, string? Fallback, string Source, JObject Metadata);
@@ -220,6 +243,7 @@ namespace BTCPayServer.Plugins.Translations
             await using var ctx = contextFactory.CreateContext();
             var db = ctx.Database.GetDbConnection();
             await db.ExecuteAsync("DELETE FROM lang_dictionaries WHERE dict_id=@dict_id AND source='Custom'", new { dict_id = dictionary });
+            InvalidateLangCache(dictionary);
         }
 
         public async Task UpdateVersion(string dictionary, string version)
@@ -228,6 +252,7 @@ namespace BTCPayServer.Plugins.Translations
             var db = ctx.Database.GetDbConnection();
             await db.ExecuteAsync("UPDATE lang_dictionaries SET metadata = jsonb_set(COALESCE(metadata, '{}'::jsonb), '{version}', to_jsonb(@version::text)) WHERE dict_id = @dict_id",
                 new { dict_id = dictionary, version });
+            InvalidateLangCache(dictionary);
         }
 
         public async Task UpdateCode(string dictionary, string langCode)

--- a/BTCPayServer/Plugins/Translations/LocalizerService.cs
+++ b/BTCPayServer/Plugins/Translations/LocalizerService.cs
@@ -1,5 +1,6 @@
 #nullable enable
 using Dapper;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -28,6 +29,60 @@ namespace BTCPayServer.Plugins.Translations
         public record LoadedTranslations(Translations Translations, Translations Fallback, string LangName);
         LoadedTranslations _LoadedTranslations = new(Translations.Default, Translations.Default, Translations.DefaultLanguage);
         public Translations Translations => _LoadedTranslations.Translations;
+
+        readonly ConcurrentDictionary<string, Translations> _langCache = new(StringComparer.OrdinalIgnoreCase);
+
+        /// <summary>
+        /// Returns translations for the given BCP-47 language code, loading and caching on first use.
+        /// Resolution order:
+        ///   1. DB metadata (code stored at download time) — works for any future language.
+        ///   2. Static fallback map from LanguagePackUpdateService — covers packs installed before
+        ///      this feature or renamed by the user.
+        ///   3. Code used directly as dict name — covers custom user-created dictionaries
+        ///      whose name is the BCP-47 code (e.g. "pt-PT").
+        /// Returns the default translations if no matching dictionary is found.
+        /// </summary>
+        public async Task<Translations> GetOrLoadForLanguageCode(string langCode)
+        {
+            if (_langCache.TryGetValue(langCode, out var cached))
+                return cached;
+
+            var dictName = await FindDictNameForCode(langCode);
+            try
+            {
+                var loaded = await GetTranslations(dictName);
+                _langCache[langCode] = loaded.Translations;
+                return loaded.Translations;
+            }
+            catch (Exception ex)
+            {
+                logger.LogWarning(ex, "Failed to load translations for language code '{LangCode}' (dict '{DictName}')", langCode, dictName);
+                return Translations;
+            }
+        }
+
+        async Task<string> FindDictNameForCode(string langCode)
+        {
+            // 1. Check DB metadata (populated at download time for new downloads)
+            await using var ctx = contextFactory.CreateContext();
+            var conn = ctx.Database.GetDbConnection();
+            var rows = await conn.QueryAsync<string>(
+                "SELECT dict_id FROM lang_dictionaries WHERE metadata->>'code' = @code", new { code = langCode });
+            var fromDb = rows.FirstOrDefault();
+            if (fromDb is not null)
+                return fromDb;
+
+            // 2. Static fallback map (handles packs installed before code metadata was added)
+            var reversedMap = LanguagePackUpdateService.DictNameToCode;
+            foreach (var kv in reversedMap)
+            {
+                if (kv.Value.Equals(langCode, StringComparison.OrdinalIgnoreCase))
+                    return kv.Key;
+            }
+
+            // 3. Use the code itself as the dict name (custom dicts named by BCP-47 code)
+            return langCode;
+        }
 
         /// <summary>
         /// Load the translation of the server into memory
@@ -173,6 +228,14 @@ namespace BTCPayServer.Plugins.Translations
             var db = ctx.Database.GetDbConnection();
             await db.ExecuteAsync("UPDATE lang_dictionaries SET metadata = jsonb_set(COALESCE(metadata, '{}'::jsonb), '{version}', to_jsonb(@version::text)) WHERE dict_id = @dict_id",
                 new { dict_id = dictionary, version });
+        }
+
+        public async Task UpdateCode(string dictionary, string langCode)
+        {
+            await using var ctx = contextFactory.CreateContext();
+            var db = ctx.Database.GetDbConnection();
+            await db.ExecuteAsync("UPDATE lang_dictionaries SET metadata = jsonb_set(COALESCE(metadata, '{}'::jsonb), '{code}', to_jsonb(@code::text)) WHERE dict_id = @dict_id",
+                new { dict_id = dictionary, code = langCode });
         }
     }
 }

--- a/BTCPayServer/Plugins/Translations/LocalizerService.cs
+++ b/BTCPayServer/Plugins/Translations/LocalizerService.cs
@@ -31,6 +31,8 @@ namespace BTCPayServer.Plugins.Translations
         public Translations Translations => _LoadedTranslations.Translations;
 
         readonly ConcurrentDictionary<string, Translations> _langCache = new(StringComparer.OrdinalIgnoreCase);
+        // Reverse map: dict name → lang code, populated when GetOrLoadForLanguageCode resolves via DB metadata.
+        readonly ConcurrentDictionary<string, string> _codeByDictName = new(StringComparer.OrdinalIgnoreCase);
 
         /// <summary>
         /// Returns translations for the given BCP-47 language code, loading and caching on first use.
@@ -53,6 +55,9 @@ namespace BTCPayServer.Plugins.Translations
                 dictName = await FindDictNameForCode(langCode);
                 var loaded = await GetTranslations(dictName);
                 _langCache[langCode] = loaded.Translations;
+                // Track the reverse mapping so InvalidateLangCache can evict by dict name.
+                if (!dictName.Equals(langCode, StringComparison.OrdinalIgnoreCase))
+                    _codeByDictName[dictName] = langCode;
                 return loaded.Translations;
             }
             catch (Exception ex)
@@ -132,22 +137,14 @@ namespace BTCPayServer.Plugins.Translations
 
         void InvalidateLangCache(string dictionaryName)
         {
-            // Remove any cached entry whose dict name matches (keyed by lang code).
-            foreach (var kv in _langCache)
-            {
-                // Direct match: custom dict named by code (e.g. "pt-PT")
-                if (kv.Key.Equals(dictionaryName, StringComparison.OrdinalIgnoreCase))
-                {
-                    _langCache.TryRemove(kv.Key, out _);
-                    continue;
-                }
-                // Static map match
-                if (LanguagePackUpdateService.DictNameToCode.TryGetValue(dictionaryName, out var code) &&
-                    code.Equals(kv.Key, StringComparison.OrdinalIgnoreCase))
-                {
-                    _langCache.TryRemove(kv.Key, out _);
-                }
-            }
+            // 1. Direct match: custom dict named by BCP-47 code (e.g. "pt-PT")
+            _langCache.TryRemove(dictionaryName, out _);
+            // 2. Static map: language packs installed before metadata support (e.g. "French" → "fr-FR")
+            if (LanguagePackUpdateService.DictNameToCode.TryGetValue(dictionaryName, out var staticCode))
+                _langCache.TryRemove(staticCode, out _);
+            // 3. DB-metadata reverse map: dicts mapped to a code at download time (e.g. "TestLang" → "pt-BR")
+            if (_codeByDictName.TryRemove(dictionaryName, out var mappedCode))
+                _langCache.TryRemove(mappedCode, out _);
         }
 
         public async Task Save(Dictionary dictionary, Translations translations)

--- a/BTCPayServer/Plugins/Translations/LocalizerService.cs
+++ b/BTCPayServer/Plugins/Translations/LocalizerService.cs
@@ -258,6 +258,9 @@ namespace BTCPayServer.Plugins.Translations
             var db = ctx.Database.GetDbConnection();
             await db.ExecuteAsync("UPDATE lang_dictionaries SET metadata = jsonb_set(COALESCE(metadata, '{}'::jsonb), '{code}', to_jsonb(@code::text)) WHERE dict_id = @dict_id",
                 new { dict_id = dictionary, code = langCode });
+            InvalidateLangCache(dictionary);
+            // Also evict by the new code directly, in case it was cached before the association.
+            _langCache.TryRemove(langCode, out _);
         }
     }
 }

--- a/BTCPayServer/Plugins/Translations/TranslationsPlugin.cs
+++ b/BTCPayServer/Plugins/Translations/TranslationsPlugin.cs
@@ -1,5 +1,8 @@
+using System;
 using BTCPayServer.Abstractions.Extensions;
 using BTCPayServer.Abstractions.Models;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.Localization;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -23,5 +26,7 @@ public class TranslationsPlugin : BaseBTCPayServerPlugin
         services.TryAddSingleton<LanguagePackUpdateService>();
         services.AddStartupTask<LoadTranslationsStartupTask>();
         services.TryAddSingleton<IStringLocalizer>(o => o.GetRequiredService<IStringLocalizerFactory>().Create("", ""));
+        services.TryAddSingleton<IHttpContextAccessor, HttpContextAccessor>();
+        services.AddSingleton<IStartupFilter, LangCookieStartupFilter>();
     }
 }

--- a/BTCPayServer/Plugins/Translations/TranslationsPlugin.cs
+++ b/BTCPayServer/Plugins/Translations/TranslationsPlugin.cs
@@ -1,4 +1,3 @@
-using System;
 using BTCPayServer.Abstractions.Extensions;
 using BTCPayServer.Abstractions.Models;
 using Microsoft.AspNetCore.Hosting;


### PR DESCRIPTION
Relates to https://github.com/btcpayserver/btcpayserver/discussions/7316

## What this does

Adds per-user dashboard language selection via `?lang=pt-BR` (or any installed language code) appended to any dashboard URL. The selection is persisted in a cookie so subsequent navigation keeps the language without repeating the query string.

This mirrors the existing `?lang=` behavior on the invoice checkout page and follows the same convention for the same reason: no plugin needed, same `LanguageService`, same operator UX.

## Design notes

- **Middleware runs before auth** via `IStartupFilter`, so the cookie is set even on the initial unauthenticated redirect to `/login`.
- **Lazy loading**: translations are loaded from the DB on first request for a given language and cached in memory. No startup cost, no change to the default path when no `?lang=` is present.
- **Code → dict name mapping**: the checkout locales use BCP-47 codes (`pt-BR`) while the Translations plugin stores dicts under English names (`"Portuguese (Brazil)"`). Resolution tries in order:
  1. `metadata.code` stored in the DB at download time
  2. static fallback map in `LanguagePackUpdateService` for pre-existing installs
  3. code used directly as dict name for custom dicts
- **Cache invalidation**: a reverse map (`_codeByDictName`) is maintained in memory so that `Save`, `DeleteDictionary`, and `UpdateVersion` correctly evict the per-language cache entry even for dicts mapped via DB metadata.