### PR TITLE
Greenfield: support webhookUrl on invoice creation

### DIFF
--- a/BTCPayServer.Client/Models/CreateInvoiceRequest.cs
+++ b/BTCPayServer.Client/Models/CreateInvoiceRequest.cs
@@ -8,5 +8,7 @@ namespace BTCPayServer.Client.Models
         [JsonConverter(typeof(NumericStringJsonConverter))]
         public decimal? Amount { get; set; }
         public string[] AdditionalSearchTerms { get; set; }
+        public string WebhookUrl { get; set; }
+        public string WebhookSecret { get; set; }
     }
 }

--- a/BTCPayServer.Tests/GreenfieldAPITests.cs
+++ b/BTCPayServer.Tests/GreenfieldAPITests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using BTCPayServer.Abstractions.Contracts;
@@ -34,6 +35,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using NBitcoin;
+using NBitcoin.DataEncoders;
 using NBitpayClient;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -2012,6 +2014,40 @@ namespace BTCPayServer.Tests
                 });
             });
             Assert.Contains("Invalid or unsupported payout method: fake payment method", validationError.Message);
+        }
+
+        [Fact(Timeout = TestTimeout)]
+        [Trait("Integration", "Integration")]
+        public async Task CanUseInvoiceWebhookUrl()
+        {
+            using var tester = CreateServerTester();
+            await tester.StartAsync();
+            var user = tester.NewAccount();
+            await user.RegisterDerivationSchemeAsync("BTC");
+            var client = await user.CreateClient();
+
+            await AssertValidationError(new[] { "WebhookUrl" }, () => client.CreateInvoice(user.StoreId,
+                new CreateInvoiceRequest { Amount = 10m, Currency = "USD", WebhookUrl = "not an url" }));
+
+            using var fakeServer = new FakeServer();
+            await fakeServer.Start();
+            var invoice = await client.CreateInvoice(user.StoreId, new CreateInvoiceRequest
+            {
+                Amount = 10m,
+                Currency = "USD",
+                WebhookUrl = fakeServer.ServerUri.AbsoluteUri,
+                WebhookSecret = "hello"
+            });
+
+            var request = await fakeServer.GetNextRequest();
+            var bytes = await request.Request.Body.ReadBytesAsync((int)request.Request.Headers.ContentLength!.Value);
+            var expectedSig = $"sha256={Encoders.Hex.EncodeData(NBitcoin.Crypto.Hashes.HMACSHA256(Encoding.UTF8.GetBytes("hello"), bytes))}";
+            Assert.Equal(expectedSig, request.Request.Headers["BTCPay-Sig"].First());
+            var evt = JsonConvert.DeserializeObject<WebhookInvoiceEvent>(Encoding.UTF8.GetString(bytes));
+            Assert.Equal(WebhookEventType.InvoiceCreated, evt.Type);
+            Assert.Equal(invoice.Id, evt.InvoiceId);
+            request.Response.StatusCode = 200;
+            fakeServer.Done();
         }
 
         [Fact(Timeout = TestTimeout)]

--- a/BTCPayServer/Controllers/GreenField/GreenfieldInvoiceController.cs
+++ b/BTCPayServer/Controllers/GreenField/GreenfieldInvoiceController.cs
@@ -211,6 +211,11 @@ namespace BTCPayServer.Controllers.Greenfield
                     "PaymentTolerance can only be between 0 and 100 percent", this);
             }
 
+            if (request.WebhookUrl != null && !Uri.TryCreate(request.WebhookUrl, UriKind.Absolute, out _))
+            {
+                ModelState.AddModelError(nameof(request.WebhookUrl), "Invalid webhookUrl, it should be an absolute URL");
+            }
+
             if (request.Checkout.DefaultLanguage != null)
             {
                 var lang = LanguageService.FindLanguage(request.Checkout.DefaultLanguage);

--- a/BTCPayServer/Controllers/UIInvoiceController.UI.cs
+++ b/BTCPayServer/Controllers/UIInvoiceController.UI.cs
@@ -145,6 +145,7 @@ namespace BTCPayServer.Controllers
                     ? null
                     : _displayFormatter.Currency(invoice.Metadata.TaxIncluded ?? 0.0m, invoice.Currency),
                 NotificationUrl = invoice.NotificationURL?.AbsoluteUri,
+                WebhookUrl = invoice.WebhookUrl,
                 RedirectUrl = invoice.RedirectURL?.AbsoluteUri,
                 TypedMetadata = invoice.Metadata,
                 StatusException = invoice.ExceptionStatus,

--- a/BTCPayServer/Controllers/UIInvoiceController.cs
+++ b/BTCPayServer/Controllers/UIInvoiceController.cs
@@ -198,6 +198,8 @@ namespace BTCPayServer.Controllers
             }
             entity.PaymentTolerance = invoice.Checkout.PaymentTolerance ?? storeBlob.PaymentTolerance;
             entity.RedirectURLTemplate = invoice.Checkout.RedirectURL?.Trim();
