### PR TITLE
add allow-user-association plan feature

### DIFF
--- a/BTCPayServer.Tests/MonetizationTests.cs
+++ b/BTCPayServer.Tests/MonetizationTests.cs
@@ -480,7 +480,10 @@ public class MonetizationTests(ITestOutputHelper helper) : UnitTestBase(helper)
         // Delete sponsor — associated employee should get detached
         await s.GoToServer(ServerNavPages.Users);
         var users = new PMO.UsersPMO(s);
-        await users.DeleteUser("sponsor@gmail.com");
+        await s.Server.WaitForEvent<MonetizationHostedService.MonetizationLockoutUpdated>(async () =>
+        {
+            await users.DeleteUser("sponsor@gmail.com");
+        });
         await AssertSubscribed(s, "employee@gmail.com", true);
         var facto = s.Server.PayTester.GetService<ApplicationDbContextFactory>();
         var settings = s.Server.PayTester.GetService<SettingsRepository>();

--- a/BTCPayServer.Tests/MonetizationTests.cs
+++ b/BTCPayServer.Tests/MonetizationTests.cs
@@ -2,6 +2,7 @@
 using System.Threading.Tasks;
 using BTCPayServer.Abstractions.Models;
 using BTCPayServer.Data;
+using BTCPayServer.Data.Subscriptions;
 using BTCPayServer.Events;
 using BTCPayServer.Plugins.Monetization;
 using BTCPayServer.Services;
@@ -284,6 +285,221 @@ public class MonetizationTests(ITestOutputHelper helper) : UnitTestBase(helper)
             await s.LogIn("enrolled-invited@gmail.com");
             Assert.Contains("subscriber-portal", s.Page.Url);
         }
