### PR TITLE
Refine global search colors

### DIFF
--- a/BTCPayServer/wwwroot/plugins/GlobalSearch/global-search.css
+++ b/BTCPayServer/wwwroot/plugins/GlobalSearch/global-search.css
@@ -19,7 +19,8 @@
     padding: 0 var(--btcpay-space-m);
     border: 1px solid var(--btcpay-body-border-light);
     border-radius: var(--btcpay-border-radius-l);
-    background: var(--btcpay-body-bg);
+    /* Darkest surface shade on dark theme (#0d1117), white on light theme */
+    background: var(--btcpay-bg-tile);
     transition: border-color var(--btcpay-transition-duration-fast), box-shadow var(--btcpay-transition-duration-fast);
 }
 
@@ -126,7 +127,8 @@
     overflow-y: auto;
     border: 1px solid var(--btcpay-body-border-medium);
     border-radius: var(--btcpay-border-radius-l);
-    background: var(--btcpay-body-bg);
+    /* Match the search bar surface: white on light theme, darkest shade on dark theme */
+    background: var(--btcpay-bg-tile);
     box-shadow: 0 12px 32px rgba(0, 0, 0, .16);
     padding: var(--btcpay-space-s);
 }
@@ -180,7 +182,7 @@
 #globalNav .globalSearch-item {
     display: block;
     width: 100%;
-    border-radius: var(--btcpay-border-radius-m);
+    border-radius: var(--btcpay-border-radius);
     color: var(--btcpay-body-link);
     padding: var(--btcpay-space-s);
     text-decoration: none;
@@ -195,7 +197,7 @@
 
 #globalNav .globalSearch-item:hover {
     color: var(--btcpay-body-text);
-    background-color: var(--btcpay-body-bg-hover);
+    background-color: var(--btcpay-body-bg);
 }
 
 #globalNav .globalSearch-item:hover .globalSearch-item-title {


### PR DESCRIPTION
Small visual tweaks to the global search to make it read as one consistent surface across light and dark themes. It's more consistent with what we currently do, and still maintains a strong presence, while being minimal and unobtrusive.

## Screenshots

<img width="1708" height="443" alt="Screenshot 2026-07-13 at 10 22 18 AM" src="https://github.com/user-attachments/assets/5e796080-c74d-428c-9dc3-22837c6536da" />
<img width="1707" height="509" alt="Screenshot 2026-07-13 at 10 22 27 AM" src="https://github.com/user-attachments/assets/19381c08-43f6-4bc0-aeef-5f546f6354f8" />
<img width="745" height="627" alt="Screenshot 2026-07-13 at 10 42 18 AM" src="https://github.com/user-attachments/assets/6038eabe-a3ca-4ac1-9b44-da8fbaf0b284" />
<img width="760" height="642" alt="Screenshot 2026-07-13 at 10 42 26 AM" src="https://github.com/user-attachments/assets/b54f2450-6901-46c3-8381-999c63c37d32" />

## Changes
- **Input bar background:** white on the light theme, our darkest shade on the dark theme.
- **Results panel / hover:** swapped the two so the panel background matches the input (white / darkest) and the hovered item is the offwhite/lighter shade instead of the other way around.
- **Hover corners:** fixed the result item to use a valid radius token so the hover highlight has rounded (4px) corners instead of square ones.
