### PR TITLE
Fix Yadio invalid rate handling

### DIFF
--- a/BTCPayServer.Rating/Providers/YadioRateProvider.cs
+++ b/BTCPayServer.Rating/Providers/YadioRateProvider.cs
@@ -27,7 +27,7 @@ namespace BTCPayServer.Services.Rates
             {
                 string name = ((JProperty)item).Name;
                 var value = results[name].Value<decimal?>();
-                if (value.HasValue)
+                if (value is > 0m)
                     list.Add(new PairRate(new CurrencyPair("BTC", name), new BidAsk(value.Value)));
             }
 


### PR DESCRIPTION
Fixes #7376

## Summary

Skip non-positive rates returned by Yadio.

## Problem

Yadio can return invalid rates such as `0`. BTCPay was accepting those values from the provider.

## Fix

Only add Yadio rates when the parsed value is greater than zero.
