### PR TITLE
fix: lightning invoice silently dropped when node doesn't return amount on reconnect

### DIFF
--- a/BTCPayServer/Payments/Lightning/LightningListener.cs
+++ b/BTCPayServer/Payments/Lightning/LightningListener.cs
@@ -484,21 +484,23 @@ namespace BTCPayServer.Payments.Lightning
             ConnectionString = connectionString;
         }
 
+        internal enum RecordedState { RecordedNow, AlreadyRecorded, RetryLater }
+
         internal bool AddListenedInvoice(ListenedInvoice invoice)
         {
             return _ListenedInvoices.TryAdd(invoice.PaymentMethodDetails.InvoiceId, invoice);
         }
 
-        internal async Task<(LightningInvoiceStatus? Status, bool PaymentRecorded)> PollPayment(ListenedInvoice listenedInvoice, CancellationToken cancellation)
+        internal async Task<(LightningInvoiceStatus? Status, RecordedState RecordedState)> PollPayment(ListenedInvoice listenedInvoice, CancellationToken cancellation)
         {
             var client = _lightningClientFactory.Create(ConnectionString, _network);
             LightningInvoice lightningInvoice = await client.GetInvoice(listenedInvoice.PaymentMethodDetails.InvoiceId, cancellation);
-            var recorded = false;
+            var state = RecordedState.RetryLater;
             if (lightningInvoice?.Status is LightningInvoiceStatus.Paid)
-                recorded = await AddPayment(lightningInvoice, listenedInvoice.InvoiceId, listenedInvoice.PaymentMethod.PaymentMethodId);
-            if (recorded)
+                state = await AddPayment(lightningInvoice, listenedInvoice.InvoiceId, listenedInvoice.PaymentMethod.PaymentMethodId);
+            if (state is RecordedState.RecordedNow)
                 Logs.PayServer.LogInformation($"{_network.CryptoCode} (Lightning): Payment detected via polling on {listenedInvoice.InvoiceId}");
-            return (lightningInvoice?.Status, recorded);
+            return (lightningInvoice?.Status, state);
         }
 
         public bool Empty => _ListenedInvoices.IsEmpty;
