### PR TITLE
Use Kraken for DASH exchange rate

### DIFF
--- a/BTCPayServer/Plugins/Altcoins/AltcoinsPlugin.Dash.cs
+++ b/BTCPayServer/Plugins/Altcoins/AltcoinsPlugin.Dash.cs
@@ -19,7 +19,7 @@ public partial class AltcoinsPlugin
             DefaultRateRules = new[]
                 {
                         "DASH_X = DASH_BTC * BTC_X",
-                        "DASH_BTC = bitfinex(DSH_USD) * bitfinex(USD_BTC)"
+                        "DASH_BTC = kraken(DASH_USD) * kraken(USD_BTC)"
                     },
             CryptoImagePath = "imlegacy/dash.png",
             DefaultSettings = BTCPayDefaultSettings.GetDefaultSettings(ChainName),


### PR DESCRIPTION
## Summary

- use Kraken's DASH/USD and BTC/USD markets for the default DASH rate rule
- replace the broken Bitfinex market dependency without relying on Binance

## Why

The DASH default rate currently depends on two Bitfinex markets, but Bitfinex no longer provides one of the required markets. This breaks the default DASH rate calculation. Binance exposes a direct DASH/BTC market, but its provider is already marked as broken in BTCPay's third-party tests and is unavailable from the CI environment. Kraken provides active DASH/USD and BTC/USD markets and is already a supported, healthy rate provider.

## Impact

DASH/BTC will be calculated through Kraken's USD markets. Other currency conversions continue to use the existing `DASH_X = DASH_BTC * BTC_X` rule.

## Checks

- `git diff --check`
- `dotnet test BTCPayServer.Tests/BTCPayServer.Tests.csproj --configuration Release --filter FullyQualifiedName~CanGetRateCryptoCurrenciesByDefault` (1 passed)
