### PR TITLE
[codex] Add POS item notes

### DIFF
--- a/BTCPayServer.Client/Models/AppCartItem.cs
+++ b/BTCPayServer.Client/Models/AppCartItem.cs
@@ -9,6 +9,7 @@ public class AppCartItem
 {
     public string Id { get; set; }
     public string Title { get; set; }
+    public string Note { get; set; }
     public int Count { get; set; }
     [JsonConverter(typeof(NumericStringJsonConverter))]
     public decimal Price { get; set; }

--- a/BTCPayServer.Tests/FastTests.cs
+++ b/BTCPayServer.Tests/FastTests.cs
@@ -13,6 +13,7 @@ using BTCPayServer.Abstractions.Contracts;
 using BTCPayServer.Abstractions.Extensions;
 using BTCPayServer.Controllers;
 using BTCPayServer.Plugins;
+using BTCPayServer.Plugins.PointOfSale;
 using BTCPayServer.Client;
 using BTCPayServer.Client.Models;
 using BTCPayServer.Configuration;
@@ -383,12 +384,14 @@ namespace BTCPayServer.Tests
                     new JObject()
                     {
                         { "id", "ddd"},
+                        { "note", "  no onions  "},
                         {"price", 4},
                         {"count", 1}
                     }
                 }}
             }, out var items));
             Assert.Equal("ddd", items[0].Id);
+            Assert.Equal("no onions", items[0].Note);
             Assert.Equal(1, items[0].Count);
             Assert.Equal(4, items[0].Price);
 
@@ -430,6 +433,69 @@ namespace BTCPayServer.Tests
                 }}
             }, out items));
         }
+
+        [Fact]
+        public void CanCreatePosReceiptWithCartItemNotes()
+        {
+            var choices = new[]
+            {
+                new AppItem
+                {
+                    Id = "pizza",
+                    Title = "Pizza",
+                    PriceType = AppItemPriceType.Fixed,
+                    Price = 10m
+                },
+                new AppItem
+                {
+                    Id = "coffee",
+                    Title = "Coffee",
+                    PriceType = AppItemPriceType.Fixed,
+                    Price = 3m
+                }
+            };
+            var longNote = new string('x', PosAppCartItem.MaxNoteLength + 1);
+            var appData = new PosAppData
+            {
+                Cart =
+                [
+                    null,
+                    new PosAppCartItem
+                    {
+                        Id = "pizza",
+                        Count = 1,
+                        Price = 10m,
+                        Note = "  no onions\nextra cheese  "
+                    },
+                    new PosAppCartItem
+                    {
+                        Id = "coffee",
+                        Count = 1,
+                        Price = 3m,
+                        Note = longNote
+                    }
+                ]
+            };
+            appData.NormalizeCartItemNotes();
+            Assert.Equal(2, appData.Cart.Length);
+
+            var order = new PoSOrder(2);
+            order.AddLine(new PoSOrder.ItemLine("pizza", 1, 10m, 0m));
+            order.AddLine(new PoSOrder.ItemLine("coffee", 1, 3m, 0m));
+
+            var receiptData = PosReceiptData.Create(
+                false,
+                choices,
+                appData,
+                order,
+                order.Calculate(),
+                "USD",
+                new DisplayFormatter(GetCurrencyNameTable()));
+
+            Assert.Equal("1 x $10.00 = $10.00\nNote: no onions\nextra cheese", receiptData.Cart["Pizza"]);
+            Assert.Equal($"1 x $3.00 = $3.00\nNote: {new string('x', PosAppCartItem.MaxNoteLength)}", receiptData.Cart["Coffee"]);
+        }
+
         PaymentMethodId BTC = PaymentTypes.CHAIN.GetPaymentMethodId("BTC");
         PaymentMethodId LTC = PaymentTypes.CHAIN.GetPaymentMethodId("LTC");
 

--- a/BTCPayServer/Plugins/PointOfSale/Controllers/UIPointOfSaleController.cs
+++ b/BTCPayServer/Plugins/PointOfSale/Controllers/UIPointOfSaleController.cs
@@ -255,6 +255,7 @@ namespace BTCPayServer.Plugins.PointOfSale.Controllers
             }
 
             jposData.Cart ??= [];
