### PR TITLE
fix: flatpickr dropdown focus inside modals

### DIFF
--- a/BTCPayServer/wwwroot/main/site.js
+++ b/BTCPayServer/wwwroot/main/site.js
@@ -353,7 +353,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
         // support for initializing with special options per instance
         if (fdtp) {
-            var parsed = JSON.parse(fdtp);
+            var parsed = Object.assign({}, JSON.parse(fdtp), { static: true });
             flatpickrInstances.push(element.flatpickr(parsed));
         } else {
             var min = element.attr("min");


### PR DESCRIPTION
## Description
This PR fixes an issue where the Flatpickr month dropdown immediately closes when clicked inside a Bootstrap modal. 

Bootstrap modals enforce focus traps (`enforceFocus`) to prevent keyboard navigation outside the modal. By default, Flatpickr renders its calendar at the end of the `document.body`. When a user clicks the month `<select>` dropdown on the calendar, Bootstrap detects focus leaving the modal and immediately steals it back, which aborts and closes the native dropdown.

This fix forces Flatpickr to render inline within the modal's DOM tree by setting `static: true` for instances initialized via the `data-fdtp` attribute, completely avoiding the focus collision.

Fixes #7384

## Before Vs After 


https://github.com/user-attachments/assets/ed1decf6-7d6c-44bb-8369-abbf60db9e9f

