### PR TITLE
Fix various bugs with Core Lightning

### DIFF
--- a/BTCPayServer/BTCPayServer.csproj
+++ b/BTCPayServer/BTCPayServer.csproj
@@ -38,7 +38,7 @@
     <PackageReference Include="YamlDotNet" Version="16.3.0" />
     <PackageReference Include="BIP78.Sender" Version="0.2.5" />
     <PackageReference Include="BTCPayServer.Hwi" Version="2.0.6" />
-    <PackageReference Include="BTCPayServer.Lightning.All" Version="1.7.4" />
+    <PackageReference Include="BTCPayServer.Lightning.All" Version="1.7.5" />
     <PackageReference Include="CsvHelper" Version="33.1.0" />
     <PackageReference Include="Fido2" Version="4.0.1" />
     <PackageReference Include="Fido2.AspNet" Version="4.0.1" />


### PR DESCRIPTION
[fix: correct CLN fundchannel fee rate conversion
](https://github.com/btcpayserver/BTCPayServer.Lightning/pull/184)
[Fix c-lightning MaxFeePercent being sent to xpay in satoshi instead of millisatoshi
](https://github.com/btcpayserver/BTCPayServer.Lightning/pull/183)