### PR TITLE
Support LUD-290 (pinLimit) for LNURL-Withdraw in checkout

### DIFF
--- a/BTCPayServer.Tests/FastTests.cs
+++ b/BTCPayServer.Tests/FastTests.cs
@@ -13,6 +13,7 @@ using BTCPayServer.Abstractions.Contracts;
 using BTCPayServer.Abstractions.Extensions;
 using BTCPayServer.Controllers;
 using BTCPayServer.Plugins;
+using BTCPayServer.Plugins.NFC;
 using BTCPayServer.Client;
 using BTCPayServer.Client.Models;
 using BTCPayServer.Configuration;
@@ -51,6 +52,21 @@ namespace BTCPayServer.Tests
         public FastTests(ITestOutputHelper helper) : base(helper)
         {
         }
+
+        [Fact]
+        public void CanDetectSecurePinTransportForLNURLWithdraw()
+        {
+            // LUD-290: the withdraw PIN travels as a plaintext query parameter, so BTCPay may only
+            // forward it over a secure transport: HTTPS, a Tor onion service, or a loopback address
+            // (the latter for regtest/dev/tests).
+            Assert.True(NFCController.IsPinTransportSecure(new Uri("https://withdraw.example.com/callback")));
+            Assert.True(NFCController.IsPinTransportSecure(new Uri("http://127.0.0.1:1234/callback")));
+            Assert.True(NFCController.IsPinTransportSecure(new Uri("http://localhost/callback")));
+            Assert.True(NFCController.IsPinTransportSecure(new Uri("http://3g2upl4pq6kufc4m.onion/callback")));
+            // Plaintext clearnet HTTP would leak the PIN and must be refused.
+            Assert.False(NFCController.IsPinTransportSecure(new Uri("http://withdraw.example.com/callback")));
+        }
+
         class DockerImage
         {
             public string User { get; private set; }

--- a/BTCPayServer.Tests/FastTests.cs
+++ b/BTCPayServer.Tests/FastTests.cs
@@ -56,12 +56,11 @@ namespace BTCPayServer.Tests
         [Fact]
         public void CanDetectSecurePinTransportForLNURLWithdraw()
         {
-            // LUD-290: the withdraw PIN travels as a plaintext query parameter, so BTCPay may only
-            // forward it over a secure transport: HTTPS, a Tor onion service, or a loopback address
-            // (the latter for regtest/dev/tests).
+            // LUD-290: the PIN is a plaintext query param, so only forward it over https, onion, or a local network.
             Assert.True(NFCController.IsPinTransportSecure(new Uri("https://withdraw.example.com/callback")));
             Assert.True(NFCController.IsPinTransportSecure(new Uri("http://127.0.0.1:1234/callback")));
             Assert.True(NFCController.IsPinTransportSecure(new Uri("http://localhost/callback")));
+            Assert.True(NFCController.IsPinTransportSecure(new Uri("http://192.168.1.5/callback")));
             Assert.True(NFCController.IsPinTransportSecure(new Uri("http://3g2upl4pq6kufc4m.onion/callback")));
             // Plaintext clearnet HTTP would leak the PIN and must be refused.
             Assert.False(NFCController.IsPinTransportSecure(new Uri("http://withdraw.example.com/callback")));

--- a/BTCPayServer.Tests/LNURLWithdrawPinTests.cs
+++ b/BTCPayServer.Tests/LNURLWithdrawPinTests.cs
@@ -1,0 +1,123 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using BTCPayServer.Client.Models;
+using Microsoft.AspNetCore.Http;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace BTCPayServer.Tests;
+
+[Collection(nameof(NonParallelizableCollectionDefinition))]
+public class LNURLWithdrawPinTests(ITestOutputHelper helper) : UnitTestBase(helper)
+{
+    // LUD-290: when a customer pays a checkout invoice with an LNURL-Withdraw that advertises a
+    // `pinLimit`, BTCPay (acting as the wallet) must collect a PIN and forward it on the callback.
+    [Fact]
+    [Trait("Integration", "Integration")]
+    [Trait("Lightning", "Lightning")]
+    public async Task CanUseLNURLWithdrawWithPin()
+    {
+        using var tester = CreateServerTester();
+        tester.ActivateLightning();
+        await tester.StartAsync();
+        var user = tester.NewAccount();
+        user.GrantAccess(true);
+        user.RegisterDerivationScheme("BTC");
+        await user.RegisterLightningNodeAsync("BTC");
+
+        var client = await user.CreateClient();
+        // 1000 sats invoice, so a pinLimit of 500 sats triggers the PIN requirement.
+        var invoice = await client.CreateInvoice(user.StoreId,
+            new CreateInvoiceRequest { Amount = 0.00001m, Currency = "BTC" });
+
+        using var fakeServer = new FakeServer();
+        await fakeServer.Start();
+        var lnurl = LNURL.LNURL.EncodeBech32(fakeServer.ServerUri);
+        var callback = new Uri(fakeServer.ServerUri, "cb");
+        var httpClient = tester.PayTester.HttpClient;
+
+        Task<HttpResponseMessage> Submit(object payload) =>
+            httpClient.PostAsync("plugins/NFC/SubmitLNURLWithdrawForInvoice",
+                new StringContent(JsonConvert.SerializeObject(payload), Encoding.UTF8, "application/json"));
+
+        async Task<HttpContext> NextRequest()
+        {
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(60));
+            return await fakeServer.GetNextRequest(cts.Token);
+        }
+
+        static async Task Respond(HttpContext ctx, JObject body)
+        {
+            ctx.Response.StatusCode = 200;
+            ctx.Response.ContentType = "application/json";
+            await ctx.Response.WriteAsync(body.ToString());
+        }
+
+        JObject WithdrawRequest(string k1, long pinLimit) => new()
+        {
+            ["tag"] = "withdrawRequest",
+            ["callback"] = callback.ToString(),
+            ["k1"] = k1,
+            ["defaultDescription"] = "PIN withdraw test",
+            ["minWithdrawable"] = 1,
+            ["maxWithdrawable"] = 100_000_000,
+            ["pinLimit"] = pinLimit
+        };
+
+        // --- Amount (1000 sats) is at/above the pinLimit (500 sats): a PIN must be requested,
+        //     and the callback must NOT be contacted yet.
+        var initiate = Submit(new { lnurl, invoiceId = invoice.Id });
+        var withdrawFetch = await NextRequest();
+        await Respond(withdrawFetch, WithdrawRequest("k1-pin", 500_000));
+        fakeServer.Done();
+
+        var initiateResponse = await initiate;
+        Assert.Equal(HttpStatusCode.OK, initiateResponse.StatusCode);
+        var initiateBody = JObject.Parse(await initiateResponse.Content.ReadAsStringAsync());
+        Assert.True(initiateBody["requiresPin"].Value<bool>());
+        var token = initiateBody["token"].Value<string>();
+        Assert.False(string.IsNullOrEmpty(token));
+
+        // --- A wrong PIN is forwarded, rejected, and the session is kept so the customer can retry.
+        var wrongAttempt = Submit(new { invoiceId = invoice.Id, token, pin = "0000" });
+        var wrongCallback = await NextRequest();
+        Assert.Equal("0000", wrongCallback.Request.Query["pin"].ToString());
+        Assert.False(string.IsNullOrEmpty(wrongCallback.Request.Query["pr"].ToString()));
+        await Respond(wrongCallback, new JObject { ["status"] = "ERROR", ["reason"] = "Invalid PIN" });
+        fakeServer.Done();
+
+        var wrongResponse = await wrongAttempt;
+        Assert.Equal(HttpStatusCode.BadRequest, wrongResponse.StatusCode);
+        Assert.Contains("Invalid PIN", await wrongResponse.Content.ReadAsStringAsync());
+
+        // --- Retrying with the correct PIN (same token/session, same k1) succeeds.
+        var rightAttempt = Submit(new { invoiceId = invoice.Id, token, pin = "1234" });
+        var rightCallback = await NextRequest();
+        Assert.Equal("1234", rightCallback.Request.Query["pin"].ToString());
+        await Respond(rightCallback, new JObject { ["status"] = "OK" });
+        fakeServer.Done();
+
+        var rightResponse = await rightAttempt;
+        Assert.Equal(HttpStatusCode.OK, rightResponse.StatusCode);
+
+        // --- When the amount is below the pinLimit, behaviour is unchanged: no PIN, the callback is
+        //     contacted straight away with no `pin` parameter.
+        var noPin = Submit(new { lnurl, invoiceId = invoice.Id });
+        var noPinFetch = await NextRequest();
+        await Respond(noPinFetch, WithdrawRequest("k1-nopin", 100_000_000));
+        fakeServer.Done();
+
+        var noPinCallback = await NextRequest();
+        Assert.True(string.IsNullOrEmpty(noPinCallback.Request.Query["pin"].ToString()));
+        await Respond(noPinCallback, new JObject { ["status"] = "OK" });
+        fakeServer.Done();
+
+        var noPinResponse = await noPin;
+        Assert.Equal(HttpStatusCode.OK, noPinResponse.StatusCode);
+    }
+}

--- a/BTCPayServer.Tests/LNURLWithdrawPinTests.cs
+++ b/BTCPayServer.Tests/LNURLWithdrawPinTests.cs
@@ -21,8 +21,7 @@ namespace BTCPayServer.Tests;
 [Collection(nameof(NonParallelizableCollectionDefinition))]
 public class LNURLWithdrawPinTests(ITestOutputHelper helper) : UnitTestBase(helper)
 {
-    // LUD-290: when a customer pays a checkout invoice with an LNURL-Withdraw that advertises a
-    // `pinLimit`, BTCPay (acting as the wallet) must collect a PIN and forward it on the callback.
+    // LUD-290: paying a checkout invoice with a pinLimit LNURL-Withdraw prompts for a PIN and forwards it.
     [Fact]
     [Trait("Integration", "Integration")]
     [Trait("Lightning", "Lightning")]
@@ -45,8 +44,7 @@ public class LNURLWithdrawPinTests(ITestOutputHelper helper) : UnitTestBase(help
         var lnurl = LNURL.LNURL.EncodeBech32(withdrawService.ServerUri);
         var httpClient = tester.PayTester.HttpClient;
 
-        // The NFC controller is routed at [Route("plugins/NFC")] with a single (template-less) action,
-        // so the endpoint is "plugins/NFC" itself - the same URL the checkout gets from Url.Action.
+        // NFCController is routed at "plugins/NFC" (single template-less action).
         async Task<(HttpStatusCode Status, string Body)> Submit(object payload)
         {
             var response = await httpClient.PostAsync("plugins/NFC",
@@ -54,8 +52,7 @@ public class LNURLWithdrawPinTests(ITestOutputHelper helper) : UnitTestBase(help
             return (response.StatusCode, await response.Content.ReadAsStringAsync());
         }
 
-        // --- Amount (1000 sats) is at/above the pinLimit (500 sats): a PIN must be requested, and the
-        //     callback must NOT be contacted yet.
+        // Amount (1000 sats) >= pinLimit (500 sats): PIN required, callback not contacted yet.
         withdrawService.PinLimitMilliSats = 500_000;
         withdrawService.ExpectedPin = "1234";
         var initiate = await Submit(new { lnurl, invoiceId = invoice.Id });
@@ -66,7 +63,7 @@ public class LNURLWithdrawPinTests(ITestOutputHelper helper) : UnitTestBase(help
         Assert.False(string.IsNullOrEmpty(token));
         Assert.Empty(withdrawService.Callbacks);
 
-        // --- A wrong PIN is forwarded, rejected, and the session is kept so the customer can retry.
+        // Wrong PIN is forwarded, rejected, and the session kept for retry.
         var wrong = await Submit(new { invoiceId = invoice.Id, token, pin = "0000" });
         Assert.True(wrong.Status == HttpStatusCode.BadRequest, $"wrong pin: {wrong.Status} {wrong.Body}");
         Assert.Contains("Invalid PIN", wrong.Body);
@@ -74,14 +71,13 @@ public class LNURLWithdrawPinTests(ITestOutputHelper helper) : UnitTestBase(help
         Assert.Equal("0000", wrongCallback.Pin);
         Assert.False(string.IsNullOrEmpty(wrongCallback.Pr));
 
-        // --- Retrying with the correct PIN (same token/session, same k1) succeeds.
+        // Correct PIN on the same session/k1 succeeds.
         var right = await Submit(new { invoiceId = invoice.Id, token, pin = "1234" });
         Assert.True(right.Status == HttpStatusCode.OK, $"right pin: {right.Status} {right.Body}");
         Assert.True(withdrawService.Callbacks.TryDequeue(out var rightCallback));
         Assert.Equal("1234", rightCallback.Pin);
 
-        // --- When the amount is below the pinLimit, behaviour is unchanged: no PIN, the callback is
-        //     contacted straight away with no `pin` parameter.
+        // Amount below pinLimit: no PIN, callback contacted directly with no pin.
         withdrawService.PinLimitMilliSats = 100_000_000; // 100k sats, above the 1000 sat amount
         withdrawService.ExpectedPin = null;
         var noPin = await Submit(new { lnurl, invoiceId = invoice.Id });
@@ -90,8 +86,7 @@ public class LNURLWithdrawPinTests(ITestOutputHelper helper) : UnitTestBase(help
         Assert.True(string.IsNullOrEmpty(noPinCallback.Pin));
     }
 
-    // Minimal external LNURL-Withdraw service: serves a withdrawRequest (optionally advertising a
-    // pinLimit) and records the callback it receives so the test can assert the forwarded PIN.
+    // Minimal withdraw service: serves a withdrawRequest (optional pinLimit) and records callbacks.
     private class FakeWithdrawService : IDisposable
     {
         private readonly IHost _host;

--- a/BTCPayServer.Tests/LNURLWithdrawPinTests.cs
+++ b/BTCPayServer.Tests/LNURLWithdrawPinTests.cs
@@ -1,11 +1,17 @@
 using System;
+using System.Collections.Concurrent;
+using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Text;
-using System.Threading;
 using System.Threading.Tasks;
 using BTCPayServer.Client.Models;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Hosting.Server.Features;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Xunit;
@@ -35,89 +41,108 @@ public class LNURLWithdrawPinTests(ITestOutputHelper helper) : UnitTestBase(help
         var invoice = await client.CreateInvoice(user.StoreId,
             new CreateInvoiceRequest { Amount = 0.00001m, Currency = "BTC" });
 
-        using var fakeServer = new FakeServer();
-        await fakeServer.Start();
-        var lnurl = LNURL.LNURL.EncodeBech32(fakeServer.ServerUri);
-        var callback = new Uri(fakeServer.ServerUri, "cb");
+        using var withdrawService = new FakeWithdrawService();
+        var lnurl = LNURL.LNURL.EncodeBech32(withdrawService.ServerUri);
         var httpClient = tester.PayTester.HttpClient;
 
-        Task<HttpResponseMessage> Submit(object payload) =>
-            httpClient.PostAsync("plugins/NFC/SubmitLNURLWithdrawForInvoice",
+        async Task<(HttpStatusCode Status, string Body)> Submit(object payload)
+        {
+            var response = await httpClient.PostAsync("plugins/NFC/SubmitLNURLWithdrawForInvoice",
                 new StringContent(JsonConvert.SerializeObject(payload), Encoding.UTF8, "application/json"));
-
-        async Task<HttpContext> NextRequest()
-        {
-            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(60));
-            return await fakeServer.GetNextRequest(cts.Token);
+            return (response.StatusCode, await response.Content.ReadAsStringAsync());
         }
 
-        static async Task Respond(HttpContext ctx, JObject body)
-        {
-            ctx.Response.StatusCode = 200;
-            ctx.Response.ContentType = "application/json";
-            await ctx.Response.WriteAsync(body.ToString());
-        }
-
-        JObject WithdrawRequest(string k1, long pinLimit) => new()
-        {
-            ["tag"] = "withdrawRequest",
-            ["callback"] = callback.ToString(),
-            ["k1"] = k1,
-            ["defaultDescription"] = "PIN withdraw test",
-            ["minWithdrawable"] = 1,
-            ["maxWithdrawable"] = 100_000_000,
-            ["pinLimit"] = pinLimit
-        };
-
-        // --- Amount (1000 sats) is at/above the pinLimit (500 sats): a PIN must be requested,
-        //     and the callback must NOT be contacted yet.
-        var initiate = Submit(new { lnurl, invoiceId = invoice.Id });
-        var withdrawFetch = await NextRequest();
-        await Respond(withdrawFetch, WithdrawRequest("k1-pin", 500_000));
-        fakeServer.Done();
-
-        var initiateResponse = await initiate;
-        Assert.Equal(HttpStatusCode.OK, initiateResponse.StatusCode);
-        var initiateBody = JObject.Parse(await initiateResponse.Content.ReadAsStringAsync());
-        Assert.True(initiateBody["requiresPin"].Value<bool>());
-        var token = initiateBody["token"].Value<string>();
+        // --- Amount (1000 sats) is at/above the pinLimit (500 sats): a PIN must be requested, and the
+        //     callback must NOT be contacted yet.
+        withdrawService.PinLimitMilliSats = 500_000;
+        withdrawService.ExpectedPin = "1234";
+        var initiate = await Submit(new { lnurl, invoiceId = invoice.Id });
+        Assert.True(initiate.Status == HttpStatusCode.OK, $"initiate: {initiate.Status} {initiate.Body}");
+        var initiateBody = JObject.Parse(initiate.Body);
+        Assert.True(initiateBody["requiresPin"]?.Value<bool>() == true, initiate.Body);
+        var token = initiateBody["token"]?.Value<string>();
         Assert.False(string.IsNullOrEmpty(token));
+        Assert.Empty(withdrawService.Callbacks);
 
         // --- A wrong PIN is forwarded, rejected, and the session is kept so the customer can retry.
-        var wrongAttempt = Submit(new { invoiceId = invoice.Id, token, pin = "0000" });
-        var wrongCallback = await NextRequest();
-        Assert.Equal("0000", wrongCallback.Request.Query["pin"].ToString());
-        Assert.False(string.IsNullOrEmpty(wrongCallback.Request.Query["pr"].ToString()));
-        await Respond(wrongCallback, new JObject { ["status"] = "ERROR", ["reason"] = "Invalid PIN" });
-        fakeServer.Done();
-
-        var wrongResponse = await wrongAttempt;
-        Assert.Equal(HttpStatusCode.BadRequest, wrongResponse.StatusCode);
-        Assert.Contains("Invalid PIN", await wrongResponse.Content.ReadAsStringAsync());
+        var wrong = await Submit(new { invoiceId = invoice.Id, token, pin = "0000" });
+        Assert.True(wrong.Status == HttpStatusCode.BadRequest, $"wrong pin: {wrong.Status} {wrong.Body}");
+        Assert.Contains("Invalid PIN", wrong.Body);
+        Assert.True(withdrawService.Callbacks.TryDequeue(out var wrongCallback));
+        Assert.Equal("0000", wrongCallback.Pin);
+        Assert.False(string.IsNullOrEmpty(wrongCallback.Pr));
 
         // --- Retrying with the correct PIN (same token/session, same k1) succeeds.
-        var rightAttempt = Submit(new { invoiceId = invoice.Id, token, pin = "1234" });
-        var rightCallback = await NextRequest();
-        Assert.Equal("1234", rightCallback.Request.Query["pin"].ToString());
-        await Respond(rightCallback, new JObject { ["status"] = "OK" });
-        fakeServer.Done();
-
-        var rightResponse = await rightAttempt;
-        Assert.Equal(HttpStatusCode.OK, rightResponse.StatusCode);
+        var right = await Submit(new { invoiceId = invoice.Id, token, pin = "1234" });
+        Assert.True(right.Status == HttpStatusCode.OK, $"right pin: {right.Status} {right.Body}");
+        Assert.True(withdrawService.Callbacks.TryDequeue(out var rightCallback));
+        Assert.Equal("1234", rightCallback.Pin);
 
         // --- When the amount is below the pinLimit, behaviour is unchanged: no PIN, the callback is
         //     contacted straight away with no `pin` parameter.
-        var noPin = Submit(new { lnurl, invoiceId = invoice.Id });
-        var noPinFetch = await NextRequest();
-        await Respond(noPinFetch, WithdrawRequest("k1-nopin", 100_000_000));
-        fakeServer.Done();
+        withdrawService.PinLimitMilliSats = 100_000_000; // 100k sats, above the 1000 sat amount
+        withdrawService.ExpectedPin = null;
+        var noPin = await Submit(new { lnurl, invoiceId = invoice.Id });
+        Assert.True(noPin.Status == HttpStatusCode.OK, $"no pin: {noPin.Status} {noPin.Body}");
+        Assert.True(withdrawService.Callbacks.TryDequeue(out var noPinCallback));
+        Assert.True(string.IsNullOrEmpty(noPinCallback.Pin));
+    }
 
-        var noPinCallback = await NextRequest();
-        Assert.True(string.IsNullOrEmpty(noPinCallback.Request.Query["pin"].ToString()));
-        await Respond(noPinCallback, new JObject { ["status"] = "OK" });
-        fakeServer.Done();
+    // Minimal external LNURL-Withdraw service: serves a withdrawRequest (optionally advertising a
+    // pinLimit) and records the callback it receives so the test can assert the forwarded PIN.
+    private class FakeWithdrawService : IDisposable
+    {
+        private readonly IHost _host;
 
-        var noPinResponse = await noPin;
-        Assert.Equal(HttpStatusCode.OK, noPinResponse.StatusCode);
+        public FakeWithdrawService()
+        {
+            _host = Host.CreateDefaultBuilder()
+                .ConfigureLogging(l => l.ClearProviders())
+                .ConfigureWebHostDefaults(web => web
+                    .UseKestrel()
+                    .UseUrls("http://127.0.0.1:0")
+                    .Configure(app => app.Run(Handle)))
+                .Build();
+            _host.Start();
+            ServerUri = new Uri(_host.GetServerFeatures<IServerAddressesFeature>().Addresses.First());
+        }
+
+        public Uri ServerUri { get; }
+        public long? PinLimitMilliSats { get; set; }
+        public string ExpectedPin { get; set; }
+        public ConcurrentQueue<(string Pin, string Pr)> Callbacks { get; } = new();
+
+        private async Task Handle(HttpContext ctx)
+        {
+            ctx.Response.ContentType = "application/json";
+            var pr = ctx.Request.Query["pr"].ToString();
+            if (string.IsNullOrEmpty(pr))
+            {
+                var withdrawRequest = new JObject
+                {
+                    ["tag"] = "withdrawRequest",
+                    ["callback"] = new Uri(ServerUri, "cb").ToString(),
+                    ["k1"] = "test-k1",
+                    ["defaultDescription"] = "PIN withdraw test",
+                    ["minWithdrawable"] = 1,
+                    ["maxWithdrawable"] = 100_000_000
+                };
+                if (PinLimitMilliSats is not null)
+                    withdrawRequest["pinLimit"] = PinLimitMilliSats.Value;
+                await ctx.Response.WriteAsync(withdrawRequest.ToString());
+            }
+            else
+            {
+                var pin = ctx.Request.Query["pin"].ToString();
+                Callbacks.Enqueue((pin, pr));
+                var ok = ExpectedPin is null || pin == ExpectedPin;
+                var result = ok
+                    ? new JObject { ["status"] = "OK" }
+                    : new JObject { ["status"] = "ERROR", ["reason"] = "Invalid PIN" };
+                await ctx.Response.WriteAsync(result.ToString());
+            }
+        }
+
+        public void Dispose() => _host.Dispose();
     }
 }

--- a/BTCPayServer.Tests/LNURLWithdrawPinTests.cs
+++ b/BTCPayServer.Tests/LNURLWithdrawPinTests.cs
@@ -45,9 +45,11 @@ public class LNURLWithdrawPinTests(ITestOutputHelper helper) : UnitTestBase(help
         var lnurl = LNURL.LNURL.EncodeBech32(withdrawService.ServerUri);
         var httpClient = tester.PayTester.HttpClient;
 
+        // The NFC controller is routed at [Route("plugins/NFC")] with a single (template-less) action,
+        // so the endpoint is "plugins/NFC" itself - the same URL the checkout gets from Url.Action.
         async Task<(HttpStatusCode Status, string Body)> Submit(object payload)
         {
-            var response = await httpClient.PostAsync("plugins/NFC/SubmitLNURLWithdrawForInvoice",
+            var response = await httpClient.PostAsync("plugins/NFC",
                 new StringContent(JsonConvert.SerializeObject(payload), Encoding.UTF8, "application/json"));
             return (response.StatusCode, await response.Content.ReadAsStringAsync());
         }

--- a/BTCPayServer.Tests/LNURLWithdrawPinTests.cs
+++ b/BTCPayServer.Tests/LNURLWithdrawPinTests.cs
@@ -84,6 +84,20 @@ public class LNURLWithdrawPinTests(ITestOutputHelper helper) : UnitTestBase(help
         Assert.True((int)noPin.Status is >= 200 and < 300, $"no pin: {noPin.Status} {noPin.Body}");
         Assert.True(withdrawService.Callbacks.TryDequeue(out var noPinCallback));
         Assert.True(string.IsNullOrEmpty(noPinCallback.Pin));
+
+        // Three wrong PINs exhaust the cap; the session is then dropped and no longer usable.
+        withdrawService.PinLimitMilliSats = 500_000;
+        withdrawService.ExpectedPin = "1234";
+        var blocked = await Submit(new { lnurl, invoiceId = invoice.Id });
+        var blockedToken = JObject.Parse(blocked.Body)["token"]?.Value<string>();
+        Assert.False(string.IsNullOrEmpty(blockedToken));
+        for (var attempt = 0; attempt < 3; attempt++)
+        {
+            var bad = await Submit(new { invoiceId = invoice.Id, token = blockedToken, pin = "0000" });
+            Assert.Equal(HttpStatusCode.BadRequest, bad.Status);
+        }
+        var afterBlock = await Submit(new { invoiceId = invoice.Id, token = blockedToken, pin = "1234" });
+        Assert.Equal(HttpStatusCode.BadRequest, afterBlock.Status);
     }
 
     // Minimal withdraw service: serves a withdrawRequest (optional pinLimit) and records callbacks.

--- a/BTCPayServer.Tests/LNURLWithdrawPinTests.cs
+++ b/BTCPayServer.Tests/LNURLWithdrawPinTests.cs
@@ -71,9 +71,9 @@ public class LNURLWithdrawPinTests(ITestOutputHelper helper) : UnitTestBase(help
         Assert.Equal("0000", wrongCallback.Pin);
         Assert.False(string.IsNullOrEmpty(wrongCallback.Pr));
 
-        // Correct PIN on the same session/k1 succeeds.
+        // Correct PIN on the same session/k1 succeeds (2xx; a reasonless OK maps to 204).
         var right = await Submit(new { invoiceId = invoice.Id, token, pin = "1234" });
-        Assert.True(right.Status == HttpStatusCode.OK, $"right pin: {right.Status} {right.Body}");
+        Assert.True((int)right.Status is >= 200 and < 300, $"right pin: {right.Status} {right.Body}");
         Assert.True(withdrawService.Callbacks.TryDequeue(out var rightCallback));
         Assert.Equal("1234", rightCallback.Pin);
 
@@ -81,7 +81,7 @@ public class LNURLWithdrawPinTests(ITestOutputHelper helper) : UnitTestBase(help
         withdrawService.PinLimitMilliSats = 100_000_000; // 100k sats, above the 1000 sat amount
         withdrawService.ExpectedPin = null;
         var noPin = await Submit(new { lnurl, invoiceId = invoice.Id });
-        Assert.True(noPin.Status == HttpStatusCode.OK, $"no pin: {noPin.Status} {noPin.Body}");
+        Assert.True((int)noPin.Status is >= 200 and < 300, $"no pin: {noPin.Status} {noPin.Body}");
         Assert.True(withdrawService.Callbacks.TryDequeue(out var noPinCallback));
         Assert.True(string.IsNullOrEmpty(noPinCallback.Pin));
     }

--- a/BTCPayServer/Plugins/NFC/NFCController.cs
+++ b/BTCPayServer/Plugins/NFC/NFCController.cs
@@ -46,12 +46,14 @@ namespace BTCPayServer.Plugins.NFC
             public string InvoiceId { get; set; }
             public long? Amount { get; set; }
 
-            // LUD-290 PIN-protected withdraw: set on the second (completion) call.
+            // LUD-290: set on the PIN completion call.
             public string Pin { get; set; }
             public string Token { get; set; }
         }
 
+        // Public checkout endpoint POSTed via fetch without a token, like the LNURL endpoints.
         [AllowAnonymous]
+        [IgnoreAntiforgeryToken]
         public async Task<IActionResult> SubmitLNURLWithdrawForInvoice([FromBody] SubmitRequest request)
         {
             var invoice = await _invoiceRepository.GetInvoice(request.InvoiceId);
@@ -60,8 +62,7 @@ namespace BTCPayServer.Plugins.NFC
                 return NotFound();
             }
 
-            // LUD-290: the customer has entered a PIN for a withdraw we already resolved and stashed.
-            // Complete it using the stored session (single fetch of the withdrawRequest, reused k1).
+            // LUD-290: complete a PIN-protected withdraw from the stashed session.
             if (!string.IsNullOrEmpty(request.Token))
             {
                 return await CompletePinProtectedWithdraw(request, invoice);
@@ -196,9 +197,8 @@ namespace BTCPayServer.Plugins.NFC
                 return BadRequest("Could not fetch BOLT11 invoice to pay to.");
             }
 
-            // LUD-290: if the withdraw service asks for a PIN at this amount, don't contact the callback
-            // yet. Stash the already-fetched request (so we reuse the same single-use k1) and ask the
-            // browser for the PIN; the callback is only hit once the customer submits it.
+            // LUD-290: PIN required - stash the fetched request (reusing its single-use k1) and ask
+            // the browser for a PIN instead of calling the callback now.
             if (info.PinLimit is not null && withdrawAmount is not null &&
                 withdrawAmount.MilliSatoshi >= info.PinLimit.MilliSatoshi)
             {
@@ -263,8 +263,7 @@ namespace BTCPayServer.Plugins.NFC
                     return Ok(result.Reason);
                 }
 
-                // Wrong PIN (or other failure): keep the session so the customer can retry against the
-                // same withdraw link/k1, until the service blocks the card or the attempts run out.
+                // Keep the session so the customer can retry, until blocked or out of attempts.
                 session.AttemptsLeft--;
                 var reason = result.Reason ?? "Unknown error";
                 if (session.AttemptsLeft <= 0 || reason.Contains("blocked", StringComparison.OrdinalIgnoreCase))
@@ -280,8 +279,7 @@ namespace BTCPayServer.Plugins.NFC
             }
         }
 
-        // LUD-290 sends the PIN as a plaintext query parameter, so it may only be forwarded over a
-        // secure transport: HTTPS, a Tor onion service (encrypted), or a loopback address (dev/tests).
+        // The PIN is a plaintext query param, so only forward it over https, onion, or loopback.
         internal static bool IsPinTransportSecure(Uri callback)
         {
             return callback.Scheme == Uri.UriSchemeHttps || callback.IsOnion() || callback.IsLoopback;
@@ -296,8 +294,7 @@ namespace BTCPayServer.Plugins.NFC
                 : LightningLikePayoutHandler.LightningLikePayoutHandlerClearnetNamedClient);
         }
 
-        // Server-side session for a PIN-protected (LUD-290) withdraw. Held only in IMemoryCache so the
-        // single-use withdrawRequest (and its k1) is fetched exactly once and reused across PIN attempts.
+        // Ephemeral session so the single-use withdrawRequest/k1 is fetched once, reused across attempts.
         private class PinWithdrawSession
         {
             public PinWithdrawSession(LNURLWithdrawRequest info, string bolt11, string invoiceId, int attemptsLeft)

--- a/BTCPayServer/Plugins/NFC/NFCController.cs
+++ b/BTCPayServer/Plugins/NFC/NFCController.cs
@@ -255,35 +255,37 @@ namespace BTCPayServer.Plugins.NFC
                 return BadRequest("Card blocked: too many incorrect PIN attempts");
             }
 
+            LNUrlStatusResponse result;
             try
             {
                 var httpClient = CreateHttpClient(session.Info.Callback);
-                var result = await session.Info.SendRequest(session.Bolt11, httpClient, request.Pin, null);
-                if (!string.IsNullOrEmpty(result.Status) && result.Status.Equals("ok", StringComparison.InvariantCultureIgnoreCase))
-                {
-                    _memoryCache.Remove(PinSessionCacheKey(request.Token));
-                    return Ok(result.Reason);
-                }
-
-                // Keep the session so the customer can retry, until blocked or out of attempts.
-                var reason = result.Reason ?? "Unknown error";
-                if (session.AttemptsLeft <= 0 || reason.Contains("blocked", StringComparison.OrdinalIgnoreCase))
-                {
-                    _memoryCache.Remove(PinSessionCacheKey(request.Token));
-                }
-
-                return BadRequest(reason);
+                result = await session.Info.SendRequest(session.Bolt11, httpClient, request.Pin, null);
             }
             catch (Exception ex)
             {
                 return BadRequest(ex.Message);
             }
+
+            if (!string.IsNullOrEmpty(result.Status) && result.Status.Equals("ok", StringComparison.InvariantCultureIgnoreCase))
+            {
+                _memoryCache.Remove(PinSessionCacheKey(request.Token));
+                return Ok(result.Reason);
+            }
+
+            // Keep the session so the customer can retry, until blocked or out of attempts.
+            var reason = result.Reason ?? "Unknown error";
+            if (session.AttemptsLeft <= 0 || reason.Contains("blocked", StringComparison.OrdinalIgnoreCase))
+            {
+                _memoryCache.Remove(PinSessionCacheKey(request.Token));
+            }
+
+            return BadRequest(reason);
         }
 
-        // The PIN is a plaintext query param, so only forward it over https, onion, or loopback.
+        // The PIN is a plaintext query param, so only forward it over https, onion, or a local network.
         internal static bool IsPinTransportSecure(Uri callback)
         {
-            return callback.Scheme == Uri.UriSchemeHttps || callback.IsOnion() || callback.IsLoopback;
+            return callback.Scheme == Uri.UriSchemeHttps || callback.IsOnion() || Extensions.IsLocalNetwork(callback.DnsSafeHost);
         }
 
         private static string PinSessionCacheKey(string token) => $"NFC_LNURLW_PIN_{token}";

--- a/BTCPayServer/Plugins/NFC/NFCController.cs
+++ b/BTCPayServer/Plugins/NFC/NFCController.cs
@@ -12,6 +12,7 @@ using BTCPayServer.Services.Stores;
 using LNURL;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Caching.Memory;
 using NBitcoin;
 using Newtonsoft.Json.Linq;
 
@@ -24,16 +25,19 @@ namespace BTCPayServer.Plugins.NFC
         private readonly InvoiceRepository _invoiceRepository;
         private readonly InvoiceActivator _invoiceActivator;
         private readonly StoreRepository _storeRepository;
+        private readonly IMemoryCache _memoryCache;
 
         public NFCController(IHttpClientFactory httpClientFactory,
             InvoiceRepository invoiceRepository,
             InvoiceActivator invoiceActivator,
-            StoreRepository storeRepository)
+            StoreRepository storeRepository,
+            IMemoryCache memoryCache)
         {
             _httpClientFactory = httpClientFactory;
             _invoiceRepository = invoiceRepository;
             _invoiceActivator = invoiceActivator;
             _storeRepository = storeRepository;
+            _memoryCache = memoryCache;
         }
 
         public class SubmitRequest
@@ -41,6 +45,10 @@ namespace BTCPayServer.Plugins.NFC
             public string Lnurl { get; set; }
             public string InvoiceId { get; set; }
             public long? Amount { get; set; }
+
+            // LUD-290 PIN-protected withdraw: set on the second (completion) call.
+            public string Pin { get; set; }
+            public string Token { get; set; }
         }
 
         [AllowAnonymous]
@@ -50,6 +58,13 @@ namespace BTCPayServer.Plugins.NFC
             if (invoice?.Status is not InvoiceStatus.New)
             {
                 return NotFound();
+            }
+
+            // LUD-290: the customer has entered a PIN for a withdraw we already resolved and stashed.
+            // Complete it using the stored session (single fetch of the withdrawRequest, reused k1).
+            if (!string.IsNullOrEmpty(request.Token))
+            {
+                return await CompletePinProtectedWithdraw(request, invoice);
             }
 
             var methods = invoice.GetPaymentPrompts();
@@ -98,6 +113,7 @@ namespace BTCPayServer.Plugins.NFC
             }
 
             string bolt11 = null;
+            LightMoney withdrawAmount = null;
             if (lnPaymentMethod is not null)
             {
                 if (!lnPaymentMethod.Activated)
@@ -123,6 +139,7 @@ namespace BTCPayServer.Plugins.NFC
                     return BadRequest("Invoice amount is not payable with the LNURL allowed amounts.");
                 }
 
+                withdrawAmount = due;
                 if (lnPaymentMethod.Activated)
                 {
                     bolt11 = lnPaymentMethod.Destination;
@@ -149,6 +166,7 @@ namespace BTCPayServer.Plugins.NFC
                 {
                     httpClient = CreateHttpClient(info.Callback);
                     var amount = LightMoney.Coins(due);
+                    withdrawAmount = amount;
                     var actionPath = Url.Action(nameof(UILNURLController.GetLNURLForInvoice), "UILNURL",
                         new { invoiceId = request.InvoiceId, cryptoCode = "BTC", amount = amount.MilliSatoshi });
                     var url = Request.GetAbsoluteUri(actionPath);
@@ -178,6 +196,24 @@ namespace BTCPayServer.Plugins.NFC
                 return BadRequest("Could not fetch BOLT11 invoice to pay to.");
             }
 
+            // LUD-290: if the withdraw service asks for a PIN at this amount, don't contact the callback
+            // yet. Stash the already-fetched request (so we reuse the same single-use k1) and ask the
+            // browser for the PIN; the callback is only hit once the customer submits it.
+            if (info.PinLimit is not null && withdrawAmount is not null &&
+                withdrawAmount.MilliSatoshi >= info.PinLimit.MilliSatoshi)
+            {
+                if (!IsPinTransportSecure(info.Callback))
+                {
+                    return BadRequest("This LNURL-Withdraw requires a PIN, but its callback does not use a secure (HTTPS) connection.");
+                }
+
+                var token = Convert.ToHexString(RandomUtils.GetBytes(32));
+                _memoryCache.Set(PinSessionCacheKey(token),
+                    new PinWithdrawSession(info, bolt11, invoice.Id, 3),
+                    new MemoryCacheEntryOptions { AbsoluteExpirationRelativeToNow = TimeSpan.FromMinutes(2) });
+                return Ok(new { requiresPin = true, token, amountSats = withdrawAmount.MilliSatoshi / 1000m });
+            }
+
             try
             {
                 var result = await info.SendRequest(bolt11, httpClient, null, null);
@@ -194,11 +230,88 @@ namespace BTCPayServer.Plugins.NFC
             }
         }
 
+        private async Task<IActionResult> CompletePinProtectedWithdraw(SubmitRequest request, InvoiceEntity invoice)
+        {
+            if (!_memoryCache.TryGetValue(PinSessionCacheKey(request.Token), out PinWithdrawSession session) || session is null)
+            {
+                return BadRequest("The PIN session has expired. Please tap your card again.");
+            }
+
+            if (!string.Equals(session.InvoiceId, invoice.Id, StringComparison.Ordinal))
+            {
+                return BadRequest("The PIN session does not match this invoice.");
+            }
+
+            if (string.IsNullOrEmpty(request.Pin))
+            {
+                return BadRequest("A PIN is required to complete this withdraw.");
+            }
+
+            if (session.AttemptsLeft <= 0)
+            {
+                _memoryCache.Remove(PinSessionCacheKey(request.Token));
+                return BadRequest("Card blocked: too many incorrect PIN attempts");
+            }
+
+            try
+            {
+                var httpClient = CreateHttpClient(session.Info.Callback);
+                var result = await session.Info.SendRequest(session.Bolt11, httpClient, request.Pin, null);
+                if (!string.IsNullOrEmpty(result.Status) && result.Status.Equals("ok", StringComparison.InvariantCultureIgnoreCase))
+                {
+                    _memoryCache.Remove(PinSessionCacheKey(request.Token));
+                    return Ok(result.Reason);
+                }
+
+                // Wrong PIN (or other failure): keep the session so the customer can retry against the
+                // same withdraw link/k1, until the service blocks the card or the attempts run out.
+                session.AttemptsLeft--;
+                var reason = result.Reason ?? "Unknown error";
+                if (session.AttemptsLeft <= 0 || reason.Contains("blocked", StringComparison.OrdinalIgnoreCase))
+                {
+                    _memoryCache.Remove(PinSessionCacheKey(request.Token));
+                }
+
+                return BadRequest(reason);
+            }
+            catch (Exception ex)
+            {
+                return BadRequest(ex.Message);
+            }
+        }
+
+        // LUD-290 sends the PIN as a plaintext query parameter, so it may only be forwarded over a
+        // secure transport: HTTPS, a Tor onion service (encrypted), or a loopback address (dev/tests).
+        internal static bool IsPinTransportSecure(Uri callback)
+        {
+            return callback.Scheme == Uri.UriSchemeHttps || callback.IsOnion() || callback.IsLoopback;
+        }
+
+        private static string PinSessionCacheKey(string token) => $"NFC_LNURLW_PIN_{token}";
+
         private HttpClient CreateHttpClient(Uri uri)
         {
             return _httpClientFactory.CreateClient(uri.IsOnion()
                 ? LightningLikePayoutHandler.LightningLikePayoutHandlerOnionNamedClient
                 : LightningLikePayoutHandler.LightningLikePayoutHandlerClearnetNamedClient);
+        }
+
+        // Server-side session for a PIN-protected (LUD-290) withdraw. Held only in IMemoryCache so the
+        // single-use withdrawRequest (and its k1) is fetched exactly once and reused across PIN attempts.
+        private class PinWithdrawSession
+        {
+            public PinWithdrawSession(LNURLWithdrawRequest info, string bolt11, string invoiceId, int attemptsLeft)
+            {
+                Info = info;
+                Bolt11 = bolt11;
+                InvoiceId = invoiceId;
+                AttemptsLeft = attemptsLeft;
+            }
+
+            public LNURLWithdrawRequest Info { get; }
+            public string Bolt11 { get; }
+            public string InvoiceId { get; }
+            public int AttemptsLeft { get; set; }
         }
     }
 }

--- a/BTCPayServer/Plugins/NFC/NFCController.cs
+++ b/BTCPayServer/Plugins/NFC/NFCController.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Net.Http;
+using System.Threading;
 using System.Threading.Tasks;
 using BTCPayServer.Abstractions.Extensions;
 using BTCPayServer.Client.Models;
@@ -247,7 +248,8 @@ namespace BTCPayServer.Plugins.NFC
                 return BadRequest("A PIN is required to complete this withdraw.");
             }
 
