### PR TITLE
Properly format Custom Range in date range selector

### DIFF
--- a/BTCPayServer.Tests/FastTests.cs
+++ b/BTCPayServer.Tests/FastTests.cs
@@ -1556,19 +1556,27 @@ bc1qfzu57kgu5jthl934f9xrdzzx8mmemx7gn07tf0grnvz504j6kzusu2v0ku
         {
             var utc = TimeZoneInfo.Utc;
             var search = new SearchString("startdate:2026-01-15 10:00:00");
-            Assert.Equal(
+
+            void AssertEqual(DateTimeOffset a, DateTimeOffset? b)
+            {
+                Assert.NotNull(b);
+                Assert.Equal(a, b);
+                Assert.Equal(a.Offset, b.Value.Offset);
+            }
+
+            AssertEqual(
                 new DateTimeOffset(2026, 1, 15, 10, 0, 0, TimeSpan.Zero),
                 search.GetFilterDate("startdate", utc));
 
             var paris = TimeZoneInfo.FindSystemTimeZoneById("Europe/Paris");
             search = new SearchString("startdate:2026-01-15 10:00:00");
-            Assert.Equal(
+            AssertEqual(
                 new DateTimeOffset(2026, 1, 15, 9, 0, 0, TimeSpan.Zero),
                 search.GetFilterDate("startdate", paris));
 
             var tokyo = TimeZoneInfo.FindSystemTimeZoneById("Asia/Tokyo");
             search = new SearchString("startdate:2026-06-30 17:00:00");
-            Assert.Equal(
+            AssertEqual(
                 new DateTimeOffset(2026, 6, 30, 8, 0, 0, TimeSpan.Zero),
                 search.GetFilterDate("startdate", tokyo));
         }

--- a/BTCPayServer.Tests/WalletTests.cs
+++ b/BTCPayServer.Tests/WalletTests.cs
@@ -1202,7 +1202,7 @@ public class WalletTests(ITestOutputHelper helper) : UnitTestBase(helper)
         var urlAfterClearAll = new Uri(s.Page.Url);
         var qsAfterClearAll = HttpUtility.ParseQueryString(urlAfterClearAll.Query);
         Assert.True(string.IsNullOrEmpty(qsAfterClearAll["SearchText"]));
-        Assert.True(string.IsNullOrEmpty(qsAfterClearAll["SearchTerm"]));
+        Assert.Equal(qsAfterClearAll["SearchTerm"], $"timezone:{selectedTimeZone}");
 
         await s.GoToInvoices(s.StoreId);
         await s.Page.ClickAsync("#DateRangeSelector");

--- a/BTCPayServer/Components/DateRangeSelector/DateRangeSelector.cs
+++ b/BTCPayServer/Components/DateRangeSelector/DateRangeSelector.cs
@@ -16,17 +16,17 @@ public class DateRangeSelector : ViewComponent
     {
         Search = search ?? throw new ArgumentNullException(nameof(search)),
         CustomRangeTitle = customRangeTitle ?? "Filter by Custom Range",
-        Url = Url
     });
 }
 
 public class DateRangeSelectorModel
 {
     private const string SearchTermRouteKey = "searchTerm";
+    private const string InputDateFormat = "yyyy-MM-ddTHH:mm:ss";
+    private (DateTimeOffset? StartDate, DateTimeOffset? EndDate)? _dateRange;
 
     public required SearchString Search { get; init; }
     public required string CustomRangeTitle { get; init; }
-    public required IUrlHelper Url { get; init; }
 
 
     public DateRangeSelectorModel()
@@ -49,6 +49,24 @@ public class DateRangeSelectorModel
     private bool IsDate(string val) => Search.GetFilterDate(val, TimeZoneInfo.Utc) is not null;
 
     public bool HasDateRange(string value) => Search.HasArrayFilter("daterange", value);
+
+    public (DateTimeOffset? StartDate, DateTimeOffset? EndDate) DateRange =>
+        _dateRange ??= Search.GetDateRange(TimeZoneInfo.Utc);
+
+    public string? StartDateInputValue => FormatInputDate(LocalDate(DateRange.StartDate));
+    public string? EndDateInputValue => FormatInputDate(LocalDate(DateRange.EndDate));
+
+    private DateTimeOffset? LocalDate(DateTimeOffset? d)
+    {
+        if (d is null)
+            return null;
+        if (BTCPayServer.TimeZones.TryGet(Search.GetExplicitTimeZone() ?? "") is {} tz)
+            d = TimeZoneInfo.ConvertTime(d.Value, tz);
+        return d;
+    }
+
+    private static string? FormatInputDate(DateTimeOffset? date) =>
+        date?.ToString(InputDateFormat, CultureInfo.InvariantCulture);
 
     public static string RemoveDatePreset(string? search)
     {

--- a/BTCPayServer/Components/DateRangeSelector/Default.cshtml
+++ b/BTCPayServer/Components/DateRangeSelector/Default.cshtml
@@ -15,7 +15,6 @@
         ("thisyear", StringLocalizer["This year"].Value),
         ("lastyear", StringLocalizer["Last year"].Value)
     };
-
 }
 
 <div class="dropdown" id="DateRangeDropdown">
@@ -29,7 +28,22 @@
             }
             else
             {
-                <span text-translate="true">Custom range</span>
+                if (Model.DateRange.StartDate is not null && Model.DateRange.EndDate is not null)
+                {
+                    <span>@ViewLocalizer["From {0} to {1}", Model.DateRange.StartDate.Value.ToBrowserDate(), Model.DateRange.EndDate.Value.ToBrowserDate()]</span>
+                }
+                else if (Model.DateRange.StartDate is not null)
+                {
+                    <span>@ViewLocalizer["From {0}", Model.DateRange.StartDate.Value.ToBrowserDate()]</span>
+                }
+                else if (Model.DateRange.EndDate is not null)
+                {
+                    <span>@ViewLocalizer["To {0}", Model.DateRange.EndDate.Value.ToBrowserDate()]</span>
+                }
+                else
+                {
+                    <span text-translate="true">Custom range</span>
+                }
             }
         }
         else
