### PR TITLE
Fix "File traversal detected" crash processing plugin commands on Windows

### DIFF
--- a/BTCPayServer/Plugins/PluginManager.cs
+++ b/BTCPayServer/Plugins/PluginManager.cs
@@ -557,7 +557,10 @@ namespace BTCPayServer.Plugins
 
         private static void AssertSafeName(string pluginDir, string plugin)
         {
-            var fullPluginDir = Path.GetFullPath(pluginDir).WithTrailingSlash();
+            // platform separator: WithTrailingSlash's '/' mismatches GetFullPath on Windows
+            var fullPluginDir = Path.GetFullPath(pluginDir);
+            if (!fullPluginDir.EndsWith(Path.DirectorySeparatorChar))
+                fullPluginDir += Path.DirectorySeparatorChar;
             var fullPath = Path.GetFullPath(Path.Combine(fullPluginDir, plugin));
             if (!fullPath.StartsWith(fullPluginDir, StringComparison.Ordinal))
                 throw new InvalidOperationException("File traversal detected");


### PR DESCRIPTION
On Windows, BTCPay crashes at startup whenever a plugin `commands` file is pending — after disabling/installing a plugin from the UI, or when the "disabling all plugins" crash-recovery queues a command for every plugin. `ExecuteCommands` calls `AssertSafeName` for each command, which throws `InvalidOperationException: File traversal detected`; because it throws before rewriting the file, the pending commands are never cleared, so every subsequent boot fails the same way.

The cause is a path-separator mismatch in `AssertSafeName`. `WithTrailingSlash()` always appends `/` (it's meant for URLs — invoice links, root paths), but `Path.GetFullPath(Path.Combine(...))` normalizes the combined path to `\` on Windows. So `fullPath` (`...\Plugins\Foo`) never starts with `fullPluginDir` (`...\Plugins/`), and the ordinal `StartsWith` rejects every plugin name.

The fix appends `Path.DirectorySeparatorChar` instead. On Linux that's `/`, so behavior is unchanged; on Windows it's `\`, matching `GetFullPath`. The traversal protection still holds — an escaping `..\..` path resolves outside the directory and fails the check.

Reproduced on Windows with the real APIs (plugin dir `%APPDATA%\BTCPayServer\Plugins`, name `BTCPayServer.Plugins.Electrum`): the current code's `StartsWith` returns false (throws); the fix returns true; and `..\..\evil` still resolves outside the dir and is rejected. `BTCPayServer.csproj` builds clean.
