### PR TITLE
Allow merchants to manually resend an invoice's triggered email

### DIFF
--- a/BTCPayServer.Data/ApplicationDbContext.cs
+++ b/BTCPayServer.Data/ApplicationDbContext.cs
@@ -65,6 +65,7 @@ namespace BTCPayServer.Data
         public DbSet<CustomerData> Customers { get; set; }
 
         public DbSet<EmailRuleData> EmailRules { get; set; }
+        public DbSet<EmailLogData> EmailLogs { get; set; }
 
         protected override void OnModelCreating(ModelBuilder builder)
         {
@@ -76,6 +77,7 @@ namespace BTCPayServer.Data
             CustomerData.OnModelCreating(builder, Database);
             CustomerIdentityData.OnModelCreating(builder, Database);
             EmailRuleData.OnModelCreating(builder, Database);
+            EmailLogData.OnModelCreating(builder, Database);
             ApplicationUser.OnModelCreating(builder, Database);
             AddressInvoiceData.OnModelCreating(builder);
             APIKeyData.OnModelCreating(builder, Database);

--- a/BTCPayServer.Data/Data/EmailLogData.cs
+++ b/BTCPayServer.Data/Data/EmailLogData.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Linq;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using NBitcoin;
+using NBitcoin.DataEncoders;
+
+namespace BTCPayServer.Data;
+
+public class EmailLogData
+{
+    public static EmailLogData Create(string? storeId) => new EmailLogData
+        {
+            Id = Encoders.Base58.EncodeData(RandomUtils.GetBytes(16)),
+            Timestamp = DateTimeOffset.UtcNow,
+            StoreId = storeId
+        };
+
+    public string Id { get; set; }
+    public string? StoreId { get; set; }
+    public StoreData? Store { get; set; }
+    public DateTimeOffset Timestamp { get; set; }
+    public string? Blob { get; set; }
+    public bool Pruned { get; set; }
+
+    internal static void OnModelCreating(ModelBuilder builder, DatabaseFacade databaseFacade)
+    {
+        var b = builder.Entity<EmailLogData>();
+        b.HasOne(o => o.Store).WithMany().OnDelete(DeleteBehavior.Cascade);
+        b.HasIndex(o => o.StoreId);
+        b.HasIndex(o => o.Timestamp);
+        b.Property(o => o.Blob).HasColumnType("JSONB");
+    }
+}
+
+public static partial class ApplicationDbContextExtensions
+{
+    public static IQueryable<EmailLogData> GetStoreLogs(this IQueryable<EmailLogData> query, string storeId) => query.Where(o => o.StoreId == storeId).OrderByDescending(o => o.Timestamp);
+
+    public static IQueryable<EmailLogData> GetServerLogs(this IQueryable<EmailLogData> query) => query.Where(o => o.StoreId == null).OrderByDescending(o => o.Timestamp);
+}

--- a/BTCPayServer.Data/Migrations/20260714122929_EmailLogs.cs
+++ b/BTCPayServer.Data/Migrations/20260714122929_EmailLogs.cs
@@ -1,0 +1,57 @@
+using System;
+using BTCPayServer.Data;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace BTCPayServer.Migrations
+{
+    /// <inheritdoc />
+    [DbContext(typeof(ApplicationDbContext))]
+    [Migration("20260714122929_EmailLogs")]
+    public partial class EmailLogs : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "EmailLogs",
+                columns: table => new
+                {
+                    Id = table.Column<string>(type: "text", nullable: false),
+                    StoreId = table.Column<string>(type: "text", nullable: true),
+                    Timestamp = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    Blob = table.Column<string>(type: "JSONB", nullable: true),
+                    Pruned = table.Column<bool>(type: "boolean", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_EmailLogs", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_EmailLogs_Stores_StoreId",
+                        column: x => x.StoreId,
+                        principalTable: "Stores",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_EmailLogs_StoreId",
+                table: "EmailLogs",
+                column: "StoreId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_EmailLogs_Timestamp",
+                table: "EmailLogs",
+                column: "Timestamp");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "EmailLogs");
+        }
+    }
+}

--- a/BTCPayServer.Data/Migrations/ApplicationDbContextModelSnapshot.cs
+++ b/BTCPayServer.Data/Migrations/ApplicationDbContextModelSnapshot.cs
@@ -18,7 +18,7 @@ namespace BTCPayServer.Migrations
         {
 #pragma warning disable 612, 618
             modelBuilder
-                .HasAnnotation("ProductVersion", "10.0.6")
+                .HasAnnotation("ProductVersion", "10.0.8")
                 .HasAnnotation("Relational:MaxIdentifierLength", 63);
 
             NpgsqlModelBuilderExtensions.UseIdentityByDefaultColumns(modelBuilder);
@@ -291,6 +291,32 @@ namespace BTCPayServer.Migrations
                     b.HasKey("CustomerId", "Type");
 
                     b.ToTable("customers_identities");
+                });
+
+            modelBuilder.Entity("BTCPayServer.Data.EmailLogData", b =>
+                {
+                    b.Property<string>("Id")
+                        .HasColumnType("text");
+
+                    b.Property<string>("Blob")
+                        .HasColumnType("JSONB");
+
+                    b.Property<bool>("Pruned")
+                        .HasColumnType("boolean");
+
+                    b.Property<string>("StoreId")
+                        .HasColumnType("text");
+
+                    b.Property<DateTimeOffset>("Timestamp")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("StoreId");
+
+                    b.HasIndex("Timestamp");
+
+                    b.ToTable("EmailLogs");
                 });
 
             modelBuilder.Entity("BTCPayServer.Data.EmailRuleData", b =>
@@ -848,11 +874,11 @@ namespace BTCPayServer.Migrations
                     b.Property<DateTimeOffset?>("Expiry")
                         .HasColumnType("timestamp with time zone");
 
-                    b.PrimitiveCollection<string[]>("OutpointsUsed")
-                        .HasColumnType("text[]");
-
                     b.Property<string>("NoSignatureTransactionId")
                         .HasColumnType("text");
+
+                    b.PrimitiveCollection<string[]>("OutpointsUsed")
+                        .HasColumnType("text[]");
 
                     b.Property<int>("State")
                         .HasColumnType("integer");
@@ -871,9 +897,9 @@ namespace BTCPayServer.Migrations
 
                     b.HasKey("Id");
 
-                    b.HasIndex("StoreId");
-
                     b.HasIndex("NoSignatureTransactionId");
+
+                    b.HasIndex("StoreId");
 
                     b.ToTable("PendingTransactions");
                 });
@@ -2128,6 +2154,16 @@ namespace BTCPayServer.Migrations
                         .IsRequired();
 
                     b.Navigation("Customer");
+                });
+
+            modelBuilder.Entity("BTCPayServer.Data.EmailLogData", b =>
+                {
+                    b.HasOne("BTCPayServer.Data.StoreData", "Store")
+                        .WithMany()
+                        .HasForeignKey("StoreId")
+                        .OnDelete(DeleteBehavior.Cascade);
+
+                    b.Navigation("Store");
                 });
 
             modelBuilder.Entity("BTCPayServer.Data.EmailRuleData", b =>

--- a/BTCPayServer.Tests/EmailsTests.cs
+++ b/BTCPayServer.Tests/EmailsTests.cs
@@ -1,8 +1,14 @@
+using System;
+using System.Linq;
+using Microsoft.EntityFrameworkCore;
 using System.Threading.Tasks;
 using BTCPayServer.Abstractions.Models;
 using BTCPayServer.Client;
 using BTCPayServer.Client.Models;
+using BTCPayServer.Data;
+using BTCPayServer.Plugins.Emails;
 using BTCPayServer.Plugins.Emails.Controllers;
+using BTCPayServer.Plugins.Emails.HostedServices;
 using BTCPayServer.Plugins.Emails.Services;
 using BTCPayServer.Plugins.Emails.Views;
 using BTCPayServer.Services;
@@ -122,6 +128,106 @@ public class EmailsTests(ITestOutputHelper helper) : UnitTestBase(helper)
         }, ""));
 
         await AssertIsLogin<StoreEmailSender>(acc.StoreId, "server@server.com");
