### PR TITLE
Flatten UI and API routes of webhooks

### DIFF
--- a/BTCPayServer.Client/BTCPayServerClient.Webhooks.cs
+++ b/BTCPayServer.Client/BTCPayServerClient.Webhooks.cs
@@ -12,20 +12,20 @@ public partial class BTCPayServerClient
         return await SendHttpRequest<StoreWebhookData>($"api/v1/stores/{storeId}/webhooks", create, HttpMethod.Post, token);
     }
 
-    public virtual async Task<StoreWebhookData> GetWebhook(string storeId, string webhookId, CancellationToken token = default)
+    public virtual async Task<StoreWebhookData> GetWebhook(string webhookId, CancellationToken token = default)
     {
-        var response = await _httpClient.SendAsync(CreateHttpRequest($"api/v1/stores/{storeId}/webhooks/{webhookId}"), token);
+        var response = await _httpClient.SendAsync(CreateHttpRequest($"api/v1/webhooks/{webhookId}"), token);
         return response.StatusCode == System.Net.HttpStatusCode.NotFound ? null : await HandleResponse<StoreWebhookData>(response);
     }
 
-    public virtual async Task<StoreWebhookData> UpdateWebhook(string storeId, string webhookId, UpdateStoreWebhookRequest update, CancellationToken token = default)
+    public virtual async Task<StoreWebhookData> UpdateWebhook(string webhookId, UpdateStoreWebhookRequest update, CancellationToken token = default)
     {
-        return await SendHttpRequest<StoreWebhookData>($"api/v1/stores/{storeId}/webhooks/{webhookId}", update, HttpMethod.Put, token);
+        return await SendHttpRequest<StoreWebhookData>($"api/v1/webhooks/{webhookId}", update, HttpMethod.Put, token);
     }
 
-    public virtual async Task<bool> DeleteWebhook(string storeId, string webhookId, CancellationToken token = default)
+    public virtual async Task<bool> DeleteWebhook(string webhookId, CancellationToken token = default)
     {
-        var response = await _httpClient.SendAsync(CreateHttpRequest($"api/v1/stores/{storeId}/webhooks/{webhookId}", method: HttpMethod.Delete), token);
+        var response = await _httpClient.SendAsync(CreateHttpRequest($"api/v1/webhooks/{webhookId}", method: HttpMethod.Delete), token);
         return response.IsSuccessStatusCode;
     }
 
@@ -34,25 +34,25 @@ public partial class BTCPayServerClient
         return await SendHttpRequest<StoreWebhookData[]>($"api/v1/stores/{storeId}/webhooks", null, HttpMethod.Get, token);
     }
 
-    public virtual async Task<WebhookDeliveryData[]> GetWebhookDeliveries(string storeId, string webhookId, CancellationToken token = default)
+    public virtual async Task<WebhookDeliveryData[]> GetWebhookDeliveries(string webhookId, CancellationToken token = default)
     {
-        return await SendHttpRequest<WebhookDeliveryData[]>($"api/v1/stores/{storeId}/webhooks/{webhookId}/deliveries", null, HttpMethod.Get, token);
+        return await SendHttpRequest<WebhookDeliveryData[]>($"api/v1/webhooks/{webhookId}/deliveries", null, HttpMethod.Get, token);
     }
 
-    public virtual async Task<WebhookDeliveryData> GetWebhookDelivery(string storeId, string webhookId, string deliveryId, CancellationToken token = default)
+    public virtual async Task<WebhookDeliveryData> GetWebhookDelivery(string webhookId, string deliveryId, CancellationToken token = default)
     {
-        var response = await _httpClient.SendAsync(CreateHttpRequest($"api/v1/stores/{storeId}/webhooks/{webhookId}/deliveries/{deliveryId}"), token);
+        var response = await _httpClient.SendAsync(CreateHttpRequest($"api/v1/webhooks/{webhookId}/deliveries/{deliveryId}"), token);
         return response.StatusCode == System.Net.HttpStatusCode.NotFound ? null : await HandleResponse<WebhookDeliveryData>(response);
     }
 
