### PR TITLE
[Fix] Standardize topbar dropdown menus

### DIFF
--- a/BTCPayServer.Tests/PlaywrightTester.cs
+++ b/BTCPayServer.Tests/PlaywrightTester.cs
@@ -428,7 +428,11 @@ namespace BTCPayServer.Tests
         public async Task ClickOnAllSectionLinks(string sectionSelector = "#menu-item")
         {
             List<string> links = [];
-            foreach (var locator in await Page.Locator($"{sectionSelector} .nav-link").AllAsync())
+            var linkLocator = Page.Locator($"{sectionSelector} a.nav-link");
+            if (await linkLocator.CountAsync() == 0)
+                linkLocator = Page.Locator($"{sectionSelector} a.dropdown-item");
+
+            foreach (var locator in await linkLocator.AllAsync())
             {
                 var link = await locator.GetAttributeAsync("href");
                 if (link is null or "/logout")

--- a/BTCPayServer/Components/GlobalNav/Default.cshtml
+++ b/BTCPayServer/Components/GlobalNav/Default.cshtml
@@ -14,6 +14,8 @@
 @{
     var pluginsUrl = Url.Action("ListPlugins", "UIServer");
     var loginName = User.Identity?.Name;
+    var activePage = ViewData["ActivePage"]?.ToString();
+    var serverEmailsPage = $"Server-{nameof(ServerNavPages.Emails)}";
     var accountDisplayName = string.IsNullOrEmpty(Model.UserName)
         ? loginName ?? string.Empty
         : string.IsNullOrEmpty(loginName)
@@ -43,17 +45,17 @@
                     <span class="btcpay-status btcpay-status--disabled globalNav-status" aria-hidden="true"></span>
                 }
             </button>
-            <ul id="globalNavPluginsMenu" class="dropdown-menu dropdown-menu-end py-0">
+            <ul id="globalNavPluginsMenu" class="dropdown-menu dropdown-menu-end">
                 @if (!string.IsNullOrEmpty(pluginsUrl))
                 {
-                    <li class="py-1 px-3">
-                        <a layout-menu-item="@nameof(ServerNavPages.Plugins)" asp-area="" asp-controller="UIServer" asp-action="ListPlugins" text-translate="true">Manage Plugins</a>
+                    <li>
+                        <a id="menu-item-@nameof(ServerNavPages.Plugins)" class="dropdown-item@(activePage == nameof(ServerNavPages.Plugins) ? " active" : "")" asp-area="" asp-controller="UIServer" asp-action="ListPlugins" text-translate="true">Manage Plugins</a>
                     </li>
-                    <li class="py-1 px-3">
-                        <a class="dropdown-item nav-link" asp-area="" asp-controller="UIServer" asp-action="ListPlugins" asp-fragment="plugins-installed" text-translate="true">Installed Plugins</a>
+                    <li>
+                        <a class="dropdown-item" asp-area="" asp-controller="UIServer" asp-action="ListPlugins" asp-fragment="plugins-installed" text-translate="true">Installed Plugins</a>
                     </li>
-                    <li class="py-1 px-3">
-                        <a class="dropdown-item nav-link" asp-area="" asp-controller="UIServer" asp-action="ListPlugins" asp-fragment="plugins-directory" text-translate="true">Plugin Directory</a>
+                    <li>
+                        <a class="dropdown-item" asp-area="" asp-controller="UIServer" asp-action="ListPlugins" asp-fragment="plugins-directory" text-translate="true">Plugin Directory</a>
                     </li>
                 }
             </ul>
@@ -71,39 +73,39 @@
                     data-global-nav-tooltip="1">
                 <vc:icon symbol="nav-server-settings" />
             </button>
-            <ul id="globalNavServerMenu" class="dropdown-menu dropdown-menu-end py-0">
-                <li class="py-1 px-3">
-                    <a layout-menu-item="@nameof(ServerNavPages.Policies)" asp-area="" asp-controller="UIServer" asp-action="Policies" text-translate="true">Policies</a>
+            <ul id="globalNavServerMenu" class="dropdown-menu dropdown-menu-end">
+                <li>
+                    <a id="menu-item-@nameof(ServerNavPages.Policies)" class="dropdown-item@(activePage == nameof(ServerNavPages.Policies) ? " active" : "")" asp-area="" asp-controller="UIServer" asp-action="Policies" text-translate="true">Policies</a>
                 </li>
-                <li class="py-1 px-3">
-                    <a layout-menu-item="@nameof(ServerNavPages.Users)" asp-controller="UIServer" asp-action="ListUsers" text-translate="true">Users</a>
+                <li>
+                    <a id="menu-item-@nameof(ServerNavPages.Users)" class="dropdown-item@(activePage == nameof(ServerNavPages.Users) ? " active" : "")" asp-controller="UIServer" asp-action="ListUsers" text-translate="true">Users</a>
                 </li>
-                <li class="py-1 px-3">
-                    <a layout-menu-item="@nameof(ServerNavPages.Roles)" asp-controller="UIServer" asp-action="ListRoles" text-translate="true">Roles</a>
+                <li>
+                    <a id="menu-item-@nameof(ServerNavPages.Roles)" class="dropdown-item@(activePage == nameof(ServerNavPages.Roles) ? " active" : "")" asp-controller="UIServer" asp-action="ListRoles" text-translate="true">Roles</a>
                 </li>
-                <li class="py-1 px-3">
-                    <a layout-menu-item="Server-@nameof(ServerNavPages.Emails)" asp-area="@EmailsPlugin.Area" asp-controller="UIServerEmail" asp-action="ServerEmailSettings" text-translate="true">Emails</a>
+                <li>
+                    <a id="menu-item-@serverEmailsPage" class="dropdown-item@(activePage == serverEmailsPage ? " active" : "")" asp-area="@EmailsPlugin.Area" asp-controller="UIServerEmail" asp-action="ServerEmailSettings" text-translate="true">Emails</a>
                 </li>
-                <li class="py-1 px-3">
-                    <a layout-menu-item="@nameof(ServerNavPages.Services)" asp-controller="UIServer" asp-action="Services" text-translate="true">Services</a>
+                <li>
+                    <a id="menu-item-@nameof(ServerNavPages.Services)" class="dropdown-item@(activePage == nameof(ServerNavPages.Services) ? " active" : "")" asp-controller="UIServer" asp-action="Services" text-translate="true">Services</a>
                 </li>
-                <li class="py-1 px-3">
-                    <a layout-menu-item="@nameof(ServerNavPages.Branding)" asp-controller="UIServer" asp-action="Branding" text-translate="true">Branding</a>
+                <li>
+                    <a id="menu-item-@nameof(ServerNavPages.Branding)" class="dropdown-item@(activePage == nameof(ServerNavPages.Branding) ? " active" : "")" asp-controller="UIServer" asp-action="Branding" text-translate="true">Branding</a>
                 </li>
-                <li class="py-1 px-3">
-                    <a layout-menu-item="@nameof(ServerNavPages.Translations)" asp-area="@TranslationsPlugin.Area" asp-controller="UITranslation" asp-action="ListTranslations" text-translate="true">Translations</a>
+                <li>
+                    <a id="menu-item-@nameof(ServerNavPages.Translations)" class="dropdown-item@(activePage == nameof(ServerNavPages.Translations) ? " active" : "")" asp-area="@TranslationsPlugin.Area" asp-controller="UITranslation" asp-action="ListTranslations" text-translate="true">Translations</a>
                 </li>
                 @if (Model.DockerDeployment)
                 {
-                    <li class="py-1 px-3">
-                        <a layout-menu-item="@nameof(ServerNavPages.Maintenance)" asp-controller="UIServer" asp-action="Maintenance" text-translate="true">Maintenance</a>
+                    <li>
+                        <a id="menu-item-@nameof(ServerNavPages.Maintenance)" class="dropdown-item@(activePage == nameof(ServerNavPages.Maintenance) ? " active" : "")" asp-controller="UIServer" asp-action="Maintenance" text-translate="true">Maintenance</a>
                     </li>
                 }
-                <li class="py-1 px-3">
-                    <a layout-menu-item="@nameof(ServerNavPages.Logs)" asp-controller="UIServer" asp-action="LogsView" text-translate="true">Logs</a>
+                <li>
+                    <a id="menu-item-@nameof(ServerNavPages.Logs)" class="dropdown-item@(activePage == nameof(ServerNavPages.Logs) ? " active" : "")" asp-controller="UIServer" asp-action="LogsView" text-translate="true">Logs</a>
                 </li>
-                <li class="py-1 px-3">
-                    <a layout-menu-item="@nameof(ServerNavPages.Files)" asp-controller="UIServer" asp-action="Files" text-translate="true">Files</a>
+                <li>
+                    <a id="menu-item-@nameof(ServerNavPages.Files)" class="dropdown-item@(activePage == nameof(ServerNavPages.Files) ? " active" : "")" asp-controller="UIServer" asp-action="Files" text-translate="true">Files</a>
                 </li>
                 <vc:ui-extension-point location="server-nav" model="@Model.MainNav" />
             </ul>
@@ -129,7 +131,7 @@
                     <vc:icon symbol="nav-account" />
                 }
             </button>
-            <ul id="globalNavAccountMenu" class="dropdown-menu dropdown-menu-end py-0" aria-labelledby="menu-item-Account">
+            <ul id="globalNavAccountMenu" class="dropdown-menu dropdown-menu-end" aria-labelledby="menu-item-Account">
                 <li class="p-3 border-bottom d-flex align-items-center gap-2">
                     @if (!string.IsNullOrEmpty(Model.UserImageUrl))
                     {
@@ -145,12 +147,12 @@
                 </li>
                 @if (!Theme.CustomTheme)
                 {
-                    <li class="py-1 px-3">
-                        <vc:theme-switch css-class="w-100 pt-2" />
+                    <li class="dropdown-item-text">
+                        <vc:theme-switch css-class="w-100" />
                     </li>
                 }
-                <li class="py-1 px-3">
-                    <div class="d-flex align-items-center justify-content-between gap-3 nav-link">
+                <li class="dropdown-item-text">
+                    <div class="d-flex align-items-center justify-content-between gap-3">
                         <label for="HideSensitiveInfo" class="fw-semibold mb-0 cursor-pointer" text-translate="true">Hide Sensitive Info</label>
                         <input id="HideSensitiveInfo" name="HideSensitiveInfo" type="checkbox" class="btcpay-toggle" />
                     </div>
@@ -158,37 +160,41 @@
                         document.getElementById('HideSensitiveInfo').checked = window.localStorage.getItem('btcpay-hide-sensitive-info') === 'true';
                     </script>
                 </li>
-                <li class="border-top py-1 px-3">
-                    <a asp-area="" asp-controller="UIManage" asp-action="Index" class="nav-link" id="Nav-ManageAccount">
+                <li><hr class="dropdown-divider" /></li>
+                <li>
+                    <a asp-area="" asp-controller="UIManage" asp-action="Index" class="dropdown-item" id="Nav-ManageAccount">
                         <span text-translate="true">Manage Account</span>
                     </a>
                 </li>
-                <li class="border-top py-1 px-3">
-                    <a layout-menu-item="@nameof(ManageNavPages.ChangePassword)" asp-controller="UIManage" asp-action="ChangePassword" text-translate="true">Password</a>
+                <li><hr class="dropdown-divider" /></li>
+                <li>
+                    <a id="menu-item-@nameof(ManageNavPages.ChangePassword)" class="dropdown-item@(activePage == nameof(ManageNavPages.ChangePassword) ? " active" : "")" asp-controller="UIManage" asp-action="ChangePassword" text-translate="true">Password</a>
                 </li>
-                <li class="py-1 px-3">
-                    <a layout-menu-item="@nameof(ManageNavPages.TwoFactorAuthentication)" asp-controller="UIManage" asp-action="TwoFactorAuthentication" text-translate="true">Two-Factor Authentication</a>
+                <li>
+                    <a id="menu-item-@nameof(ManageNavPages.TwoFactorAuthentication)" class="dropdown-item@(activePage == nameof(ManageNavPages.TwoFactorAuthentication) ? " active" : "")" asp-controller="UIManage" asp-action="TwoFactorAuthentication" text-translate="true">Two-Factor Authentication</a>
                 </li>
-                <li class="py-1 px-3">
-                    <a layout-menu-item="@nameof(ManageNavPages.Passkeys)" asp-controller="UIManage" asp-action="Passkeys" text-translate="true">Passkeys</a>
+                <li>
+                    <a id="menu-item-@nameof(ManageNavPages.Passkeys)" class="dropdown-item@(activePage == nameof(ManageNavPages.Passkeys) ? " active" : "")" asp-controller="UIManage" asp-action="Passkeys" text-translate="true">Passkeys</a>
                 </li>
-                <li class="py-1 px-3">
-                    <a layout-menu-item="@nameof(ManageNavPages.APIKeys)" asp-controller="UIManage" asp-action="APIKeys" text-translate="true">API Keys</a>
+                <li>
+                    <a id="menu-item-@nameof(ManageNavPages.APIKeys)" class="dropdown-item@(activePage == nameof(ManageNavPages.APIKeys) ? " active" : "")" asp-controller="UIManage" asp-action="APIKeys" text-translate="true">API Keys</a>
                 </li>
-                <li class="py-1 px-3">
-                    <a layout-menu-item="@nameof(ManageNavPages.Notifications)" asp-controller="UIManage" asp-action="NotificationSettings" text-translate="true">Notifications</a>
+                <li>
+                    <a id="menu-item-@nameof(ManageNavPages.Notifications)" class="dropdown-item@(activePage == nameof(ManageNavPages.Notifications) ? " active" : "")" asp-controller="UIManage" asp-action="NotificationSettings" text-translate="true">Notifications</a>
                 </li>
                 <vc:ui-extension-point location="user-nav" model="@Model.MainNav" />
                 @if (!string.IsNullOrWhiteSpace(Model.ContactUrl))
                 {
-                    <li class="py-1 px-3 border-top">
-                        <a href="@Model.ContactUrl" class="nav-link" id="Nav-ContactUs">
+                    <li><hr class="dropdown-divider" /></li>
+                    <li>
+                        <a href="@Model.ContactUrl" class="dropdown-item" id="Nav-ContactUs">
                             <span text-translate="true">Contact Us</span>
                         </a>
                     </li>
                 }
-                <li class="border-top py-1 px-3">
-                    <a asp-area="" asp-controller="UIAccount" asp-action="Logout" class="nav-link text-danger" id="Nav-Logout">
+                <li><hr class="dropdown-divider" /></li>
+                <li>
+                    <a asp-area="" asp-controller="UIAccount" asp-action="Logout" class="dropdown-item text-danger" id="Nav-Logout">
                         <span text-translate="true">Logout</span>
                     </a>
                 </li>

--- a/BTCPayServer/Plugins/Impersonation/Views/UserNav.cshtml
+++ b/BTCPayServer/Plugins/Impersonation/Views/UserNav.cshtml
@@ -1,4 +1,4 @@
 @using BTCPayServer.Plugins.Impersonation
-<li class="py-1 px-3">
-    <a layout-menu-item="@nameof(UIImpersonationController.LoginCodes)" asp-area="@ImpersonationPlugin.Area" asp-controller="UIImpersonation" asp-action="LoginCodes" text-translate="true">Login Codes</a>
+<li>
+    <a id="menu-item-@nameof(UIImpersonationController.LoginCodes)" class="dropdown-item@(ViewData["ActivePage"]?.ToString() == nameof(UIImpersonationController.LoginCodes) ? " active" : "")" asp-area="@ImpersonationPlugin.Area" asp-controller="UIImpersonation" asp-action="LoginCodes" text-translate="true">Login Codes</a>
 </li>

--- a/BTCPayServer/Plugins/Monetization/Views/NavExtension.cshtml
+++ b/BTCPayServer/Plugins/Monetization/Views/NavExtension.cshtml
@@ -1,10 +1,11 @@
 @model BTCPayServer.Components.MainNav.MainNavViewModel
 
-<li class="nav-item nav-item-sub" permission="@Policies.CanModifyServerSettings">
+<li permission="@Policies.CanModifyServerSettings">
     <a
+        id="menu-item-@nameof(MonetizationPlugin)"
+        class="dropdown-item@(ViewData["ActivePage"]?.ToString() == nameof(MonetizationPlugin) ? " active" : "")"
         asp-area="@MonetizationPlugin.Area"
         asp-controller="UIServerMonetization"
         asp-action="Monetization"
-        layout-menu-item="@nameof(MonetizationPlugin)"
         text-translate="true">Monetization</a>
 </li>

--- a/BTCPayServer/Plugins/Monetization/Views/UserNavExtension.cshtml
+++ b/BTCPayServer/Plugins/Monetization/Views/UserNavExtension.cshtml
@@ -3,7 +3,7 @@
 
 @if (Settings.Settings is { OfferingId: not null, DefaultPlanId: not null })
 {
-    <li class="nav-item nav-item-sub">
-        <a layout-menu-item="ManageBilling" asp-area="@MonetizationPlugin.Area" asp-controller="UIUserMonetization" asp-action="ManageBilling" text-translate="true">Manage billing</a>
+    <li>
+        <a id="menu-item-ManageBilling" class="dropdown-item@(ViewData["ActivePage"]?.ToString() == "ManageBilling" ? " active" : "")" asp-area="@MonetizationPlugin.Area" asp-controller="UIUserMonetization" asp-action="ManageBilling" text-translate="true">Manage billing</a>
     </li>
 }

--- a/BTCPayServer/wwwroot/main/layout.css
+++ b/BTCPayServer/wwwroot/main/layout.css
@@ -196,75 +196,13 @@
     text-decoration: none;
 }
 
-#globalNav .dropdown-menu {
+#globalNav #globalNavAccountMenu {
     min-width: 220px;
-    border: 1px solid var(--btcpay-body-border-medium);
-    border-radius: var(--btcpay-border-radius-l);
-    background: var(--btcpay-body-bg);
-    box-shadow: 0 12px 24px rgba(0, 0, 0, .12);
-    padding: .25rem 0;
 }
 
 #globalNav #globalNavServerMenu,
 #globalNav #globalNavPluginsMenu {
     min-width: 250px;