+            jposData.NormalizeCartItemNotes();
 
             if (currentView is PosViewType.Print)
                 return NotFound();

--- a/BTCPayServer/Plugins/PointOfSale/Views/Public/Cart.cshtml
+++ b/BTCPayServer/Plugins/PointOfSale/Views/Public/Cart.cshtml
@@ -119,6 +119,7 @@
                             <td class="align-middle">
                                 <h6 class="fw-semibold mb-1">{{ item.title }}</h6>
                                 <button type="button" v-on:click="removeFromCart(item.id)" class="btn btn-sm btn-link p-0 text-danger fw-semibold" text-translate="true">Remove</button>
+                                <textarea class="form-control form-control-sm mt-2" rows="2" maxlength="500" v-model="item.note" v-on:click.stop placeholder="@StringLocalizer["Item note"]"></textarea>
                             </td>
                             <td class="align-middle">
                                 <div class="d-flex align-items-center gap-2 justify-content-end quantity">

--- a/BTCPayServer/Services/Apps/AppService.cs
+++ b/BTCPayServer/Services/Apps/AppService.cs
@@ -508,6 +508,7 @@ retry:
                     if (id == null)
                         continue;
                     var title = o.GetValue("title", StringComparison.InvariantCulture)?.ToString();
+                    var note = o.GetValue("note", StringComparison.InvariantCulture)?.ToString();
                     var countStr = o.GetValue("count", StringComparison.InvariantCulture)?.ToString() ?? string.Empty;
                     var price = o.GetValue("price") switch
                     {
@@ -518,7 +519,14 @@ retry:
                     };
                     if (int.TryParse(countStr, out var count))
                     {
-                        cartItems.Add(new AppCartItem { Id = id, Title = title, Count = count, Price = price });
+                        cartItems.Add(new AppCartItem
+                        {
+                            Id = id,
+                            Title = title,
+                            Note = PosAppCartItem.NormalizeNote(note),
+                            Count = count,
+                            Price = price
+                        });
                     }
                 }
                 return true;

--- a/BTCPayServer/Services/Invoices/PosAppData.cs
+++ b/BTCPayServer/Services/Invoices/PosAppData.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Globalization;
+using System.Linq;
 using BTCPayServer.Plugins.PointOfSale;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -68,10 +69,23 @@ public class PosAppData
         Tip = summary.Tip;
         Total = summary.PriceTaxIncludedWithTips;
     }
+
+    internal void NormalizeCartItemNotes()
+    {
+        if (Cart is null)
+            return;
+
+        Cart = Cart.Where(item => item is not null).ToArray();
+        foreach (var item in Cart)
+            item.NormalizeNote();
+    }
 }
 
 public class PosAppCartItem
 {
+    public const int MaxNoteLength = 500;
+    string _note;
+
     [JsonProperty(PropertyName = "id")]
     public string Id { get; set; }
 
@@ -82,6 +96,13 @@ public class PosAppCartItem
     [JsonProperty(PropertyName = "title")]
     public string Title { get; set; }
 
+    [JsonProperty(PropertyName = "note", NullValueHandling = NullValueHandling.Ignore)]
+    public string Note
+    {
+        get => _note;
+        set => _note = NormalizeNote(value);
+    }
+
     [JsonProperty(PropertyName = "count")]
     public int Count { get; set; }
 
@@ -90,6 +111,20 @@ public class PosAppCartItem
 
     [JsonProperty(PropertyName = "image")]
     public string Image { get; set; }
+
+    internal void NormalizeNote()
+    {
+        Note = Note;
+    }
+
+    public static string NormalizeNote(string note)
+    {
+        if (string.IsNullOrWhiteSpace(note))
+            return null;
+
+        note = note.Trim();
+        return note.Length <= MaxNoteLength ? note : note[..MaxNoteLength];
+    }
 }
 
 public class PosAppCartItemPriceJsonConverter : JsonConverter