-            if (session.AttemptsLeft <= 0)
+            // Consume one attempt atomically so concurrent submits can't exceed the cap.
+            if (Interlocked.Decrement(ref session.AttemptsLeft) < 0)
             {
                 _memoryCache.Remove(PinSessionCacheKey(request.Token));
                 return BadRequest("Card blocked: too many incorrect PIN attempts");
@@ -264,7 +266,6 @@ namespace BTCPayServer.Plugins.NFC
                 }
 
                 // Keep the session so the customer can retry, until blocked or out of attempts.
-                session.AttemptsLeft--;
                 var reason = result.Reason ?? "Unknown error";
                 if (session.AttemptsLeft <= 0 || reason.Contains("blocked", StringComparison.OrdinalIgnoreCase))
                 {
@@ -308,7 +309,7 @@ namespace BTCPayServer.Plugins.NFC
             public LNURLWithdrawRequest Info { get; }
             public string Bolt11 { get; }
             public string InvoiceId { get; }
-            public int AttemptsLeft { get; set; }
+            public int AttemptsLeft; // field (not property) for Interlocked
         }
     }
 }

--- a/BTCPayServer/Plugins/NFC/Views/CheckoutEnd.cshtml
+++ b/BTCPayServer/Plugins/NFC/Views/CheckoutEnd.cshtml
@@ -2,17 +2,17 @@
     <div v-if="display" class="mt-4" id="NFC">
         <div v-if="nfcErrorMessage" class="alert alert-danger" v-text="nfcErrorMessage"></div>
         <div v-if="nfcWarningMessage" class="alert alert-warning" v-text="nfcWarningMessage"></div>