+    }
+
+    [Fact(Timeout = TestUtils.LongRunningTestTimeout)]
+    [Trait("Integration", "Integration")]
+    public async Task SendingEmailCreatesEmailLog()
+    {
+        using var tester = CreateServerTester(newDb: true);
+        await tester.StartAsync();
+
+        var acc = tester.NewAccount();
+        await acc.GrantAccessAsync(true);
+
+        var settings = tester.PayTester.GetService<SettingsRepository>();
+        await settings.UpdateSetting(new PoliciesSettings() { DisableStoresToUseServerEmailSettings = false });
+
+        Assert.IsType<RedirectToActionResult>(await acc.GetController<UIStoresEmailController>().StoreEmailSettings(acc.StoreId, new(new()
+        {
+            From = "store@store.com",
+            Login = "store@store.com",
+            Password = "store@store.com",
+            Port = tester.MailPitSettings.SmtpPort,
+            Server = tester.MailPitSettings.Hostname
+        }){ IsCustomSMTP = true }, ""));
+
+        var dbContextFactory = tester.PayTester.GetService<ApplicationDbContextFactory>();
+        var emailSenderFactory = tester.PayTester.GetService<EmailSenderFactory>();
+
+        await tester.AssertHasEmail(async () =>
+        {
+            var sender = await emailSenderFactory.GetEmailSender(acc.StoreId);
+            sender.SendEmail(MailboxAddress.Parse("destination@test.com"), "log test subject", "log test body");
+        });
+
+        EmailLogData? logRow = null;
+        await TestUtils.EventuallyAsync(async () =>
+        {
+            await using var ctx = dbContextFactory.CreateContext();
+            logRow = await ctx.EmailLogs.Where(l => l.StoreId == acc.StoreId).OrderByDescending(l => l.Timestamp).FirstOrDefaultAsync();
+            Assert.NotNull(logRow);
+        });
+
+        var blob = logRow!.GetBlob();
+        Assert.NotNull(blob);
+        Assert.Equal(EmailLogStatus.Sent, blob!.Status);
+        Assert.Equal("log test subject", blob.Subject);
+        Assert.Contains("destination@test.com", blob.To);
+        Assert.Null(blob.Error);
+    }
+
+    [Fact(Timeout = TestUtils.LongRunningTestTimeout)]
+    [Trait("Integration", "Integration")]
+    public async Task FailedSendCreatesFailedEmailLogAndCanBeResent()
+    {
+        using var tester = CreateServerTester(newDb: true);
+        await tester.StartAsync();
+
+        var acc = tester.NewAccount();
+        await acc.GrantAccessAsync(true);
+
+        var settings = tester.PayTester.GetService<SettingsRepository>();
+        await settings.UpdateSetting(new PoliciesSettings() { DisableStoresToUseServerEmailSettings = false });
+
+        Assert.IsType<RedirectToActionResult>(await acc.GetController<UIStoresEmailController>().StoreEmailSettings(acc.StoreId, new(new()
+        {
+            From = "store@store.com",
+            Login = "store@store.com",
+            Password = "store@store.com",
+            Port = 1,
+            Server = "127.0.0.1"
+        }) { IsCustomSMTP = true }, ""));
+
+        var dbContextFactory = tester.PayTester.GetService<ApplicationDbContextFactory>();
+        var emailSenderFactory = tester.PayTester.GetService<EmailSenderFactory>();
+        var sender = await emailSenderFactory.GetEmailSender(acc.StoreId);
+        sender.SendEmail(MailboxAddress.Parse("destination@test.com"), "failing subject", "failing body");
+
+        EmailLogData? logRow = null;
+        await TestUtils.EventuallyAsync(async () =>
+        {
+            await using var ctx = dbContextFactory.CreateContext();
+            logRow = await ctx.EmailLogs.Where(l => l.StoreId == acc.StoreId).OrderByDescending(l => l.Timestamp).FirstOrDefaultAsync();
+            Assert.NotNull(logRow);
+            Assert.Equal(EmailLogStatus.Failed, logRow!.GetBlob()!.Status);
+        });
+        Assert.NotNull(logRow!.GetBlob()!.Error);
+
+        Assert.IsType<RedirectToActionResult>(await acc.GetController<UIStoresEmailController>().StoreEmailSettings(acc.StoreId, new(new()
+        {
+            From = "store@store.com",
+            Login = "store@store.com",
+            Password = "store@store.com",
+            Port = tester.MailPitSettings.SmtpPort,
+            Server = tester.MailPitSettings.Hostname
+        }) { IsCustomSMTP = true }, ""));
+
+        var message = await tester.AssertHasEmail(async () =>
+        {
+            await acc.GetController<UIStoreEmailLogsController>().ResendStoreEmails(acc.StoreId, new[] { logRow.Id });
+        });
+        Assert.Equal("failing subject", message.Subject);
     }
 
     [Fact]

--- a/BTCPayServer/Controllers/UIInvoiceController.UI.cs
+++ b/BTCPayServer/Controllers/UIInvoiceController.UI.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.WebSockets;
+using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using BTCPayServer.Abstractions.Constants;
@@ -11,6 +12,7 @@ using BTCPayServer.Abstractions.Models;
 using BTCPayServer.Client;
 using BTCPayServer.Client.Models;
 using BTCPayServer.Data;
+using BTCPayServer.Events;
 using BTCPayServer.Filters;
 using BTCPayServer.Models;
 using BTCPayServer.Models.AppViewModels;
@@ -19,7 +21,10 @@ using BTCPayServer.Models.PaymentRequestViewModels;
 using BTCPayServer.Payments;
 using BTCPayServer.Payments.Lightning;
 using BTCPayServer.Payouts;
+using BTCPayServer.Plugins.Emails.HostedServices;
 using BTCPayServer.Plugins.Wallets;
+using BTCPayServer.Plugins.Webhooks;
+using BTCPayServer.Plugins.Webhooks.TriggerProviders;
 using BTCPayServer.Plugins.Webhooks.Views;
 using BTCPayServer.Rating;
 using BTCPayServer.Services;
@@ -189,7 +194,47 @@ namespace BTCPayServer.Controllers
 
             model.AdditionalData = additionalData;
 
+            await using var emailRuleCtx = _dbContextFactory.CreateContext();
+            var occurredTriggers = GetOccurredEmailTriggers(invoice, details.Payments.Any());
+            model.ResendableEmailRules = await emailRuleCtx.EmailRules.Where(r => r.StoreId == invoice.StoreId && occurredTriggers.Contains(r.Trigger)).ToListAsync();
+
             return View(model);
+        }
+
+        [HttpPost("i/{invoiceId}/resend-email")]
+        [Authorize(Policy = Policies.CanModifyStoreSettings, AuthenticationSchemes = AuthenticationSchemes.Cookie)]
+        public async Task<IActionResult> ResendEmail(string invoiceId, string trigger)
+        {
+            var invoice = await _InvoiceRepository.GetInvoice(invoiceId);
+            if (invoice is null)
+                return NotFound();
+
+            var store = await _StoreRepository.GetStoreByInvoiceId(invoice.Id);
+            if (store is null)
+                return NotFound();
+
+            var model = new JObject
+            {
+                ["Store"] = new JObject { ["Id"] = invoice.StoreId, ["Name"] = store.StoreName }
+            };
+            InvoiceTriggerProvider.AddInvoiceToModel(model, invoice, _linkGenerator);
+
+            _EventAggregator.Publish(new TriggerEvent(invoice.StoreId, trigger, model, new ResendTriggerOwner(invoice)));
+
+            TempData[WellKnownTempData.SuccessMessage] = "Email resent.";
+            return RedirectToAction(nameof(Invoice), new { invoiceId });
+        }
+
+        private class ResendTriggerOwner(InvoiceEntity invoice) : ITriggerOwner
+        {
+            public Task BeforeSending(EmailRuleMatchContext context)
+            {
+                if (InvoiceTriggerProvider.GetMailboxAddress(invoice.Metadata) is { } mb && context.MatchedRule.GetBTCPayAdditionalData()?.CustomerEmail is true)
+                {
+                    context.To.Insert(0, mb);
+                }
+                return Task.CompletedTask;
+            }
         }
 
         [XFrameOptions(null)]
