### PR TITLE
fix: lightning invoices stuck when node doesn't return amount during live session

### DIFF
--- a/BTCPayServer/Payments/Lightning/LightningListener.cs
+++ b/BTCPayServer/Payments/Lightning/LightningListener.cs
@@ -284,17 +284,8 @@ namespace BTCPayServer.Payments.Lightning
                 if (!instance.Empty)
                 {
                     instance.EnsureListening(_Cts.Token);
-                    // Re-poll periodically during live sessions to catch invoices stuck in RetryLater
-                    // (e.g. nodes that return null amount in the initial WS notification).
-                    // PollAllListenedInvoices is normally only called on session start (reconnect path),
-                    // leaving RetryLater invoices unresolved until the next disconnect.
-                    if (instance.IsListening &&
-                        instance.LastFullPoll is { } last &&
-                        DateTimeOffset.UtcNow - last > TimeSpan.FromMinutes(5.0))
-                    {
-                        instance.LastFullPoll = DateTimeOffset.UtcNow;
-                        _ = instance.PollAllListenedInvoices(_Cts.Token);
-                    }
+                    if (instance.IsListening && !instance.PaidButNoAmountEmpty)
+                        _ = instance.PollPaidButNoAmountInvoices(_Cts.Token);
                 }
             }
         }
@@ -511,6 +502,7 @@ namespace BTCPayServer.Payments.Lightning
             if (lightningInvoice is null)
             {
                 _ListenedInvoices.TryRemove(listenedInvoice.PaymentMethodDetails.InvoiceId, out _);
+                _PaidButNoAmount.TryRemove(listenedInvoice.PaymentMethodDetails.InvoiceId, out _);
                 return;
             }
             if (await AddPayment(lightningInvoice, listenedInvoice.InvoiceId, listenedInvoice.PaymentMethod.PaymentMethodId))
@@ -605,12 +597,32 @@ namespace BTCPayServer.Payments.Lightning
 
         bool _ErrorAlreadyLogged = false;
         readonly ConcurrentDictionary<string, ListenedInvoice> _ListenedInvoices = new ConcurrentDictionary<string, ListenedInvoice>();
+        readonly ConcurrentDictionary<string, bool> _PaidButNoAmount = new ConcurrentDictionary<string, bool>();
+        public bool PaidButNoAmountEmpty => _PaidButNoAmount.IsEmpty;
+
+        internal async Task PollPaidButNoAmountInvoices(CancellationToken cancellation)
+        {
+            foreach (var id in _PaidButNoAmount.Keys)
+            {
+                if (_ListenedInvoices.TryGetValue(id, out var invoice))
+                    await PollPayment(invoice, cancellation);
+                else
+                    _PaidButNoAmount.TryRemove(id, out _);
+            }
+        }
 
         internal async Task<bool> AddPayment(LightningInvoice notification, string invoiceId, PaymentMethodId paymentMethodId)
         {
             var state = await AddPaymentCore(notification, invoiceId, paymentMethodId);
             if (state is not RecordedState.RetryLater)
+            {
                 _ListenedInvoices.TryRemove(notification.Id, out _);
+                _PaidButNoAmount.TryRemove(notification.Id, out _);
+            }
+            else if (notification.Status is LightningInvoiceStatus.Paid)
+            {
+                _PaidButNoAmount.TryAdd(notification.Id, true);
+            }
             return state is RecordedState.RecordedNow;
         }
         enum RecordedState { RecordedNow, AlreadyRecorded, RetryLater, Expired }
@@ -700,7 +712,10 @@ namespace BTCPayServer.Payments.Lightning
             foreach (var invoice in _ListenedInvoices)
             {
                 if (invoice.Value.IsExpired())
-                    _ListenedInvoices.TryRemove(invoice.Key, out var _);
+                {
+                    _ListenedInvoices.TryRemove(invoice.Key, out _);
+                    _PaidButNoAmount.TryRemove(invoice.Key, out _);
+                }
             }
 
             if (_ListenedInvoices.IsEmpty)

--- a/BTCPayServer/Payments/Lightning/LightningListener.cs
+++ b/BTCPayServer/Payments/Lightning/LightningListener.cs
@@ -282,7 +282,20 @@ namespace BTCPayServer.Payments.Lightning
             {
                 instance.RemoveExpiredInvoices();
                 if (!instance.Empty)
+                {
                     instance.EnsureListening(_Cts.Token);
+                    // Re-poll periodically during live sessions to catch invoices stuck in RetryLater
+                    // (e.g. nodes that return null amount in the initial WS notification).
+                    // PollAllListenedInvoices is normally only called on session start (reconnect path),
+                    // leaving RetryLater invoices unresolved until the next disconnect.
+                    if (instance.IsListening &&
+                        instance.LastFullPoll is { } last &&
+                        DateTimeOffset.UtcNow - last > TimeSpan.FromMinutes(5.0))
+                    {
+                        instance.LastFullPoll = DateTimeOffset.UtcNow;
+                        _ = instance.PollAllListenedInvoices(_Cts.Token);
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
so basically found this while looking at the reconnect fix from #7402

the issue is when a LN node sends a paid notification but with a null amount (phoenixd does this, some CLN setups too), `AddPaymentCore` returns `RetryLater` and the invoice stays in `_ListenedInvoices` waiting for the next poll. thats expected.

but the problem is `PollAllListenedInvoices` only runs when a new session starts (basically on reconnect). if the websocket session stays alive the whole time, those `RetryLater` invoices just sit there. they never get re-polled.

then eventually the invoice expires, `RemoveExpiredInvoices` cleans it up, and the payment never gets recorded in BTCPay even tho the sats are already sitting in the merchants wallet.

the fix is pretty simple. `CheckConnection` already runs every minute from the timer, so added a check there - if the session is alive and the last full poll was more than 5 minutes ago, trigger a poll.

also moved the `LastFullPoll` update to before dispatching the poll instead of after it finishes. otherwise if the node is slow theres a chance multiple polls can get kicked off before the timestamp gets updated.

before:

* `RetryLater` invoices only got rescued if a reconnect happened

after:

* they get rescued within 5 min even if the websocket session never drops
