### PR TITLE
Add Backup button to Maintenance page

### DIFF
--- a/BTCPayServer/Controllers/UIServerController.cs
+++ b/BTCPayServer/Controllers/UIServerController.cs
@@ -250,6 +250,13 @@ namespace BTCPayServer.Controllers
                     return error;
                 TempData[WellKnownTempData.SuccessMessage] = StringLocalizer["The old docker images will be cleaned soon..."].Value;
             }
+            else if (command == "backup")
+            {
+                var error = await RunSSH(vm, $"backup.sh");
+                if (error != null)
+                    return error;
+                TempData[WellKnownTempData.SuccessMessage] = StringLocalizer["A backup is being created. It will be saved to {0} on the host.", "/var/lib/docker/volumes/backup_datadir/_data"].Value;
+            }
             else if (command == "restart")
             {
                 var error = await RunSSH(vm, $"btcpay-restart.sh");

--- a/BTCPayServer/Views/UIServer/Maintenance.cshtml
+++ b/BTCPayServer/Views/UIServer/Maintenance.cshtml
@@ -37,6 +37,14 @@
                 </div>
             </div>
 
+            <h4 class="mt-5 mb-2" text-translate="true">Backup</h4>
+            <p text-translate="true">Create a backup of your BTCPay Server data.</p>
+            <div class="form-group">
+                <div class="input-group">
+                    <button name="command" type="submit" class="btn btn-secondary" value="backup" disabled="@(Model.CanUseSSH ? null : "disabled")" text-translate="true">Backup</button>
+                </div>
+            </div>
+
             <h4 class="mt-5 mb-2" text-translate="true">Update</h4>
             <p text-translate="true">Update to the latest version of BTCPay Server.</p>
             <div class="form-group">


### PR DESCRIPTION
## Summary

Adds a **Backup** button to the Server → Maintenance page that triggers the existing `backup.sh` script from [btcpayserver-docker](https://github.com/btcpayserver/btcpayserver-docker/blob/master/backup.sh) via SSH, following the same pattern as Update/Restart/Clean.

The new button sits between **Clean** and **Update** so users have a natural "back up before you update" workflow. It is disabled when SSH is not configured (same `Model.CanUseSSH` guard as the other buttons).

On success, the user gets a flash message indicating the host directory the archive will land in: `/var/lib/docker/volumes/backup_datadir/_data`.

## Changes

- `BTCPayServer/Controllers/UIServerController.cs` — new `else if (command == "backup")` branch in the existing `Maintenance` POST action, calls `RunSSH(vm, "backup.sh")` with the same error-handling pattern as the sibling commands.
- `BTCPayServer/Views/UIServer/Maintenance.cshtml` — new Backup section mirroring the Clean section markup verbatim (heading, description, `btn-secondary` button, `text-translate="true"` for i18n, `disabled` guard).

No view-model, SSH plumbing, or new tests required — reuses the existing `MaintenanceViewModel.CanUseSSH`, `RunSSH` helper, and `nohup ... & disown` background-execution pattern.

## Testing

- [x] `dotnet build BTCPayServer/BTCPayServer.csproj` — clean (0 errors, same 7 pre-existing warnings as `master`).
- [ ] Manual: button appears on Maintenance page and is disabled when SSH is not configured.
- [ ] Manual: clicking Backup on a properly-configured host triggers `backup.sh`; archive appears under `/var/lib/docker/volumes/backup_datadir/_data/<timestamp>-backup.tar.gz`.
- [ ] Manual: success flash message shown after dispatch.

## Notes

The existing 4 buttons (Restart/Update/Clean/Change Domain) have no unit tests covering them, so I followed precedent and didn't add any. Happy to add coverage if maintainers prefer.