### PR TITLE
Greenfield: document offering and plan creation as returning 200

### DIFF
--- a/BTCPayServer/wwwroot/swagger/v1/swagger.template.subscriptions.json
+++ b/BTCPayServer/wwwroot/swagger/v1/swagger.template.subscriptions.json
@@ -159,7 +159,7 @@
                     }
                 },
                 "responses": {
-                    "201": {
+                    "200": {
                         "description": "Offering created successfully.",
                         "content": {
                             "application/json": {
@@ -211,7 +211,7 @@
                     }
                 },
                 "responses": {
-                    "201": {
+                    "200": {
                         "description": "Plan created successfully.",
                         "content": {
                             "application/json": {


### PR DESCRIPTION
While going through the subscription Greenfield API in #7027, @ndeet noticed that creating an offering and creating a plan return `200 OK`, even though the API reference documents both as `201 Created`.

Both endpoints build their response by delegating to the corresponding `GET` helper (`GetOffering` / `GetOfferingPlan`), which returns `Ok(...)` — so the created resource came back with a 200. This wraps the success response to return 201 with the exact same body, matching the Swagger definition. It also lines up with the user-creation endpoint, the only other creation endpoint documented as 201, which already returns it.

Error and not-found paths are untouched (the wrapper only rewrites the successful `OkObjectResult`). No client or response-shape change, so existing consumers and the `CanUseSubscriptionAPI` integration test are unaffected — the C# client accepts any 2xx.

This is just the status-code point from #7027; the other items in that issue are separate, so I've left it as `Refs #7027` rather than closing it.

Refs #7027
