### PR TITLE
Subscription plan retirement

### DIFF
--- a/BTCPayServer.Tests/SubscriptionTests.cs
+++ b/BTCPayServer.Tests/SubscriptionTests.cs
@@ -923,6 +923,257 @@ public class SubscriptionTests(ITestOutputHelper testOutputHelper) : UnitTestBas
         await offering.AssertHasNotSubscriber("enterprise@example.com");
     }
 
+
+    [Fact]
+    [Trait("Playwright", "Playwright-2")]
+    public async Task CanRetirePlanWithNoSubscribers()
+    {
+        await using var s = CreatePlaywrightTester();
+        await s.StartAsync();
+        await s.RegisterNewUser();
+        await s.CreateNewStore();
+        var offering = await CreateNewSubscription(s);
+        await offering.GoToPlans();
+        await s.Page.Locator("tr[data-plan-name='Pro Plan'] a:has-text('Retire')").ClickAsync();
+        await s.Page.WaitForSelectorAsync("#ConfirmModal");
+        await s.Page.ClickAsync("#ConfirmContinue");
+        await s.FindAlertMessage(partialText: "has been retired");
+        var status = await s.Page.Locator("tr[data-plan-name='Pro Plan'] .subscriber-status").InnerTextAsync();
+        Assert.Contains("Retired", status);
+        await s.Page.Locator("tr[data-plan-name='Pro Plan'] a:has-text('Restore')").ClickAsync();
+        await s.Page.WaitForSelectorAsync("#ConfirmModal");
+        await s.Page.ClickAsync("#ConfirmContinue");
+        await s.FindAlertMessage(partialText: "restored to active");
+        status = await s.Page.Locator("tr[data-plan-name='Pro Plan'] .subscriber-status").InnerTextAsync();
+        Assert.Contains("Active", status);
+    }
+
+    [Fact]
+    [Trait("Playwright", "Playwright-2")]
+    public async Task CanRetirePlanWithDoNothing()
+    {
+        await using var s = CreatePlaywrightTester();
+        await s.StartAsync();
+        await s.RegisterNewUser();
+        await s.CreateNewStore();
+        await s.AddDerivationScheme();
+        var offering = await CreateNewSubscription(s);
+        await s.Server.WaitForEvent<SubscriptionEvent.NewSubscriber>(async () =>
+        {
+            await offering.NewSubscriber("Basic Plan", "basic@example.com", false, mine: true);
+        });
+        await offering.GoToPlans();
+        await s.Page.Locator("tr[data-plan-name='Basic Plan'] a:has-text('Retire')").ClickAsync();
+        await s.Page.WaitForSelectorAsync("#retirePlanModal");
+        await s.Page.CheckAsync("#retireAction-nothing");
+        await s.Page.ClickAsync("#retirePlanForm button[type='submit']");
+        await s.FindAlertMessage(partialText: "has been retired");
+        var status = await s.Page.Locator("tr[data-plan-name='Basic Plan'] .subscriber-status").InnerTextAsync();
+        Assert.Contains("Retiring", status);
+        await offering.GoToSubscribers();
+        await offering.AssertHasSubscriber("basic@example.com", new()
+        {
+            Active = OfferingPMO.ActiveState.Active
+        });
+        await offering.GoToPlans();
+        var dropdownToggle = s.Page.Locator("tr[data-plan-name='Basic Plan'] .plan-name-col span.dropdown-toggle");
+        Assert.Equal(0, await dropdownToggle.CountAsync());
+    }
+
+
+    [Fact]
+    [Trait("Playwright", "Playwright-2")]
+    public async Task CanRetirePlanWithDisableAutoRenew()
+    {
+        await using var s = CreatePlaywrightTester();
+        await s.StartAsync();
+        await s.RegisterNewUser();
+        await s.CreateNewStore();
+        await s.AddDerivationScheme();
+        var offering = await CreateNewSubscription(s);
+        await s.Server.WaitForEvent<SubscriptionEvent.NewSubscriber>(async () =>
+        {
+            await offering.NewSubscriber("Enterprise Plan", "enterprise@example.com", true);
+        });
+        await offering.GoToPlans();
+        await s.Page.WaitForSelectorAsync("tr[data-plan-name='Enterprise Plan'] td:has-text('1 Members')");
+        await s.Page.Locator("tr[data-plan-name='Enterprise Plan'] a:has-text('Retire')").ClickAsync();
+        await s.Page.WaitForSelectorAsync("#retirePlanModal.show");
+        await s.Page.CheckAsync("#retireAction-autorenew");
+        await s.Page.ClickAsync("#retirePlanForm button[type='submit']");
+        await s.FindAlertMessage(partialText: "has been retired");
+        await offering.GoToSubscribers();
+        await offering.AssertHasSubscriber("enterprise@example.com", new()
+        {
+            Active = OfferingPMO.ActiveState.Active
+        });
+        await using var portal = await offering.GoToPortal("enterprise@example.com");
+        var autoRenew = await s.Page.Locator("#autoRenewal").IsCheckedAsync();
+        Assert.False(autoRenew);
+    }
+
+    [Fact]
+    [Trait("Playwright", "Playwright-2")]
+    public async Task CanRetirePlanWithSuspendAll()
+    {
+        await using var s = CreatePlaywrightTester();
+        await s.StartAsync();
+        await s.RegisterNewUser();
+        await s.CreateNewStore();
+        await s.AddDerivationScheme();
+        var offering = await CreateNewSubscription(s);
+        await s.Server.WaitForEvent<SubscriptionEvent.NewSubscriber>(async () =>
+        {
+            await offering.NewSubscriber("Enterprise Plan", "enterprise@example.com", true);
+        });
+        await offering.GoToPlans();
+        await s.Page.WaitForSelectorAsync("tr[data-plan-name='Enterprise Plan'] td:has-text('1 Members')");
+        await s.Page.Locator("tr[data-plan-name='Enterprise Plan'] a:has-text('Retire')").ClickAsync();
+        await s.Page.WaitForSelectorAsync("#retirePlanModal.show");
+        await s.Page.CheckAsync("#retireAction-suspend");
+        await s.Page.ClickAsync("#retirePlanForm button[type='submit']");
+        await s.FindAlertMessage(partialText: "has been retired");
+        await offering.GoToSubscribers();
+        await offering.AssertHasSubscriber("enterprise@example.com", new()
+        {
+            Active = OfferingPMO.ActiveState.Suspended
+        });
+        await offering.GoToPlans();
+        var status = await s.Page.Locator("tr[data-plan-name='Enterprise Plan'] .subscriber-status").InnerTextAsync();
+        Assert.Contains("Retired", status);
+    }
+
+    [Fact]
+    [Trait("Playwright", "Playwright-2")]
+    public async Task CanRetirePlanWithMigrateAtPeriodEnd()
+    {
+        await using var s = CreatePlaywrightTester();
+        await s.StartAsync();
+        await s.RegisterNewUser();
+        await s.CreateNewStore();
+        await s.AddDerivationScheme();
+        var offering = await CreateNewSubscription(s);
+        await s.Server.WaitForEvent<SubscriptionEvent.NewSubscriber>(async () =>
+        {
+            await offering.NewSubscriber("Enterprise Plan", "enterprise@example.com", true);
+        });
+        await offering.GoToPlans();
+        await s.Page.WaitForSelectorAsync("tr[data-plan-name='Enterprise Plan'] td:has-text('1 Members')");
+        await s.Page.Locator("tr[data-plan-name='Enterprise Plan'] a:has-text('Retire')").ClickAsync();
+        await s.Page.WaitForSelectorAsync("#retirePlanModal.show");
+        await s.Page.CheckAsync("#retireAction-migrate");
+        await s.Page.SelectOptionAsync("#retireMigratePlanId", new SelectOptionValue { Label = "Basic Plan" });
+        await s.Page.SelectOptionAsync("#retireMigrateTiming", new SelectOptionValue { Value = "period-end" });
+        await s.Page.ClickAsync("#retirePlanForm button[type='submit']");
+        await s.FindAlertMessage(partialText: "has been retired");
+        await offering.GoToSubscribers();
+        await offering.AssertHasSubscriber("enterprise@example.com", new()
+        {
+            Active = OfferingPMO.ActiveState.Active
+        });
+        await using var portal = await offering.GoToPortal("enterprise@example.com");
+        await portal.AssertScheduledChange("Basic Plan");
+    }
+
+    [Fact]
+    [Trait("Playwright", "Playwright-2")]
+    public async Task CanRetirePlanWithMigrateImmediatelyEnoughCredit()
+    {
+        await using var s = CreatePlaywrightTester();
+        await s.StartAsync();
+        await s.RegisterNewUser();
+        await s.CreateNewStore();
+        await s.AddDerivationScheme();
+        var offering = await CreateNewSubscription(s);
+        await s.Server.WaitForEvent<SubscriptionEvent.NewSubscriber>(async () =>
+        {
+            await offering.NewSubscriber("Enterprise Plan", "enterprise@example.com", true);
+        });
+        await offering.GoToSubscribers();
+        await offering.Credit("enterprise@example.com", 50m);
+        await offering.GoToPlans();
+        await s.Page.WaitForSelectorAsync("tr[data-plan-name='Enterprise Plan'] td:has-text('1 Members')");
+        await s.Page.Locator("tr[data-plan-name='Enterprise Plan'] a:has-text('Retire')").ClickAsync();
+        await s.Page.WaitForSelectorAsync("#retirePlanModal.show");
+        await s.Page.CheckAsync("#retireAction-migrate");
+        await s.Page.SelectOptionAsync("#retireMigratePlanId", new SelectOptionValue { Label = "Basic Plan" });
+        await s.Page.SelectOptionAsync("#retireMigrateTiming", new SelectOptionValue { Value = "immediate" });
+        await s.Page.ClickAsync("#retirePlanForm button[type='submit']");
+        await s.FindAlertMessage(partialText: "has been retired");
+        await offering.GoToSubscribers();
+        await offering.AssertHasSubscriber("enterprise@example.com", new()
+        {
+            Active = OfferingPMO.ActiveState.Active
+        });
+        await using var portal = await offering.GoToPortal("enterprise@example.com");
+        await portal.AssertPlan("Basic Plan");
+    }
+
+    [Fact]
+    [Trait("Playwright", "Playwright-2")]
+    public async Task CanRetirePlanWithMigrateImmediatelyInsufficientCredit()
+    {
+        await using var s = CreatePlaywrightTester();
+        await s.StartAsync();
+        await s.RegisterNewUser();
+        await s.CreateNewStore();
+        await s.AddDerivationScheme();
+        var offering = await CreateNewSubscription(s);
+        await s.Server.WaitForEvent<SubscriptionEvent.NewSubscriber>(async () =>
+        {
+            await offering.NewSubscriber("Basic Plan", "basic@example.com", false, mine: true);
+        });
+        await offering.GoToPlans();
+        await s.Page.WaitForSelectorAsync("tr[data-plan-name='Basic Plan'] td:has-text('1 Members')");
+        await s.Page.Locator("tr[data-plan-name='Basic Plan'] a:has-text('Retire')").ClickAsync();
+        await s.Page.WaitForSelectorAsync("#retirePlanModal");
+        await s.Page.CheckAsync("#retireAction-migrate");
+        await s.Page.SelectOptionAsync("#retireMigratePlanId", new SelectOptionValue { Label = "Enterprise Plan" });
+        await s.Page.SelectOptionAsync("#retireMigrateTiming", new SelectOptionValue { Value = "immediate" });
+        await s.Page.ClickAsync("#retirePlanForm button[type='submit']");
+        await s.FindAlertMessage(partialText: "has been retired");
+        await offering.GoToSubscribers();
+        await offering.AssertHasSubscriber("basic@example.com", new()
+        {
+            Active = OfferingPMO.ActiveState.Inactive
+        });
+        await using var portal = await offering.GoToPortal("basic@example.com");
+        await portal.AssertScheduledChange("Enterprise Plan");
+    }
+
+    [Fact]
+    [Trait("Playwright", "Playwright-2")]
+    public async Task RetiredPlanBlocksNewSubscriberAndCheckout()
+    {
+        await using var s = CreatePlaywrightTester();
+        await s.StartAsync();
+        await s.RegisterNewUser();
+        await s.CreateNewStore();
+        await s.AddDerivationScheme();
+        var offering = await CreateNewSubscription(s);
+        await offering.GoToPlans();
+        await s.Page.Locator("tr[data-plan-name='Pro Plan'] a:has-text('Retire')").ClickAsync();
+        await s.Page.WaitForSelectorAsync("#ConfirmModal");
+        await s.Page.ClickAsync("#ConfirmContinue");
+        await s.FindAlertMessage(partialText: "has been retired");
+        await offering.GoToSubscribers();
+        await s.Page.ClickAsync(".new-subscriber");
+        await s.Page.WaitForSelectorAsync("#newSubscriberModal");
+        var planOptions = await s.Page.Locator("#newSubscriber-plan option").AllInnerTextsAsync();
+        Assert.DoesNotContain("Pro Plan", planOptions);
+        await s.Page.ClickAsync("#newSubscriberModal .btn-close");
+        await offering.GoToPlans();
+
+        await s.Server.WaitForEvent<SubscriptionEvent.NewSubscriber>(async () =>
+        {
+            await offering.NewSubscriber("Basic Plan", "basic@example.com", false, mine: true);
+        });
+        await offering.GoToSubscribers();
+        await using var portal = await offering.GoToPortal("basic@example.com");
+        var planContainers = await s.Page.Locator(".changeplan-container").AllInnerTextsAsync();
+        Assert.DoesNotContain("Pro Plan", string.Join(" ", planContainers));
+    }
+
     public class OfferingPMO(PlaywrightTester s)
     {
         public Task Configure()

--- a/BTCPayServer/Plugins/Subscriptions/Controllers/UIOfferingController.cs
+++ b/BTCPayServer/Plugins/Subscriptions/Controllers/UIOfferingController.cs
@@ -279,6 +279,15 @@ public partial class UIOfferingController(
                         });
                         return GoToOffering(storeId, offeringId);
                     }