@@ -550,7 +552,8 @@ namespace BTCPayServer.Payments.Lightning
                         if (notification.Status == LightningInvoiceStatus.Paid &&
                             notification.PaidAt.HasValue && (notification.AmountReceived ?? notification.Amount) != null)
                         {
-                            if (await AddPayment(notification, listenedInvoice.InvoiceId, listenedInvoice.PaymentMethod.PaymentMethodId))
+                            var state = await AddPayment(notification, listenedInvoice.InvoiceId, listenedInvoice.PaymentMethod.PaymentMethodId);
+                            if (state is RecordedState.RecordedNow)
                             {
                                 Logs.PayServer.LogInformation("{CryptoCode} (Lightning): Payment detected via notification ({InvoiceId})", _network.CryptoCode,
                                     listenedInvoice.InvoiceId);
@@ -598,9 +601,9 @@ namespace BTCPayServer.Payments.Lightning
         {
             foreach (var invoice in _ListenedInvoices.Values)
             {
-                var (status, recorded) = await PollPayment(invoice, cancellation);
+                var (status, state) = await PollPayment(invoice, cancellation);
                 if (status is null ||
-                    (status is LightningInvoiceStatus.Paid && recorded) ||
+                    (status is LightningInvoiceStatus.Paid && state is RecordedState.RecordedNow or RecordedState.AlreadyRecorded) ||
                     status is LightningInvoiceStatus.Expired)
                     _ListenedInvoices.TryRemove(invoice.PaymentMethodDetails.InvoiceId, out var _);
             }
@@ -615,11 +618,11 @@ namespace BTCPayServer.Payments.Lightning
         bool _ErrorAlreadyLogged = false;
         readonly ConcurrentDictionary<string, ListenedInvoice> _ListenedInvoices = new ConcurrentDictionary<string, ListenedInvoice>();
 
-        public async Task<bool> AddPayment(LightningInvoice notification, string invoiceId, PaymentMethodId paymentMethodId)
+        internal async Task<RecordedState> AddPayment(LightningInvoice notification, string invoiceId, PaymentMethodId paymentMethodId)
         {
             var invoiceEntity = await _invoiceRepository.GetInvoice(invoiceId);
             if (notification?.PaidAt is null || invoiceEntity is null)
-                return false;
+                return RecordedState.AlreadyRecorded;
 
             var paidAmount = notification.AmountReceived ?? notification.Amount;
             if (paidAmount is null)
@@ -627,7 +630,7 @@ namespace BTCPayServer.Payments.Lightning
                 Logs.PayServer.LogWarning(
                     "{CryptoCode} (Lightning): Invoice {InvoiceId} is paid according to the node but no amount was returned; cannot record the payment yet.",
                     _network.CryptoCode, invoiceId);
-                return false;
+                return RecordedState.RetryLater;
             }
 
             var handler = _handlers[paymentMethodId];
@@ -665,7 +668,7 @@ namespace BTCPayServer.Payments.Lightning
                     _eventAggregator.Publish(new InvoiceEvent(invoice, InvoiceEvent.ReceivedPayment) { Payment = payment });
             }
 
-            return payment != null;
+            return payment != null ? RecordedState.RecordedNow : RecordedState.AlreadyRecorded;
         }
 
         internal void RemoveExpiredInvoices()

--- a/BTCPayServer/Payments/Lightning/LightningListener.cs
+++ b/BTCPayServer/Payments/Lightning/LightningListener.cs
@@ -489,17 +489,16 @@ namespace BTCPayServer.Payments.Lightning
             return _ListenedInvoices.TryAdd(invoice.PaymentMethodDetails.InvoiceId, invoice);
         }
 
-        internal async Task<LightningInvoiceStatus?> PollPayment(ListenedInvoice listenedInvoice, CancellationToken cancellation)
+        internal async Task<(LightningInvoiceStatus? Status, bool PaymentRecorded)> PollPayment(ListenedInvoice listenedInvoice, CancellationToken cancellation)
         {
             var client = _lightningClientFactory.Create(ConnectionString, _network);
             LightningInvoice lightningInvoice = await client.GetInvoice(listenedInvoice.PaymentMethodDetails.InvoiceId, cancellation);
-            if (lightningInvoice?.Status is LightningInvoiceStatus.Paid &&
-                await AddPayment(lightningInvoice, listenedInvoice.InvoiceId, listenedInvoice.PaymentMethod.PaymentMethodId))
-            {
+            var recorded = false;
+            if (lightningInvoice?.Status is LightningInvoiceStatus.Paid)
+                recorded = await AddPayment(lightningInvoice, listenedInvoice.InvoiceId, listenedInvoice.PaymentMethod.PaymentMethodId);
+            if (recorded)
                 Logs.PayServer.LogInformation($"{_network.CryptoCode} (Lightning): Payment detected via polling on {listenedInvoice.InvoiceId}");
-            }
-
-            return lightningInvoice?.Status;
+            return (lightningInvoice?.Status, recorded);
         }
 
         public bool Empty => _ListenedInvoices.IsEmpty;
