### PR TITLE
 Greenfield: support payoutMethods array on invoice refund 

### DIFF
--- a/BTCPayServer.Client/Models/RefundInvoiceRequest.cs
+++ b/BTCPayServer.Client/Models/RefundInvoiceRequest.cs
@@ -1,4 +1,5 @@
 #nullable enable
+using System;
 using BTCPayServer.JsonConverters;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
@@ -17,7 +18,15 @@ namespace BTCPayServer.Client.Models
     public class RefundInvoiceRequest
     {
         public string? Name { get; set; } = null;
+
+        [Obsolete("Use PayoutMethods instead")]
         public string? PayoutMethodId { get; set; }
+
+        /// <summary>
+        /// The payout methods the refund can be claimed in. If null, falls back to <see cref="PayoutMethodId"/>,
+        /// and if that is also null, to the default payout method of the original invoice.
+        /// </summary>
+        public string[]? PayoutMethods { get; set; }
         public string? Description { get; set; } = null;
         
         [JsonConverter(typeof(StringEnumConverter))]

--- a/BTCPayServer.Tests/GreenfieldAPITests.cs
+++ b/BTCPayServer.Tests/GreenfieldAPITests.cs
@@ -1651,6 +1651,9 @@ namespace BTCPayServer.Tests
         [Trait("Integration", "Integration")]
         public async Task CanRefundInvoice()
         {
+            // RefundInvoiceRequest.PayoutMethodId is deprecated in favor of PayoutMethods, but is
+            // still exercised throughout this test to guarantee backward compatibility.
+#pragma warning disable CS0618 // Type or member is obsolete
             using var tester = CreateServerTester();
             await tester.StartAsync();
             var user = tester.NewAccount();
@@ -1880,6 +1883,30 @@ namespace BTCPayServer.Tests
             });
             Assert.Equal(1.0m, refund.Amount);
             Assert.Equal("BTC", refund.Currency);
+#pragma warning restore CS0618 // Type or member is obsolete
+
+            // The new `payoutMethods` array supersedes the deprecated single `payoutMethodId`.
+            invoice = await client.CreateInvoice(user.StoreId, new CreateInvoiceRequest { Amount = 5000.0m, Currency = "USD" });
+            await client.MarkInvoiceStatus(invoice.Id, new MarkInvoiceStatusRequest { Status = InvoiceStatus.Settled });
+
+            refund = await client.RefundInvoice(invoice.Id, new RefundInvoiceRequest
+            {
+                PayoutMethods = new[] { method.PaymentMethodId },
+                RefundVariant = RefundVariant.CurrentRate
+            });
+            Assert.Equal(1.0m, refund.Amount);
+            Assert.Equal("BTC", refund.Currency);
+
+            // Invalid entries in `payoutMethods` are reported under the `PayoutMethods` key.
+            validationError = await AssertValidationError(new[] { "PayoutMethods" }, async () =>
+            {
+                await client.RefundInvoice(invoice.Id, new RefundInvoiceRequest
+                {
+                    PayoutMethods = new[] { "fake payment method" },
+                    RefundVariant = RefundVariant.CurrentRate
+                });
+            });
+            Assert.Contains("PayoutMethods: Please select one of the payment methods which were available for the original invoice", validationError.Message);
         }
 
         [Fact(Timeout = TestTimeout)]

--- a/BTCPayServer.Tests/GreenfieldAPITests.cs
+++ b/BTCPayServer.Tests/GreenfieldAPITests.cs
@@ -1907,6 +1907,18 @@ namespace BTCPayServer.Tests
                 });
             });
             Assert.Contains("PayoutMethods: Please select one of the payment methods which were available for the original invoice", validationError.Message);
+
+            // A mix of valid and invalid entries is rejected: the invalid entry is reported and the
+            // request is not silently truncated to the valid subset.
+            validationError = await AssertValidationError(new[] { "PayoutMethods" }, async () =>
+            {
+                await client.RefundInvoice(invoice.Id, new RefundInvoiceRequest
+                {
+                    PayoutMethods = new[] { method.PaymentMethodId, "fake payment method" },
+                    RefundVariant = RefundVariant.CurrentRate
+                });
+            });
+            Assert.Contains("Invalid or unsupported payout method: fake payment method", validationError.Message);
         }
 
         [Fact(Timeout = TestTimeout)]

--- a/BTCPayServer.Tests/UnitTest1.cs
+++ b/BTCPayServer.Tests/UnitTest1.cs
@@ -2936,7 +2936,7 @@ namespace BTCPayServer.Tests
                 var inv = await client.CreateInvoice(acc.StoreId, new CreateInvoiceRequest() { Amount = 10m, Currency = "USD" });
                 await acc.PayInvoice(inv.Id);
                 await client.MarkInvoiceStatus(inv.Id, new MarkInvoiceStatusRequest() { Status = InvoiceStatus.Settled });
