### PR TITLE
Display Bylls rate source as Bull Bitcoin

### DIFF
--- a/BTCPayServer.Rating/Providers/ByllsRateProvider.cs
+++ b/BTCPayServer.Rating/Providers/ByllsRateProvider.cs
@@ -14,7 +14,7 @@ namespace BTCPayServer.Services.Rates
             _httpClient = httpClient ?? new HttpClient();
         }
 
-        public RateSourceInfo RateSourceInfo => new RateSourceInfo("bylls", "Bylls", "https://bylls.com/api/price?from_currency=BTC&to_currency=CAD");
+        public RateSourceInfo RateSourceInfo => new RateSourceInfo("bylls", "Bull Bitcoin", "https://bylls.com/api/price?from_currency=BTC&to_currency=CAD");
 
         public async Task<PairRate[]> GetRatesAsync(CancellationToken cancellationToken)
         {


### PR DESCRIPTION
The Bylls rate source is publicly shown in BTCPay Server's rate source list. Bylls is now Bull Bitcoin, so this PR updates the publicly visible display name to Bull Bitcoin while leaving the provider id, endpoint, and existing rate-script compatibility unchanged.