@@ -1324,5 +1369,39 @@ namespace BTCPayServer.Controllers
             var authorizationResult = await _authorizationService.AuthorizeAsync(User, invoice.StoreId, Policies.CanViewInvoices);
             return authorizationResult.Succeeded;
         }
+
+        private static List<string> GetPlausibleWebhookEventTypes(InvoiceEntity invoice, bool hasPayments)
+        {
+            var types = new List<string> { WebhookEventType.InvoiceCreated };
+
+            if (hasPayments)
+                types.Add(WebhookEventType.InvoiceReceivedPayment);
+
+            switch (invoice.Status)
+            {
+                case InvoiceStatus.Settled:
+                    types.Add(WebhookEventType.InvoiceSettled);
+                    types.Add(WebhookEventType.InvoicePaymentSettled);
+                    if (invoice.ExceptionStatus == InvoiceExceptionStatus.PaidLate)
+                        types.Add(WebhookEventType.InvoicePaidAfterExpiration);
+                    break;
+
+                case InvoiceStatus.Expired:
+                    types.Add(invoice.ExceptionStatus == InvoiceExceptionStatus.PaidPartial ? WebhookEventType.InvoiceExpiredPaidPartial : WebhookEventType.InvoiceExpired);
+                    break;
+
+                case InvoiceStatus.Invalid:
+                    types.Add(WebhookEventType.InvoiceInvalid);
+                    break;
+
+                case InvoiceStatus.Processing:
+                    types.Add(WebhookEventType.InvoiceReceivedPayment);
+                    break;
+            }
+            return types;
+        }
+
+        private static List<string> GetOccurredEmailTriggers(InvoiceEntity invoice, bool hasPayments)
+            => GetPlausibleWebhookEventTypes(invoice, hasPayments).Select(EmailRuleData.GetWebhookTriggerName).Distinct().ToList();
     }
 }

--- a/BTCPayServer/Controllers/UIInvoiceController.UI.cs
+++ b/BTCPayServer/Controllers/UIInvoiceController.UI.cs
@@ -216,19 +216,16 @@ namespace BTCPayServer.Controllers
             if (store is null)
                 return NotFound();
 
-            var details = InvoicePopulatePayments(invoice);
-            var occurredTriggers = GetOccurredEmailTriggers(invoice, details.Payments.Any());
-            if (!occurredTriggers.Contains(trigger))
-            {
-                TempData[WellKnownTempData.ErrorMessage] = StringLocalizer["This trigger doesn't apply to this invoice."].Value;
-                return RedirectToAction(nameof(Invoice), new { invoiceId });
-            }
 
+            var occurredTriggers = GetOccurredEmailTriggers(invoice, invoice.GetPayments(false).Any());
+            if (string.IsNullOrEmpty(trigger) || !occurredTriggers.Contains(trigger))
+                return NotFound();
+            
             await using var emailRuleCtx = _dbContextFactory.CreateContext();
             var ruleExists = await emailRuleCtx.EmailRules.AnyAsync(r => r.StoreId == invoice.StoreId && r.Trigger == trigger);
             if (!ruleExists)
             {
-                TempData[WellKnownTempData.ErrorMessage] = StringLocalizer["No matching email rule found for this store."].Value;
+                TempData[WellKnownTempData.ErrorMessage] = StringLocalizer["No matching email rule found for this trigger."].Value;
                 return RedirectToAction(nameof(Invoice), new { invoiceId });
             }
 
@@ -236,7 +233,7 @@ namespace BTCPayServer.Controllers
             InvoiceTriggerProvider.AddInvoiceToModel(model, invoice, _linkGenerator);
             _EventAggregator.Publish(new TriggerEvent(invoice.StoreId, trigger, model, new ResendTriggerOwner(invoice)));
 
-            TempData[WellKnownTempData.SuccessMessage] = "Email resent.";
+            TempData[WellKnownTempData.SuccessMessage] = StringLocalizer["Email resent."].Value;
             return RedirectToAction(nameof(Invoice), new { invoiceId });
         }
 

--- a/BTCPayServer/Controllers/UIInvoiceController.UI.cs
+++ b/BTCPayServer/Controllers/UIInvoiceController.UI.cs
@@ -194,10 +194,13 @@ namespace BTCPayServer.Controllers
 
             model.AdditionalData = additionalData;
 
-            await using var emailRuleCtx = _dbContextFactory.CreateContext();
-            var occurredTriggers = GetOccurredEmailTriggers(invoice, details.Payments.Any());
-            model.ResendableEmailRules = await emailRuleCtx.EmailRules.Where(r => r.StoreId == invoice.StoreId && occurredTriggers.Contains(r.Trigger)).ToListAsync();
-
+            var canResendEmail = (await _authorizationService.AuthorizeAsync(User, invoice.StoreId, Policies.CanModifyStoreSettings)).Succeeded;
+            if (canResendEmail)
+            {
+                await using var emailRuleCtx = _dbContextFactory.CreateContext();
+                var occurredTriggers = GetOccurredEmailTriggers(invoice, details.Payments.Any());
+                model.ResendableEmailRules = await emailRuleCtx.EmailRules.Where(r => r.StoreId == invoice.StoreId && occurredTriggers.Contains(r.Trigger)).ToListAsync();
+            }
             return View(model);
         }
 
@@ -213,12 +216,24 @@ namespace BTCPayServer.Controllers
             if (store is null)
                 return NotFound();
 
-            var model = new JObject
+            var details = InvoicePopulatePayments(invoice);
+            var occurredTriggers = GetOccurredEmailTriggers(invoice, details.Payments.Any());
+            if (!occurredTriggers.Contains(trigger))
             {
-                ["Store"] = new JObject { ["Id"] = invoice.StoreId, ["Name"] = store.StoreName }
-            };
-            InvoiceTriggerProvider.AddInvoiceToModel(model, invoice, _linkGenerator);
+                TempData[WellKnownTempData.ErrorMessage] = StringLocalizer["This trigger doesn't apply to this invoice."].Value;
+                return RedirectToAction(nameof(Invoice), new { invoiceId });
+            }
 
+            await using var emailRuleCtx = _dbContextFactory.CreateContext();
+            var ruleExists = await emailRuleCtx.EmailRules.AnyAsync(r => r.StoreId == invoice.StoreId && r.Trigger == trigger);
+            if (!ruleExists)
+            {
+                TempData[WellKnownTempData.ErrorMessage] = StringLocalizer["No matching email rule found for this store."].Value;
+                return RedirectToAction(nameof(Invoice), new { invoiceId });
+            }
+
+            var model = new JObject { ["Store"] = new JObject { ["Id"] = invoice.StoreId, ["Name"] = store.StoreName } };
+            InvoiceTriggerProvider.AddInvoiceToModel(model, invoice, _linkGenerator);
             _EventAggregator.Publish(new TriggerEvent(invoice.StoreId, trigger, model, new ResendTriggerOwner(invoice)));
 
             TempData[WellKnownTempData.SuccessMessage] = "Email resent.";

--- a/BTCPayServer/Controllers/UIInvoiceController.UI.cs
+++ b/BTCPayServer/Controllers/UIInvoiceController.UI.cs
@@ -24,6 +24,7 @@ using BTCPayServer.Payouts;
 using BTCPayServer.Plugins.Emails.HostedServices;
 using BTCPayServer.Plugins.Wallets;
 using BTCPayServer.Plugins.Webhooks;
