### PR TITLE
Fix: Archiving invoices with a custom range filter threw error 403

### DIFF
--- a/BTCPayServer.Tests/PlaywrightTests.cs
+++ b/BTCPayServer.Tests/PlaywrightTests.cs
@@ -2288,7 +2288,7 @@ namespace BTCPayServer.Tests
             });
 
             // ensure archived invoices are not accessible for logged out users
-            await s.Server.PayTester.InvoiceRepository.ToggleInvoiceArchival(i, true);
+            await s.Server.PayTester.InvoiceRepository.ToggleInvoiceArchival(s.StoreId, i);
             await s.GoToHome();
             await s.Logout();
 

--- a/BTCPayServer/Controllers/GreenField/GreenfieldInvoiceController.cs
+++ b/BTCPayServer/Controllers/GreenField/GreenfieldInvoiceController.cs
@@ -146,7 +146,7 @@ namespace BTCPayServer.Controllers.Greenfield
             var invoice = HttpContext.GetInvoiceDataOrNull();
             if (invoice is null)
                 return InvoiceNotFound();
-            await _invoiceRepository.ToggleInvoiceArchival(invoiceId, true, storeId ?? HttpContext.GetStoreData().Id);
+            await _invoiceRepository.ToggleInvoiceArchival(HttpContext.GetStoreData().Id, invoiceId, true);
             return Ok();
         }
 
@@ -277,7 +277,7 @@ namespace BTCPayServer.Controllers.Greenfield
             if (!ModelState.IsValid)
                 return this.CreateValidationError(ModelState);
 
-            await _invoiceRepository.ToggleInvoiceArchival(invoiceId, false, storeId ?? HttpContext.GetStoreData().Id);
+            await _invoiceRepository.ToggleInvoiceArchival(HttpContext.GetStoreData().Id, invoiceId, false);
             return await GetInvoice(storeId, invoiceId);
         }
 

--- a/BTCPayServer/Controllers/UIInvoiceController.UI.cs
+++ b/BTCPayServer/Controllers/UIInvoiceController.UI.cs
@@ -26,6 +26,7 @@ using BTCPayServer.Services;
 using BTCPayServer.Services.Apps;
 using BTCPayServer.Services.Invoices;
 using BTCPayServer.Services.Rates;
+using Dapper;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Localization;
@@ -599,29 +600,20 @@ namespace BTCPayServer.Controllers
         [Authorize(AuthenticationSchemes = AuthenticationSchemes.Cookie, Policy = Policies.CanViewInvoices)]
         public async Task<IActionResult> ToggleArchive(string invoiceId)
         {
-            var invoice = (await _InvoiceRepository.GetInvoices(new InvoiceQuery
-            {
-                InvoiceId = [invoiceId],
-                UserId = GetUserIdForInvoiceQuery(),
-                IncludeAddresses = false,
-                IncludeArchived = true,
-            })).FirstOrDefault();
-            if (invoice == null)
-                return NotFound();
-            await _InvoiceRepository.ToggleInvoiceArchival(invoiceId, !invoice.Archived);
+            var archived = await _InvoiceRepository.ToggleInvoiceArchival(HttpContext.GetStoreData().Id, invoiceId);
             TempData.SetStatusMessageModel(new StatusMessageModel
             {
                 Severity = StatusMessageModel.StatusSeverity.Success,
-                Message = invoice.Archived
-                    ? StringLocalizer["The invoice has been unarchived and will appear in the invoice list by default again."].Value
-                    : StringLocalizer["The invoice has been archived and will no longer appear in the invoice list by default."].Value
+                Message = archived
+                    ? StringLocalizer["The invoice has been archived and will no longer appear in the invoice list by default."].Value
+                    : StringLocalizer["The invoice has been unarchived and will appear in the invoice list by default again."].Value
             });
-            return RedirectToAction(nameof(invoice), new { invoiceId });
+            return RedirectToAction(nameof(Invoice), new { invoiceId });
         }
 
-        [HttpPost]
+        [HttpPost("/stores/{storeId}/invoices/mass-action")]
         [Authorize(AuthenticationSchemes = AuthenticationSchemes.Cookie, Policy = Policies.CanViewInvoices)]
