### PR TITLE
Fix iOS touch lockup on keypad POS item +/− buttons

### DIFF
--- a/BTCPayServer/Plugins/PointOfSale/Views/Public/VueLight.cshtml
+++ b/BTCPayServer/Plugins/PointOfSale/Views/Public/VueLight.cshtml
@@ -173,6 +173,7 @@
                             </button>
                         </div>
                     </div>
+                    <div class="posItem-added"><vc:icon symbol="checkmark" /></div>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
Fixes #7378

## Summary

The keypad POS view (`VueLight.cshtml`) was missing the `.posItem-added` overlay element that `Cart.cshtml` has. This caused the `+` and `−` buttons to become permanently unresponsive after the first tap on iOS Safari.

**Root cause:** `common.js` attaches a `transitionend` listener to each `.posItem` element to remove the `posItem--added` class after the green overlay fades out. That class sets `pointer-events: none` on the entire row. Without the overlay element, there is no CSS transition, so `transitionend` never fires on iOS Safari and `pointer-events: none` sticks forever.

On Android, an incidental Bootstrap button transition happens to fire `transitionend` and accidentally clears the class — masking the bug on that platform.

## Change

Add the missing `<div class="posItem-added">` overlay to each item row in `VueLight.cshtml`, matching what `Cart.cshtml` already has.

```diff
+                    <div class="posItem-added"><vc:icon symbol="checkmark" /></div>
```

## Testing

1. Create a Point of Sale app with style set to **Keypad**
2. Enable item selection
3. Open on iOS Safari
4. Tap **+** on any item — item is added
5. Tap **+** again — previously broken, now works correctly