@@ -599,9 +598,9 @@ namespace BTCPayServer.Payments.Lightning
         {
             foreach (var invoice in _ListenedInvoices.Values)
             {
-                var status = await PollPayment(invoice, cancellation);
+                var (status, recorded) = await PollPayment(invoice, cancellation);
                 if (status is null ||
-                    status is LightningInvoiceStatus.Paid ||
+                    (status is LightningInvoiceStatus.Paid && recorded) ||
                     status is LightningInvoiceStatus.Expired)
                     _ListenedInvoices.TryRemove(invoice.PaymentMethodDetails.InvoiceId, out var _);
             }

--- a/BTCPayServer/Payments/Lightning/LightningListener.cs
+++ b/BTCPayServer/Payments/Lightning/LightningListener.cs
@@ -620,10 +620,13 @@ namespace BTCPayServer.Payments.Lightning
 
         internal async Task<RecordedState> AddPayment(LightningInvoice notification, string invoiceId, PaymentMethodId paymentMethodId)
         {
+            if (notification is null)
+                return RecordedState.RetryLater;
             var invoiceEntity = await _invoiceRepository.GetInvoice(invoiceId);
-            if (notification?.PaidAt is null || invoiceEntity is null)
+            if (invoiceEntity is null)
                 return RecordedState.AlreadyRecorded;
 
+            var paidAt = notification.PaidAt ?? DateTimeOffset.UtcNow;
             var paidAmount = notification.AmountReceived ?? notification.Amount;
             if (paidAmount is null)
             {
@@ -638,7 +641,7 @@ namespace BTCPayServer.Payments.Lightning
             var paymentData = new PaymentData()
             {
                 Id = paymentHash?.ToString() ?? notification.BOLT11,
-                Created = notification.PaidAt.Value,
+                Created = paidAt,
                 Status = PaymentStatus.Settled,
                 Currency = _network.CryptoCode,
                 InvoiceDataId = invoiceId,

--- a/BTCPayServer/Payments/Lightning/LightningListener.cs
+++ b/BTCPayServer/Payments/Lightning/LightningListener.cs
@@ -484,23 +484,29 @@ namespace BTCPayServer.Payments.Lightning
             ConnectionString = connectionString;
         }
 
-        internal enum RecordedState { RecordedNow, AlreadyRecorded, RetryLater }
+        internal enum RecordedState { RecordedNow, AlreadyRecorded, RetryLater, Expired }
 
         internal bool AddListenedInvoice(ListenedInvoice invoice)
         {
             return _ListenedInvoices.TryAdd(invoice.PaymentMethodDetails.InvoiceId, invoice);
         }
 
-        internal async Task<(LightningInvoiceStatus? Status, RecordedState RecordedState)> PollPayment(ListenedInvoice listenedInvoice, CancellationToken cancellation)
+        /// <summary>
+        /// Poll payment to the selected invoice
+        /// </summary>
+        /// <param name="listenedInvoice"></param>
+        /// <param name="cancellation"></param>
+        /// <returns>true if this payment shouldn't be polled again</returns>
+        internal async Task<bool> PollPayment(ListenedInvoice listenedInvoice, CancellationToken cancellation)
         {
             var client = _lightningClientFactory.Create(ConnectionString, _network);
-            LightningInvoice lightningInvoice = await client.GetInvoice(listenedInvoice.PaymentMethodDetails.InvoiceId, cancellation);
-            var state = RecordedState.RetryLater;
-            if (lightningInvoice?.Status is LightningInvoiceStatus.Paid)
-                state = await AddPayment(lightningInvoice, listenedInvoice.InvoiceId, listenedInvoice.PaymentMethod.PaymentMethodId);
+            var lightningInvoice = await client.GetInvoice(listenedInvoice.PaymentMethodDetails.InvoiceId, cancellation);
+            if (lightningInvoice is null)
+                return true;
+            var state = await AddPayment(lightningInvoice, listenedInvoice.InvoiceId, listenedInvoice.PaymentMethod.PaymentMethodId);
             if (state is RecordedState.RecordedNow)
                 Logs.PayServer.LogInformation($"{_network.CryptoCode} (Lightning): Payment detected via polling on {listenedInvoice.InvoiceId}");
-            return (lightningInvoice?.Status, state);
+            return state is not RecordedState.RetryLater;
         }
 
         public bool Empty => _ListenedInvoices.IsEmpty;
@@ -545,26 +551,17 @@ namespace BTCPayServer.Payments.Lightning
                     var notification = await session.WaitInvoice(cancellation);
                     if (!_ListenedInvoices.TryGetValue(notification.Id, out var listenedInvoice))
                         continue;
-                    if (notification.Id == listenedInvoice.PaymentMethodDetails.InvoiceId &&
-                        (notification.BOLT11 == listenedInvoice.PaymentMethod.Destination ||
-                        notification.GetPaymentHash(_network.NBitcoinNetwork) == GetPaymentHash(listenedInvoice)))
+                    if (notification.BOLT11 == listenedInvoice.PaymentMethod.Destination ||
+                        notification.GetPaymentHash(_network.NBitcoinNetwork) == GetPaymentHash(listenedInvoice))
                     {
-                        if (notification.Status == LightningInvoiceStatus.Paid &&
-                            notification.PaidAt.HasValue && (notification.AmountReceived ?? notification.Amount) != null)
+                        var state = await AddPayment(notification, listenedInvoice.InvoiceId, listenedInvoice.PaymentMethod.PaymentMethodId);
+                        if (state is RecordedState.RecordedNow)
                         {
-                            var state = await AddPayment(notification, listenedInvoice.InvoiceId, listenedInvoice.PaymentMethod.PaymentMethodId);
-                            if (state is RecordedState.RecordedNow)
-                            {
-                                Logs.PayServer.LogInformation("{CryptoCode} (Lightning): Payment detected via notification ({InvoiceId})", _network.CryptoCode,
-                                    listenedInvoice.InvoiceId);
-                            }
-
-                            _ListenedInvoices.TryRemove(notification.Id, out var _);
+                            Logs.PayServer.LogInformation("{CryptoCode} (Lightning): Payment detected via notification ({InvoiceId})", _network.CryptoCode,
+                                listenedInvoice.InvoiceId);
                         }
-                        else if (notification.Status == LightningInvoiceStatus.Expired)
-                        {
+                        if (state is not RecordedState.RetryLater)
                             _ListenedInvoices.TryRemove(notification.Id, out var _);
-                        }
                     }
                 }
             }
@@ -601,10 +598,7 @@ namespace BTCPayServer.Payments.Lightning
         {
             foreach (var invoice in _ListenedInvoices.Values)
             {
-                var (status, state) = await PollPayment(invoice, cancellation);
-                if (status is null ||
-                    (status is LightningInvoiceStatus.Paid && state is RecordedState.RecordedNow or RecordedState.AlreadyRecorded) ||
-                    status is LightningInvoiceStatus.Expired)
+                if (await PollPayment(invoice, cancellation))
                     _ListenedInvoices.TryRemove(invoice.PaymentMethodDetails.InvoiceId, out var _);
             }
 
@@ -620,11 +614,13 @@ namespace BTCPayServer.Payments.Lightning
 
         internal async Task<RecordedState> AddPayment(LightningInvoice notification, string invoiceId, PaymentMethodId paymentMethodId)
         {
-            if (notification is null)
-                return RecordedState.RetryLater;
             var invoiceEntity = await _invoiceRepository.GetInvoice(invoiceId);
             if (invoiceEntity is null)
                 return RecordedState.AlreadyRecorded;
+            if (notification.Status is LightningInvoiceStatus.Expired)
+                return RecordedState.Expired;
+            if (notification.Status is LightningInvoiceStatus.Unpaid)
+                return RecordedState.RetryLater;
 
             var paidAt = notification.PaidAt ?? DateTimeOffset.UtcNow;
             var paidAmount = notification.AmountReceived ?? notification.Amount;
@@ -653,25 +649,24 @@ namespace BTCPayServer.Payments.Lightning
                 });
 
             var payment = await _paymentService.AddPayment(paymentData, [notification.BOLT11]);
-            if (payment != null)
-            {
-                if (notification.Preimage is not null)
-                {
-                    var details = (LigthningPaymentPromptDetails)handler.ParsePaymentPromptDetails(invoiceEntity.GetPaymentPrompt(handler.PaymentMethodId)!
-                        .Details);
-                    if (details.Preimage is null)
-                    {
-                        details.Preimage = uint256.Parse(notification.Preimage);
-                        await _invoiceRepository.UpdatePaymentDetails(invoiceId, handler, details);
-                    }
-                }
+            if (payment is null)
+                return RecordedState.AlreadyRecorded;
 
-                var invoice = await _invoiceRepository.GetInvoice(invoiceId);
-                if (invoice != null)
-                    _eventAggregator.Publish(new InvoiceEvent(invoice, InvoiceEvent.ReceivedPayment) { Payment = payment });
+            if (notification.Preimage is not null)
+            {
+                var details = (LigthningPaymentPromptDetails)handler.ParsePaymentPromptDetails(invoiceEntity.GetPaymentPrompt(handler.PaymentMethodId)!
+                    .Details);
+                if (details.Preimage is null)
+                {
+                    details.Preimage = uint256.Parse(notification.Preimage);
+                    await _invoiceRepository.UpdatePaymentDetails(invoiceId, handler, details);
+                }
             }
 
-            return payment != null ? RecordedState.RecordedNow : RecordedState.AlreadyRecorded;
+            var invoice = await _invoiceRepository.GetInvoice(invoiceId);
+            if (invoice != null)
+                _eventAggregator.Publish(new InvoiceEvent(invoice, InvoiceEvent.ReceivedPayment) { Payment = payment });
+            return RecordedState.RecordedNow;
         }
 
         internal void RemoveExpiredInvoices()

--- a/BTCPayServer/Payments/Lightning/LightningListener.cs
+++ b/BTCPayServer/Payments/Lightning/LightningListener.cs
@@ -21,6 +21,8 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using NBitcoin;
+using NBitcoin.Crypto;
+using NBitcoin.DataEncoders;
 using NBXplorer;
 using Newtonsoft.Json.Linq;
 
@@ -484,29 +486,22 @@ namespace BTCPayServer.Payments.Lightning
             ConnectionString = connectionString;
         }
 
