### PR TITLE
Add support for core lightning 26.06

### DIFF
--- a/BTCPayServer.Tests/docker-compose.altcoins.yml
+++ b/BTCPayServer.Tests/docker-compose.altcoins.yml
@@ -170,7 +170,7 @@ services:
       - "bitcoin_datadir:/data"
 
   customer_lightningd:
-    image: btcpayserver/lightning:v25.05
+    image: btcpayserver/lightning:v26.06.1
     stop_signal: SIGKILL
     restart: unless-stopped
     environment:
@@ -199,7 +199,7 @@ services:
       - bitcoind
 
   merchant_lightningd:
-    image: btcpayserver/lightning:v25.05
+    image: btcpayserver/lightning:v26.06.1
     stop_signal: SIGKILL
     restart: unless-stopped
     environment:

--- a/BTCPayServer.Tests/docker-compose.mutinynet.yml
+++ b/BTCPayServer.Tests/docker-compose.mutinynet.yml
@@ -110,7 +110,7 @@ services:
       - "bitcoin_datadir:/data"
 
   customer_lightningd:
-    image: btcpayserver/lightning:v25.05
+    image: btcpayserver/lightning:v26.06.1
     stop_signal: SIGKILL
     restart: unless-stopped
     environment:
@@ -139,7 +139,7 @@ services:
       - bitcoind
 
   merchant_lightningd:
-    image: btcpayserver/lightning:v25.05
+    image: btcpayserver/lightning:v26.06.1
     stop_signal: SIGKILL
     restart: unless-stopped
     environment:

--- a/BTCPayServer.Tests/docker-compose.testnet.yml
+++ b/BTCPayServer.Tests/docker-compose.testnet.yml
@@ -102,7 +102,7 @@ services:
       - "bitcoin_datadir:/data"
 
   customer_lightningd:
-    image: btcpayserver/lightning:v25.05
+    image: btcpayserver/lightning:v26.06.1
     stop_signal: SIGKILL
     restart: unless-stopped
     environment:
@@ -131,7 +131,7 @@ services:
       - bitcoind
 
   merchant_lightningd:
-    image: btcpayserver/lightning:v25.05
+    image: btcpayserver/lightning:v26.06.1
     stop_signal: SIGKILL
     restart: unless-stopped
     environment:

--- a/BTCPayServer.Tests/docker-compose.yml
+++ b/BTCPayServer.Tests/docker-compose.yml
@@ -155,7 +155,7 @@ services:
       - "bitcoin_datadir:/data"
 
   customer_lightningd:
-    image: btcpayserver/lightning:v25.05
+    image: btcpayserver/lightning:v26.06.1
     stop_signal: SIGKILL
     restart: unless-stopped
     environment:
@@ -184,7 +184,7 @@ services:
       - bitcoind
 
   merchant_lightningd:
-    image: btcpayserver/lightning:v25.05
+    image: btcpayserver/lightning:v26.06.1
     stop_signal: SIGKILL
     restart: unless-stopped
     environment:

--- a/BTCPayServer/BTCPayServer.csproj
+++ b/BTCPayServer/BTCPayServer.csproj
@@ -38,7 +38,7 @@
     <PackageReference Include="YamlDotNet" Version="16.3.0" />
     <PackageReference Include="BIP78.Sender" Version="0.2.5" />
     <PackageReference Include="BTCPayServer.Hwi" Version="2.0.6" />
-    <PackageReference Include="BTCPayServer.Lightning.All" Version="1.7.1" />
+    <PackageReference Include="BTCPayServer.Lightning.All" Version="1.7.2" />
     <PackageReference Include="CsvHelper" Version="33.1.0" />
     <PackageReference Include="Fido2" Version="4.0.1" />
     <PackageReference Include="Fido2.AspNet" Version="4.0.1" />

--- a/Changelog.md
+++ b/Changelog.md
@@ -34,6 +34,7 @@
 * Uninstall button is missing for language packs (#7390 #7392) @teamssUTXO
 * Lightning invoice silently dropped when the node doesn't return amount on reconnection (#7402) @atharrva01
 * The Server Policies page would timeout when the server had too many apps (#7406) @NicolasDorier
+* Fix support for Core lightning 26.06 (#7412) @NicolasDorier
 
 ### Improvements
 


### PR DESCRIPTION
Core lightning deprecated `pay` and `keysend`, so we need to bump the library for https://github.com/btcpayserver/BTCPayServer.Lightning/commit/d51e7701f872291d79e19f375c2a619f1b77ee7d