### PR TITLE
don't silently drop paid LN invoices when amount is missing on expiry

### DIFF
--- a/BTCPayServer.Tests/LightningListenerTests.cs
+++ b/BTCPayServer.Tests/LightningListenerTests.cs
@@ -1,0 +1,142 @@
+using System;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using BTCPayServer.Lightning;
+using BTCPayServer.Payments;
+using BTCPayServer.Payments.Lightning;
+using BTCPayServer.Services;
+using BTCPayServer.Services.Invoices;
+using Dapper;
+using Microsoft.EntityFrameworkCore;
+using NBitcoin;
+using Xunit;
+using static BTCPayServer.Payments.Lightning.LightningInstanceListener;
+
+namespace BTCPayServer.Tests
+{
+    [Trait("Integration", "Integration")]
+    public class LightningListenerTests(ITestOutputHelper helper) : UnitTestBase(helper)
+    {
+        [Fact]
+        public async Task DoesNotSilentlyDropInvoiceWaitingForAmount()
+        {
+            var tester = CreateDBTester();
+            await tester.MigrateUntil();
+            var invoiceRepository = tester.GetInvoiceRepository();
+
+            await using (var ctx = tester.CreateContext())
+            {
+                var conn = ctx.Database.GetDbConnection();
+                await conn.ExecuteAsync(
+                    "INSERT INTO \"Invoices\" (\"Id\", \"Created\", \"Status\", \"Currency\", \"Blob2\") VALUES ('inv1', NOW(), 'New', 'USD', '{}')");
+            }
+
+            var networkProvider = CreateNetworkProvider();
+            var network = networkProvider.GetNetwork<BTCPayNetwork>("BTC");
+            var paymentMethodId = PaymentMethodId.Parse("BTC-LN");
+            var handlers = new PaymentMethodHandlerDictionary(Array.Empty<IPaymentMethodHandler>());
+            var paymentService = new PaymentService(new EventAggregator(BTCPayLogs), tester.CreateContextFactory(), handlers, invoiceRepository);
+
+            LightningInstanceListener NewListener(FakeLightningClient client) => new LightningInstanceListener(
+                invoiceRepository,
+                new EventAggregator(BTCPayLogs),
+                new FakeLightningClientFactory(client),
+                network,
+                handlers,
+                "dummy",
+                paymentService,
+                BTCPayLogs);
+
+            // An unpaid invoice must be retried later, not evicted.
+            var unpaidListener = NewListener(new FakeLightningClient());
+            var unpaidNotification = new LightningInvoice { Id = "ln-unpaid", Status = LightningInvoiceStatus.Unpaid };
+            unpaidListener.AddListenedInvoice(new ListenedInvoice(
+                DateTimeOffset.UtcNow.AddMinutes(10),
+                new LigthningPaymentPromptDetails { InvoiceId = "ln-unpaid" },
+                new PaymentPrompt { PaymentMethodId = paymentMethodId },
+                network,
+                "inv1"));
+            var unpaidState = await unpaidListener.AddPayment(unpaidNotification, "inv1", paymentMethodId);
+            Assert.Equal(RecordedState.RetryLaterUnpaid, unpaidState);
+            Assert.False(unpaidListener.Empty);
+
+            // The Lightning node reports the invoice as Paid, but withholds the settled amount.
+            var fakeClient = new FakeLightningClient();
+            var listener = NewListener(fakeClient);
+            var listenedInvoice = new ListenedInvoice(
+                DateTimeOffset.UtcNow - TimeSpan.FromMinutes(1), // already expired
+                new LigthningPaymentPromptDetails { InvoiceId = "ln-missing-amount" },
+                new PaymentPrompt { PaymentMethodId = paymentMethodId },
+                network,
+                "inv1");
+            listener.AddListenedInvoice(listenedInvoice);
+
+            fakeClient.NextInvoice = new LightningInvoice
+            {
+                Id = "ln-missing-amount",
+                Status = LightningInvoiceStatus.Paid,
+                PaidAt = DateTimeOffset.UtcNow,
+                Amount = null,
+                AmountReceived = null,
+            };
+
+            var missingAmountState = await listener.AddPayment(fakeClient.NextInvoice, "inv1", paymentMethodId);
+            Assert.Equal(RecordedState.RetryLaterMissingAmount, missingAmountState);
+            Assert.False(listener.Empty);
+            Assert.Equal(0, fakeClient.GetInvoiceCalls);
+
+            // RemoveExpiredInvoices must give the invoice one last poll before giving up on it,
+            // instead of silently dropping it the moment it expires.
+            await listener.RemoveExpiredInvoices(CancellationToken.None);
+
+            Assert.Equal(1, fakeClient.GetInvoiceCalls);
+            Assert.True(listener.Empty);
+        }
+
+        private class FakeLightningClientFactory : LightningClientFactoryService
+        {
+            private readonly ILightningClient _client;
+
+            public FakeLightningClientFactory(ILightningClient client)
+                : base(null, Array.Empty<Func<HttpClient, ILightningConnectionStringHandler>>(), Array.Empty<ILightningConnectionStringHandler>())
+            {
+                _client = client;
+            }
+
+            public override ILightningClient Create(string lightningConnectionString, BTCPayNetwork network) => _client;
+        }
+
+        private class FakeLightningClient : ILightningClient
+        {
+            public LightningInvoice NextInvoice { get; set; }
+            public int GetInvoiceCalls { get; private set; }
+
+            public Task<LightningInvoice> GetInvoice(string invoiceId, CancellationToken cancellation)
+            {
+                GetInvoiceCalls++;
+                return Task.FromResult(NextInvoice);
+            }
+
+            public Task<LightningInvoice> GetInvoice(uint256 paymentHash, CancellationToken cancellation) => throw new NotImplementedException();
+            public Task<LightningInvoice[]> ListInvoices(CancellationToken cancellation) => throw new NotImplementedException();
+            public Task<LightningInvoice[]> ListInvoices(ListInvoicesParams request, CancellationToken cancellation) => throw new NotImplementedException();
+            public Task<LightningPayment> GetPayment(string paymentHash, CancellationToken cancellation) => throw new NotImplementedException();
+            public Task<LightningPayment[]> ListPayments(CancellationToken cancellation) => throw new NotImplementedException();
+            public Task<LightningPayment[]> ListPayments(ListPaymentsParams request, CancellationToken cancellation) => throw new NotImplementedException();
+            public Task<LightningInvoice> CreateInvoice(LightMoney amount, string description, TimeSpan expiry, CancellationToken cancellation) => throw new NotImplementedException();
+            public Task<LightningInvoice> CreateInvoice(CreateInvoiceParams createInvoiceRequest, CancellationToken cancellation) => throw new NotImplementedException();
+            public Task<ILightningInvoiceListener> Listen(CancellationToken cancellation) => throw new NotImplementedException();
+            public Task<LightningNodeInformation> GetInfo(CancellationToken cancellation) => throw new NotImplementedException();
+            public Task<LightningNodeBalance> GetBalance(CancellationToken cancellation) => throw new NotImplementedException();
+            public Task<PayResponse> Pay(PayInvoiceParams payParams, CancellationToken cancellation) => throw new NotImplementedException();
+            public Task<PayResponse> Pay(string bolt11, PayInvoiceParams payParams, CancellationToken cancellation) => throw new NotImplementedException();
+            public Task<PayResponse> Pay(string bolt11, CancellationToken cancellation) => throw new NotImplementedException();
+            public Task<OpenChannelResponse> OpenChannel(OpenChannelRequest openChannelRequest, CancellationToken cancellation) => throw new NotImplementedException();
+            public Task<BitcoinAddress> GetDepositAddress(CancellationToken cancellation) => throw new NotImplementedException();
+            public Task<ConnectionResult> ConnectTo(NodeInfo nodeInfo, CancellationToken cancellation) => throw new NotImplementedException();
+            public Task CancelInvoice(string invoiceId, CancellationToken cancellation) => throw new NotImplementedException();
+            public Task<LightningChannel[]> ListChannels(CancellationToken cancellation) => throw new NotImplementedException();
+        }
+    }
+}

