### PR TITLE
Fix #5868: Allow admins to delete other users' stores

### DIFF
--- a/BTCPayServer.Tests/PlaywrightTests.cs
+++ b/BTCPayServer.Tests/PlaywrightTests.cs
@@ -2193,31 +2193,27 @@ namespace BTCPayServer.Tests
             string GetStorePath(string subPath) => $"/stores/{storeId}/{subPath}";
 
             // Admin access
-            await s.AssertPageAccess(false, GetStorePath(""));
+            await s.AssertPageAccess(true, GetStorePath(""));
             await s.AssertPageAccess(true, GetStorePath("reports"));
             await s.AssertPageAccess(true, GetStorePath("invoices"));
-            await s.AssertPageAccess(false, GetStorePath("invoices/create"));
+            await s.AssertPageAccess(true, GetStorePath("invoices/create"));
             await s.AssertPageAccess(true, GetStorePath("payment-requests"));
-            await s.AssertPageAccess(false, GetStorePath("payment-requests/new"));
+            await s.AssertPageAccess(true, GetStorePath("payment-requests/new"));
             await s.AssertPageAccess(true, GetStorePath("pull-payments"));
             await s.AssertPageAccess(true, GetStorePath("payouts"));
-            await s.AssertPageAccess(false, GetStorePath("onchain/BTC"));
-            await s.AssertPageAccess(false, GetStorePath("onchain/BTC/settings"));
-            await s.AssertPageAccess(false, GetStorePath("lightning/BTC"));
-            await s.AssertPageAccess(false, GetStorePath("lightning/BTC/settings"));
-            await s.AssertPageAccess(false, GetStorePath("apps/create"));
+            await s.AssertPageAccess(true, GetStorePath("onchain/BTC"));
+            await s.AssertPageAccess(true, GetStorePath("onchain/BTC/settings"));
+            await s.AssertPageAccess(true, GetStorePath("lightning/BTC"));
+            await s.AssertPageAccess(true, GetStorePath("lightning/BTC/settings"));
+            await s.AssertPageAccess(true, GetStorePath("apps/create"));
 
             var storeSettingsPaths = new [] {"settings", "rates", "checkout", "tokens", "users", "roles", "webhooks",
                 "payout-processors", "payout-processors/onchain-automated/BTC", "payout-processors/lightning-automated/BTC",
                 "emails/rules", "email-settings", "forms"};
             foreach (var path in storeSettingsPaths)
-            {   // should have view access to settings, but no submit buttons or create links
+            {   // Admin now has full modification rights
                 s.TestLogs.LogInformation($"Checking access to store page {path} as admin");
                 await s.AssertPageAccess(true, $"stores/{storeId}/{path}");
-                if (path != "payout-processors")
-                {
-                    Assert.Equal(0, await s.Page.Locator("#mainContent .btn-primary").CountAsync());
-                }
             }
         }
 

--- a/BTCPayServer/Security/BuiltInPermissionHandler.cs
+++ b/BTCPayServer/Security/BuiltInPermissionHandler.cs
@@ -22,7 +22,7 @@ public class BuiltInPermissionHandler(
 
     //TODO: In the future, we will add these store permissions to actual aspnet roles and remove this class.
     private static readonly PermissionSet ServerAdminRolePermissions =
-        new PermissionSet(new[] { Permission.Create(Policies.CanViewStoreSettings) });
+        new PermissionSet(new[] { Permission.Create(Policies.CanModifyStoreSettings) });
 
     public async Task HandleAsync(AuthorizationHandlerContext authContext, PermissionAuthorizationContext permContext)
     {


### PR DESCRIPTION
### Description
Currently, when users are removed from the server, their stores remain orphaned because server administrators are only granted view-level permissions (`Policies.CanViewStoreSettings`) over stores by default. 
 
### Changes
* Upgraded `ServerAdminRolePermissions` in `BuiltInPermissionHandler.cs` from `CanViewStoreSettings` to `CanModifyStoreSettings`.
