### PR TITLE
Add BIP-329 wallet label import

### DIFF
--- a/BTCPayServer.Tests/FastTests.cs
+++ b/BTCPayServer.Tests/FastTests.cs
@@ -29,6 +29,7 @@ using BTCPayServer.Services.Fees;
 using BTCPayServer.Services.Invoices;
 using BTCPayServer.Services.Rates;
 using BTCPayServer.Services.Wallets;
+using BTCPayServer.Services.Wallets.Import;
 using BTCPayServer.Validation;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Configuration.Memory;
@@ -224,6 +225,36 @@ namespace BTCPayServer.Tests
             Assert.False(blob.ReceiptOptions.Enabled);
             blob = JsonConvert.DeserializeObject<StoreBlob>(JsonConvert.SerializeObject(blob));
             Assert.False(blob.ReceiptOptions.Enabled);
+        }
+
+        [Fact]
+        public async Task CanParseBip329LabelsImport()
+        {
+            var network = Network.RegTest;
+            var txId = "aecb52b892f5e12454b3ee1ad554ffe28c1cca35ffdfaa441c74a30cf7a279f0";
+            var address = new Key().PubKey.GetAddress(ScriptPubKeyType.Segwit, network).ToString();
+            var mainnetAddress = new Key().PubKey.GetAddress(ScriptPubKeyType.Segwit, Network.Main).ToString();
+            var input =
+                $"{{\"type\":\"tx\",\"ref\":\"{txId.ToUpperInvariant()}\",\"label\":\" fee reimbursement \"}}\n" +
+                $"{{\"type\":\"addr\",\"ref\":\"{address}\",\"label\":\"donations\"}}\n" +
+                $"{{\"type\":\"output\",\"ref\":\"{txId}:1\",\"label\":\"change\"}}\n" +
+                "\n" +
+                $"{{\"type\":\"tx\",\"ref\":\"{txId.ToUpperInvariant()}\",\"label\":\" fee reimbursement \"}}\n" +
+                $"{{\"type\":\"addr\",\"ref\":\"{mainnetAddress}\",\"label\":\"wrong network\"}}\n" +
+                $"{{\"type\":\"xpub\",\"ref\":\"xpub-ref\",\"label\":\"unsupported type\"}}\n" +
+                $"{{\"type\":\"tx\",\"ref\":\"not-a-txid\",\"label\":\"bad ref\"}}\n" +
+                $"{{\"type\":\"tx\",\"ref\":\"{txId}\",\"label\":\"\"}}\n" +
+                $"{{\"type\":\"tx\",\"ref\":\"{txId}\"}}\n" +
+                "not json\n";
+
+            var result = await Bip329Import.Parse(new StringReader(input), network);
+
+            Assert.Equal(3, result.Labels.Count);
+            // duplicate line deduped, invalid lines skipped, blank line ignored
+            Assert.Equal(6, result.SkippedLines);
+            Assert.Contains(result.Labels, l => l is { ObjectType: WalletObjectData.Types.Tx, Label: "fee reimbursement" } && l.ObjectId == txId);
+            Assert.Contains(result.Labels, l => l is { ObjectType: WalletObjectData.Types.Address, Label: "donations" } && l.ObjectId == address);
+            Assert.Contains(result.Labels, l => l is { ObjectType: WalletObjectData.Types.Utxo, Label: "change" } && l.ObjectId == OutPoint.Parse($"{txId}-1").ToString());
         }
 
         [Fact]

--- a/BTCPayServer.Tests/FastTests.cs
+++ b/BTCPayServer.Tests/FastTests.cs
@@ -245,13 +245,16 @@ namespace BTCPayServer.Tests
                 $"{{\"type\":\"tx\",\"ref\":\"not-a-txid\",\"label\":\"bad ref\"}}\n" +
                 $"{{\"type\":\"tx\",\"ref\":\"{txId}\",\"label\":\"\"}}\n" +
                 $"{{\"type\":\"tx\",\"ref\":\"{txId}\"}}\n" +
