### PR TITLE
Add plugin compatibility regression check to release CI

### DIFF
--- a/.circleci/check-btcpay-plugin-compat.sh
+++ b/.circleci/check-btcpay-plugin-compat.sh
@@ -180,12 +180,12 @@ fi
 printf 'dotnet SDK: '
 dotnet --version
 
-printf '\n==================== PASS: master ====================\n'
+printf '\n======= PASS: master =======\n'
 splice_all "$BTCPAY_MASTER_ABS"
 build_all MASTER_RESULT
 
 if [ -n "$BTCPAY_BASELINE_REF" ]; then
-  printf '\n==================== PASS: baseline (%s) ====================\n' "$BTCPAY_BASELINE_REF"
+  printf '\n======= PASS: baseline (%s) ========\n' "$BTCPAY_BASELINE_REF"
   splice_all "$BTCPAY_BASELINE_ABS"
   build_all BASE_RESULT
 fi
@@ -222,7 +222,7 @@ for name in "${!MASTER_RESULT[@]}"; do
 done
 
 if [ -z "$BTCPAY_BASELINE_REF" ]; then
-  printf 'OK:     %s\n' "${plain_ok[*]:-(none)}"
+  printf 'OK: %s\n' "${plain_ok[*]:-(none)}"
   printf 'FAILED: %s\n' "${plain_fail[*]:-(none)}"
   if [ "${#plain_fail[@]}" -eq 0 ]; then
     printf 'All plugin builds passed.\n'
@@ -230,10 +230,10 @@ if [ -z "$BTCPAY_BASELINE_REF" ]; then
     printf 'One or more plugin builds failed. See output above.\n'
   fi
 else
-  printf 'still-ok:     %s\n' "${still_ok[*]:-(none)}"
+  printf 'still-ok: %s\n' "${still_ok[*]:-(none)}"
   printf 'still-broken: %s\n' "${still_broken[*]:-(none)}"
-  printf 'newly-fixed:  %s\n' "${newly_fixed[*]:-(none)}"
-  printf 'REGRESSION:   %s\n' "${regressions[*]:-(none)}"
+  printf 'newly-fixed: %s\n' "${newly_fixed[*]:-(none)}"
+  printf 'REGRESSION: %s\n' "${regressions[*]:-(none)}"
   printf '\n'
   if [ "${#regressions[@]}" -gt 0 ]; then
     printf '!! %d plugin(s) built against %s but FAIL against master.\n' "${#regressions[@]}" "$BTCPAY_BASELINE_REF"

--- a/.circleci/check-btcpay-plugin-compat.sh
+++ b/.circleci/check-btcpay-plugin-compat.sh
@@ -3,7 +3,6 @@ set -u
 
 ROOT_DIR="${1:-btcpay-plugin-check}"
 BTCPAY_BASELINE_REF="${BTCPAY_BASELINE_REF:-}"
-BLOCK_ON_REGRESSION="${BLOCK_ON_REGRESSION:-}"
 
 BTCPAY_REPO="https://github.com/btcpayserver/btcpayserver.git"
 EXOLIX_REPO="https://github.com/Nisaba/btcpayserver-plugins.git"
@@ -69,7 +68,7 @@ if [ -n "$BTCPAY_BASELINE_REF" ]; then
 
   printf '\n==> Building BTCPay Server baseline once\n'
   if ! dotnet build "btcpayserver-baseline/BTCPayServer/BTCPayServer.csproj" -c Release --nologo -v quiet /clp:ErrorsOnly; then
-    printf '!! Baseline BTCPay failed to build; disabling diff and reporting absolute results.\n'
+    printf '!! WARNING: baseline BTCPay (%s) failed to build.\n' "$BTCPAY_BASELINE_REF"
     BTCPAY_BASELINE_REF=""
   fi
 fi
@@ -248,7 +247,4 @@ else
   fi
 fi
 
-if [ -n "$BTCPAY_BASELINE_REF" ] && [ -n "$BLOCK_ON_REGRESSION" ] && [ "${#regressions[@]}" -gt 0 ]; then
-  exit 1
-fi
 exit 0

--- a/.circleci/check-btcpay-plugin-compat.sh
+++ b/.circleci/check-btcpay-plugin-compat.sh
@@ -2,6 +2,9 @@
 set -u
 
 ROOT_DIR="${1:-btcpay-plugin-check}"
+BTCPAY_BASELINE_REF="${BTCPAY_BASELINE_REF:-}"
+BLOCK_ON_REGRESSION="${BLOCK_ON_REGRESSION:-}"
+
 BTCPAY_REPO="https://github.com/btcpayserver/btcpayserver.git"
 EXOLIX_REPO="https://github.com/Nisaba/btcpayserver-plugins.git"
 SAMROCK_REPO="https://github.com/rockstardev/SamRockProtocol.git"