--- a/BTCPayServer/Payments/Lightning/LightningListener.cs
+++ b/BTCPayServer/Payments/Lightning/LightningListener.cs
@@ -121,7 +121,7 @@ namespace BTCPayServer.Payments.Lightning
                         }
 
                         if (_CheckInvoices.Reader.Count is 0)
-                            this.CheckConnections();
+                            await this.CheckConnections();
                     }
                 }
                 catch when (cancellation.IsCancellationRequested)
@@ -251,13 +251,13 @@ namespace BTCPayServer.Payments.Lightning
                 }
             }));
             _CheckingInvoice = CheckingInvoice(_Cts.Token);
-            _ListenPoller = new Timer(s =>
+            _ListenPoller = new Timer(async s =>
             {
                 if (needCheckOfflinePayments)
                     return;
                 try
                 {
-                    CheckConnections();
+                    await CheckConnections();
                 }
                 catch { }
             }, null, 0, (int)PollInterval.TotalMilliseconds);
@@ -265,22 +265,17 @@ namespace BTCPayServer.Payments.Lightning
             return Task.CompletedTask;
         }
 
-        private void CheckConnections()
+        private async Task CheckConnections()
         {
+            List<LightningInstanceListener> instances;
             lock (_InstanceListeners)
             {
-                foreach (var key in _InstanceListeners.Keys)
-                {
-                    CheckConnection(key.Item1, key.Item2);
-                }
+                instances = _InstanceListeners.Values.ToList();
             }
-        }
 