-        internal enum RecordedState { RecordedNow, AlreadyRecorded, RetryLater, Expired }
-
         internal bool AddListenedInvoice(ListenedInvoice invoice)
         {
             return _ListenedInvoices.TryAdd(invoice.PaymentMethodDetails.InvoiceId, invoice);
         }
 
-        /// <summary>
-        /// Poll payment to the selected invoice
-        /// </summary>
-        /// <param name="listenedInvoice"></param>
-        /// <param name="cancellation"></param>
-        /// <returns>true if this payment shouldn't be polled again</returns>
-        internal async Task<bool> PollPayment(ListenedInvoice listenedInvoice, CancellationToken cancellation)
+        internal async Task PollPayment(ListenedInvoice listenedInvoice, CancellationToken cancellation)
         {
             var client = _lightningClientFactory.Create(ConnectionString, _network);
             var lightningInvoice = await client.GetInvoice(listenedInvoice.PaymentMethodDetails.InvoiceId, cancellation);
             if (lightningInvoice is null)
-                return true;
-            var state = await AddPayment(lightningInvoice, listenedInvoice.InvoiceId, listenedInvoice.PaymentMethod.PaymentMethodId);
-            if (state is RecordedState.RecordedNow)
+            {
+                _ListenedInvoices.TryRemove(listenedInvoice.PaymentMethodDetails.InvoiceId, out _);
+                return;
+            }
+            if (await AddPayment(lightningInvoice, listenedInvoice.InvoiceId, listenedInvoice.PaymentMethod.PaymentMethodId))
                 Logs.PayServer.LogInformation($"{_network.CryptoCode} (Lightning): Payment detected via polling on {listenedInvoice.InvoiceId}");
-            return state is not RecordedState.RetryLater;
         }
 
         public bool Empty => _ListenedInvoices.IsEmpty;
