### PR TITLE
bind to all interface even outside of the test container

### DIFF
--- a/BTCPayServer.Tests/BTCPayServerTester.cs
+++ b/BTCPayServer.Tests/BTCPayServerTester.cs
@@ -42,7 +42,7 @@ namespace BTCPayServer.Tests
     {
         internal readonly string _Directory;
         public ILoggerProvider LoggerProvider { get; }
-
+        public bool? BindAllInterfaces { get; set; }
         ILog TestLogs;
         public BTCPayServerTester(ILog testLogs, ILoggerProvider loggerProvider, string scope)
         {
@@ -124,9 +124,9 @@ namespace BTCPayServer.Tests
             }
 
             config.AppendLine($"{chain.ToLowerInvariant()}=1");
-            if (InContainer)
+            if (BindAllInterfaces ?? InContainer)
             {
-                config.AppendLine($"bind=0.0.0.0");
+                config.AppendLine("bind=0.0.0.0");
             }
             config.AppendLine($"port={Port}");
             config.AppendLine($"chains={string.Join(',', Chains)}");


### PR DESCRIPTION
need this to have block/tx notification working even outside of the container (have invoice paid/settled)

related to https://github.com/btcpay-monero/btcpayserver-monero-plugin/pull/107