### PR TITLE
Add copy and QR actions for store ID

### DIFF
--- a/BTCPayServer/Views/UIStores/GeneralSettings.cshtml
+++ b/BTCPayServer/Views/UIStores/GeneralSettings.cshtml
@@ -1,10 +1,12 @@
 @using BTCPayServer.Abstractions.Contracts
 @using BTCPayServer.Client
+@inject BTCPayServer.Security.ContentSecurityPolicies Csp
 @inject IFileService FileService;
 @model GeneralSettingsViewModel
 @{
 	ViewData.SetLayoutModel(new LayoutModel("General", StringLocalizer["General"]).SetCategory(WellKnownCategories.Store));
 	var canUpload = await FileService.IsAvailable();
+    Csp.UnsafeEval();
 }
 <form method="post" enctype="multipart/form-data" permissioned="@Policies.CanModifyStoreSettings">
     <div class="sticky-header">
@@ -22,7 +24,22 @@
             }
             <div class="form-group">
                 <label asp-for="Id" class="form-label"></label>
-                <input asp-for="Id" readonly class="form-control" />
+                <div class="input-group">
+                    <input asp-for="Id" readonly class="form-control" />
+                    <button type="button"
+                            class="btn btn-outline-secondary only-for-js"
+                            data-store-id-qr
+                            aria-label="@StringLocalizer["Show store ID QR"]">
+                        <vc:icon symbol="qr-code" />
+                    </button>
+                    <button type="button"
+                            class="btn btn-outline-secondary only-for-js clipboard-button"
+                            data-clipboard="@Model.Id"
+                            data-clipboard-confirm="@StringLocalizer["Copied"]"
+                            aria-label="@StringLocalizer["Copy store ID"]">
+                        <vc:icon symbol="actions-copy" />
+                    </button>
+                </div>
             </div>
             <div class="form-group">
                 <label asp-for="StoreName" class="form-label"></label>
@@ -240,10 +257,27 @@
 </div>
 
 <partial name="_Confirm" model="@(new ConfirmModel(StringLocalizer["Delete store"], StringLocalizer["The store will be permanently deleted. This action will also delete all invoices, apps and data associated with the store."], StringLocalizer["Delete"]))" permission="@Policies.CanModifyStoreSettings" />
+<partial name="ShowQR" />
+
+@section PageHeadContent {
+    <link href="~/vendor/vue-qrcode-reader/vue-qrcode-reader.css" rel="stylesheet" asp-append-version="true" />
+}
 
 @section PageFootContent {
+    <script src="~/vendor/vuejs/vue.min.js" asp-append-version="true"></script>
+    <script src="~/vendor/vue-qrcode/vue-qrcode.min.js" asp-append-version="true"></script>
+    <script src="~/vendor/ur-registry/urlib.min.js" asp-append-version="true"></script>
+    <script src="~/vendor/vue-qrcode-reader/VueQrcodeReader.umd.min.js" asp-append-version="true"></script>
     <partial name="_ValidationScriptsPartial"/>
     <script>
+    document.addEventListener("DOMContentLoaded", function () {
+        const storeId = @Safe.Json(Model.Id);
+        const qrApp = initQRShow({ title: "Store ID QR" });
+        delegate("click", "button[data-store-id-qr]", e => {
+            e.preventDefault();
+            qrApp.showData(storeId, "Store ID");
+        });
+    });
     (() => {
         const $colorValue = document.getElementById('BrandColor');
         const $colorInput = document.getElementById('BrandColorInput');

--- a/BTCPayServer/Views/UIStores/GeneralSettings.cshtml
+++ b/BTCPayServer/Views/UIStores/GeneralSettings.cshtml
@@ -259,23 +259,17 @@
 <partial name="_Confirm" model="@(new ConfirmModel(StringLocalizer["Delete store"], StringLocalizer["The store will be permanently deleted. This action will also delete all invoices, apps and data associated with the store."], StringLocalizer["Delete"]))" permission="@Policies.CanModifyStoreSettings" />
 <partial name="ShowQR" />
 
-@section PageHeadContent {
-    <link href="~/vendor/vue-qrcode-reader/vue-qrcode-reader.css" rel="stylesheet" asp-append-version="true" />
-}
-
 @section PageFootContent {
     <script src="~/vendor/vuejs/vue.min.js" asp-append-version="true"></script>
     <script src="~/vendor/vue-qrcode/vue-qrcode.min.js" asp-append-version="true"></script>
-    <script src="~/vendor/ur-registry/urlib.min.js" asp-append-version="true"></script>
-    <script src="~/vendor/vue-qrcode-reader/VueQrcodeReader.umd.min.js" asp-append-version="true"></script>
     <partial name="_ValidationScriptsPartial"/>
     <script>
     document.addEventListener("DOMContentLoaded", function () {
         const storeId = @Safe.Json(Model.Id);
-        const qrApp = initQRShow({ title: "Store ID QR" });
+        const qrApp = initQRShow({ title: @Safe.Json(StringLocalizer["Store Id QR Code"].Value) });
         delegate("click", "button[data-store-id-qr]", e => {
             e.preventDefault();
-            qrApp.showData(storeId, "Store ID");
+            qrApp.showData(storeId, @Safe.Json(StringLocalizer["Store Id"].Value));
         });
     });
     (() => {


### PR DESCRIPTION
## Summary

Adds inline QR and copy actions to the `Store Id` field on the Store Settings page.

## Motivation

Some setup flows require moving a store ID from the BTCPay UI to another device or app. This change makes that easier without changing store behavior or API surface.

## Changes

- wraps the `Store Id` input in an input group
- adds a QR button to display the raw store ID in the existing QR modal
- adds a copy button to copy the store ID to the clipboard
- removes the need for a separate text link by keeping both actions inline with the field

## Notes

- UI-only change
- QR payload is the raw store ID only

## Testing

- `dotnet build BTCPayServer/BTCPayServer.csproj`
- manually verified the Store Settings page in a local BTCPay instance
- verified the QR modal opens from the new inline button
- verified the copy action still renders correctly