@@ -551,17 +546,10 @@ namespace BTCPayServer.Payments.Lightning
                     var notification = await session.WaitInvoice(cancellation);
                     if (!_ListenedInvoices.TryGetValue(notification.Id, out var listenedInvoice))
                         continue;
-                    if (notification.BOLT11 == listenedInvoice.PaymentMethod.Destination ||
-                        notification.GetPaymentHash(_network.NBitcoinNetwork) == GetPaymentHash(listenedInvoice))
+                    if (await AddPayment(notification, listenedInvoice.InvoiceId, listenedInvoice.PaymentMethod.PaymentMethodId))
                     {
-                        var state = await AddPayment(notification, listenedInvoice.InvoiceId, listenedInvoice.PaymentMethod.PaymentMethodId);
-                        if (state is RecordedState.RecordedNow)
-                        {
-                            Logs.PayServer.LogInformation("{CryptoCode} (Lightning): Payment detected via notification ({InvoiceId})", _network.CryptoCode,
-                                listenedInvoice.InvoiceId);
-                        }
-                        if (state is not RecordedState.RetryLater)
-                            _ListenedInvoices.TryRemove(notification.Id, out var _);
+                        Logs.PayServer.LogInformation("{CryptoCode} (Lightning): Payment detected via notification ({InvoiceId})", _network.CryptoCode,
+                            listenedInvoice.InvoiceId);
                     }
                 }
             }