-    public virtual async Task<string> RedeliverWebhook(string storeId, string webhookId, string deliveryId, CancellationToken token = default)
+    public virtual async Task<string> RedeliverWebhook(string webhookId, string deliveryId, CancellationToken token = default)
     {
-        return await SendHttpRequest<string>($"api/v1/stores/{storeId}/webhooks/{webhookId}/deliveries/{deliveryId}/redeliver", null, HttpMethod.Post, token);
+        return await SendHttpRequest<string>($"api/v1/webhooks/{webhookId}/deliveries/{deliveryId}/redeliver", null, HttpMethod.Post, token);
     }
 
-    public virtual async Task<WebhookEvent> GetWebhookDeliveryRequest(string storeId, string webhookId, string deliveryId, CancellationToken token = default)
+    public virtual async Task<WebhookEvent> GetWebhookDeliveryRequest(string webhookId, string deliveryId, CancellationToken token = default)
     {
-        var response = await _httpClient.SendAsync(CreateHttpRequest($"api/v1/stores/{storeId}/webhooks/{webhookId}/deliveries/{deliveryId}/request"), token);
+        var response = await _httpClient.SendAsync(CreateHttpRequest($"api/v1/webhooks/{webhookId}/deliveries/{deliveryId}/request"), token);
         return response.StatusCode == System.Net.HttpStatusCode.NotFound ? null : await HandleResponse<WebhookEvent>(response);
     }
 }

--- a/BTCPayServer.Tests/GreenfieldAPITests.cs
+++ b/BTCPayServer.Tests/GreenfieldAPITests.cs
@@ -2125,7 +2125,7 @@ namespace BTCPayServer.Tests
                             Assert.Equal(inv.Id, o.InvoiceId);
                             Assert.True(o.ManuallyMarked);
                         });
-                    Assert.NotNull(await client.GetWebhookDelivery(evt.StoreId, evt.WebhookId, evt.DeliveryId));
+                    Assert.NotNull(await client.GetWebhookDelivery(evt.WebhookId, evt.DeliveryId));
                 }
             }
 

--- a/BTCPayServer.Tests/WebhooksTests.cs
+++ b/BTCPayServer.Tests/WebhooksTests.cs
@@ -399,7 +399,7 @@ public class WebhooksTests(ITestOutputHelper log) : UnitTestBase(log)
             });
             Assert.NotNull(hook.Secret);
             AssertHook(fakeServer, hook);
-            hook = await clientProfile.GetWebhook(user.StoreId, hook.Id);
+            hook = await clientProfile.GetWebhook(hook.Id);
             AssertHook(fakeServer, hook);
             var hooks = await clientProfile.GetWebhooks(user.StoreId);
             hook = Assert.Single(hooks);
@@ -409,7 +409,7 @@ public class WebhooksTests(ITestOutputHelper log) : UnitTestBase(log)
             var req = await fakeServer.GetNextRequest();
             req.Response.StatusCode = 200;
             fakeServer.Done();