+                $"{{\"type\":\"tx\",\"ref\":\"{txId}\",\"label\":{{}}}}\n" +
+                $"{{\"type\":\"tx\",\"ref\":[1],\"label\":\"array ref\"}}\n" +
+                $"{{\"type\":5,\"ref\":\"{txId}\",\"label\":\"numeric type\"}}\n" +
                 "not json\n";
 
             var result = await Bip329Import.Parse(new StringReader(input), network);
 
             Assert.Equal(3, result.Labels.Count);
             // duplicate line deduped, invalid lines skipped, blank line ignored
-            Assert.Equal(6, result.SkippedLines);
+            Assert.Equal(9, result.SkippedLines);
             Assert.Contains(result.Labels, l => l is { ObjectType: WalletObjectData.Types.Tx, Label: "fee reimbursement" } && l.ObjectId == txId);
             Assert.Contains(result.Labels, l => l is { ObjectType: WalletObjectData.Types.Address, Label: "donations" } && l.ObjectId == address);
             Assert.Contains(result.Labels, l => l is { ObjectType: WalletObjectData.Types.Utxo, Label: "change" } && l.ObjectId == OutPoint.Parse($"{txId}-1").ToString());

--- a/BTCPayServer.Tests/WalletTests.cs
+++ b/BTCPayServer.Tests/WalletTests.cs
@@ -778,10 +778,23 @@ public class WalletTests(ITestOutputHelper helper) : UnitTestBase(helper)
         });
 
         await s.InWalletTransactions().AssertHasLabels(targetLabel);
+
+        // Import BIP-329 labels from the transactions page toolbar (#6663)
+        var walletId = new WalletId(s.StoreId, "BTC");
+        const string toolbarLabel = "bip329-toolbar";
+        var toolbarTxId = transactions[1].TransactionHash.ToString();
+        var toolbarFile = Path.Combine(Path.GetTempPath(), $"bip329-{Guid.NewGuid():N}.jsonl");
+        await File.WriteAllTextAsync(toolbarFile, $"{{\"type\":\"tx\",\"ref\":\"{toolbarTxId}\",\"label\":\"{toolbarLabel}\"}}\n");
+        await s.Page.SetInputFilesAsync("#Dropdowns .wallet-labels__import-file", toolbarFile);
+        await s.Page.WaitForURLAsync(s.ServerUri + $"wallets/{walletId}/labels");
+        await s.FindAlertMessage(partialText: "Imported 1 label(s).");
+        var toolbarTx = await client.GetOnChainWalletTransaction(s.StoreId, "BTC", toolbarTxId);
+        Assert.Contains(toolbarLabel, toolbarTx.Labels.Keys);
+
+        await s.GoToWalletTransactions(s.WalletId);
         // The label dropdown exposes a "Manage Labels" link that navigates to the wallet labels page (#7252)
         await s.SearchFilters.LabelSelectorToggle.ClickAsync();
         await s.Page.ClickAsync("#LabelSelectorMenu a:has-text('Manage Labels')");
-        var walletId = new WalletId(s.StoreId , "BTC");
         await s.Page.WaitForURLAsync(s.ServerUri + $"wallets/{walletId}/labels");
 
         // Import BIP-329 labels from the wallet labels page (#6663)

--- a/BTCPayServer.Tests/WalletTests.cs
+++ b/BTCPayServer.Tests/WalletTests.cs
@@ -783,6 +783,20 @@ public class WalletTests(ITestOutputHelper helper) : UnitTestBase(helper)
         await s.Page.ClickAsync("#LabelSelectorMenu a:has-text('Manage Labels')");
         var walletId = new WalletId(s.StoreId , "BTC");
         await s.Page.WaitForURLAsync(s.ServerUri + $"wallets/{walletId}/labels");
