### PR TITLE
POS: format keypad amounts using the store checkout language

### DIFF
--- a/BTCPayServer/Plugins/PointOfSale/Controllers/UIPointOfSaleController.cs
+++ b/BTCPayServer/Plugins/PointOfSale/Controllers/UIPointOfSaleController.cs
@@ -143,6 +143,7 @@ namespace BTCPayServer.Plugins.PointOfSale.Controllers
                 AppId = appId,
                 StoreId = store.Id,
                 HtmlLang = settings.HtmlLang,
+                DefaultLang = storeBlob.DefaultLang,
                 HtmlMetaTags= settings.HtmlMetaTags,
                 Description = settings.Description,
                 NotAvailable = StringLocalizer["Not available in Keypad POS"].Value

--- a/BTCPayServer/Plugins/PointOfSale/Models/ViewPointOfSaleViewModel.cs
+++ b/BTCPayServer/Plugins/PointOfSale/Models/ViewPointOfSaleViewModel.cs
@@ -80,6 +80,7 @@ namespace BTCPayServer.Plugins.PointOfSale.Models
         public string CustomTipText { get; set; }
         public int[] CustomTipPercentages { get; set; }
         public string HtmlLang { get; set; }
+        public string DefaultLang { get; set; }
         public string HtmlMetaTags{ get; set; }
         public string Description { get; set; }
         public SelectList AllCategories { get; set; }

--- a/BTCPayServer/wwwroot/pos/common.js
+++ b/BTCPayServer/wwwroot/pos/common.js
@@ -273,6 +273,9 @@ const posCommon = {
             this.payButtonLoading = true;
         },
         getLocale(currency) {
+            // Prefer the store's checkout language so amounts are grouped and
+            // formatted according to the merchant's locale (e.g. 1,234 vs 1.234)
+            if (this.defaultLang) return this.defaultLang
             switch (currency) {
                 case 'USD': return 'en-US'
                 case 'EUR': return 'de-DE'


### PR DESCRIPTION
The Point of Sale keypad derived its number-formatting locale solely from the currency code (`getLocale` in `pos/common.js`: USD→en-US, EUR→de-DE, JPY→ja-JP, else `navigator.language`), so the store checkout language had no effect on how amounts are grouped and separated (e.g. `1,234` vs `1.234`), as reported in #7365.

This passes the store checkout `DefaultLang` to the POS view model and prefers it as the `Intl.NumberFormat` locale when set, falling back to the existing currency-based heuristic when the store has no checkout language configured — so default behavior and existing tests are unchanged.

Scope note: this fixes the number/separator formatting, which is the part that can follow the per-store checkout language. The keypad static text ("Charge", tab labels) is localized via the server-side `text-translate` system (a single server-wide language, not per-store); making it per-store would need client-side i18n and is left as a separate follow-up.

@NicolasDorier flagged in the issue that this should be better supported.

Fixes #7365