### PR TITLE
Bumping LND to 0.21.0-beta

### DIFF
--- a/BTCPayServer.Tests/docker-compose.altcoins.yml
+++ b/BTCPayServer.Tests/docker-compose.altcoins.yml
@@ -240,7 +240,7 @@ services:
       - "postgres_test_datadir:/var/lib/postgresql"
 
   merchant_lnd:
-    image: btcpayserver/lnd:v0.19.3-beta-1
+    image: btcpayserver/lnd:v0.21.0-beta
     restart: unless-stopped
     environment:
       LND_CHAIN: "btc"
@@ -278,7 +278,7 @@ services:
       - bitcoind
 
   customer_lnd:
-    image: btcpayserver/lnd:v0.19.3-beta-1
+    image: btcpayserver/lnd:v0.21.0-beta
     restart: unless-stopped
     environment:
       LND_CHAIN: "btc"

--- a/BTCPayServer.Tests/docker-compose.mutinynet.yml
+++ b/BTCPayServer.Tests/docker-compose.mutinynet.yml
@@ -179,7 +179,7 @@ services:
       - "postgres_test_datadir:/var/lib/postgresql"
 
   merchant_lnd:
-    image: btcpayserver/lnd:v0.19.3-beta-1
+    image: btcpayserver/lnd:v0.21.0-beta
     restart: unless-stopped
     environment:
       LND_CHAIN: "btc"
@@ -217,7 +217,7 @@ services:
       - bitcoind
 
   customer_lnd:
-    image: btcpayserver/lnd:v0.19.3-beta-1
+    image: btcpayserver/lnd:v0.21.0-beta
     restart: unless-stopped
     environment:
       LND_CHAIN: "btc"

--- a/BTCPayServer.Tests/docker-compose.testnet.yml
+++ b/BTCPayServer.Tests/docker-compose.testnet.yml
@@ -171,7 +171,7 @@ services:
       - "postgres_test_datadir:/var/lib/postgresql"
 
   merchant_lnd:
-    image: btcpayserver/lnd:v0.19.3-beta-1
+    image: btcpayserver/lnd:v0.21.0-beta
     restart: unless-stopped
     environment:
       LND_CHAIN: "btc"
@@ -209,7 +209,7 @@ services:
       - bitcoind
 
   customer_lnd:
-    image: btcpayserver/lnd:v0.19.3-beta-1
+    image: btcpayserver/lnd:v0.21.0-beta
     restart: unless-stopped
     environment:
       LND_CHAIN: "btc"

--- a/BTCPayServer.Tests/docker-compose.yml
+++ b/BTCPayServer.Tests/docker-compose.yml
@@ -225,7 +225,7 @@ services:
       - "postgres_test_datadir:/var/lib/postgresql"
 
   merchant_lnd:
-    image: btcpayserver/lnd:v0.19.3-beta-1
+    image: btcpayserver/lnd:v0.21.0-beta
     restart: unless-stopped
     environment:
       LND_CHAIN: "btc"
@@ -263,7 +263,7 @@ services:
       - bitcoind
 
   customer_lnd:
-    image: btcpayserver/lnd:v0.19.3-beta-1
+    image: btcpayserver/lnd:v0.21.0-beta
     restart: unless-stopped
     environment:
       LND_CHAIN: "btc"


### PR DESCRIPTION
Docker image: https://hub.docker.com/repository/docker/btcpayserver/lnd/tags/v0.21.0-beta
Tag: https://github.com/btcpayserver/lnd/releases/tag/basedon-v0.21.0-beta
BTCPayServer.Lightning: https://github.com/btcpayserver/BTCPayServer.Lightning/pull/181 (merged, tests passing)