+
+        // Import BIP-329 labels from the wallet labels page (#6663)
+        const string importedLabel = "bip329-imported";
+        var importedTxId = transactions[0].TransactionHash.ToString();
+        var importFile = Path.Combine(Path.GetTempPath(), $"bip329-{Guid.NewGuid():N}.jsonl");
+        await File.WriteAllTextAsync(importFile,
+            $"{{\"type\":\"tx\",\"ref\":\"{importedTxId}\",\"label\":\"{importedLabel}\"}}\n" +
+            "not json\n");
+        await s.Page.SetInputFilesAsync(".wallet-labels__import-file", importFile);
+        await s.Page.ClickAsync(".wallet-labels__import-button");
+        await s.FindAlertMessage(partialText: "Imported 1 label(s), skipped 1 line(s).");
+        Assert.True(await s.Page.Locator($".transaction-label:has-text('{importedLabel}')").IsVisibleAsync());
+        var importedTx = await client.GetOnChainWalletTransaction(s.StoreId, "BTC", importedTxId);
+        Assert.Contains(importedLabel, importedTx.Labels.Keys);
     }
 
     [Fact]

--- a/BTCPayServer/Plugins/Wallets/Controllers/UIWalletsController.cs
+++ b/BTCPayServer/Plugins/Wallets/Controllers/UIWalletsController.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Data.Common;
 using System.Globalization;
+using System.IO;
 using System.Linq;
 using System.Net.Mime;
 using System.Text;
@@ -33,6 +34,7 @@ using BTCPayServer.Services.Rates;
 using BTCPayServer.Services.Stores;
 using BTCPayServer.Services.Wallets;
 using BTCPayServer.Services.Wallets.Export;
+using BTCPayServer.Services.Wallets.Import;
 using BTCPayServer.Plugins.Wallets;
 using Dapper;
 using Microsoft.AspNetCore.Authorization;
@@ -2271,6 +2273,46 @@ namespace BTCPayServer.Controllers
                 TempData[WellKnownTempData.ErrorMessage] = StringLocalizer["The label could not be renamed."].Value;
             }
 
+            return RedirectToAction(nameof(WalletLabels), new { walletId });
+        }
+
+        const int MaxLabelImportSize = 1_000_000;
+        [HttpPost("{walletId}/labels/import")]
+        [Authorize(Policy = WalletPolicies.CanManageWalletTransactions, AuthenticationSchemes = AuthenticationSchemes.Cookie)]
+        public async Task<IActionResult> ImportWalletLabels(
+            [ModelBinder(typeof(WalletIdModelBinder))]
+            WalletId walletId, IFormFile? file)
+        {
+            if (file is null || file.Length == 0)
+            {
+                TempData[WellKnownTempData.ErrorMessage] = StringLocalizer["Please select a BIP-329 file to import."].Value;
+                return RedirectToAction(nameof(WalletLabels), new { walletId });
+            }
+
+            if (file.Length > MaxLabelImportSize)
+            {
+                TempData[WellKnownTempData.ErrorMessage] = StringLocalizer["The import file is too big (1 MB maximum)."].Value;
+                return RedirectToAction(nameof(WalletLabels), new { walletId });
+            }
+
+            var network = handlers.GetBitcoinHandler(walletId.CryptoCode).Network;
+            using var reader = new StreamReader(file.OpenReadStream());
+            var import = await Bip329Import.Parse(reader, network.NBitcoinNetwork);
+            if (import.Labels.Count == 0)
+            {
+                TempData[WellKnownTempData.ErrorMessage] = StringLocalizer["No labels could be imported from this file. Expected BIP-329 format: one JSON object per line."].Value;
+                return RedirectToAction(nameof(WalletLabels), new { walletId });
+            }
+
+            var reqs = import.Labels
+                .GroupBy(l => (l.ObjectType, l.ObjectId))
+                .Select(g => (new WalletObjectId(walletId, g.Key.ObjectType, g.Key.ObjectId), g.Select(l => l.Label).ToArray()))
+                .ToArray();
+            await WalletRepository.AddWalletObjectLabels(reqs);
+
+            TempData[WellKnownTempData.SuccessMessage] = import.SkippedLines == 0
+                ? StringLocalizer["Imported {0} label(s).", import.Labels.Count].Value
+                : StringLocalizer["Imported {0} label(s), skipped {1} line(s).", import.Labels.Count, import.SkippedLines].Value;
             return RedirectToAction(nameof(WalletLabels), new { walletId });
         }
 

