### PR TITLE
Improve topbar visual separation

### DIFF
--- a/BTCPayServer/wwwroot/main/layout.css
+++ b/BTCPayServer/wwwroot/main/layout.css
@@ -161,7 +161,7 @@
     border: 0;
     cursor: pointer;
     outline: none;
-    color: var(--btcpay-body-text-muted);
+    color: var(--btcpay-nav-link);
     border-radius: var(--btcpay-border-radius-m);
 }
 
@@ -875,7 +875,8 @@
         min-height: var(--global-nav-height);
         padding: var(--btcpay-space-s) var(--content-padding-horizontal);
         justify-content: space-between;
-        background: var(--btcpay-body-bg);
+        background: var(--btcpay-header-bg);
+        border-bottom: var(--menu-border);
     }
 
     #StoreSelector {

--- a/BTCPayServer/wwwroot/plugins/GlobalSearch/global-search.css
+++ b/BTCPayServer/wwwroot/plugins/GlobalSearch/global-search.css
@@ -17,7 +17,7 @@
     gap: var(--btcpay-space-s);
     height: var(--button-height);
     padding: 0 var(--btcpay-space-m);
-    border: 1px solid var(--btcpay-body-border-light);
+    border: 1px solid var(--btcpay-body-border-medium);
     border-radius: var(--btcpay-border-radius-l);
     background: var(--btcpay-body-bg);
     transition: border-color var(--btcpay-transition-duration-fast), box-shadow var(--btcpay-transition-duration-fast);


### PR DESCRIPTION
This PR giive the topbar a distinct background and bottom border, and increase the contrast of the search field and navigation icons. 

This makes the user account (icons on the right) and search section easier to identify without changing the existing layout or mobile behavior and it's very minimal code change.

@NicolasDorier pointed out a concern that in that case secondary search, like on the invoice or wallet can lose on visibility, so I am attaching screenshots to showcase that they don't imo.

## Before this PR

<img width="1492" height="850" alt="Screenshot 2026-07-11 at 16 12 57" src="https://github.com/user-attachments/assets/328e6770-1a9a-425b-b4e5-2a72834f4208" />


## After this PR
<img width="1512" height="578" alt="Screenshot 2026-07-11 at 16 17 49" src="https://github.com/user-attachments/assets/205e7785-4d46-4cd2-95ed-490e31e3807a" />
<img width="1502" height="826" alt="Screenshot 2026-07-11 at 16 19 42" src="https://github.com/user-attachments/assets/1295d68d-2bd9-4441-bbcf-30df470bc3b2" />
<img width="1507" height="814" alt="Screenshot 2026-07-11 at 16 19 50" src="https://github.com/user-attachments/assets/8e1130e6-9b5d-4c27-95fc-d399be993c6f" />
<img width="503" height="630" alt="Screenshot 2026-07-11 at 16 20 03" src="https://github.com/user-attachments/assets/0b46eb3c-142c-49a4-a951-37e0cee56df6" />
<img width="1512" height="831" alt="Screenshot 2026-07-11 at 16 19 21" src="https://github.com/user-attachments/assets/3f5cea87-07a7-4744-8f13-217a0753c43e" />