-            hook = await clientProfile.UpdateWebhook(user.StoreId, hook.Id, new UpdateStoreWebhookRequest()
+            hook = await clientProfile.UpdateWebhook(hook.Id, new UpdateStoreWebhookRequest()
             {
                 Url = hook.Url,
                 Secret = "lol",
@@ -420,15 +420,15 @@ public class WebhooksTests(ITestOutputHelper log) : UnitTestBase(log)
             WebhookDeliveryData delivery = null;
             await TestUtils.EventuallyAsync(async () =>
             {
-                var deliveries = await clientProfile.GetWebhookDeliveries(user.StoreId, hook.Id);
+                var deliveries = await clientProfile.GetWebhookDeliveries(hook.Id);
                 delivery = Assert.Single(deliveries);
             });
 
-            delivery = await clientProfile.GetWebhookDelivery(user.StoreId, hook.Id, delivery.Id);
+            delivery = await clientProfile.GetWebhookDelivery(hook.Id, delivery.Id);
             Assert.NotNull(delivery);
             Assert.Equal(WebhookDeliveryStatus.HttpSuccess, delivery.Status);
 
-            var newDeliveryId = await clientProfile.RedeliverWebhook(user.StoreId, hook.Id, delivery.Id);
+            var newDeliveryId = await clientProfile.RedeliverWebhook(hook.Id, delivery.Id);
             req = await fakeServer.GetNextRequest();
             req.Response.StatusCode = 404;
             Assert.StartsWith("BTCPayServer", Assert.Single(req.Request.Headers.UserAgent));
@@ -436,30 +436,30 @@ public class WebhooksTests(ITestOutputHelper log) : UnitTestBase(log)
             {
                 // Releasing semaphore several times may help making this test less flaky
                 fakeServer.Done();
-                var newDelivery = await clientProfile.GetWebhookDelivery(user.StoreId, hook.Id, newDeliveryId);
+                var newDelivery = await clientProfile.GetWebhookDelivery(hook.Id, newDeliveryId);
                 Assert.NotNull(newDelivery);
                 Assert.Equal(404, newDelivery.HttpCode);
-                var req2 = await clientProfile.GetWebhookDeliveryRequest(user.StoreId, hook.Id, newDeliveryId);
+                var req2 = await clientProfile.GetWebhookDeliveryRequest(hook.Id, newDeliveryId);
                 Assert.Equal(delivery.Id, req2.OriginalDeliveryId);
                 Assert.True(req2.IsRedelivery);
                 Assert.Equal(WebhookDeliveryStatus.HttpError, newDelivery.Status);
             });
-            var deliveries = await clientProfile.GetWebhookDeliveries(user.StoreId, hook.Id);
+            var deliveries = await clientProfile.GetWebhookDeliveries(hook.Id);
             Assert.Equal(2, deliveries.Length);
             Assert.Equal(newDeliveryId, deliveries[0].Id);
-            var jObj = await clientProfile.GetWebhookDeliveryRequest(user.StoreId, hook.Id, newDeliveryId);
+            var jObj = await clientProfile.GetWebhookDeliveryRequest(hook.Id, newDeliveryId);
             Assert.NotNull(jObj);
 
             TestLogs.LogInformation("Should not be able to access webhook without proper auth");
             var unauthorized = await user.CreateClient(Policies.CanCreateInvoice);
             await AssertEx.AssertHttpError(403, async () =>
             {
-                await unauthorized.GetWebhookDeliveryRequest(user.StoreId, hook.Id, newDeliveryId);
+                await unauthorized.GetWebhookDeliveryRequest(hook.Id, newDeliveryId);
             });
 
             TestLogs.LogInformation("Can use btcpay.store.canmodifystoresettings to query webhooks");
             clientProfile = await user.CreateClient(Policies.CanModifyStoreSettings, Policies.CanCreateInvoice);
-            await clientProfile.GetWebhookDeliveryRequest(user.StoreId, hook.Id, newDeliveryId);
+            await clientProfile.GetWebhookDeliveryRequest(hook.Id, newDeliveryId);
 
 
             TestLogs.LogInformation("Can prune deliveries");
@@ -467,19 +467,12 @@ public class WebhooksTests(ITestOutputHelper log) : UnitTestBase(log)
             cleanup.BatchSize = 1;
             cleanup.PruneAfter = TimeSpan.Zero;
             await cleanup.Do(CancellationToken.None);
-            await AssertEx.AssertHttpError(409, () => clientProfile.RedeliverWebhook(user.StoreId, hook.Id, delivery.Id));
+            await AssertEx.AssertHttpError(409, () => clientProfile.RedeliverWebhook(hook.Id, delivery.Id));
 
             TestLogs.LogInformation("Testing corner cases");
-            Assert.Null(await clientProfile.GetWebhookDeliveryRequest(user.StoreId, "lol", newDeliveryId));
-            Assert.Null(await clientProfile.GetWebhookDeliveryRequest(user.StoreId, hook.Id, "lol"));
-            Assert.Null(await clientProfile.GetWebhookDeliveryRequest(user.StoreId, "lol", "lol"));
-            Assert.Null(await clientProfile.GetWebhook(user.StoreId, "lol"));
-            await AssertEx.AssertHttpError(404, async () =>
-            {
-                await clientProfile.UpdateWebhook(user.StoreId, "lol", new UpdateStoreWebhookRequest() { Url = hook.Url });
-            });
+            Assert.Null(await clientProfile.GetWebhookDeliveryRequest(hook.Id, "lol"));
 
-            Assert.True(await clientProfile.DeleteWebhook(user.StoreId, hook.Id));
-            Assert.False(await clientProfile.DeleteWebhook(user.StoreId, hook.Id));
+            Assert.True(await clientProfile.DeleteWebhook(hook.Id));
+            Assert.False(await clientProfile.DeleteWebhook(hook.Id));
         }
 }