-        public void CheckConnection(string cryptoCode, string connStr)
-        {
-            if (_InstanceListeners.TryGetValue((cryptoCode, connStr), out var instance))
+            foreach (var instance in instances)
             {
-                instance.RemoveExpiredInvoices();
+                await instance.RemoveExpiredInvoices(_Cts.Token);
                 if (!instance.Empty)
                     instance.EnsureListening(_Cts.Token);
             }
@@ -491,17 +486,19 @@ namespace BTCPayServer.Payments.Lightning
             return _ListenedInvoices.TryAdd(invoice.PaymentMethodDetails.InvoiceId, invoice);
         }
 
-        internal async Task PollPayment(ListenedInvoice listenedInvoice, CancellationToken cancellation)
+        internal async Task<RecordedState> PollPayment(ListenedInvoice listenedInvoice, CancellationToken cancellation)
         {
             var client = _lightningClientFactory.Create(ConnectionString, _network);
             var lightningInvoice = await client.GetInvoice(listenedInvoice.PaymentMethodDetails.InvoiceId, cancellation);
             if (lightningInvoice is null)
             {
                 _ListenedInvoices.TryRemove(listenedInvoice.PaymentMethodDetails.InvoiceId, out _);
-                return;
+                return RecordedState.AlreadyRecorded;
             }
-            if (await AddPayment(lightningInvoice, listenedInvoice.InvoiceId, listenedInvoice.PaymentMethod.PaymentMethodId))
+            var state = await AddPayment(lightningInvoice, listenedInvoice.InvoiceId, listenedInvoice.PaymentMethod.PaymentMethodId);
+            if (state is RecordedState.RecordedNow)
                 Logs.PayServer.LogInformation($"{_network.CryptoCode} (Lightning): Payment detected via polling on {listenedInvoice.InvoiceId}");
+            return state;
         }
 
         public bool Empty => _ListenedInvoices.IsEmpty;
@@ -546,7 +543,8 @@ namespace BTCPayServer.Payments.Lightning
                     var notification = await session.WaitInvoice(cancellation);
                     if (!_ListenedInvoices.TryGetValue(notification.Id, out var listenedInvoice))
                         continue;