+    }
+
+    [Fact]
+    [Trait("Playwright", "Playwright-2")]
+    public async Task CanAssociateUsersToSubscriber()
+    {
+        await using var s = CreatePlaywrightTester(newDb: true);
+        await s.StartAsync();
+        await s.RegisterNewUser(true);
+        var (_, storeId) = await s.CreateNewStore();
+        await GoToMonetization(s);
+        await s.ClickPagePrimary();
+        await s.ConfirmModal();
+        await s.FindAlertMessage(partialText: "Monetization activated");
+        var offeringPMO = await GoToOffering(s);
+        var edit = await offeringPMO.Edit("Starter Plan");
+        edit.EnableFeatures = ["allow-user-association"];
+        await edit.Save();
+        await GoToMonetization(s);
+        offeringPMO = await GoToOffering(s);
+        var sponsorEv = await s.Server.WaitForEvent<SubscriptionEvent.NewSubscriber>(async () =>
+        {
+            await CreateUserAsAdmin(s, "sponsor@gmail.com", byPassMonetization: false);
+        });
+        Assert.Equal("sponsor@gmail.com", sponsorEv.Subscriber.Customer.Email.Get());
+        await AssertSubscribed(s, "sponsor@gmail.com", true);
+        await s.AddUserToStore(storeId, "sponsor@gmail.com", "Owner");
+
+        string inviteLink;
+        await using (await s.SwitchPage())
+        {
+            await s.GoToUrl("/");
+            await s.LogIn("sponsor@gmail.com");
+            await s.GoToUrl($"/stores/{storeId}/users");
+            await s.Page.FillAsync("#Email", "employee@gmail.com");
+            await s.Page.ClickAsync("input[type='submit'], button[type='submit']");
+            await s.Page.WaitForSelectorAsync("a[href*='/invite/']");
+            inviteLink = await s.Page.Locator("a[href*='/invite/']").First.GetAttributeAsync("href");
+        }
+
+        await using (await s.SwitchPage())
+        {
+            await s.GoToUrl(inviteLink!);
+            await s.Page.FillAsync("#Password", s.Password);
+            await s.Page.FillAsync("#ConfirmPassword", s.Password);
+            await s.ClickPagePrimary();
+        }
+        await AssertSubscribed(s, "employee@gmail.com", false);
+        await CanLog(s, "employee@gmail.com");
+
+        await GoToMonetization(s);
+        offeringPMO = await GoToOffering(s);
+        var lockoutUpdated = await s.Server.WaitForEvent<MonetizationHostedService.MonetizationLockoutUpdated>(async () =>
+        {
+            await offeringPMO.GoToPlans();
+            edit = await offeringPMO.Edit("Starter Plan");
+            edit.DisableFeatures = ["can-access"];
+            await edit.Save();
+        });
+        Assert.Equal(2, lockoutUpdated.Updated.Length);
+        Assert.All(lockoutUpdated.Updated, u => Assert.True(u.LockoutEnabled));
+        await using (await s.SwitchPage())
+        {
+            await s.GoToUrl("/");
+            await s.LogIn("employee@gmail.com");
+            await s.FindAlertMessage(StatusMessageModel.StatusSeverity.Warning, partialText: "Your user account is currently disabled.");
+        }
+
+        await GoToMonetization(s);
+        offeringPMO = await GoToOffering(s);
+        lockoutUpdated = await s.Server.WaitForEvent<MonetizationHostedService.MonetizationLockoutUpdated>(async () =>
+        {
+            await offeringPMO.GoToPlans();
+            edit = await offeringPMO.Edit("Starter Plan");
+            edit.EnableFeatures = ["can-access"];
+            await edit.Save();
+        });
+        Assert.Equal(2, lockoutUpdated.Updated.Length);
+        Assert.All(lockoutUpdated.Updated, u => Assert.False(u.LockoutEnabled));
+        await CanLog(s, "employee@gmail.com");
+
+        lockoutUpdated = await s.Server.WaitForEvent<MonetizationHostedService.MonetizationLockoutUpdated>(async () =>
+        {
+            await offeringPMO.GoToPlans();
+            edit = await offeringPMO.Edit("Starter Plan");
+            edit.DisableFeatures = ["allow-user-association"];
+            await edit.Save();
+        });
+        await AssertSubscribed(s, "employee@gmail.com", true);
+
+        var facto = s.Server.PayTester.GetService<ApplicationDbContextFactory>();
+        var settings = s.Server.PayTester.GetService<SettingsRepository>();
+        var monetization = await settings.GetSettingAsync<MonetizationSettings>() ?? new();
+        await using (var ctx = facto.CreateContext())
+        {
+            var employeeSub = await ctx.Subscribers.GetBySelector(monetization.OfferingId, CustomerSelector.ByEmail("employee@gmail.com"));
+            Assert.NotNull(employeeSub);
+            Assert.Equal(SubscriberData.PhaseTypes.Expired, employeeSub.Phase);
+            Assert.False(employeeSub.IsActive);
+        }
+        await using (await s.SwitchPage())
+        {
+            await s.GoToUrl("/");
+            await s.LogIn("employee@gmail.com");
+            Assert.Contains("subscriber-portal", s.Page.Url);
+        }
+
+        // case: Re-enable allow-user-association, expire sponsor, invite new employee — should be locked
+        await offeringPMO.GoToPlans();
+        edit = await offeringPMO.Edit("Starter Plan");
+        edit.EnableFeatures = ["allow-user-association"];
+        await edit.Save();
+        string inviteLink2;
+        await using (await s.SwitchPage())
+        {
+            await s.GoToUrl("/");
+            await s.LogIn("sponsor@gmail.com");
+            await s.GoToUrl($"/stores/{storeId}/users");
+            await s.Page.FillAsync("#Email", "employee2@gmail.com");
+            await s.Page.ClickAsync("input[type='submit'], button[type='submit']");
+            await s.Page.WaitForSelectorAsync("a[href*='/invite/']");
+            inviteLink2 = await s.Page.Locator("a[href*='/invite/']").First.GetAttributeAsync("href");
+        }
+        await GoToMonetization(s);
+        offeringPMO = await GoToOffering(s);
+        await offeringPMO.GoToSubscribers();
+        await s.Server.WaitForEvent<MonetizationHostedService.MonetizationLockoutUpdated>(async () =>
+        {
+            await offeringPMO.Suspend("sponsor@gmail.com", "Testing case");
+        });
+        await using (await s.SwitchPage())
+        {
+            await s.GoToUrl(inviteLink2!);
+            await s.Page.FillAsync("#Password", s.Password);
+            await s.Page.FillAsync("#ConfirmPassword", s.Password);
+            await s.ClickPagePrimary();
+        }
+        await AssertSubscribed(s, "employee2@gmail.com", false);
+        await using (await s.SwitchPage())
+        {
+            await s.GoToUrl("/");
+            await s.LogIn("employee2@gmail.com");
+            await s.FindAlertMessage(StatusMessageModel.StatusSeverity.Warning, partialText: "Your user account is currently disabled.");
+        }
+    }
+
+    [Fact]
+    [Trait("Playwright", "Playwright-2")]
+    public async Task WhenSponsorDeleted_AssociatedUsersGetDetachedWithExpiredSubscription()
+    {
+        await using var s = CreatePlaywrightTester(newDb: true);
+        await s.StartAsync();
+        await s.RegisterNewUser(true);
+        var (_, storeId) = await s.CreateNewStore();
+        await GoToMonetization(s);
+        await s.ClickPagePrimary();
+        await s.ConfirmModal();
+        await s.FindAlertMessage(partialText: "Monetization activated");
+        var offeringPMO = await GoToOffering(s);
+        var edit = await offeringPMO.Edit("Starter Plan");
+        edit.EnableFeatures = ["allow-user-association"];
+        await edit.Save();
+        await GoToMonetization(s);
+        offeringPMO = await GoToOffering(s);
+        var sponsorEv = await s.Server.WaitForEvent<SubscriptionEvent.NewSubscriber>(async () =>
+        {
+            await CreateUserAsAdmin(s, "sponsor@gmail.com", byPassMonetization: false);
+        });
+        Assert.Equal("sponsor@gmail.com", sponsorEv.Subscriber.Customer.Email.Get());
+        await AssertSubscribed(s, "sponsor@gmail.com", true);
+        await s.AddUserToStore(storeId, "sponsor@gmail.com", "Owner");
+        string inviteLink;
+        await using (await s.SwitchPage())
+        {
+            await s.GoToUrl("/");
+            await s.LogIn("sponsor@gmail.com");
+            await s.GoToUrl($"/stores/{storeId}/users");
+            await s.Page.FillAsync("#Email", "employee@gmail.com");
+            await s.Page.ClickAsync("input[type='submit'], button[type='submit']");
+            await s.Page.WaitForSelectorAsync("a[href*='/invite/']");
+            inviteLink = await s.Page.Locator("a[href*='/invite/']").First.GetAttributeAsync("href");
+        }
+        await using (await s.SwitchPage())
+        {
+            await s.GoToUrl(inviteLink!);
+            await s.Page.FillAsync("#Password", s.Password);
+            await s.Page.FillAsync("#ConfirmPassword", s.Password);
+            await s.ClickPagePrimary();
+        }
+        await AssertSubscribed(s, "employee@gmail.com", false);
+        await CanLog(s, "employee@gmail.com");
+
+        // Delete sponsor — associated employee should get detached
+        await s.GoToServer(ServerNavPages.Users);
+        var users = new PMO.UsersPMO(s);
+        await users.DeleteUser("sponsor@gmail.com");
+        await AssertSubscribed(s, "employee@gmail.com", true);
+        var facto = s.Server.PayTester.GetService<ApplicationDbContextFactory>();
+        var settings = s.Server.PayTester.GetService<SettingsRepository>();
+        var monetization = await settings.GetSettingAsync<MonetizationSettings>() ?? new();
+        await using var ctx = facto.CreateContext();
+        var employeeSub = await ctx.Subscribers.GetBySelector(monetization.OfferingId, CustomerSelector.ByEmail("employee@gmail.com"));
+        Assert.NotNull(employeeSub);
+        Assert.Equal(SubscriberData.PhaseTypes.Expired, employeeSub.Phase);
+        Assert.False(employeeSub.IsActive);
+        await using (await s.SwitchPage())
+        {
+            await s.GoToUrl("/");
+            await s.LogIn("employee@gmail.com");
+            Assert.Contains("subscriber-portal", s.Page.Url);
+        }
+        await GoToMonetization(s);
+        offeringPMO = await GoToOffering(s);
+        await offeringPMO.GoToSubscribers();
+        await offeringPMO.AssertHasNotSubscriber("sponsor@gmail.com");
     }
 
     private async Task SetBypassMonetization(PlaywrightTester s, string email, bool bypass)