--- a/BTCPayServer/Plugins/Webhooks/Controllers/GreenfieldStoreWebhooksController.cs
+++ b/BTCPayServer/Plugins/Webhooks/Controllers/GreenfieldStoreWebhooksController.cs
@@ -30,6 +30,7 @@ namespace BTCPayServer.Plugins.Webhooks.Controllers
         public WebhookSender WebhookSender { get; }
 
         [HttpGet("~/api/v1/stores/{storeId}/webhooks/{webhookId?}")]
+        [HttpGet("~/api/v1/webhooks/{webhookId}")]
         public async Task<IActionResult> ListWebhooks(string storeId, string webhookId)
         {
             if (webhookId is null)
@@ -69,6 +70,7 @@ namespace BTCPayServer.Plugins.Webhooks.Controllers
         }
 
         [HttpPut("~/api/v1/stores/{storeId}/webhooks/{webhookId}")]
+        [HttpPut("~/api/v1/webhooks/{webhookId}")]
         public async Task<IActionResult> UpdateWebhook(string storeId, string webhookId, Client.Models.UpdateStoreWebhookRequest update)
         {
             ValidateWebhookRequest(update);
@@ -77,10 +79,11 @@ namespace BTCPayServer.Plugins.Webhooks.Controllers
             var w = await StoreRepository.GetWebhook(CurrentStoreId, webhookId);
             if (w is null)
                 return WebhookNotFound();
-            await StoreRepository.UpdateWebhook(storeId, webhookId, ToModel(update));
-            return await ListWebhooks(storeId, webhookId);
+            await StoreRepository.UpdateWebhook(CurrentStoreId, webhookId, ToModel(update));
+            return await ListWebhooks(CurrentStoreId, webhookId);
         }
         [HttpDelete("~/api/v1/stores/{storeId}/webhooks/{webhookId}")]
+        [HttpDelete("~/api/v1/webhooks/{webhookId}")]
         public async Task<IActionResult> DeleteWebhook(string storeId, string webhookId)
         {
             var w = await StoreRepository.GetWebhook(CurrentStoreId, webhookId);
@@ -118,6 +121,7 @@ namespace BTCPayServer.Plugins.Webhooks.Controllers
 
 
         [HttpGet("~/api/v1/stores/{storeId}/webhooks/{webhookId}/deliveries/{deliveryId?}")]
+        [HttpGet("~/api/v1/webhooks/{webhookId}/deliveries/{deliveryId?}")]
         public async Task<IActionResult> ListDeliveries(string storeId, string webhookId, string deliveryId, int? count = null)
         {
             if (deliveryId is null)
@@ -135,6 +139,7 @@ namespace BTCPayServer.Plugins.Webhooks.Controllers
             }
         }
         [HttpPost("~/api/v1/stores/{storeId}/webhooks/{webhookId}/deliveries/{deliveryId}/redeliver")]
+        [HttpPost("~/api/v1/webhooks/{webhookId}/deliveries/{deliveryId}/redeliver")]
         public async Task<IActionResult> RedeliverWebhook(string storeId, string webhookId, string deliveryId)
         {
             var delivery = await StoreRepository.GetWebhookDelivery(CurrentStoreId, webhookId, deliveryId);
@@ -151,6 +156,7 @@ namespace BTCPayServer.Plugins.Webhooks.Controllers
         }
 
         [HttpGet("~/api/v1/stores/{storeId}/webhooks/{webhookId}/deliveries/{deliveryId}/request")]
+        [HttpGet("~/api/v1/webhooks/{webhookId}/deliveries/{deliveryId}/request")]
         public async Task<IActionResult> GetDeliveryRequest(string storeId, string webhookId, string deliveryId)
         {
             var delivery = await StoreRepository.GetWebhookDelivery(CurrentStoreId, webhookId, deliveryId);

--- a/BTCPayServer/Plugins/Webhooks/Controllers/UIStoreWebhooksController.cs
+++ b/BTCPayServer/Plugins/Webhooks/Controllers/UIStoreWebhooksController.cs
@@ -68,6 +68,7 @@ public class UIStoreWebhooksController(
         });
     }
 
+    [HttpPost("~/webhooks/{webhookId}/remove")]
     [HttpPost("{storeId}/webhooks/{webhookId}/remove")]
     [Authorize(Policy = Policies.CanModifyStoreSettings, AuthenticationSchemes = AuthenticationSchemes.Cookie)]
     public async Task<IActionResult> DeleteWebhook(string webhookId)
