### PR TITLE
Refresh label filter dropdown when labels are added inline

### DIFF
--- a/BTCPayServer/Components/LabelSelector/Default.cshtml
+++ b/BTCPayServer/Components/LabelSelector/Default.cshtml
@@ -136,10 +136,31 @@
                 $anchor.after(fragment);
             }
 
-            $labelSearch.addEventListener('click', e => e.stopPropagation());
-            $labelSearch.addEventListener('input', () => {
+            function renderCurrentLabelItems() {
                 const query = $labelSearch.value.toLowerCase().trim();
                 renderLabelItems(query ? allLabels.filter(label => label.text.toLowerCase().includes(query)) : initialLabels);
+            }
+
+            $labelSearch.addEventListener('click', e => e.stopPropagation());
+            $labelSearch.addEventListener('input', renderCurrentLabelItems);
+
+            // Keep the filter dropdown in sync when labels are added inline via a LabelManager
+            // (e.g. on a transaction or payment request row) without requiring a page reload.
+            document.addEventListener('labelmanager:changed', ({ detail }) => {
+                const changedLabels = Array.isArray(detail && detail.labels) ? detail.labels : [];
+                let added = false;
+                changedLabels.forEach(text => {
+                    if (!text || allLabels.some(label => label.text.toLowerCase() === text.toLowerCase())) return;
+                    const label = { text, color: '', textColor: '', usageCount: 0 };
+                    allLabels.push(label);
+                    initialLabels.push(label);
+                    added = true;
+                });
+                if (!added) return;
+                const byText = (a, b) => a.text.toLowerCase().localeCompare(b.text.toLowerCase());
+                allLabels.sort(byText);
+                initialLabels.sort(byText);
+                renderCurrentLabelItems();
             });
         })();
     </script>

--- a/BTCPayServer/wwwroot/main/site.js
+++ b/BTCPayServer/wwwroot/main/site.js
@@ -179,6 +179,7 @@ async function initLabelManager (elementId) {
         async onChange (values) {
             const labels = Array.isArray(values) ? values : values.split(',');
             element.dispatchEvent(new CustomEvent("labelmanager:changed", {
+                bubbles: true,
                 detail: {
                     id: objectId,
                     type: objectType,


### PR DESCRIPTION
Fixes #7251

### Problem

The label filter dropdown on the Wallet Transactions and Payment Requests pages is rendered by the shared `LabelSelector` view component, which bakes its options into static JS arrays at page-render time. When a label is created/applied inline via a `LabelManager` (on a transaction or payment request row), the filter dropdown does not include the new label until a full page reload.

### Fix

- Make the `LabelManager` `labelmanager:changed` event bubble so a single delegated listener can catch it — necessary because transaction rows are loaded lazily via infinite scroll.
- Have the `LabelSelector` listen for `labelmanager:changed`, merge any newly applied labels into its option arrays, and re-render the current view (preserving the active label search query).

Using the event payload (rather than refetching `labels.json`) keeps the refresh scoped to the object type being filtered and avoids a race with the label-persistence request. Because the change lives in the shared component plus `site.js`, both affected pages are fixed.

Known limitation (out of scope): if a wallet has zero labels initially, the `LabelSelector` block isn't rendered at all (`@if (Model.Labels.Any())`), so the very first label still needs a reload to make the dropdown appear — this PR fixes the existing dropdown going stale.

### Manual test steps

1. Open **Wallet → Transactions** for a wallet that already has some labels.
2. Open the **Labels** filter dropdown and note the current labels.
3. On any transaction row, add a brand-new label via the inline label editor (type a name that doesn't exist yet and confirm it).
4. Open the **Labels** filter dropdown again — the new label now appears **without reloading the page**. Selecting it filters correctly.
5. Repeat on **Store → Payment Requests** using the inline label editor on a payment request row — the new label appears in that page's filter dropdown without a reload.
6. Regression: the label-search box inside the dropdown still filters the list as before.