@@ -12,12 +15,14 @@ SHOPIFY_REPO="https://github.com/btcpayserver/btcpayserver-shopify-plugin.git"
 MONERO_REPO="https://github.com/btcpay-monero/btcpayserver-monero-plugin.git"
 BLINK_REPO="https://github.com/Kukks/BTCPayServerPlugins.git"
 
+BTCPAY_SPLICE_ABS=""
+
 replace_btcpay_copy() {
   local target="$1"
 
   rm -rf "$target"
   mkdir -p "$(dirname "$target")"
-  cp -a "$BTCPAY_MASTER_ABS" "$target"
+  cp -a "$BTCPAY_SPLICE_ABS" "$target"
 }
 
 run_build() {
@@ -50,12 +55,24 @@ mkdir "$ROOT_DIR"
 cd "$ROOT_DIR"
 ROOT_ABS="$(pwd)"
 BTCPAY_MASTER_ABS="$ROOT_ABS/btcpayserver-master"
+BTCPAY_BASELINE_ABS="$ROOT_ABS/btcpayserver-baseline"
 
 printf '==> Cloning BTCPay Server master\n'
 git clone --depth 1 --branch master "$BTCPAY_REPO" btcpayserver-master
 
 printf '\n==> Building BTCPay Server master once\n'
 dotnet build "btcpayserver-master/BTCPayServer/BTCPayServer.csproj" -c Release --nologo -v quiet /clp:ErrorsOnly || exit 1
+
+if [ -n "$BTCPAY_BASELINE_REF" ]; then
+  printf '\n==> Cloning BTCPay Server baseline (%s)\n' "$BTCPAY_BASELINE_REF"
+  git clone --depth 1 --branch "$BTCPAY_BASELINE_REF" "$BTCPAY_REPO" btcpayserver-baseline
+
+  printf '\n==> Building BTCPay Server baseline once\n'
+  if ! dotnet build "btcpayserver-baseline/BTCPayServer/BTCPayServer.csproj" -c Release --nologo -v quiet /clp:ErrorsOnly; then
+    printf '!! Baseline BTCPay failed to build; disabling diff and reporting absolute results.\n'
+    BTCPAY_BASELINE_REF=""
+  fi
+fi
 
 printf '\n==> Cloning plugin source repositories\n'
 git clone "$EXOLIX_REPO" exolix-plugin
@@ -70,85 +87,168 @@ git clone "$BLINK_REPO" blink
 printf '\n==> Initializing non-BTCPay plugin submodules\n'
 GIT_LFS_SKIP_SMUDGE=1 git -C blink submodule update --init --depth 1 --recommend-shallow --filter=blob:none submodules/walletwasabi
 
-printf '\n==> Replacing BTCPay submodules with copies of built BTCPay master\n'
-replace_btcpay_copy exolix-plugin/btcpayserver
-replace_btcpay_copy boltz/btcpayserver
-replace_btcpay_copy samrock-protocol/submodules/btcpayserver
-replace_btcpay_copy payroll/submodules/btcpayserver
-replace_btcpay_copy boltcards-plugin/btcpayserver
-replace_btcpay_copy shopify-plugin/btcpayserver
-replace_btcpay_copy shopify-plugin/submodules/btcpayserver
-replace_btcpay_copy monero-plugin/submodules/btcpayserver
-replace_btcpay_copy blink/submodules/btcpayserver
-
-printf '\n==> Replacing SamRock Boltz submodule with the cloned Boltz repo\n'
+printf '\n==> Wiring SamRock Boltz submodule from the cloned Boltz repo\n'
 rm -rf samrock-protocol/submodules/boltz
 git clone ./boltz samrock-protocol/submodules/boltz
-replace_btcpay_copy samrock-protocol/submodules/boltz/btcpayserver
 
 printf '\n==> Applying compatibility patches in disposable plugin checkouts\n'
 retarget_net10 samrock-protocol/Plugins/SamRockProtocol/SamRockProtocol.csproj
 retarget_net10 shopify-plugin/Plugins/BTCPayServer.Plugins.ShopifyPlugin/BTCPayServer.Plugins.ShopifyPlugin.csproj
 rm -f monero-plugin/global.json
 
+splice_all() {
+  BTCPAY_SPLICE_ABS="$1"
+  replace_btcpay_copy exolix-plugin/btcpayserver
+  replace_btcpay_copy boltz/btcpayserver
+  replace_btcpay_copy samrock-protocol/submodules/btcpayserver
+  replace_btcpay_copy payroll/submodules/btcpayserver
+  replace_btcpay_copy boltcards-plugin/btcpayserver
+  replace_btcpay_copy shopify-plugin/btcpayserver
+  replace_btcpay_copy shopify-plugin/submodules/btcpayserver
+  replace_btcpay_copy monero-plugin/submodules/btcpayserver
+  replace_btcpay_copy blink/submodules/btcpayserver
+  replace_btcpay_copy samrock-protocol/submodules/boltz/btcpayserver
+}
+
+declare -A MASTER_RESULT
+declare -A BASE_RESULT
+
+build_all() {
+  local -n _res="$1"
+
+  (
+    cd exolix-plugin
+    run_build "exolix-plugin" "BTCPayServer.Plugins.Exolix/BTCPayServer.Plugins.Exolix.csproj"
+  )
+  _res["exolix-plugin"]=$?
+
+  (
+    cd boltz
+    run_build "boltz" "BTCPayServer.Plugins.Boltz/BTCPayServer.Plugins.Boltz.csproj"
+  )
+  _res["boltz"]=$?
+
+  (
+    cd samrock-protocol
+    run_build "samrock-protocol" "Plugins/SamRockProtocol/SamRockProtocol.csproj"
+  )
+  _res["samrock-protocol"]=$?
+
+  (
+    cd payroll
+    run_build "payroll" "Plugins/BTCPayServer.RockstarDev.Plugins.Payroll/BTCPayServer.RockstarDev.Plugins.Payroll.csproj"
+  )
+  _res["payroll"]=$?
+
+  (
+    cd boltcards-plugin
+    run_build "boltcards-plugin" "BTCPayServer.Plugins.Boltcards/BTCPayServer.Plugins.Boltcards.csproj"
+  )
+  _res["boltcards-plugin"]=$?
+
+  (
+    cd shopify-plugin
+    run_build "shopify-plugin" "Plugins/BTCPayServer.Plugins.ShopifyPlugin/BTCPayServer.Plugins.ShopifyPlugin.csproj"
+  )
+  _res["shopify-plugin"]=$?
+
+  (
+    cd monero-plugin
+    run_build "monero-plugin" "Plugins/Monero/BTCPayServer.Plugins.Monero.csproj"
+  )
+  _res["monero-plugin"]=$?
+
+  (
+    cd blink
+    blink_status=0
+    for project in Plugins/*/*.csproj; do
+      plugin_name="$(basename "$(dirname "$project")")"
+      plugin_name="${plugin_name#BTCPayServer.Plugins.}"
+      run_build "kukks-$plugin_name" "$project" || blink_status=1
+    done
+    exit "$blink_status"
+  )
+  _res["blink"]=$?
+}
+
 printf '\n==> Environment\n'
 printf 'BTCPay master: '
 git -C btcpayserver-master rev-parse HEAD
+if [ -n "$BTCPAY_BASELINE_REF" ]; then
+  printf 'BTCPay baseline (%s): ' "$BTCPAY_BASELINE_REF"
+  git -C btcpayserver-baseline rev-parse HEAD
+fi
 printf 'dotnet SDK: '
 dotnet --version
 
-status=0
+printf '\n==================== PASS: master ====================\n'
+splice_all "$BTCPAY_MASTER_ABS"
+build_all MASTER_RESULT
 
-(
-  cd exolix-plugin
-  run_build "exolix-plugin" "BTCPayServer.Plugins.Exolix/BTCPayServer.Plugins.Exolix.csproj"
-) || status=1
-
-(
-  cd boltz
-  run_build "boltz" "BTCPayServer.Plugins.Boltz/BTCPayServer.Plugins.Boltz.csproj"
-) || status=1
-
-(
-  cd samrock-protocol
-  run_build "samrock-protocol" "Plugins/SamRockProtocol/SamRockProtocol.csproj"
-) || status=1
-
-(
-  cd payroll
-  run_build "payroll" "Plugins/BTCPayServer.RockstarDev.Plugins.Payroll/BTCPayServer.RockstarDev.Plugins.Payroll.csproj"
-) || status=1
-
-(
-  cd boltcards-plugin
-  run_build "boltcards-plugin" "BTCPayServer.Plugins.Boltcards/BTCPayServer.Plugins.Boltcards.csproj"
-) || status=1
-
-(
-  cd shopify-plugin
-  run_build "shopify-plugin" "Plugins/BTCPayServer.Plugins.ShopifyPlugin/BTCPayServer.Plugins.ShopifyPlugin.csproj"
-) || status=1
-
-(
-  cd monero-plugin
-  run_build "monero-plugin" "Plugins/Monero/BTCPayServer.Plugins.Monero.csproj"
-) || status=1
-
-(
-  cd blink
-  for project in Plugins/*/*.csproj; do
-    plugin_name="$(basename "$(dirname "$project")")"
-    plugin_name="${plugin_name#BTCPayServer.Plugins.}"
-    run_build "kukks-$plugin_name" "$project" || status=1
-  done
-  exit "$status"
-) || status=1
-
-printf '\n==> Summary\n'
-if [ "$status" -eq 0 ]; then
-  printf 'All plugin builds passed.\n'
-else
-  printf 'One or more plugin builds failed. See output above.\n'
+if [ -n "$BTCPAY_BASELINE_REF" ]; then
+  printf '\n==================== PASS: baseline (%s) ====================\n' "$BTCPAY_BASELINE_REF"
+  splice_all "$BTCPAY_BASELINE_ABS"
+  build_all BASE_RESULT
 fi
 
-exit "$status"
+printf '\n==> Summary\n'
+
+regressions=()
+still_broken=()
+still_ok=()
+newly_fixed=()
+plain_fail=()
+plain_ok=()
+
+for name in "${!MASTER_RESULT[@]}"; do
+  m="${MASTER_RESULT[$name]}"
+  if [ -z "$BTCPAY_BASELINE_REF" ]; then
+    if [ "$m" -eq 0 ]; then
+      plain_ok+=("$name")
+    else
+      plain_fail+=("$name")
+    fi
+    continue
+  fi
+  b="${BASE_RESULT[$name]:-1}"
+  if [ "$b" -eq 0 ] && [ "$m" -ne 0 ]; then
+    regressions+=("$name")
+  elif [ "$b" -ne 0 ] && [ "$m" -ne 0 ]; then
+    still_broken+=("$name")
+  elif [ "$b" -ne 0 ] && [ "$m" -eq 0 ]; then
+    newly_fixed+=("$name")
+  else
+    still_ok+=("$name")
+  fi
+done
+
+if [ -z "$BTCPAY_BASELINE_REF" ]; then
+  printf 'OK:     %s\n' "${plain_ok[*]:-(none)}"
+  printf 'FAILED: %s\n' "${plain_fail[*]:-(none)}"
+  if [ "${#plain_fail[@]}" -eq 0 ]; then
+    printf 'All plugin builds passed.\n'
+  else
+    printf 'One or more plugin builds failed. See output above.\n'
+  fi
+else
+  printf 'still-ok:     %s\n' "${still_ok[*]:-(none)}"
+  printf 'still-broken: %s\n' "${still_broken[*]:-(none)}"
+  printf 'newly-fixed:  %s\n' "${newly_fixed[*]:-(none)}"
+  printf 'REGRESSION:   %s\n' "${regressions[*]:-(none)}"
+  printf '\n'
+  if [ "${#regressions[@]}" -gt 0 ]; then
+    printf '!! %d plugin(s) built against %s but FAIL against master.\n' "${#regressions[@]}" "$BTCPAY_BASELINE_REF"
+    printf '!! These are user-facing regressions: consider a Core fix (revert + [Obsolete]),\n'
+    printf '!! or ping the author only if Core cannot absorb it.\n'
+  else
+    printf 'No new regressions versus %s.\n' "$BTCPAY_BASELINE_REF"
+  fi
+  if [ "${#still_broken[@]}" -gt 0 ]; then
+    printf '(Note: still-broken plugins were already broken before this release.)\n'
+  fi
+fi
+
+if [ -n "$BTCPAY_BASELINE_REF" ] && [ -n "$BLOCK_ON_REGRESSION" ] && [ "${#regressions[@]}" -gt 0 ]; then
+  exit 1
+fi
+exit 0

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,7 +63,8 @@ jobs:
       - run:
           name: Check BTCPay plugin compatibility
           command: |
-            cd .circleci && ./check-btcpay-plugin-compat.sh
+            cd .circleci
+            BTCPAY_BASELINE_REF="v2.3.9" ./check-btcpay-plugin-compat.sh || true
   # publish jobs require $DOCKERHUB_REPO, $DOCKERHUB_USER, $DOCKERHUB_PASS defined
   docker:
     docker:


### PR DESCRIPTION
Builds on the plugin compat check from #7351  Two changes made:


Non-blocking. The check now always exits 0, so a broken plugin can't fail release_checks and hold back the release. 


Diff against last release. BTCPAY_BASELINE_REF is the last release version. When set, each plugin is also built against that release tag, and results are classified into the following:

1. Regression: built successfully on previous release, fails on master (the upcoming release). User-facing breaking changes

2. still-broken: already broken before this release (not new)

3. newly-fixed / still-ok

Baseline is currently hardcoded to v2.3.9 in config.yml @NicolasDorier this means a maintainer has to bump it on every release. Do we want that, should we infer it (e.g. previous tag from $CIRCLE_TAG), or set it as a CircleCI env var?

Cc. @NicolasDorier 