### PR TITLE
Return NotFound in payouts view when the pull payment no longer exists

### DIFF
--- a/BTCPayServer/Controllers/UIStorePullPaymentsController.PullPayments.cs
+++ b/BTCPayServer/Controllers/UIStorePullPaymentsController.PullPayments.cs
@@ -547,8 +547,11 @@ namespace BTCPayServer.Controllers
                 ctx.Payouts.Where(p => p.StoreDataId == storeId && (p.PullPaymentDataId == null || !p.PullPaymentData.Archived));
             if (pullPaymentId != null)
             {
+                var pp = await ctx.PullPayments.FindAsync(pullPaymentId);
+                if (pp is null)
+                    return NotFound();
                 payoutRequest = payoutRequest.Where(p => p.PullPaymentDataId == vm.PullPaymentId);
-                vm.PullPaymentName = (await ctx.PullPayments.FindAsync(pullPaymentId)).GetBlob().Name;
+                vm.PullPaymentName = pp.GetBlob().Name;
             }
 
             vm.PayoutMethodCount = (await payoutRequest.GroupBy(data => data.PayoutMethodId)


### PR DESCRIPTION
The payouts view loaded the pull payment name like this:

```csharp
vm.PullPaymentName = (await ctx.PullPayments.FindAsync(pullPaymentId)).GetBlob().Name;
```

`FindAsync` returns `null` when the pull payment id no longer exists — for example a deleted/archived pull payment, or a stale bookmarked `/stores/{storeId}/pull-payments/{pullPaymentId}/payouts` URL. Calling `.GetBlob()` on that `null` throws a `NullReferenceException`, so the page returns a 500.

This looks up the pull payment up front and returns `NotFound()` if it's missing, matching the pattern used elsewhere in the controllers.