-                var refund = await client.RefundInvoice(inv.Id, new RefundInvoiceRequest() { RefundVariant = RefundVariant.Fiat, PayoutMethodId = "BTC-CHAIN" });
+                var refund = await client.RefundInvoice(inv.Id, new RefundInvoiceRequest() { RefundVariant = RefundVariant.Fiat, PayoutMethods = new[] { "BTC-CHAIN" } });
 
                 async Task AssertData(string currency, decimal awaiting, decimal limit, decimal completed, bool fullyPaid)
                 {

--- a/BTCPayServer/Controllers/GreenField/GreenfieldInvoiceController.cs
+++ b/BTCPayServer/Controllers/GreenField/GreenfieldInvoiceController.cs
@@ -334,26 +334,40 @@ namespace BTCPayServer.Controllers.Greenfield
                 return this.CreateAPIError("non-refundable", "Cannot refund this invoice");
 
             PaymentPrompt? paymentPrompt = null;
-            PayoutMethodId? payoutMethodId = null;
-            if (request.PayoutMethodId is null)
-                request.PayoutMethodId = invoice.GetDefaultPaymentMethodId(store, _networkProvider)?.ToString();
 
-            if (request.PayoutMethodId is not null && PayoutMethodId.TryParse(request.PayoutMethodId, out payoutMethodId))
+            // `payoutMethods` (array) supersedes the deprecated single `payoutMethodId`.
+            // If neither is provided, fall back to the default payout method of the original invoice.
+            string?[] requestedPayoutMethods;
+#pragma warning disable CS0618 // Type or member is obsolete
+            var errorKey = request.PayoutMethods is not null ? nameof(request.PayoutMethods) : nameof(request.PayoutMethodId);
+            if (request.PayoutMethods is { } payoutMethods)
+                requestedPayoutMethods = payoutMethods;
+            else if (request.PayoutMethodId is { } legacyPayoutMethodId)
+                requestedPayoutMethods = [legacyPayoutMethodId];
+            else
+                requestedPayoutMethods = [invoice.GetDefaultPaymentMethodId(store, _networkProvider)?.ToString()];
+#pragma warning restore CS0618 // Type or member is obsolete
+
+            var supported = _payoutHandlers.GetSupportedPayoutMethods(store);
+            var payoutMethodIds = new List<PayoutMethodId>();
+            foreach (var p in requestedPayoutMethods)
             {
-                var supported = _payoutHandlers.GetSupportedPayoutMethods(store);
-                if (supported.Contains(payoutMethodId))
-                {
-                    var paymentMethodId = invoice.GetClosestPaymentMethodId([payoutMethodId]);
-                    paymentPrompt = paymentMethodId is null ? null : invoice.GetPaymentPrompt(paymentMethodId);
-                }
+                if (p is not null && PayoutMethodId.TryParse(p, out var pmid) && supported.Contains(pmid) && !payoutMethodIds.Contains(pmid))
+                    payoutMethodIds.Add(pmid);
+            }
+
+            if (payoutMethodIds.Count > 0)
+            {
+                var paymentMethodId = invoice.GetClosestPaymentMethodId(payoutMethodIds);
+                paymentPrompt = paymentMethodId is null ? null : invoice.GetPaymentPrompt(paymentMethodId);
             }
             if (paymentPrompt is null)
             {
-                ModelState.AddModelError(nameof(request.PayoutMethodId), "Please select one of the payment methods which were available for the original invoice");
+                ModelState.AddModelError(errorKey, "Please select one of the payment methods which were available for the original invoice");
             }
             if (request.RefundVariant is null)
                 ModelState.AddModelError(nameof(request.RefundVariant), "`refundVariant` is mandatory");
-            if (!ModelState.IsValid || paymentPrompt is null || payoutMethodId is null)
+            if (!ModelState.IsValid || paymentPrompt is null || payoutMethodIds.Count == 0)
                 return this.CreateValidationError(ModelState);
 
             var accounting = paymentPrompt.Calculate();
@@ -379,7 +393,7 @@ namespace BTCPayServer.Controllers.Greenfield
             {
                 Name = request.Name ?? $"Refund {invoice.Id}",
                 Description = request.Description,
-                PayoutMethods = new[] { payoutMethodId.ToString() },
+                PayoutMethods = payoutMethodIds.Select(p => p.ToString()).ToArray(),
             };
 
             if (request.RefundVariant != RefundVariant.Custom)

--- a/BTCPayServer/Controllers/GreenField/GreenfieldInvoiceController.cs
+++ b/BTCPayServer/Controllers/GreenField/GreenfieldInvoiceController.cs
@@ -349,11 +349,21 @@ namespace BTCPayServer.Controllers.Greenfield
 #pragma warning restore CS0618 // Type or member is obsolete
 
             var supported = _payoutHandlers.GetSupportedPayoutMethods(store);
+            // When the caller explicitly provides `payoutMethods`, reject invalid/unsupported entries
+            // instead of silently dropping them (consistent with the pull payment endpoint).
+            var explicitlyRequested = request.PayoutMethods is not null;
             var payoutMethodIds = new List<PayoutMethodId>();
             foreach (var p in requestedPayoutMethods)
             {
-                if (p is not null && PayoutMethodId.TryParse(p, out var pmid) && supported.Contains(pmid) && !payoutMethodIds.Contains(pmid))
-                    payoutMethodIds.Add(pmid);
+                if (p is not null && PayoutMethodId.TryParse(p, out var pmid) && supported.Contains(pmid))
+                {
+                    if (!payoutMethodIds.Contains(pmid))
+                        payoutMethodIds.Add(pmid);
+                }
+                else if (explicitlyRequested)
+                {
+                    ModelState.AddModelError(errorKey, $"Invalid or unsupported payout method: {p}");
+                }
             }
 
             if (payoutMethodIds.Count > 0)

--- a/BTCPayServer/wwwroot/swagger/v1/swagger.template.invoices.json
+++ b/BTCPayServer/wwwroot/swagger/v1/swagger.template.invoices.json
@@ -1428,19 +1428,9 @@
                         "type": "string",
                         "description": "Description of the pull payment"
                     },
