### PR TITLE
fix: bulk archive pull payments scoped to current store

### DIFF
--- a/BTCPayServer/Controllers/UIStorePullPaymentsController.PullPayments.cs
+++ b/BTCPayServer/Controllers/UIStorePullPaymentsController.PullPayments.cs
@@ -282,7 +282,7 @@ namespace BTCPayServer.Controllers
                 switch (command)
                 {
                     case "archive":
-                        await _pullPaymentService.Cancel(new PullPaymentHostedService.CancelRequest(selectedItems));
+                        await _pullPaymentService.Cancel(new PullPaymentHostedService.CancelRequest(selectedItems) { StoreIds = new[] { storeId } });
                         TempData.SetStatusMessageModel(new StatusMessageModel
                         {
                             Message = StringLocalizer["Pull payments archived"].Value,

--- a/BTCPayServer/HostedServices/PullPaymentHostedService.cs
+++ b/BTCPayServer/HostedServices/PullPaymentHostedService.cs
@@ -775,14 +775,19 @@ namespace BTCPayServer.HostedServices
                 List<PayoutData> payouts = null;
                 if (cancel.PullPaymentIds != null)
                 {
-                    foreach (var ppId in cancel.PullPaymentIds)
+                    var ppIds = cancel.StoreIds == null
+                        ? cancel.PullPaymentIds
+                        : (await ctx.PullPayments
+                            .Where(pp => cancel.PullPaymentIds.Contains(pp.Id) && cancel.StoreIds.Contains(pp.StoreId))
+                            .Select(pp => pp.Id)
+                            .ToListAsync()).ToArray();
+                    foreach (var ppId in ppIds)
                     {
                         ctx.PullPayments.Attach(new Data.PullPaymentData() { Id = ppId, Archived = true })
                             .Property(o => o.Archived).IsModified = true;
                     }
                     payouts = await ctx.Payouts
-                        .Where(p => cancel.PullPaymentIds.Contains(p.PullPaymentDataId))
-                        .Where(p => cancel.StoreIds == null || cancel.StoreIds.Contains(p.StoreDataId))
+                        .Where(p => ppIds.Contains(p.PullPaymentDataId))
                         .ToListAsync();
 
                     cancel.PayoutIds = payouts.Select(data => data.Id).ToArray();


### PR DESCRIPTION
I found a missing store check in the bulk archive endpoint added in #7400

when you POST to mass-action with a list of pull payment IDs, there was no check that those IDs actually belong to your store. so a user with archive permission on store A could archive pull payments from store B just by including foreign IDs in the request body.

the single archive endpoint is fine because pullPaymentId is a route param and gets validated by the auth middleware. bulk action takes IDs from the body so that check never runs.

fix is pretty small, pass the current storeId into the cancel request and filter in HandleCancel before touching anything in the db.