### PR TITLE
fix : translation url

### DIFF
--- a/BTCPayServer/Plugins/Translations/LanguagePackUpdateService.cs
+++ b/BTCPayServer/Plugins/Translations/LanguagePackUpdateService.cs
@@ -42,7 +42,7 @@ namespace BTCPayServer.Plugins.Translations
             }
 
             var fileName = Uri.EscapeDataString(language.ToLowerInvariant());
-            var url = $"https://raw.githubusercontent.com/btcpayserver/btcpayserver-translator/main/translations/{fileName}.json";
+            var url = $"https://raw.githubusercontent.com/btcpayserver/btcpayserver-translator/main/Translator/translations/{fileName}.json";
 
             var httpClient = httpClientFactory.CreateClient();
             httpClient.Timeout = TimeSpan.FromSeconds(30);


### PR DESCRIPTION
Related to #7341 

This just fix the translator repository URL. So, translation functions are  fixed while awaiting the first part of the translation revamp.