### PR TITLE
Add editable invoice comments

### DIFF
--- a/BTCPayServer.Client/Models/InvoiceData.cs
+++ b/BTCPayServer.Client/Models/InvoiceData.cs
@@ -19,6 +19,7 @@ namespace BTCPayServer.Client.Models
         public InvoiceType Type { get; set; }
         public string Currency { get; set; }
         public JObject Metadata { get; set; }
+        public string Comment { get; set; }
         public CheckoutOptions Checkout { get; set; } = new CheckoutOptions();
         public ReceiptOptions Receipt { get; set; } = new ReceiptOptions();
         public class ReceiptOptions

--- a/BTCPayServer.Client/Models/UpdateInvoiceRequest.cs
+++ b/BTCPayServer.Client/Models/UpdateInvoiceRequest.cs
@@ -5,5 +5,6 @@ namespace BTCPayServer.Client.Models
     public class UpdateInvoiceRequest
     {
         public JObject Metadata { get; set; }
+        public string Comment { get; set; }
     }
 }

--- a/BTCPayServer.Tests/PlaywrightTests.cs
+++ b/BTCPayServer.Tests/PlaywrightTests.cs
@@ -1215,6 +1215,14 @@ namespace BTCPayServer.Tests
             var invId = await s.CreateInvoice(storeId: s.StoreId, amount: 10_000);
             await s.GoToInvoiceCheckout(invId);
             await s.PayInvoice();
+
+            // We can leave a comment on the invoice, and it should be included in the export
+            await s.GoToInvoice(invId);
+            await s.Page.FillAsync("#InvoiceComment", "refunded manually from cashier wallet");
+            await s.Page.ClickAsync("#SaveComment");
+            await s.FindAlertMessage(partialText: "The comment has been saved.");
+            await Expect(s.Page.Locator("#InvoiceComment")).ToHaveValueAsync("refunded manually from cashier wallet");
+
             await s.GoToInvoices(s.StoreId);
             await s.ClickViewReport();
 