+            entity.WebhookUrl = invoice.WebhookUrl?.Trim();
+            entity.WebhookSecret = invoice.WebhookSecret;
             if (additionalTags != null)
                 entity.InternalTags.AddRange(additionalTags);
             return await CreateInvoiceCoreRaw(entity, store, excludeFilter, invoice.AdditionalSearchTerms, cancellationToken, entityManipulator);

--- a/BTCPayServer/Models/InvoicingModels/InvoiceDetailsModel.cs
+++ b/BTCPayServer/Models/InvoicingModels/InvoiceDetailsModel.cs
@@ -114,6 +114,7 @@ namespace BTCPayServer.Models.InvoicingModels
             internal set;
         }
 
+        public string WebhookUrl { get; set; }
         public string RedirectUrl { get; set; }
         public string Fiat
         {

--- a/BTCPayServer/Plugins/Webhooks/HostedServices/WebhookProviderHostedService.cs
+++ b/BTCPayServer/Plugins/Webhooks/HostedServices/WebhookProviderHostedService.cs
@@ -4,6 +4,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using BTCPayServer.Client.Models;
 using BTCPayServer.Data;
+using BTCPayServer.Events;
 using BTCPayServer.HostedServices;
 using BTCPayServer.Plugins.Emails.HostedServices;
 using Microsoft.Extensions.Logging;
@@ -51,6 +52,23 @@ public class WebhookProviderHostedService(
             ev.Timestamp = delivery.Timestamp;
             ev.IsRedelivery = false;
             webhookSender.EnqueueDelivery(new(webhook.Id, ev, delivery, webhook.GetBlob()));
+        }
+
+        if (evt is InvoiceEvent { Invoice: { WebhookUrl: { } invoiceWebhookUrl } invoice })
+        {
+            var ev = Clone(webhookEvent);
+            var delivery = Data.WebhookDeliveryData.Create(null);
+            ev.DeliveryId = delivery.Id;
+            ev.OriginalDeliveryId = delivery.Id;
+            ev.Timestamp = delivery.Timestamp;
+            ev.IsRedelivery = false;
+            webhookSender.EnqueueDelivery(new(null, ev, delivery, new WebhookBlob
+            {
+                Url = invoiceWebhookUrl,
+                Secret = invoice.WebhookSecret,
+                AutomaticRedelivery = true,
+                AuthorizedEvents = new AuthorizedWebhookEvents { Everything = true }
+            }));
         }
 
         if (await GetStore(webhookEvent) is {} store)

--- a/BTCPayServer/Plugins/Webhooks/WebhookSender.cs
+++ b/BTCPayServer/Plugins/Webhooks/WebhookSender.cs
@@ -106,14 +106,14 @@ public class WebhookSender(
 
     public void EnqueueDelivery(WebhookDeliveryRequest context)
     {
-        _processingQueue.Enqueue(context.WebhookId, cancellationToken => Process(context, cancellationToken));
+        _processingQueue.Enqueue(context.WebhookId ?? context.Delivery.Id, cancellationToken => Process(context, cancellationToken));
     }
 
     private async Task Process(WebhookDeliveryRequest ctx, CancellationToken cancellationToken)
     {
         try
         {
-            var wh = (await StoreRepository.GetWebhook(ctx.WebhookId))?.GetBlob();
+            var wh = ctx.WebhookId is null ? ctx.WebhookBlob : (await StoreRepository.GetWebhook(ctx.WebhookId))?.GetBlob();
             if (wh is null || !wh.ShouldDeliver(ctx.WebhookEvent.Type))
                 return;
             var result = await SendAndSaveDelivery(ctx, cancellationToken);
@@ -128,7 +128,7 @@ public class WebhookSender(
                          })
                 {
                     await Task.Delay(wait, cancellationToken);
-                    var localCtx = await CreateRedeliveryRequest(originalDeliveryId);
+                    var localCtx = ctx.WebhookId is null ? ctx : await CreateRedeliveryRequest(originalDeliveryId);
                     // This may have changed
                     if (localCtx is null || !localCtx.WebhookBlob.AutomaticRedelivery ||
                         !localCtx.WebhookBlob.ShouldDeliver(ctx.WebhookEvent.Type))
@@ -213,7 +213,8 @@ public class WebhookSender(
         CancellationToken cancellationToken)
     {
         var result = await SendDelivery(ctx, cancellationToken);
-        await StoreRepository.AddWebhookDelivery(ctx.Delivery);
+        if (ctx.WebhookId is not null)
+            await StoreRepository.AddWebhookDelivery(ctx.Delivery);
 
         return result;
     }
@@ -231,7 +232,7 @@ public class WebhookSender(
             .ToArray();
     }
     public class WebhookDeliveryRequest(
-        string webhookId,
+        string? webhookId,
         WebhookEvent webhookEvent,
         WebhookDeliveryData delivery,
         WebhookBlob webhookBlob)
@@ -239,7 +240,10 @@ public class WebhookSender(
         public WebhookEvent WebhookEvent { get; } = webhookEvent;
         public WebhookDeliveryData Delivery { get; } = delivery;
         public WebhookBlob WebhookBlob { get; } = webhookBlob;
-        public string WebhookId { get; } = webhookId;
+        /// <summary>
+        /// If null, the webhook isn't stored in database (ex: webhook set at invoice creation), so the delivery isn't saved.
+        /// </summary>
+        public string? WebhookId { get; } = webhookId;
     }
 
     public class DeliveryResult

--- a/BTCPayServer/Plugins/Webhooks/WebhookSender.cs
+++ b/BTCPayServer/Plugins/Webhooks/WebhookSender.cs
@@ -106,7 +106,7 @@ public class WebhookSender(
 
     public void EnqueueDelivery(WebhookDeliveryRequest context)
     {
-        _processingQueue.Enqueue(context.WebhookId ?? context.Delivery.Id, cancellationToken => Process(context, cancellationToken));
+        _processingQueue.Enqueue(context.WebhookId ?? context.WebhookBlob.Url, cancellationToken => Process(context, cancellationToken));
     }
 
     private async Task Process(WebhookDeliveryRequest ctx, CancellationToken cancellationToken)

--- a/BTCPayServer/Services/Invoices/InvoiceEntity.cs
+++ b/BTCPayServer/Services/Invoices/InvoiceEntity.cs
@@ -505,6 +505,11 @@ namespace BTCPayServer.Services.Invoices
 
         [JsonIgnore]
         public Uri NotificationURL => FillPlaceholdersUri(NotificationURLTemplate);
+
+        [JsonProperty]
+        public string WebhookUrl { get; set; }
+        [JsonProperty]
+        public string WebhookSecret { get; set; }
         public string ServerUrl { get; set; }
 
         [Obsolete("Use Set/GetPaymentPrompts() instead")]

--- a/BTCPayServer/Views/UIInvoice/Invoice.cshtml
+++ b/BTCPayServer/Views/UIInvoice/Invoice.cshtml
@@ -290,6 +290,13 @@
                         <td>@Model.NotificationUrl</td>
                     </tr>
                 }
+                @if (!string.IsNullOrEmpty(Model.WebhookUrl))
+                {
+                    <tr>
+                        <th>Webhook Url</th>
+                        <td>@Model.WebhookUrl</td>
+                    </tr>
+                }
                 @if (!string.IsNullOrEmpty(Model.RedirectUrl))
                 {
                     <tr>

--- a/BTCPayServer/wwwroot/swagger/v1/swagger.template.invoices.json
+++ b/BTCPayServer/wwwroot/swagger/v1/swagger.template.invoices.json
@@ -1071,6 +1071,18 @@
                                 },
                                 "description": "Additional search term to help you find this invoice via text search",
                                 "nullable": true
+                            },
+                            "webhookUrl": {
+                                "type": "string",
+                                "format": "url",
+                                "nullable": true,
+                                "description": "If set, all the webhook events of this invoice will also be sent to this URL, in addition to the webhooks configured on the store. Useful when several websites share the same store and each needs to receive events for its own invoices.",
+                                "example": "https://example.com/callback"
+                            },
+                            "webhookSecret": {
+                                "type": "string",
+                                "nullable": true,
+                                "description": "The secret used to compute the `BTCPay-Sig` header of the deliveries sent to `webhookUrl`, so the receiver can authenticate the payload. If null, the `BTCPay-Sig` is computed with an empty secret."
                             }
                         }
                     }


### PR DESCRIPTION
Closes #7052.

Webhooks can only be configured per store, so when several websites share one store, every site receives every invoice's events and has to filter out or forward what isn't theirs. The legacy BitPay API had a per-invoice notificationURL for exactly this, but it never made it to Greenfield, and the legacy one sends old unsigned IPN payloads anyway.

This adds an optional `webhookUrl` (plus `webhookSecret`) to invoice creation. When set, all webhook events of that invoice are also delivered to that URL, signed with `BTCPay-Sig` like regular webhooks. Store webhooks behave exactly as before, and nothing changes if you don't pass the field. The URL is also visible on the invoice details page.

Tested on a local instance with two receivers sharing one store: one as the store webhook, the other passed as `webhookUrl` on a single invoice. That invoice's created/settled events arrived at both endpoints with a valid signature from the per-invoice secret, while other invoices only hit the store webhook. Invalid URLs are rejected at creation. There's a new integration test covering delivery, signature and validation.

One note: since these webhooks aren't stored on the store, their deliveries don't appear in the webhook delivery list and can't be redelivered from the UI. Automatic retry on failed delivery still applies.

<img width="1440" height="1000" alt="pr-evidence-invoice-webhookurl" src="https://github.com/user-attachments/assets/61b48c0f-ae95-420d-afe6-93bca580a0de" />
