### PR TITLE
Feature: Administrators can "log as" any user

### DIFF
--- a/BTCPayServer.Tests/ImpersonationTests.cs
+++ b/BTCPayServer.Tests/ImpersonationTests.cs
@@ -9,6 +9,34 @@ namespace BTCPayServer.Tests;
 
 public class ImpersonationTests(ITestOutputHelper helper) : UnitTestBase(helper)
 {
+
+    [Fact]
+    [Trait("Playwright", "Playwright")]
+    public async Task AdminCanImpersonate()
+    {
+        await using var s = CreatePlaywrightTester();
+        await s.StartAsync();
+
+        var user = await s.RegisterNewUser(isAdmin: false);
+        var userStore = await s.CreateNewStore();
+        await s.Logout();
+        await s.GoToRegister();
+        var admin = await s.RegisterNewUser(isAdmin: true);
+        var adminStore = await s.CreateNewStore();
+        await s.GoToServer(ServerNavPages.Users);
+        var users = new PMO.UsersPMO(s);
+        await users.LogAs(user);
+        await s.GoToStore(userStore.storeId);
+        await s.Page.WaitForSelectorAsync(".back-prev-login");
+        Assert.Contains(user, await s.Page.ContentAsync());
+
+        await s.Page.ClickAsync(".back-prev-login");
+        await s.GoToStore(adminStore.storeId);
+        Assert.Equal(0, await s.Page.Locator(".back-prev-login").CountAsync());
+        Assert.Contains(admin, await s.Page.ContentAsync());
+        await s.GoToServer(ServerNavPages.Users);
+    }
+
     [Fact]
     [Trait("Playwright", "Playwright")]
     public async Task CanSigninWithLoginCode()

--- a/BTCPayServer.Tests/PMO/UsersPMO.cs
+++ b/BTCPayServer.Tests/PMO/UsersPMO.cs
@@ -12,4 +12,10 @@ public class UsersPMO(PlaywrightTester s)
     }
 
     private static string Row(string email) => $"tr[data-email=\"{email}\"]";
+
+    public async Task LogAs(string email)
+    {
+        await s.Page.ClickAsync($"{Row(email)} .user-impersonate");
+        await s.Page.ClickAsync(".btn-primary");
+    }
 }

--- a/BTCPayServer/Plugins/Impersonation/ImpersonationContext.cs
+++ b/BTCPayServer/Plugins/Impersonation/ImpersonationContext.cs
@@ -1,0 +1,42 @@
+#nullable enable
+using System.Security.Claims;
+using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Options;
+
+namespace BTCPayServer.Plugins.Impersonation;
+
+public class ImpersonationContext(
+    IHttpContextAccessor httpContextAccessor,
+    IOptionsMonitor<CookieAuthenticationOptions> cookieOptions
+    )
+{
+    readonly HttpContext _context = httpContextAccessor.HttpContext!;
+    readonly CookieAuthenticationOptions _cookieOptions = cookieOptions.Get(IdentityConstants.ApplicationScheme);
+    string ImpersonatorCookieName => _cookieOptions.Cookie.Name + "_prev";
+
+    public ClaimsPrincipal? Revert()
+    {
+        if (_cookieOptions.CookieManager.GetRequestCookie(_context, ImpersonatorCookieName) is string v)
+        {
+            _cookieOptions.CookieManager.DeleteCookie(_context, ImpersonatorCookieName, _cookieOptions.Cookie.Build(_context));
+            var ticket = _cookieOptions.TicketDataFormat.Unprotect(v);
+            if (ticket is null)
+                return null;
+            _cookieOptions.CookieManager.AppendResponseCookie(_context, _cookieOptions.Cookie.Name ?? "", v, _cookieOptions.Cookie.Build(_context));
+            return ticket.Principal;
+        }
+        return null;
+    }
+
+    public void StartImpersonation()
+    {
+        if (_cookieOptions.CookieManager.GetRequestCookie(_context, _cookieOptions.Cookie.Name ?? "") is string v)
+        {
+            _cookieOptions.CookieManager.AppendResponseCookie(_context, ImpersonatorCookieName, v, _cookieOptions.Cookie.Build(_context));
+        }
+    }
+
+    public bool IsImpersonating => _cookieOptions.CookieManager.GetRequestCookie(_context, ImpersonatorCookieName) is not null;
+}