-                    "payoutMethodId": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/PayoutMethodId"
-                            }
-                        ],
-                        "deprecated": true,
-                        "description": "Deprecated, use `payoutMethods` instead. The single payout method the refund can be claimed in.",
-                        "nullable": true
-                    },
                     "payoutMethods": {
                         "type": "array",
-                        "description": "The list of payout methods the refund can be claimed in. Available options can be queried from the `StorePaymentMethods_GetStorePaymentMethods` endpoint. If `null`, falls back to `payoutMethodId`, and if that is also `null`, to the default payout method of the original invoice.",
+                        "description": "The list of payout methods the refund can be claimed in. Available options can be queried from the `StorePaymentMethods_GetStorePaymentMethods` endpoint. If `null`, falls back to the deprecated single payout method, and if that is also `null`, to the default payout method of the original invoice.",
                         "items": {
                             "type": "string",
                             "example": "BTC-CHAIN"

--- a/BTCPayServer/wwwroot/swagger/v1/swagger.template.invoices.json
+++ b/BTCPayServer/wwwroot/swagger/v1/swagger.template.invoices.json
@@ -1429,7 +1429,23 @@
                         "description": "Description of the pull payment"
                     },
                     "payoutMethodId": {
-                        "$ref": "#/components/schemas/PayoutMethodId"
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/PayoutMethodId"
+                            }
+                        ],
+                        "deprecated": true,
+                        "description": "Deprecated, use `payoutMethods` instead. The single payout method the refund can be claimed in.",
+                        "nullable": true
+                    },
+                    "payoutMethods": {
+                        "type": "array",
+                        "description": "The list of payout methods the refund can be claimed in. Available options can be queried from the `StorePaymentMethods_GetStorePaymentMethods` endpoint. If `null`, falls back to `payoutMethodId`, and if that is also `null`, to the default payout method of the original invoice.",
+                        "items": {
+                            "type": "string",
+                            "example": "BTC-CHAIN"
+                        },
+                        "nullable": true
                     },
                     "refundVariant": {
                         "type": "string",


### PR DESCRIPTION
Closes #6185.

Added optional `payoutMethods` array to refund endpoint, same as pull payment already has. `payoutMethodId` still works, just marked obsolete now.

Pull payment took `payoutMethods` as optional array already, refund only took single required `payoutMethodId` - that's the mismatch issue was about. Two options in the thread: Nicolas wanted to just drop `payoutMethodId`, but that's breaking and ndeet called it out. Went non-breaking since we're on 2.4.0.

Resolve order: `payoutMethods` first, falls back to `payoutMethodId`, falls back to invoice default if neither passed. Old clients see no difference.

- `RefundInvoiceRequest.cs` - new `PayoutMethods` field, `payoutMethodId` marked obsolete
- `GreenfieldInvoiceController.cs` - resolving logic, pull payment now gets all methods not just one
- swagger json - new field documented, old one deprecated
- refund test updated

Extended `CanRefundInvoice` instead of writing a new test. Still covers all old `payoutMethodId` cases plus added array path.

<img width="1281" height="587" alt="image" src="https://github.com/user-attachments/assets/3626496f-794e-483c-b238-fe573e5d0306" />

Note: test store only has BTC onchain, so didn't test refund with multiple different payout methods (needs lightning). Array just passes straight into `CreatePullPaymentRequest.PayoutMethods` which already handles multiple, and that's covered by pull payment tests.