-        <div v-if="pinRequired" id="NFC-Pin">
-            <div v-if="pinError" class="alert alert-danger" v-text="pinError"></div>
+        <div v-if="pin.required" id="NFC-Pin">
+            <div v-if="pin.error" class="alert alert-danger" v-text="pin.error"></div>
             <label class="form-label" for="NFC-Pin-Input" v-text="pinPromptText"></label>
             <input id="NFC-Pin-Input" class="form-control form-control-lg text-center" type="text" inputmode="numeric"
-                   maxlength="4" pattern="[0-9]{4}" autocomplete="off" v-model="pin"
-                   :disabled="pinSubmitting" v-on:keyup.enter="submitPin" />
+                   maxlength="4" pattern="[0-9]{4}" autocomplete="off" v-model="pin.value"
+                   :disabled="pin.submitting" v-on:keyup.enter="submitPin" />
             <div class="d-flex gap-2 mt-3">
                 <button class="btn btn-secondary rounded-pill flex-grow-1" type="button" id="NFC-Pin-Cancel"
-                        :disabled="pinSubmitting" v-on:click="cancelPin">Cancel</button>
+                        :disabled="pin.submitting" v-on:click="cancelPin">Cancel</button>
                 <button class="btn btn-primary rounded-pill flex-grow-1" type="button" id="NFC-Pin-Submit"
