### PR TITLE
Server report for plugin stats

### DIFF
--- a/BTCPayServer/HostedServices/PluginUpdateFetcher.cs
+++ b/BTCPayServer/HostedServices/PluginUpdateFetcher.cs
@@ -80,12 +80,14 @@ namespace BTCPayServer.HostedServices
 
             var installedPlugins = pluginService.Installed;
             var remotePlugins = await pluginService.GetRemotePlugins(null, cancellationToken);
+            _ = pluginService.ReportInstalledPlugins(cancellationToken);
             //take the latest version of each plugin
             var remotePluginsList = remotePlugins
                 .GroupBy(plugin => plugin.Identifier)
                 .Select(group => group.OrderByDescending(plugin => plugin.Version).First())
                 .Where(pair => installedPlugins.ContainsKey(pair.Identifier) || disabledPlugins.ContainsKey(pair.Name))
                 .ToDictionary(plugin => plugin.Identifier, plugin => plugin.Version);
+
             var notify = new HashSet<string>();
             foreach (var pair in remotePluginsList)
             {

--- a/BTCPayServer/Hosting/BTCPayServerServices.cs
+++ b/BTCPayServer/Hosting/BTCPayServerServices.cs
@@ -118,6 +118,9 @@ namespace BTCPayServer.Hosting
                 if (!Uri.TryCreate(pluginSource, UriKind.Absolute, out var r) || (r.Scheme != "https" && r.Scheme != "http"))
                     r = new Uri(PoliciesSettings.DefaultPluginSource, UriKind.Absolute);
                 httpClient.BaseAddress = r;
+
+                var env = prov.GetRequiredService<BTCPayServerEnvironment>();
+                httpClient.DefaultRequestHeaders.UserAgent.ParseAdd($"BTCPayServer/{env.Version}");
             });
 
             services.AddSingleton<PrettyNameProvider>();

--- a/BTCPayServer/Plugins/PluginBuilderClient.cs
+++ b/BTCPayServer/Plugins/PluginBuilderClient.cs
@@ -118,5 +118,16 @@ namespace BTCPayServer.Plugins
 
             return result;
         }
+
+        public async Task ReportInstalledPlugins(IEnumerable<InstalledPluginRequest> plugins, CancellationToken cancellationToken = default)
+        {
+            try
+            {
+                var json = JsonConvert.SerializeObject(plugins, serializerSettings);
+                using var content = new StringContent(json, Encoding.UTF8, "application/json");
+                await _httpClient.PostAsync("api/v1/telemetry/plugins", content, cancellationToken);
+            }
+            catch {}
+        }
     }
 }

--- a/BTCPayServer/Plugins/PluginService.cs
+++ b/BTCPayServer/Plugins/PluginService.cs
@@ -164,6 +164,18 @@ namespace BTCPayServer.Plugins
             return manifest;
         }
 
+        public async Task ReportInstalledPlugins(CancellationToken cancellationToken = default)
+        {
+            if (Env.IsDeveloping || Env.Build == "Debug")
+                return;
+
+            var plugins = Installed.Select(p => new InstalledPluginRequest(p.Key, p.Value.ToString())).ToList();
+            if (plugins.Count == 0)
+                return;
+
+            await _pluginBuilderClient.ReportInstalledPlugins(plugins, cancellationToken);
+        }
+
         public void InstallPlugin(string plugin)
         {
             PluginManager.QueueCommands(_dataDirectories.Value.PluginDir, ("install", plugin));


### PR DESCRIPTION
Include  telemetry for installed plugins

Periodically reports installed plugins to the plugin builder via POST /api/v1/telemetry/plugins, leveraging PluginUpdateFetcher periodic task.

Adds BTCPayServer/{version} User-Agent header to all plugin builder requests.

Skipped on Debug builds and Regtest/Development environments.

Links to https://github.com/btcpayserver/btcpayserver-plugin-builder/pull/220

Cc. @NicolasDorier 