### PR TITLE
Keep Store Settings nav expanded on all subpages

### DIFF
--- a/BTCPayServer/Plugins/Bitpay/Views/CreateToken.cshtml
+++ b/BTCPayServer/Plugins/Bitpay/Views/CreateToken.cshtml
@@ -1,7 +1,7 @@
 @model CreateTokenViewModel
 @{
     var store = Context.GetStoreDataOrNull();
-    ViewData.SetLayoutModel(new(nameof(StoreNavPages.Tokens), StringLocalizer["Create New Token"]));
+    ViewData.SetLayoutModel(new LayoutModel(nameof(StoreNavPages.Tokens), StringLocalizer["Create New Token"]).SetCategory(WellKnownCategories.Store));
     ViewBag.HidePublicKey ??= false;
     ViewBag.ShowStores ??= false;
     Layout = "_Layout";

--- a/BTCPayServer/Plugins/Bitpay/Views/RequestPairing.cshtml
+++ b/BTCPayServer/Plugins/Bitpay/Views/RequestPairing.cshtml
@@ -3,7 +3,7 @@
 @{
     var store = Context.GetStoreDataOrNull();
     Layout = store is null ? "_LayoutWizard" : "_Layout";
-    ViewData.SetLayoutModel(new(nameof(StoreNavPages.Tokens), StringLocalizer["Pairing Permission"]));
+    ViewData.SetLayoutModel(new LayoutModel(nameof(StoreNavPages.Tokens), StringLocalizer["Pairing Permission"]).SetCategory(WellKnownCategories.Store));
 }
 
 @if (store is null)

--- a/BTCPayServer/Plugins/Bitpay/Views/ShowToken.cshtml
+++ b/BTCPayServer/Plugins/Bitpay/Views/ShowToken.cshtml
@@ -1,6 +1,6 @@
 ﻿@model BTCPayServer.Plugins.Bitpay.Security.BitTokenEntity
 @{
-    ViewData.SetLayoutModel(new(nameof(StoreNavPages.Tokens), StringLocalizer["Access Tokens"]));
+    ViewData.SetLayoutModel(new LayoutModel(nameof(StoreNavPages.Tokens), StringLocalizer["Access Tokens"]).SetCategory(WellKnownCategories.Store));
     Layout = "_Layout";
 }
 <h2 class="mb-2 mb-lg-3">@ViewData["Title"]</h2>

--- a/BTCPayServer/Views/UILightningAutomatedPayoutProcessors/Configure.cshtml
+++ b/BTCPayServer/Views/UILightningAutomatedPayoutProcessors/Configure.cshtml
@@ -3,7 +3,7 @@
 @model BTCPayServer.PayoutProcessors.Lightning.UILightningAutomatedPayoutProcessorsController.LightningTransferViewModel
 @{
     var storeId = Context.GetStoreData().Id;
-    ViewData.SetLayoutModel(new(nameof(StoreNavPages.PayoutProcessors), StringLocalizer["Lightning Payout Processor"]));
+    ViewData.SetLayoutModel(new LayoutModel(nameof(StoreNavPages.PayoutProcessors), StringLocalizer["Lightning Payout Processor"]).SetCategory(WellKnownCategories.Store));
 }
 
 <form method="post" permissioned="@Policies.CanModifyStoreSettings">

--- a/BTCPayServer/Views/UIOnChainAutomatedPayoutProcessors/Configure.cshtml
+++ b/BTCPayServer/Views/UIOnChainAutomatedPayoutProcessors/Configure.cshtml
@@ -4,7 +4,7 @@
 @{
     var storeId = Context.GetStoreData().Id;
     var cryptoCode = Context.GetRouteValue("cryptocode")?.ToString();
-    ViewData.SetLayoutModel(new(nameof(StoreNavPages.PayoutProcessors), StringLocalizer["On-Chain Payout Processor"]));
+    ViewData.SetLayoutModel(new LayoutModel(nameof(StoreNavPages.PayoutProcessors), StringLocalizer["On-Chain Payout Processor"]).SetCategory(WellKnownCategories.Store));
 }
 
 <form method="post" permissioned="@Policies.CanModifyStoreSettings">


### PR DESCRIPTION
## Why

When viewing a sub-page of a store settings page (for example the On-Chain or Lightning payout processor configuration, or the access token create and pairing pages), the Settings group in the sidebar collapsed and its parent item was no longer highlighted. That made it easy to lose track of where you were within the store settings.

This sets the store category on the sub-pages that were missing it, so the Settings group stays expanded and the parent page stays selected:

- On-Chain payout processor configuration
- Lightning payout processor configuration
- Access Tokens: create token, show token, and pairing permission

Other settings sub-pages (roles, webhooks, emails, forms) already set the category and were unaffected.


## Before Example

I discovered this while working on the containerization PR, so tossed this PR up to fix the functional issue.

<img width="1223" height="617" alt="Screenshot 2026-07-13 at 2 43 09 PM" src="https://github.com/user-attachments/assets/feffcb3e-6193-4594-9707-b42939acb12e" />
<img width="1217" height="614" alt="Screenshot 2026-07-13 at 2 43 17 PM" src="https://github.com/user-attachments/assets/9e29eb8e-c9b4-4718-a821-2ceffa0783f1" />