### PR TITLE
Fix NBXplorer error rendering

### DIFF
--- a/BTCPayServer/Views/Shared/Bitcoin/NBXSyncSummary.cshtml
+++ b/BTCPayServer/Views/Shared/Bitcoin/NBXSyncSummary.cshtml
@@ -41,7 +41,7 @@
                     <li text-translate="true">The node is offline</li>
                     @if (line.Error != null)
                     {
-                        <li>@StringLocalizer["Last error:"] line.Error</li>
+                        <li>@StringLocalizer["Last error:"] @line.Error</li>
                     }
                 </ul>
             }


### PR DESCRIPTION
This fixes a small rendering bug in the NBXplorer sync summary.

One offline-node branch rendered the literal text `line.Error` instead of the
actual error value. The other branch in the same view already rendered
`@line.Error`, so this makes the offline/error display consistent.

Tested:

- `git diff --check`

Not run:

- The .NET test suite, because `dotnet` is not installed in this environment.