-}
-
-#globalNav .dropdown-menu li {
-    list-style: none;
-    margin: 0;
-    padding: 0;
-}
-
-#globalNav .dropdown-menu > li > a,
-#globalNav .dropdown-menu .menu-item,
-#globalNav .dropdown-menu .dropdown-item,
-#globalNav .dropdown-menu .nav-item .nav-link,
-#globalNav .dropdown-menu .nav-link {
-    display: block;
-    width: 100%;
-    padding: .45rem .6rem;
-    clear: both;
-    font-weight: var(--btcpay-font-weight-semibold);
-    color: var(--bs-dropdown-link-color);
-    text-decoration: none;
-    white-space: normal;
-    background-color: transparent;
-    border: 0;
-    border-radius: 0;
-}
-
-#globalNav #globalNavServerMenu > li,
-#globalNav #globalNavPluginsMenu > li,
-#globalNav #globalNavServerMenu > .nav-item,
-#globalNav #globalNavPluginsMenu > .nav-item {
-    padding: .25rem .75rem;
-}
-
-#globalNav #globalNavServerMenu > li > a,
-#globalNav #globalNavPluginsMenu > li > a,
-#globalNav #globalNavServerMenu > .nav-item > a,
-#globalNav #globalNavPluginsMenu > .nav-item > a {
-    border-radius: var(--btcpay-border-radius-m);
-    padding: .45rem .6rem;
-}
-
-#globalNav .dropdown-menu > li > a:hover,
-#globalNav .dropdown-menu .menu-item:hover,
-#globalNav .dropdown-menu .dropdown-item:hover,
-#globalNav .dropdown-menu .nav-item .nav-link:hover,
-#globalNav .dropdown-menu .nav-link:hover {
-    color: var(--bs-dropdown-link-hover-color);
-    background-color: var(--bs-dropdown-link-hover-bg);
-}
-
-#globalNav .dropdown-menu > li > a.active,
-#globalNav .dropdown-menu .menu-item.active,
-#globalNav .dropdown-menu .dropdown-item.active,
-#globalNav .dropdown-menu .nav-item .nav-link.active,
-#globalNav .dropdown-menu .nav-link.active {
-    color: var(--bs-dropdown-link-active-color);
-    background-color: var(--bs-dropdown-link-active-bg);
 }
 
 /* Global Search */
