### PR TITLE
feat: add separate CanSendStoreEmail permission for store email API

### DIFF
--- a/BTCPayServer.Client/Permissions.cs
+++ b/BTCPayServer.Client/Permissions.cs
@@ -15,6 +15,7 @@ namespace BTCPayServer.Client
         public const string CanModifyServerSettings = "btcpay.server.canmodifyserversettings";
         public const string CanModifyStoreSettings = "btcpay.store.canmodifystoresettings";
         public const string CanModifyWebhooks = "btcpay.store.webhooks.canmodifywebhooks";
+        public const string CanSendStoreEmail = "btcpay.store.cansendstoreemails";
         public const string CanModifyStoreSettingsUnscoped = "btcpay.store.canmodifystoresettings:";
         public const string CanViewStoreSettings = "btcpay.store.canviewstoresettings";
         public const string CanViewReports = "btcpay.store.canviewreports";

--- a/BTCPayServer/Controllers/GreenField/GreenfieldStoreEmailController.cs
+++ b/BTCPayServer/Controllers/GreenField/GreenfieldStoreEmailController.cs
@@ -27,7 +27,7 @@ namespace BTCPayServer.Controllers.GreenField
             _storeRepository = storeRepository;
         }
 
-        [Authorize(Policy = Policies.CanModifyStoreSettings, AuthenticationSchemes = AuthenticationSchemes.Greenfield)]
+        [Authorize(Policy = Policies.CanSendStoreEmail, AuthenticationSchemes = AuthenticationSchemes.Greenfield)]
         [HttpPost("~/api/v1/stores/{storeId}/email/send")]
         public async Task<IActionResult> SendEmailFromStore(string storeId,
             [FromBody] SendEmailRequest request)

--- a/BTCPayServer/Hosting/BTCPayServerServices.cs
+++ b/BTCPayServer/Hosting/BTCPayServerServices.cs
@@ -550,6 +550,10 @@ namespace BTCPayServer.Hosting
                     new PermissionDisplay("Modify stores webhooks", "Allows modifying the webhooks of all your stores."),
                     new PermissionDisplay("Modify selected stores' webhooks", "Allows modifying the webhooks of the selected stores.")),
                 new PolicyDefinition(
+                    Policies.CanSendStoreEmail,
+                    new PermissionDisplay("Send store emails", "Allows sending emails on behalf of all your stores."),
+                    new PermissionDisplay("Send selected stores' emails", "Allows sending emails on behalf of the selected stores.")),
+                new PolicyDefinition(
                     Policies.CanModifyServerSettings,
                     new PermissionDisplay("Manage your server", "Grants total control on the server settings of your server."),
                     includedPermissions: new[] { Policies.CanUseInternalLightningNode, Policies.CanManageUsers }),
@@ -565,7 +569,8 @@ namespace BTCPayServer.Hosting
                         Policies.CanModifyWebhooks,
                         Policies.CanModifyPaymentRequests,
                         Policies.CanManagePayouts,
-                        Policies.CanUseLightningNodeInStore
+                        Policies.CanUseLightningNodeInStore,
+                        Policies.CanSendStoreEmail
                     }),
                 new PolicyDefinition(
                     Policies.CanViewStoreSettings,


### PR DESCRIPTION
closes : https://github.com/btcpayserver/btcpayserver/issues/6159