@@ -1224,6 +1232,7 @@ namespace BTCPayServer.Tests
             csvInvTester
                 .ForInvoice(invId)
                 .AssertValues(
+                    ("InvoiceComment", "refunded manually from cashier wallet"),
                     ("Rate (BTC_CAD)", "4500"),
                     ("Rate (BTC_JPY)", "700000"),
                     ("Rate (BTC_EUR)", "4000"),

--- a/BTCPayServer.Tests/UnitTest1.cs
+++ b/BTCPayServer.Tests/UnitTest1.cs
@@ -557,7 +557,7 @@ namespace BTCPayServer.Tests
 
             var time = invoice.InvoiceTime;
             AssertSearchInvoice(acc, true, invoice.Id, $"startdate:{time.ToString("yyyy-MM-dd HH:mm:ss")}");
-            AssertSearchInvoice(acc, true, invoice.Id, $"enddate:{time.ToString().ToLowerInvariant()}");
+            AssertSearchInvoice(acc, true, invoice.Id, $"enddate:{time.ToString(CultureInfo.InvariantCulture).ToLowerInvariant()}");
             AssertSearchInvoice(acc, false, invoice.Id,
                 $"startdate:{time.AddSeconds(1).ToString("yyyy-MM-dd HH:mm:ss")}");
             AssertSearchInvoice(acc, false, invoice.Id,
@@ -1640,11 +1640,35 @@ namespace BTCPayServer.Tests
             {
                 Amount = 50.513m,
                 Currency = "USD",
+                Comment = "  API comment  ",
                 Metadata = new JObject() { new JProperty("taxIncluded", 50.516m), new JProperty("orderId", "000000161") }
             });
             Assert.Equal(50.51m, invoice5g.Amount);
             Assert.Equal(50.51m, (decimal)invoice5g.Metadata["taxIncluded"]);
             Assert.Equal("000000161", (string)invoice5g.Metadata["orderId"]);
+            Assert.Equal("API comment", invoice5g.Comment);
+
+            invoice5g = await greenfield.GetInvoice(invoice5g.Id);
+            Assert.Equal("API comment", invoice5g.Comment);
+
+            invoice5g = await greenfield.UpdateInvoice(invoice5g.Id, new UpdateInvoiceRequest
+            {
+                Comment = "  Updated API comment  "
+            });
+            Assert.Equal("Updated API comment", invoice5g.Comment);
+
+            invoice5g = await greenfield.UpdateInvoice(invoice5g.Id, new UpdateInvoiceRequest
+            {
+                Metadata = new JObject { new JProperty("orderId", "000000162") }
+            });
+            Assert.Equal("Updated API comment", invoice5g.Comment);
+            Assert.Equal("000000162", (string)invoice5g.Metadata["orderId"]);
+
+            invoice5g = await greenfield.UpdateInvoice(invoice5g.Id, new UpdateInvoiceRequest
+            {
+                Comment = ""
+            });
+            Assert.Equal("", invoice5g.Comment);
 
             var zeroInvoice = await greenfield.CreateInvoice(user.StoreId, new CreateInvoiceRequest()
             {

--- a/BTCPayServer.Tests/UnitTest1.cs
+++ b/BTCPayServer.Tests/UnitTest1.cs
@@ -538,6 +538,23 @@ namespace BTCPayServer.Tests
             AssertSearchInvoice(acc, true, invoice.Id, "status:settled,exceptionstatus:paidPartial");
             AssertSearchInvoice(acc, true, invoice.Id, "status:settled,status:invalid,exceptionstatus:paidPartial,exceptionstatus:paidOver");
 
+            var invoiceController = acc.GetController<UIInvoiceController>();
+            var comment = "refunded manually from cashier wallet";
+            await invoiceController.Comment(invoice.Id, comment);
+
+            var listResult = await invoiceController.ListInvoices(new InvoicesModel { StoreId = acc.StoreId });
+            var listModel = (InvoicesModel)((ViewResult)listResult).Model;
+            var listedInvoice = Assert.Single(listModel.Invoices, i => i.InvoiceId == invoice.Id);
+            Assert.Equal(comment, listedInvoice.Comment);
+
+            // The comment should be included in the invoices export/report
+            var invoicesReport = await GetReport(acc, new() { ViewName = "Invoices" });
+            var reportInvoiceIdIndex = invoicesReport.GetIndex("InvoiceId");
+            var reportCommentIndex = invoicesReport.GetIndex("InvoiceComment");
+            Assert.Contains(invoicesReport.Data, d =>
+                d[reportInvoiceIdIndex].Value<string>() == invoice.Id &&
+                d[reportCommentIndex]?.Value<string>() == comment);
+
             var time = invoice.InvoiceTime;
             AssertSearchInvoice(acc, true, invoice.Id, $"startdate:{time.ToString("yyyy-MM-dd HH:mm:ss")}");
             AssertSearchInvoice(acc, true, invoice.Id, $"enddate:{time.ToString().ToLowerInvariant()}");

--- a/BTCPayServer.Tests/WalletTests.cs
+++ b/BTCPayServer.Tests/WalletTests.cs
@@ -1202,7 +1202,7 @@ public class WalletTests(ITestOutputHelper helper) : UnitTestBase(helper)
         var urlAfterClearAll = new Uri(s.Page.Url);
         var qsAfterClearAll = HttpUtility.ParseQueryString(urlAfterClearAll.Query);
         Assert.True(string.IsNullOrEmpty(qsAfterClearAll["SearchText"]));
-        Assert.Equal(qsAfterClearAll["SearchTerm"], $"timezone:{selectedTimeZone}");
+        Assert.Equal($"timezone:{selectedTimeZone}", qsAfterClearAll["SearchTerm"]);
 
         await s.GoToInvoices(s.StoreId);
         await s.Page.ClickAsync("#DateRangeSelector");

--- a/BTCPayServer/Controllers/GreenField/GreenfieldInvoiceController.cs
+++ b/BTCPayServer/Controllers/GreenField/GreenfieldInvoiceController.cs
@@ -158,7 +158,13 @@ namespace BTCPayServer.Controllers.Greenfield
         {
             if (HttpContext.GetInvoiceDataOrNull() is null)
                 return InvoiceNotFound();
-            var invoice = await _invoiceRepository.UpdateInvoiceMetadata(invoiceId, request.Metadata);
+            if (request.Metadata is not null)
+                await _invoiceRepository.UpdateInvoiceMetadata(invoiceId, request.Metadata);
+            if (request.Comment is not null)
+                await _invoiceRepository.UpdateInvoiceComment(invoiceId, request.Comment);
+            var invoice = await _invoiceRepository.GetInvoice(invoiceId);
+            if (invoice is null)
+                return InvoiceNotFound();
             return Ok(ToModel(invoice));
         }
 
@@ -692,6 +698,7 @@ namespace BTCPayServer.Controllers.Greenfield
                 AdditionalStatus = entity.ExceptionStatus,
                 Currency = entity.Currency,
                 Archived = entity.Archived,
+                Comment = string.IsNullOrWhiteSpace(entity.Comment) ? "" : entity.Comment,
                 Metadata = entity.Metadata.ToJObject(),
                 AvailableStatusesForManualMarking = statuses.ToArray(),
                 Checkout = new InvoiceDataBase.CheckoutOptions

--- a/BTCPayServer/Controllers/GreenField/GreenfieldInvoiceController.cs
+++ b/BTCPayServer/Controllers/GreenField/GreenfieldInvoiceController.cs
@@ -158,7 +158,7 @@ namespace BTCPayServer.Controllers.Greenfield
         {
             if (HttpContext.GetInvoiceDataOrNull() is null)
                 return InvoiceNotFound();
-            var invoice = await _invoiceRepository.UpdateInvoiceMetadata(invoiceId, storeId ?? HttpContext.GetStoreData().Id, request.Metadata);
+            var invoice = await _invoiceRepository.UpdateInvoiceMetadata(invoiceId, request.Metadata);
             return Ok(ToModel(invoice));
         }
 

--- a/BTCPayServer/Controllers/UIInvoiceController.UI.cs
+++ b/BTCPayServer/Controllers/UIInvoiceController.UI.cs
@@ -151,7 +151,7 @@ namespace BTCPayServer.Controllers
                 Events = await _InvoiceRepository.GetInvoiceLogs(invoice.Id),
                 Metadata = metaData,
                 Archived = invoice.Archived,
-                Comment = invoice.Metadata.Comment,
+                Comment = invoice.Comment,
                 HasRefund = invoice.Refunds.Any(),
                 CanRefund = invoiceState.CanRefund(),
                 Refunds = invoice.Refunds,
@@ -607,7 +607,7 @@ namespace BTCPayServer.Controllers
         [HttpPost("invoices/{invoiceId}/comment")]
         [HttpPost("/stores/{storeId}/invoices/{invoiceId}/comment")]
         [Authorize(AuthenticationSchemes = AuthenticationSchemes.Cookie, Policy = Policies.CanViewInvoices)]
-        public async Task<IActionResult> Comment(string invoiceId, string comment, string returnUrl = null)
+        public async Task<IActionResult> Comment(string invoiceId, string comment, string? returnUrl = null)
         {
             var invoice = (await _InvoiceRepository.GetInvoices(new InvoiceQuery
             {
@@ -618,9 +618,7 @@ namespace BTCPayServer.Controllers
             if (invoice is null)
                 return NotFound();
 
-            var updated = await _InvoiceRepository.UpdateInvoiceComment(invoiceId, invoice.StoreId, comment);
-            if (updated is null)
-                return NotFound();
+            await _InvoiceRepository.UpdateInvoiceComment(invoiceId, comment);
             TempData.SetStatusMessageModel(new StatusMessageModel
             {
                 Severity = StatusMessageModel.StatusSeverity.Success,
@@ -1126,7 +1124,7 @@ namespace BTCPayServer.Controllers
                     RedirectUrl = invoice.RedirectURL?.AbsoluteUri ?? string.Empty,
                     Amount = invoice.Price,
                     Currency = invoice.Currency,
-                    Comment = invoice.Metadata.Comment,
+                    Comment = invoice.Comment,
                     CanMarkInvalid = state.CanMarkInvalid(),
                     CanMarkSettled = state.CanMarkComplete(),
                     Details = InvoicePopulatePayments(invoice),

--- a/BTCPayServer/Controllers/UIInvoiceController.UI.cs
+++ b/BTCPayServer/Controllers/UIInvoiceController.UI.cs
@@ -151,6 +151,7 @@ namespace BTCPayServer.Controllers
                 Events = await _InvoiceRepository.GetInvoiceLogs(invoice.Id),
                 Metadata = metaData,
                 Archived = invoice.Archived,
+                Comment = invoice.Metadata.Comment,
                 HasRefund = invoice.Refunds.Any(),
                 CanRefund = invoiceState.CanRefund(),
                 Refunds = invoice.Refunds,
@@ -600,6 +601,35 @@ namespace BTCPayServer.Controllers
                     ? StringLocalizer["The invoice has been archived and will no longer appear in the invoice list by default."].Value
                     : StringLocalizer["The invoice has been unarchived and will appear in the invoice list by default again."].Value
             });
+            return RedirectToAction(nameof(Invoice), new { invoiceId });
+        }
+
+        [HttpPost("invoices/{invoiceId}/comment")]
+        [HttpPost("/stores/{storeId}/invoices/{invoiceId}/comment")]
+        [Authorize(AuthenticationSchemes = AuthenticationSchemes.Cookie, Policy = Policies.CanViewInvoices)]
+        public async Task<IActionResult> Comment(string invoiceId, string comment, string returnUrl = null)
+        {
+            var invoice = (await _InvoiceRepository.GetInvoices(new InvoiceQuery
+            {
+                InvoiceId = [invoiceId],
+                StoreId = [HttpContext.GetStoreData().Id],
+                UserId = GetUserIdForInvoiceQuery()
+            })).FirstOrDefault();
+            if (invoice is null)
+                return NotFound();
+
+            var updated = await _InvoiceRepository.UpdateInvoiceComment(invoiceId, invoice.StoreId, comment);
+            if (updated is null)
+                return NotFound();
+            TempData.SetStatusMessageModel(new StatusMessageModel
+            {
+                Severity = StatusMessageModel.StatusSeverity.Success,
+                Message = string.IsNullOrWhiteSpace(comment)
+                    ? StringLocalizer["The comment has been removed."].Value
+                    : StringLocalizer["The comment has been saved."].Value
+            });
+            if (!string.IsNullOrEmpty(returnUrl) && Url.IsLocalUrl(returnUrl))
+                return Redirect(returnUrl);
             return RedirectToAction(nameof(Invoice), new { invoiceId });
         }
 
@@ -1096,6 +1126,7 @@ namespace BTCPayServer.Controllers
                     RedirectUrl = invoice.RedirectURL?.AbsoluteUri ?? string.Empty,
                     Amount = invoice.Price,
                     Currency = invoice.Currency,
+                    Comment = invoice.Metadata.Comment,
                     CanMarkInvalid = state.CanMarkInvalid(),
                     CanMarkSettled = state.CanMarkComplete(),
                     Details = InvoicePopulatePayments(invoice),

--- a/BTCPayServer/Controllers/UIInvoiceController.cs
+++ b/BTCPayServer/Controllers/UIInvoiceController.cs
@@ -167,6 +167,7 @@ namespace BTCPayServer.Controllers
             entity.ReceiptOptions = invoice.Receipt ?? new InvoiceDataBase.ReceiptOptions();
             if (invoice.Metadata != null)
                 entity.Metadata = InvoiceMetadata.FromJObject(invoice.Metadata);
+            entity.Comment = string.IsNullOrWhiteSpace(invoice.Comment) ? null : invoice.Comment.Trim();
             invoice.Checkout ??= new CreateInvoiceRequest.CheckoutOptions();
             entity.Currency = invoice.Currency;
             if (invoice.Amount is decimal v)

--- a/BTCPayServer/Models/InvoicingModels/InvoiceDetailsModel.cs
+++ b/BTCPayServer/Models/InvoicingModels/InvoiceDetailsModel.cs
@@ -129,6 +129,7 @@ namespace BTCPayServer.Models.InvoicingModels
         public Dictionary<string, object> AdditionalData { get; set; }
         public List<PaymentEntity> Payments { get; set; }
         public bool Archived { get; set; }
+        public string Comment { get; set; }
         public bool CanRefund { get; set; }
         public bool ShowCheckout { get; set; }
         public List<RefundData> Refunds { get; set; }

--- a/BTCPayServer/Models/InvoicingModels/InvoicesModel.cs
+++ b/BTCPayServer/Models/InvoicingModels/InvoicesModel.cs
@@ -27,6 +27,7 @@ namespace BTCPayServer.Models.InvoicingModels
         public bool ShowCheckout { get; set; }
         public decimal Amount { get; set; }
         public string Currency { get; set; }
+        public string Comment { get; set; }
         public InvoiceDetailsModel Details { get; set; }
         public bool HasRefund { get; set; }
     }

--- a/BTCPayServer/SearchString.cs
+++ b/BTCPayServer/SearchString.cs
@@ -167,7 +167,7 @@ namespace BTCPayServer
             {
                 return localDateTime.Kind switch
                 {
-                    DateTimeKind.Local => new DateTimeOffset(localDateTime, TimeZoneInfo.Local.GetUtcOffset(localDateTime)),
+                    DateTimeKind.Local => new DateTimeOffset(localDateTime, TimeZoneInfo.Local.GetUtcOffset(localDateTime)).ToUniversalTime(),
                     DateTimeKind.Utc => new DateTimeOffset(localDateTime, TimeSpan.Zero),
                     DateTimeKind.Unspecified when tz is not null => new DateTimeOffset(localDateTime, tz.GetUtcOffset(localDateTime)).ToUniversalTime(),
                     DateTimeKind.Unspecified when tz is null => null,

--- a/BTCPayServer/Services/Invoices/InvoiceEntity.cs
+++ b/BTCPayServer/Services/Invoices/InvoiceEntity.cs
@@ -146,6 +146,16 @@ namespace BTCPayServer.Services.Invoices
             get => this.GetAdditionalData<decimal?>("taxOnTip");
             set => this.SetAdditionalData("taxOnTip", value);
         }
+        /// <summary>
+        /// A free-text comment that merchants/admins can use to add context to an invoice
+        /// (e.g. why it was refunded manually). It is editable after creation and included in exports.
+        /// </summary>
+        [JsonIgnore]
+        public string Comment
+        {
+            get => this.GetAdditionalData<string>("comment");
+            set => this.SetAdditionalData("comment", value);
+        }
 
         /// <summary>
         /// posData is a field that may be treated differently for presentation and in some legacy API

--- a/BTCPayServer/Services/Invoices/InvoiceEntity.cs
+++ b/BTCPayServer/Services/Invoices/InvoiceEntity.cs
@@ -146,16 +146,6 @@ namespace BTCPayServer.Services.Invoices
             get => this.GetAdditionalData<decimal?>("taxOnTip");
             set => this.SetAdditionalData("taxOnTip", value);
         }
-        /// <summary>
-        /// A free-text comment that merchants/admins can use to add context to an invoice
-        /// (e.g. why it was refunded manually). It is editable after creation and included in exports.
-        /// </summary>
-        [JsonIgnore]
-        public string Comment
-        {
-            get => this.GetAdditionalData<string>("comment");
-            set => this.SetAdditionalData("comment", value);
-        }
 
         /// <summary>
         /// posData is a field that may be treated differently for presentation and in some legacy API
@@ -771,6 +761,8 @@ namespace BTCPayServer.Services.Invoices
         public decimal NetSettled { get; private set; }
         [JsonIgnore]
         public bool DisableAccounting { get; set; }
+
+        public string Comment { get; set; }
 
         public RequestBaseUrl GetRequestBaseUrl() => RequestBaseUrl.FromUrl(ServerUrl);
     }

--- a/BTCPayServer/Services/Invoices/InvoiceRepository.cs
+++ b/BTCPayServer/Services/Invoices/InvoiceRepository.cs
@@ -586,7 +586,7 @@ retry:
         public async Task UpdateInvoiceComment(string invoiceId, string comment)
         {
             await using var context = _applicationDbContextFactory.CreateContext();
-            var newComment = string.IsNullOrWhiteSpace(comment) ? null : comment.Trim();
+            var newComment = string.IsNullOrWhiteSpace(comment?.Trim()) ? null : comment.Trim();
             var sql = newComment is null
                 ? """
                   UPDATE "Invoices"

--- a/BTCPayServer/Services/Invoices/InvoiceRepository.cs
+++ b/BTCPayServer/Services/Invoices/InvoiceRepository.cs
@@ -541,15 +541,16 @@ retry:
             }
         }
 
-        public async Task<InvoiceEntity> UpdateInvoiceMetadata(string invoiceId, string storeId, JObject metadata)
+        [Obsolete("The storeId parameter is now ignored. This method is deprecated and will be removed in a future release.")]
+        public Task<InvoiceEntity> UpdateInvoiceMetadata(string invoiceId, string storeId, JObject metadata)
+            => UpdateInvoiceMetadata(invoiceId, metadata);
+        public async Task<InvoiceEntity> UpdateInvoiceMetadata(string invoiceId, JObject metadata)
         {
 retry:
             using (var context = _applicationDbContextFactory.CreateContext())
             {
                 var invoiceData = await GetInvoiceRaw(invoiceId, context);
-                if (invoiceData == null || (storeId != null &&
-                                            !invoiceData.StoreDataId.Equals(storeId,
-                                                StringComparison.InvariantCultureIgnoreCase)))
+                if (invoiceData == null)
                     return null;
                 var blob = invoiceData.GetBlob();
 
@@ -582,38 +583,27 @@ retry:
                 return ToEntity(invoiceData);
             }
         }
-        public async Task<InvoiceEntity> UpdateInvoiceComment(string invoiceId, string storeId, string comment)
+        public async Task UpdateInvoiceComment(string invoiceId, string comment)
         {
-retry:
-            using (var context = _applicationDbContextFactory.CreateContext())
+            await using var context = _applicationDbContextFactory.CreateContext();
+            var newComment = string.IsNullOrWhiteSpace(comment) ? null : comment.Trim();
+            var sql = newComment is null
+                ? """
+                  UPDATE "Invoices"
+                  SET "Blob2" = COALESCE("Blob2", '{}'::jsonb) - 'comment'
+                  WHERE "Id" = @Id
+                  """
+                : """
+                  UPDATE "Invoices"
+                  SET "Blob2" = jsonb_set(COALESCE("Blob2", '{}'::jsonb), '{comment}', to_jsonb(@Comment::text), true)
+                  WHERE "Id" = @Id
+                  """;
+
+            await context.Database.GetDbConnection().ExecuteAsync(sql, new
             {
-                var invoiceData = await GetInvoiceRaw(invoiceId, context);
-                if (invoiceData == null || (storeId != null &&
-                                            !invoiceData.StoreDataId.Equals(storeId,
-                                                StringComparison.InvariantCultureIgnoreCase)))
-                    return null;
-                var blob = invoiceData.GetBlob();
-                var oldComment = blob.Metadata.Comment;
-                var newComment = string.IsNullOrWhiteSpace(comment) ? null : comment.Trim();
-                if (newComment != oldComment)
-                {
-                    if (!string.IsNullOrEmpty(oldComment))
-                        RemoveFromTextSearch(context, invoiceData, oldComment);
-                    if (!string.IsNullOrEmpty(newComment))
-                        AddToTextSearch(context, invoiceData, new[] { newComment });
-                }
-                blob.Metadata.Comment = newComment;
-                invoiceData.SetBlob(blob);
-                try
-                {
-                    await context.SaveChangesAsync();
-                }
-                catch (DbUpdateConcurrencyException)
-                {
-                    goto retry;
-                }
-                return ToEntity(invoiceData);
-            }
+                Id = invoiceId,
+                Comment = newComment
+            });
         }
         public async Task<bool> MarkInvoiceStatus(string invoiceId, InvoiceStatus status)
         {
@@ -669,6 +659,8 @@ retry:
             var res = await GetInvoiceRaw(id, context, includeAddressData);
             return res == null ? null : ToEntity(res);
         }
+
+        [Obsolete("This method is deprecated and will be removed in a future release.")]
         public async Task<InvoiceEntity[]> GetInvoices(string[] invoiceIds)
         {
             var invoiceIdSet = invoiceIds.ToHashSet();

--- a/BTCPayServer/Services/Invoices/InvoiceRepository.cs
+++ b/BTCPayServer/Services/Invoices/InvoiceRepository.cs
@@ -582,6 +582,39 @@ retry:
                 return ToEntity(invoiceData);
             }
         }
+        public async Task<InvoiceEntity> UpdateInvoiceComment(string invoiceId, string storeId, string comment)
+        {
+retry:
+            using (var context = _applicationDbContextFactory.CreateContext())
+            {
+                var invoiceData = await GetInvoiceRaw(invoiceId, context);
+                if (invoiceData == null || (storeId != null &&
+                                            !invoiceData.StoreDataId.Equals(storeId,
+                                                StringComparison.InvariantCultureIgnoreCase)))
+                    return null;
+                var blob = invoiceData.GetBlob();
+                var oldComment = blob.Metadata.Comment;
+                var newComment = string.IsNullOrWhiteSpace(comment) ? null : comment.Trim();
+                if (newComment != oldComment)
+                {
+                    if (!string.IsNullOrEmpty(oldComment))
+                        RemoveFromTextSearch(context, invoiceData, oldComment);
+                    if (!string.IsNullOrEmpty(newComment))
+                        AddToTextSearch(context, invoiceData, new[] { newComment });
+                }
+                blob.Metadata.Comment = newComment;
+                invoiceData.SetBlob(blob);
+                try
+                {
+                    await context.SaveChangesAsync();
+                }
+                catch (DbUpdateConcurrencyException)
+                {
+                    goto retry;
+                }
+                return ToEntity(invoiceData);
+            }
+        }
         public async Task<bool> MarkInvoiceStatus(string invoiceId, InvoiceStatus status)
         {
             using (var context = _applicationDbContextFactory.CreateContext())

--- a/BTCPayServer/Services/Reporting/InvoicesReportProvider.cs
+++ b/BTCPayServer/Services/Reporting/InvoicesReportProvider.cs
@@ -182,7 +182,7 @@ public class InvoicesReportProvider : ReportProvider
         data.Add(invoiceEntity?.GetInvoiceState().ToString());
         data.Add(invoiceEntity?.Status.ToString());
         data.Add(invoiceEntity?.ExceptionStatus is null or InvoiceExceptionStatus.None ? "" : invoiceEntity.ExceptionStatus.ToString());
-        data.Add(invoiceEntity?.Metadata.Comment);
+        data.Add(invoiceEntity?.Comment);
 
 
         data.Add(payment?.ReceivedTime);

--- a/BTCPayServer/Services/Reporting/InvoicesReportProvider.cs
+++ b/BTCPayServer/Services/Reporting/InvoicesReportProvider.cs
@@ -100,6 +100,7 @@ public class InvoicesReportProvider : ReportProvider
                 new("InvoiceFullStatus", "text"),
                 new("InvoiceStatus", "text"),
                 new("InvoiceExceptionStatus", "text"),
+                new("InvoiceComment", "text"),
 
                 new("PaymentReceivedDate", "datetime"),
                 new("PaymentId", "text"),
@@ -181,6 +182,7 @@ public class InvoicesReportProvider : ReportProvider
         data.Add(invoiceEntity?.GetInvoiceState().ToString());
         data.Add(invoiceEntity?.Status.ToString());
         data.Add(invoiceEntity?.ExceptionStatus is null or InvoiceExceptionStatus.None ? "" : invoiceEntity.ExceptionStatus.ToString());
+        data.Add(invoiceEntity?.Metadata.Comment);
 
 
         data.Add(payment?.ReceivedTime);
@@ -232,7 +234,9 @@ public class InvoicesReportProvider : ReportProvider
             // When we have this field to non-zero, then the invoice has a taxIncluded metadata
             is ["posData", "tax"]
             // Verbose data
-            or ["itemDesc"])
+            or ["itemDesc"]
+            // Exported explicitly as the InvoiceComment column
+            or ["comment"])
             return;
         switch (obj)
         {

--- a/BTCPayServer/Views/UIInvoice/Invoice.cshtml
+++ b/BTCPayServer/Views/UIInvoice/Invoice.cshtml
@@ -306,6 +306,16 @@
             </table>
         </div>
         <div class="d-flex flex-column gap-5">
+            <div>
+                <h3 class="mb-3">Comment</h3>
+                <form asp-action="Comment" asp-route-invoiceId="@Model.Id" method="post">
+                    <div class="form-group">
+                        <textarea name="comment" id="InvoiceComment" class="form-control" rows="3"
+                                  placeholder="@StringLocalizer["Add a note or comment for this invoice"]">@Model.Comment</textarea>
+                    </div>
+                    <button type="submit" id="SaveComment" class="btn btn-primary">Save Comment</button>
+                </form>
+            </div>
             @if (!string.IsNullOrEmpty(Model.TypedMetadata.ItemCode) ||
                     !string.IsNullOrEmpty(Model.TypedMetadata.ItemDesc))
             {

--- a/BTCPayServer/Views/UIInvoice/ListInvoices.cshtml
+++ b/BTCPayServer/Views/UIInvoice/ListInvoices.cshtml
@@ -28,6 +28,14 @@
             min-width: 200px;
             max-width: 300px;
         }
+        /* Keep the invoice comment popover above adjacent rows */
+        #invoices .dropup .dropdown-menu {
+            z-index: 1080;
+        }
+        #invoices tr:has(.dropup .dropdown-menu.show) {
+            position: relative;
+            z-index: 1080;
+        }
         @@media (max-width: 568px) {
             #SearchText {
                 width: 100%;
@@ -160,14 +168,17 @@
 
 @if (Model.Invoices.Any())
 {
-    <form method="post" asp-action="MassAction" asp-route-storeId="@Model.StoreId">
+    @* Standalone mass-action form: its controls reference it via the form="mass-action-form" attribute
+       so the per-row comment forms below are not nested inside it (nested forms are invalid HTML). *@
+    <form id="mass-action-form" method="post" asp-action="MassAction" asp-route-storeId="@Model.StoreId">
         <input type="hidden" name="storeId" value="@Model.StoreId" />
-        <div class="table-responsive">
+    </form>
+    <div class="table-responsive-md">
             <table id="invoices" class="table table-hover mass-action">
                 <thead class="mass-action-head">
                     <tr>
                         <th class="mass-action-select-col only-for-js">
-                            <input type="checkbox" class="form-check-input mass-action-select-all" />
+                            <input type="checkbox" class="form-check-input mass-action-select-all" form="mass-action-form" />
                         </th>
                         <vc:date-column></vc:date-column>
                         <th text-translate="true" class="text-nowrap">Invoice Id</th>
@@ -180,7 +191,7 @@
                 <thead class="mass-action-actions">
                     <tr>
                         <th class="mass-action-select-col only-for-js">
-                            <input type="checkbox" class="form-check-input mass-action-select-all" />
+                            <input type="checkbox" class="form-check-input mass-action-select-all" form="mass-action-form" />
                         </th>
                         <th colspan="6">
                             <div class="d-flex flex-wrap align-items-center justify-content-between gap-3">
@@ -189,18 +200,18 @@
                                     <span text-translate="true">selected</span>
                                 </div>
                                 <div class="d-inline-flex align-items-center gap-3">
-                                    <button type="submit" name="command" value="archive" id="ArchiveSelected" class="btn btn-link">
+                                    <button type="submit" name="command" value="archive" id="ArchiveSelected" class="btn btn-link" form="mass-action-form">
                                         <vc:icon symbol="actions-archive" />
                                         <span text-translate="true">Archive</span>
                                     </button>
                                     @if (Model.Search.HasBooleanFilter("includearchived"))
                                     {
-                                        <button type="submit" name="command" value="unarchive" id="UnarchiveSelected" class="btn btn-link">
+                                        <button type="submit" name="command" value="unarchive" id="UnarchiveSelected" class="btn btn-link" form="mass-action-form">
                                             <vc:icon symbol="actions-archive" />
                                             <span text-translate="true">Unarchive</span>
                                         </button>
                                     }
-                                    <button type="submit" name="command" value="cpfp" id="BumpFee" class="btn btn-link">
+                                    <button type="submit" name="command" value="cpfp" id="BumpFee" class="btn btn-link" form="mass-action-form">
                                         <vc:icon symbol="actions-send" />
                                         <span text-translate="true">Bump fee</span>
                                     </button>
@@ -215,7 +226,7 @@
                         var detailsId = $"invoice_details_{invoice.InvoiceId}";
                         <tr id="invoice_@invoice.InvoiceId" class="mass-action-row">
                             <td class="only-for-js align-middle">
-                                <input name="selectedItems" type="checkbox" class="form-check-input mass-action-select" value="@invoice.InvoiceId" />
+                                <input name="selectedItems" type="checkbox" class="form-check-input mass-action-select" value="@invoice.InvoiceId" form="mass-action-form" />
                             </td>
                             <td class="align-middle date-col">@invoice.Date.ToBrowserDate()</td>
                             <td class="text-break align-middle invoiceId-col">
@@ -239,9 +250,24 @@
                             <td class="align-middle amount-col">
                                 <span data-sensitive>@DisplayFormatter.Currency(invoice.Amount, invoice.Currency)</span>
                             </td>
-                            <td class="align-middle text-end">
-                                <div class="d-inline-flex align-items-center gap-2">
-                                    <button class="accordion-button collapsed only-for-js ms-0 d-inline-block" type="button" data-bs-toggle="collapse" data-bs-target="#@detailsId" aria-expanded="false" aria-controls="@detailsId">
+                            <td class="align-middle text-end text-nowrap" style="width:1px">
+                                <div class="d-inline-flex align-items-center" style="gap:16px;padding-left:24px">
+                                    <span class="dropup">
+                                        <button class="btn btn-link p-0 @(!string.IsNullOrEmpty(invoice.Comment) ? "text-primary" : "text-secondary")" type="button" data-bs-toggle="dropdown" data-bs-auto-close="outside" aria-haspopup="true" aria-expanded="false" title="@(!string.IsNullOrEmpty(invoice.Comment) ? invoice.Comment : StringLocalizer["Add a comment"])">
+                                            <vc:icon symbol="actions-comment" />
+                                        </button>
+                                        <div class="dropdown-menu dropdown-menu-end">
+                                            <form asp-action="Comment" asp-route-invoiceId="@invoice.InvoiceId" asp-route-returnUrl="@Context.Request.GetCurrentPathWithQueryString()" method="post">
+                                                <div class="input-group p-2">
+                                                    <textarea name="comment" rows="3" cols="20" class="form-control form-control-sm p-1" placeholder="@StringLocalizer["Add a note or comment for this invoice"]">@invoice.Comment</textarea>
+                                                </div>
+                                                <div class="p-2">
+                                                    <button type="submit" class="btn btn-primary btn-sm w-100" text-translate="true">Save comment</button>
+                                                </div>
+                                            </form>
+                                        </div>
+                                    </span>
+                                    <button class="accordion-button collapsed only-for-js ms-0 d-inline-block" style="width:auto" type="button" data-bs-toggle="collapse" data-bs-target="#@detailsId" aria-expanded="false" aria-controls="@detailsId">
                                         <vc:icon symbol="caret-down" />
                                     </button>
                                 </div>
@@ -258,8 +284,7 @@
             </table>
         </div>
 
-        <vc:pager view-model="Model" />
-    </form>
+    <vc:pager view-model="Model" />
 }
 else
 {

--- a/BTCPayServer/wwwroot/swagger/v1/swagger.template.invoices.json
+++ b/BTCPayServer/wwwroot/swagger/v1/swagger.template.invoices.json
@@ -754,6 +754,11 @@
                     "metadata": {
                         "$ref": "#/components/schemas/InvoiceMetadata"
                     },
+                    "comment": {
+                        "type": "string",
+                        "nullable": true,
+                        "description": "A private comment on the invoice, visible to store users."
+                    },
                     "checkout": {
                         "type": "object",
                         "nullable": true,
@@ -1077,6 +1082,11 @@
                 "properties": {
                     "metadata": {
                         "$ref": "#/components/schemas/InvoiceMetadata"
+                    },
+                    "comment": {
+                        "type": "string",
+                        "nullable": true,
+                        "description": "A private comment on the invoice, visible to store users."
                     }
                 }
             },


### PR DESCRIPTION
Closes #6799.

Adds a free-text comment field to invoices so merchants/admins can record context (e.g. "refunded manually from cashier wallet"). Anyone who can view a store's invoices can leave or edit a comment. Kept it simple, we could remove the invoice detail addition if it adds too much noise.

## Screenshots

<img width="1313" height="342" alt="Screenshot 2026-07-11 at 1 05 50 AM" src="https://github.com/user-attachments/assets/5110bd6b-51e2-43f6-993c-ec2f0e07f931" />
<img width="741" height="504" alt="Screenshot 2026-07-11 at 1 06 01 AM" src="https://github.com/user-attachments/assets/1cc6faad-6c9a-4b7f-8e48-324321e55e1d" />


## Changes
- **Metadata:** the comment is stored on invoice metadata and is editable after creation.
- **Invoice details page:** a Comment box to add, edit, or clear the note.
- **Invoice list:** a comment icon in the actions column shows the current note on hover and opens an inline editor, so you don't have to open each invoice.
- **Reports export:** the comment is included in the Invoices report as an `InvoiceComment` column (CSV and JSON).

## Tests
- Unit test: saving a comment, showing it in the list, and exporting it in the report.
- Playwright test: editing a comment on the details page and asserting it in the CSV export.