+using BTCPayServer.Plugins.Webhooks.HostedServices;
 using BTCPayServer.Plugins.Webhooks.TriggerProviders;
 using BTCPayServer.Plugins.Webhooks.Views;
 using BTCPayServer.Rating;
@@ -231,22 +232,14 @@ namespace BTCPayServer.Controllers
 
             var model = new JObject { ["Store"] = new JObject { ["Id"] = invoice.StoreId, ["Name"] = store.StoreName } };
             InvoiceTriggerProvider.AddInvoiceToModel(model, invoice, _linkGenerator);
-            _EventAggregator.Publish(new TriggerEvent(invoice.StoreId, trigger, model, new ResendTriggerOwner(invoice)));
+
+            var invoiceEvent = new Events.InvoiceEvent(invoice, Events.InvoiceEvent.Created);
+            var webhookEvent = new WebhookInvoiceEvent(WebhookEventType.InvoiceCreated, invoice.StoreId);
+            var ctx = new WebhookTriggerContext<Events.InvoiceEvent>(store, invoiceEvent, webhookEvent);
+            _EventAggregator.Publish(new TriggerEvent(invoice.StoreId, trigger, model, new WebhookProviderHostedService.WebhookTriggerOwner(_invoiceTriggerProvider, ctx)));
 
             TempData[WellKnownTempData.SuccessMessage] = StringLocalizer["Email resent."].Value;
             return RedirectToAction(nameof(Invoice), new { invoiceId });
-        }
-
-        private class ResendTriggerOwner(InvoiceEntity invoice) : ITriggerOwner
-        {
-            public Task BeforeSending(EmailRuleMatchContext context)
-            {
-                if (InvoiceTriggerProvider.GetMailboxAddress(invoice.Metadata) is { } mb && context.MatchedRule.GetBTCPayAdditionalData()?.CustomerEmail is true)
-                {
-                    context.To.Insert(0, mb);
-                }
-                return Task.CompletedTask;
-            }
         }
 
         [XFrameOptions(null)]

--- a/BTCPayServer/Controllers/UIInvoiceController.cs
+++ b/BTCPayServer/Controllers/UIInvoiceController.cs
@@ -30,6 +30,7 @@ using BTCPayServer.Payouts;
 using BTCPayServer.Plugins.Webhooks;
 using Microsoft.AspNetCore.Mvc.Localization;
 using Microsoft.Extensions.Localization;
+using BTCPayServer.Plugins.Webhooks.TriggerProviders;
 
 namespace BTCPayServer.Controllers
 {
@@ -58,6 +59,7 @@ namespace BTCPayServer.Controllers
         private readonly AppService _appService;
         private readonly UriResolver _uriResolver;
         private readonly PermissionService _permissionService;
+        private readonly InvoiceTriggerProvider _invoiceTriggerProvider;
 
         public WebhookSender WebhookNotificationManager { get; }
         public IEnumerable<IGlobalCheckoutModelExtension> GlobalCheckoutModelExtensions { get; }
@@ -91,7 +93,8 @@ namespace BTCPayServer.Controllers
             IStringLocalizer stringLocalizer,
             ViewLocalizer viewLocalizer,
             PrettyNameProvider prettyName,
-            PermissionService permissionService)
+            PermissionService permissionService,
+            InvoiceTriggerProvider invoiceTriggerProvider)
         {
             _displayFormatter = displayFormatter;
             _CurrencyNameTable = currencyNameTable ?? throw new ArgumentNullException(nameof(currencyNameTable));
@@ -120,6 +123,7 @@ namespace BTCPayServer.Controllers
             StringLocalizer = stringLocalizer;
             ViewLocalizer = viewLocalizer;
             _permissionService = permissionService;
+            _invoiceTriggerProvider = invoiceTriggerProvider;
         }
 
         internal async Task<InvoiceEntity> CreatePaymentRequestInvoice(Data.PaymentRequestData prData, decimal? amount, decimal amountDue, StoreData storeData, HttpRequest request, CancellationToken cancellationToken)

--- a/BTCPayServer/Models/InvoicingModels/InvoiceDetailsModel.cs
+++ b/BTCPayServer/Models/InvoicingModels/InvoiceDetailsModel.cs
@@ -120,6 +120,7 @@ namespace BTCPayServer.Models.InvoicingModels
             get;
             set;
         }
+        public List<EmailRuleData> ResendableEmailRules { get; set; } = new();
         public InvoiceMetadata TypedMetadata { get; set; }
         public DateTimeOffset MonitoringDate { get; internal set; }
         public InvoiceEventData[] Events { get; internal set; }

--- a/BTCPayServer/Plugins/Emails/Controllers/UIEmailLogControllerBase.cs
+++ b/BTCPayServer/Plugins/Emails/Controllers/UIEmailLogControllerBase.cs
@@ -1,0 +1,92 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Encodings.Web;
+using System.Threading.Tasks;
+using BTCPayServer.Abstractions.Constants;
+using BTCPayServer.Abstractions.Extensions;
+using BTCPayServer.Abstractions.Models;
+using BTCPayServer.Client;
+using BTCPayServer.Data;
+using BTCPayServer.Plugins.Emails.Services;
+using BTCPayServer.Plugins.Emails.Views;
+using BTCPayServer.Plugins.Emails.Views.Shared;
+using Dapper;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Localization;
+using MimeKit;
+using Npgsql;
+
+namespace BTCPayServer.Plugins.Emails.Controllers;
+
+public class UIEmailLogControllerBase(ApplicationDbContextFactory dbContextFactory, EmailSenderFactory emailSenderFactory) : Controller
+{
+
+
+    public class EmailLogsControllerContext
+    {
+        public string? StoreId { get; set; }
+        public string ModifyPermission { get; set; } = Client.Policies.CanModifyStoreSettings;
+        public Func<ApplicationDbContext, Task<List<EmailLogData>>> LogsQuery = null!;
+        public Func<string?, IActionResult> RedirectToLogsList = null!;
+    }
+
+
+    protected async Task<IActionResult> EmailLogsListCore(EmailLogsControllerContext context, int skip = 0, int count = 50)
+    {
+        await using var ctx = dbContextFactory.CreateContext();
+        var all = await context.LogsQuery(ctx);
+        var vm = new EmailLogsViewModel
+        {
+            StoreId = context.StoreId,
+            ModifyPermission = context.ModifyPermission,
+            Skip = skip,
+            Count = count,
+            Total = all.Count,
+            Logs = all.Skip(skip).Take(count).ToList()
+        };
+        return View("EmailLogsList", vm);
+    }
+
+    protected async Task<IActionResult> EmailLogsResendCore(EmailLogsControllerContext context, string[] ids, string? redirectUrl)
+    {
+        if (ids is not { Length: > 0 })
+        {
+            TempData[WellKnownTempData.ErrorMessage] = "Select at least one email to resend.";
+            return context.RedirectToLogsList(redirectUrl);
+        }
+
+        await using var ctx = dbContextFactory.CreateContext();
+        var logs = await ctx.EmailLogs.Where(l => l.StoreId == context.StoreId && ids.Contains(l.Id)).ToListAsync();
+
+        var sender = await emailSenderFactory.GetEmailSender(context.StoreId);
+        var resent = 0;
+        foreach (var log in logs)
+        {
+            var blob = log.GetBlob();
+            if (blob is null)
+                continue;
+            sender.SendEmail(ParseAddresses(blob.To), ParseAddresses(blob.CC), ParseAddresses(blob.BCC), blob.Subject, blob.Body, context.StoreId, blob.Trigger);
+            resent++;
+        }
+
+        TempData[WellKnownTempData.SuccessMessage] = $"Queued {resent} email(s) for resend.";
+        return context.RedirectToLogsList(redirectUrl);
+    }
+
+    private static MailboxAddress[] ParseAddresses(string[] addresses)
+        => addresses.Select(a => MailboxAddressValidator.TryParse(a, out var mb) ? mb : null).Where(mb => mb is not null).ToArray()!;
+
+}
+
+public class EmailLogsViewModel
+{
+    public string? StoreId { get; set; }
+    public string ModifyPermission { get; set; } = null!;
+    public int Skip { get; set; }
+    public int Count { get; set; }
+    public int Total { get; set; }
+    public List<EmailLogData> Logs { get; set; } = new();
+}

