### PR TITLE
feat:add includePaymentMethods to POST invoice creation endpoint 

### DIFF
--- a/BTCPayServer.Client/Models/CreateInvoiceRequest.cs
+++ b/BTCPayServer.Client/Models/CreateInvoiceRequest.cs
@@ -8,5 +8,6 @@ namespace BTCPayServer.Client.Models
         [JsonConverter(typeof(NumericStringJsonConverter))]
         public decimal? Amount { get; set; }
         public string[] AdditionalSearchTerms { get; set; }
+        public bool IncludePaymentMethods { get; set; }
     }
 }

--- a/BTCPayServer.Client/Models/InvoiceData.cs
+++ b/BTCPayServer.Client/Models/InvoiceData.cs
@@ -109,7 +109,7 @@ namespace BTCPayServer.Client.Models
         public InvoiceStatus[] AvailableStatusesForManualMarking { get; set; }
         public bool Archived { get; set; }
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
-        public InvoicePaymentMethodDataModel[] PaymentMethods { get; set; } = Array.Empty<InvoicePaymentMethodDataModel>();
+        public InvoicePaymentMethodDataModel[] PaymentMethods { get; set; }
     }
 
     public enum InvoiceStatus

--- a/BTCPayServer.Tests/GreenfieldAPITests.cs
+++ b/BTCPayServer.Tests/GreenfieldAPITests.cs
@@ -1935,13 +1935,13 @@ namespace BTCPayServer.Tests
 
             Assert.NotNull(invoices);
             Assert.Single(invoices);
-            Assert.NotNull(invoices.First().PaymentMethods);
+            Assert.Null(invoices.First().PaymentMethods);
             Assert.Equal(newInvoice.Id, invoices.First().Id);
 
             invoices = await viewOnly.GetInvoices(user.StoreId, textSearch: "Banana");
             Assert.NotNull(invoices);
             Assert.Single(invoices);
-            Assert.NotNull(invoices.First().PaymentMethods);
+            Assert.Null(invoices.First().PaymentMethods);
             Assert.Equal(newInvoice.Id, invoices.First().Id);
 
             invoices = await viewOnly.GetInvoices(user.StoreId, textSearch: "apples");
@@ -1954,7 +1954,7 @@ namespace BTCPayServer.Tests
                 endDate: DateTimeOffset.Now.AddHours(1));
 
             Assert.NotNull(invoicesFiltered);
-            Assert.NotNull(invoicesFiltered.First().PaymentMethods);
+            Assert.Null(invoicesFiltered.First().PaymentMethods);
             Assert.Single(invoicesFiltered);
             Assert.Equal(newInvoice.Id, invoicesFiltered.First().Id);
 
@@ -2021,6 +2021,18 @@ namespace BTCPayServer.Tests
             Assert.Equal("BTC-CHAIN", paymentMethod.PaymentMethodId);
             Assert.Equal("BTC", paymentMethod.Currency);
             Assert.Empty(paymentMethod.Payments);
+
+            // includePaymentMethods=false (default): no payment methods in creation response
+            var invoiceWithoutMethods = await client.CreateInvoice(user.StoreId,
+                new CreateInvoiceRequest { Currency = "USD", Amount = 1 });
+            Assert.Null(invoiceWithoutMethods.PaymentMethods);
+
+            // includePaymentMethods=true: payment methods returned inline with creation response
+            var invoiceWithMethods = await client.CreateInvoice(user.StoreId,
+                new CreateInvoiceRequest { Currency = "USD", Amount = 1, IncludePaymentMethods = true });
+            Assert.NotNull(invoiceWithMethods.PaymentMethods);
+            Assert.Single(invoiceWithMethods.PaymentMethods);
+            Assert.Equal("BTC-CHAIN", invoiceWithMethods.PaymentMethods.First().PaymentMethodId);
 
 
             //update

--- a/BTCPayServer/Controllers/GreenField/GreenfieldInvoiceController.cs
+++ b/BTCPayServer/Controllers/GreenField/GreenfieldInvoiceController.cs
@@ -227,7 +227,7 @@ namespace BTCPayServer.Controllers.Greenfield
             {
                 var invoice = await _invoiceController.CreateInvoiceCoreRaw(request, store,
                     Request.GetAbsoluteRoot());
-                return Ok(ToModel(invoice));
+                return Ok(ToModel(invoice, request.IncludePaymentMethods));
             }
             catch (BitpayHttpException e)
             {


### PR DESCRIPTION
## Summary

Adds `includePaymentMethods` support to the POST invoice creation endpoint.

When `true`, payment methods are returned inline with the invoice creation response, avoiding an additional round-trip to:
`GET .../payment-methods`

Closes #7366