@@ -586,20 +574,13 @@ namespace BTCPayServer.Payments.Lightning
             }
         }
 
-        private uint256? GetPaymentHash(ListenedInvoice listenedInvoice)
-        {
-            return listenedInvoice.PaymentMethodDetails.PaymentHash ??
-                   BOLT11PaymentRequest.Parse(listenedInvoice.PaymentMethod.Destination, _network.NBitcoinNetwork).PaymentHash;
-        }
-
         public DateTimeOffset? LastFullPoll { get; set; }
 
         internal async Task PollAllListenedInvoices(CancellationToken cancellation)
         {
             foreach (var invoice in _ListenedInvoices.Values)
             {
-                if (await PollPayment(invoice, cancellation))
-                    _ListenedInvoices.TryRemove(invoice.PaymentMethodDetails.InvoiceId, out var _);
+                await PollPayment(invoice, cancellation);
             }
 
             LastFullPoll = DateTimeOffset.UtcNow;
@@ -612,16 +593,23 @@ namespace BTCPayServer.Payments.Lightning
         bool _ErrorAlreadyLogged = false;
         readonly ConcurrentDictionary<string, ListenedInvoice> _ListenedInvoices = new ConcurrentDictionary<string, ListenedInvoice>();
 
-        internal async Task<RecordedState> AddPayment(LightningInvoice notification, string invoiceId, PaymentMethodId paymentMethodId)
+        internal async Task<bool> AddPayment(LightningInvoice notification, string invoiceId, PaymentMethodId paymentMethodId)
         {
-            var invoiceEntity = await _invoiceRepository.GetInvoice(invoiceId);
-            if (invoiceEntity is null)
-                return RecordedState.AlreadyRecorded;
+            var state = await AddPaymentCore(notification, invoiceId, paymentMethodId);
+            if (state is not RecordedState.RetryLater)
+                _ListenedInvoices.TryRemove(notification.Id, out _);
+            return state is RecordedState.RecordedNow;
+        }
+        enum RecordedState { RecordedNow, AlreadyRecorded, RetryLater, Expired }
+        async Task<RecordedState> AddPaymentCore(LightningInvoice notification, string invoiceId, PaymentMethodId paymentMethodId)
+        {
             if (notification.Status is LightningInvoiceStatus.Expired)
                 return RecordedState.Expired;
             if (notification.Status is LightningInvoiceStatus.Unpaid)
                 return RecordedState.RetryLater;
-
+            var invoiceEntity = await _invoiceRepository.GetInvoice(invoiceId);
+            if (invoiceEntity is null)
+                return RecordedState.AlreadyRecorded;
             var paidAt = notification.PaidAt ?? DateTimeOffset.UtcNow;
             var paidAmount = notification.AmountReceived ?? notification.Amount;
             if (paidAmount is null)
@@ -634,6 +622,8 @@ namespace BTCPayServer.Payments.Lightning
 
             var handler = _handlers[paymentMethodId];
             var paymentHash = notification.GetPaymentHash(_network.NBitcoinNetwork);
+
+            var preimage = GetValidPreimage(notification, paymentHash);
             var paymentData = new PaymentData()
             {
                 Id = paymentHash?.ToString() ?? notification.BOLT11,
@@ -645,20 +635,20 @@ namespace BTCPayServer.Payments.Lightning
             }.Set(invoiceEntity, handler,
                 new LightningLikePaymentData()
                 {
-                    PaymentHash = paymentHash, Preimage = string.IsNullOrEmpty(notification.Preimage) ? null : uint256.Parse(notification.Preimage),
+                    PaymentHash = paymentHash, Preimage = preimage,
                 });
 
             var payment = await _paymentService.AddPayment(paymentData, [notification.BOLT11]);
             if (payment is null)
                 return RecordedState.AlreadyRecorded;
 
-            if (notification.Preimage is not null)
+            if (preimage is not null)
             {
                 var details = (LigthningPaymentPromptDetails)handler.ParsePaymentPromptDetails(invoiceEntity.GetPaymentPrompt(handler.PaymentMethodId)!
                     .Details);
                 if (details.Preimage is null)
                 {
-                    details.Preimage = uint256.Parse(notification.Preimage);
+                    details.Preimage = preimage;
                     await _invoiceRepository.UpdatePaymentDetails(invoiceId, handler, details);
                 }
             }
@@ -667,6 +657,29 @@ namespace BTCPayServer.Payments.Lightning
             if (invoice != null)
                 _eventAggregator.Publish(new InvoiceEvent(invoice, InvoiceEvent.ReceivedPayment) { Payment = payment });
             return RecordedState.RecordedNow;
+        }
+
+        private uint256? GetValidPreimage(LightningInvoice notification, uint256? paymentHash)
+        {
+            uint256? preimage = null;
+            if (!string.IsNullOrEmpty(notification.Preimage) &&
+                HexEncoder.IsWellFormed(notification.Preimage) &&
+                notification.Preimage.Length == 64 &&
+                paymentHash is not null)
+            {
+                var candidatePreimage = Encoders.Hex.DecodeData(notification.Preimage);
+                if (Hashes.SHA256(candidatePreimage).AsSpan().SequenceEqual(paymentHash.ToBytes(false)))
+                {
+                    Array.Reverse(candidatePreimage);
+                    preimage = new uint256(candidatePreimage);
+                }
+                else
+                    Logs.PayServer.LogWarning(
+                        "{CryptoCode} (Lightning): Invoice {InvoiceId} has a preimage but it doesn't match the payment hash.",
+                        _network.CryptoCode, notification.Id);
+            }
+
+            return preimage;
         }
 
         internal void RemoveExpiredInvoices()


### PR DESCRIPTION
so i was digging into how the lightning listener handles reconnects and found something that's been bugging me

basically when the server reconnects to a lightning node, it runs a catch-up poll (PollAllListenedInvoices) to check if any payments came in while we were offline. the problem is, if the node says the invoice is Paid but doesn't return an amount (which can happen with top-up/amount-less invoices or just transient node state right after a restart), AddPayment returns false. but the old code was still removing the invoice from _ListenedInvoices like everything was fine. so the payment just... disappears. no error, no UI feedback, merchant never gets notified.

the fix is pretty small, i changed PollPayment to return a tuple (status, recorded) and now PollAllListenedInvoices only evicts the invoice if the payment was actually written to the db. if it wasn't, the invoice stays in the list and gets retried on the next poll cycle.

there's a similar issue in the notification path too (the WaitInvoice loop) where a paid notification with null amount gets silently skipped, didn't touch that here but worth a follow up

tested the build locally, no new errors