### PR TITLE
Add tooltips to global navigation icons

### DIFF
--- a/BTCPayServer/Blazor/NotificationsDropDown.razor
+++ b/BTCPayServer/Blazor/NotificationsDropDown.razor
@@ -15,14 +15,11 @@
 <div id="Notifications" class="dropdown @(!_JSRuntime.IsPreRendering() ? "rendered" : "")">
 	<button id="NotificationsHandle"
             class="mainMenuButton globalNav-btn dropdown-toggle"
-            title="@StringLocalizer["Notifications"]"
             type="button"
             data-bs-toggle="dropdown"
             data-bs-display="static"
             data-bs-auto-close="outside"
-            data-bs-trigger="hover"
-            data-bs-placement="bottom"
-            data-global-nav-tooltip="1"
+            aria-label="@StringLocalizer["Notifications"]"
             aria-expanded="false">
 		<Icon Symbol="nav-notifications" />
 		@if (HasUnseenNotifications)

--- a/BTCPayServer/Components/GlobalNav/Default.cshtml
+++ b/BTCPayServer/Components/GlobalNav/Default.cshtml
@@ -27,18 +27,19 @@
     <vc:ui-extension-point location="global-nav" model="Model"></vc:ui-extension-point>
     <div id="mainNavSettings" class="d-flex align-items-center gap-1">
         <vc:ui-extension-point location="global-nav-icons" model="Model"></vc:ui-extension-point>
-        <component type="typeof(BTCPayServer.Blazor.NotificationsDropDown)" render-mode="ServerPrerendered" />
+        <div data-global-nav-tooltip>
+            <component type="typeof(BTCPayServer.Blazor.NotificationsDropDown)" render-mode="ServerPrerendered" />
+        </div>
 
-        <div class="dropdown" permission="@Policies.CanModifyServerSettings">
+        <div class="dropdown"
+             permission="@Policies.CanModifyServerSettings"
+             data-global-nav-tooltip>
             <button id="globalNavPluginsToggle"
                     class="globalNav-btn"
                     type="button"
                     data-bs-toggle="dropdown"
                     aria-expanded="false"