@@ -508,6 +446,7 @@
 }
 
 #NotificationsDropdown {
+    min-width: 220px;
     border-radius: var(--btcpay-border-radius-l);
     background-color: var(--btcpay-body-bg);
     box-shadow: 0 8px 24px rgba(0, 0, 0, 16%);

--- a/BTCPayServer/wwwroot/plugins/GlobalSearch/global-search.css
+++ b/BTCPayServer/wwwroot/plugins/GlobalSearch/global-search.css
@@ -194,7 +194,12 @@
 }
 
 #globalNav .globalSearch-item:hover {
-    background: var(--btcpay-neutral-100);
+    color: var(--btcpay-body-text);
+    background-color: var(--btcpay-body-bg-hover);
+}
+
+#globalNav .globalSearch-item:hover .globalSearch-item-title {
+    color: var(--btcpay-body-text);
 }
 
 #globalNav .globalSearch-item-title {


### PR DESCRIPTION
## Summary

This updates the topbar dropdown menus so they look and behave more consistently with the rest of BTCPay Server.

The Plugins, Server Settings, and Account menus now use the standard dropdown styling, spacing, dividers, hover states, and active item highlight. This makes the menus easier to scan and less visually different from other dropdowns in the app.

The Global Search result hover/focus state was also fixed.