--- a/BTCPayServer/Plugins/Emails/Controllers/UIEmailLogControllerBase.cs
+++ b/BTCPayServer/Plugins/Emails/Controllers/UIEmailLogControllerBase.cs
@@ -76,9 +76,8 @@ public class UIEmailLogControllerBase(ApplicationDbContextFactory dbContextFacto
         return context.RedirectToLogsList(redirectUrl);
     }
 
-    private static MailboxAddress[] ParseAddresses(string[] addresses)
-        => addresses.Select(a => MailboxAddressValidator.TryParse(a, out var mb) ? mb : null).Where(mb => mb is not null).ToArray()!;
-
+    private static MailboxAddress[] ParseAddresses(string[]? addresses)
+        => addresses?.Select(a => MailboxAddressValidator.TryParse(a, out var mb) ? mb : null).OfType<MailboxAddress>().ToArray() ?? Array.Empty<MailboxAddress>();
 }
 
 public class EmailLogsViewModel

--- a/BTCPayServer/Plugins/Emails/Controllers/UIServerEmailLogsController.cs
+++ b/BTCPayServer/Plugins/Emails/Controllers/UIServerEmailLogsController.cs
@@ -1,0 +1,45 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Encodings.Web;
+using System.Threading.Tasks;
+using BTCPayServer.Abstractions.Constants;
+using BTCPayServer.Abstractions.Extensions;
+using BTCPayServer.Abstractions.Models;
+using BTCPayServer.Client;
+using BTCPayServer.Data;
+using BTCPayServer.Plugins.Emails.Services;
+using BTCPayServer.Plugins.Emails.Views;
+using BTCPayServer.Plugins.Emails.Views.Shared;
+using Dapper;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Localization;
+using MimeKit;
+
+namespace BTCPayServer.Plugins.Emails.Controllers;
+
+[Area(EmailsPlugin.Area)]
+[Route("server/emails/logs")]
+[Authorize(AuthenticationSchemes = AuthenticationSchemes.Cookie)]
+[Authorize(Policy = Policies.CanModifyServerSettings, AuthenticationSchemes = AuthenticationSchemes.Cookie)]
+public class UIServerEmailLogsController(ApplicationDbContextFactory dbContextFactory, EmailSenderFactory emailSenderFactory)
+    : UIEmailLogControllerBase(dbContextFactory, emailSenderFactory)
+{
+    [HttpGet("")]
+    public Task<IActionResult> ServerEmailLogsList(int skip = 0, int count = 50) => EmailLogsListCore(CreateContext(), skip, count);
+
+    [HttpPost("resend")]
+    public Task<IActionResult> ResendServerEmails(string[] ids) => EmailLogsResendCore(CreateContext(), ids, null);
+
+    private EmailLogsControllerContext CreateContext()
+        => new()
+        {
+            StoreId = null,
+            ModifyPermission = Policies.CanModifyServerSettings,
+            LogsQuery = (ctx) => ctx.EmailLogs.AsQueryable().GetServerLogs().ToListAsync(),
+            RedirectToLogsList = (redirectUrl) => redirectUrl != null ? LocalRedirect(redirectUrl) : RedirectToAction(nameof(ServerEmailLogsList))
+        };
+}

--- a/BTCPayServer/Plugins/Emails/Controllers/UIStoreEmailLogsController.cs
+++ b/BTCPayServer/Plugins/Emails/Controllers/UIStoreEmailLogsController.cs
@@ -1,0 +1,48 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Encodings.Web;
+using System.Threading.Tasks;
+using BTCPayServer.Abstractions.Constants;
+using BTCPayServer.Abstractions.Extensions;
+using BTCPayServer.Abstractions.Models;
+using BTCPayServer.Client;
+using BTCPayServer.Data;
+using BTCPayServer.Plugins.Emails.Services;
+using BTCPayServer.Plugins.Emails.Views;
+using BTCPayServer.Plugins.Emails.Views.Shared;
+using Dapper;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Localization;
+using MimeKit;
+using Npgsql;
+
+namespace BTCPayServer.Plugins.Emails.Controllers;
+
+[Area(EmailsPlugin.Area)]
+[Route("stores/{storeId}/emails/logs")]
+[Authorize(AuthenticationSchemes = AuthenticationSchemes.Cookie)]
+[Authorize(Policy = Policies.CanViewStoreSettings, AuthenticationSchemes = AuthenticationSchemes.Cookie)]
+public class UIStoreEmailLogsController( ApplicationDbContextFactory dbContextFactory, EmailSenderFactory emailSenderFactory)
+    : UIEmailLogControllerBase(dbContextFactory, emailSenderFactory)
+{
+    [HttpGet("")]
+    public Task<IActionResult> StoreEmailLogsList(string storeId, int skip = 0, int count = 50) => EmailLogsListCore(CreateContext(storeId), skip, count);
+
+    [HttpPost("resend")]
+    [Authorize(Policy = Policies.CanModifyStoreSettings, AuthenticationSchemes = AuthenticationSchemes.Cookie)]
+    public Task<IActionResult> ResendStoreEmails(string storeId, string[] ids) => EmailLogsResendCore(CreateContext(storeId), ids, null);
+
+    private EmailLogsControllerContext CreateContext(string storeId)
+        => new()
+        {
+            StoreId = storeId,
+            ModifyPermission = Policies.CanModifyStoreSettings,
+            LogsQuery = (ctx) => ctx.EmailLogs.AsQueryable().GetStoreLogs(storeId).ToListAsync(),
+            RedirectToLogsList = (redirectUrl) => redirectUrl != null ? LocalRedirect(redirectUrl) : RedirectToAction(nameof(StoreEmailLogsList), new { storeId })
+        };
+
+}

--- a/BTCPayServer/Plugins/Emails/EmailLogDataExtensions.cs
+++ b/BTCPayServer/Plugins/Emails/EmailLogDataExtensions.cs
@@ -1,0 +1,34 @@
+using System;
+using BTCPayServer.Data;
+using Newtonsoft.Json;
+
+namespace BTCPayServer.Plugins.Emails;
+
+public enum EmailLogStatus { Sent, Failed }
+
+public class EmailLogBlob
+{
+    [JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
+    public EmailLogStatus Status { get; set; }
+    public string Trigger { get; set; }
+    public string[] To { get; set; } 
+    public string[] CC { get; set; } 
+    public string[] BCC { get; set; } 
+    public string Subject { get; set; } 
+    public string Body { get; set; } 
+    [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+    public string? Error { get; set; }
+}
+
+#nullable enable
+public static class EmailLogDataExtensions
+{
+    public static EmailLogBlob? GetBlob(this EmailLogData log) => log.Blob is null ? null : JsonConvert.DeserializeObject<EmailLogBlob>(log.Blob);
+
+    public static void SetBlob(this EmailLogData log, EmailLogBlob blob)
+    {
+        ArgumentNullException.ThrowIfNull(blob);
+        log.Blob = JsonConvert.SerializeObject(blob);
+    }
+}
+#nullable restore

--- a/BTCPayServer/Plugins/Emails/EmailsPlugin.cs
+++ b/BTCPayServer/Plugins/Emails/EmailsPlugin.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using BTCPayServer.Abstractions.Models;
 using BTCPayServer.Client;
@@ -45,6 +46,7 @@ public class EmailsPlugin : BaseBTCPayServerPlugin
 
         services.AddSingleton<IEmailTriggerViewModelTransformer, StoreTransformer>();
         services.AddSingleton<IEmailTriggerEventTransformer, StoreTransformer>();
+        services.AddScheduledTask<CleanupEmailLogsTask>(TimeSpan.FromHours(12.0));
         services.AddDefaultTranslations(StoreTransformer.TranslatedStrings);
 
 

--- a/BTCPayServer/Plugins/Emails/HostedServices/CleanupEmailLogsTask.cs
+++ b/BTCPayServer/Plugins/Emails/HostedServices/CleanupEmailLogsTask.cs
@@ -1,0 +1,20 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using BTCPayServer.Data;
+using BTCPayServer.HostedServices;
+using Microsoft.EntityFrameworkCore;
+
+namespace BTCPayServer.Plugins.Emails.HostedServices;
+
+public class CleanupEmailLogsTask(ApplicationDbContextFactory dbContextFactory) : IPeriodicTask
+{
+    public TimeSpan PruneAfter { get; set; } = TimeSpan.FromDays(10);
+
+    public async Task Do(CancellationToken cancellationToken)
+    {
+        await using var ctx = dbContextFactory.CreateContext();
+        var cutoff = DateTimeOffset.UtcNow - PruneAfter;
+        await ctx.EmailLogs.Where(l => l.Timestamp < cutoff).ExecuteDeleteAsync(cancellationToken);
+    }
+}

--- a/BTCPayServer/Plugins/Emails/HostedServices/EmailRuleProcessorSender.cs
+++ b/BTCPayServer/Plugins/Emails/HostedServices/EmailRuleProcessorSender.cs
@@ -87,7 +87,8 @@ public class StoreEmailRuleProcessorSender(
                         await triggEvent.Owner.BeforeSending(matchedContext);
                     if (matchedContext.To.Count == 0)
                         continue;
-                    sender.SendEmail(matchedContext.To.ToArray(), matchedContext.CC.ToArray(), matchedContext.BCC.ToArray(), subject.Render(triggEvent.Model), body.Render(triggEvent.Model));
+                    sender.SendEmail(matchedContext.To.ToArray(), matchedContext.CC.ToArray(), matchedContext.BCC.ToArray(), subject.Render(triggEvent.Model),
+                        body.Render(triggEvent.Model), triggEvent.StoreId, triggEvent.Trigger);
                 }
             }
         }