-                    title="@StringLocalizer["Plugins"]"
-                    data-bs-trigger="hover"
-                    data-bs-placement="bottom"
-                    data-global-nav-tooltip="1">
+                    aria-label="@StringLocalizer["Plugins"]">
                 <vc:icon symbol="nav-plugin" />
                 @if (PluginService.GetDisabledPlugins().Any())
                 {
@@ -61,16 +62,15 @@
             </ul>
         </div>
 
-        <div class="dropdown" permission="@Policies.CanModifyServerSettings">
+        <div class="dropdown"
+             permission="@Policies.CanModifyServerSettings"
+             data-global-nav-tooltip>
             <button id="globalNavServerToggle"
                     class="globalNav-btn"
                     type="button"
                     data-bs-toggle="dropdown"
                     aria-expanded="false"
-                    title="@StringLocalizer["Server Settings"]"
-                    data-bs-trigger="hover"
-                    data-bs-placement="bottom"
-                    data-global-nav-tooltip="1">
+                    aria-label="@StringLocalizer["Server Settings"]">
                 <vc:icon symbol="nav-server-settings" />
             </button>
             <ul id="globalNavServerMenu" class="dropdown-menu dropdown-menu-end">
@@ -111,17 +111,14 @@
             </ul>
         </div>
 
-        <div class="dropdown">
+        <div class="dropdown" data-global-nav-tooltip>
             <button id="menu-item-Account"
                     class="globalNav-btn menu-item nav-link"
                     type="button"
                     data-bs-toggle="dropdown"
                     data-bs-auto-close="outside"
                     aria-expanded="false"
-                    title="@StringLocalizer["Account"]"
-                    data-bs-trigger="hover"
-                    data-bs-placement="bottom"
-                    data-global-nav-tooltip="1">
+                    aria-label="@StringLocalizer["Account"]">
                 @if (!string.IsNullOrEmpty(Model.UserImageUrl))
                 {
                     <img src="@Model.UserImageUrl" alt="Profile picture" class="profile-picture" style="--profile-picture-size:1.5rem" />

--- a/BTCPayServer/Plugins/GlobalSearch/Views/NavExtension.cshtml
+++ b/BTCPayServer/Plugins/GlobalSearch/Views/NavExtension.cshtml
@@ -18,10 +18,7 @@
         class="globalNav-btn d-lg-none"
         type="button"
         aria-label="@StringLocalizer["Search"]"
-        title="@StringLocalizer["Search"]"
-        data-bs-trigger="hover"
-        data-bs-placement="bottom"
-        data-global-nav-tooltip="1">
+        data-global-nav-tooltip>
     <vc:icon symbol="actions-search" />
 </button>
 <div id="globalSearchShell" class="globalSearch-shell">
@@ -90,4 +87,3 @@
 </script>
 <link href="~/plugins/GlobalSearch/global-search.css" rel="stylesheet" asp-append-version="true" />
 <script src="~/plugins/GlobalSearch/global-search.js" asp-append-version="true"></script>
-

--- a/BTCPayServer/wwwroot/main/layout.css
+++ b/BTCPayServer/wwwroot/main/layout.css
@@ -170,6 +170,25 @@
     background: var(--btcpay-neutral-100);
 }
 
+.globalNav-tooltip {
+    --btcpay-tooltip-padding-x: .75rem;
+    --btcpay-tooltip-padding-y: .375rem;
+    --btcpay-tooltip-font-size: var(--btcpay-font-size-m);
+    --btcpay-tooltip-color: var(--btcpay-body-text);
+    --btcpay-tooltip-bg: var(--btcpay-neutral-200);
+    --btcpay-tooltip-border-radius: .125rem;
+    --btcpay-tooltip-opacity: 1;
+}
+
+.globalNav-tooltip .tooltip-arrow {
+    display: none;
+}
+
+.globalNav-tooltip .tooltip-inner {
+    border: 1px solid var(--btcpay-neutral-400);
+    box-shadow: 0 2px 6px rgba(0, 0, 0, .2);
+}
+
 #globalNav .globalNav-btn .globalNav-status {
     position: absolute;
     top: .25rem;

--- a/BTCPayServer/wwwroot/main/site.js
+++ b/BTCPayServer/wwwroot/main/site.js
@@ -262,54 +262,75 @@ const initGlobalNavTooltips = () => {
     const header = document.getElementById('mainMenuHead');
     if (!header) return;
 
-    if (window.bootstrap?.Dropdown) {
-        header.addEventListener('show.bs.dropdown', event => {
-            const source = event.target;
-            if (!(source instanceof Element)) return;
+    const Tooltip = window.bootstrap?.Tooltip;
+    const Dropdown = window.bootstrap?.Dropdown;
+    const tooltipSelector = '[data-global-nav-tooltip]:not([data-bs-toggle="dropdown"])';
+    const tooltipTargets = Array.from(header.querySelectorAll(tooltipSelector));
+    const getDropdownToggle = source => source.matches('[data-bs-toggle="dropdown"]')
+        ? source
+        : source.querySelector('[data-bs-toggle="dropdown"]');
+    const getTooltipLabel = target => {
+        const labelledControl = target.matches('[aria-label]')
+            ? target
+            : target.querySelector('[aria-label]');
+        return labelledControl?.getAttribute('aria-label') || '';
+    };
+    const hideAllTooltips = () => {
+        tooltipTargets.forEach(target => Tooltip?.getInstance(target)?.hide());
+    };
 
-            const currentToggle = source.matches('[data-bs-toggle="dropdown"]')
-                ? source
-                : source.querySelector('[data-bs-toggle="dropdown"]');
-            if (!(currentToggle instanceof Element)) return;
-
-            header.querySelectorAll('[data-bs-toggle="dropdown"][aria-expanded="true"]').forEach(openToggle => {
-                if (openToggle === currentToggle) return;
-                window.bootstrap.Dropdown.getOrCreateInstance(openToggle).hide();
+    if (Tooltip) {
+        tooltipTargets.forEach(target => {
+            Tooltip.getOrCreateInstance(target, {
+                trigger: 'hover focus',
+                placement: 'bottom',
+                delay: 0,
+                animation: false,
+                customClass: 'globalNav-tooltip',
+                title: () => getTooltipLabel(target)
             });
         });
     }
 
-    if (!window.bootstrap?.Tooltip) return;
-    const tooltipTargets = Array.from(header.querySelectorAll('[data-global-nav-tooltip]'))
-        // Bootstrap supports only one component instance per element.
-        // Dropdown toggles therefore cannot also be Bootstrap tooltips.
-        .filter(target => (target.dataset.bsToggle || '').toLowerCase() !== 'dropdown');
-    if (!tooltipTargets.length) return;
-    const tooltipTargetSet = new Set(tooltipTargets);
+    if (Dropdown) {
+        header.addEventListener('show.bs.dropdown', event => {
+            const source = event.target;
+            if (!(source instanceof Element)) return;
 
-    const getTooltipOptions = target => ({
-        trigger: target.dataset.bsTrigger || 'hover',
-        placement: target.dataset.bsPlacement || 'bottom'
-    });
-    const hideAllTooltips = () => {
-        tooltipTargets.forEach(target => {
-            window.bootstrap.Tooltip.getInstance(target)?.hide();
+            const currentToggle = getDropdownToggle(source);
+            if (!(currentToggle instanceof Element)) return;
+
+            const tooltipTarget = currentToggle.closest('[data-global-nav-tooltip]');
+            if (tooltipTarget instanceof Element) {
+                const tooltip = Tooltip?.getInstance(tooltipTarget);
+                tooltip?.hide();
+                tooltip?.disable();
+            }
+
+            header.querySelectorAll('[data-bs-toggle="dropdown"][aria-expanded="true"]').forEach(openToggle => {
+                if (openToggle === currentToggle) return;
+                Dropdown.getOrCreateInstance(openToggle).hide();
+            });
         });
-    };
+        header.addEventListener('hidden.bs.dropdown', event => {
+            const source = event.target;
+            if (!(source instanceof Element)) return;
 
-    tooltipTargets.forEach(target => {
-        window.bootstrap.Tooltip.getOrCreateInstance(target, getTooltipOptions(target));
-    });
+            const currentToggle = getDropdownToggle(source);
+            const tooltipTarget = currentToggle?.closest('[data-global-nav-tooltip]');
+            if (tooltipTarget instanceof Element) {
+                Tooltip?.getInstance(tooltipTarget)?.enable();
+            }
+        });
+    }
 
     header.addEventListener('click', event => {
         const target = event.target;
         if (!(target instanceof Element)) return;
         const tooltipTarget = target.closest('[data-global-nav-tooltip]');
-        if (!(tooltipTarget instanceof Element) || !tooltipTargetSet.has(tooltipTarget)) return;
+        if (!(tooltipTarget instanceof Element) || !tooltipTarget.matches(tooltipSelector)) return;
         window.requestAnimationFrame(hideAllTooltips);
     });
-    header.addEventListener('shown.bs.dropdown', hideAllTooltips);
-    header.addEventListener('hide.bs.dropdown', hideAllTooltips);
 };
 
 document.addEventListener("DOMContentLoaded", () => {


### PR DESCRIPTION
Sometimes communicating functionalities with icons is difficult. I've noticed myself that I sometimes struggle figuring out which icon does what.

This PR Adds hover tooltips to Notifications, Plugins, Server Settings, Account, and mobile Search.
Tooltips appear immediately for closed controls and are hidden while a dropdown menu is open. All controls use the same styling and their existing accessible labels as tooltip text.

Notifications is implemented differently because its button and unread badge belong to a stateful Blazor component. Its tooltip is attached to a stable wrapper in the global navigation, while its accessible label remains inside the Blazor component. The other controls are regular Razor markup, so both parts can live in the same file.

## Before this PR

https://github.com/user-attachments/assets/ea39a010-0a54-47d9-8c5c-b2b2ef558119


## After this PR
https://github.com/user-attachments/assets/84423709-1be1-40a3-a8f3-f6e707abb342