@@ -93,6 +94,7 @@ public class UIStoreWebhooksController(
         return RedirectToAction(nameof(Webhooks), new { storeId });
     }
 
+    [HttpGet("~/webhooks/{webhookId}")]
     [HttpGet("{storeId}/webhooks/{webhookId}")]
     [Authorize(Policy = Policies.CanModifyStoreSettings, AuthenticationSchemes = AuthenticationSchemes.Cookie)]
     public async Task<IActionResult> ModifyWebhook(string webhookId)
@@ -109,6 +111,7 @@ public class UIStoreWebhooksController(
         });
     }
 
+    [HttpPost("~/webhooks/{webhookId}")]
     [HttpPost("{storeId}/webhooks/{webhookId}")]
     [Authorize(Policy = Policies.CanModifyStoreSettings, AuthenticationSchemes = AuthenticationSchemes.Cookie)]
     public async Task<IActionResult> ModifyWebhook(string webhookId, EditWebhookViewModel viewModel)
@@ -124,6 +127,7 @@ public class UIStoreWebhooksController(
         return RedirectToAction(nameof(Webhooks), new { storeId = CurrentStore.Id });
     }
 
+    [HttpPost("~/webhooks/{webhookId}/deliveries/{deliveryId}/redeliver")]
     [HttpPost("{storeId}/webhooks/{webhookId}/deliveries/{deliveryId}/redeliver")]
     [Authorize(Policy = Policies.CanModifyStoreSettings, AuthenticationSchemes = AuthenticationSchemes.Cookie)]
     public async Task<IActionResult> RedeliverWebhook(string webhookId, string deliveryId)
@@ -140,11 +144,11 @@ public class UIStoreWebhooksController(
         return RedirectToAction(nameof(ModifyWebhook),
             new
             {
-                storeId = CurrentStore.Id,
                 webhookId
             });
     }
 
+    [HttpGet("~/webhooks/{webhookId}/deliveries/{deliveryId}/request")]
     [HttpGet("{storeId}/webhooks/{webhookId}/deliveries/{deliveryId}/request")]
     [Authorize(Policy = Policies.CanModifyStoreSettings, AuthenticationSchemes = AuthenticationSchemes.Cookie)]
     public async Task<IActionResult> WebhookDelivery(string webhookId, string deliveryId)

--- a/BTCPayServer/Plugins/Webhooks/Views/ModifyWebhook.cshtml
+++ b/BTCPayServer/Plugins/Webhooks/Views/ModifyWebhook.cshtml
@@ -96,7 +96,6 @@
                 {
                     <li class="list-group-item ">
                         <form asp-action="RedeliverWebhook"
-                              asp-route-storeId="@Context.GetRouteValue("storeId")"
                               asp-route-webhookId="@Context.GetRouteValue("webhookId")"
                               asp-route-deliveryId="@delivery.Id"
                               method="post">
@@ -115,7 +114,6 @@
                                     @if (!delivery.Pruned) {
                                         <span class="ms-3">
                                             <a asp-action="WebhookDelivery"
-                                               asp-route-storeId="@this.Context.GetRouteValue("storeId")"
                                                asp-route-webhookId="@this.Context.GetRouteValue("webhookId")"
                                                asp-route-deliveryId="@delivery.Id"
                                                class="btn btn-link delivery-content" target="_blank">

--- a/BTCPayServer/Plugins/Webhooks/Views/Webhooks.cshtml
+++ b/BTCPayServer/Plugins/Webhooks/Views/Webhooks.cshtml
@@ -51,8 +51,8 @@
                                 </td>
                                 <td class="d-block text-break">@wh.Url</td>
                                 <td class="actions-col text-md-nowrap" permission="@Policies.CanModifyStoreSettings">
-                                    <a asp-action="ModifyWebhook" asp-route-storeId="@Context.GetRouteValue("storeId")" asp-route-webhookId="@wh.Id" text-translate="true">Modify</a> -
-                                    <a asp-action="DeleteWebhook" asp-route-storeId="@Context.GetRouteValue("storeId")" asp-route-webhookId="@wh.Id" data-bs-toggle="modal" data-bs-target="#ConfirmModal" data-confirm-input="@StringLocalizer["Delete"]" text-translate="true">Delete</a>
+                                    <a asp-action="ModifyWebhook" asp-route-webhookId="@wh.Id" text-translate="true">Modify</a> -
+                                    <a asp-action="DeleteWebhook" asp-route-webhookId="@wh.Id" data-bs-toggle="modal" data-bs-target="#ConfirmModal" data-confirm-input="@StringLocalizer["Delete"]" text-translate="true">Delete</a>
                                 </td>
                             </tr>
                         }

--- a/BTCPayServer/Plugins/Webhooks/WebhooksPlugin.cs
+++ b/BTCPayServer/Plugins/Webhooks/WebhooksPlugin.cs
@@ -12,6 +12,7 @@ using BTCPayServer.Plugins.Translations.Controllers;
 using BTCPayServer.Plugins.Webhooks.Controllers;
 using BTCPayServer.Plugins.Webhooks.HostedServices;
 using BTCPayServer.Plugins.Webhooks.TriggerProviders;
+using BTCPayServer.Security;
 using BTCPayServer.Services;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -32,6 +33,9 @@ public class WebhooksPlugin : BaseBTCPayServerPlugin
         services.AddSingleton<IHostedService, WebhookSender>(o => o.GetRequiredService<WebhookSender>());
         services.AddScheduledTask<CleanupWebhookDeliveriesTask>(TimeSpan.FromHours(6.0));
         services.AddScheduledTask<DbPeriodicTask>(TimeSpan.FromHours(1.0));
+        services.AddSingleton(new BuiltInPermissionScopeProvider.RouteValueToStoreIdQuery(
+            "webhookId", "SELECT \"StoreId\" FROM \"StoreWebhooks\" WHERE \"WebhookId\"=@id"
+        ));
 
         services.AddHttpClient(WebhookSender.OnionNamedClient)
             .ConfigurePrimaryHttpMessageHandler<Socks5HttpClientHandler>();

--- a/BTCPayServer/wwwroot/swagger/v1/swagger.template.webhooks.json
+++ b/BTCPayServer/wwwroot/swagger/v1/swagger.template.webhooks.json
@@ -88,11 +88,8 @@
                 ]
             }
         },