--- a/BTCPayServer/Services/Invoices/PosReceiptData.cs
+++ b/BTCPayServer/Services/Invoices/PosReceiptData.cs
@@ -73,6 +73,9 @@ public class PosReceiptData
         Dictionary<string,string> cartData = new();
         foreach (var cartItem in jposData.Cart ?? [])
         {
+            if (cartItem is null)
+                continue;
+
             var selectedChoice = appItems.FirstOrDefault(item => item.Id == cartItem.Id);
             if (selectedChoice is null)
                 continue;
@@ -87,7 +90,10 @@ public class PosReceiptData
             var totalPrice = displayFormatter.Currency(cartItem.Price * cartItem.Count, currency, DisplayFormatter.CurrencyFormat.Symbol);
             var ident = selectedChoice.Title ?? selectedChoice.Id;
             var key = selectedChoice.PriceType == AppItemPriceType.Fixed ? ident : $"{ident} ({singlePrice})";
-            cartData.Add(key, $"{cartItem.Count} x {singlePrice} = {totalPrice}");
+            var value = $"{cartItem.Count} x {singlePrice} = {totalPrice}";
+            if (!string.IsNullOrEmpty(cartItem.Note))
+                value = $"{value}\nNote: {cartItem.Note}";
+            cartData.Add(key, value);
         }
 
         for (var i = 0; i < (jposData.Amounts ?? []).Length; i++)

--- a/BTCPayServer/wwwroot/pos/common.js
+++ b/BTCPayServer/wwwroot/pos/common.js
@@ -205,7 +205,7 @@ const posCommon = {
             const data = { subTotal: this.summary.priceTaxExcluded, total: this.summary.priceTaxIncludedWithTips }
             const amounts = this.amounts.filter(e => e) // clear empty or zero values
             if (amounts) data.amounts = amounts.map(parseFloat)
-            if (this.cart) data.cart = this.cart
+            if (this.cart) data.cart = this.cart.map(this.prepareCartItem)
             if (this.summary.discount > 0) data.discountAmount = this.summary.discount
             if (this.discountPercentNumeric > 0) data.discountPercentage = this.discountPercentNumeric
             if (this.summary.tip > 0) data.tip = this.summary.tip
@@ -367,6 +367,15 @@ const posCommon = {
                 this.removeFromCart(itemInCart.id);
             }
             this.posOrder.setCart(this.cart, this.amounts, this.defaultTaxRate, this.taxIncludedInPrice);
+        },
+        prepareCartItem(item) {
+            const cartItem = { ...item };
+            if (typeof cartItem.note === 'string') {
+                const note = cartItem.note.trim().slice(0, 500);
+                if (note) cartItem.note = note;
+                else delete cartItem.note;
+            }
+            return cartItem;
         },
         clear() {
             this.cart = [];


### PR DESCRIPTION
## Summary

This adds the first scoped slice for the expanded Point of Sale functionality requested in discussion #5515: item-level notes in the cart.

Customers can now enter a note for each cart line. The note is submitted as `posData.cart[].note`, normalized server-side, preserved in parsed cart items, and shown in the POS receipt cart data.

## Bounty context

The original discussion offers a 500,000 sats bounty for expanded POS functionality, including item notes and menu modifiers. The bounty was reconfirmed as active by @zdforcier on 2026-06-14 in discussion #5515.

BTC payout address if this slice is accepted for the bounty: `bc1qev5ant33v5y89qqjvcf4mh9hlax5svqf5xd7gc`

## Implementation notes

- Adds a 500-character note field to cart lines in the cart UI.
- Sends trimmed notes in POS metadata without changing pricing or inventory calculations.
- Normalizes notes server-side before invoice metadata is created.
- Includes notes in receipt cart line details.
- Exposes parsed notes through `AppCartItem` for reporting/inventory consumers that parse POS cart data.

## Validation

- `node --check BTCPayServer/wwwroot/pos/common.js`
- `git diff --check`

I could not run the focused .NET tests locally because this environment does not have the `dotnet` CLI installed.