-        public async Task<IActionResult> MassAction(string command, string[] selectedItems, string? storeId = null)
+        public async Task<IActionResult> MassAction(string command, string[] selectedItems, string storeId)
         {
             IActionResult NotSupported(string err)
             {
@@ -636,19 +628,19 @@ namespace BTCPayServer.Controllers
             switch (command)
             {
                 case "archive":
-                    await _InvoiceRepository.MassArchive(selectedItems);
+                    await _InvoiceRepository.MassArchive(storeId, selectedItems);
                     TempData[WellKnownTempData.SuccessMessage] = selectedItems.Length == 1
                         ? StringLocalizer["{0} invoice archived.", selectedItems.Length].Value
                         : StringLocalizer["{0} invoices archived.", selectedItems.Length].Value;
                     break;
 
                 case "unarchive":
-                    await _InvoiceRepository.MassArchive(selectedItems, false);
+                    await _InvoiceRepository.MassArchive(storeId, selectedItems, false);
                     TempData[WellKnownTempData.SuccessMessage] = selectedItems.Length == 1
                         ? StringLocalizer["{0} invoice unarchived.", selectedItems.Length].Value
                         : StringLocalizer["{0} invoices unarchived.", selectedItems.Length].Value;
                     break;
-                case "cpfp" when storeId is not null:
+                case "cpfp":
                     var network = _NetworkProvider.DefaultNetwork;
                     var explorer = network is null ? null : _ExplorerClients.GetExplorerClient(network);
                     if (explorer is null || network is null)
@@ -660,7 +652,7 @@ namespace BTCPayServer.Controllers
                     if (derivationScheme is null)
                         return NotSupported("This feature is only available to BTC wallets");
                     var btc = PaymentTypes.CHAIN.GetPaymentMethodId("BTC");
-                    var bumpableAddresses = await GetAddresses(btc, selectedItems);
+                    var bumpableAddresses = await GetAddresses(btc, storeId, selectedItems);
                     var utxos = await explorer.GetUTXOsAsync(derivationScheme);
                     var bumpableUTXOs = utxos.GetUnspentUTXOs().Where(u => u.Confirmations == 0 && bumpableAddresses.Contains(u.ScriptPubKey.Hash.ToString())).ToArray();
                     if (bumpableUTXOs.Length == 0)
@@ -685,10 +677,23 @@ namespace BTCPayServer.Controllers
             return RedirectToAction(nameof(ListInvoices), new { storeId });
         }
 
-        private async Task<HashSet<string>> GetAddresses(PaymentMethodId paymentMethodId, string[] selectedItems)
+        private async Task<HashSet<string>> GetAddresses(PaymentMethodId paymentMethodId, string storeId, string[] selectedItems)
         {
-            using var ctx = _dbContextFactory.CreateContext();
-            return new HashSet<string>(await ctx.AddressInvoices.Where(i => selectedItems.Contains(i.InvoiceDataId) && i.PaymentMethodId == paymentMethodId.ToString()).Select(i => i.Address).ToArrayAsync());
+            await using var ctx = _dbContextFactory.CreateContext();
+            var conn = ctx.Database.GetDbConnection();
+            var addresses = await conn.QueryAsync<string>(
+                """
+                SELECT ai."Address"
+                     FROM unnest(@selectedItems) AS s("InvoiceDataId")
+                     INNER JOIN "AddressInvoices" ai
+                         ON ai."InvoiceDataId" = s."InvoiceDataId"
+                     INNER JOIN "Invoices" i
+                         ON ai."InvoiceDataId" = i."Id"
+                     WHERE ai."PaymentMethodId" = @paymentMethodId
+                       AND i."StoreDataId" = @storeId
+                """,
+                new { selectedItems, paymentMethodId = paymentMethodId.ToString(), storeId });
+            return new HashSet<string>(addresses);
         }
 
         [HttpGet("i/{invoiceId}")]
@@ -1051,7 +1056,6 @@ namespace BTCPayServer.Controllers
         }
 
         [HttpGet("/stores/{storeId}/invoices")]
-        [HttpGet("invoices")]
         [Authorize(AuthenticationSchemes = AuthenticationSchemes.Cookie, Policy = Policies.CanViewInvoices)]
         public async Task<IActionResult> ListInvoices(InvoicesModel? model = null)
         {

--- a/BTCPayServer/Services/Invoices/InvoiceRepository.cs
+++ b/BTCPayServer/Services/Invoices/InvoiceRepository.cs
@@ -494,29 +494,53 @@ retry:
             }
         }
 
