### PR TITLE
Fix: Xpub became unparseable in 2.3.8

### DIFF
--- a/BTCPayServer.Client/BTCPayServer.Client.csproj
+++ b/BTCPayServer.Client/BTCPayServer.Client.csproj
@@ -31,7 +31,7 @@
   </ItemGroup>
     <ItemGroup>
       <PackageReference Include="BTCPayServer.Lightning.Common" Version="1.5.3" />
-      <PackageReference Include="NBitcoin" Version="10.0.1" />
+      <PackageReference Include="NBitcoin" Version="10.0.3" />
       <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     </ItemGroup>
   <ItemGroup>

--- a/BTCPayServer.Rating/BTCPayServer.Rating.csproj
+++ b/BTCPayServer.Rating/BTCPayServer.Rating.csproj
@@ -6,7 +6,7 @@
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.3.0" />
     <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="6.0.0" />
-    <PackageReference Include="NBitcoin" Version="10.0.1" />
+    <PackageReference Include="NBitcoin" Version="10.0.3" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="DigitalRuby.ExchangeSharp" Version="1.2.1" />
   </ItemGroup>

--- a/BTCPayServer/BTCPayServer.csproj
+++ b/BTCPayServer/BTCPayServer.csproj
@@ -34,7 +34,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="NBitcoin" Version="10.0.1" />
+    <PackageReference Include="NBitcoin" Version="10.0.3" />
     <PackageReference Include="YamlDotNet" Version="16.3.0" />
     <PackageReference Include="BIP78.Sender" Version="0.2.5" />
     <PackageReference Include="BTCPayServer.Hwi" Version="2.0.6" />

--- a/BTCPayServer/Program.cs
+++ b/BTCPayServer/Program.cs
@@ -25,6 +25,9 @@ namespace BTCPayServer
     {
         static async Task Main(string[] args)
         {
+            // Some old instances were not as strict into parsing public keys
+            // we don't want to break this.
+            NBitcoin.ExtPubKey.SkipInvalidMasterExtPubKeyCheck = true;
             if (args.Length > 0 && args[0] == "run")
                 args = args.Skip(1).ToArray(); // Hack to make dotnet watch work
 


### PR DESCRIPTION
An update in NBitcoin made the parsing of XPUB stricter than before. While most users shouldn't be impacted, a few people seems to be. This PR relax the parsing rules of XPUBs.

```
OnChainAutomatedPayoutSenderFactory:5za96yEZmbaeNCaoZjwJn4cZVvVz3ju7tUcLcpeEL7bd:BTC-CHAIN: InitializeTasks failed
NBitcoin.JsonConverters.JsonObjectException: Invalid derivation strategy
   at NBXplorer.JsonConverters.DerivationStrategyJsonConverter.ReadJson(JsonReader reader, Type objectType, Object existingValue, JsonSerializer serializer)
   at NBXplorer.JsonConverters.CachedSerializer.ReadJson(JsonReader reader, Type objectType, Object existingValue, JsonSerializer serializer)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.DeserializeConvertable(JsonConverter converter, JsonReader reader, Type objectType, Object existingValue)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.SetPropertyValue(JsonProperty property, JsonConverter propertyConverter, JsonContainerContract containerContract, JsonProperty containerProperty, JsonReader reader, Object target)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.PopulateObject(Object newObject, JsonReader reader, JsonObjectContract contract, JsonProperty member, String id)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.CreateObject(JsonReader reader, Type objectType, JsonContract contract, JsonProperty member, JsonContainerContract containerContract, JsonProperty containerMember, Object existingValue)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.Deserialize(JsonReader reader, Type objectType, Boolean checkAdditionalContent)
   at Newtonsoft.Json.Linq.JToken.ToObject(Type objectType, JsonSerializer jsonSerializer)
   at BTCPayServer.Payments.Bitcoin.BitcoinLikePaymentHandler.ParsePaymentMethodConfig(JToken config) in /source/BTCPayServer/Payments/Bitcoin/BitcoinLikePaymentHandler.cs:line 74^C   at BTCPayServer.PayoutProcessors.BaseAutomatedPayoutProcessor`1.Act()
   at BTCPayServer.HostedServices.BaseAsyncService.CreateLoopTask(Func`1 act, String caller) in /source/BTCPayServer/HostedServices/BaseAsyncService.cs:line 55
```