-                    if (await AddPayment(notification, listenedInvoice.InvoiceId, listenedInvoice.PaymentMethod.PaymentMethodId))
+                    var state = await AddPayment(notification, listenedInvoice.InvoiceId, listenedInvoice.PaymentMethod.PaymentMethodId);
+                    if (state is RecordedState.RecordedNow)
                     {
                         Logs.PayServer.LogInformation("{CryptoCode} (Lightning): Payment detected via notification ({InvoiceId})", _network.CryptoCode,
                             listenedInvoice.InvoiceId);
@@ -593,20 +591,20 @@ namespace BTCPayServer.Payments.Lightning
         bool _ErrorAlreadyLogged = false;
         readonly ConcurrentDictionary<string, ListenedInvoice> _ListenedInvoices = new ConcurrentDictionary<string, ListenedInvoice>();
 
-        internal async Task<bool> AddPayment(LightningInvoice notification, string invoiceId, PaymentMethodId paymentMethodId)
+        internal async Task<RecordedState> AddPayment(LightningInvoice notification, string invoiceId, PaymentMethodId paymentMethodId)
         {
             var state = await AddPaymentCore(notification, invoiceId, paymentMethodId);
-            if (state is not RecordedState.RetryLater)
+            if (state is not (RecordedState.RetryLaterUnpaid or RecordedState.RetryLaterMissingAmount))
                 _ListenedInvoices.TryRemove(notification.Id, out _);
-            return state is RecordedState.RecordedNow;
+            return state;
         }
-        enum RecordedState { RecordedNow, AlreadyRecorded, RetryLater, Expired }
+        internal enum RecordedState { RecordedNow, AlreadyRecorded, RetryLaterUnpaid, RetryLaterMissingAmount, Expired }
         async Task<RecordedState> AddPaymentCore(LightningInvoice notification, string invoiceId, PaymentMethodId paymentMethodId)
         {
             if (notification.Status is LightningInvoiceStatus.Expired)
                 return RecordedState.Expired;
             if (notification.Status is LightningInvoiceStatus.Unpaid)
-                return RecordedState.RetryLater;
+                return RecordedState.RetryLaterUnpaid;
             var invoiceEntity = await _invoiceRepository.GetInvoice(invoiceId);
             if (invoiceEntity is null)
                 return RecordedState.AlreadyRecorded;
@@ -617,7 +615,7 @@ namespace BTCPayServer.Payments.Lightning
                 Logs.PayServer.LogWarning(
                     "{CryptoCode} (Lightning): Invoice {InvoiceId} is paid according to the node but no amount was returned; cannot record the payment yet.",
                     _network.CryptoCode, invoiceId);
-                return RecordedState.RetryLater;
+                return RecordedState.RetryLaterMissingAmount;
             }
 
             var handler = _handlers[paymentMethodId];
@@ -682,12 +680,26 @@ namespace BTCPayServer.Payments.Lightning
             return preimage;
         }
 
-        internal void RemoveExpiredInvoices()
+        internal async Task RemoveExpiredInvoices(CancellationToken cancellation)
         {
             foreach (var invoice in _ListenedInvoices)
             {
-                if (invoice.Value.IsExpired())
-                    _ListenedInvoices.TryRemove(invoice.Key, out var _);
+                if (!invoice.Value.IsExpired())
+                    continue;
+                // Give it one last chance: the node may now report the settlement amount
+                // it withheld during a previous RetryLaterMissingAmount poll.
+                var state = await PollPayment(invoice.Value, cancellation);
+                if (state is RecordedState.RetryLaterMissingAmount)
+                {
+                    Logs.PayServer.LogWarning(
+                        "{CryptoCode} (Lightning): Invoice {InvoiceId} expired while the node never reported a settlement amount; giving up, the payment may be unrecorded.",
+                        _network.CryptoCode, invoice.Value.InvoiceId);
+                    _ListenedInvoices.TryRemove(invoice.Key, out _);
+                }
+                else if (state is RecordedState.RetryLaterUnpaid)
+                {
+                    _ListenedInvoices.TryRemove(invoice.Key, out _);
+                }
             }
 
             if (_ListenedInvoices.IsEmpty)

--- a/BTCPayServer/Services/LightningClientFactoryService.cs
+++ b/BTCPayServer/Services/LightningClientFactoryService.cs
@@ -34,7 +34,7 @@ namespace BTCPayServer.Services
 
         public static string OnionNamedClient { get; set; } = "lightning.onion";
 
-        public ILightningClient Create(string lightningConnectionString, BTCPayNetwork network)
+        public virtual ILightningClient Create(string lightningConnectionString, BTCPayNetwork network)
         {
             ArgumentNullException.ThrowIfNull(lightningConnectionString);
             ArgumentNullException.ThrowIfNull(network);


### PR DESCRIPTION
 Found this while going through the lightning poll logic after #7402. Basically if a node reports an invoice as Paid but doesn't return an amount yet (happens sometimes after reconnects), and the BTCPay invoice expires before the amount shows up, RemoveExpiredInvoices was just dropping it silently - no retry, no log, nothing. Payment essentially vanishes from our tracking even though the customer paid.

This PR gives it one last poll before giving up. If the node still can't give us an amount, we now log a warning so at least it's visible instead of just disappearing.

plit the old RetryLater state into RetryLaterUnpaid and RetryLaterMissingAmount so we can tell these two cases apart (unpaid expiry is fine to drop quietly, missing-amount is the risky one).

Added a regression test (LightningListenerTests.cs) covering both states and the final-poll-before-evict behavior.