--- a/BTCPayServer/Plugins/Wallets/Views/UIWallets/WalletLabels.cshtml
+++ b/BTCPayServer/Plugins/Wallets/Views/UIWallets/WalletLabels.cshtml
@@ -40,6 +40,12 @@
 
 <partial name="_StatusMessage" />
 
+<form method="post" enctype="multipart/form-data" asp-action="ImportWalletLabels" asp-route-walletId="@Model.WalletId"
+      class="wallet-labels__import d-flex flex-wrap align-items-center gap-2 mb-4" permission="@WalletPolicies.CanManageWalletTransactions">
+    <input type="file" name="file" class="form-control wallet-labels__import-file w-auto" accept=".jsonl,.json,.txt" required />
+    <button type="submit" class="btn btn-secondary wallet-labels__import-button" text-translate="true">Import BIP-329 labels</button>
+</form>
+
 @if (Model.Labels.Any())
 {
     <div class="table-responsive-md">

--- a/BTCPayServer/Plugins/Wallets/Views/UIWallets/WalletTransactions.cshtml
+++ b/BTCPayServer/Plugins/Wallets/Views/UIWallets/WalletTransactions.cshtml
@@ -165,6 +165,14 @@
 
         // the actions div marks the end of the list table
         observer.observe($actions);
+
+        delegate('click', '.wallet-labels__import-button', event => {
+            event.target.closest('form').querySelector('.wallet-labels__import-file').click()
+        })
+        delegate('change', '.wallet-labels__import-file', event => {
+            if (event.target.files.length > 0)
+                event.target.closest('form').submit()
+        })
     </script>
 }
 
@@ -197,6 +205,11 @@
                 </div>
             </form>
         </div>
+        <form asp-action="ImportWalletLabels" asp-route-walletId="@walletId" method="post" enctype="multipart/form-data"
+              class="wallet-labels__import" permission="@WalletPolicies.CanManageWalletTransactions">
+            <input type="file" name="file" class="wallet-labels__import-file d-none" accept=".jsonl,.json,.txt" aria-hidden="true" tabindex="-1" />
+            <button type="button" class="btn btn-secondary wallet-labels__import-button" text-translate="true">Import BIP-329 labels</button>
+        </form>
     </div>
 </div>
 <partial name="_StatusMessage" />