--- a/BTCPayServer/Plugins/Impersonation/ImpersonationPlugin.cs
+++ b/BTCPayServer/Plugins/Impersonation/ImpersonationPlugin.cs
@@ -16,8 +16,10 @@ public class ImpersonationPlugin : BaseBTCPayServerPlugin
 
     public override void Execute(IServiceCollection services)
     {
+        services.AddUIExtension("layout-banner", "/Plugins/Impersonation/Views/Banner.cshtml");
         services.AddUIExtension("user-nav", "/Plugins/Impersonation/Views/UserNav.cshtml");
         services.AddSingleton<UserLoginCodeService>();
+        services.AddScoped<ImpersonationContext>();
         services.AddPolicyDefinitions(new[]
         {
             new PolicyDefinition(

--- a/BTCPayServer/Plugins/Impersonation/LinkGenerator.Impersonation.cs
+++ b/BTCPayServer/Plugins/Impersonation/LinkGenerator.Impersonation.cs
@@ -7,8 +7,8 @@ namespace Microsoft.AspNetCore.Mvc;
 
 public static class ImpersonationUrlHelperExtensions
 {
-    public static string LoginCodeLink(this LinkGenerator urlHelper, string loginCode, string? returnUrl, RequestBaseUrl requestBaseUrl)
+    public static string LoginCodeLink(this LinkGenerator urlHelper, string loginCode, string? returnUrl, bool? impersonate, RequestBaseUrl requestBaseUrl)
     {
-        return urlHelper.GetUriByAction(nameof(UIImpersonationController.LoginUsingCode), "UIImpersonation", new { area = ImpersonationPlugin.Area, loginCode, returnUrl }, requestBaseUrl);
+        return urlHelper.GetUriByAction(nameof(UIImpersonationController.LoginUsingCode), "UIImpersonation", new { area = ImpersonationPlugin.Area, loginCode, returnUrl, impersonate }, requestBaseUrl);
     }
 }

--- a/BTCPayServer/Plugins/Impersonation/UIImpersonationController.cs
+++ b/BTCPayServer/Plugins/Impersonation/UIImpersonationController.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using System.Security.Claims;
 using System.Threading.Tasks;
 using BTCPayServer.Abstractions.Constants;
@@ -6,6 +7,7 @@ using BTCPayServer.Abstractions.Extensions;
 using BTCPayServer.Client;
 using BTCPayServer.Controllers;
 using BTCPayServer.Data;
+using BTCPayServer.Plugins.Impersonation.Views;
 using BTCPayServer.Services;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authorization;
@@ -21,15 +23,42 @@ namespace BTCPayServer.Plugins.Impersonation;
 [Area(ImpersonationPlugin.Area)]
 public class UIImpersonationController(
     UserLoginCodeService userLoginCodeService,
+    ImpersonationContext impersonationContext,
     IStringLocalizer stringLocalizer,
     UserManager<ApplicationUser> userManager,
     SignInManager<ApplicationUser> signInManager,
     ViewLocalizer viewLocalizer,
-    UserService userService) : Controller
+    UserService userService,
+    LinkGenerator linkGenerator) : Controller
 {
     public IStringLocalizer StringLocalizer { get; } = stringLocalizer;
     private UserService.CanLoginContext CreateLoginContext(ApplicationUser user)
         => new(user, StringLocalizer, viewLocalizer, this.HttpContext.Request.GetRequestBaseUrl());
+
+
+    [HttpGet("server/users/{userId}/log-as-user")]
+    public async Task<IActionResult> LogAsUser([FromServices] IAuthorizationService authorizationService, string userId, bool login = false)
+    {
+        var user = await userManager.FindByIdAsync(userId);
+        if (user == null)
+            return NotFound();
+
+        if (!(await authorizationService.AuthorizeAsync(HttpContext.User, userId, ImpersonationPlugin.CanImpersonateUser)).Succeeded)
+            return Forbid();
+
+        if (login)
+        {
+            var loginCode = userLoginCodeService.Generate(user.Id);
+            return Redirect(linkGenerator.LoginCodeLink(loginCode, null, true, HttpContext.Request.GetRequestBaseUrl()));
+        }
+
+        return View(new LogAsUserViewModel
+        {
+            Id = user.Id,
+            Email = user.Email,
+            ReturnUrl = Url.Action(nameof(UIServerController.ListUsers), "UIServer")
+        });
+    }
 
     [HttpGet("/account/login-codes")]
     [Authorize(AuthenticationSchemes = AuthenticationSchemes.Cookie, Policy = Policies.CanViewProfile)]
@@ -42,21 +71,29 @@ public class UIImpersonationController(
     [HttpGet("/login/code")]
     [AllowAnonymous]
     [RateLimitsFilter(ZoneLimits.Login, Scope = RateLimitsScope.RemoteAddress)]
-    public async Task<IActionResult> LoginUsingCode(string loginCode, string returnUrl = null)
+    public async Task<IActionResult> LoginUsingCode(string loginCode, string returnUrl = null, bool? impersonate = null)
     {
-        return await LoginCodeResult(loginCode, returnUrl);
+        return await LoginCodeResult(loginCode, returnUrl, impersonate);
     }
 
     [HttpPost("/login/code")]
     [AllowAnonymous]
     [ValidateAntiForgeryToken]
     [RateLimitsFilter(ZoneLimits.Login, Scope = RateLimitsScope.RemoteAddress)]
-    public async Task<IActionResult> LoginWithCode(string loginCode, string returnUrl = null)
+    public async Task<IActionResult> LoginWithCode(string loginCode, string returnUrl = null, bool? impersonate = null)
     {
-        return await LoginCodeResult(loginCode, returnUrl);
+        return await LoginCodeResult(loginCode, returnUrl, impersonate);
     }
 
-    private async Task<IActionResult> LoginCodeResult(string loginCode, string returnUrl)
+    [HttpPost("/login/code/revert")]
+    [AllowAnonymous]
+    public IActionResult RevertImpersonation()
+    {
+        var impersonator = impersonationContext.Revert();
+        return Login(email: impersonator?.FindFirst(ClaimTypes.Email)?.Value);
+    }
+
+    private async Task<IActionResult> LoginCodeResult(string loginCode, string returnUrl, bool? impersonate)
     {
         if (!string.IsNullOrEmpty(loginCode))
         {
@@ -101,6 +138,11 @@ public class UIImpersonationController(
                 ExpiresUtc = now.AddDays(1)
             };
 
+            if (impersonate is true)
+            {
+                impersonationContext.StartImpersonation();
+            }
+
             await signInManager.SignInAsync(user, authProperties, AuthenticationSchemes.Cookie);
         }
 
@@ -110,6 +152,6 @@ public class UIImpersonationController(
     private IActionResult Login(string returnUrl = null, string email = null)
     {
         email ??= User.FindFirst(ClaimTypes.Email)?.Value;
-        return RedirectToAction(nameof(UIAccountController.Login), "UIAccount", new { area = "", email, returnUrl });
+        return RedirectToAction(nameof(UIAccountController.Login), "UIAccount", new { email, returnUrl });
     }
 }

--- a/BTCPayServer/Plugins/Impersonation/UserLoginCode.razor
+++ b/BTCPayServer/Plugins/Impersonation/UserLoginCode.razor
@@ -95,7 +95,9 @@
     {
         var req = HttpContextAccessor.HttpContext?.Request;
         if (req == null) return "";
-        return LinkGenerator.LoginCodeLink(loginCode, RedirectUrl, req.GetRequestBaseUrl());
+        var currentUserId = HttpContextAccessor.HttpContext?.User.GetIdOrNull();
+        var impersonate = ImpersonatedUserId is not null && ImpersonatedUserId != currentUserId;
+        return LinkGenerator.LoginCodeLink(loginCode, RedirectUrl, impersonate, req.GetRequestBaseUrl());
     }
 
     private double Percent => Math.Round(_seconds / Seconds * 100);

--- a/BTCPayServer/Plugins/Impersonation/Views/Banner.cshtml
+++ b/BTCPayServer/Plugins/Impersonation/Views/Banner.cshtml
@@ -1,0 +1,31 @@
+@using BTCPayServer.Plugins.Impersonation
+@inject ImpersonationContext ImpersonationContext
+
+@if (ImpersonationContext.IsImpersonating)
+{
+    <style>
+        :root {
+            --info-bg: #cff4fc;
+        }
+        .alert-translucent {
+            border-radius: 6px;
+            padding: 0.5rem;
+            margin-bottom: 0.5rem;
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+        }
+        .alert-translucent.alert-info {
+            background: var(--info-bg);
+            border: 1px solid var(--btcpay-info-border);
+        }
+    </style>
+
+    var impersonatedEmail = User.FindFirst(System.Security.Claims.ClaimTypes.Email)?.Value;
+    <div class="alert-translucent alert-info" role="alert">
+        <span>@ViewLocalizer["You are signed in as <b>{0}</b>.", impersonatedEmail ?? StringLocalizer["another account"].Value]</span>
+        <form asp-area="@ImpersonationPlugin.Area" asp-controller="UIImpersonation" asp-action="RevertImpersonation" method="post" class="m-0">
+            <button class="btn btn-info back-prev-login" type="submit">@StringLocalizer["Back to previous login"]</button>
+        </form>
+    </div>
+}

--- a/BTCPayServer/Plugins/Impersonation/Views/LogAsUser.cshtml
+++ b/BTCPayServer/Plugins/Impersonation/Views/LogAsUser.cshtml
@@ -1,0 +1,31 @@
+@using BTCPayServer.Plugins.Impersonation
+@model BTCPayServer.Plugins.Impersonation.Views.LogAsUserViewModel
+
+@{
+    Layout = "_LayoutWizard";
+    ViewData.SetTitle(StringLocalizer["Log as user"]);
+}
+
+@section Navbar {
+    <a href="@Url.EnsureLocal(Model.ReturnUrl, Context.Request)" class="back">
+        <vc:icon symbol="back" />
+    </a>
+}
+
+<header class="text-center">
+    <h1>@ViewData["Title"]</h1>
+    <p class="lead text-secondary mt-3">@StringLocalizer["Scan this login code to log in as {0}.", Model.Email]</p>
+</header>
+
+<div class="d-flex flex-column align-items-center mt-4">
+    <component type="typeof(UserLoginCode)"
+               render-mode="ServerPrerendered"
+               param-impersonated-user-id="@Model.Id" />
+
+    <a
+        asp-area="@ImpersonationPlugin.Area"
+        asp-action="LogAsUser"
+       asp-route-userId="@Model.Id"
+       asp-route-login="true"
+       class="btn btn-primary mt-4">@StringLocalizer["Log as user {0}", Model.Email]</a>
+</div>

--- a/BTCPayServer/Plugins/Impersonation/Views/LogAsUserViewModel.cs
+++ b/BTCPayServer/Plugins/Impersonation/Views/LogAsUserViewModel.cs
@@ -1,0 +1,10 @@
+#nullable enable
+
+namespace BTCPayServer.Plugins.Impersonation.Views;
+
+public class LogAsUserViewModel
+{
+    public string? ReturnUrl { get; set; }
+    public string Email { get; set; } = string.Empty;
+    public string Id { get; set; } = string.Empty;
+}

--- a/BTCPayServer/Views/UIServer/ListUsers.cshtml
+++ b/BTCPayServer/Views/UIServer/ListUsers.cshtml
@@ -119,6 +119,10 @@
                                 }
                             </a>
                         }
+                        @if (user.Id == currentUserId || !user.IsAdmin)
+                        {
+                            <a asp-area="@ImpersonationPlugin.Area" asp-action="LogAsUser" asp-controller="UIImpersonation" asp-route-userId="@user.Id" class="text-nowrap user-impersonate" text-translate="true">Log as user</a>
+                        }
                         <a asp-action="User" asp-route-userId="@user.Id" class="user-edit" text-translate="true">Edit</a>
                         <a asp-action="ResetUserPassword" asp-route-userId="@user.Id" class="reset-password text-nowrap" text-translate="true">Password Reset</a>
                         <a asp-action="DeleteUser" asp-route-userId="@user.Id" class="delete-user" text-translate="true">Remove</a>


### PR DESCRIPTION
## Motivation

Impersonation is a security feature that allows one user to sign in as another user.

A limited form of this already exists:

* Before 2.3.8, an administrator could impersonate a user by issuing a Login Code QR code from the Point of Sale update page. After the QR code is scanned, the device is redirected to a logged-in Point of Sale page and can access the store’s invoices.
* When a user asks for assistance, an administrator can review that user’s store settings through Server `Server Settings -> Users`. However, this only provides a read-only view of the store, which limits the administrator’s ability to provide meaningful support.

A more explicit impersonation feature should be introduced to improve the support experience.

Related to https://github.com/btcpayserver/btcpayserver/discussions/7312

## User experience

Administrators can now `Log as User` from `Server Settings -> Users`.

<img width="2728" height="1214" alt="image" src="https://github.com/user-attachments/assets/652aa2ff-d9a8-4a7a-a5c4-3da0630df77e" />

After clicking on it, the administrator can either scan the QR Code or click on the button to log as if he was the user.

<img width="1200" height="940" alt="image" src="https://github.com/user-attachments/assets/837d7502-5433-4076-98fa-47def8c42245" />

The administrator can then return to his previous logged in session by click on `Back to previous login`.

<img width="2870" height="502" alt="image" src="https://github.com/user-attachments/assets/4d034a1b-f142-4fc7-9ccd-3c7c1fa4dfd9" />