--- a/BTCPayServer/Plugins/Monetization/Controllers/UIServerMonetizationController.cs
+++ b/BTCPayServer/Plugins/Monetization/Controllers/UIServerMonetizationController.cs
@@ -365,6 +365,7 @@ public class UIServerMonetizationController(
         var features = new[]
         {
             (MonetizationFeatures.CanAccess, StringLocalizer["Can access BTCPay Server"].Value),
+            (MonetizationFeatures.AllowUserAssociation, StringLocalizer["Allow user association"].Value),
         }.Select(e => new FeatureData()
         {
             CustomId = e.Item1,

--- a/BTCPayServer/Plugins/Monetization/DataExtensions.cs
+++ b/BTCPayServer/Plugins/Monetization/DataExtensions.cs
@@ -9,6 +9,7 @@ namespace BTCPayServer.Plugins.Monetization;
 public static class SubscriberDataExtensions
 {
     public const string IdentityType = "ApplicationUserId";
+    public const string AssociatedIdentityType = "AssociatedApplicationUserId";
     public static string? GetApplicationUserId(this SubscriberData subscriber)
         => subscriber.Customer.GetContact(IdentityType);
 }

--- a/BTCPayServer/Plugins/Monetization/MonetizationFeatures.cs
+++ b/BTCPayServer/Plugins/Monetization/MonetizationFeatures.cs
@@ -3,4 +3,5 @@ namespace BTCPayServer.Plugins.Monetization;
 public class MonetizationFeatures
 {
     public const string CanAccess = "can-access";
+    public const string AllowUserAssociation = "allow-user-association";
 }

--- a/BTCPayServer/Plugins/Monetization/MonetizationHostedService.cs
+++ b/BTCPayServer/Plugins/Monetization/MonetizationHostedService.cs
@@ -186,7 +186,7 @@ public class MonetizationHostedService(
                                     identityType = SubscriberDataExtensions.AssociatedIdentityType,
                                     userId = reg.User.Id
                                 });
-                        var canAccess = await ctx.Plans.HasFeature(inviterSub.PlanId, MonetizationFeatures.CanAccess);
+                        var canAccess = inviterSub.IsActive && await ctx.Plans.HasFeature(inviterSub.PlanId, MonetizationFeatures.CanAccess);
                         await userService.SetDisabled(reg.User.Id, !canAccess);
                         return;
                     }
@@ -209,17 +209,53 @@ public class MonetizationHostedService(
         else if (evt is UserEvent.Deleted deleted)
         {
             await using var ctx = dbContextFactory.CreateContext();
+            var associatedUserIds = (await ctx.Database.GetDbConnection().QueryAsync<string>("""
+                SELECT ci.value FROM customers_identities ci
+                JOIN subs_subscribers ss ON ss.customer_id = ci.customer_id
+                JOIN customers_identities ci2 ON ci2.customer_id = ss.customer_id AND ci2.type = @primaryType AND ci2.value = @id
+                WHERE ci.type = @associatedType
+                """, new
+                    {
+                        primaryType = Monetization.SubscriberDataExtensions.IdentityType,
+                        associatedType = Monetization.SubscriberDataExtensions.AssociatedIdentityType,
+                        id = deleted.User.Id
+                    })).ToArray();
+
+            if (associatedUserIds.Length > 0)
+            {
+                await ctx.Database.GetDbConnection().ExecuteAsync("""
+                DELETE FROM customers_identities WHERE type = @associatedType AND value = ANY(@userIds)
+                """, new
+                    {
+                        associatedType = Monetization.SubscriberDataExtensions.AssociatedIdentityType,
+                        userIds = associatedUserIds
+                    });
+
+                var settings = monetizationSettingsAccessor.Settings;
+                foreach (var userId in associatedUserIds)
+                {
+                    var user = await ctx.Users.FindAsync(userId);
+                    if (user is null)
+                        continue;
+                    await MigrateUsers(settings.OfferingId, settings.DefaultPlanId, OneUserQuery, parameters =>
+                    {
+                        parameters.Add("userId", userId);
+                        parameters.Add("email", user.Email);
+                        parameters.Add("customerId", CustomerData.GenerateId());
+                    }, forceExpired: true);
+                }
+            }
+
             await ctx.Database.GetDbConnection()
-                .ExecuteAsync("""
+               .ExecuteAsync("""
                               DELETE FROM subs_subscribers s
                                   USING customers_identities ci
-                              WHERE ci.customer_id = s.customer_id
-                                AND ci.type = @type
-                                AND ci.value = @id;
+                              WHERE ci.customer_id = s.customer_id AND ci.type = @type AND ci.value = @id;
                               DELETE FROM customers_identities ci
                               WHERE ci.type = ANY(ARRAY[@type, @associatedType]) AND ci.value = @id;
                               """, new { type = Monetization.SubscriberDataExtensions.IdentityType, associatedType = Monetization.SubscriberDataExtensions.AssociatedIdentityType, id = deleted.User.Id });
         }
+
     }
 
     private async Task UpdateUserLockout(SubscriptionEvent.SubscriberEvent evt, UserManager<ApplicationUser> userManager, bool activated)
@@ -230,6 +266,26 @@ public class MonetizationHostedService(
             await userService.SetDisabled(user.Id, !activated) is not UserService.SetDisabledResult.Error)
         {
             EventAggregator.Publish(new MonetizationLockoutUpdated([(user.Id, !activated)]));
+        }
+
+        await using var ctx = dbContextFactory.CreateContext();
+        var associatedUserIds = (await ctx.Database.GetDbConnection().QueryAsync<string>("""
+            SELECT ci.value FROM customers_identities ci
+            WHERE ci.customer_id = @customerId AND ci.type = @associatedType
+            """, new
+            {
+                customerId = evt.Subscriber.CustomerId,
+                associatedType = SubscriberDataExtensions.AssociatedIdentityType
+            })).ToArray();
+
+        foreach (var assocUserId in associatedUserIds)
+        {
+            var assocUser = await userManager.FindByIdAsync(assocUserId);
+            if (assocUser is not null &&
+                await userService.SetDisabled(assocUser.Id, !activated) is not UserService.SetDisabledResult.Error)
+            {
+                EventAggregator.Publish(new MonetizationLockoutUpdated([(assocUser.Id, !activated)]));
+            }
         }
     }
 
@@ -268,7 +324,7 @@ public class MonetizationHostedService(
                 parameters.Add("userId", userId);
                 parameters.Add("email", user.Email);
                 parameters.Add("customerId", CustomerData.GenerateId());
-            });
+            }, forceExpired: true);
         }
     }
 
@@ -315,7 +371,8 @@ public class MonetizationHostedService(
                                         )
                                         """;
 
-    public async Task<(string CustomerId, string UserId)[]> MigrateUsers(string? offeringId, string? planId, string usersQuery = AllUsersQuery, Action<DynamicParameters>? addParameters = null)
+    public async Task<(string CustomerId, string UserId)[]> MigrateUsers(string? offeringId, string? planId, string usersQuery = AllUsersQuery,
+        Action<DynamicParameters>? addParameters = null, bool forceExpired = false)
     {
         if (offeringId is null || planId is null)
             return Array.Empty<(string CustomerId, string UserId)>();
@@ -326,7 +383,7 @@ public class MonetizationHostedService(
                 .FirstOrDefault(p => p.Id == planId) is not { } plan)
             return Array.Empty<(string CustomerId, string UserId)>();
 
-        var hasTrial = plan.TrialDays > 0;
+        var hasTrial = !forceExpired && plan.TrialDays > 0;
         var dummy = new SubscriberData();
         dummy.Plan = plan;
         if (hasTrial)
@@ -440,7 +497,7 @@ public class MonetizationHostedService(
                                      NOT (ss.active AND @canAccess) AS lockout_enabled,
                                      CASE WHEN (ss.active AND @canAccess) THEN NULL ELSE 'infinity'::timestamptz END lockout_end
                               FROM unnest(@userIds) AS user_id
-                                       JOIN customers_identities ci ON ci.type = @applicationUserId AND ci.value = user_id
+                                       JOIN customers_identities ci ON ci.type = ANY(ARRAY[@applicationUserId, @associatedApplicationUserId]) AND ci.value = user_id
                                        JOIN subs_subscribers ss ON ss.customer_id = ci.customer_id
                                        JOIN "AspNetUsers" ON "AspNetUsers"."Id" = user_id
                               WHERE ss.plan_id = @planId
@@ -457,6 +514,7 @@ public class MonetizationHostedService(
                     planId = plan.Id,
                     salt = RandomUtils.GetUInt256().ToString(),
                     applicationUserId = SubscriberDataExtensions.IdentityType,
+                    associatedApplicationUserId = SubscriberDataExtensions.AssociatedIdentityType,
                     canAccess
                 })).ToArray();
         foreach (var update in updated)

--- a/BTCPayServer/Plugins/Monetization/MonetizationHostedService.cs
+++ b/BTCPayServer/Plugins/Monetization/MonetizationHostedService.cs
@@ -44,6 +44,7 @@ public class MonetizationHostedService(
         this.SubscribeAny<UserEvent.BypassMonetizationChanged>();
         this.SubscribeAny<UserEvent.Registered>();
         this.SubscribeAny<UserEvent.Deleted>();
+        this.SubscribeAny<StoreUserEvent.Removed>();
     }
 
     protected override async Task ProcessEvent(object evt, CancellationToken cancellationToken)
@@ -206,6 +207,35 @@ public class MonetizationHostedService(
                     EventAggregator.Publish(new SubscriptionEvent.NewSubscriber(s, reg.RequestBaseUrl));
             }
         }
+        else if (evt is StoreUserEvent.Removed removedFromStore)
+        {
+            await using var ctx = dbContextFactory.CreateContext();
+            var settings = monetizationSettingsAccessor.Settings;
+            if (settings.OfferingId is null)
+                return;
+
+            var deleted = await ctx.Database.GetDbConnection().ExecuteAsync("""
+                DELETE FROM customers_identities WHERE type = @associatedType AND value = @userId
+                """, new
+                        {
+                            associatedType = SubscriberDataExtensions.AssociatedIdentityType,
+                            userId = removedFromStore.UserId
+                        });
+
+            if (deleted == 0) return;
+
+            var user = await ctx.Users.FindAsync(removedFromStore.UserId);
+            if (user is null)
+                return;
+
+            await MigrateUsers(settings.OfferingId, settings.DefaultPlanId, OneUserQuery, parameters =>
+            {
+                parameters.Add("userId", removedFromStore.UserId);
+                parameters.Add("email", user.Email);
+                parameters.Add("customerId", CustomerData.GenerateId());
+            }, forceExpired: true);
+        }
+
         else if (evt is UserEvent.Deleted deleted)
         {
             await using var ctx = dbContextFactory.CreateContext();

--- a/BTCPayServer/Plugins/Monetization/MonetizationHostedService.cs
+++ b/BTCPayServer/Plugins/Monetization/MonetizationHostedService.cs
@@ -215,13 +215,16 @@ public class MonetizationHostedService(
 
             var deleted = await ctx.Database.GetDbConnection().ExecuteAsync("""
                 DELETE FROM customers_identities ci
-                USING customers c
-                WHERE ci.customer_id = c.id AND ci.type = @associatedType AND ci.value = @userId AND c.store_id = @storeId
+                WHERE ci.type = @associatedType AND ci.value = @userId
+                  AND ci.customer_id IN (
+                      SELECT ss.customer_id FROM subs_subscribers ss
+                      WHERE ss.offering_id = @offeringId
+                  )
                 """, new
                         {
                             associatedType = SubscriberDataExtensions.AssociatedIdentityType,
                             userId = removedFromStore.UserId,
-                            storeId = removedFromStore.StoreId
+                            offeringId = removedOfferingId
                         });
 
             if (deleted == 0) return;
@@ -241,8 +244,8 @@ public class MonetizationHostedService(
         else if (evt is UserEvent.Deleted deleted)
         {
             await using var ctx = dbContextFactory.CreateContext();
-            var associatedUserIds = (await ctx.Database.GetDbConnection().QueryAsync<string>("""
-                SELECT ci.value FROM customers_identities ci
+            var associatedUsers = (await ctx.Database.GetDbConnection().QueryAsync<(string CustomerId, string UserId)>("""
+                SELECT ci.customer_id, ci.value FROM customers_identities ci
                 JOIN subs_subscribers ss ON ss.customer_id = ci.customer_id
                 JOIN customers_identities ci2 ON ci2.customer_id = ss.customer_id AND ci2.type = @primaryType AND ci2.value = @id
                 WHERE ci.type = @associatedType
@@ -253,11 +256,17 @@ public class MonetizationHostedService(
                         id = deleted.User.Id
                     })).ToArray();
 
-            if (associatedUserIds.Length > 0)
+            if (associatedUsers.Length > 0)
             {
+                var customerIds = associatedUsers.Select(u => u.CustomerId).ToArray();
+                var associatedUserIds = associatedUsers.Select(u => u.UserId).ToArray();
                 await ctx.Database.GetDbConnection().ExecuteAsync("""
-                    DELETE FROM customers_identities WHERE type = @associatedType AND value = ANY(@userIds)
-                    """, new { associatedType = Monetization.SubscriberDataExtensions.AssociatedIdentityType, userIds = associatedUserIds });
+                    DELETE FROM customers_identities WHERE type = @associatedType AND customer_id = ANY(@customerIds)
+                    """, new
+                        {
+                            associatedType = Monetization.SubscriberDataExtensions.AssociatedIdentityType,
+                            customerIds
+                        });
 
                 if (monetizationSettingsAccessor.Settings is { OfferingId: { } removedOfferingId, DefaultPlanId: { } removedDefaultPlanId })
                 {
@@ -275,17 +284,19 @@ public class MonetizationHostedService(
                     }
                 }
             }
-
             await ctx.Database.GetDbConnection()
                .ExecuteAsync("""
-                              DELETE FROM subs_subscribers s
-                                  USING customers_identities ci
-                              WHERE ci.customer_id = s.customer_id AND ci.type = @type AND ci.value = @id;
-                              DELETE FROM customers_identities ci
-                              WHERE ci.type = ANY(ARRAY[@type, @associatedType]) AND ci.value = @id;
-                              """, new { type = Monetization.SubscriberDataExtensions.IdentityType, associatedType = Monetization.SubscriberDataExtensions.AssociatedIdentityType, id = deleted.User.Id });
+                      DELETE FROM subs_subscribers s
+                          USING customers_identities ci
+                      WHERE ci.customer_id = s.customer_id AND ci.type = @type AND ci.value = @id;
+                      DELETE FROM customers_identities ci
+                      WHERE ci.type = ANY(ARRAY[@type, @associatedType]) AND ci.value = @id;
+                      """, new {
+                   type = Monetization.SubscriberDataExtensions.IdentityType,
+                   associatedType = Monetization.SubscriberDataExtensions.AssociatedIdentityType,
+                   id = deleted.User.Id
+               });
         }
-
     }
 
     private async Task UpdateUserLockout(SubscriptionEvent.SubscriberEvent evt, UserManager<ApplicationUser> userManager, bool activated)
@@ -321,26 +332,24 @@ public class MonetizationHostedService(
 
     private async Task DetachAndLockAssociatedUsers(ApplicationDbContext ctx, PlanData plan)
     {
-        var associatedUserIds = (await ctx.Database.GetDbConnection().QueryAsync<string>("""
-            SELECT ci.value FROM customers_identities ci
+        var associatedUsers = (await ctx.Database.GetDbConnection().QueryAsync<(string CustomerId, string UserId)>("""
+            SELECT ci.customer_id, ci.value FROM customers_identities ci
             JOIN subs_subscribers ss ON ss.customer_id = ci.customer_id
             WHERE ss.plan_id = @planId AND ci.type = @associatedIdentityType
-            """, new
-            {
-                planId = plan.Id,
-                associatedIdentityType = SubscriberDataExtensions.AssociatedIdentityType
-            })).ToArray();
+            """, new { planId = plan.Id, associatedIdentityType = SubscriberDataExtensions.AssociatedIdentityType })).ToArray();
 
-        if (associatedUserIds.Length == 0)
+        if (associatedUsers.Length == 0)
             return;
 
+        var customerIds = associatedUsers.Select(u => u.CustomerId).ToArray();
+        var associatedUserIds = associatedUsers.Select(u => u.UserId).ToArray();
         await ctx.Database.GetDbConnection().ExecuteAsync("""
-        DELETE FROM customers_identities WHERE type = @associatedIdentityType AND value = ANY(@userIds)
+        DELETE FROM customers_identities WHERE type = @associatedIdentityType AND customer_id = ANY(@customerIds)
         """, new
-        {
-            associatedIdentityType = SubscriberDataExtensions.AssociatedIdentityType,
-            userIds = associatedUserIds
-        });
+            {
+                associatedIdentityType = SubscriberDataExtensions.AssociatedIdentityType,
+                customerIds
+            });
 
         if (monetizationSettingsAccessor.Settings is not { OfferingId: { } offeringId, DefaultPlanId: { } defaultPlanId })
             return;

--- a/BTCPayServer/Plugins/Monetization/MonetizationHostedService.cs
+++ b/BTCPayServer/Plugins/Monetization/MonetizationHostedService.cs
@@ -210,16 +210,18 @@ public class MonetizationHostedService(
         else if (evt is StoreUserEvent.Removed removedFromStore)
         {
             await using var ctx = dbContextFactory.CreateContext();
-            var settings = monetizationSettingsAccessor.Settings;
-            if (settings.OfferingId is null)
+            if (monetizationSettingsAccessor.Settings is not { OfferingId: { } removedOfferingId, DefaultPlanId: { } removedDefaultPlanId })
                 return;
 
             var deleted = await ctx.Database.GetDbConnection().ExecuteAsync("""
-                DELETE FROM customers_identities WHERE type = @associatedType AND value = @userId
+                DELETE FROM customers_identities ci
+                USING customers c
+                WHERE ci.customer_id = c.id AND ci.type = @associatedType AND ci.value = @userId AND c.store_id = @storeId
                 """, new
                         {
                             associatedType = SubscriberDataExtensions.AssociatedIdentityType,
-                            userId = removedFromStore.UserId
+                            userId = removedFromStore.UserId,
+                            storeId = removedFromStore.StoreId
                         });
 
             if (deleted == 0) return;
@@ -228,7 +230,7 @@ public class MonetizationHostedService(
             if (user is null)
                 return;
 
-            await MigrateUsers(settings.OfferingId, settings.DefaultPlanId, OneUserQuery, parameters =>
+            await MigrateUsers(removedOfferingId, removedDefaultPlanId, OneUserQuery, parameters =>
             {
                 parameters.Add("userId", removedFromStore.UserId);
                 parameters.Add("email", user.Email);
@@ -254,25 +256,23 @@ public class MonetizationHostedService(
             if (associatedUserIds.Length > 0)
             {
                 await ctx.Database.GetDbConnection().ExecuteAsync("""
-                DELETE FROM customers_identities WHERE type = @associatedType AND value = ANY(@userIds)
-                """, new
-                    {
-                        associatedType = Monetization.SubscriberDataExtensions.AssociatedIdentityType,
-                        userIds = associatedUserIds
-                    });
+                    DELETE FROM customers_identities WHERE type = @associatedType AND value = ANY(@userIds)
+                    """, new { associatedType = Monetization.SubscriberDataExtensions.AssociatedIdentityType, userIds = associatedUserIds });
 
-                var settings = monetizationSettingsAccessor.Settings;
-                foreach (var userId in associatedUserIds)
+                if (monetizationSettingsAccessor.Settings is { OfferingId: { } removedOfferingId, DefaultPlanId: { } removedDefaultPlanId })
                 {
-                    var user = await ctx.Users.FindAsync(userId);
-                    if (user is null)
-                        continue;
-                    await MigrateUsers(settings.OfferingId, settings.DefaultPlanId, OneUserQuery, parameters =>
+                    foreach (var userId in associatedUserIds)
                     {
-                        parameters.Add("userId", userId);
-                        parameters.Add("email", user.Email);
-                        parameters.Add("customerId", CustomerData.GenerateId());
-                    }, forceExpired: true);
+                        var user = await ctx.Users.FindAsync(userId);
+                        if (user is null)
+                            continue;
+                        await MigrateUsers(removedOfferingId, removedDefaultPlanId, OneUserQuery, parameters =>
+                        {
+                            parameters.Add("userId", userId);
+                            parameters.Add("email", user.Email);
+                            parameters.Add("customerId", CustomerData.GenerateId());
+                        }, forceExpired: true);
+                    }
                 }
             }
 
@@ -342,14 +342,15 @@ public class MonetizationHostedService(
             userIds = associatedUserIds
         });
 
-        var settings = monetizationSettingsAccessor.Settings;
+        if (monetizationSettingsAccessor.Settings is not { OfferingId: { } offeringId, DefaultPlanId: { } defaultPlanId })
+            return;
+
         foreach (var userId in associatedUserIds)
         {
             var user = await ctx.Users.FindAsync(userId);
             if (user is null)
                 continue;
-
-            await MigrateUsers(settings.OfferingId, settings.DefaultPlanId, OneUserQuery, parameters =>
+            await MigrateUsers(offeringId, defaultPlanId, OneUserQuery, parameters =>
             {
                 parameters.Add("userId", userId);
                 parameters.Add("email", user.Email);

--- a/BTCPayServer/Plugins/Monetization/MonetizationHostedService.cs
+++ b/BTCPayServer/Plugins/Monetization/MonetizationHostedService.cs
@@ -97,6 +97,9 @@ public class MonetizationHostedService(
         {
             await using var ctx = dbContextFactory.CreateContext();
             await UpdateUserLockoutStatus(ctx, pu.Plan);
+
+            if (pu.Plan.GetFeature(MonetizationFeatures.AllowUserAssociation) is null)
+                await DetachAndLockAssociatedUsers(ctx, pu.Plan);
         }
 
 
@@ -165,6 +168,31 @@ public class MonetizationHostedService(
             var userSub = await ctx.Subscribers.GetBySelector(offeringId, CustomerSelector.ByIdentity(SubscriberDataExtensions.IdentityType, reg.User.Id));
             if (userSub is not null)
                 return;
+
+            if (reg is UserEvent.Invited { InvitedByUser: { } inviter })
+            {
+                var inviterSub = await ctx.Subscribers.GetBySelector(offeringId, CustomerSelector.ByIdentity(SubscriberDataExtensions.IdentityType, inviter.Id));
+                if (inviterSub is not null)
+                {
+                    await inviterSub.Plan.EnsureFeatureLoaded(ctx);
+                    if (inviterSub.Plan.GetFeature(MonetizationFeatures.AllowUserAssociation) is not null)
+                    {
+                        await ctx.Database.GetDbConnection().ExecuteAsync("""
+                            INSERT INTO customers_identities (customer_id, type, value)
+                            VALUES (@customerId, @identityType, @userId) ON CONFLICT DO NOTHING;
+                            """, new
+                                {
+                                    customerId = inviterSub.CustomerId,
+                                    identityType = SubscriberDataExtensions.AssociatedIdentityType,
+                                    userId = reg.User.Id
+                                });
+                        var canAccess = await ctx.Plans.HasFeature(inviterSub.PlanId, MonetizationFeatures.CanAccess);
+                        await userService.SetDisabled(reg.User.Id, !canAccess);
+                        return;
+                    }
+                }
+            }
+
             var inserted = (await MigrateUsers(offeringId, defaultPlanId, OneUserQuery, parameters =>
             {
                 parameters.Add("userId", reg.User.Id);
@@ -189,8 +217,8 @@ public class MonetizationHostedService(
                                 AND ci.type = @type
                                 AND ci.value = @id;
                               DELETE FROM customers_identities ci
-                              WHERE ci.type = @type AND ci.value = @id;
-                              """, new { type = Monetization.SubscriberDataExtensions.IdentityType, id = deleted.User.Id });
+                              WHERE ci.type = ANY(ARRAY[@type, @associatedType]) AND ci.value = @id;
+                              """, new { type = Monetization.SubscriberDataExtensions.IdentityType, associatedType = Monetization.SubscriberDataExtensions.AssociatedIdentityType, id = deleted.User.Id });
         }
     }
 
@@ -202,6 +230,45 @@ public class MonetizationHostedService(
             await userService.SetDisabled(user.Id, !activated) is not UserService.SetDisabledResult.Error)
         {
             EventAggregator.Publish(new MonetizationLockoutUpdated([(user.Id, !activated)]));
+        }
+    }
+
+    private async Task DetachAndLockAssociatedUsers(ApplicationDbContext ctx, PlanData plan)
+    {
+        var associatedUserIds = (await ctx.Database.GetDbConnection().QueryAsync<string>("""
+            SELECT ci.value FROM customers_identities ci
+            JOIN subs_subscribers ss ON ss.customer_id = ci.customer_id
+            WHERE ss.plan_id = @planId AND ci.type = @associatedIdentityType
+            """, new
+            {
+                planId = plan.Id,
+                associatedIdentityType = SubscriberDataExtensions.AssociatedIdentityType
+            })).ToArray();
+
+        if (associatedUserIds.Length == 0)
+            return;
+
+        await ctx.Database.GetDbConnection().ExecuteAsync("""
+        DELETE FROM customers_identities WHERE type = @associatedIdentityType AND value = ANY(@userIds)
+        """, new
+        {
+            associatedIdentityType = SubscriberDataExtensions.AssociatedIdentityType,
+            userIds = associatedUserIds
+        });
+
+        var settings = monetizationSettingsAccessor.Settings;
+        foreach (var userId in associatedUserIds)
+        {
+            var user = await ctx.Users.FindAsync(userId);
+            if (user is null)
+                continue;
+
+            await MigrateUsers(settings.OfferingId, settings.DefaultPlanId, OneUserQuery, parameters =>
+            {
+                parameters.Add("userId", userId);
+                parameters.Add("email", user.Email);
+                parameters.Add("customerId", CustomerData.GenerateId());
+            });
         }
     }
 
@@ -408,7 +475,9 @@ public class MonetizationHostedService(
                                     SELECT ci.value
                                     FROM subs_subscribers s
                                     JOIN customers_identities ci ON ci.customer_id = s.customer_id
-                                    WHERE s.offering_id=@offeringId AND s.plan_id = @planId AND ci.type = @applicationUserId
-                                    """, new { planId = plan.Id, offeringId = plan.OfferingId, applicationUserId = SubscriberDataExtensions.IdentityType }))
+                                    WHERE s.offering_id=@offeringId AND s.plan_id = @planId AND ci.type = ANY(ARRAY[@applicationUserId, @associatedApplicationUserId])
+                                    """,
+            new { planId = plan.Id, offeringId = plan.OfferingId, applicationUserId = SubscriberDataExtensions.IdentityType,
+                associatedApplicationUserId = SubscriberDataExtensions.AssociatedIdentityType }))
             .ToArray();
 }


### PR DESCRIPTION
Related to https://github.com/btcpayserver/btcpayserver/discussions/7101


Every user on a monetized BTCPay Server instance must be a paying subscriber. This means a store owner adding an employee to their store forces that employee to also subscribe even though they're not the one running the business.

This PR adds an allow-user-association plan feature. When enabled on a plan, users invited by a subscriber get attached to their subscription instead of needing their own. 
They inherit the subscriber's access. When the feature is removed, associated users are detached, enrolled as their own expired subscribers, and redirected to billing on next login.
The per-user model remains the default, this is opt-in per plan.


Let me know what you think, and if this is a good first step, I can go ahead and add tests

Cc. @NicolasDorier 