--- a/BTCPayServer/Services/WalletRepository.cs
+++ b/BTCPayServer/Services/WalletRepository.cs
@@ -662,19 +662,19 @@ namespace BTCPayServer.Services
 
         public async Task AddWalletObjectLabels((WalletObjectId id, string[] labels)[] reqs)
         {
-            var objs = new List<WalletObjectData>();
+            var objs = new Dictionary<WalletObjectId, WalletObjectData>();
             var links = new List<WalletObjectLinkData>();
             foreach (var (id, labels) in reqs)
             {
-                objs.Add(NewWalletObjectData(id));
-                foreach (var l in labels.Select(l => l.Trim().Truncate(MaxLabelSize)))
+                objs.TryAdd(id, NewWalletObjectData(id));
+                foreach (var l in labels.Select(l => l.Trim().Truncate(MaxLabelSize)).Distinct())
                 {
                     var label = CreateLabel(id.WalletId, l);
-                    objs.Add(label.ObjectData);
+                    objs.TryAdd(label.Id, label.ObjectData);
                     links.Add(NewWalletObjectLinkData(label.Id, id));
                 }
             }
-            await EnsureCreated(objs, links);
+            await EnsureCreated(objs.Values.ToList(), links);
         }
         public Task AddWalletTransactionAttachment(WalletId walletId, uint256 txId, Attachment attachment)
         {

--- a/BTCPayServer/Services/WalletRepository.cs
+++ b/BTCPayServer/Services/WalletRepository.cs
@@ -657,14 +657,22 @@ namespace BTCPayServer.Services
         public async Task AddWalletObjectLabels(WalletObjectId id, params string[] labels)
         {
             ArgumentNullException.ThrowIfNull(id);
+            await AddWalletObjectLabels(new[] { (id, labels) });
+        }
+
+        public async Task AddWalletObjectLabels((WalletObjectId id, string[] labels)[] reqs)
+        {
             var objs = new List<WalletObjectData>();
             var links = new List<WalletObjectLinkData>();
-            objs.Add(NewWalletObjectData(id));
-            foreach (var l in labels.Select(l => l.Trim().Truncate(MaxLabelSize)))
+            foreach (var (id, labels) in reqs)
             {
-                var label = CreateLabel(id.WalletId, l);
-                objs.Add(label.ObjectData);
-                links.Add(NewWalletObjectLinkData(label.Id, id));
+                objs.Add(NewWalletObjectData(id));
+                foreach (var l in labels.Select(l => l.Trim().Truncate(MaxLabelSize)))
+                {
+                    var label = CreateLabel(id.WalletId, l);
+                    objs.Add(label.ObjectData);
+                    links.Add(NewWalletObjectLinkData(label.Id, id));
+                }
             }
             await EnsureCreated(objs, links);
         }

--- a/BTCPayServer/Services/Wallets/Import/Bip329Import.cs
+++ b/BTCPayServer/Services/Wallets/Import/Bip329Import.cs
@@ -1,0 +1,83 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using BTCPayServer.Data;
+using NBitcoin;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace BTCPayServer.Services.Wallets.Import
+{
+    // https://github.com/bitcoin/bips/blob/master/bip-0329.mediawiki
+    public static class Bip329Import
+    {
+        public record ImportedLabel(string ObjectType, string ObjectId, string Label);
+        public record Result(List<ImportedLabel> Labels, int SkippedLines);
+
+        public static async Task<Result> Parse(TextReader reader, Network network)
+        {
+            var labels = new List<ImportedLabel>();
+            var seen = new HashSet<ImportedLabel>();
+            var skipped = 0;
+            while (await reader.ReadLineAsync() is { } line)
+            {
+                line = line.Trim();
+                if (line.Length == 0)
+                    continue;
+                var entry = TryParseLine(line, network);
+                if (entry is null)
+                    skipped++;
+                else if (seen.Add(entry))
+                    labels.Add(entry);
+            }
+            return new Result(labels, skipped);
+        }
+
+        static ImportedLabel? TryParseLine(string line, Network network)
+        {
+            JObject obj;
+            try
+            {
+                obj = JObject.Parse(line);
+            }
+            catch (JsonException)
+            {
+                return null;
+            }
+            var label = obj["label"]?.Value<string>()?.Trim();
+            var reference = obj["ref"]?.Value<string>();
+            if (string.IsNullOrEmpty(label) || string.IsNullOrEmpty(reference))
+                return null;
+            return obj["type"]?.Value<string>() switch
+            {
+                "tx" when uint256.TryParse(reference, out var txId) =>
+                    new ImportedLabel(WalletObjectData.Types.Tx, txId.ToString(), label),
+                "addr" when TryParseAddress(reference, network) is { } address =>
+                    new ImportedLabel(WalletObjectData.Types.Address, address, label),
+                "output" when TryParseOutpoint(reference) is { } outpoint =>
+                    new ImportedLabel(WalletObjectData.Types.Utxo, outpoint, label),
+                _ => null
+            };
+        }
+
+        static string? TryParseAddress(string str, Network network)
+        {
+            try
+            {
+                return BitcoinAddress.Create(str, network).ToString();
+            }
+            catch (FormatException)
+            {
+                return null;
+            }
+        }
+
+        static string? TryParseOutpoint(string str)
+        {
+            // BIP-329 references outputs as <txid>:<vout>, NBitcoin parses <txid>-<vout>
+            return OutPoint.TryParse(str.Replace(':', '-'), out var outpoint) ? outpoint!.ToString() : null;
+        }
+    }
+}

--- a/BTCPayServer/Services/Wallets/Import/Bip329Import.cs
+++ b/BTCPayServer/Services/Wallets/Import/Bip329Import.cs
@@ -46,11 +46,11 @@ namespace BTCPayServer.Services.Wallets.Import
             {
                 return null;
             }
-            var label = obj["label"]?.Value<string>()?.Trim();
-            var reference = obj["ref"]?.Value<string>();
+            var label = GetString(obj, "label")?.Trim();
+            var reference = GetString(obj, "ref");
             if (string.IsNullOrEmpty(label) || string.IsNullOrEmpty(reference))
                 return null;
-            return obj["type"]?.Value<string>() switch
+            return GetString(obj, "type") switch
             {
                 "tx" when uint256.TryParse(reference, out var txId) =>
                     new ImportedLabel(WalletObjectData.Types.Tx, txId.ToString(), label),
@@ -61,6 +61,9 @@ namespace BTCPayServer.Services.Wallets.Import
                 _ => null
             };
         }