-                        :disabled="pinSubmitting || !isPinValid" v-on:click="submitPin">Confirm PIN</button>
+                        :disabled="pin.submitting || !isPinValid" v-on:click="submitPin">Confirm PIN</button>
             </div>
         </div>
         <button v-else class="btn btn-secondary rounded-pill w-100" type="button" id="PayByNFC"
@@ -66,10 +66,10 @@ Vue.component("lnurl-withdraw-checkout", {
             }
         },
         isPinValid () {
-            return /^[0-9]{4}$/.test(this.pin)
+            return /^[0-9]{4}$/.test(this.pin.value)
         },
         pinPromptText () {
-            return `Enter the 4-digit PIN to withdraw ${this.pinAmountSats} sats`
+            return `Enter the 4-digit PIN to withdraw ${this.pin.amountSats} sats`
         }
     },
     data () {
@@ -77,12 +77,14 @@ Vue.component("lnurl-withdraw-checkout", {
 				url: @Safe.Json(Url.ActionAbsolute(Context.Request, "SubmitLNURLWithdrawForInvoice", "NFC").ToString()),
             amount: 0,
             submitting: false,
-            pinRequired: false,
-            pinToken: null,
-            pinAmountSats: 0,
-            pin: '',
-            pinError: null,
-            pinSubmitting: false
+            pin: {
+                required: false,
+                token: null,
+                amountSats: 0,
+                value: '',
+                error: null,
+                submitting: false
+            }
         }
     },
     beforeMount () {
@@ -162,42 +164,42 @@ Vue.component("lnurl-withdraw-checkout", {
             return text
         },
         startPinEntry (data) {
-            this.pinRequired = true
-            this.pinToken = data.token
-            this.pinAmountSats = data.amountSats
-            this.pin = ''
-            this.pinError = null
+            this.pin.required = true
+            this.pin.token = data.token
+            this.pin.amountSats = data.amountSats
+            this.pin.value = ''
+            this.pin.error = null
         },
         cancelPin () {
-            this.pinRequired = false
-            this.pinToken = null
-            this.pin = ''
-            this.pinError = null
+            this.pin.required = false
+            this.pin.token = null
+            this.pin.value = ''
+            this.pin.error = null
         },
         async submitPin () {
-            if (!this.isPinValid || this.pinSubmitting) {
+            if (!this.isPinValid || this.pin.submitting) {
                 return
             }
-            this.pinSubmitting = true
-            this.pinError = null
+            this.pin.submitting = true
+            this.pin.error = null
 
-            const body = JSON.stringify({ invoiceId: this.model.invoiceId, token: this.pinToken, pin: this.pin })
+            const body = JSON.stringify({ invoiceId: this.model.invoiceId, token: this.pin.token, pin: this.pin.value })
             const opts = { method: 'POST', headers: { 'Content-Type': 'application/json' }, body }
             try {
                 const response = await fetch(this.url, opts)
                 const result = await response.text()
                 if (response.ok) {
-                    this.pinRequired = false
-                    this.pin = ''
+                    this.pin.required = false
+                    this.pin.value = ''
                     this.$emit('handle-nfc-result', result)
                 } else {
-                    this.pin = ''
-                    this.pinError = this.parseReason(result) || 'Invalid PIN'
+                    this.pin.value = ''
+                    this.pin.error = this.parseReason(result) || 'Invalid PIN'
                 }
             } catch (error) {
-                this.pinError = `${error}`
+                this.pin.error = `${error}`
             }
-            this.pinSubmitting = false
+            this.pin.submitting = false
         }
     }
 });

--- a/BTCPayServer/Plugins/NFC/Views/CheckoutEnd.cshtml
+++ b/BTCPayServer/Plugins/NFC/Views/CheckoutEnd.cshtml
@@ -132,7 +132,7 @@ Vue.component("lnurl-withdraw-checkout", {
             try {
                 const result = await response.text()
                 if (response.ok) {
-                    // LUD-290: the withdraw service requires a PIN before we can complete it
+                    // LUD-290: PIN required before completing
                     const parsed = this.tryParseJson(result)
                     if (parsed && typeof parsed === 'object' && parsed.requiresPin) {
                         this.startPinEntry(parsed)
@@ -181,7 +181,6 @@ Vue.component("lnurl-withdraw-checkout", {
             this.pinSubmitting = true
             this.pinError = null
 
-            // LUD-290: complete the withdraw the server stashed for us, now with the PIN
             const body = JSON.stringify({ invoiceId: this.model.invoiceId, token: this.pinToken, pin: this.pin })
             const opts = { method: 'POST', headers: { 'Content-Type': 'application/json' }, body }
             try {

--- a/BTCPayServer/Plugins/NFC/Views/CheckoutEnd.cshtml
+++ b/BTCPayServer/Plugins/NFC/Views/CheckoutEnd.cshtml
@@ -2,7 +2,20 @@
     <div v-if="display" class="mt-4" id="NFC">
         <div v-if="nfcErrorMessage" class="alert alert-danger" v-text="nfcErrorMessage"></div>
         <div v-if="nfcWarningMessage" class="alert alert-warning" v-text="nfcWarningMessage"></div>
-        <button class="btn btn-secondary rounded-pill w-100" type="button" id="PayByNFC"
+        <div v-if="pinRequired" id="NFC-Pin">
+            <div v-if="pinError" class="alert alert-danger" v-text="pinError"></div>
+            <label class="form-label" for="NFC-Pin-Input" v-text="pinPromptText"></label>
+            <input id="NFC-Pin-Input" class="form-control form-control-lg text-center" type="text" inputmode="numeric"
+                   maxlength="4" pattern="[0-9]{4}" autocomplete="off" v-model="pin"
+                   :disabled="pinSubmitting" v-on:keyup.enter="submitPin" />
+            <div class="d-flex gap-2 mt-3">
+                <button class="btn btn-secondary rounded-pill flex-grow-1" type="button" id="NFC-Pin-Cancel"
+                        :disabled="pinSubmitting" v-on:click="cancelPin">Cancel</button>
+                <button class="btn btn-primary rounded-pill flex-grow-1" type="button" id="NFC-Pin-Submit"
+                        :disabled="pinSubmitting || !isPinValid" v-on:click="submitPin">Confirm PIN</button>
+            </div>
+        </div>
+        <button v-else class="btn btn-secondary rounded-pill w-100" type="button" id="PayByNFC"
                 :disabled="nfcScanning || submitting" v-on:click="handleClick">{{btnText}}</button>
     </div>
 </template>
@@ -24,7 +37,7 @@ Vue.component("lnurl-withdraw-checkout", {
                 availablePaymentMethods: availablePaymentMethods,
                 invoiceBitcoinUrl: paymentUrl
             } = this.model
-            const lnurlwAvailable = 
+            const lnurlwAvailable =
                 // Either we have LN or LNURL available directly
                 !!availablePaymentMethods.find(pm => ['BTC-LNURL', 'BTC-LN'].includes(pm.paymentMethodId)) ||
                 // Or the BIP21 payment URL flags Lightning support
@@ -51,13 +64,25 @@ Vue.component("lnurl-withdraw-checkout", {
             } else {
                 return this.$t('pay_by_lnurl')
             }
+        },
+        isPinValid () {
+            return /^[0-9]{4}$/.test(this.pin)
+        },
+        pinPromptText () {
+            return `Enter the 4-digit PIN to withdraw ${this.pinAmountSats} sats`
         }
     },
     data () {
         return {
 				url: @Safe.Json(Url.ActionAbsolute(Context.Request, "SubmitLNURLWithdrawForInvoice", "NFC").ToString()),
             amount: 0,
-            submitting: false
+            submitting: false,
+            pinRequired: false,
+            pinToken: null,
+            pinAmountSats: 0,
+            pin: '',
+            pinError: null,
+            pinSubmitting: false
         }
     },
     beforeMount () {
@@ -97,7 +122,7 @@ Vue.component("lnurl-withdraw-checkout", {
         async sendData (data) {
             this.submitting = true
             this.$emit('handle-nfc-data')
-            
+
             // Post LNURL-Withdraw data to server
             const body = JSON.stringify({ lnurl: data, invoiceId: this.model.invoiceId, amount: this.amount })
             const opts = { method: 'POST', headers: { 'Content-Type': 'application/json' }, body }
@@ -106,12 +131,74 @@ Vue.component("lnurl-withdraw-checkout", {
             // Handle response
             try {
                 const result = await response.text()
-                const action = response.ok ? 'handle-nfc-result' : 'handle-nfc-error'
-                this.$emit(action, result)
+                if (response.ok) {
+                    // LUD-290: the withdraw service requires a PIN before we can complete it
+                    const parsed = this.tryParseJson(result)
+                    if (parsed && typeof parsed === 'object' && parsed.requiresPin) {
+                        this.startPinEntry(parsed)
+                        this.submitting = false
+                        return
+                    }
+                    this.$emit('handle-nfc-result', result)
+                } else {
+                    this.$emit('handle-nfc-error', result)
+                }
             } catch (error) {
                 this.$emit('handle-nfc-error', error)
             }
             this.submitting = false
+        },
+        tryParseJson (text) {
+            try {
+                return JSON.parse(text)
+            } catch {
+                return null
+            }
+        },
+        parseReason (text) {
+            const parsed = this.tryParseJson(text)
+            if (typeof parsed === 'string') return parsed
+            if (parsed && typeof parsed === 'object' && parsed.reason) return parsed.reason
+            return text
+        },
+        startPinEntry (data) {
+            this.pinRequired = true
+            this.pinToken = data.token
+            this.pinAmountSats = data.amountSats
+            this.pin = ''
+            this.pinError = null
+        },
+        cancelPin () {
+            this.pinRequired = false
+            this.pinToken = null
+            this.pin = ''
+            this.pinError = null
+        },
+        async submitPin () {
+            if (!this.isPinValid || this.pinSubmitting) {
+                return
+            }
+            this.pinSubmitting = true
+            this.pinError = null
+
+            // LUD-290: complete the withdraw the server stashed for us, now with the PIN
+            const body = JSON.stringify({ invoiceId: this.model.invoiceId, token: this.pinToken, pin: this.pin })
+            const opts = { method: 'POST', headers: { 'Content-Type': 'application/json' }, body }
+            try {
+                const response = await fetch(this.url, opts)
+                const result = await response.text()
+                if (response.ok) {
+                    this.pinRequired = false
+                    this.pin = ''
+                    this.$emit('handle-nfc-result', result)
+                } else {
+                    this.pin = ''
+                    this.pinError = this.parseReason(result) || 'Invalid PIN'
+                }
+            } catch (error) {
+                this.pinError = `${error}`
+            }
+            this.pinSubmitting = false
         }
     }
 });

--- a/BTCPayServer/Plugins/NFC/Views/CheckoutEnd.cshtml
+++ b/BTCPayServer/Plugins/NFC/Views/CheckoutEnd.cshtml
@@ -141,7 +141,7 @@ Vue.component("lnurl-withdraw-checkout", {
                     }
                     this.$emit('handle-nfc-result', result)
                 } else {
-                    this.$emit('handle-nfc-error', result)
+                    this.$emit('handle-nfc-error', this.parseReason(result))
                 }
             } catch (error) {
                 this.$emit('handle-nfc-error', error)


### PR DESCRIPTION
## What

Adds [LUD-290](https://github.com/lnurl/luds/pull/290) support to the NFC checkout. When a customer pays an invoice by tapping an LNURL-Withdraw that requires a PIN for the amount, BTCPay now asks for the 4-digit PIN and forwards it to complete the payment.

This is the wallet side of the spec, for Bolt Cards: issuers like [boltcard-tools-terminal](https://github.com/boltcard/boltcard-tools-terminal) and [boltcard-lndhub](https://github.com/boltcard/boltcard-lndhub) can require a PIN above a set amount, so a lost or stolen card can't be drained.

## Screenshot

<!-- attach nfc-pin-preview.png here -->
_PIN entry: the 4-digit field shows the amount, with Confirm / Cancel._

## Also fixes

NFC withdraw has been returning 400 since #7199 applied CSRF protection to all UI controllers — it caught `NFCController` too, even though the checkout posts without a token. Restored with `[IgnoreAntiforgeryToken]`, like the other LNURL endpoints.

## Testing

- Fast unit test for the PIN transport guard.
- Lightning integration test driving the full flow against a fake withdraw service: prompt → wrong PIN → retry → success, plus below-threshold (no PIN) and three-strikes-blocked.