### PR TITLE
Add Bitcoin.co.ke rate provider

### DIFF
--- a/BTCPayServer.Rating/Providers/BitcoinKenyaRateProvider.cs
+++ b/BTCPayServer.Rating/Providers/BitcoinKenyaRateProvider.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using BTCPayServer.Rating;
+using Newtonsoft.Json.Linq;
+
+namespace BTCPayServer.Services.Rates
+{
+    public class BitcoinKenyaRateProvider : IRateProvider
+    {
+        public RateSourceInfo RateSourceInfo => new("bitcoinkenya", "Bitcoin.co.ke", "https://trex.bitcoin.co.ke/btcpay/rates");
+        private readonly HttpClient _httpClient;
+
+        public BitcoinKenyaRateProvider(HttpClient httpClient)
+        {
+            _httpClient = httpClient ?? new HttpClient();
+        }
+
+        public async Task<PairRate[]> GetRatesAsync(CancellationToken cancellationToken)
+        {
+            using var request = new HttpRequestMessage(HttpMethod.Get, RateSourceInfo.Url);
+            request.Headers.UserAgent.ParseAdd("BTCPay-BitcoinKenya/1.0");
+            using var response = await _httpClient.SendAsync(request, cancellationToken);
+            response.EnsureSuccessStatusCode();
+            var jobj = await response.Content.ReadAsAsync<JObject>(cancellationToken);
+            if (jobj["BTC"] is not JObject results)
+                return Array.Empty<PairRate>();
+            var list = new List<PairRate>();
+            foreach (var prop in results.Properties())
+            {
+                var value = prop.Value.Value<decimal?>();
+                if (value.HasValue && value.Value > 0m)
+                    list.Add(new PairRate(new CurrencyPair("BTC", prop.Name), new BidAsk(value.Value)));
+            }
+            return list.ToArray();
+        }
+    }
+}

--- a/BTCPayServer/Hosting/BTCPayServerServices.cs
+++ b/BTCPayServer/Hosting/BTCPayServerServices.cs
@@ -752,6 +752,7 @@ namespace BTCPayServer.Hosting
             services.AddRateProvider<BudaRateProvider>();
             services.AddRateProvider<BitbankRateProvider>();
             services.AddRateProvider<BitnobRateProvider>();
+            services.AddRateProvider<BitcoinKenyaRateProvider>();
             services.AddRateProvider<BitpayRateProvider>();
             services.AddRateProvider<RipioExchangeProvider>();
             services.AddRateProvider<CryptoMarketExchangeRateProvider>();


### PR DESCRIPTION
## Summary

Adds a public rate provider operated by [bitcoin.co.ke](https://bitcoin.co.ke), a Kenyan Bitcoin community service, covering BTC against KES and 40+ other African and major currencies (TZS, UGX, ZAR, NGN, GHS, EGP, MAD, USD, EUR, GBP, etc.).

## Motivation

Today, Bitnob is the only reliable BTC/KES rate source shipped with BTCPay Server. When Bitnob has API issues, every Kenyan BTCPay merchant breaks. This PR adds a redundant source operated by an independent Kenyan operator so merchants can configure Bitcoin.co.ke as a primary or fallback.

## Implementation

- Single `GET` request to `https://trex.bitcoin.co.ke/btcpay/rates` per `GetRatesAsync()` call (respects the "only 1 request" constraint noted in `BTCPayServerServices.cs`)
- Yadio-shaped response: `{"BTC": {"KES": ..., "USD": ..., ...}}`
- `EnsureSuccessStatusCode()` so 5xx propagates to `BackgroundFetcherRateProvider` for normal exponential backoff handling
- Filters non-positive values (matches `BitnobRateProvider` precedent: *"When API is broken, they return 0"*)
- ~30 lines of code, modeled after `YadioRateProvider`

## Service operator

- **bitcoin.co.ke** — Kenyan Bitcoin community service
- Free public endpoint, no API key, no auth
- Rates refreshed every 60s
- AWS infrastructure in af-south-1 (ElastiCache + Lambda + CloudFront)
- Status page: `status.trex.bitcoin.co.ke`

## Testing

Built and ran BTCPay locally on master + this patch, created a store, set rate source to "Bitcoin.co.ke", generated a 10,000 KES invoice.

### Rate source dropdown shows the new provider

<img width="2152" height="1621" alt="chrome_Rates_-_Google_Chrome_1XZnCjx6eM" src="https://github.com/user-attachments/assets/452e1b1d-f308-420c-8259-1bbd9ee0b704" />


### Invoice creation calls the provider correctly

Rate fetched and used for conversion: `Rate for BTC_KES: bitcoinkenya(BTC_KES) = 9944291.0248373`. 10,000 KES → 0.00100561 BTC.

<img width="2010" height="1399" alt="chrome_Invoice_QysnNeoQj2yV51xWBUru9y_-_Google_Chrome_HlcLAccQbo" src="https://github.com/user-attachments/assets/f21c5697-0e55-47e2-946b-f2611c9a7526" />