+
+        static string? GetString(JObject obj, string name)
+            => obj[name] is JValue { Type: JTokenType.String, Value: string s } ? s : null;
 
         static string? TryParseAddress(string str, Network network)
         {


### PR DESCRIPTION
Closes #6663.

BTCPay can export wallet labels in BIP-329 format, but there was no way to import them back, labels were effectively lost when migrating to a new server, and label files from BIP-329-aware wallets (Sparrow, Envoy) couldn't be loaded either.

This adds an import counterpart to the existing export:

- **Wallet Labels page** gets an "Import BIP-329 labels" upload form (visible with `CanManageWalletTransactions`, also shown in the empty state since a fresh server is the main migration case).
- **`Bip329Import`** parses JSONL per [BIP-329](https://github.com/bitcoin/bips/blob/master/bip-0329.mediawiki): `tx`, `addr` and `output` rows map to the existing `tx`/`address`/`utxo` wallet objects. Invalid lines (malformed JSON, bad refs, wrong-network addresses, unsupported types) are skipped and reported, duplicates are deduped, refs are normalized to match stored object ids.
- **`WalletRepository.AddWalletObjectLabels`** gets a batch overload (same pattern as `AddWalletTransactionAttachments`) so an import is a single `EnsureCreated` upsert, idempotent, re-importing the same file is a no-op. Label trimming/truncation stays centralized in the repository.
- Uploads are capped at 1 MB; the user gets a status message with imported/skipped counts.

No schema changes, no Greenfield surface, export untouched.

#### Testing

- `CanParseBip329LabelsImport` (Fast): valid/invalid/duplicate/blank lines, wrong-network address, ref normalization for all three types.
- Extended `CanSearchLabelFilterInWalletTransactions` (Playwright): uploads a BIP-329 file with one valid row and one junk line from the labels page, asserts the status message counts, the label appearing on the page, and the label landing on the transaction via the Greenfield API.

#### Screenshots

<img width="1265" height="1338" alt="bip329-import-form" src="https://github.com/user-attachments/assets/f1581efb-6727-4369-afb0-28888e3f6f62" />

<img width="1265" height="1452" alt="bip329-import-success" src="https://github.com/user-attachments/assets/0560a8bf-0ef9-4b7a-847b-c460a3ed017c" />