--- a/BTCPayServer/Plugins/Emails/Services/EmailSender.cs
+++ b/BTCPayServer/Plugins/Emails/Services/EmailSender.cs
@@ -1,5 +1,6 @@
 #nullable enable
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using BTCPayServer.Data;
 using BTCPayServer.Logging;
@@ -39,9 +40,9 @@ public abstract class EmailSender(IBackgroundJobClient jobClient, EventAggregato
             var blob = new EmailLogBlob
             {
                 Trigger = trigger ?? "Unknown",
-                To = Array.ConvertAll(email, m => m.ToString()),
-                CC = Array.ConvertAll(cc, m => m.ToString()),
-                BCC = Array.ConvertAll(bcc, m => m.ToString()),
+                To = Array.ConvertAll(email ?? [], m => m.ToString()),
+                CC = Array.ConvertAll(cc ?? [], m => m.ToString()),
+                BCC = Array.ConvertAll(bcc ?? [], m => m.ToString()),
                 Subject = subject,
                 Body = message
             };
@@ -68,7 +69,7 @@ public abstract class EmailSender(IBackgroundJobClient jobClient, EventAggregato
                 log.SetBlob(blob);
                 await using var ctx = dbContextFactory.CreateContext();
                 ctx.EmailLogs.Add(log);
-                await ctx.SaveChangesAsync(cancellationToken);
+                await ctx.SaveChangesAsync(CancellationToken.None);
             }
         }, TimeSpan.Zero);
     }

--- a/BTCPayServer/Plugins/Emails/Services/EmailSender.cs
+++ b/BTCPayServer/Plugins/Emails/Services/EmailSender.cs
@@ -1,14 +1,18 @@
 #nullable enable
 using System;
 using System.Threading.Tasks;
+using BTCPayServer.Data;
 using BTCPayServer.Logging;
 using BTCPayServer.Services;
+using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.Extensions.Logging;
 using MimeKit;
+using static BTCPayServer.Plugins.Monetization.Views.SelectExistingOfferingModalViewModel;
 
 namespace BTCPayServer.Plugins.Emails.Services;
 