+                    if (migrateToPlanId == planId)
+                    {
+                        TempData.SetStatusMessageModel(new()
+                        {
+                            Severity = StatusMessageModel.StatusSeverity.Error,
+                            Html = StringLocalizer["Cannot migrate subscribers to the plan being retired."]
+                        });
+                        return GoToOffering(storeId, offeringId);
+                    }
                     var targetPlan = await ctx.Plans.GetPlanFromId(migrateToPlanId, offeringId, storeId);
                     if (targetPlan is null || targetPlan.Status != PlanData.PlanStatus.Active)
                     {

--- a/BTCPayServer/Plugins/Subscriptions/Controllers/UIOfferingController.cs
+++ b/BTCPayServer/Plugins/Subscriptions/Controllers/UIOfferingController.cs
@@ -254,9 +254,6 @@ public partial class UIOfferingController(
             return NotFound();
 
         var activeSubscribers = await ctx.Subscribers.Where(s => s.PlanId == planId && s.IsActive).ToListAsync();
-        plan.Status = PlanData.PlanStatus.Retired;
-        await ctx.SaveChangesAsync();
-        eventAggregator.Publish(new SubscriptionEvent.PlanUpdated(plan));
         if (activeSubscribers.Any())
         {
             switch (retireAction)
@@ -273,17 +270,29 @@ public partial class UIOfferingController(
                     break;
 
                 case "migrate":
-                    if (migrateToPlanId is not null)
+                    if (migrateToPlanId is null)
                     {
-                        var targetPlan = await ctx.Plans.GetPlanFromId(migrateToPlanId, offeringId, storeId);
-                        if (targetPlan is not null && targetPlan.Status == PlanData.PlanStatus.Active)
+                        TempData.SetStatusMessageModel(new()
                         {
-                            var immediate = migrateTiming == "immediate";
-                            await SubsService.BulkMigratePlan(planId, migrateToPlanId, offeringId, immediate);
-                            await SubscriptionHostedService.UpdatePlanStats(ctx, planId);
-                            await SubscriptionHostedService.UpdatePlanStats(ctx, migrateToPlanId);
-                        }
+                            Severity = StatusMessageModel.StatusSeverity.Error,
+                            Html = StringLocalizer["Please select a plan to migrate subscribers to."]
+                        });
+                        return GoToOffering(storeId, offeringId);
                     }
+                    var targetPlan = await ctx.Plans.GetPlanFromId(migrateToPlanId, offeringId, storeId);
+                    if (targetPlan is null || targetPlan.Status != PlanData.PlanStatus.Active)
+                    {
+                        TempData.SetStatusMessageModel(new()
+                        {
+                            Severity = StatusMessageModel.StatusSeverity.Error,
+                            Html = StringLocalizer["The selected migration plan is unavailable."]
+                        });
+                        return GoToOffering(storeId, offeringId);
+                    }
+                    var immediate = migrateTiming == "immediate";
+                    await SubsService.BulkMigratePlan(planId, migrateToPlanId, offeringId, immediate);
+                    await SubscriptionHostedService.UpdatePlanStats(ctx, planId);
+                    await SubscriptionHostedService.UpdatePlanStats(ctx, migrateToPlanId);
                     break;
 
                 case "nothing":
@@ -291,6 +300,9 @@ public partial class UIOfferingController(
                     break;
             }
         }
+        plan.Status = PlanData.PlanStatus.Retired;
+        await ctx.SaveChangesAsync();
+        eventAggregator.Publish(new SubscriptionEvent.PlanUpdated(plan));
         TempData.SetStatusSuccess(StringLocalizer["Plan '{0}' has been retired.", plan.Name]);
         return GoToOffering(storeId, offeringId);
     }

--- a/BTCPayServer/Plugins/Subscriptions/Controllers/UIOfferingController.cs
+++ b/BTCPayServer/Plugins/Subscriptions/Controllers/UIOfferingController.cs
@@ -56,6 +56,16 @@ public partial class UIOfferingController(
         if (plan is null)
             return NotFound();
 
+        if (plan.Status == PlanData.PlanStatus.Retired)
+        {
+            TempData.SetStatusMessageModel(new()
+            {
+                Severity = StatusMessageModel.StatusSeverity.Error,
+                Html = StringLocalizer["Cannot create a new subscriber on a retired plan."]
+            });
+            return GoToOffering(storeId, offeringId, SubscriptionSection.Subscribers);
+        }
+
         var checkoutData = new PlanCheckoutData()
         {
             PlanId = planId,
@@ -233,7 +243,73 @@ public partial class UIOfferingController(
         return GoToOffering(storeId, offeringId, SubscriptionSection.Plans);
     }
 
+    [HttpPost("stores/{storeId}/offerings/{offeringId}/plans/{planId}/retire")]
+    [Authorize(Policy = SubscriptionsPolicies.CanModifyOfferings, AuthenticationSchemes = AuthenticationSchemes.Cookie)]
+    public async Task<IActionResult> RetirePlan(string storeId, string offeringId, string planId,
+        string retireAction = "nothing", string? migrateToPlanId = null, string? migrateTiming = null)
+    {
+        await using var ctx = DbContextFactory.CreateContext();
+        var plan = await ctx.Plans.GetPlanFromId(planId, offeringId, storeId);
+        if (plan is null)
+            return NotFound();
 
+        var activeSubscribers = await ctx.Subscribers.Where(s => s.PlanId == planId && s.IsActive).ToListAsync();
+        plan.Status = PlanData.PlanStatus.Retired;
+        await ctx.SaveChangesAsync();
+        eventAggregator.Publish(new SubscriptionEvent.PlanUpdated(plan));
+        if (activeSubscribers.Any())
+        {
+            switch (retireAction)
+            {
+                case "disable-autorenew":
+                    foreach (var sub in activeSubscribers)
+                        sub.AutoRenew = false;
+                    await ctx.SaveChangesAsync();
+                    break;
+
+                case "suspend":
+                    foreach (var sub in activeSubscribers)
+                        await SubsService.Suspend(sub.Id, $"Plan '{plan.Name}' has been retired.");
+                    break;
+
+                case "migrate":
+                    if (migrateToPlanId is not null)
+                    {
+                        var targetPlan = await ctx.Plans.GetPlanFromId(migrateToPlanId, offeringId, storeId);
+                        if (targetPlan is not null && targetPlan.Status == PlanData.PlanStatus.Active)
+                        {
+                            var immediate = migrateTiming == "immediate";
+                            await SubsService.BulkMigratePlan(planId, migrateToPlanId, offeringId, immediate);
+                            await SubscriptionHostedService.UpdatePlanStats(ctx, planId);
+                            await SubscriptionHostedService.UpdatePlanStats(ctx, migrateToPlanId);
+                        }
+                    }
+                    break;
+
+                case "nothing":
+                default:
+                    break;
+            }
+        }
+        TempData.SetStatusSuccess(StringLocalizer["Plan '{0}' has been retired.", plan.Name]);
+        return GoToOffering(storeId, offeringId);
+    }
+
+    [HttpPost("stores/{storeId}/offerings/{offeringId}/plans/{planId}/unretire")]
+    [Authorize(Policy = SubscriptionsPolicies.CanModifyOfferings, AuthenticationSchemes = AuthenticationSchemes.Cookie)]
+    public async Task<IActionResult> UnretirePlan(string storeId, string offeringId, string planId)
+    {
+        await using var ctx = DbContextFactory.CreateContext();
+        var plan = await ctx.Plans.GetPlanFromId(planId, offeringId, storeId);
+        if (plan is null)
+            return NotFound();
+
+        plan.Status = PlanData.PlanStatus.Active;
+        await ctx.SaveChangesAsync();
+        eventAggregator.Publish(new SubscriptionEvent.PlanUpdated(plan));
+        TempData.SetStatusSuccess(StringLocalizer["Plan '{0}' has been restored to active state.", plan.Name]);
+        return GoToOffering(storeId, offeringId);
+    }
 
     public static string CreateOfferingCondition(string offeringId)
         => Predicate(OfferingCondition(offeringId));

--- a/BTCPayServer/Plugins/Subscriptions/Controllers/UIPlanCheckoutController.cs
+++ b/BTCPayServer/Plugins/Subscriptions/Controllers/UIPlanCheckoutController.cs
@@ -1,8 +1,9 @@
-﻿#nullable enable
+#nullable enable
 using System.Threading;
 using System.Threading.Tasks;
 using BTCPayServer.Client.Models;
 using BTCPayServer.Data;
+using BTCPayServer.Data.Subscriptions;
 using BTCPayServer.Models;
 using BTCPayServer.Services;
 using BTCPayServer.Views.UIStoreMembership;
@@ -31,8 +32,9 @@ public class UIPlanCheckoutController(
         await using var ctx = DbContextFactory.CreateContext();
         var checkout = await ctx.PlanCheckouts.GetCheckout(checkoutId);
         var plan = checkout?.Plan;
-        if (plan is null || checkout is null)
+        if (plan is null || checkout is null || plan?.Status == PlanData.PlanStatus.Retired)
             return NotFound();
+
         string? prefilledEmail = null;
         if (checkout.Subscriber is not null)
             prefilledEmail = checkout.Subscriber.Customer.Email.Get();
@@ -77,6 +79,10 @@ public class UIPlanCheckoutController(
         var checkout = await ctx.PlanCheckouts.GetCheckout(checkoutId);
         if (checkout is null)
             return NotFound();
+
+        if (checkout.Plan.Status == PlanData.PlanStatus.Retired)
+            return NotFound();
+
         var checkoutInvoice = checkout.InvoiceId is null ? null : await ctx.Invoices.FindAsync([checkout.InvoiceId], cancellationToken);
         if (checkoutInvoice is not null)
         {

--- a/BTCPayServer/Plugins/Subscriptions/Controllers/UISubscriberPortalController.cs
+++ b/BTCPayServer/Plugins/Subscriptions/Controllers/UISubscriberPortalController.cs
@@ -66,7 +66,7 @@ public class UISubscriberPortalController(
         if (session is null || store is null)
             return NotFound();
 
-        var planChanges = session.Subscriber.Plan.PlanChanges
+        var planChanges = session.Subscriber.Plan.PlanChanges.Where(p => p.PlanChange.Status == PlanData.PlanStatus.Active)
             .Select(p => new SubscriberPortalViewModel.PlanChange(p.PlanChange)
             {
                 ChangeType = p.Type
@@ -117,7 +117,7 @@ public class UISubscriberPortalController(
         var credit = session.Subscriber.GetCredit();
         var displayFormat = DisplayFormatter.CurrencyFormat.Symbol;
         vm.MigratePopups = new();
-        foreach (var change in session.Subscriber.Plan.PlanChanges)
+        foreach (var change in session.Subscriber.Plan.PlanChanges.Where(c => c.PlanChange.Status == PlanData.PlanStatus.Active))
         {
             if (change.PlanChange.Currency != curr)
                 continue;

--- a/BTCPayServer/Plugins/Subscriptions/SubscriptionHostedService.cs
+++ b/BTCPayServer/Plugins/Subscriptions/SubscriptionHostedService.cs
@@ -520,7 +520,8 @@ public class SubscriptionHostedService(
                 {
                     checkout.CreditedByInvoice += diff;
                     await subCtx.CreditSubscriber(sub, $"Credit purchase (Inv: {invoice.Id})", diff);
-                    await TryStartPlan(subCtx, checkout, sub);
+                    if (plan.Status != PlanData.PlanStatus.Retired)
+                        await TryStartPlan(subCtx, checkout, sub);
                 }
                 else
                 {

--- a/BTCPayServer/Plugins/Subscriptions/SubscriptionHostedService.cs
+++ b/BTCPayServer/Plugins/Subscriptions/SubscriptionHostedService.cs
@@ -196,10 +196,11 @@ public class SubscriptionHostedService(
                 var charged = await subCtx.TryChargeSubscriber(sub, $"Migration to plan '{targetPlan.Name}'", targetPlan.Price);
                 if (charged)
                 {
+                    var prevPlan = sub.Plan;
                     using var scope = sub.NewPlanScope(targetPlan);
                     sub.StartNextPlan(now);
                     scope.Commit();
-                    subCtx.AddEvent(new SubscriptionEvent.PlanStarted(sub, sub.Plan));
+                    subCtx.AddEvent(new SubscriptionEvent.PlanStarted(sub, prevPlan));
                 }
             }
             else

--- a/BTCPayServer/Plugins/Subscriptions/SubscriptionHostedService.cs
+++ b/BTCPayServer/Plugins/Subscriptions/SubscriptionHostedService.cs
@@ -165,6 +165,62 @@ public class SubscriptionHostedService(
         }
     }
 
+    public async Task BulkMigratePlan(string planId, string targetPlanId, string offeringId, bool immediate)
+    {
+        await using var subCtx = CreateContext(CancellationToken);
+        var ctx = subCtx.Context;
+        var targetPlan = await ctx.Plans.FirstOrDefaultAsync(p => p.Id == targetPlanId && p.OfferingId == offeringId);
+        if (targetPlan is null)
+            return;
+
+        var activeSubscribers = await ctx.Subscribers.IncludeAll().Where(s => s.PlanId == planId && s.IsActive).ToListAsync();
+        await ctx.PlanFeatures.FetchPlanFeaturesAsync(activeSubscribers.Select(s => s.Plan));
+        var now = subCtx.Now;
+        var expiredSubscribers = new List<SubscriberData>();
+        foreach (var sub in activeSubscribers)
+        {
+            if (!immediate)
+            {
+                sub.NewPlanId = targetPlanId;
+                sub.NewPlan = targetPlan;
+                continue;
+            }
+            var unusedAmount = subCtx.RoundAmount(sub.GetUnusedPeriodAmount(now) ?? 0m, sub.Plan.Currency);
+            var availableCredit = sub.GetCredit() + unusedAmount;
+            var canAfford = availableCredit >= targetPlan.Price;
+            if (canAfford)
+            {
+                if (unusedAmount > 0)
+                    await subCtx.CreditSubscriber(sub, $"Refund for unused period on plan '{sub.Plan.Name}'", unusedAmount);
+
+                var charged = await subCtx.TryChargeSubscriber(sub, $"Migration to plan '{targetPlan.Name}'", targetPlan.Price);
+                if (charged)
+                {
+                    using var scope = sub.NewPlanScope(targetPlan);
+                    sub.StartNextPlan(now);
+                    scope.Commit();
+                    subCtx.AddEvent(new SubscriptionEvent.PlanStarted(sub, sub.Plan));
+                }
+            }
+            else
+            {
+                sub.PeriodEnd = now;
+                sub.GracePeriodEnd = null;
+                sub.TrialEnd = null;
+                sub.AutoRenew = false;
+                expiredSubscribers.Add(sub);
+            }
+        }
+        await ctx.SaveChangesAsync();
+        await UpdateSubscriptionStates(subCtx, new MemberSelector.PassedDate(null, now.AddSeconds(1)));
+        foreach (var sub in expiredSubscribers)
+        {
+            sub.NewPlanId = targetPlanId;
+            sub.NewPlan = targetPlan;
+        }
+        await ctx.SaveChangesAsync();
+    }
+
     record UpdateDatesRequest(long SubId, DateTimeOffset StartDate, DateTimeOffset? ExpirationDate);
 
     public Task UpdateDates(long subId, DateTimeOffset startDate, DateTimeOffset? expirationDate)
@@ -690,6 +746,9 @@ public class SubscriptionHostedService(
         {
             plan = await ctx.Plans.GetPlanFromId(planId, portal.Subscriber.OfferingId);
             if (plan is null)
+                return new PlanMigrationResult.NotFound();
+
+            if (plan.Status == PlanData.PlanStatus.Retired)
                 return new PlanMigrationResult.NotFound();
 
             var planChangeRecord  = portal.Subscriber.Plan.PlanChanges

--- a/BTCPayServer/Plugins/Subscriptions/Views/UIOffering/Offering.cshtml
+++ b/BTCPayServer/Plugins/Subscriptions/Views/UIOffering/Offering.cshtml
@@ -106,21 +106,27 @@
                             data-plan-id="@p.Data.Id"
                             data-plan-name="@p.Data.Name"
                             data-allow-trial="@(p.Data.TrialDays > 0)">
-                            <td class="fw-semibold text-nowrap plan-name-col">
-                                <span class="dropdown-toggle" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                                    @p.Data.Name
-                                </span>
-                                <div class="dropdown-menu">
-                                    <a
-                                        href="#"
-                                        text-translate="true"
-                                        class="new-subscriber-link dropdown-item lh-base"
-                                        data-bs-toggle="modal"
-                                        data-bs-target="#newSubscriberModal">
-                                        Create a new subscriber
-                                    </a>
-                                </div>
-                            </td>
+							<td class="fw-semibold text-nowrap plan-name-col">
+								@if (p.Data.Status == PlanData.PlanStatus.Active)
+								{
+									<span class="dropdown-toggle" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+										@p.Data.Name
+									</span>
+									<div class="dropdown-menu">
+										<a href="#"
+										   text-translate="true"
+										   class="new-subscriber-link dropdown-item lh-base"
+										   data-bs-toggle="modal"
+										   data-bs-target="#newSubscriberModal">
+											Create a new subscriber
+										</a>
+									</div>
+								}
+								else
+								{
+									<span>@p.Data.Name</span>
+								}
+							</td>
                             <td>
                                 <vc:truncate-center
                                     text="@p.Data.Id"
@@ -149,6 +155,50 @@
                                        asp-route-offeringId="@offeringId"
                                        asp-route-planId="@p.Data.Id"
                                        permission="@SubscriptionsPolicies.CanModifyOfferings">Edit</a>
+
+									@if (p.Data.Status == PlanData.PlanStatus.Active)
+									{
+										@if (p.Data.MemberCount > 0)
+										{
+											<a href="#"
+												data-bs-toggle="modal"
+												data-bs-target="#retirePlanModal"
+												data-plan-id="@p.Data.Id"
+												data-plan-name="@p.Data.Name"
+												data-retire-url="@Url.Action("RetirePlan", new { storeId, offeringId, planId = p.Data.Id })"
+												permission="@SubscriptionsPolicies.CanModifyOfferings"
+												text-translate="true">Retire</a>
+										}
+										else
+										{
+											<a asp-action="RetirePlan"
+												asp-route-storeId="@storeId"
+												asp-route-offeringId="@offeringId"
+												asp-route-planId="@p.Data.Id"
+												data-bs-toggle="modal"
+												data-bs-target="#ConfirmModal"
+												data-title="@StringLocalizer["Retire Plan"]"
+												data-description="@ViewLocalizer["Are you sure you want to retire <b>{0}</b>?", Html.Encode(p.Data.Name)]"
+												data-confirm="@StringLocalizer["Retire"]"
+												data-action="@Url.Action("RetirePlan", new { storeId, offeringId, planId = p.Data.Id })"
+												permission="@SubscriptionsPolicies.CanModifyOfferings"
+												text-translate="true">Retire</a>
+										}
+									}
+									else
+									{
+										<a asp-action="UnretirePlan"
+											asp-route-storeId="@storeId"
+											asp-route-offeringId="@offeringId"
+											asp-route-planId="@p.Data.Id"
+											data-bs-toggle="modal"
+											data-bs-target="#ConfirmModal"
+											data-description="@ViewLocalizer["This will restore plan <b>{0}</b> to active.", Html.Encode(p.Data.Name)]"
+											data-confirm="@StringLocalizer["Restore"]"
+											data-action="@Url.Action("UnretirePlan", new { storeId, offeringId, planId = p.Data.Id })"
+											permission="@SubscriptionsPolicies.CanModifyOfferings"
+											text-translate="true">Restore</a>
+									}
                                     <a
                                         asp-action="DeletePlan"
                                         asp-route-storeId="@storeId"
@@ -173,6 +223,7 @@
             </table>
         </div>
         <partial name="_Confirm" model="@(new ConfirmModel(StringLocalizer["Remove plan"], StringLocalizer["This action will remove this plan. Are you sure?"], StringLocalizer["Delete"]))" />
+		<partial name="RetirePlanModal" model="@Model.SelectablePlans" />
     }
     else if (Model.Section == SubscriptionSection.Subscribers)
     {

--- a/BTCPayServer/Plugins/Subscriptions/Views/UIOffering/RetirePlanModal.cshtml
+++ b/BTCPayServer/Plugins/Subscriptions/Views/UIOffering/RetirePlanModal.cshtml
@@ -94,16 +94,27 @@
             const migrateTimingSelect = document.getElementById('retireMigrateTiming');
             if (migrateTimingSelect) migrateTimingSelect.value = 'period-end';
 
-            const migrateSelect = document.getElementById('retireMigratePlanId');
+			const migrateSelect = document.getElementById('retireMigratePlanId');
+            const migrateRadio = document.getElementById('retireAction-migrate');
             if (migrateSelect) {
                 Array.from(migrateSelect.options).forEach(function (opt) {
                     opt.hidden = opt.value === planId;
+                    opt.disabled = opt.value === planId;
                 });
-                const firstVisible = Array.from(migrateSelect.options).find(o => !o.hidden);
-                if (firstVisible) {
-                    migrateSelect.value = firstVisible.value;
-                    if (migratePlanInput) migratePlanInput.value = firstVisible.value;
+                const validTargets = Array.from(migrateSelect.options).filter(o => !o.hidden);
+                const hasTarget = validTargets.length > 0;
+                if (hasTarget) {
+                    migrateSelect.value = validTargets[0].value;
+                    if (migratePlanInput) migratePlanInput.value = validTargets[0].value;
+                } else {
+                    migrateSelect.value = '';
+                    if (migratePlanInput) migratePlanInput.value = '';
                 }
+                if (migrateRadio) {
+                    migrateRadio.disabled = !hasTarget;
+                    migrateRadio.closest('.form-check').classList.toggle('text-muted', !hasTarget);
+                }
+                if (migrateSelect) migrateSelect.disabled = !hasTarget;
             }
         });
 

--- a/BTCPayServer/Plugins/Subscriptions/Views/UIOffering/RetirePlanModal.cshtml
+++ b/BTCPayServer/Plugins/Subscriptions/Views/UIOffering/RetirePlanModal.cshtml
@@ -1,0 +1,143 @@
+@model List<SubscriptionsViewModel.SelectablePlan>
+<div class="modal fade" id="retirePlanModal" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-centered">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h4 class="modal-title" text-translate="true">Retire Plan</h4>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="@StringLocalizer["Close"]">
+                    <vc:icon symbol="close" />
+                </button>
+            </div>
+            <div class="modal-body">
+                <p>You are about to retire <strong id="retirePlanName"></strong>.</p>
+                <p class="text-muted" text-translate="true">
+                    No new subscriptions or plan migrations to this plan will be allowed.
+                    Choose what to do with existing active subscribers:
+                </p>
+                <div class="form-check mb-2">
+                    <input class="form-check-input" type="radio" name="retireAction" id="retireAction-nothing" value="nothing" checked>
+					<label class="form-check-label" for="retireAction-nothing" text-translate="true">Do nothing</label>
+                </div>
+                <div class="form-check mb-2">
+                    <input class="form-check-input" type="radio" name="retireAction" id="retireAction-autorenew" value="disable-autorenew">
+					<label class="form-check-label" for="retireAction-autorenew" text-translate="true">Turn off auto-renew</label>
+                </div>
+                <div class="form-check mb-2">
+                    <input class="form-check-input" type="radio" name="retireAction" id="retireAction-suspend" value="suspend">
+					<label class="form-check-label" for="retireAction-suspend" text-translate="true">Immediately suspend all</label>
+                </div>
+                @if (Model.Any())
+                {
+                    <div class="form-check mb-3">
+                        <input class="form-check-input" type="radio" name="retireAction" id="retireAction-migrate" value="migrate">
+						<label class="form-check-label" for="retireAction-migrate" text-translate="true">Migrate all</label>
+                    </div>
+                    <div id="migratePlanSelector" style="display:none;" class="ms-4">
+                        <label class="form-label" text-translate="true">Migrate to plan</label>
+                        <select id="retireMigratePlanId" name="migrateToPlanId" class="form-select">
+                            @foreach (var plan in Model)
+                            {
+                                <option value="@plan.Id">@plan.Name</option>
+                            }
+                        </select>
+
+						<label class="form-label" text-translate="true">When</label>
+						<select id="retireMigrateTiming" name="migrateTiming" class="form-select">
+							<option value="period-end">At period end</option>
+							<option value="immediate">Immediately (billing adjusted from credit balance)</option>
+						</select>
+                    </div>
+                }
+            </div>
+            <div class="modal-footer">
+                <form id="retirePlanForm" method="post">
+                    <input type="hidden" id="retirePlanId" name="planId" />
+                    <input type="hidden" id="retireActionInput" name="retireAction" value="nothing" />
+					<input type="hidden" id="retireMigratePlanInput" name="migrateToPlanId" />
+					<input type="hidden" id="retireMigrateTimingInput" name="migrateTiming" value="period-end" />
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal" text-translate="true">Cancel</button>
+                    <button type="submit" class="btn btn-success" text-translate="true">Retire Plan</button>
+                </form>
+            </div>
+        </div>
+    </div>
+</div>
+<script>
+    document.addEventListener('DOMContentLoaded', function () {
+        const modal = document.getElementById('retirePlanModal');
+        const form = document.getElementById('retirePlanForm');
+        const planIdInput = document.getElementById('retirePlanId');
+        const actionInput = document.getElementById('retireActionInput');
+        const migratePlanInput = document.getElementById('retireMigratePlanInput');
+        const migrateTimingInput = document.getElementById('retireMigrateTimingInput');
+        const migratePlanSelector = document.getElementById('migratePlanSelector');
+        const radios = modal.querySelectorAll('input[name="retireAction"]');
+
+        modal.addEventListener('show.bs.modal', function (event) {
+            const trigger = event.relatedTarget;
+            if (!trigger) return;
+
+            const planId = trigger.getAttribute('data-plan-id');
+            const planName = trigger.getAttribute('data-plan-name');
+            const retireUrl = trigger.getAttribute('data-retire-url');
+
+            document.getElementById('retirePlanName').textContent = planName;
+            planIdInput.value = planId;
+            form.action = retireUrl;
+
+            modal.querySelector('#retireAction-nothing').checked = true;
+            actionInput.value = 'nothing';
+            if (migratePlanSelector) migratePlanSelector.style.display = 'none';
+            if (migratePlanInput) migratePlanInput.value = '';
+            if (migrateTimingInput) migrateTimingInput.value = 'period-end';
+
+            const migrateTimingSelect = document.getElementById('retireMigrateTiming');
+            if (migrateTimingSelect) migrateTimingSelect.value = 'period-end';
+
+            const migrateSelect = document.getElementById('retireMigratePlanId');
+            if (migrateSelect) {
+                Array.from(migrateSelect.options).forEach(function (opt) {
+                    opt.hidden = opt.value === planId;
+                });
+                const firstVisible = Array.from(migrateSelect.options).find(o => !o.hidden);
+                if (firstVisible) {
+                    migrateSelect.value = firstVisible.value;
+                    if (migratePlanInput) migratePlanInput.value = firstVisible.value;
+                }
+            }
+        });
+
+        radios.forEach(function (radio) {
+            radio.addEventListener('change', function () {
+                actionInput.value = this.value;
+                if (migratePlanSelector) {
+                    migratePlanSelector.style.display = this.value === 'migrate' ? '' : 'none';
+                }
+                if (migratePlanInput) {
+                    migratePlanInput.value = this.value === 'migrate'
+                        ? document.getElementById('retireMigratePlanId').value
+                        : '';
+                }
+                if (migrateTimingInput && this.value !== 'migrate') {
+                    migrateTimingInput.value = 'period-end';
+                    const migrateTimingSelect = document.getElementById('retireMigrateTiming');
+                    if (migrateTimingSelect) migrateTimingSelect.value = 'period-end';
+                }
+            });
+        });
+
+        const migrateSelect = document.getElementById('retireMigratePlanId');
+        if (migrateSelect) {
+            migrateSelect.addEventListener('change', function () {
+                if (migratePlanInput) migratePlanInput.value = this.value;
+            });
+        }
+
+        const migrateTimingSelect = document.getElementById('retireMigrateTiming');
+        if (migrateTimingSelect) {
+            migrateTimingSelect.addEventListener('change', function () {
+                if (migrateTimingInput) migrateTimingInput.value = this.value;
+            });
+        }
+    });
+</script>


### PR DESCRIPTION

Adds the ability to retire subscription plans, preventing new subscriptions and migrations to a retired plan while giving admins control over what happens to existing subscribers.

When Plan in retired state:

- No new subscriptions can be created on a retired plan
- No existing subscriber can upgrade or downgrade to a retired plan
-admin can restore a retired plan to active at any time

When retiring a plan with active subscribers, an admin chooses what happens to those subscribers. Options include:

- **Do nothing** subscribers continue renewing as normal
- **Turn off auto-renew** subscribers keep access until their current period ends, then expire
- **Immediately suspend all active subscribers** 
- **Migrate all** move subscribers to another plan, either at period end or immediately

For immediate migration:
- Credit balance is adjusted (unused period refunded, new plan charged)
- If a subscriber can't afford the new plan, they expire and the new plan is queued so "Pay Now" takes them to the correct plan rather than back to the retired one

Other improvements covered in PR

- Retired plans are hidden from the "Add subscriber" modal
- Retired plans don't appear as upgrade/downgrade options in the subscriber portal
- `CreatePlanMigrationCheckout` rejects retired plans
- Plan changes (upgrade/downgrade config) in `AddPlan` already filter to active plans only
- "Create subscriber" dropdown is hidden for retired plans in plan view


Cc. @NicolasDorier 