### PR TITLE
Greenfield: support includePaymentMethods on get invoice

### DIFF
--- a/BTCPayServer.Client/BTCPayServerClient.Invoices.cs
+++ b/BTCPayServer.Client/BTCPayServerClient.Invoices.cs
@@ -41,10 +41,11 @@ public partial class BTCPayServerClient
         return await SendHttpRequest<IEnumerable<InvoiceData>>($"api/v1/stores/{storeId}/invoices", queryPayload, HttpMethod.Get, token);
     }
 
-    public virtual async Task<InvoiceData> GetInvoice(string invoiceId, CancellationToken token = default)
+    public virtual async Task<InvoiceData> GetInvoice(string invoiceId, bool includePaymentMethods = false, CancellationToken token = default)
     {
         if (invoiceId == null) throw new ArgumentNullException(nameof(invoiceId));
-        return await SendHttpRequest<InvoiceData>($"api/v1/invoices/{invoiceId}", null, HttpMethod.Get, token);
+        var queryPayload = new Dictionary<string, object> { { nameof(includePaymentMethods), includePaymentMethods } };
+        return await SendHttpRequest<InvoiceData>($"api/v1/invoices/{invoiceId}", queryPayload, HttpMethod.Get, token);
     }
 
     public virtual async Task<InvoicePaymentMethodDataModel[]> GetInvoicePaymentMethods(string invoiceId,

--- a/BTCPayServer.Tests/GreenfieldAPITests.cs
+++ b/BTCPayServer.Tests/GreenfieldAPITests.cs
@@ -1976,6 +1976,12 @@ namespace BTCPayServer.Tests
             Assert.NotNull(invoices.First().PaymentMethods);
             Assert.Equal(newInvoice.Id, invoices.First().Id);
 
+            //get single invoice, payment methods excluded by default and included on demand
+            var singleInvoice = await viewOnly.GetInvoice(newInvoice.Id);
+            Assert.Empty(singleInvoice.PaymentMethods);
+            singleInvoice = await viewOnly.GetInvoice(newInvoice.Id, includePaymentMethods: true);
+            Assert.NotEmpty(singleInvoice.PaymentMethods);
+
             invoices = await viewOnly.GetInvoices(user.StoreId, textSearch: "Banana");
             Assert.NotNull(invoices);
             Assert.Single(invoices);

--- a/BTCPayServer/Controllers/GreenField/GreenfieldInvoiceController.cs
+++ b/BTCPayServer/Controllers/GreenField/GreenfieldInvoiceController.cs
@@ -129,12 +129,12 @@ namespace BTCPayServer.Controllers.Greenfield
             AuthenticationSchemes = AuthenticationSchemes.Greenfield)]
         [HttpGet("~/api/v1/stores/{storeId}/invoices/{invoiceId}")]
         [HttpGet("~/api/v1/invoices/{invoiceId}")]
-        public async Task<IActionResult> GetInvoice(string? storeId, string invoiceId)
+        public async Task<IActionResult> GetInvoice(string? storeId, string invoiceId, [FromQuery] bool includePaymentMethods = false)
         {
             var invoice = HttpContext.GetInvoiceDataOrNull();
             if (invoice is null)
                 return InvoiceNotFound();
-            return Ok(ToModel(invoice));
+            return Ok(ToModel(invoice, includePaymentMethods));
         }
 
         [Authorize(Policy = Policies.CanModifyInvoices,

--- a/BTCPayServer/wwwroot/swagger/v1/swagger.template.invoices.json
+++ b/BTCPayServer/wwwroot/swagger/v1/swagger.template.invoices.json
@@ -199,6 +199,16 @@
                 "parameters": [
                     {
                         "$ref": "#/components/parameters/InvoiceId"
+                    },
+                    {
+                        "name": "includePaymentMethods",
+                        "in": "query",
+                        "required": false,
+                        "description": "Includes payment methods available to the response",
+                        "schema": {
+                            "type": "boolean",
+                            "default": false
+                        }
                     }
                 ],
                 "description": "View information about the specified invoice. The store is resolved automatically from the invoice.",


### PR DESCRIPTION
The list endpoint already lets you pass includePaymentMethods=true to get payment methods inline, but the single invoice GET didn't. So if you had one invoice and wanted its addresses, you had to make a second call to /payment-methods.

This just wires the same flag into GET invoice so you can get everything in one call. Off by default, so nothing changes for existing callers.

Also updated the client SDK and swagger docs to match.