-public abstract class EmailSender(IBackgroundJobClient jobClient, EventAggregator eventAggregator, Logs logs) : IEmailSender
+public abstract class EmailSender(IBackgroundJobClient jobClient, EventAggregator eventAggregator,
+    ApplicationDbContextFactory dbContextFactory, Logs logs) : IEmailSender
 {
     public EventAggregator EventAggregator { get; } = eventAggregator;
     public Logs Logs { get; } = logs;
@@ -18,7 +22,9 @@ public abstract class EmailSender(IBackgroundJobClient jobClient, EventAggregato
         SendEmail(new[] { email }, Array.Empty<MailboxAddress>(), Array.Empty<MailboxAddress>(), subject, message);
     }
 
-    public void SendEmail(MailboxAddress[] email, MailboxAddress[] cc, MailboxAddress[] bcc, string subject, string message)
+    public virtual void SendEmail(MailboxAddress[] email, MailboxAddress[] cc, MailboxAddress[] bcc, string subject, string message) => SendEmail(email, cc, bcc, subject, message, null, null);
+
+    public void SendEmail(MailboxAddress[] email, MailboxAddress[] cc, MailboxAddress[] bcc, string subject, string message, string? storeId, string? trigger)
     {
         jobClient.Schedule(async cancellationToken =>
         {
@@ -29,11 +35,41 @@ public abstract class EmailSender(IBackgroundJobClient jobClient, EventAggregato
                 return;
             }
 
-            using var smtp = await emailSettings.CreateSmtpClient();
-            var mail = emailSettings.CreateMailMessage(email, cc, bcc, subject, message, true);
-            var response = await smtp.SendAsync(mail, cancellationToken);
-            await smtp.DisconnectAsync(true, cancellationToken);
-            EventAggregator.Publish(new Events.EmailSentEvent(response, mail));
+            var log = EmailLogData.Create(storeId);
+            var blob = new EmailLogBlob
+            {
+                Trigger = trigger ?? "Unknown",
+                To = Array.ConvertAll(email, m => m.ToString()),
+                CC = Array.ConvertAll(cc, m => m.ToString()),
+                BCC = Array.ConvertAll(bcc, m => m.ToString()),
+                Subject = subject,
+                Body = message
+            };
+
+            try
+            {
+                using var smtp = await emailSettings.CreateSmtpClient();
+                var mail = emailSettings.CreateMailMessage(email, cc, bcc, subject, message, true);
+                var response = await smtp.SendAsync(mail, cancellationToken);
+                await smtp.DisconnectAsync(true, cancellationToken);
+
+                blob.Status = EmailLogStatus.Sent;
+                EventAggregator.Publish(new Events.EmailSentEvent(response, mail));
+            }
+            catch (Exception ex)
+            {
+                blob.Status = EmailLogStatus.Failed;
+                blob.Error = ex.Message;
+                Logs.Configuration.LogWarning(ex, "Failed to send email ({Trigger})", trigger);
+                throw;
+            }
+            finally
+            {
+                log.SetBlob(blob);
+                await using var ctx = dbContextFactory.CreateContext();
+                ctx.EmailLogs.Add(log);
+                await ctx.SaveChangesAsync(cancellationToken);
+            }
         }, TimeSpan.Zero);
     }
 

--- a/BTCPayServer/Plugins/Emails/Services/EmailSenderFactory.cs
+++ b/BTCPayServer/Plugins/Emails/Services/EmailSenderFactory.cs
@@ -1,5 +1,6 @@
 #nullable enable
 using System.Threading.Tasks;
+using BTCPayServer.Data;
 using BTCPayServer.Logging;
 using BTCPayServer.Services;
 using BTCPayServer.Services.Stores;
@@ -11,6 +12,7 @@ public class EmailSenderFactory(
     SettingsRepository settingsSettingsRepository,
     EventAggregator eventAggregator,
     ISettingsAccessor<PoliciesSettings> policiesSettings,
+    ApplicationDbContextFactory dbContextFactory,
     StoreRepository storeRepository,
     Logs logs)
 {
@@ -18,12 +20,12 @@ public class EmailSenderFactory(
 
     public Task<IEmailSender> GetEmailSender(string? storeId = null)
     {
-        var serverSender = new ServerEmailSender(settingsSettingsRepository, jobClient, eventAggregator, Logs);
+        var serverSender = new ServerEmailSender(settingsSettingsRepository, jobClient, eventAggregator, dbContextFactory, Logs);
         if (string.IsNullOrEmpty(storeId))
             return Task.FromResult<IEmailSender>(serverSender);
         return Task.FromResult<IEmailSender>(new StoreEmailSender(storeRepository,
             !policiesSettings.Settings.DisableStoresToUseServerEmailSettings ? serverSender : null, jobClient,
-            eventAggregator, storeId, Logs));
+            eventAggregator, dbContextFactory, storeId, Logs));
     }
 
     public async Task<bool> IsComplete(string? storeId = null)

--- a/BTCPayServer/Plugins/Emails/Services/IEmailSender.cs
+++ b/BTCPayServer/Plugins/Emails/Services/IEmailSender.cs
@@ -8,5 +8,6 @@ public interface IEmailSender
 {
     void SendEmail(MailboxAddress email, string subject, string message);
     void SendEmail(MailboxAddress[] email, MailboxAddress[] cc, MailboxAddress[] bcc, string subject, string message);
+    void SendEmail(MailboxAddress[] email, MailboxAddress[] cc, MailboxAddress[] bcc, string subject, string message, string? storeId, string? trigger);
     Task<EmailSettings?> GetEmailSettings();
 }

--- a/BTCPayServer/Plugins/Emails/Services/ServerEmailSender.cs
+++ b/BTCPayServer/Plugins/Emails/Services/ServerEmailSender.cs
@@ -1,5 +1,6 @@
 #nullable enable
 using System.Threading.Tasks;
+using BTCPayServer.Data;
 using BTCPayServer.Logging;
 using BTCPayServer.Services;
 
@@ -8,7 +9,8 @@ namespace BTCPayServer.Plugins.Emails.Services;
 class ServerEmailSender(SettingsRepository settingsRepository,
     IBackgroundJobClient backgroundJobClient,
     EventAggregator eventAggregator,
-    Logs logs) : EmailSender(backgroundJobClient, eventAggregator, logs)
+    ApplicationDbContextFactory dbContextFactory,
+    Logs logs) : EmailSender(backgroundJobClient, eventAggregator, dbContextFactory, logs)
 {
     public override Task<EmailSettings?> GetEmailSettings()
         => settingsRepository.GetSettingAsync<EmailSettings>();

--- a/BTCPayServer/Plugins/Emails/Services/StoreEmailSender.cs
+++ b/BTCPayServer/Plugins/Emails/Services/StoreEmailSender.cs
@@ -5,6 +5,9 @@ using BTCPayServer.Data;
 using BTCPayServer.Logging;
 using BTCPayServer.Services;
 using BTCPayServer.Services.Stores;
+using MimeKit;
+using static BTCPayServer.Plugins.Monetization.Views.SelectExistingOfferingModalViewModel;
+using static QRCoder.PayloadGenerator;
 
 namespace BTCPayServer.Plugins.Emails.Services;
 
@@ -13,13 +16,16 @@ class StoreEmailSender(
     EmailSender? fallback,
     IBackgroundJobClient backgroundJobClient,
     EventAggregator eventAggregator,
+    ApplicationDbContextFactory dbContextFactory,
     string storeId,
     Logs logs)
-    : EmailSender(backgroundJobClient, eventAggregator, logs)
+    : EmailSender(backgroundJobClient, eventAggregator, dbContextFactory, logs)
 {
     public StoreRepository StoreRepository { get; } = storeRepository;
     public EmailSender? FallbackSender { get; } = fallback;
     public string StoreId { get; } = storeId ?? throw new ArgumentNullException(nameof(storeId));
+
+    public override void SendEmail(MailboxAddress[] email, MailboxAddress[] cc, MailboxAddress[] bcc, string subject, string message) => SendEmail(email, cc, bcc, subject, message, StoreId, null);
 
     public override async Task<EmailSettings?> GetEmailSettings()
     {

--- a/BTCPayServer/Plugins/Emails/Views/Shared/EmailLogsList.cshtml
+++ b/BTCPayServer/Plugins/Emails/Views/Shared/EmailLogsList.cshtml
@@ -1,0 +1,70 @@
+@using BTCPayServer.Data
+@using BTCPayServer.Plugins.Emails.Controllers
+@using BTCPayServer.Views.Server
+@model EmailLogsViewModel
+
+@{
+	if (Model.StoreId is null)
+	{
+		ViewData.SetLayoutModel(new LayoutModel("Server-" + nameof(ServerNavPages.Emails), StringLocalizer["Sent Emails"]).SetCategory(WellKnownCategories.Server));
+	}
+	else
+	{
+		ViewData.SetLayoutModel(new LayoutModel(nameof(StoreNavPages.Emails), StringLocalizer["Sent Emails"]).SetCategory(WellKnownCategories.Store));
+	}
+}
+
+<div class="sticky-header">
+	<nav aria-label="breadcrumb">
+		<ol class="breadcrumb">
+			<li class="breadcrumb-item">
+				@if (Model.StoreId is not null)
+				{
+					<a asp-controller="UIStoresEmail" asp-action="StoreEmailSettings" asp-route-storeId="@Model.StoreId" text-translate="true">Emails</a>
+				}
+				else
+				{
+					<a asp-controller="UIServerEmail" asp-action="ServerEmailSettings" text-translate="true">Server Emails</a>
+				}
+			</li>
+			<li class="breadcrumb-item active" aria-current="page">@ViewData.GetTitle()</li>
+		</ol>
+		<h2>@ViewData.GetTitle()</h2>
+	</nav>
+	@if (Model.Logs.Any())
+    {
+		<button type="submit" form="EmailLogsForm" class="btn btn-primary" permission="@Model.ModifyPermission" text-translate="true">
+			Resend selected emails
+		</button>
+    }
+</div>
+
+<partial name="_StatusMessage" />
+
+<p text-translate="true">A log of emails sent in the last 10 days.</p>
+
+@if (Model.Logs.Any())
+{
+	@if (Model.StoreId is not null)
+	{
+		<form id="EmailLogsForm" asp-controller="UIStoreEmailLogs" asp-action="ResendStoreEmails" asp-route-storeId="@Model.StoreId" method="post">
+			<partial name="_EmailLogsTable" model="@Model" />
+		</form>
+	}
+	else
+	{
+		<form id="EmailLogsForm" asp-controller="UIServerEmailLogs" asp-action="ResendServerEmails" method="post">
+			<partial name="_EmailLogsTable" model="@Model" />
+		</form>
+	}
+
+	<script>
+		document.getElementById("SelectAll").addEventListener("change", function () {
+			document.querySelectorAll(".row-checkbox").forEach(cb => cb.checked = this.checked);
+		});
+	</script>
+}
+else
+{
+	<p class="text-secondary" text-translate="true">No emails have been sent yet.</p>
+}

--- a/BTCPayServer/Plugins/Emails/Views/Shared/EmailSettings.cshtml
+++ b/BTCPayServer/Plugins/Emails/Views/Shared/EmailSettings.cshtml
@@ -18,22 +18,48 @@
         <div class="d-flex justify-content-end">
             <button cheat-mode="true" id="mailpit" type="submit" class="btn btn-info" name="command" value="mailpit">Use mailpit</button>
             @if (Model.StoreId is null)
-            {
-                <a id="ConfigureEmailRules" class="btn btn-secondary" asp-area="@EmailsPlugin.Area" asp-controller="UIServerEmailRules"
-                   asp-action="ServerEmailRulesList"
-                   permission="@Model.ModifyPermission" text-translate="true">
-                    Go to email rules
-                </a>
-            }
+			{
+				<div class="btn-group">
+					<a id="ConfigureEmailRules" class="btn btn-secondary" asp-area="@EmailsPlugin.Area" asp-controller="UIServerEmailRules"
+					   asp-action="ServerEmailRulesList"
+					   permission="@Model.ModifyPermission" text-translate="true">
+						Go to email rules
+					</a>
+					<button type="button" class="btn btn-secondary dropdown-toggle dropdown-toggle-split" data-bs-toggle="dropdown" aria-expanded="false">
+						<span class="visually-hidden">Toggle Dropdown</span>
+					</button>
+					<ul class="dropdown-menu dropdown-menu-end" style="min-width: auto;">
+						<li>
+							<a id="ViewSentEmails" class="dropdown-item px-3 py-2" asp-area="@EmailsPlugin.Area" asp-controller="UIServerEmailLogs"
+							   asp-action="ServerEmailLogsList" permission="@Model.ModifyPermission" text-translate="true">
+								View email logs
+							</a>
+						</li>
+					</ul>
+				</div>
+			}
             else
-            {
-                <a id="ConfigureEmailRules" class="btn btn-secondary" asp-area="@EmailsPlugin.Area" asp-controller="UIStoreEmailRules"
-                   asp-action="StoreEmailRulesList"
-                   asp-route-storeId="@Model.StoreId"
-                   permission="@Model.ViewPermission" text-translate="true">
-                    Go to email rules
-                </a>
-            }
+			{
+				<div class="btn-group">
+					<a id="ConfigureEmailRules" class="btn btn-secondary" asp-area="@EmailsPlugin.Area" asp-controller="UIStoreEmailRules"
+					   asp-action="StoreEmailRulesList"
+					   asp-route-storeId="@Model.StoreId"
+					   permission="@Model.ViewPermission" text-translate="true">
+						Go to email rules
+					</a>
+					<button type="button" class="btn btn-secondary dropdown-toggle dropdown-toggle-split" data-bs-toggle="dropdown" aria-expanded="false">
+						<span class="visually-hidden">Toggle Dropdown</span>
+					</button>
+					<ul class="dropdown-menu dropdown-menu-end" style="min-width: auto;">
+						<li>
+							<a id="ViewSentEmails" class="dropdown-item px-3 py-2" asp-area="@EmailsPlugin.Area" asp-controller="UIStoreEmailLogs"
+							   asp-action="StoreEmailLogsList" asp-route-storeId="@Model.StoreId" permission="@Model.ViewPermission" text-translate="true">
+								View email logs
+							</a>
+						</li>
+					</ul>
+				</div>
+			}
             <button id="page-primary" type="submit" class="btn btn-primary" name="command" value="Save" permission="@Model.ModifyPermission" text-translate="true">Save</button>
         </div>
     </div>

--- a/BTCPayServer/Plugins/Emails/Views/Shared/_EmailLogsTable.cshtml
+++ b/BTCPayServer/Plugins/Emails/Views/Shared/_EmailLogsTable.cshtml
@@ -32,7 +32,7 @@
 						}
 					</td>
 					<td>@blob.Trigger</td>
-					<td>@string.Join(", ", blob.To)</td>
+					<td>@string.Join(", ", blob.To ?? Array.Empty<string>())</td>
 					<td>@blob.Subject</td>
 					<td>@log.Timestamp.ToBrowserDate()</td>
 				</tr>

--- a/BTCPayServer/Plugins/Emails/Views/Shared/_EmailLogsTable.cshtml
+++ b/BTCPayServer/Plugins/Emails/Views/Shared/_EmailLogsTable.cshtml
@@ -1,0 +1,42 @@
+@using BTCPayServer.Data
+@using BTCPayServer.Plugins.Emails.Controllers
+@model EmailLogsViewModel
+
+<div class="table-responsive">
+	<table class="table table-hover">
+		<thead>
+			<tr>
+				<th style="width:1%"><input type="checkbox" id="SelectAll" class="form-check-input" /></th>
+				<th text-translate="true">Status</th>
+				<th text-translate="true">Trigger</th>
+				<th text-translate="true">To</th>
+				<th text-translate="true">Subject</th>
+				<th text-translate="true">Date</th>
+			</tr>
+		</thead>
+		<tbody>
+			@foreach (var log in Model.Logs)
+			{
+				var blob = log.GetBlob();
+				if (blob is null) { continue; }
+				<tr>
+					<td><input type="checkbox" name="ids" value="@log.Id" class="form-check-input row-checkbox" /></td>
+					<td>
+						@if (blob.Status == EmailLogStatus.Sent)
+						{
+							<span class="badge bg-success" text-translate="true">Sent</span>
+						}
+						else
+						{
+							<span class="badge bg-danger" data-bs-toggle="tooltip" title="@blob.Error" text-translate="true">Failed</span>
+						}
+					</td>
+					<td>@blob.Trigger</td>
+					<td>@string.Join(", ", blob.To)</td>
+					<td>@blob.Subject</td>
+					<td>@log.Timestamp.ToBrowserDate()</td>
+				</tr>
+			}
+		</tbody>
+	</table>
+</div>

--- a/BTCPayServer/Plugins/Webhooks/HostedServices/WebhookProviderHostedService.cs
+++ b/BTCPayServer/Plugins/Webhooks/HostedServices/WebhookProviderHostedService.cs
@@ -23,7 +23,7 @@ public class WebhookProviderHostedService(
     ILogger<WebhookProviderHostedService> logger)
     : EventHostedServiceBase(eventAggregator, logger)
 {
-    class WebhookTriggerOwner(WebhookTriggerProvider provider, WebhookTriggerContext ctx) : ITriggerOwner
+    internal class WebhookTriggerOwner(WebhookTriggerProvider provider, WebhookTriggerContext ctx) : ITriggerOwner
     {
         public Task BeforeSending(EmailRuleMatchContext context)
         => provider.BeforeSending(context, ctx);

--- a/BTCPayServer/Views/UIInvoice/Invoice.cshtml
+++ b/BTCPayServer/Views/UIInvoice/Invoice.cshtml
@@ -562,6 +562,37 @@
                 </section>
 
             }
+			@if (Model.ResendableEmailRules.Any())
+			{
+				<section class="mt-4 d-print-none">
+					<h3 class="mb-3">Emails</h3>
+					<div class="table-responsive-xl">
+						<table class="table table-hover mb-5">
+							<thead>
+								<tr>
+									<th>Trigger</th>
+									<th class="text-end">Action</th>
+								</tr>
+							</thead>
+							<tbody>
+								@foreach (var rule in Model.ResendableEmailRules)
+								{
+									<tr>
+										<td>@(rule.Subject ?? rule.Trigger)</td>
+										<td class="text-end">
+											<form asp-action="ResendEmail" asp-route-invoiceId="@Model.Id" method="post" class="d-inline">
+												<input type="hidden" name="trigger" value="@rule.Trigger" />
+												<button type="submit" class="btn btn-link p-0">Resend</button>
+											</form>
+										</td>
+									</tr>
+								}
+							</tbody>
+						</table>
+					</div>
+				</section>
+			}
+
             @if ((Model.Refunds?.Count ?? 0) > 0)
             {
                 <section class="mt-4">


### PR DESCRIPTION
Resolves https://github.com/btcpayserver/btcpayserver/discussions/6549


"My smtp relay went offline. So I have paid invoices whom did not receive their email tickets. It would be nice to be able to manually trigger an email for an invoice. The button could live in the invoice detail page where you could have a dropdown menu with your custom emails you can select to re-send."

This PR adds "Resend email" action to the invoice detail page, letting merchants manually re-fire one of their store's Email Rules against a specific invoice.

<img width="950" height="775" alt="image" src="https://github.com/user-attachments/assets/1cf80628-272e-4bff-a618-0937d9053c27" />

<img width="965" height="770" alt="image" src="https://github.com/user-attachments/assets/97a27109-5b04-4003-b25d-87b2b9640845" />


Cc. @NicolasDorier 