### PR TITLE
Fix: Server not recovering after a plugin crash

### DIFF
--- a/BTCPayServer/Plugins/PluginManager.cs
+++ b/BTCPayServer/Plugins/PluginManager.cs
@@ -37,7 +37,7 @@ namespace BTCPayServer.Plugins
 
         public static bool IsExceptionByPlugin(Exception exception, [MaybeNullWhen(false)] out PreloadedPlugin preloadedPlugin)
         {
-            if (ExtractPluginsFromStackTrace(exception, out preloadedPlugin)) return true;
+            if (ExtractPluginFromStackTrace(exception, out preloadedPlugin)) return true;
 
             var fromAssembly = exception is TypeLoadException
                 ? Regex.Match(exception.Message, "from assembly '(.*?),").Groups[1].Value
@@ -72,9 +72,24 @@ namespace BTCPayServer.Plugins
             return false;
         }
 
-        private static bool ExtractPluginsFromStackTrace(Exception exception, [MaybeNullWhen(false)] out PreloadedPlugin preloadedPlugin)
+        private static bool ExtractPluginFromStackTrace(Exception exception, [MaybeNullWhen(false)] out PreloadedPlugin preloadedPlugin)
         {
-            var pluginsByName = _preloadedPlugins.Where(p => p.Loader is not null).ToDictionary(p => p.Assembly.FullName ?? "", p => p);
+            Dictionary<string, PreloadedPlugin> pluginsByName = new();
+
+            foreach (var preloaded in _preloadedPlugins.Where(p => p.Loader is not null && !string.IsNullOrEmpty(p.Assembly.FullName)))
+            {
+                pluginsByName.TryAdd(preloaded.Assembly.FullName!, preloaded);
+                foreach (var assembly in preloaded.Loader!.LoadContext.Assemblies)
+                {
+                    pluginsByName.TryAdd(assembly.FullName!, preloaded);
+                }
+            }
+            return ExtractPluginFromStackTrace(exception, out preloadedPlugin, pluginsByName);
+        }
+
+        private static bool ExtractPluginFromStackTrace(Exception exception, out PreloadedPlugin? preloadedPlugin,
+            Dictionary<string, PreloadedPlugin> pluginsByName)
+        {
             var trace = new StackTrace(exception, true);
             foreach (var frame in trace.GetFrames().Reverse())
             {
@@ -88,7 +103,20 @@ namespace BTCPayServer.Plugins
                 }
             }
             preloadedPlugin = null;
-            return false;
+            if (exception is AggregateException aggregateException)
+            {
+                foreach (var ex in aggregateException.InnerExceptions)
+                {
+                    if (ExtractPluginFromStackTrace(ex, out preloadedPlugin, pluginsByName))
+                        return true;
+                }
+
+                return false;
+            }
+            else if (exception.InnerException is not null)
+                return ExtractPluginFromStackTrace(exception.InnerException, out preloadedPlugin, pluginsByName);
+            else
+                return false;
         }
 
         public record PreloadedPlugin(IBTCPayServerPlugin Instance, PluginLoader? Loader, Assembly Assembly);
@@ -496,8 +524,12 @@ namespace BTCPayServer.Plugins
             return commands.Select(s =>
             {
                 var split = s.Split(':');
+                if (split.Length != 2)
+                    return (string.Empty, string.Empty);
                 return (split[0].ToLower(CultureInfo.InvariantCulture), split[1]);
-            }).ToArray();
+            })
+            .Where(s => s.Item1 != "")
+            .ToArray();
         }
 
         public static void QueueCommands(string pluginsFolder, params (string action, string plugin)[] commands)


### PR DESCRIPTION
A user reported the following crash. BTCPay Server was unable to detect which plugin caused the crash.
The reason is that `BoardingUtxoPollService` is not in the plugin assembly, but in a dependant assembly of the plugin.

This PR now looks to the dependencies in order to determine which plugin crashed.

```
info: NArk.Core.Services.BoardingUtxoPollService: BoardingUtxoPollService started (interval=30s)
fail: Microsoft.Extensions.Hosting.Internal.Host: Hosting failed to start
System.MissingMethodException: Method not found: 'NBitcoin.Scripting.OutputDescriptor NArk.Core.ArkServerInfo.get_SignerKey()'.
   at NArk.Swaps.Services.SwapsManagementService.StartAsync(CancellationToken cancellationToken)
   at System.Runtime.CompilerServices.AsyncMethodBuilderCore.Start[TStateMachine](http://tstatemachine&%20statemachine/)
   at NArk.Swaps.Services.SwapsManagementService.StartAsync(CancellationToken cancellationToken)
   at NArk.Swaps.Hosting.SwapHostedLifecycle.StartAsync(CancellationToken cancellationToken) in /build/submodules/NNark/NArk.Swaps/Hosting/SwapHostedLifecycle.cs:line 10
   at Microsoft.Extensions.Hosting.Internal.Host.<StartAsync>b__14_1(IHostedService service, CancellationToken token)
   at Microsoft.Extensions.Hosting.Internal.Host.ForeachService[T](http://ienumerable`1%20services,%20cancellationtoken%20token,%20boolean%20concurrent,%20boolean%20abortonfirstexception,%20list`1%20exceptions,%20func`3%20operation/)
info: NArk.Swaps.Services.SwapsManagementService: Disposing swap management service
info: NArk.Core.Services.SweeperService: Sweeper service disposed
warn: NArk.Core.Transport.CachingClientTransport: Failed to fetch server info from Ark operator
System.TypeLoadException: Could not load type 'NBitcoin.Scripting.OutputDescriptor' from assembly 'NBitcoin, Version=10.0.1.0, Culture=neutral, PublicKeyToken=null'.
   at NArk.Transport.GrpcClient.GrpcClientTransport.GetServerInfoAsync(CancellationToken cancellationToken)
```