-        "/api/v1/stores/{storeId}/webhooks/{webhookId}": {
+        "/api/v1/webhooks/{webhookId}": {
             "parameters": [
-                {
-                    "$ref": "#/components/parameters/StoreId"
-                },
                 {
                     "$ref": "#/components/parameters/WebhookId"
                 }
@@ -202,11 +199,8 @@
                 ]
             }
         },
-        "/api/v1/stores/{storeId}/webhooks/{webhookId}/deliveries": {
+        "/api/v1/webhooks/{webhookId}/deliveries": {
             "parameters": [
-                {
-                    "$ref": "#/components/parameters/StoreId"
-                },
                 {
                     "$ref": "#/components/parameters/WebhookId"
                 }
@@ -254,11 +248,8 @@
                 ]
             }
         },
-        "/api/v1/stores/{storeId}/webhooks/{webhookId}/deliveries/{deliveryId}": {
+        "/api/v1/webhooks/{webhookId}/deliveries/{deliveryId}": {
             "parameters": [
-                {
-                    "$ref": "#/components/parameters/StoreId"
-                },
                 {
                     "$ref": "#/components/parameters/WebhookId"
                 },
@@ -298,11 +289,8 @@
                 ]
             }
         },
-        "/api/v1/stores/{storeId}/webhooks/{webhookId}/deliveries/{deliveryId}/request": {
+        "/api/v1/webhooks/{webhookId}/deliveries/{deliveryId}/request": {
             "parameters": [
-                {
-                    "$ref": "#/components/parameters/StoreId"
-                },
                 {
                     "$ref": "#/components/parameters/WebhookId"
                 },
@@ -346,11 +334,8 @@
                 ]
             }
         },
-        "/api/v1/stores/{storeId}/webhooks/{webhookId}/deliveries/{deliveryId}/redeliver": {
+        "/api/v1/webhooks/{webhookId}/deliveries/{deliveryId}/redeliver": {
             "parameters": [
-                {
-                    "$ref": "#/components/parameters/StoreId"
-                },
                 {
                     "$ref": "#/components/parameters/WebhookId"
                 },


### PR DESCRIPTION
Follow up of https://github.com/btcpayserver/btcpayserver/issues/7287.

Routes like `/api/v1/stores/{storeId}/webhooks/{webhookId}` become `/api/v1/webhooks/{webhookId}`. The old route are still supported.