@@ -39,9 +53,10 @@
     </button>
     <div class="dropdown-menu" aria-labelledby="DateRangeSelector">
         <div class="px-3 py-2" style="min-width: 18rem;">
+            <button type="submit" id="DateRangeTimeZoneButton" name="FilterCommand" class="d-none"></button>
             <label for="DateRangeTimeZone" class="form-label small text-muted mb-1" text-translate="true">Query timezone</label>
             <!-- The input will get filled automatically by the browser (thanks to the timezone attribute) if the search string doesn't have a timezone -->
-            <input id="DateRangeTimeZone" name="TimeZone" class="form-control form-control-sm" timezone value="@Model.Search.GetExplicitTimeZone()" list="DateRangeTimeZoneOptions" autocomplete="off" />
+            <input id="DateRangeTimeZone" class="form-control form-control-sm" timezone value="@Model.Search.GetExplicitTimeZone()" list="DateRangeTimeZoneOptions" autocomplete="off" />
             <datalist id="DateRangeTimeZoneOptions">
                 @foreach (var timeZone in Model.TimeZones)
                 {
@@ -82,7 +97,8 @@
                     <div class="col-sm-9">
                         <div class="input-group">
                             <input id="dtpStartDate" class="form-control flatdtpicker" type="datetime-local"
-                                   data-fdtp='{ "enableTime": true, "enableSeconds": true, "dateFormat": "Y-m-d H:i:S", "defaultHour": 0 }'
+                                   data-fdtp='{ "altInput": true, "enableTime": true, "enableSeconds": true, "dateFormat": "Y-m-d H:i:S", "minuteIncrement": 1, "defaultHour": 0 }'
+                                   value="@Model.StartDateInputValue"
                                    placeholder="@StringLocalizer["Start Date"]" />
                             <button type="button" class="btn btn-secondary input-group-clear" title="@StringLocalizer["Clear"]">
                                 <vc:icon symbol="close" />
@@ -95,7 +111,8 @@
                     <div class="col-sm-9">
                         <div class="input-group">
                             <input id="dtpEndDate" class="form-control flatdtpicker" type="datetime-local"
-                                   data-fdtp='{ "enableTime": true, "enableSeconds": true, "dateFormat": "Y-m-d H:i:S", "defaultHour": 0 }'
+                                   data-fdtp='{ "altInput": true, "enableTime": true, "enableSeconds": true, "dateFormat": "Y-m-d H:i:S", "minuteIncrement": 1, "defaultHour": 0 }'
+                                   value="@Model.EndDateInputValue"
                                    placeholder="@StringLocalizer["End Date"]" />
                             <button type="button" class="btn btn-secondary input-group-clear" title="@StringLocalizer["Clear"]">
                                 <vc:icon symbol="close" />
@@ -115,7 +132,9 @@
     (function() {
         var dateRangeTimeZone = document.getElementById('DateRangeTimeZone');
         var defaultOption = document.getElementById('DateRangeTimeZone-DefaultOption');
-        var defaultValue = Intl.DateTimeFormat().resolvedOptions().timeZone + ' (' + @Safe.Json(StringLocalizer["Default"].Value) + ')';
+        var tzSubmit = document.getElementById("DateRangeTimeZoneButton");
+        var browserTz = Intl.DateTimeFormat().resolvedOptions().timeZone;
+        var defaultValue = browserTz + ' (' + @Safe.Json(StringLocalizer["Default"].Value) + ')';
         defaultOption.value = defaultValue;
 
          var expicitTimeZone = @Safe.Json(Model.Search.GetExplicitTimeZone());
@@ -126,25 +145,31 @@
              dateRangeTimeZone.value = window.defaultDateTimeFormat.timeZone ?? defaultValue;
          }
 
-         function updatePreferredTimeZone() {
+         if (!window.getPreferredTimeZone() && browserTz === dateRangeTimeZone.value)
+         {
+             dateRangeTimeZone.value = defaultOption.value;
+         }
+
+         function updateTimeZone() {
              if (dateRangeTimeZone.value === defaultValue || dateRangeTimeZone.value === "") {
-                 dateRangeTimeZone.value = defaultValue;
+                 tzSubmit.value = "set-timezone:" + browserTz;
                  window.clearPreferredTimeZone();
              } else {
+                 tzSubmit.value = "set-timezone:" + dateRangeTimeZone.value;
                  window.setPreferredTimeZone(dateRangeTimeZone.value);
              }
          }
 
         dateRangeTimeZone.addEventListener('change', function () {
-            updatePreferredTimeZone();
-            this.closest('form').submit();
+            updateTimeZone();
+            this.closest('form').requestSubmit(tzSubmit);
         });
 
         dateRangeTimeZone.addEventListener('keydown', function (event) {
             if (event.key === 'Enter') {
                 event.preventDefault();
-                updatePreferredTimeZone();
-                this.closest('form').submit();
+                updateTimeZone();
+                this.closest('form').requestSubmit(tzSubmit);
             }
         });
 

--- a/BTCPayServer/Components/Pager/Default.cshtml
+++ b/BTCPayServer/Components/Pager/Default.cshtml
@@ -78,13 +78,9 @@
         {
             { "searchTerm", Model.SearchTerm },
             { "skip", skip },
-            { "count", count }
+            { "count", count },
+            { "searchText", Model.SearchText }
         };
-        if (Model.TimeZone is not null)
-        {
-            if (TimeZones.TryGet(Model.TimeZone) is {} tz)
-                query.Add("timeZone", tz.Id);
-        }
 
         if (Model.PaginationQuery != null)
         {

--- a/BTCPayServer/Models/BasePagingViewModel.cs
+++ b/BTCPayServer/Models/BasePagingViewModel.cs
@@ -39,15 +39,9 @@ namespace BTCPayServer.Models
         public string SearchText { get; set; }
         public string FilterCommand { get; set; }
 
-        public string TimeZone { get; set; }
-
         public SearchString GetSearch()
         {
             var search = SearchString.Combine([SearchTerm, SearchText]);
-            if (TimeZone is not null)
-            {
-                search.SetFilter("timezone", TimeZones.TryGet(TimeZone)?.Id);
-            }
             if (FilterCommand is not null)
                 RunFilterCommand(search);
             AddUIFilters(search);
@@ -72,6 +66,13 @@ namespace BTCPayServer.Models
                 }
             }
 
+            if (FilterCommand.StartsWith("set-timezone:"))
+            {
+                var tz = FilterCommand.Substring("set-timezone:".Length);
+                if (TimeZones.TryGet(tz) is { } tzo)
+                    search.SetFilter("timezone", tzo.Id);
+            }
+
             if (FilterCommand.StartsWith("unset:"))
             {
                 var k = FilterCommand.Substring("unset:".Length);
@@ -80,7 +81,10 @@ namespace BTCPayServer.Models
 
             if (FilterCommand is "reset")
             {
+                var tz = search.GetFilterString("timezone");
                 search.Filters.Clear();
+                if (tz != null)
+                    search.SetFilter("timezone", tz);
                 search.TextSearch = "";
                 return;
             }

--- a/BTCPayServer/SearchString.cs
+++ b/BTCPayServer/SearchString.cs
@@ -169,7 +169,7 @@ namespace BTCPayServer
                 {
                     DateTimeKind.Local => new DateTimeOffset(localDateTime, TimeZoneInfo.Local.GetUtcOffset(localDateTime)),
                     DateTimeKind.Utc => new DateTimeOffset(localDateTime, TimeSpan.Zero),
-                    DateTimeKind.Unspecified when tz is not null => new DateTimeOffset(localDateTime, tz.GetUtcOffset(localDateTime)),
+                    DateTimeKind.Unspecified when tz is not null => new DateTimeOffset(localDateTime, tz.GetUtcOffset(localDateTime)).ToUniversalTime(),
                     DateTimeKind.Unspecified when tz is null => null,
                     _ => throw new ArgumentOutOfRangeException()
                 };
@@ -202,7 +202,6 @@ namespace BTCPayServer
             var localDate = (key, val) switch
             {
                 ("startdate", "today") => today,
-                ("enddate", "today") => today.AddDays(1).AddTicks(-1),
                 ("startdate", "yesterday") => today.AddDays(-1),
                 ("enddate", "yesterday") => today.AddTicks(-1),
                 ("startdate", "thisweek") => startOfThisWeek,


### PR DESCRIPTION
The date in the custom range popup is formatting according to browser preferences.

<img width="1526" height="794" alt="image" src="https://github.com/user-attachments/assets/e83774a4-6dc3-4708-a842-84578c6ef182" />

If selecting a custom range, the dates are now shown:

<img width="2566" height="786" alt="image" src="https://github.com/user-attachments/assets/63fb686b-cad2-4560-af1f-2515ce8da8ad" />

Finally, selecting any pre configured date range (such as Last month), automatically set the Custom Range start date and end date, allowing the user to slightly change a date.