-        public async Task MassArchive(string[] invoiceIds, bool archive = true)
+        public async Task MassArchive(string storeId, string[] invoiceIds, bool archive = true)
         {
-            using var context = _applicationDbContextFactory.CreateContext();
-            var items = context.Invoices.Where(a => invoiceIds.Contains(a.Id));
-            foreach (InvoiceData invoice in items)
+            await using var context = _applicationDbContextFactory.CreateContext();
+            var conn = context.Database.GetDbConnection();
+            await conn.ExecuteAsync(
+                """
+                UPDATE "Invoices" i
+                SET "Archived" = @archive
+                FROM unnest(@invoiceIds) AS ids("Id")
+                WHERE i."StoreDataId" = @storeId
+                  AND i."Id" = ids."Id"
+                  AND i."Archived" IS DISTINCT FROM @archive;
+                """,
+                new { archive, storeId, invoiceIds });
+        }
+
+        public async Task<bool> ToggleInvoiceArchival(string storeId, string invoiceId, bool? archived = null)
+        {
+            await using var context = _applicationDbContextFactory.CreateContext();
+            var conn = context.Database.GetDbConnection();
+            if (archived is null)
             {
-                invoice.Archived = archive;
+                return await conn.ExecuteScalarAsync<bool>(
+                    """
+                    UPDATE "Invoices" i
+                    SET "Archived" = NOT "Archived"
+                    WHERE i."StoreDataId" = @storeId
+                      AND i."Id" = @invoiceId
+                    RETURNING "Archived";
+                    """,
+                    new { storeId, invoiceId });
             }
-
-            await context.SaveChangesAsync();
+            else
+            {
+                await conn.ExecuteAsync(
+                    """
+                    UPDATE "Invoices" i
+                    SET "Archived" = @archived
+                    WHERE i."StoreDataId" = @storeId
+                      AND i."Id" = @invoiceId
+                      AND i."Archived" IS DISTINCT FROM @archived;
+                    """,
+                    new { storeId, invoiceId, archived });
+                return archived.Value;
+            }
         }
 
-        public async Task ToggleInvoiceArchival(string invoiceId, bool archived, string storeId = null)
-        {
-            using var context = _applicationDbContextFactory.CreateContext();
-            var invoiceData = await context.FindAsync<InvoiceData>(invoiceId).ConfigureAwait(false);
-            if (invoiceData == null || invoiceData.Archived == archived ||
-                (storeId != null &&
-                 !invoiceData.StoreDataId.Equals(storeId, StringComparison.InvariantCultureIgnoreCase)))
-                return;
-            invoiceData.Archived = archived;
-            await context.SaveChangesAsync().ConfigureAwait(false);
-        }
         public async Task<InvoiceEntity> UpdateInvoiceMetadata(string invoiceId, string storeId, JObject metadata)
         {
 retry:

--- a/BTCPayServer/Views/UIInvoice/ListInvoices.cshtml
+++ b/BTCPayServer/Views/UIInvoice/ListInvoices.cshtml
@@ -1,4 +1,5 @@
 @using BTCPayServer.Client
+@using BTCPayServer.Controllers
 @using BTCPayServer.Services
 @inject DisplayFormatter DisplayFormatter
 @model InvoicesModel
@@ -57,6 +58,7 @@
 
     @* Custom Range Modal *@
     <script>
+        var invoicesUrl = @Safe.Json(Url.Action(nameof(UIInvoiceController.ListInvoices), new { storeId = Model.StoreId }));
         const timezoneOffset = new Date().getTimezoneOffset();
 
         delegate('click', '.showInvoice', e => {
@@ -82,7 +84,7 @@
             }
 
             if (filterString !== "") {
-                var redirectUri = "/invoices?Count=" + $("#Count").val() +
+                var redirectUri = invoicesUrl + "?Count=" + $("#Count").val() +
                     "&timezoneoffset=" + $("#TimezoneOffset").val() +
                     "&SearchTerm=" + filterString;
 
@@ -314,7 +316,7 @@
 
 @if (Model.Invoices.Any())
 {
-    <form method="post" asp-action="MassAction">
+    <form method="post" asp-action="MassAction" asp-route-storeId="@Model.StoreId">
         <input type="hidden" name="storeId" value="@Model.StoreId" />
         <div class="table-responsive">
             <table id="invoices" class="table table-hover mass-action">


### PR DESCRIPTION
Fix https://github.com/btcpayserver/btcpayserver/issues/7383

Took the occasion to use postgres queries rather than relying on Entity Framework, which save some roundtrips.