### PR TITLE
fix: IDOR in ArchivePullPayment — cross-store pull payment archival and payout cancellation

### DIFF
--- a/BTCPayServer/Controllers/UIStorePullPaymentsController.PullPayments.cs
+++ b/BTCPayServer/Controllers/UIStorePullPaymentsController.PullPayments.cs
@@ -270,6 +270,10 @@ namespace BTCPayServer.Controllers
         public async Task<IActionResult> ArchivePullPaymentPost(string storeId,
             string pullPaymentId)
         {
+            await using var ctx = _dbContextFactory.CreateContext();
+            var pp = await ctx.PullPayments.FindAsync(pullPaymentId);
+            if (pp?.StoreId != storeId)
+                return NotFound();
             await _pullPaymentService.Cancel(new PullPaymentHostedService.CancelRequest(pullPaymentId));
             TempData.SetStatusMessageModel(new StatusMessageModel
             {


### PR DESCRIPTION
## Summary

Automated security fix for **IDOR in ArchivePullPayment — cross-store pull payment archival and payout cancellation** (High).

**CWE**: CWE-CWE-639
**OWASP**: A01:2021-Broken Access Control
**Fix Confidence**: high

## What Changed
Added an ownership check in the pull payment archive POST action before invoking the hosted service cancellation. The endpoint now loads the pull payment and returns NotFound unless it belongs to the store ID from the authorized route, preventing cross-store archival and payout cancellation.

## Verification Checklist

- [ ] Review the code change
- [ ] Run tests to verify no regression
- [x] Verify the vulnerability is addressed — *already verified by Cerberus Sentinel*

---
*Created by [Cerberus](https://github.com/Donjon-Cerberus) Merlin*
