### PR TITLE
[WIP] Redesign the invoice detail view

### DIFF
--- a/BTCPayServer/Controllers/UIInvoiceController.UI.cs
+++ b/BTCPayServer/Controllers/UIInvoiceController.UI.cs
@@ -162,6 +162,8 @@ namespace BTCPayServer.Controllers
                                     .ToList()
             };
 
+            model.StoreHasWebhooks = (await _StoreRepository.GetWebhooks(invoice.StoreId)).Length > 0;
+
             var details = InvoicePopulatePayments(invoice);
             model.CryptoPayments = details.CryptoPayments;
             model.Payments = details.Payments;
@@ -1160,7 +1162,8 @@ namespace BTCPayServer.Controllers
         [HttpGet("/stores/{storeId}/invoices/create")]
         [HttpGet("invoices/create")]
         [Authorize(Policy = Policies.CanCreateInvoice, AuthenticationSchemes = AuthenticationSchemes.Cookie)]
-        public async Task<IActionResult> CreateInvoice(InvoicesModel? model = null)
+        public async Task<IActionResult> CreateInvoice(InvoicesModel? model = null, decimal? amount = null,
+            string? currency = null, string? orderId = null, string? sourceInvoiceId = null)
         {
             if (string.IsNullOrEmpty(model?.StoreId))
             {
@@ -1181,9 +1184,17 @@ namespace BTCPayServer.Controllers
             var vm = new CreateInvoiceModel
             {
                 StoreId = model.StoreId,
-                Currency = storeBlob.DefaultCurrency,
+                Amount = amount,
+                Currency = string.IsNullOrEmpty(currency) ? storeBlob.DefaultCurrency : currency,
+                OrderId = orderId,
                 AvailablePaymentMethods = GetPaymentMethodsSelectList(store)
             };
+            // Charging the remainder of an underpaid invoice: carry the origin so the two can be
+            // reconciled against one order.
+            if (!string.IsNullOrEmpty(sourceInvoiceId))
+            {
+                vm.Metadata = new JObject { ["sourceInvoiceId"] = sourceInvoiceId }.ToString(Newtonsoft.Json.Formatting.Indented);
+            }
 
             return View(vm);
         }

--- a/BTCPayServer/Models/InvoicingModels/InvoiceDetailsModel.cs
+++ b/BTCPayServer/Models/InvoicingModels/InvoiceDetailsModel.cs
@@ -87,6 +87,9 @@ namespace BTCPayServer.Models.InvoicingModels
         }
 
         public List<DeliveryViewModel> Deliveries { get; set; } = new ();
+
+        /// <summary>Lets the view tell "nothing fired" apart from "nothing is configured".</summary>
+        public bool StoreHasWebhooks { get; set; }
         public string TaxIncluded { get; set; }
 
         public string TransactionSpeed { get; set; }

--- a/BTCPayServer/Plugins/Webhooks/Views/EditWebhookViewModel.cs
+++ b/BTCPayServer/Plugins/Webhooks/Views/EditWebhookViewModel.cs
@@ -19,6 +19,7 @@ namespace BTCPayServer.Plugins.Webhooks.Views
             Id = s.Id;
             Success = blob.Status == WebhookDeliveryStatus.HttpSuccess;
             ErrorMessage = blob.ErrorMessage ?? "Success";
+            HttpCode = blob.HttpCode;
             Time = s.Timestamp;
             DeliveryTime = s.DeliveryTime;
             var evt = blob.ReadRequestAs<WebhookEvent>();
@@ -36,6 +37,7 @@ namespace BTCPayServer.Plugins.Webhooks.Views
         public string WebhookId { get; set; }
         public bool Success { get; set; }
         public string ErrorMessage { get; set; }
+        public int? HttpCode { get; set; }
         public string PayloadUrl { get; set; }
     }
     public class EditWebhookViewModel

--- a/BTCPayServer/Views/UIInvoice/Invoice.cshtml
+++ b/BTCPayServer/Views/UIInvoice/Invoice.cshtml
@@ -1,34 +1,146 @@
 @using BTCPayServer.Client
+@using BTCPayServer.Client.Models
+@using BTCPayServer.Payments
+@using BTCPayServer.Payments.Bitcoin
+@using BTCPayServer.Payments.Lightning
+@using BTCPayServer.Services
+@using BTCPayServer.Services.Invoices
+@using Newtonsoft.Json
+@inject PaymentMethodHandlerDictionary Handlers
+@inject TransactionLinkProviders TransactionLinkProviders
+@inject DisplayFormatter DisplayFormatter
+@inject PrettyNameProvider PrettyName
 @model InvoiceDetailsModel
 @{
     ViewData.SetLayoutModel(new("Invoices", StringLocalizer["Invoice {0}", Model.Id]));
+    var hasPayments = Model.Payments?.Any() is true;
+    var isInvalid = Model.State.Status == InvoiceStatus.Invalid;
+    var primaryPaid = Model.CryptoPayments?.FirstOrDefault(p => p.Paid != null)?.Paid;
+    var stillDueAmount = Model.CryptoPayments?.FirstOrDefault(p => p.Due != null)?.Due;
+    var overpaidAmount = Model.Overpaid ? Model.CryptoPayments?.FirstOrDefault(p => p.Overpaid != null)?.Overpaid : null;
+
+    // Hero aggregates (progress bar, payment count, total network fee)
+    var accountedPayments = (Model.Payments ?? new List<PaymentEntity>()).Where(p => p.Accounted).ToList();
+    var invoicePrice = Model.Entity?.Price ?? 0m;
+    var paidTowardsInvoice = accountedPayments.Where(p => p.InvoicePaidAmount is not null).Sum(p => p.InvoicePaidAmount.Gross);
+    var paidPct = invoicePrice > 0 ? (int)Math.Round(Math.Clamp(paidTowardsInvoice / invoicePrice * 100m, 0m, 100m)) : (hasPayments ? 100 : 0);
+    var paymentCount = accountedPayments.Count;
+    var totalNetworkFee = accountedPayments.Sum(p => p.PaymentMethodFee);
+    var networkFeeCurrency = accountedPayments.FirstOrDefault()?.Currency;
+    var paymentLink = $"{Context.Request.Scheme}://{Context.Request.Host}/i/{Model.Id}";
+    var statusVar = Model.State.Status switch
+    {
+        InvoiceStatus.Settled => "--btcpay-success",
+        InvoiceStatus.Processing => "--btcpay-warning",
+        InvoiceStatus.New => "--btcpay-primary",
+        InvoiceStatus.Invalid => "--btcpay-danger",
+        _ => "--btcpay-body-text-muted"
+    };
+    (string Label, string Css)? exception = Model.StatusException switch
+    {
+        InvoiceExceptionStatus.PaidOver => (StringLocalizer["Overpaid"].Value, "info"),
+        InvoiceExceptionStatus.PaidPartial => (StringLocalizer["Paid Partial"].Value, "warning"),
+        InvoiceExceptionStatus.PaidLate => (StringLocalizer["Paid Late"].Value, "warning"),
+        _ => null
+    };
+}
+
+@functions {
+    string EventDotColor(string css) => css switch
+    {
+        "success" => "var(--btcpay-success)",
+        "danger" => "var(--btcpay-danger)",
+        "warning" => "var(--btcpay-warning)",
+        "info" => "var(--btcpay-info)",
+        _ => "var(--btcpay-body-text-muted)"
+    };
+
+    static decimal? ParseAmount(Newtonsoft.Json.Linq.JToken t)
+    {
+        if (t is null || t.Type == Newtonsoft.Json.Linq.JTokenType.Null)
+            return null;
+        if (t is Newtonsoft.Json.Linq.JObject o)
+            return o.Value<decimal?>("value") ?? o.Value<decimal?>("amount");
+        return decimal.TryParse(t.ToString(), System.Globalization.NumberStyles.Any, System.Globalization.CultureInfo.InvariantCulture, out var d) ? d : null;
+    }
+
+    // Lifecycle events (shown in Activity) contain "new event: invoice_…"; everything
+    // else (timings, rate lookups, payjoin notices, …) is treated as a debug event.
+    static readonly System.Text.RegularExpressions.Regex EventCodeRx =
+        new(@"new event:\s*(invoice_\w+)", System.Text.RegularExpressions.RegexOptions.Compiled);
+
+    static bool IsActivityEvent(string message) =>
+        !string.IsNullOrEmpty(message) && EventCodeRx.IsMatch(message);
+
+    string ActivityLabel(string message)
+    {
+        var code = EventCodeRx.Match(message).Groups[1].Value;
+        return code switch
+        {
+            "invoice_created" => StringLocalizer["Invoice created"].Value,
+            "invoice_receivedPayment" => StringLocalizer["Payment received"].Value,
+            "invoice_paidInFull" => StringLocalizer["Paid in full"].Value,
+            "invoice_paymentSettled" => StringLocalizer["Payment settled"].Value,
+            "invoice_confirmedPaid" => StringLocalizer["Payment confirmed"].Value,
+            "invoice_completed" => StringLocalizer["Invoice completed"].Value,
+            "invoice_expired" => StringLocalizer["Invoice expired"].Value,
+            "invoice_expiredPaidPartial" => StringLocalizer["Expired — partially paid"].Value,
+            "invoice_expiredPaidLate" => StringLocalizer["Expired — paid late"].Value,
+            "invoice_failedToConfirm" => StringLocalizer["Failed to confirm"].Value,
+            "invoice_markedInvalid" => StringLocalizer["Marked invalid"].Value,
+            "invoice_markedCompleted" => StringLocalizer["Marked settled"].Value,
+            "invoice_paidAfterExpiration" => StringLocalizer["Paid after expiration"].Value,
+            _ => Humanize(code)
+        };
+    }
+
+    // Opinionated dot color for an activity event: green = good, red = bad, etc.
+    string ActivityDotCss(string message)
+    {
+        var code = EventCodeRx.Match(message).Groups[1].Value;
+        return code switch
+        {
+            "invoice_receivedPayment" or "invoice_paidInFull" or "invoice_paymentSettled"
+                or "invoice_confirmedPaid" or "invoice_completed" or "invoice_markedCompleted" => "success",
+            "invoice_expired" or "invoice_expiredPaidPartial" or "invoice_failedToConfirm"
+                or "invoice_markedInvalid" => "danger",
+            "invoice_expiredPaidLate" or "invoice_paidAfterExpiration" => "warning",
+            "invoice_created" => "info",
+            _ => null
+        };
+    }
+
+    static string Humanize(string code)
+    {
+        var s = code.StartsWith("invoice_") ? code["invoice_".Length..] : code;
+        s = System.Text.RegularExpressions.Regex.Replace(s, "(?<=[a-z0-9])([A-Z])", " $1");
+        return s.Length == 0 ? code : char.ToUpperInvariant(s[0]) + s[1..].ToLowerInvariant();
+    }
+
+    // View model for a single settled/received payment card.
+    class PayCard
+    {
+        public bool IsLightning { get; init; }
+        public bool Replaced { get; init; }
+        public string Method { get; init; }
+        public int? ConfCount { get; init; }
+        public int? ConfReq { get; init; }
+        public string Amount { get; init; }
+        public string FiatValue { get; init; }
+        public string NetworkFee { get; init; }
+        public string FeeFiat { get; init; }
+        public string Rate { get; init; }
+        public string Destination { get; init; }
+        public string TxId { get; init; }
+        public string TxLink { get; init; }
+        public string AdditionalInfo { get; init; }
+        public string LnComment { get; init; }
+        public string LnAddress { get; init; }
+    }
 }
 
 @section PageHeadContent {
     <meta name="robots" content="noindex,nofollow">
-    <style>
-        #posData td > table:last-child {
-            margin-bottom: 0 !important;
-        }
-
-        #posData table > tbody > tr:first-child > td > h4 {
-            margin-top: 0 !important;
-        }
-        .invoice-information {
-            display: flex;
-            flex-wrap: wrap;
-            gap: var(--btcpay-space-xl) var(--btcpay-space-xxl);
-        }
-
-            .invoice-information > div {
-                max-width: 540px;
-            }
-
-                .invoice-information > div table th {
-                    width: 200px;
-                    font-weight: var(--btcpay-font-weight-semibold);
-                }
-    </style>
 }
 
 @section PageFootContent {
@@ -46,9 +158,22 @@
 
         delegate('click', '#IssueRefund', async e => {
             e.preventDefault()
-            const { href: url } = e.target
+            const url = e.target.closest('a').href
             const response = await fetch(url)
             await handleRefundResponse(response)
+        })
+
+        delegate('click', '.mark-invoice-settled', async e => {
+            const button = e.target.closest('.mark-invoice-settled')
+            if (!confirm('Mark this invoice as settled?')) return
+            button.classList.add('disabled')
+            const response = await fetch(button.dataset.url, { method: 'POST' })
+            if (response.ok) {
+                window.location.reload()
+            } else {
+                button.classList.remove('disabled')
+                alert('Invoice state update failed')
+            }
         })
 
         delegate('submit', '#RefundForm', async e => {
@@ -143,6 +268,18 @@
         delegate('change', '#SubtractPercentage', updateSubtractPercentageResult);
         delegate('change', '#CustomCurrency', updateSubtractPercentageResult);
         delegate('change', '#CustomAmount', updateSubtractPercentageResult);
+
+        document.addEventListener('DOMContentLoaded', () => {
+            document.querySelectorAll(".webhook-time-tooltip").forEach(function (el) {
+                formatDateTimes(null, el.content);
+                el.content.querySelectorAll('time').forEach(time => {
+                    var span = document.createElement('span');
+                    span.innerHTML = time.innerHTML;
+                    time.replaceWith(span);
+                });
+                el.parentElement.setAttribute('title', el.innerHTML);
+            });
+        });
     </script>
 }
 
@@ -167,7 +304,10 @@
     </div>
 }
 
-<div class="sticky-header">
+<partial name="_StatusMessage" />
+
+<div class="invoice-detail">
+    @* Static invoice header (breadcrumb above, title/status + actions in one row), not sticky *@
     <nav aria-label="breadcrumb">
         <ol class="breadcrumb">
             <li class="breadcrumb-item">
@@ -175,482 +315,616 @@
             </li>
             <li class="breadcrumb-item active" aria-current="page">Invoice</li>
         </ol>
-        <h2>@ViewData["Title"]</h2>
     </nav>
-    <div>
-        @if (Model.ShowCheckout)
+    <div class="d-flex flex-wrap justify-content-between align-items-start gap-3 mb-3">
+        <div>
+            <div class="d-flex align-items-center flex-wrap gap-3">
+                <h2 class="mb-0" text-translate="true">Invoice</h2>
+                <vc:invoice-status invoice-id="@Model.Id" state="Model.State" payments="Model.Payments"
+                                   is-archived="Model.Archived" has-refund="Model.HasRefund" />
+                @if (exception is { } exh)
+                {
+                    <span class="badge bg-@exh.Css">@exh.Label</span>
+                }
+            </div>
+            <div class="inv-id-line mt-1">
+                <vc:truncate-center text="@Model.Id" padding="30" classes="font-monospace" />
+                <span>&middot;</span>
+                <span>@StringLocalizer["created"] @Model.CreatedDate.ToBrowserDate()</span>
+            </div>
+        </div>
+        <div class="d-flex gap-2 flex-wrap">
+            @if (Model.ShowCheckout)
+            {
+                <a asp-action="Checkout" class="invoice-checkout-link btn btn-primary text-nowrap" asp-route-invoiceId="@Model.Id">Checkout</a>
+            }
+            @if (Model.ShowReceipt)
+            {
+                <a asp-action="InvoiceReceipt" asp-route-invoiceId="@Model.Id" id="Receipt" class="btn btn-secondary" target="InvoiceReceipt-@Model.Id">Receipt</a>
+            }
+            @if (Model.CanRefund)
+            {
+                <a asp-action="Refund" asp-route-invoiceId="@Model.Id" id="IssueRefund" class="btn btn-primary text-nowrap" data-bs-toggle="modal" data-bs-target="#RefundModal" permission="@Policies.CanCreateNonApprovedPullPayments">Issue Refund</a>
+            }
+            <form asp-action="ToggleArchive" asp-route-invoiceId="@Model.Id" method="post">
+                <button type="submit" class="btn btn-secondary" id="btn-archive-toggle">
+                    @if (Model.Archived)
+                    {
+                        <span class="text-nowrap" title="@StringLocalizer["Unarchive this invoice"]">Unarchive</span>
+                    }
+                    else
+                    {
+                        <span class="text-nowrap" title="@StringLocalizer["Archive this invoice so that it does not appear in the invoice list by default"]">Archive</span>
+                    }
+                </button>
+            </form>
+        </div>
+    </div>
+
+    @* Hero *@
+    <div class="inv-card mb-2">
+        @if (hasPayments)
         {
-            <a asp-action="Checkout" class="invoice-checkout-link btn btn-primary text-nowrap" asp-route-invoiceId="@Model.Id">Checkout</a>
-        }
-        @if (Model.ShowReceipt)
-        {
-            <a asp-action="InvoiceReceipt" asp-route-invoiceId="@Model.Id" id="Receipt" class="btn btn-secondary" target="InvoiceReceipt-@Model.Id">Receipt</a>
-        }
-        @if (Model.CanRefund)
-        {
-            <a asp-action="Refund" asp-route-invoiceId="@Model.Id" id="IssueRefund" class="btn btn-primary text-nowrap" data-bs-toggle="modal" data-bs-target="#RefundModal" permission="@Policies.CanCreateNonApprovedPullPayments">Issue Refund</a>
+            <div class="d-flex flex-wrap justify-content-between align-items-start gap-4">
+                <div>
+                    <div class="inv-hero-label" text-translate="true">Paid</div>
+                    <div class="inv-hero-amount" data-sensitive>@primaryPaid</div>
+                </div>
+                <div class="text-end">
+                    @if (Model.StillDue && stillDueAmount != null)
+                    {
+                        <div class="inv-hero-label" text-translate="true">Still Due</div>
+                        <div class="fw-semibold" style="font-size:1.5rem;color:var(--btcpay-warning)" data-sensitive>@stillDueAmount</div>
+                    }
+                    else if (overpaidAmount != null)
+                    {
+                        <div class="inv-hero-label" text-translate="true">Overpaid</div>
+                        <div class="fw-semibold" style="font-size:1.5rem;color:var(--btcpay-info)" data-sensitive>@overpaidAmount</div>
+                    }
+                    else
+                    {
+                        <div class="inv-hero-label" text-translate="true">Invoice Total</div>
+                        <div class="fw-semibold" style="font-size:1.5rem" data-sensitive>@Model.Fiat</div>
+                    }
+                </div>
+            </div>
+            <div class="inv-progress mt-3"><span class="inv-progress-fill" style="width:@(paidPct)%;background:var(@statusVar)"></span></div>
+            <div class="d-flex flex-wrap justify-content-between gap-2 mt-2 text-secondary">
+                <span>@StringLocalizer["{0}% paid", paidPct] &middot; @StringLocalizer["{0} payment(s)", paymentCount]</span>
+                @if (totalNetworkFee > 0 && networkFeeCurrency != null)
+                {
+                    <span data-sensitive>@StringLocalizer["includes {0} network fee", DisplayFormatter.Currency(totalNetworkFee, networkFeeCurrency)]</span>
+                }
+            </div>
         }
         else
         {
-            <button class="btn btn-secondary text-nowrap" title="@StringLocalizer["You can only refund an invoice that has been settled. Please wait for the transaction to confirm on the blockchain before attempting to refund it."]" disabled>Issue refund</button>
+            <div class="inv-hero-label" text-translate="true">Amount Due</div>
+            <div class="inv-hero-amount" data-sensitive>@Model.Fiat</div>
         }
-        <form asp-action="ToggleArchive" asp-route-invoiceId="@Model.Id" method="post">
-            <button type="submit" class="btn btn-secondary" id="btn-archive-toggle">
-                @if (Model.Archived)
-                {
-                    <span class="text-nowrap" title="@StringLocalizer["Unarchive this invoice"]">Unarchive</span>
-                }
-                else
-                {
-                    <span class="text-nowrap" title="@StringLocalizer["Archive this invoice so that it does not appear in the invoice list by default"]">Archive</span>
-                }
-            </button>
-        </form>
     </div>
-</div>
 
-<partial name="_StatusMessage" />
+    @* Contextual banner with actions *@
+    @if (Model.StatusException == InvoiceExceptionStatus.PaidPartial)
+    {
+        <div class="inv-card mb-2 d-flex flex-wrap justify-content-between align-items-center gap-3">
+            <div class="d-flex align-items-start gap-2" style="min-width:0">
+                <vc:icon symbol="warning" css-class="inv-banner-icon text-warning" />
+                <span>@StringLocalizer["Partial payment received. Send the payer an updated link for the remaining {0}, or settle manually.", stillDueAmount]</span>
+            </div>
+            <div class="d-flex gap-2 flex-wrap">
+                <button type="button" class="btn btn-secondary text-nowrap clipboard-button" data-clipboard="@paymentLink" text-translate="true">Copy payment link</button>
+                <button type="button" class="btn btn-secondary text-nowrap mark-invoice-settled" data-url="@Url.Action("ChangeInvoiceState", new { invoiceId = Model.Id, newState = "settled" })" text-translate="true">Mark settled</button>
+            </div>
+        </div>
+    }
+    else if (Model.StatusException == InvoiceExceptionStatus.PaidOver)
+    {
+        <div class="inv-card mb-2 d-flex flex-wrap justify-content-between align-items-center gap-3">
+            <div class="d-flex align-items-start gap-2" style="min-width:0">
+                <vc:icon symbol="info" css-class="inv-banner-icon text-info" />
+                <span text-translate="true">This invoice was overpaid. Consider issuing a refund for the excess amount.</span>
+            </div>
+        </div>
+    }
+    else if (Model.StatusException == InvoiceExceptionStatus.PaidLate)
+    {
+        <div class="inv-card mb-2 d-flex align-items-start gap-2">
+            <vc:icon symbol="warning" css-class="inv-banner-icon text-warning" />
+            <span text-translate="true">Payment was received after the invoice expired. The exchange rate may have shifted.</span>
+        </div>
+    }
+    @if (isInvalid)
+    {
+        <div class="inv-card mb-2 d-flex align-items-start gap-2">
+            <vc:icon symbol="cross" css-class="inv-banner-icon text-danger" />
+            <span text-translate="true">This payment did not confirm and is considered invalid. Do not ship goods or deliver services.</span>
+        </div>
+    }
 
-<div class="invoice-details">
-    <div class="invoice-information mb-5">
-        <div>
-            <h3 class="mb-3">General Information</h3>
-            <table class="table mb-0">
-                <tr>
-                    <th>Store</th>
-                    <td>
-                        <a href="@Model.StoreLink" rel="noreferrer noopener">@Model.StoreName</a>
-                    </td>
-                </tr>
-                <tr>
-                    <th>Invoice Id</th>
-                    <td>@Model.Id</td>
-                </tr>
-                @if (!string.IsNullOrEmpty(Model.TypedMetadata.OrderId))
-                {
+    @* Order items — only for invoices created from POS/cart data *@
+    @if (Model.TypedMetadata?.PosData?["cart"] is Newtonsoft.Json.Linq.JArray cartArr && cartArr.OfType<Newtonsoft.Json.Linq.JObject>().Any())
+    {
+        var orderCurrency = Model.Entity?.Currency ?? "USD";
+        var orderTax = Model.TypedMetadata?.TaxIncluded ?? 0m;
+        var orderTotal = Model.Entity?.Price ?? 0m;
+        var orderItems = new List<(string Name, decimal Qty, decimal Price)>();
+        foreach (var it in cartArr.OfType<Newtonsoft.Json.Linq.JObject>())
+        {
+            var name = it.Value<string>("title") ?? it.Value<string>("name") ?? StringLocalizer["Item"].Value;
+            var qty = it.Value<decimal?>("count") ?? it.Value<decimal?>("quantity") ?? 1m;
+            var price = ParseAmount(it["price"]) ?? 0m;
+            orderItems.Add((name, qty, price));
+        }
+        var orderSubtotal = orderItems.Sum(x => x.Qty * x.Price);
+        <div class="inv-card mb-2">
+            <div class="inv-stitle" text-translate="true">Order Summary</div>
+            <table class="inv-cart">
+                <thead>
                     <tr>
-                        <th>Order Id</th>
-                        <td>
-                            @if (!string.IsNullOrEmpty(Model.TypedMetadata.OrderUrl))
-                            {
-                                <a href="@Model.TypedMetadata.OrderUrl" rel="noreferrer noopener" target="_blank">
-                                    @if (string.IsNullOrEmpty(Model.TypedMetadata.OrderId))
-                                    {
-                                        <span>View Order</span>
-                                    }
-                                    else
-                                    {
-                                        @Model.TypedMetadata.OrderId
-                                    }
-                                </a>
-                            }
-                            else
-                            {
-                                <span>@Model.TypedMetadata.OrderId</span>
-                            }
-                        </td>
+                        <th text-translate="true">Item</th>
+                        <th class="num" text-translate="true">Qty</th>
+                        <th class="num" text-translate="true">Price</th>
                     </tr>
-                }
-                @if (Model.TypedMetadata.PaymentRequestId is not null)
-                {
+                </thead>
+                <tbody>
+                    @foreach (var it in orderItems)
+                    {
+                        <tr>
+                            <td>@it.Name</td>
+                            <td class="num">&times;@it.Qty.ToString("0.####")</td>
+                            <td class="num" data-sensitive>@DisplayFormatter.Currency(it.Price, orderCurrency, DisplayFormatter.CurrencyFormat.Symbol)</td>
+                        </tr>
+                    }
+                </tbody>
+                <tfoot>
                     <tr>
-                        <th>Payment Request Id</th>
-                        <td>
-                            <a href="@Model.PaymentRequestLink" rel="noreferrer noopener">@Model.TypedMetadata.PaymentRequestId</a>
-                        </td>
+                        <td colspan="2" text-translate="true">Subtotal</td>
+                        <td class="num" data-sensitive>@DisplayFormatter.Currency(orderSubtotal, orderCurrency, DisplayFormatter.CurrencyFormat.Symbol)</td>
                     </tr>
-                }
-                <tr>
-                    <th>State</th>
-                    <td>
-                        <vc:invoice-status invoice-id="@Model.Id" state="Model.State" payments="Model.Payments"
-                                           is-archived="Model.Archived" has-refund="Model.HasRefund" />
-                    </td>
-                </tr>
-                <tr>
-                    <th>Created Date</th>
-                    <td>@Model.CreatedDate.ToBrowserDate()</td>
-                </tr>
-                <tr>
-                    <th>Expiration Date</th>
-                    <td>@Model.ExpirationDate.ToBrowserDate()</td>
-                </tr>
-                <tr>
-                    <th>Monitoring Date</th>
-                    <td>@Model.MonitoringDate.ToBrowserDate()</td>
-                </tr>
-                <tr>
-                    <th>Transaction Speed</th>
-                    <td>@Model.TransactionSpeed</td>
-                </tr>
-                <tr>
-                    <th>Total Amount Due</th>
-                    <td><span data-sensitive>@Model.Fiat</span></td>
-                </tr>
-                @if (!string.IsNullOrEmpty(Model.NotificationUrl))
-                {
                     <tr>
-                        <th>Notification Url</th>
-                        <td>@Model.NotificationUrl</td>
+                        <td colspan="2" text-translate="true">Tax</td>
+                        <td class="num" data-sensitive>@DisplayFormatter.Currency(orderTax, orderCurrency, DisplayFormatter.CurrencyFormat.Symbol)</td>
                     </tr>
-                }
-                @if (!string.IsNullOrEmpty(Model.RedirectUrl))
-                {
-                    <tr>
-                        <th>Redirect Url</th>
-                        <td>
-                            <a href="@Model.RedirectUrl" rel="noreferrer noopener">@Model.RedirectUrl</a>
-                        </td>
+                    <tr class="total">
+                        <td colspan="2" text-translate="true">Total</td>
+                        <td class="num" data-sensitive>@DisplayFormatter.Currency(orderTotal, orderCurrency, DisplayFormatter.CurrencyFormat.Symbol)</td>
                     </tr>
-                }
+                </tfoot>
             </table>
         </div>
-        <div class="d-flex flex-column gap-5">
-            <div>
-                <h3 class="mb-3">Comment</h3>
-                <form asp-action="Comment" asp-route-invoiceId="@Model.Id" method="post">
-                    <div class="form-group">
-                        <textarea name="comment" id="InvoiceComment" class="form-control" rows="3"
-                                  placeholder="@StringLocalizer["Add a note or comment for this invoice"]">@Model.Comment</textarea>
-                    </div>
-                    <button type="submit" id="SaveComment" class="btn btn-primary">Save Comment</button>
-                </form>
-            </div>
-            @if (!string.IsNullOrEmpty(Model.TypedMetadata.ItemCode) ||
-                    !string.IsNullOrEmpty(Model.TypedMetadata.ItemDesc))
+    }
+
+    @* Refund *@
+    @if ((Model.Refunds?.Count ?? 0) > 0)
+    {
+        <div class="inv-card mb-2">
+            <div class="inv-stitle" text-translate="true">Refunds</div>
+            @foreach (var refund in Model.Refunds)
             {
-                <div>
-                    <h3 class="mb-3">
-                        <span>Product Information</span>
-                        <a href="https://docs.btcpayserver.org/Development/InvoiceMetadata/" target="_blank" rel="noreferrer noopener">
-                            <vc:icon symbol="info" />
-                        </a>
-                    </h3>
-                    <table class="table mb-0">
-                        @if (!string.IsNullOrEmpty(Model.TypedMetadata.ItemCode))
-                        {
-                            <tr>
-                                <th>Item code</th>
-                                <td>@Model.TypedMetadata.ItemCode</td>
-                            </tr>
-                        }
-                        @if (!string.IsNullOrEmpty(Model.TypedMetadata.ItemDesc))
-                        {
-                            <tr>
-                                <th>Item Description</th>
-                                <td>@Model.TypedMetadata.ItemDesc</td>
-                            </tr>
-                        }
-                    </table>
+                <div class="inv-flat mb-2">
+                    <span class="inv-dot" style="background:var(--btcpay-info)"></span>
+                    <div class="flex-grow-1" style="min-width:0">
+                        <div class="fw-semibold">@refund.PullPaymentData.Limit @refund.PullPaymentData.Currency</div>
+                        <div class="text-secondary">@refund.PullPaymentData.StartDate.ToBrowserDate()</div>
+                    </div>
+                    <a asp-action="ViewPullPayment" asp-controller="UIPullPayment" asp-route-pullPaymentId="@refund.PullPaymentDataId" target="_blank" class="btn btn-link p-0" text-translate="true">View Pull Payment</a>
                 </div>
             }
-            @if (Model.TypedMetadata.BuyerName is not null ||
-                    Model.TypedMetadata.BuyerEmail is not null ||
-                    Model.TypedMetadata.BuyerPhone is not null ||
-                    Model.TypedMetadata.BuyerAddress1 is not null ||
-                    Model.TypedMetadata.BuyerAddress2 is not null ||
-                    Model.TypedMetadata.BuyerCity is not null ||
-                    Model.TypedMetadata.BuyerState is not null ||
-                    Model.TypedMetadata.BuyerCountry is not null ||
-                    Model.TypedMetadata.BuyerZip is not null)
+        </div>
+    }
+
+    @* Payments *@
+    @{
+        var paymentCards = new List<PayCard>();
+        var invoiceCurrency = Model.Entity?.Currency;
+        foreach (var payment in Model.Payments ?? new List<PaymentEntity>())
+        {
+            if (!Handlers.TryGetValue(payment.PaymentMethodId, out var h))
             {
-                <div>
-                    <h3 class="mb-3">
-                        <span>Buyer Information</span>
-                        <a href="https://docs.btcpayserver.org/Development/InvoiceMetadata/" target="_blank" rel="noreferrer noopener">
-                            <vc:icon symbol="info" />
-                        </a>
-                    </h3>
-                    <table class="table mb-0">
-                        @if (Model.TypedMetadata.BuyerName is not null)
+                continue;
+            }
+            var pmRate = Model.CryptoPayments?.FirstOrDefault(cp => cp.PaymentMethodId == payment.PaymentMethodId)?.Rate;
+            var fiatValue = payment.InvoicePaidAmount is { } ipa && invoiceCurrency != null ? DisplayFormatter.Currency(ipa.Gross, invoiceCurrency) : null;
+            if (h is BitcoinLikePaymentHandler bh)
+            {
+                var d = bh.ParsePaymentDetails(payment.Details);
+                var confReq = NBXplorerListener.ConfirmationRequired(payment.InvoiceEntity, d);
+                var confCount = (int)Math.Min(confReq, d.ConfirmationCount);
+                var feeFiat = invoiceCurrency != null && payment.PaymentMethodFee > 0 ? DisplayFormatter.Currency(payment.PaymentMethodFee * payment.Rate, invoiceCurrency) : null;
+                paymentCards.Add(new PayCard
+                {
+                    IsLightning = false,
+                    Replaced = !payment.Accounted,
+                    Method = $"{bh.Network.DisplayName} On-Chain",
+                    ConfCount = confCount,
+                    ConfReq = confReq,
+                    Amount = DisplayFormatter.Currency(payment.Value, payment.Currency),
+                    FiatValue = fiatValue,
+                    NetworkFee = payment.PaymentMethodFee > 0 ? DisplayFormatter.Currency(payment.PaymentMethodFee, payment.Currency) : null,
+                    FeeFiat = feeFiat,
+                    Rate = pmRate,
+                    Destination = payment.Destination,
+                    TxId = d.Outpoint.Hash.ToString(),
+                    TxLink = TransactionLinkProviders.GetTransactionLink(payment.PaymentMethodId, d.Outpoint.ToString()),
+                    AdditionalInfo = d.PayjoinInformation is not null ? StringLocalizer["Payjoin"].Value : null
+                });
+            }
+            else if (h is ILightningPaymentHandler lh)
+            {
+                var d = lh.ParsePaymentDetails(payment.Details);
+                string lnComment = null, lnAddress = null;
+                if (lh.ParsePaymentPromptDetails(Model.Entity.GetPaymentPrompt(payment.PaymentMethodId)?.Details) is LNURLPayPaymentMethodDetails lnurl)
+                {
+                    lnComment = lnurl.ProvidedComment;
+                    lnAddress = lnurl.ConsumedLightningAddress;
+                }
+                paymentCards.Add(new PayCard
+                {
+                    IsLightning = true,
+                    Method = $"{lh.Network.DisplayName} Lightning",
+                    Amount = DisplayFormatter.Currency(payment.Value, lh.Network.CryptoCode, divisibility: payment.Divisibility),
+                    FiatValue = fiatValue,
+                    Rate = pmRate,
+                    Destination = d.BOLT11,
+                    TxId = d.Preimage,
+                    LnComment = lnComment,
+                    LnAddress = lnAddress
+                });
+            }
+        }
+    }
+    @if (paymentCards.Any())
+    {
+        <div class="inv-card mb-2">
+            <div class="inv-stitle" text-translate="true">Payments</div>
+            <div class="table-responsive">
+            <table class="inv-cart inv-payments">
+                <thead>
+                    <tr>
+                        <th>#</th>
+                        <th text-translate="true">Method</th>
+                        <th class="num" text-translate="true">Amount</th>
+                        <th class="num" text-translate="true">Fee</th>
+                        <th class="num" text-translate="true">Confs</th>
+                        <th class="tx" text-translate="true">Transaction</th>
+                        <th></th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @{ var i = 0; }
+                    @foreach (var pc in paymentCards)
+                    {
+                        i++;
+                        var last = i == paymentCards.Count;
+                        var hasDetails = !string.IsNullOrEmpty(pc.Destination) || pc.FiatValue != null || pc.Rate != null
+                            || !string.IsNullOrEmpty(pc.LnAddress) || !string.IsNullOrEmpty(pc.LnComment);
+                        <tr class="@(pc.Replaced ? "inv-replaced " : "")@(last ? "inv-last-payment" : "")" title="@(pc.Replaced ? StringLocalizer["Replaced (double-spent)"].Value : null)">
+                            <td>@i</td>
+                            <td class="text-nowrap">
+                                <span class="inv-method-dot" style="background:@(pc.IsLightning ? "var(--btcpay-warning)" : "#f7931a")"></span>@pc.Method
+                                @if (!string.IsNullOrEmpty(pc.AdditionalInfo))
+                                {
+                                    <span class="text-secondary">(@pc.AdditionalInfo)</span>
+                                }
+                            </td>
+                            <td class="num font-monospace" data-sensitive>@pc.Amount</td>
+                            <td class="num font-monospace" data-sensitive>@(pc.NetworkFee ?? "—")</td>
+                            <td class="num text-nowrap">
+                                @if (pc.ConfReq is int req)
+                                {
+                                    var cnt = pc.ConfCount ?? 0;
+                                    var confColor = cnt >= req ? "var(--btcpay-success)" : "var(--btcpay-warning)";
+                                    <span class="text-nowrap" style="color:@confColor">
+                                        @if (cnt >= req)
+                                        {
+                                            <vc:icon symbol="checkmark" css-class="inv-conf-check" />
+                                        }
+                                        @cnt/@req
+                                    </span>
+                                }
+                                else
+                                {
+                                    <span>—</span>
+                                }
+                            </td>
+                            <td class="tx">
+                                @if (!string.IsNullOrEmpty(pc.TxId))
+                                {
+                                    <vc:truncate-center text="@pc.TxId" link="@pc.TxLink" classes="font-monospace" />
+                                }
+                                else
+                                {
+                                    <span>—</span>
+                                }
+                            </td>
+                            <td class="num">
+                                @if (hasDetails)
+                                {
+                                    <button type="button" class="btn btn-link p-0 inv-row-toggle" data-bs-toggle="collapse" data-bs-target="#pay-details-@i" aria-expanded="false" aria-controls="pay-details-@i" title="@StringLocalizer["Toggle details"]">
+                                        <vc:icon symbol="caret-down" />
+                                    </button>
+                                }
+                            </td>
+                        </tr>
+                        @if (hasDetails)
                         {
-                            <tr>
-                                <th>Name</th>
-                                <td>@Model.TypedMetadata.BuyerName</td>
-                            </tr>
-                        }
-                        @if (Model.TypedMetadata.BuyerEmail is not null)
-                        {
-                            <tr>
-                                <th>Email</th>
-                                <td>
-                                    <a href="mailto:@Model.TypedMetadata.BuyerEmail">@Model.TypedMetadata.BuyerEmail</a>
+                            <tr class="inv-details-row @(last ? "inv-last-payment" : "")">
+                                <td colspan="7">
+                                    <div id="pay-details-@i" class="collapse">
+                                        <div class="inv-inset">
+                                            @if (!string.IsNullOrEmpty(pc.Destination))
+                                            {
+                                                <div class="inv-row">
+                                                    <span class="inv-rl">@(pc.IsLightning ? StringLocalizer["BOLT11"] : StringLocalizer["Destination"])</span>
+                                                    <span class="inv-rv"><vc:truncate-center text="@pc.Destination" classes="font-monospace" /></span>
+                                                </div>
+                                            }
+                                            @if (pc.FiatValue != null)
+                                            {
+                                                <div class="inv-row"><span class="inv-rl" text-translate="true">Fiat Value</span><span class="inv-rv" data-sensitive>@pc.FiatValue</span></div>
+                                            }
+                                            @if (pc.Rate != null)
+                                            {
+                                                <div class="inv-row"><span class="inv-rl" text-translate="true">Exchange Rate</span><span class="inv-rv" data-sensitive>@pc.Rate</span></div>
+                                            }
+                                            @if (pc.NetworkFee != null && pc.FeeFiat != null)
+                                            {
+                                                <div class="inv-row"><span class="inv-rl" text-translate="true">Network Fee</span><span class="inv-rv font-monospace" data-sensitive>@pc.NetworkFee (~@pc.FeeFiat)</span></div>
+                                            }
+                                            @if (!string.IsNullOrEmpty(pc.LnAddress))
+                                            {
+                                                <div class="inv-row"><span class="inv-rl" text-translate="true">Lightning Address</span><span class="inv-rv">@pc.LnAddress</span></div>
+                                            }
+                                            @if (!string.IsNullOrEmpty(pc.LnComment))
+                                            {
+                                                <div class="inv-row"><span class="inv-rl" text-translate="true">Comment</span><span class="inv-rv">@pc.LnComment</span></div>
+                                            }
+                                        </div>
+                                    </div>
                                 </td>
                             </tr>
                         }
-                        @if (Model.TypedMetadata.BuyerPhone is not null)
-                        {
-                            <tr>
-                                <th>Phone</th>
-                                <td>@Model.TypedMetadata.BuyerPhone</td>
-                            </tr>
-                        }
-                        @if (Model.TypedMetadata.BuyerAddress1 is not null)
-                        {
-                            <tr>
-                                <th>Address 1</th>
-                                <td>@Model.TypedMetadata.BuyerAddress1</td>
-                            </tr>
-                        }
-                        @if (Model.TypedMetadata.BuyerAddress2 is not null)
-                        {
-                            <tr>
-                                <th>Address 2</th>
-                                <td>@Model.TypedMetadata.BuyerAddress2</td>
-                            </tr>
-                        }
-                        @if (Model.TypedMetadata.BuyerCity is not null)
-                        {
-                            <tr>
-                                <th>City</th>
-                                <td>@Model.TypedMetadata.BuyerCity</td>
-                            </tr>
-                        }
-                        @if (Model.TypedMetadata.BuyerState is not null)
-                        {
-                            <tr>
-                                <th>State</th>
-                                <td>@Model.TypedMetadata.BuyerState</td>
-                            </tr>
-                        }
-                        @if (Model.TypedMetadata.BuyerCountry is not null)
-                        {
-                            <tr>
-                                <th>Country</th>
-                                <td>@Model.TypedMetadata.BuyerCountry</td>
-                            </tr>
-                        }
-                        @if (Model.TypedMetadata.BuyerZip is not null)
-                        {
-                            <tr>
-                                <th>Zip</th>
-                                <td>@Model.TypedMetadata.BuyerZip</td>
-                            </tr>
-                        }
-                    </table>
-                </div>
-            }
-            @if (Model.ReceiptData?.Any() is true)
-            {
-                <div>
-                    <h3 class="mb-3">
-                        <span>Receipt Information</span>
-                        <a href="https://docs.btcpayserver.org/Development/InvoiceMetadata/" target="_blank" rel="noreferrer noopener">
-                            <vc:icon symbol="info" />
-                        </a>
-                    </h3>
-                    <partial name="PosData" model="(Model.ReceiptData, 1)" />
-                </div>
-            }
-            @if (Model.AdditionalData?.Any() is true)
-            {
-                <div>
-                    <h3 class="mb-3">
-                        <span>Additional Information</span>
-                        <a href="https://docs.btcpayserver.org/Development/InvoiceMetadata/" target="_blank" rel="noreferrer noopener">
-                            <vc:icon symbol="info" />
-                        </a>
-                    </h3>
-                    <partial name="PosData" model="(Model.AdditionalData, 1)" />
-                </div>
-            }
+                    }
+                </tbody>
+            </table>
+            </div>
         </div>
-    </div>
-    <div class="row">
-        <div class="col-xxl-constrain">
-            <h3 class="mb-3">Invoice Summary</h3>
-            <partial name="ListInvoicesPaymentsPartial" model="(Model, true)" />
+    }
+    else
+    {
+        <div class="inv-card mb-2 text-center" style="padding:var(--btcpay-space-xl)">
+            <div class="text-secondary">
+                @(Model.State.Status == InvoiceStatus.New ? StringLocalizer["Waiting for the buyer to send payment…"] : StringLocalizer["No payment was received for this invoice."])
+            </div>
+        </div>
+    }
 
-            @if (Model.Deliveries.Any())
-            {
-                <section class="mt-4 d-print-none">
-                    <h3 class="mb-3">Webhooks</h3>
-                    <div class="table-responsive-xl">
-                        <table class="table table-hover mb-5">
-                            <thead>
-                                <tr>
-                                    <th>Status</th>
-                                    <th>ID</th>
-                                    <th>Type</th>
-                                    <th>Url</th>
-                                    <th>Date</th>
-                                    <th class="text-end">Action</th>
-                                </tr>
-                            </thead>
-                            <tbody>
-                                @foreach (var delivery in Model.Deliveries)
+    @* Info + Buyer + Product *@
+    <div class="row g-4 mb-2">
+        <div class="col-lg-6">
+            <div class="inv-card h-100">
+                <div class="inv-stitle" text-translate="true">Invoice Info</div>
+                <div class="inv-row"><span class="inv-rl" text-translate="true">Store</span><span class="inv-rv"><a href="@Model.StoreLink" rel="noreferrer noopener">@Model.StoreName</a></span></div>
+                @if (!string.IsNullOrEmpty(Model.TypedMetadata.OrderId))
+                {
+                    <div class="inv-row"><span class="inv-rl" text-translate="true">Order Id</span><span class="inv-rv">
+                        @if (!string.IsNullOrEmpty(Model.TypedMetadata.OrderUrl))
+                        {
+                            <a href="@Model.TypedMetadata.OrderUrl" rel="noreferrer noopener" target="_blank">@Model.TypedMetadata.OrderId</a>
+                        }
+                        else
+                        {
+                            <span>@Model.TypedMetadata.OrderId</span>
+                        }
+                    </span></div>
+                }
+                @if (Model.TypedMetadata.PaymentRequestId is not null)
+                {
+                    <div class="inv-row"><span class="inv-rl" text-translate="true">Payment Request</span><span class="inv-rv"><a href="@Model.PaymentRequestLink" rel="noreferrer noopener">@Model.TypedMetadata.PaymentRequestId</a></span></div>
+                }
+                @if (!string.IsNullOrEmpty(Model.TypedMetadata.ItemDesc))
+                {
+                    <div class="inv-row"><span class="inv-rl" text-translate="true">Description</span><span class="inv-rv">@Model.TypedMetadata.ItemDesc</span></div>
+                }
+                @if (!string.IsNullOrEmpty(Model.TypedMetadata.ItemCode))
+                {
+                    <div class="inv-row"><span class="inv-rl" text-translate="true">Item code</span><span class="inv-rv">@Model.TypedMetadata.ItemCode</span></div>
+                }
+                <div class="inv-row"><span class="inv-rl" text-translate="true">Created</span><span class="inv-rv">@Model.CreatedDate.ToBrowserDate()</span></div>
+                <div class="inv-row"><span class="inv-rl" text-translate="true">Expiration</span><span class="inv-rv">@Model.ExpirationDate.ToBrowserDate()</span></div>
+                @if (!string.IsNullOrEmpty(Model.RedirectUrl))
+                {
+                    <div class="inv-row"><span class="inv-rl" text-translate="true">Redirect</span><span class="inv-rv"><a href="@Model.RedirectUrl" rel="noreferrer noopener" class="text-truncate">@Model.RedirectUrl</a></span></div>
+                }
+            </div>
+        </div>
+        @{
+            var hasBuyer = Model.TypedMetadata.BuyerName is not null || Model.TypedMetadata.BuyerEmail is not null || Model.TypedMetadata.BuyerPhone is not null
+                || Model.TypedMetadata.BuyerAddress1 is not null || Model.TypedMetadata.BuyerAddress2 is not null || Model.TypedMetadata.BuyerCity is not null
+                || Model.TypedMetadata.BuyerState is not null || Model.TypedMetadata.BuyerCountry is not null || Model.TypedMetadata.BuyerZip is not null;
+        }
+        @if (hasBuyer)
+        {
+            <div class="col-lg-6">
+                <div class="inv-card h-100">
+                    <div class="inv-stitle" text-translate="true">Buyer</div>
+                    @if (Model.TypedMetadata.BuyerName is not null)
+                    {
+                        <div class="inv-row"><span class="inv-rl" text-translate="true">Name</span><span class="inv-rv">@Model.TypedMetadata.BuyerName</span></div>
+                    }
+                    @if (Model.TypedMetadata.BuyerEmail is not null)
+                    {
+                        <div class="inv-row"><span class="inv-rl" text-translate="true">Email</span><span class="inv-rv"><a href="mailto:@Model.TypedMetadata.BuyerEmail">@Model.TypedMetadata.BuyerEmail</a></span></div>
+                    }
+                    @if (Model.TypedMetadata.BuyerPhone is not null)
+                    {
+                        <div class="inv-row"><span class="inv-rl" text-translate="true">Phone</span><span class="inv-rv">@Model.TypedMetadata.BuyerPhone</span></div>
+                    }
+                    @if (Model.TypedMetadata.BuyerAddress1 is not null)
+                    {
+                        <div class="inv-row"><span class="inv-rl" text-translate="true">Address</span><span class="inv-rv">@Model.TypedMetadata.BuyerAddress1</span></div>
+                    }
+                    @if (Model.TypedMetadata.BuyerAddress2 is not null)
+                    {
+                        <div class="inv-row"><span class="inv-rl" text-translate="true">Address 2</span><span class="inv-rv">@Model.TypedMetadata.BuyerAddress2</span></div>
+                    }
+                    @if (Model.TypedMetadata.BuyerCity is not null)
+                    {
+                        <div class="inv-row"><span class="inv-rl" text-translate="true">City</span><span class="inv-rv">@Model.TypedMetadata.BuyerCity</span></div>
+                    }
+                    @if (Model.TypedMetadata.BuyerState is not null)
+                    {
+                        <div class="inv-row"><span class="inv-rl" text-translate="true">State</span><span class="inv-rv">@Model.TypedMetadata.BuyerState</span></div>
+                    }
+                    @if (Model.TypedMetadata.BuyerZip is not null)
+                    {
+                        <div class="inv-row"><span class="inv-rl" text-translate="true">Zip</span><span class="inv-rv">@Model.TypedMetadata.BuyerZip</span></div>
+                    }
+                    @if (Model.TypedMetadata.BuyerCountry is not null)
+                    {
+                        <div class="inv-row"><span class="inv-rl" text-translate="true">Country</span><span class="inv-rv">@Model.TypedMetadata.BuyerCountry</span></div>
+                    }
+                </div>
+            </div>
+        }
+    </div>
+
+    @* Comment *@
+    <div class="inv-card mb-2 invoice-comment">
+        <div class="inv-stitle" text-translate="true">Comment</div>
+        <form asp-action="Comment" asp-route-invoiceId="@Model.Id" method="post">
+            <div class="form-group">
+                <textarea name="comment" id="InvoiceComment" class="form-control" rows="3"
+                          placeholder="@StringLocalizer["Add a note or comment for this invoice"]">@Model.Comment</textarea>
+            </div>
+            <button type="submit" id="SaveComment" class="btn btn-primary">Save Comment</button>
+        </form>
+    </div>
+
+
+    @* Activity (collapsible) *@
+    @if (Model.Events is { Length: > 0 })
+    {
+        var orderedEvents = Model.Events.Reverse().ToList();
+        var activityEvents = orderedEvents.Where(e => IsActivityEvent(e.Message)).ToList();
+        var debugEvents = orderedEvents.Where(e => !IsActivityEvent(e.Message)).ToList();
+        <div class="inv-card p-0 mb-2 d-print-none" style="overflow:hidden">
+            <button class="inv-collapse-head" type="button" data-bs-toggle="collapse" data-bs-target="#EventTimeline" aria-expanded="true" aria-controls="EventTimeline">
+                <span text-translate="true">Activity</span>
+                <span class="inv-count">@activityEvents.Count</span>
+                <span class="ms-auto"><vc:icon symbol="caret-down" /></span>
+            </button>
+            <div class="collapse show" id="EventTimeline">
+                <div class="d-flex flex-column gap-2 p-3 pt-0">
+                    @foreach (var evt in activityEvents)
+                    {
+                        <div class="inv-flat">
+                            <span class="inv-dot" style="background:@EventDotColor(ActivityDotCss(evt.Message))"></span>
+                            <div class="flex-grow-1" style="min-width:0">
+                                <div>@ActivityLabel(evt.Message)</div>
+                            </div>
+                            <span class="text-secondary text-nowrap">@evt.Timestamp.ToBrowserDate()</span>
+                        </div>
+                    }
+                    @if (debugEvents.Count > 0)
+                    {
+                        <button type="button" class="btn btn-link p-0 align-self-start inv-debug-toggle" data-bs-toggle="collapse" data-bs-target="#DebugEvents" aria-expanded="false" aria-controls="DebugEvents">
+                            <span class="when-collapsed" text-translate="true">Show debug events</span>
+                            <span class="when-expanded" text-translate="true">Hide debug events</span>
+                        </button>
+                        <div class="collapse" id="DebugEvents">
+                            <div class="inv-debug-log d-flex flex-column">
+                                @foreach (var evt in debugEvents)
                                 {
-                                    <tr>
-                                        <form asp-action="RedeliverWebhook"
-                                              asp-route-storeId="@Model.StoreId"
-                                              asp-route-invoiceId="@Model.Id"
-                                              asp-route-deliveryId="@delivery.Id"
-                                              method="post">
-                                        <td>
-                                            <span>
-                                                @if (delivery.Success)
-                                                {
-                                                    <vc:icon symbol="checkmark" css-class="text-success" />
-                                                }
-                                                else
-                                                {
-                                                    <span title="@delivery.ErrorMessage">
-                                                        <vc:icon symbol="cross" css-class="text-danger"/>
-                                                    </span>
-                                                }
-                                            </span>
-                                        </td>
-                                        <td>
-                                                @if (!delivery.Pruned)
-                                                {
-                                                <span>
-                                                    <a asp-action="WebhookDelivery"
-                                                       asp-route-invoiceId="@Model.Id"
-                                                       asp-route-deliveryId="@delivery.Id"
-                                                       class="delivery-content"
-                                                       target="_blank">
-                                                            @delivery.Id
-                                                    </a>
-                                                </span>
-                                                }
-                                        </td>
-                                        <td>
-                                            <span>@delivery.Type</span>
-                                        </td>
-                                        <td>
-                                            <span class="text-break" data-bs-toggle="tooltip" title="@delivery.PayloadUrl" style="cursor: pointer;">
-                                                <span style="max-width: 250px;">@delivery.PayloadUrl</span>
-                                            </span>
-                                        </td>
-                                        <td>
-                                            @{
-                                                var timeDiff = delivery.DeliveryTime - delivery.Time;
-                                                var hasSignificantDelay = Math.Abs(timeDiff.TotalMinutes) > 2;
+                                    <div class="d-flex justify-content-between gap-3">
+                                        <span>@evt.Message</span>
+                                        <span class="text-nowrap">@evt.Timestamp.ToBrowserDate()</span>
+                                    </div>
+                                }
+                            </div>
+                        </div>
+                    }
+                </div>
+            </div>
+        </div>
+    }
+
+    @* Webhook Deliveries *@
+    @if (Model.Deliveries.Any())
+    {
+        <div class="inv-card mb-2 d-print-none">
+            <div class="inv-stitle" text-translate="true">Webhook Deliveries</div>
+            <div class="table-responsive">
+            <table class="inv-cart inv-payments">
+                <thead>
+                    <tr>
+                        <th></th>
+                        <th text-translate="true">Event</th>
+                        <th style="width:100%" text-translate="true">Payload URL</th>
+                        <th class="num text-nowrap" text-translate="true">Delivered</th>
+                        <th></th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @foreach (var delivery in Model.Deliveries)
+                    {
+                        var timeDiff = delivery.DeliveryTime - delivery.Time;
+                        var hasSignificantDelay = Math.Abs(timeDiff.TotalMinutes) > 2;
+                        <tr>
+                            <td>
+                                <span class="inv-dot" style="background:@(delivery.Success ? "var(--btcpay-success)" : "var(--btcpay-danger)")" title="@(delivery.Success ? null : delivery.ErrorMessage)"></span>
+                            </td>
+                            <td class="text-nowrap">@delivery.Type</td>
+                            <td>
+                                <span class="text-secondary font-monospace text-truncate d-inline-block align-middle" style="max-width:100%" title="@delivery.PayloadUrl">@delivery.PayloadUrl</span>
+                            </td>
+                            <td class="num text-nowrap">
+                                <span class="webhook-time text-secondary" data-bs-html="true" data-bs-toggle="tooltip">
+                                    <template class="webhook-time-tooltip">
+                                        <div class="text-start">
+                                            <span><b text-translate="true">Created at</b>:&nbsp;@delivery.Time.ToBrowserDate()</span><br />
+                                            <span><b text-translate="true">Delivered at</b>:&nbsp;@delivery.DeliveryTime.ToBrowserDate()</span>
+                                            @if (hasSignificantDelay)
+                                            {
+                                                <br /><span><b text-translate="true">Delay</b>:&nbsp;<span>@StringLocalizer["{0} minutes", @timeDiff.TotalMinutes.ToString("F1")]</span></span>
                                             }
-                                            <span>
-                                                <span class="webhook-time" data-bs-html="true" data-bs-toggle="tooltip">
-                                                    <template class="webhook-time-tooltip">
-                                                        <div class="text-start">
-                                                            <span><b text-translate="true">Created at</b>:&nbsp;@delivery.Time.ToBrowserDate()</span><br />
-                                                            <span><b text-translate="true">Delivered at</b>:&nbsp;@delivery.DeliveryTime.ToBrowserDate()</span>
-                                                            @if (hasSignificantDelay)
-                                                            {
-                                                                <br />
-                                                                <span><b text-translate="true">Delay</b>:&nbsp;<span>@StringLocalizer["{0} minutes", @timeDiff.TotalMinutes.ToString("F1")]</span></span>
-                                                                <br />
-                                                                <br />
-                                                                <span text-translate="true">A delay means your service either failed to process earlier deliveries or is taking too long to respond.</span>
-                                                            }
-                                                        </div>
-                                                    </template>
-
-                                                    <span class="delivery-time">@delivery.DeliveryTime.ToBrowserDate()</span>
-                                                    @if (hasSignificantDelay)
-                                                    {
-                                                        <vc:icon symbol="warning" css-class="mb-1 text-warning" />
-                                                    }
-                                                </span>
-                                            </span>
-                                        </td>
-                                        <td class="text-end">
-                                                @if (!delivery.Pruned)
-                                                {
-                                                <button id="#redeliver-@delivery.Id"
-                                                        type="submit"
-                                                        class="btn btn-link p-0 redeliver">
-                                                    Redeliver
-                                                </button>
-                                                }
-                                        </td>
-                                        </form>
-                                    </tr>
-                                }
-                            </tbody>
-                        </table>
-                    </div>
-                </section>
-
-            }
-            @if ((Model.Refunds?.Count ?? 0) > 0)
-            {
-                <section class="mt-4">
-                    <h3 class="mb-3">Refunds</h3>
-                    <div class="table-responsive-xl">
-                        <table class="table table-hover mb-5">
-                            <thead>
-                                <tr>
-                                    <th>Pull Payment</th>
-                                    <th>Amount</th>
-                                    <th>Date</th>
-                                </tr>
-                            </thead>
-                            <tbody>
-                                @foreach (var refund in Model.Refunds)
+                                        </div>
+                                    </template>
+                                    <span class="delivery-time">@delivery.DeliveryTime.ToBrowserDate()</span>
+                                    @if (hasSignificantDelay)
+                                    {
+                                        <vc:icon symbol="warning" css-class="text-warning" />
+                                    }
+                                </span>
+                            </td>
+                            <td class="num">
+                                @if (!delivery.Pruned)
                                 {
-                                    <tr>
-
-                                        <td>
-                                            <span>
-                                                <a asp-action="ViewPullPayment" asp-controller="UIPullPayment"
-                                                   asp-route-pullPaymentId="@refund.PullPaymentDataId"
-                                                   class="delivery-content"
-                                                   target="_blank">
-                                                    @refund.PullPaymentData.Id
-                                                </a>
-                                            </span>
-                                        </td>
-                                        <td>
-											<span>@refund.PullPaymentData.Limit @refund.PullPaymentData.Currency</span>
-                                        </td>
-                                        <td>
-                                            <span>@refund.PullPaymentData.StartDate.ToBrowserDate()</span>
-                                        </td>
-                                    </tr>
+                                    <form asp-action="RedeliverWebhook" asp-route-storeId="@Model.StoreId" asp-route-invoiceId="@Model.Id" asp-route-deliveryId="@delivery.Id" method="post">
+                                        <button type="submit" class="btn btn-link p-0 redeliver" title="@StringLocalizer["Redeliver"]"><vc:icon symbol="actions-refresh" /></button>
+                                    </form>
                                 }
-                            </tbody>
-                        </table>
-                    </div>
-                </section>
-            }
-
-            @if (Model.Events is { Length: > 0 })
-            {
-                <section class="mt-5 d-print-none">
-                    <h3 class="mb-0">Events</h3>
-                    <table class="table table-hover mt-3 mb-4">
-                        <thead>
-                            <tr>
-                                <vc:date-column></vc:date-column>
-                                <th>Message</th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                            @foreach (var evt in Model.Events)
-                            {
-                                var cssClass = string.IsNullOrEmpty(evt.GetCssClass()) ? null : $"text-{evt.GetCssClass()}";
-                                <tr>
-                                    <td class="@cssClass">@evt.Timestamp.ToBrowserDate()</td>
-                                    <td class="@cssClass">@evt.Message</td>
-                                </tr>
-                            }
-                        </tbody>
-                    </table>
-                </section>
-            }
+                            </td>
+                        </tr>
+                    }
+                </tbody>
+            </table>
+            </div>
         </div>
-    </div>
+    }
+
+    @* Metadata (collapsible) *@
+    @if (Model.Metadata?.Any() is true)
+    {
+        <div class="inv-card p-0 mb-2 d-print-none" style="overflow:hidden">
+            <button class="inv-collapse-head" type="button" data-bs-toggle="collapse" data-bs-target="#Metadata" aria-expanded="false" aria-controls="Metadata">
+                <span text-translate="true">Metadata</span>
+                <span class="ms-auto"><vc:icon symbol="caret-down" /></span>
+            </button>
+            <div class="collapse" id="Metadata">
+                <pre class="font-monospace m-3 mt-0 p-3 rounded" style="background:var(--btcpay-body-bg);font-size:var(--btcpay-font-size-m)">@JsonConvert.SerializeObject(Model.Metadata, Formatting.Indented)</pre>
+            </div>
+        </div>
+    }
 </div>
-<script>
-    document.addEventListener('DOMContentLoaded', () => {
-        document.querySelectorAll(".webhook-time-tooltip").forEach(function (el) {
-            formatDateTimes(null, el.content);
-            // Somehow <time> isn't supported in tooltip... we replace it by <span>
-            el.content.querySelectorAll('time').forEach(time => {
-                var span = document.createElement('span');
-                span.innerHTML = time.innerHTML;
-                time.replaceWith(span);
-            });
-            el.parentElement.setAttribute('title', el.innerHTML);
-        });
-    });
-</script>

--- a/BTCPayServer/Views/UIInvoice/Invoice.cshtml
+++ b/BTCPayServer/Views/UIInvoice/Invoice.cshtml
@@ -1,4 +1,16 @@
 @using BTCPayServer.Client
+@using BTCPayServer.Controllers
+@using BTCPayServer.Client.Models
+@using BTCPayServer.Payments
+@using BTCPayServer.Payments.Bitcoin
+@using BTCPayServer.Payments.Lightning
+@using BTCPayServer.Services
+@using BTCPayServer.Services.Invoices
+@using Newtonsoft.Json
+@inject PaymentMethodHandlerDictionary Handlers
+@inject TransactionLinkProviders TransactionLinkProviders
+@inject DisplayFormatter DisplayFormatter
+@inject PrettyNameProvider PrettyName
 @model InvoiceDetailsModel
 @{
     ViewData.SetLayoutModel(new("Invoices", StringLocalizer["Invoice {0}", Model.Id]));
@@ -6,45 +18,147 @@
         new(StringLocalizer["Invoices"], Action: nameof(BTCPayServer.Controllers.UIInvoiceController.ListInvoices), RouteValues: new { Model.StoreId }),
         new(Model.Id, Active: true)
     ]);
+    var hasPayments = Model.Payments?.Any() is true;
+    var isInvalid = Model.State.Status == InvoiceStatus.Invalid;
+    var primaryPaid = Model.CryptoPayments?.FirstOrDefault(p => p.Paid != null)?.Paid;
+    var stillDueAmount = Model.CryptoPayments?.FirstOrDefault(p => p.Due != null)?.Due;
+    var overpaidAmount = Model.Overpaid ? Model.CryptoPayments?.FirstOrDefault(p => p.Overpaid != null)?.Overpaid : null;
+
+    // Hero aggregates (progress bar, payment count, total network fee)
+    var accountedPayments = (Model.Payments ?? new List<PaymentEntity>()).Where(p => p.Accounted).ToList();
+    var invoicePrice = Model.Entity?.Price ?? 0m;
+    var paidTowardsInvoice = accountedPayments.Where(p => p.InvoicePaidAmount is not null).Sum(p => p.InvoicePaidAmount.Gross);
+    var paidPct = invoicePrice > 0 ? (int)Math.Round(Math.Clamp(paidTowardsInvoice / invoicePrice * 100m, 0m, 100m)) : (hasPayments ? 100 : 0);
+    var paymentCount = accountedPayments.Count;
+    // Fees are denominated in the payment method's own currency, so they are totalled per
+    // currency rather than summed into one meaningless figure.
+    var networkFees = accountedPayments
+        .Where(p => p.PaymentMethodFee > 0)
+        .GroupBy(p => p.Currency)
+        .Select(g => DisplayFormatter.Currency(g.Sum(p => p.PaymentMethodFee), g.Key))
+        .ToList();
+    var paymentLink = Url.Action(nameof(UIInvoiceController.Checkout), "UIInvoice", new { invoiceId = Model.Id }, Context.Request.Scheme);
+    var statusVar = Model.State.Status switch
+    {
+        InvoiceStatus.Settled => "--btcpay-success",
+        InvoiceStatus.Processing => "--btcpay-warning",
+        InvoiceStatus.New => "--btcpay-primary",
+        InvoiceStatus.Invalid => "--btcpay-danger",
+        _ => "--btcpay-body-text-muted"
+    };
+    (string Label, string Css)? exception = Model.StatusException switch
+    {
+        InvoiceExceptionStatus.PaidOver => (StringLocalizer["Overpaid"].Value, "info"),
+        InvoiceExceptionStatus.PaidPartial => (StringLocalizer["Paid Partial"].Value, "warning"),
+        InvoiceExceptionStatus.PaidLate => (StringLocalizer["Paid Late"].Value, "warning"),
+        _ => null
+    };
+}
+
+@functions {
+    string EventDotColor(string css) => css switch
+    {
+        "success" => "var(--btcpay-success)",
+        "danger" => "var(--btcpay-danger)",
+        "warning" => "var(--btcpay-warning)",
+        "info" => "var(--btcpay-info)",
+        _ => "var(--btcpay-body-text-muted)"
+    };
+
+    static decimal? ParseAmount(Newtonsoft.Json.Linq.JToken t)
+    {
+        if (t is null || t.Type == Newtonsoft.Json.Linq.JTokenType.Null)
+            return null;
+        if (t is Newtonsoft.Json.Linq.JObject o)
+            return o.Value<decimal?>("value") ?? o.Value<decimal?>("amount");
+        return decimal.TryParse(t.ToString(), System.Globalization.NumberStyles.Any, System.Globalization.CultureInfo.InvariantCulture, out var d) ? d : null;
+    }
+
+    // Lifecycle events (shown in Activity) contain "new event: invoice_…"; everything
+    // else (timings, rate lookups, payjoin notices, …) is treated as a debug event.
+    static readonly System.Text.RegularExpressions.Regex EventCodeRx =
+        new(@"new event:\s*(invoice_\w+)", System.Text.RegularExpressions.RegexOptions.Compiled);
+
+    static bool IsActivityEvent(string message) =>
+        !string.IsNullOrEmpty(message) && EventCodeRx.IsMatch(message);
+
+    // Warnings and errors are worth surfacing even when they are not lifecycle events,
+    // since they are often the reason the merchant opened this invoice.
+    static bool IsNotable(InvoiceEventData evt) =>
+        evt.Severity is InvoiceEventData.EventSeverity.Warning or InvoiceEventData.EventSeverity.Error;
+
+    static bool ShowInActivity(InvoiceEventData evt) =>
+        IsActivityEvent(evt.Message) || IsNotable(evt);
+
+    string ActivityLabel(string message)
+    {
+        var code = EventCodeRx.Match(message).Groups[1].Value;
+        return code switch
+        {
+            "invoice_created" => StringLocalizer["Invoice created"].Value,
+            "invoice_receivedPayment" => StringLocalizer["Payment received"].Value,
+            "invoice_paidInFull" => StringLocalizer["Paid in full"].Value,
+            "invoice_paymentSettled" => StringLocalizer["Payment settled"].Value,
+            "invoice_confirmedPaid" => StringLocalizer["Payment confirmed"].Value,
+            "invoice_completed" => StringLocalizer["Invoice completed"].Value,
+            "invoice_expired" => StringLocalizer["Invoice expired"].Value,
+            "invoice_expiredPaidPartial" => StringLocalizer["Expired — partially paid"].Value,
+            "invoice_expiredPaidLate" => StringLocalizer["Expired — paid late"].Value,
+            "invoice_failedToConfirm" => StringLocalizer["Failed to confirm"].Value,
+            "invoice_markedInvalid" => StringLocalizer["Marked invalid"].Value,
+            "invoice_markedCompleted" => StringLocalizer["Marked settled"].Value,
+            "invoice_paidAfterExpiration" => StringLocalizer["Paid after expiration"].Value,
+            _ => Humanize(code)
+        };
+    }
+
+    // Opinionated dot color for an activity event: green = good, red = bad, etc.
+    string ActivityDotCss(string message)
+    {
+        var code = EventCodeRx.Match(message).Groups[1].Value;
+        return code switch
+        {
+            "invoice_receivedPayment" or "invoice_paidInFull" or "invoice_paymentSettled"
+                or "invoice_confirmedPaid" or "invoice_completed" or "invoice_markedCompleted" => "success",
+            "invoice_expired" or "invoice_expiredPaidPartial" or "invoice_failedToConfirm"
+                or "invoice_markedInvalid" => "danger",
+            "invoice_expiredPaidLate" or "invoice_paidAfterExpiration" => "warning",
+            "invoice_created" => "info",
+            _ => null
+        };
+    }
+
+    static string Humanize(string code)
+    {
+        var s = code.StartsWith("invoice_") ? code["invoice_".Length..] : code;
+        s = System.Text.RegularExpressions.Regex.Replace(s, "(?<=[a-z0-9])([A-Z])", " $1");
+        return s.Length == 0 ? code : char.ToUpperInvariant(s[0]) + s[1..].ToLowerInvariant();
+    }
+
+    // View model for a single settled/received payment card.
+    class PayCard
+    {
+        public bool IsLightning { get; init; }
+        public bool Replaced { get; init; }
+        public string Method { get; init; }
+        public int? ConfCount { get; init; }
+        public int? ConfReq { get; init; }
+        public string Amount { get; init; }
+        public string FiatValue { get; init; }
+        public string NetworkFee { get; init; }
+        public string FeeFiat { get; init; }
+        public string Rate { get; init; }
+        public string Destination { get; init; }
+        public string TxId { get; init; }
+        public string TxLink { get; init; }
+        public string AdditionalInfo { get; init; }
+        public string LnComment { get; init; }
+        public string LnAddress { get; init; }
+    }
 }
 
 @section PageHeadContent {
     <meta name="robots" content="noindex,nofollow">
-    <style>
-        #posData td > table:last-child {
-            margin-bottom: 0 !important;
-        }
-
-        #posData table > tbody > tr:first-child > td > h4 {
-            margin-top: 0 !important;
-        }
-        .invoice-information {
-            display: flex;
-            flex-wrap: wrap;
-            gap: var(--btcpay-space-xl) var(--btcpay-space-xxl);
-        }
-
-            .invoice-information > div {
-                max-width: 540px;
-            }
-
-                .invoice-information > div table th {
-                    width: 200px;
-                    font-weight: var(--btcpay-font-weight-semibold);
-                }
-
-        .invoice-comment__value {
-            overflow-wrap: anywhere;
-        }
-
-        .invoice-comment__toggle {
-            margin-left: var(--btcpay-space-s);
-        }
-
-        .invoice-comment__dropdown {
-            min-width: 18rem;
-        }
-    </style>
 }
 
 @section PageFootContent {
@@ -62,9 +176,25 @@
 
         delegate('click', '#IssueRefund', async e => {
             e.preventDefault()
-            const { href: url } = e.target
+            const url = e.target.closest('a').href
             const response = await fetch(url)
             await handleRefundResponse(response)
+        })
+
+        delegate('click', '.mark-invoice-settled', async e => {
+            const button = e.target.closest('.mark-invoice-settled')
+            button.classList.add('disabled')
+            const token = document.querySelector('input[name="__RequestVerificationToken"]')?.value
+            const response = await fetch(button.dataset.url, {
+                method: 'POST',
+                headers: token ? { 'RequestVerificationToken': token } : {}
+            })
+            if (response.ok) {
+                window.location.reload()
+            } else {
+                button.classList.remove('disabled')
+                alert('Invoice state update failed')
+            }
         })
 
         delegate('submit', '#RefundForm', async e => {
@@ -159,6 +289,18 @@
         delegate('change', '#SubtractPercentage', updateSubtractPercentageResult);
         delegate('change', '#CustomCurrency', updateSubtractPercentageResult);
         delegate('change', '#CustomAmount', updateSubtractPercentageResult);
+
+        document.addEventListener('DOMContentLoaded', () => {
+            document.querySelectorAll(".webhook-time-tooltip").forEach(function (el) {
+                formatDateTimes(null, el.content);
+                el.content.querySelectorAll('time').forEach(time => {
+                    var span = document.createElement('span');
+                    span.innerHTML = time.innerHTML;
+                    time.replaceWith(span);
+                });
+                el.parentElement.setAttribute('title', el.innerHTML);
+            });
+        });
     </script>
 }
 
@@ -168,7 +310,7 @@
         <div class="modal-dialog modal-dialog-centered">
             <div class="modal-content">
                 <div class="modal-header">
-                    <h4 class="modal-title" id="RefundTitle" text-translate="true">Issue Refund</h4>
+                    <h4 class="modal-title" id="RefundTitle">Issue Refund</h4>
                     <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="@StringLocalizer["Close"]">
                         <vc:icon symbol="close" />
                     </button>
@@ -183,129 +325,502 @@
     </div>
 }
 
-<div class="sticky-header">
-    <vc:title-header />
-    <div>
-        @if (Model.ShowCheckout)
+<partial name="_StatusMessage" />
+
+<div class="invoice-detail">
+    <div class="d-flex flex-wrap justify-content-between align-items-start gap-3 mb-3">
+        <div>
+            <div class="d-flex align-items-center flex-wrap gap-3">
+                <h2 class="mb-0" text-translate="true">Invoice</h2>
+                <vc:invoice-status invoice-id="@Model.Id" state="Model.State" payments="Model.Payments"
+                                   is-archived="Model.Archived" has-refund="Model.HasRefund" />
+                @if (exception is { } exh)
+                {
+                    <span class="badge bg-@exh.Css">@exh.Label</span>
+                }
+            </div>
+            <div class="inv-id-line mt-1">
+                <vc:truncate-center text="@Model.Id" padding="30" classes="font-monospace" />
+                <span>&middot;</span>
+                <span>@StringLocalizer["created"] @Model.CreatedDate.ToBrowserDate()</span>
+            </div>
+        </div>
+        <div class="d-flex gap-2 flex-wrap">
+            @if (Model.ShowCheckout)
+            {
+                <a asp-action="Checkout" class="invoice-checkout-link btn btn-primary text-nowrap" asp-route-invoiceId="@Model.Id">Checkout</a>
+            }
+            @if (Model.ShowReceipt)
+            {
+                <a asp-action="InvoiceReceipt" asp-route-invoiceId="@Model.Id" id="Receipt" class="btn btn-secondary" target="InvoiceReceipt-@Model.Id">Receipt</a>
+            }
+            @if (Model.CanRefund)
+            {
+                <a asp-action="Refund" asp-route-invoiceId="@Model.Id" id="IssueRefund" class="btn btn-primary text-nowrap" data-bs-toggle="modal" data-bs-target="#RefundModal" permission="@Policies.CanCreateNonApprovedPullPayments">Issue Refund</a>
+            }
+            <form asp-action="ToggleArchive" asp-route-invoiceId="@Model.Id" method="post">
+                <button type="submit" class="btn btn-secondary" id="btn-archive-toggle">
+                    @if (Model.Archived)
+                    {
+                        <span class="text-nowrap" title="@StringLocalizer["Unarchive this invoice"]">Unarchive</span>
+                    }
+                    else
+                    {
+                        <span class="text-nowrap" title="@StringLocalizer["Archive this invoice so that it does not appear in the invoice list by default"]">Archive</span>
+                    }
+                </button>
+            </form>
+        </div>
+    </div>
+
+    @* Hero *@
+    <div class="inv-card mb-2">
+        @if (hasPayments)
         {
-            <a asp-action="Checkout" class="invoice-checkout-link btn btn-primary text-nowrap" asp-route-invoiceId="@Model.Id" text-translate="true">Checkout</a>
-        }
-        @if (Model.ShowReceipt)
-        {
-            <a asp-action="InvoiceReceipt" asp-route-invoiceId="@Model.Id" id="Receipt" class="btn btn-secondary" target="InvoiceReceipt-@Model.Id" text-translate="true">Receipt</a>
-        }
-        @if (Model.CanRefund)
-        {
-            <a asp-action="Refund" asp-route-invoiceId="@Model.Id" id="IssueRefund" class="btn btn-primary text-nowrap" data-bs-toggle="modal" data-bs-target="#RefundModal" permission="@Policies.CanCreateNonApprovedPullPayments" text-translate="true">Issue Refund</a>
+            <div class="d-flex flex-wrap justify-content-between align-items-start gap-4">
+                <div>
+                    <div class="inv-hero-label" text-translate="true">Paid</div>
+                    <div class="inv-hero-amount" data-sensitive>@primaryPaid</div>
+                </div>
+                <div class="text-end">
+                    @if (Model.StillDue && stillDueAmount != null)
+                    {
+                        <div class="inv-hero-label" text-translate="true">Still Due</div>
+                        <div class="fw-semibold" style="font-size:1.5rem;color:var(--btcpay-warning)" data-sensitive>@stillDueAmount</div>
+                    }
+                    else if (overpaidAmount != null)
+                    {
+                        <div class="inv-hero-label" text-translate="true">Overpaid</div>
+                        <div class="fw-semibold" style="font-size:1.5rem;color:var(--btcpay-info)" data-sensitive>@overpaidAmount</div>
+                    }
+                    else
+                    {
+                        <div class="inv-hero-label" text-translate="true">Invoice Total</div>
+                        <div class="fw-semibold" style="font-size:1.5rem" data-sensitive>@Model.Fiat</div>
+                    }
+                </div>
+            </div>
+            <div class="inv-progress mt-3"><span class="inv-progress-fill" style="width:@(paidPct)%;background:var(@statusVar)"></span></div>
+            <div class="d-flex flex-wrap justify-content-between gap-2 mt-2 text-secondary">
+                <span>@StringLocalizer["{0}% paid", paidPct] &middot; @StringLocalizer["{0} payment(s)", paymentCount]</span>
+                @if (networkFees.Count > 0)
+                {
+                    <span data-sensitive>@StringLocalizer["includes {0} network fee", string.Join(" + ", networkFees)]</span>
+                }
+            </div>
         }
         else
         {
-            <button class="btn btn-secondary text-nowrap" title="@StringLocalizer["You can only refund an invoice that has been settled. Please wait for the transaction to confirm on the blockchain before attempting to refund it."]" disabled text-translate="true">Issue refund</button>
+            <div class="inv-hero-label" text-translate="true">Amount Due</div>
+            <div class="inv-hero-amount" data-sensitive>@Model.Fiat</div>
         }
-        <form asp-action="ToggleArchive" asp-route-invoiceId="@Model.Id" method="post">
-            <button type="submit" class="btn btn-secondary" id="btn-archive-toggle">
-                @if (Model.Archived)
-                {
-                    <span class="text-nowrap" title="@StringLocalizer["Unarchive this invoice"]" text-translate="true">Unarchive</span>
-                }
-                else
-                {
-                    <span class="text-nowrap" title="@StringLocalizer["Archive this invoice so that it does not appear in the invoice list by default"]" text-translate="true">Archive</span>
-                }
-            </button>
-        </form>
     </div>
-</div>
 
-<partial name="_StatusMessage" />
+    @* Contextual banner with actions *@
+    @if (Model.StatusException == InvoiceExceptionStatus.PaidPartial)
+    {
+        @* Expiry and monitoring expiry are different clocks. A payment arriving before the
+           monitoring date is still credited; after it, the original link is a dead end. *@
+        var expired = Model.State.Status is InvoiceStatus.Expired or InvoiceStatus.Invalid;
+        var stillMonitored = DateTimeOffset.UtcNow < Model.MonitoringDate;
+        var linkStillWorks = !expired || stillMonitored;
+        var remainder = invoicePrice - paidTowardsInvoice;
+        <div class="inv-card mb-2 d-flex flex-wrap justify-content-between align-items-center gap-3">
+            <div class="d-flex align-items-start gap-2" style="min-width:0">
+                <vc:icon symbol="warning" css-class="inv-banner-icon text-warning" />
+                <span>
+                    @if (!expired)
+                    {
+                        @StringLocalizer["Partial payment received. Send the payer an updated link for the remaining {0}, or settle manually.", stillDueAmount]
+                    }
+                    else if (stillMonitored)
+                    {
+                        @ViewLocalizer["This invoice expired after a partial payment of {0}. Payments received before {1} are still detected, so the existing link can be used for the remaining {2}.", primaryPaid, Model.MonitoringDate.ToBrowserDate(), stillDueAmount]
+                    }
+                    else
+                    {
+                        @StringLocalizer["This invoice expired after a partial payment, and is no longer being monitored, so the original link will not credit anything. Charge the remaining {0} on a new invoice, refund what was received, or settle manually.", stillDueAmount]
+                    }
+                </span>
+            </div>
+            <div class="d-flex gap-2 flex-wrap">
+                @if (linkStillWorks)
+                {
+                    <button type="button" class="btn btn-secondary text-nowrap clipboard-button" data-clipboard="@paymentLink" text-translate="true">Copy payment link</button>
+                }
+                @if (remainder > 0)
+                {
+                    <a class="btn btn-secondary text-nowrap charge-remainder"
+                       asp-action="CreateInvoice"
+                       asp-route-storeId="@Model.StoreId"
+                       asp-route-amount="@remainder.ToString(System.Globalization.CultureInfo.InvariantCulture)"
+                       asp-route-currency="@Model.Entity?.Currency"
+                       asp-route-orderId="@Model.TypedMetadata.OrderId"
+                       asp-route-sourceInvoiceId="@Model.Id"
+                       permission="@Policies.CanCreateInvoice" text-translate="true">Charge remainder</a>
+                }
+                @if (expired && Model.CanRefund)
+                {
+                    <a asp-action="Refund" asp-route-invoiceId="@Model.Id" class="btn btn-secondary text-nowrap" data-bs-toggle="modal" data-bs-target="#RefundModal" permission="@Policies.CanCreateNonApprovedPullPayments" text-translate="true">Issue refund</a>
+                }
+                <button type="button" class="btn btn-secondary text-nowrap mark-invoice-settled" data-url="@Url.Action("ChangeInvoiceState", new { invoiceId = Model.Id, newState = "settled" })" text-translate="true">Mark settled</button>
+            </div>
+        </div>
+    }
+    else if (Model.StatusException == InvoiceExceptionStatus.PaidOver)
+    {
+        <div class="inv-card mb-2 d-flex flex-wrap justify-content-between align-items-center gap-3">
+            <div class="d-flex align-items-start gap-2" style="min-width:0">
+                <vc:icon symbol="info" css-class="inv-banner-icon text-info" />
+                <span text-translate="true">This invoice was overpaid. Consider issuing a refund for the excess amount.</span>
+            </div>
+        </div>
+    }
+    else if (Model.StatusException == InvoiceExceptionStatus.PaidLate)
+    {
+        <div class="inv-card mb-2 d-flex align-items-start gap-2">
+            <vc:icon symbol="warning" css-class="inv-banner-icon text-warning" />
+            <span text-translate="true">Payment was received after the invoice expired. The exchange rate may have shifted.</span>
+        </div>
+    }
+    @if (isInvalid)
+    {
+        <div class="inv-card mb-2 d-flex align-items-start gap-2">
+            <vc:icon symbol="cross" css-class="inv-banner-icon text-danger" />
+            <span text-translate="true">This payment did not confirm and is considered invalid. Do not ship goods or deliver services.</span>
+        </div>
+    }
 
-<div class="invoice-details">
-    <div class="invoice-information mb-5">
-        <div>
-            <h3 class="mb-3" text-translate="true">General Information</h3>
-            <table class="table mb-0">
-                <tr>
-                    <th text-translate="true">Store</th>
-                    <td>
-                        <a href="@Model.StoreLink" rel="noreferrer noopener">@Model.StoreName</a>
-                    </td>
-                </tr>
-                <tr>
-                    <th text-translate="true">Invoice Id</th>
-                    <td>@Model.Id</td>
-                </tr>
+    @* Order items — only for invoices created from POS/cart data *@
+    @if (Model.TypedMetadata?.PosData?["cart"] is Newtonsoft.Json.Linq.JArray cartArr && cartArr.OfType<Newtonsoft.Json.Linq.JObject>().Any())
+    {
+        var orderCurrency = Model.Entity?.Currency ?? "USD";
+        var orderTax = Model.TypedMetadata?.TaxIncluded ?? 0m;
+        var orderTotal = Model.Entity?.Price ?? 0m;
+        var orderItems = new List<(string Name, decimal Qty, decimal Price)>();
+        foreach (var it in cartArr.OfType<Newtonsoft.Json.Linq.JObject>())
+        {
+            var name = it.Value<string>("title") ?? it.Value<string>("name") ?? StringLocalizer["Item"].Value;
+            var qty = it.Value<decimal?>("count") ?? it.Value<decimal?>("quantity") ?? 1m;
+            var price = ParseAmount(it["price"]) ?? 0m;
+            orderItems.Add((name, qty, price));
+        }
+        var orderSubtotal = orderItems.Sum(x => x.Qty * x.Price);
+        <div class="inv-card mb-2">
+            <div class="inv-stitle" text-translate="true">Order Summary</div>
+            <table class="inv-cart">
+                <thead>
+                    <tr>
+                        <th text-translate="true">Item</th>
+                        <th class="num" text-translate="true">Qty</th>
+                        <th class="num" text-translate="true">Price</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @foreach (var it in orderItems)
+                    {
+                        <tr>
+                            <td>@it.Name</td>
+                            <td class="num">&times;@it.Qty.ToString("0.####")</td>
+                            <td class="num" data-sensitive>@DisplayFormatter.Currency(it.Price, orderCurrency, DisplayFormatter.CurrencyFormat.Symbol)</td>
+                        </tr>
+                    }
+                </tbody>
+                <tfoot>
+                    <tr>
+                        <td colspan="2" text-translate="true">Subtotal</td>
+                        <td class="num" data-sensitive>@DisplayFormatter.Currency(orderSubtotal, orderCurrency, DisplayFormatter.CurrencyFormat.Symbol)</td>
+                    </tr>
+                    <tr>
+                        <td colspan="2" text-translate="true">Tax</td>
+                        <td class="num" data-sensitive>@DisplayFormatter.Currency(orderTax, orderCurrency, DisplayFormatter.CurrencyFormat.Symbol)</td>
+                    </tr>
+                    <tr class="total">
+                        <td colspan="2" text-translate="true">Total</td>
+                        <td class="num" data-sensitive>@DisplayFormatter.Currency(orderTotal, orderCurrency, DisplayFormatter.CurrencyFormat.Symbol)</td>
+                    </tr>
+                </tfoot>
+            </table>
+        </div>
+    }
+
+    @* Refund *@
+    @if ((Model.Refunds?.Count ?? 0) > 0)
+    {
+        <div class="inv-card mb-2">
+            <div class="inv-stitle" text-translate="true">Refunds</div>
+            @foreach (var refund in Model.Refunds)
+            {
+                <div class="inv-flat mb-2">
+                    <span class="inv-dot" style="background:var(--btcpay-info)"></span>
+                    <div class="flex-grow-1" style="min-width:0">
+                        <div class="fw-semibold">@refund.PullPaymentData.Limit @refund.PullPaymentData.Currency</div>
+                        <div class="text-secondary">@refund.PullPaymentData.StartDate.ToBrowserDate()</div>
+                    </div>
+                    <a asp-action="ViewPullPayment" asp-controller="UIPullPayment" asp-route-pullPaymentId="@refund.PullPaymentDataId" target="_blank" class="btn btn-link p-0" text-translate="true">View Pull Payment</a>
+                </div>
+            }
+        </div>
+    }
+
+    @* Payments *@
+    @{
+        var paymentCards = new List<PayCard>();
+        var invoiceCurrency = Model.Entity?.Currency;
+        foreach (var payment in Model.Payments ?? new List<PaymentEntity>())
+        {
+            Handlers.TryGetValue(payment.PaymentMethodId, out var h);
+            var pmRate = Model.CryptoPayments?.FirstOrDefault(cp => cp.PaymentMethodId == payment.PaymentMethodId)?.Rate;
+            var fiatValue = payment.InvoicePaidAmount is { } ipa && invoiceCurrency != null ? DisplayFormatter.Currency(ipa.Gross, invoiceCurrency) : null;
+            if (h is BitcoinLikePaymentHandler bh)
+            {
+                var d = bh.ParsePaymentDetails(payment.Details);
+                var confReq = NBXplorerListener.ConfirmationRequired(payment.InvoiceEntity, d);
+                var confCount = (int)Math.Min(confReq, d.ConfirmationCount);
+                var feeFiat = invoiceCurrency != null && payment.PaymentMethodFee > 0 ? DisplayFormatter.Currency(payment.PaymentMethodFee * payment.Rate, invoiceCurrency) : null;
+                paymentCards.Add(new PayCard
+                {
+                    IsLightning = false,
+                    Replaced = !payment.Accounted,
+                    Method = $"{bh.Network.DisplayName} On-Chain",
+                    ConfCount = confCount,
+                    ConfReq = confReq,
+                    Amount = DisplayFormatter.Currency(payment.Value, payment.Currency),
+                    FiatValue = fiatValue,
+                    NetworkFee = payment.PaymentMethodFee > 0 ? DisplayFormatter.Currency(payment.PaymentMethodFee, payment.Currency) : null,
+                    FeeFiat = feeFiat,
+                    Rate = pmRate,
+                    Destination = payment.Destination,
+                    TxId = d.Outpoint.Hash.ToString(),
+                    TxLink = TransactionLinkProviders.GetTransactionLink(payment.PaymentMethodId, d.Outpoint.Hash.ToString()),
+                    AdditionalInfo = d.PayjoinInformation is not null ? StringLocalizer["Payjoin"].Value : null
+                });
+            }
+            else if (h is ILightningPaymentHandler lh)
+            {
+                var d = lh.ParsePaymentDetails(payment.Details);
+                string lnComment = null, lnAddress = null;
+                if (lh.ParsePaymentPromptDetails(Model.Entity.GetPaymentPrompt(payment.PaymentMethodId)?.Details) is LNURLPayPaymentMethodDetails lnurl)
+                {
+                    lnComment = lnurl.ProvidedComment;
+                    lnAddress = lnurl.ConsumedLightningAddress;
+                }
+                paymentCards.Add(new PayCard
+                {
+                    IsLightning = true,
+                    Method = $"{lh.Network.DisplayName} Lightning",
+                    Amount = DisplayFormatter.Currency(payment.Value, lh.Network.CryptoCode, divisibility: payment.Divisibility),
+                    FiatValue = fiatValue,
+                    Rate = pmRate,
+                    Destination = d.BOLT11,
+                    TxId = d.Preimage,
+                    LnComment = lnComment,
+                    LnAddress = lnAddress
+                });
+            }
+            else
+            {
+                // No handler registered for this payment method, for example a plugin that is no
+                // longer installed. Show what the payment itself carries rather than dropping the row.
+                paymentCards.Add(new PayCard
+                {
+                    Replaced = !payment.Accounted,
+                    Method = payment.PaymentMethodId.ToString(),
+                    Amount = DisplayFormatter.Currency(payment.Value, payment.Currency),
+                    FiatValue = fiatValue,
+                    NetworkFee = payment.PaymentMethodFee > 0 ? DisplayFormatter.Currency(payment.PaymentMethodFee, payment.Currency) : null,
+                    Rate = pmRate,
+                    Destination = payment.Destination
+                });
+            }
+        }
+    }
+    @if (paymentCards.Any())
+    {
+        <div class="inv-card mb-2">
+            <div class="inv-stitle" text-translate="true">Payments</div>
+            <div class="table-responsive">
+            <table class="inv-cart inv-payments">
+                <thead>
+                    <tr>
+                        <th>#</th>
+                        <th text-translate="true">Method</th>
+                        <th class="num" text-translate="true">Amount</th>
+                        <th class="num" text-translate="true">Fee</th>
+                        <th class="num" text-translate="true">Confs</th>
+                        <th class="tx" text-translate="true">Transaction</th>
+                        <th></th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @{ var i = 0; }
+                    @foreach (var pc in paymentCards)
+                    {
+                        i++;
+                        var last = i == paymentCards.Count;
+                        var hasDetails = !string.IsNullOrEmpty(pc.Destination) || pc.FiatValue != null || pc.Rate != null
+                            || !string.IsNullOrEmpty(pc.LnAddress) || !string.IsNullOrEmpty(pc.LnComment);
+                        <tr class="@(pc.Replaced ? "inv-replaced " : "")@(last ? "inv-last-payment" : "")" title="@(pc.Replaced ? StringLocalizer["Replaced (double-spent)"].Value : null)">
+                            <td>@i</td>
+                            <td class="text-nowrap">
+                                <span class="inv-method-dot" style="background:@(pc.IsLightning ? "var(--btcpay-warning)" : "#f7931a")"></span>@pc.Method
+                                @if (!string.IsNullOrEmpty(pc.AdditionalInfo))
+                                {
+                                    <span class="text-secondary">(@pc.AdditionalInfo)</span>
+                                }
+                            </td>
+                            <td class="num font-monospace" data-sensitive>@pc.Amount</td>
+                            <td class="num font-monospace" data-sensitive>@(pc.NetworkFee ?? "—")</td>
+                            <td class="num text-nowrap">
+                                @if (pc.ConfReq is int req)
+                                {
+                                    var cnt = pc.ConfCount ?? 0;
+                                    var confColor = cnt >= req ? "var(--btcpay-success)" : "var(--btcpay-warning)";
+                                    <span class="text-nowrap" style="color:@confColor">
+                                        @if (cnt >= req)
+                                        {
+                                            <vc:icon symbol="checkmark" css-class="inv-conf-check" />
+                                        }
+                                        @cnt/@req
+                                    </span>
+                                }
+                                else
+                                {
+                                    <span>—</span>
+                                }
+                            </td>
+                            <td class="tx">
+                                @if (!string.IsNullOrEmpty(pc.TxId))
+                                {
+                                    <vc:truncate-center text="@pc.TxId" link="@pc.TxLink" classes="font-monospace" />
+                                }
+                                else
+                                {
+                                    <span>—</span>
+                                }
+                            </td>
+                            <td class="num">
+                                @if (hasDetails)
+                                {
+                                    <button type="button" class="btn btn-link p-0 inv-row-toggle" data-bs-toggle="collapse" data-bs-target="#pay-details-@i" aria-expanded="false" aria-controls="pay-details-@i" title="@StringLocalizer["Toggle details"]">
+                                        <vc:icon symbol="caret-down" />
+                                    </button>
+                                }
+                            </td>
+                        </tr>
+                        @if (hasDetails)
+                        {
+                            <tr class="inv-details-row @(last ? "inv-last-payment" : "")">
+                                <td colspan="7">
+                                    <div id="pay-details-@i" class="collapse">
+                                        <div class="inv-inset">
+                                            @if (!string.IsNullOrEmpty(pc.Destination))
+                                            {
+                                                <div class="inv-row">
+                                                    <span class="inv-rl">@(pc.IsLightning ? StringLocalizer["BOLT11"] : StringLocalizer["Destination"])</span>
+                                                    <span class="inv-rv"><vc:truncate-center text="@pc.Destination" classes="font-monospace" /></span>
+                                                </div>
+                                            }
+                                            @if (pc.FiatValue != null)
+                                            {
+                                                <div class="inv-row"><span class="inv-rl" text-translate="true">Fiat Value</span><span class="inv-rv" data-sensitive>@pc.FiatValue</span></div>
+                                            }
+                                            @if (pc.Rate != null)
+                                            {
+                                                <div class="inv-row"><span class="inv-rl" text-translate="true">Exchange Rate</span><span class="inv-rv" data-sensitive>@pc.Rate</span></div>
+                                            }
+                                            @if (pc.NetworkFee != null && pc.FeeFiat != null)
+                                            {
+                                                <div class="inv-row"><span class="inv-rl" text-translate="true">Network Fee</span><span class="inv-rv font-monospace" data-sensitive>@pc.NetworkFee (~@pc.FeeFiat)</span></div>
+                                            }
+                                            @if (!string.IsNullOrEmpty(pc.LnAddress))
+                                            {
+                                                <div class="inv-row"><span class="inv-rl" text-translate="true">Lightning Address</span><span class="inv-rv">@pc.LnAddress</span></div>
+                                            }
+                                            @if (!string.IsNullOrEmpty(pc.LnComment))
+                                            {
+                                                <div class="inv-row"><span class="inv-rl" text-translate="true">Comment</span><span class="inv-rv">@pc.LnComment</span></div>
+                                            }
+                                        </div>
+                                    </div>
+                                </td>
+                            </tr>
+                        }
+                    }
+                </tbody>
+            </table>
+            </div>
+        </div>
+    }
+    else
+    {
+        <div class="inv-card mb-2 text-center" style="padding:var(--btcpay-space-xl)">
+            <div class="text-secondary">
+                @(Model.State.Status == InvoiceStatus.New ? StringLocalizer["Waiting for the buyer to send payment…"] : StringLocalizer["No payment was received for this invoice."])
+            </div>
+        </div>
+    }
+
+    @* Info + Buyer + Product *@
+    <div class="row g-4 mb-2">
+        <div class="col-lg-6">
+            <div class="inv-card h-100">
+                <div class="inv-stitle" text-translate="true">Invoice Info</div>
+                <div class="inv-row"><span class="inv-rl" text-translate="true">Store</span><span class="inv-rv"><a href="@Model.StoreLink" rel="noreferrer noopener">@Model.StoreName</a></span></div>
                 @if (!string.IsNullOrEmpty(Model.TypedMetadata.OrderId))
                 {
-                    <tr>
-                        <th text-translate="true">Order Id</th>
-                        <td>
-                            @if (!string.IsNullOrEmpty(Model.TypedMetadata.OrderUrl))
-                            {
-                                <a href="@Model.TypedMetadata.OrderUrl" rel="noreferrer noopener" target="_blank">
-                                    @if (string.IsNullOrEmpty(Model.TypedMetadata.OrderId))
-                                    {
-                                        <span text-translate="true">View Order</span>
-                                    }
-                                    else
-                                    {
-                                        @Model.TypedMetadata.OrderId
-                                    }
-                                </a>
-                            }
-                            else
-                            {
-                                <span>@Model.TypedMetadata.OrderId</span>
-                            }
-                        </td>
-                    </tr>
+                    <div class="inv-row"><span class="inv-rl" text-translate="true">Order Id</span><span class="inv-rv">
+                        @if (!string.IsNullOrEmpty(Model.TypedMetadata.OrderUrl))
+                        {
+                            <a href="@Model.TypedMetadata.OrderUrl" rel="noreferrer noopener" target="_blank">@Model.TypedMetadata.OrderId</a>
+                        }
+                        else
+                        {
+                            <span>@Model.TypedMetadata.OrderId</span>
+                        }
+                    </span></div>
                 }
                 @if (Model.TypedMetadata.PaymentRequestId is not null)
                 {
-                    <tr>
-                        <th text-translate="true">Payment Request Id</th>
-                        <td>
-                            <a href="@Model.PaymentRequestLink" rel="noreferrer noopener">@Model.TypedMetadata.PaymentRequestId</a>
-                        </td>
-                    </tr>
+                    <div class="inv-row"><span class="inv-rl" text-translate="true">Payment Request</span><span class="inv-rv"><a href="@Model.PaymentRequestLink" rel="noreferrer noopener">@Model.TypedMetadata.PaymentRequestId</a></span></div>
                 }
-                <tr>
-                    <th text-translate="true">State</th>
-                    <td>
-                        <vc:invoice-status invoice-id="@Model.Id" state="Model.State" payments="Model.Payments"
-                                           is-archived="Model.Archived" has-refund="Model.HasRefund" />
-                    </td>
-                </tr>
-                <tr>
-                    <th text-translate="true">Created Date</th>
-                    <td>@Model.CreatedDate.ToBrowserDate()</td>
-                </tr>
-                <tr>
-                    <th text-translate="true">Expiration Date</th>
-                    <td>@Model.ExpirationDate.ToBrowserDate()</td>
-                </tr>
-                <tr>
-                    <th text-translate="true">Monitoring Date</th>
-                    <td>@Model.MonitoringDate.ToBrowserDate()</td>
-                </tr>
-                <tr>
-                    <th text-translate="true">Transaction Speed</th>
-                    <td>@Model.TransactionSpeed</td>
-                </tr>
-                <tr>
-                    <th text-translate="true">Total Amount Due</th>
-                    <td><span data-sensitive>@Model.Fiat</span></td>
-                </tr>
-                <tr>
-                    <th text-translate="true">Comment</th>
-                    <td>
-                        <div class="invoice-comment d-flex align-items-start gap-2">
+                @if (!string.IsNullOrEmpty(Model.TypedMetadata.ItemDesc))
+                {
+                    <div class="inv-row"><span class="inv-rl" text-translate="true">Description</span><span class="inv-rv">@Model.TypedMetadata.ItemDesc</span></div>
+                }
+                @if (!string.IsNullOrEmpty(Model.TypedMetadata.ItemCode))
+                {
+                    <div class="inv-row"><span class="inv-rl" text-translate="true">Item code</span><span class="inv-rv">@Model.TypedMetadata.ItemCode</span></div>
+                }
+                @if (Model.TypedMetadata.TaxIncluded is { } taxIncluded && taxIncluded > 0)
+                {
+                    <div class="inv-row"><span class="inv-rl" text-translate="true">Tax included</span><span class="inv-rv" data-sensitive>@DisplayFormatter.Currency(taxIncluded, Model.Entity?.Currency)</span></div>
+                }
+                @if (Model.TypedMetadata.TaxOnTip is { } taxOnTip && taxOnTip > 0)
+                {
+                    <div class="inv-row"><span class="inv-rl" text-translate="true">Tax on tip</span><span class="inv-rv" data-sensitive>@DisplayFormatter.Currency(taxOnTip, Model.Entity?.Currency)</span></div>
+                }
+                @if (Model.TypedMetadata.Physical is { } physical)
+                {
+                    <div class="inv-row"><span class="inv-rl" text-translate="true">Physical</span><span class="inv-rv">@(physical ? StringLocalizer["Yes"] : StringLocalizer["No"])</span></div>
+                }
+                <div class="inv-row"><span class="inv-rl" text-translate="true">Created</span><span class="inv-rv">@Model.CreatedDate.ToBrowserDate()</span></div>
+                <div class="inv-row"><span class="inv-rl" text-translate="true">Expiration</span><span class="inv-rv">@Model.ExpirationDate.ToBrowserDate()</span></div>
+                @if (!string.IsNullOrEmpty(Model.RedirectUrl))
+                {
+                    <div class="inv-row"><span class="inv-rl" text-translate="true">Redirect</span><span class="inv-rv"><a href="@Model.RedirectUrl" rel="noreferrer noopener" class="text-truncate">@Model.RedirectUrl</a></span></div>
+                }
+                <div class="inv-row">
+                    <span class="inv-rl" text-translate="true">Comment</span>
+                    <span class="inv-rv">
+                        <span class="invoice-comment d-inline-flex align-items-start gap-2">
                             @if (!string.IsNullOrEmpty(Model.Comment))
                             {
                                 <span class="invoice-comment__value">@Model.Comment</span>
                             }
                             else
                             {
-                                <span class="invoice-comment__value text-secondary" text-translate="true">No comment</span>
+                                <span class="invoice-comment__value text-secondary" text-translate="true">Add a comment</span>
                             }
                             <span class="dropdown">
                                 <button class="invoice-comment__toggle btn btn-link p-0 @(!string.IsNullOrEmpty(Model.Comment) ? "text-primary" : "text-secondary")" type="button" data-bs-toggle="dropdown" data-bs-auto-close="outside" aria-haspopup="true" aria-expanded="false" title="@(!string.IsNullOrEmpty(Model.Comment) ? StringLocalizer["Modify the comment"] : StringLocalizer["Add a comment"])">
@@ -322,364 +837,248 @@
                                     </form>
                                 </div>
                             </span>
-                        </div>
-                    </td>
-                </tr>
-                @if (!string.IsNullOrEmpty(Model.NotificationUrl))
-                {
-                    <tr>
-                        <th text-translate="true">Notification Url</th>
-                        <td>@Model.NotificationUrl</td>
-                    </tr>
-                }
-                @if (!string.IsNullOrEmpty(Model.RedirectUrl))
-                {
-                    <tr>
-                        <th text-translate="true">Redirect Url</th>
-                        <td>
-                            <a href="@Model.RedirectUrl" rel="noreferrer noopener">@Model.RedirectUrl</a>
-                        </td>
-                    </tr>
-                }
-            </table>
+                        </span>
+                    </span>
+                </div>
+            </div>
         </div>
-        <div class="d-flex flex-column gap-5">
-            @if (!string.IsNullOrEmpty(Model.TypedMetadata.ItemCode) ||
-                    !string.IsNullOrEmpty(Model.TypedMetadata.ItemDesc))
-            {
-                <div>
-                    <h3 class="mb-3">
-                        <span text-translate="true">Product Information</span>
-                        <a href="https://docs.btcpayserver.org/Development/InvoiceMetadata/" target="_blank" rel="noreferrer noopener">
-                            <vc:icon symbol="info" />
-                        </a>
-                    </h3>
-                    <table class="table mb-0">
-                        @if (!string.IsNullOrEmpty(Model.TypedMetadata.ItemCode))
-                        {
-                            <tr>
-                                <th text-translate="true">Item code</th>
-                                <td>@Model.TypedMetadata.ItemCode</td>
-                            </tr>
-                        }
-                        @if (!string.IsNullOrEmpty(Model.TypedMetadata.ItemDesc))
-                        {
-                            <tr>
-                                <th text-translate="true">Item Description</th>
-                                <td>@Model.TypedMetadata.ItemDesc</td>
-                            </tr>
-                        }
-                    </table>
+        @{
+            var hasBuyer = Model.TypedMetadata.BuyerName is not null || Model.TypedMetadata.BuyerEmail is not null || Model.TypedMetadata.BuyerPhone is not null
+                || Model.TypedMetadata.BuyerAddress1 is not null || Model.TypedMetadata.BuyerAddress2 is not null || Model.TypedMetadata.BuyerCity is not null
+                || Model.TypedMetadata.BuyerState is not null || Model.TypedMetadata.BuyerCountry is not null || Model.TypedMetadata.BuyerZip is not null;
+        }
+        @if (hasBuyer)
+        {
+            <div class="col-lg-6">
+                <div class="inv-card h-100">
+                    <div class="inv-stitle" text-translate="true">Buyer</div>
+                    @if (Model.TypedMetadata.BuyerName is not null)
+                    {
+                        <div class="inv-row"><span class="inv-rl" text-translate="true">Name</span><span class="inv-rv">@Model.TypedMetadata.BuyerName</span></div>
+                    }
+                    @if (Model.TypedMetadata.BuyerEmail is not null)
+                    {
+                        <div class="inv-row"><span class="inv-rl" text-translate="true">Email</span><span class="inv-rv"><a href="mailto:@Model.TypedMetadata.BuyerEmail">@Model.TypedMetadata.BuyerEmail</a></span></div>
+                    }
+                    @if (Model.TypedMetadata.BuyerPhone is not null)
+                    {
+                        <div class="inv-row"><span class="inv-rl" text-translate="true">Phone</span><span class="inv-rv">@Model.TypedMetadata.BuyerPhone</span></div>
+                    }
+                    @if (Model.TypedMetadata.BuyerAddress1 is not null)
+                    {
+                        <div class="inv-row"><span class="inv-rl" text-translate="true">Address</span><span class="inv-rv">@Model.TypedMetadata.BuyerAddress1</span></div>
+                    }
+                    @if (Model.TypedMetadata.BuyerAddress2 is not null)
+                    {
+                        <div class="inv-row"><span class="inv-rl" text-translate="true">Address 2</span><span class="inv-rv">@Model.TypedMetadata.BuyerAddress2</span></div>
+                    }
+                    @if (Model.TypedMetadata.BuyerCity is not null)
+                    {
+                        <div class="inv-row"><span class="inv-rl" text-translate="true">City</span><span class="inv-rv">@Model.TypedMetadata.BuyerCity</span></div>
+                    }
+                    @if (Model.TypedMetadata.BuyerState is not null)
+                    {
+                        <div class="inv-row"><span class="inv-rl" text-translate="true">State</span><span class="inv-rv">@Model.TypedMetadata.BuyerState</span></div>
+                    }
+                    @if (Model.TypedMetadata.BuyerZip is not null)
+                    {
+                        <div class="inv-row"><span class="inv-rl" text-translate="true">Zip</span><span class="inv-rv">@Model.TypedMetadata.BuyerZip</span></div>
+                    }
+                    @if (Model.TypedMetadata.BuyerCountry is not null)
+                    {
+                        <div class="inv-row"><span class="inv-rl" text-translate="true">Country</span><span class="inv-rv">@Model.TypedMetadata.BuyerCountry</span></div>
+                    }
                 </div>
-            }
-            @if (Model.TypedMetadata.BuyerName is not null ||
-                    Model.TypedMetadata.BuyerEmail is not null ||
-                    Model.TypedMetadata.BuyerPhone is not null ||
-                    Model.TypedMetadata.BuyerAddress1 is not null ||
-                    Model.TypedMetadata.BuyerAddress2 is not null ||
-                    Model.TypedMetadata.BuyerCity is not null ||
-                    Model.TypedMetadata.BuyerState is not null ||
-                    Model.TypedMetadata.BuyerCountry is not null ||
-                    Model.TypedMetadata.BuyerZip is not null)
-            {
-                <div>
-                    <h3 class="mb-3">
-                        <span text-translate="true">Buyer Information</span>
-                        <a href="https://docs.btcpayserver.org/Development/InvoiceMetadata/" target="_blank" rel="noreferrer noopener">
-                            <vc:icon symbol="info" />
-                        </a>
-                    </h3>
-                    <table class="table mb-0">
-                        @if (Model.TypedMetadata.BuyerName is not null)
-                        {
-                            <tr>
-                                <th text-translate="true">Name</th>
-                                <td>@Model.TypedMetadata.BuyerName</td>
-                            </tr>
-                        }
-                        @if (Model.TypedMetadata.BuyerEmail is not null)
-                        {
-                            <tr>
-                                <th text-translate="true">Email</th>
-                                <td>
-                                    <a href="mailto:@Model.TypedMetadata.BuyerEmail">@Model.TypedMetadata.BuyerEmail</a>
-                                </td>
-                            </tr>
-                        }
-                        @if (Model.TypedMetadata.BuyerPhone is not null)
-                        {
-                            <tr>
-                                <th text-translate="true">Phone</th>
-                                <td>@Model.TypedMetadata.BuyerPhone</td>
-                            </tr>
-                        }
-                        @if (Model.TypedMetadata.BuyerAddress1 is not null)
-                        {
-                            <tr>
-                                <th text-translate="true">Address 1</th>
-                                <td>@Model.TypedMetadata.BuyerAddress1</td>
-                            </tr>
-                        }
-                        @if (Model.TypedMetadata.BuyerAddress2 is not null)
-                        {
-                            <tr>
-                                <th text-translate="true">Address 2</th>
-                                <td>@Model.TypedMetadata.BuyerAddress2</td>
-                            </tr>
-                        }
-                        @if (Model.TypedMetadata.BuyerCity is not null)
-                        {
-                            <tr>
-                                <th text-translate="true">City</th>
-                                <td>@Model.TypedMetadata.BuyerCity</td>
-                            </tr>
-                        }
-                        @if (Model.TypedMetadata.BuyerState is not null)
-                        {
-                            <tr>
-                                <th text-translate="true">State</th>
-                                <td>@Model.TypedMetadata.BuyerState</td>
-                            </tr>
-                        }
-                        @if (Model.TypedMetadata.BuyerCountry is not null)
-                        {
-                            <tr>
-                                <th text-translate="true">Country</th>
-                                <td>@Model.TypedMetadata.BuyerCountry</td>
-                            </tr>
-                        }
-                        @if (Model.TypedMetadata.BuyerZip is not null)
-                        {
-                            <tr>
-                                <th text-translate="true">Zip</th>
-                                <td>@Model.TypedMetadata.BuyerZip</td>
-                            </tr>
-                        }
-                    </table>
-                </div>
-            }
-            @if (Model.ReceiptData?.Any() is true)
-            {
-                <div>
-                    <h3 class="mb-3">
-                        <span text-translate="true">Receipt Information</span>
-                        <a href="https://docs.btcpayserver.org/Development/InvoiceMetadata/" target="_blank" rel="noreferrer noopener">
-                            <vc:icon symbol="info" />
-                        </a>
-                    </h3>
-                    <partial name="PosData" model="(Model.ReceiptData, 1)" />
-                </div>
-            }
-            @if (Model.AdditionalData?.Any() is true)
-            {
-                <div>
-                    <h3 class="mb-3">
-                        <span text-translate="true">Additional Information</span>
-                        <a href="https://docs.btcpayserver.org/Development/InvoiceMetadata/" target="_blank" rel="noreferrer noopener">
-                            <vc:icon symbol="info" />
-                        </a>
-                    </h3>
-                    <partial name="PosData" model="(Model.AdditionalData, 1)" />
-                </div>
-            }
-        </div>
+            </div>
+        }
     </div>
-    <div class="row">
-        <div class="col-xxl-constrain">
-            <h3 class="mb-3" text-translate="true">Invoice Summary</h3>
-            <partial name="ListInvoicesPaymentsPartial" model="(Model, true)" />
 
+
+    @* Activity (collapsible) *@
+    @if (Model.Events is { Length: > 0 })
+    {
+        var orderedEvents = Model.Events.Reverse().ToList();
+        var activityEvents = orderedEvents.Where(ShowInActivity).ToList();
+        var debugEvents = orderedEvents.Where(e => !ShowInActivity(e)).ToList();
+        <div class="inv-card p-0 mb-2 d-print-none" style="overflow:hidden">
+            <button class="inv-collapse-head" type="button" data-bs-toggle="collapse" data-bs-target="#EventTimeline" aria-expanded="true" aria-controls="EventTimeline">
+                <span text-translate="true">Activity</span>
+                <span class="inv-count">@activityEvents.Count</span>
+                <span class="ms-auto"><vc:icon symbol="caret-down" /></span>
+            </button>
+            <div class="collapse show" id="EventTimeline">
+                <div class="d-flex flex-column gap-2 p-3 pt-0">
+                    @foreach (var evt in activityEvents)
+                    {
+                        var isLifecycle = IsActivityEvent(evt.Message);
+                        var dotCss = isLifecycle && !IsNotable(evt) ? ActivityDotCss(evt.Message) : evt.GetCssClass();
+                        <div class="inv-flat">
+                            <span class="inv-dot" style="background:@EventDotColor(dotCss)"></span>
+                            <div class="flex-grow-1" style="min-width:0">
+                                <div>@(isLifecycle ? ActivityLabel(evt.Message) : evt.Message)</div>
+                            </div>
+                            <span class="text-secondary text-nowrap">@evt.Timestamp.ToBrowserDate()</span>
+                        </div>
+                    }
+                    @if (debugEvents.Count > 0)
+                    {
+                        <button type="button" class="btn btn-link p-0 align-self-start inv-debug-toggle" data-bs-toggle="collapse" data-bs-target="#DebugEvents" aria-expanded="false" aria-controls="DebugEvents">
+                            <span class="when-collapsed">@StringLocalizer["Show {0} debug events", debugEvents.Count]</span>
+                            <span class="when-expanded">@StringLocalizer["Hide {0} debug events", debugEvents.Count]</span>
+                        </button>
+                        <div class="collapse" id="DebugEvents">
+                            <div class="inv-debug-log d-flex flex-column">
+                                @foreach (var evt in debugEvents)
+                                {
+                                    <div class="d-flex justify-content-between gap-3">
+                                        <span>@evt.Message</span>
+                                        <span class="text-nowrap">@evt.Timestamp.ToBrowserDate()</span>
+                                    </div>
+                                }
+                            </div>
+                        </div>
+                    }
+                </div>
+            </div>
+        </div>
+    }
+
+    @* Webhooks. Always rendered: "no deliveries" answers the question of whether a webhook
+       fired at all, which hiding the section leaves ambiguous. *@
+    <div class="inv-card mb-2 d-print-none" id="WebhookDeliveries">
+        <div class="inv-stitle">
+            <span text-translate="true">Webhooks</span>
             @if (Model.Deliveries.Any())
             {
-                <section class="mt-4 d-print-none">
-                    <h3 class="mb-3" text-translate="true">Webhooks</h3>
-                    <div class="table-responsive-xl">
-                        <table class="table table-hover mb-5">
-                            <thead>
-                                <tr>
-                                    <th text-translate="true">Status</th>
-                                    <th text-translate="true">ID</th>
-                                    <th text-translate="true">Type</th>
-                                    <th text-translate="true">Url</th>
-                                    <th text-translate="true">Date</th>
-                                    <th class="text-end" text-translate="true">Action</th>
-                                </tr>
-                            </thead>
-                            <tbody>
-                                @foreach (var delivery in Model.Deliveries)
-                                {
-                                    <tr>
-                                        <form asp-action="RedeliverWebhook"
-                                              asp-route-storeId="@Model.StoreId"
-                                              asp-route-invoiceId="@Model.Id"
-                                              asp-route-deliveryId="@delivery.Id"
-                                              method="post">
-                                        <td>
-                                            <span>
-                                                @if (delivery.Success)
-                                                {
-                                                    <vc:icon symbol="checkmark" css-class="text-success" />
-                                                }
-                                                else
-                                                {
-                                                    <span title="@delivery.ErrorMessage">
-                                                        <vc:icon symbol="cross" css-class="text-danger"/>
-                                                    </span>
-                                                }
-                                            </span>
-                                        </td>
-                                        <td>
-                                                @if (!delivery.Pruned)
-                                                {
-                                                <span>
-                                                    <a asp-action="WebhookDelivery"
-                                                       asp-route-invoiceId="@Model.Id"
-                                                       asp-route-deliveryId="@delivery.Id"
-                                                       class="delivery-content"
-                                                       target="_blank">
-                                                            @delivery.Id
-                                                    </a>
-                                                </span>
-                                                }
-                                        </td>
-                                        <td>
-                                            <span>@delivery.Type</span>
-                                        </td>
-                                        <td>
-                                            <span class="text-break" data-bs-toggle="tooltip" title="@delivery.PayloadUrl" style="cursor: pointer;">
-                                                <span style="max-width: 250px;">@delivery.PayloadUrl</span>
-                                            </span>
-                                        </td>
-                                        <td>
-                                            @{
-                                                var timeDiff = delivery.DeliveryTime - delivery.Time;
-                                                var hasSignificantDelay = Math.Abs(timeDiff.TotalMinutes) > 2;
-                                            }
-                                            <span>
-                                                <span class="webhook-time" data-bs-html="true" data-bs-toggle="tooltip">
-                                                    <template class="webhook-time-tooltip">
-                                                        <div class="text-start">
-                                                            <span><b text-translate="true">Created at</b>:&nbsp;@delivery.Time.ToBrowserDate()</span><br />
-                                                            <span><b text-translate="true">Delivered at</b>:&nbsp;@delivery.DeliveryTime.ToBrowserDate()</span>
-                                                            @if (hasSignificantDelay)
-                                                            {
-                                                                <br />
-                                                                <span><b text-translate="true">Delay</b>:&nbsp;<span>@StringLocalizer["{0} minutes", @timeDiff.TotalMinutes.ToString("F1")]</span></span>
-                                                                <br />
-                                                                <br />
-                                                                <span text-translate="true">A delay means your service either failed to process earlier deliveries or is taking too long to respond.</span>
-                                                            }
-                                                        </div>
-                                                    </template>
-
-                                                    <span class="delivery-time">@delivery.DeliveryTime.ToBrowserDate()</span>
-                                                    @if (hasSignificantDelay)
-                                                    {
-                                                        <vc:icon symbol="warning" css-class="mb-1 text-warning" />
-                                                    }
-                                                </span>
-                                            </span>
-                                        </td>
-                                        <td class="text-end">
-                                                @if (!delivery.Pruned)
-                                                {
-                                                <button id="#redeliver-@delivery.Id"
-                                                        type="submit"
-                                                        class="btn btn-link p-0 redeliver"
-                                                        text-translate="true">
-                                                    Redeliver
-                                                </button>
-                                                }
-                                        </td>
-                                        </form>
-                                    </tr>
-                                }
-                            </tbody>
-                        </table>
-                    </div>
-                </section>
-
+                <span class="inv-count">@Model.Deliveries.Count</span>
             }
-            @if ((Model.Refunds?.Count ?? 0) > 0)
-            {
-                <section class="mt-4">
-                    <h3 class="mb-3" text-translate="true">Refunds</h3>
-                    <div class="table-responsive-xl">
-                        <table class="table table-hover mb-5">
-                            <thead>
-                                <tr>
-                                    <th text-translate="true">Pull Payment</th>
-                                    <th text-translate="true">Amount</th>
-                                    <th text-translate="true">Date</th>
-                                </tr>
-                            </thead>
-                            <tbody>
-                                @foreach (var refund in Model.Refunds)
-                                {
-                                    <tr>
-
-                                        <td>
-                                            <span>
-                                                <a asp-action="ViewPullPayment" asp-controller="UIPullPayment"
-                                                   asp-route-pullPaymentId="@refund.PullPaymentDataId"
-                                                   class="delivery-content"
-                                                   target="_blank">
-                                                    @refund.PullPaymentData.Id
-                                                </a>
-                                            </span>
-                                        </td>
-                                        <td>
-											<span>@refund.PullPaymentData.Limit @refund.PullPaymentData.Currency</span>
-                                        </td>
-                                        <td>
-                                            <span>@refund.PullPaymentData.StartDate.ToBrowserDate()</span>
-                                        </td>
-                                    </tr>
-                                }
-                            </tbody>
-                        </table>
-                    </div>
-                </section>
-            }
-
-            @if (Model.Events is { Length: > 0 })
-            {
-                <section class="mt-5 d-print-none">
-                    <h3 class="mb-0" text-translate="true">Events</h3>
-                    <table class="table table-hover mt-3 mb-4">
-                        <thead>
-                            <tr>
-                                <vc:date-column></vc:date-column>
-                                <th text-translate="true">Message</th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                            @foreach (var evt in Model.Events)
-                            {
-                                var cssClass = string.IsNullOrEmpty(evt.GetCssClass()) ? null : $"text-{evt.GetCssClass()}";
-                                <tr>
-                                    <td class="@cssClass">@evt.Timestamp.ToBrowserDate()</td>
-                                    <td class="@cssClass">@evt.Message</td>
-                                </tr>
-                            }
-                        </tbody>
-                    </table>
-                </section>
-            }
+            <a class="ms-auto webhook-settings-link" asp-area="@BTCPayServer.Plugins.Webhooks.WebhooksPlugin.Area" asp-controller="UIStoreWebhooks" asp-action="Webhooks" asp-route-storeId="@Model.StoreId" permission="@Policies.CanViewStoreSettings" text-translate="true">Settings</a>
         </div>
+        @if (Model.Deliveries.Any())
+        {
+            <div class="table-responsive">
+            <table class="inv-cart inv-webhooks">
+                <thead>
+                    <tr>
+                        <th text-translate="true">Event</th>
+                        <th text-translate="true">Status</th>
+                        <th text-translate="true">Attempted</th>
+                        <th></th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @foreach (var delivery in Model.Deliveries)
+                    {
+                        var timeDiff = delivery.DeliveryTime - delivery.Time;
+                        var hasSignificantDelay = Math.Abs(timeDiff.TotalMinutes) > 2;
+                        <tr>
+                            <td>
+                                <div class="inv-webhooks__event">@delivery.Type</div>
+                                <div class="inv-webhooks__url text-secondary" title="@delivery.PayloadUrl">@delivery.PayloadUrl</div>
+                            </td>
+                            <td>
+                                @if (delivery.HttpCode is { } code)
+                                {
+                                    <span class="badge rounded-pill @(delivery.Success ? "text-bg-success" : "text-bg-danger")">@code</span>
+                                }
+                                else if (!delivery.Success)
+                                {
+                                    <span class="badge rounded-pill text-bg-danger" title="@delivery.ErrorMessage" text-translate="true">Failed</span>
+                                }
+                                @* No HTTP code means the request never completed, so the exception is
+                                   the only detail there is. *@
+                                @if (!delivery.Success && delivery.HttpCode is null && !string.IsNullOrEmpty(delivery.ErrorMessage))
+                                {
+                                    <div class="text-danger webhook-error">@delivery.ErrorMessage</div>
+                                }
+                            </td>
+                            <td class="text-nowrap">
+                                <span class="webhook-time" data-bs-html="true" data-bs-toggle="tooltip">
+                                    <template class="webhook-time-tooltip">
+                                        <div class="text-start">
+                                            <span><b text-translate="true">Created at</b>:&nbsp;@delivery.Time.ToBrowserDate()</span><br />
+                                            <span><b text-translate="true">Delivered at</b>:&nbsp;@delivery.DeliveryTime.ToBrowserDate()</span>
+                                            @if (hasSignificantDelay)
+                                            {
+                                                <br /><span><b text-translate="true">Delay</b>:&nbsp;<span>@StringLocalizer["{0} minutes", @timeDiff.TotalMinutes.ToString("F1")]</span></span>
+                                                <br /><br />
+                                                <span text-translate="true">A delay means your service either failed to process earlier deliveries or is taking too long to respond.</span>
+                                            }
+                                        </div>
+                                    </template>
+                                    <span class="delivery-time">@delivery.DeliveryTime.ToBrowserDate()</span>
+                                    @if (hasSignificantDelay)
+                                    {
+                                        <vc:icon symbol="warning" css-class="text-warning" />
+                                    }
+                                </span>
+                            </td>
+                            <td class="inv-webhooks__actions text-end text-nowrap">
+                                @if (!delivery.Pruned)
+                                {
+                                    <a class="inv-webhooks__payload" asp-action="WebhookDelivery" asp-route-invoiceId="@Model.Id" asp-route-deliveryId="@delivery.Id" target="_blank" rel="noreferrer noopener" text-translate="true">Payload</a>
+                                    @if (!delivery.Success)
+                                    {
+                                        <form asp-action="RedeliverWebhook" asp-route-storeId="@Model.StoreId" asp-route-invoiceId="@Model.Id" asp-route-deliveryId="@delivery.Id" method="post" class="d-inline">
+                                            <button type="submit" class="btn btn-link p-0 redeliver text-nowrap" text-translate="true">Redeliver</button>
+                                        </form>
+                                    }
+                                }
+                            </td>
+                        </tr>
+                    }
+                </tbody>
+            </table>
+            </div>
+        }
+        else if (!Model.StoreHasWebhooks)
+        {
+            <div class="text-secondary">
+                @ViewLocalizer["No webhooks are configured for this store, so nothing was sent. {0} to notify your systems when invoices change.",
+                    Html.ActionLink(StringLocalizer["Add one"].Value, "NewWebhook", "UIStoreWebhooks", new { area = BTCPayServer.Plugins.Webhooks.WebhooksPlugin.Area, storeId = Model.StoreId })]
+            </div>
+        }
+        else
+        {
+            <div class="text-secondary" text-translate="true">This store has webhooks, but none were sent for this invoice.</div>
+        }
     </div>
+
+    @* Receipt data and any metadata beyond the well known fields, rendered readably.
+       The raw blob below stays as the fallback for anything not covered here. *@
+    @if (Model.ReceiptData?.Any() is true)
+    {
+        <div class="inv-card mb-2 d-print-none" id="ReceiptData">
+            <div class="inv-stitle" text-translate="true">Receipt Data</div>
+            <partial name="PosData" model="(Model.ReceiptData, 1)" />
+        </div>
+    }
+
+    @if (Model.AdditionalData?.Any() is true)
+    {
+        <div class="inv-card mb-2 d-print-none" id="AdditionalData">
+            <div class="inv-stitle d-flex align-items-center gap-2">
+                <span text-translate="true">Additional Information</span>
+                <a href="https://docs.btcpayserver.org/Development/InvoiceMetadata/" target="_blank" rel="noreferrer noopener" title="@StringLocalizer["Invoice metadata documentation"]">
+                    <vc:icon symbol="info" />
+                </a>
+            </div>
+            <partial name="PosData" model="(Model.AdditionalData, 1)" />
+        </div>
+    }
+
+    @* Metadata (collapsible) *@
+    @if (Model.Metadata?.Any() is true)
+    {
+        <div class="inv-card p-0 mb-2 d-print-none" style="overflow:hidden">
+            <button class="inv-collapse-head" type="button" data-bs-toggle="collapse" data-bs-target="#Metadata" aria-expanded="false" aria-controls="Metadata">
+                <span text-translate="true">Raw metadata</span>
+                <span class="inv-count">@Model.Metadata.Count</span>
+                <span class="ms-auto"><vc:icon symbol="caret-down" /></span>
+            </button>
+            <div class="collapse" id="Metadata">
+                <pre class="font-monospace m-3 mt-0 p-3 rounded" style="background:var(--btcpay-body-bg);font-size:var(--btcpay-font-size-m)">@JsonConvert.SerializeObject(Model.Metadata, Formatting.Indented)</pre>
+            </div>
+        </div>
+    }
 </div>
-<script>
-    document.addEventListener('DOMContentLoaded', () => {
-        document.querySelectorAll(".webhook-time-tooltip").forEach(function (el) {
-            formatDateTimes(null, el.content);
-            // Somehow <time> isn't supported in tooltip... we replace it by <span>
-            el.content.querySelectorAll('time').forEach(time => {
-                var span = document.createElement('span');
-                span.innerHTML = time.innerHTML;
-                time.replaceWith(span);
-            });
-            el.parentElement.setAttribute('title', el.innerHTML);
-        });
-    });
-</script>

--- a/BTCPayServer/wwwroot/main/site.css
+++ b/BTCPayServer/wwwroot/main/site.css
@@ -153,13 +153,25 @@ a.unobtrusive-link {
 
 /* Badges */
 .badge-new,
+.badge-pending,
+.badge-expired,
+.badge-invalid,
+.badge-unusual,
+.badge-processing,
+.badge-settled {
+    border-radius: 9999px;
+    padding: .4em .9em;
+    font-weight: var(--btcpay-font-weight-semibold);
+    letter-spacing: .01em;
+}
+.badge-new,
 .badge-pending {
-    background: #d4edda;
-    color: #000;
+    background: var(--btcpay-info);
+    color: var(--btcpay-info-text);
 }
 .badge-expired {
-    background: #eee;
-    color: #000;
+    background: var(--btcpay-neutral-500);
+    color: var(--btcpay-white);
 }
 .badge-invalid {
     background: var(--btcpay-danger);
@@ -265,6 +277,291 @@ h2 .icon.icon-info {
 [class*="field-validation"]:not(:empty) {
     display: inline-block;
     margin-top: .5rem;
+}
+
+/* Invoice details view */
+.invoice-detail {
+    width: 100%;
+}
+.inv-card {
+    background: var(--btcpay-bg-tile);
+    border: 1px solid var(--btcpay-body-border-light);
+    border-radius: var(--btcpay-border-radius-l);
+    padding: var(--btcpay-space-l);
+}
+.inv-stitle {
+    display: flex;
+    align-items: center;
+    gap: var(--btcpay-space-s);
+    margin-bottom: var(--btcpay-space-m);
+    color: var(--btcpay-body-text-muted);
+    font-size: var(--btcpay-font-size-m);
+    font-weight: var(--btcpay-font-weight-semibold);
+    text-transform: uppercase;
+    letter-spacing: .08em;
+}
+.inv-id-line {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: var(--btcpay-space-s);
+    color: var(--btcpay-body-text-muted);
+    font-size: var(--btcpay-font-size-m);
+}
+.invoice-detail .truncate-center {
+    gap: var(--btcpay-space-m);
+}
+
+/* Hero */
+.inv-hero-amount {
+    font-size: 2rem;
+    font-weight: var(--btcpay-font-weight-bold);
+    line-height: 1.1;
+}
+.inv-hero-label {
+    margin-bottom: var(--btcpay-space-xs);
+    color: var(--btcpay-body-text-muted);
+    font-size: var(--btcpay-font-size-m);
+    font-weight: var(--btcpay-font-weight-semibold);
+    text-transform: uppercase;
+    letter-spacing: .08em;
+}
+
+/* Label / value rows */
+.inv-row {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    gap: var(--btcpay-space-m);
+    padding: var(--btcpay-space-s) 0;
+    border-bottom: 1px solid var(--btcpay-body-border-light);
+}
+.inv-row:last-child {
+    border-bottom: 0;
+}
+.inv-rl {
+    flex-shrink: 0;
+    color: var(--btcpay-body-text-muted);
+    font-size: var(--btcpay-font-size-m);
+}
+.inv-rv {
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    gap: var(--btcpay-space-xs);
+    min-width: 0;
+    font-size: var(--btcpay-font-size-m);
+    text-align: right;
+}
+.inv-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 0 var(--btcpay-space-xl);
+}
+@media (max-width: 640px) {
+    .inv-grid {
+        grid-template-columns: 1fr;
+    }
+}
+.inv-inset {
+    display: flex;
+    flex-direction: column;
+    gap: var(--btcpay-space-s);
+    margin-top: var(--btcpay-space-m);
+    padding: var(--btcpay-space-m);
+    background: var(--btcpay-body-bg);
+    border-radius: var(--btcpay-border-radius);
+}
+.inv-inset .inv-row {
+    padding: 0;
+    border-bottom: 0;
+}
+
+/* Flat list rows (refunds, events, deliveries) and status dots */
+.inv-flat {
+    display: flex;
+    align-items: center;
+    gap: var(--btcpay-space-m);
+    padding: var(--btcpay-space-s) var(--btcpay-space-m);
+    background: var(--btcpay-body-bg);
+    border-radius: var(--btcpay-border-radius);
+}
+.inv-dot,
+.inv-method-dot {
+    flex-shrink: 0;
+    width: 8px;
+    height: 8px;
+    border-radius: 4px;
+}
+.inv-method-dot {
+    margin-right: var(--btcpay-space-xs);
+}
+
+/* Collapsible sections */
+.inv-collapse-head {
+    width: 100%;
+    display: flex;
+    align-items: center;
+    gap: var(--btcpay-space-s);
+    padding: var(--btcpay-space-m) var(--btcpay-space-l);
+    background: none;
+    border: 0;
+    color: var(--btcpay-body-text-muted);
+    font-size: var(--btcpay-font-size-m);
+    font-weight: var(--btcpay-font-weight-semibold);
+    text-transform: uppercase;
+    letter-spacing: .08em;
+}
+.inv-collapse-head .icon {
+    --icon-size: 1.5rem;
+    transition: transform .2s ease;
+}
+.inv-collapse-head[aria-expanded="true"] .icon {
+    transform: rotate(180deg);
+}
+.inv-count {
+    padding: .1rem .55rem;
+    background: var(--btcpay-body-bg);
+    border-radius: 9999px;
+    font-size: var(--btcpay-font-size-m);
+}
+
+/* Hero payment progress bar */
+.inv-progress {
+    display: block;
+    width: 100%;
+    height: 8px;
+    background: var(--btcpay-body-border-light);
+    border-radius: 4px;
+    overflow: hidden;
+}
+.inv-progress-fill {
+    display: block;
+    height: 100%;
+    border-radius: 4px;
+}
+
+/* Contextual banner icon */
+.inv-banner-icon {
+    --icon-size: 1.5rem;
+    flex-shrink: 0;
+}
+
+/* Payments table */
+.inv-payments th,
+.inv-payments td {
+    padding-right: var(--btcpay-space-l);
+}
+.inv-payments th:last-child,
+.inv-payments td:last-child {
+    padding-left: var(--btcpay-space-m);
+    padding-right: 0;
+}
+.inv-payments .tx {
+    text-align: right;
+}
+.inv-payments tr.inv-replaced td {
+    text-decoration: line-through;
+    opacity: .6;
+}
+.inv-payments tr.inv-last-payment td {
+    border-bottom: 0;
+}
+.inv-payments .inv-row-toggle .icon {
+    --icon-size: 1.25rem;
+    transition: transform .2s ease;
+}
+.inv-payments .inv-conf-check {
+    --icon-size: 1em;
+    vertical-align: -0.125em;
+    margin-right: .15em;
+}
+.inv-payments .inv-row-toggle[aria-expanded="true"] .icon {
+    transform: rotate(180deg);
+}
+.inv-payments tr.inv-details-row td {
+    padding: 0;
+}
+.inv-payments tr.inv-details-row .inv-inset {
+    margin-top: 0;
+    margin-bottom: var(--btcpay-space-s);
+}
+
+/* Activity debug events */
+.inv-debug-toggle .when-expanded {
+    display: none;
+}
+.inv-debug-toggle[aria-expanded="true"] .when-collapsed {
+    display: none;
+}
+.inv-debug-toggle[aria-expanded="true"] .when-expanded {
+    display: inline;
+}
+.inv-debug-log {
+    gap: var(--btcpay-space-xs);
+    padding: var(--btcpay-space-s) 0 0;
+    color: var(--btcpay-body-text-muted);
+    font-family: var(--btcpay-font-monospace);
+    font-size: var(--btcpay-font-size-xs);
+}
+
+/* Confirmation progress bar */
+.conf-track {
+    display: inline-block;
+    width: 60px;
+    height: 6px;
+    background: var(--btcpay-body-border-light);
+    border-radius: 3px;
+    overflow: hidden;
+    vertical-align: middle;
+}
+.conf-fill {
+    display: block;
+    height: 100%;
+    border-radius: 3px;
+}
+
+/* Comment */
+.invoice-comment textarea {
+    max-width: 100%;
+}
+
+/* Order items table */
+.inv-cart {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: var(--btcpay-font-size-m);
+}
+.inv-cart th,
+.inv-cart td {
+    padding: var(--btcpay-space-s) 0;
+}
+.inv-cart thead th {
+    color: var(--btcpay-body-text-muted);
+    font-size: var(--btcpay-font-size-m);
+    font-weight: var(--btcpay-font-weight-semibold);
+    text-transform: uppercase;
+    letter-spacing: .06em;
+    border-bottom: 1px solid var(--btcpay-body-border-light);
+}
+.inv-cart tbody td {
+    border-bottom: 1px solid var(--btcpay-body-border-light);
+}
+.inv-cart .num {
+    text-align: right;
+    white-space: nowrap;
+}
+.inv-cart tfoot td {
+    color: var(--btcpay-body-text-muted);
+}
+.inv-cart tfoot tr:first-child td {
+    padding-top: var(--btcpay-space-m);
+}
+.inv-cart tfoot .total td {
+    padding-top: var(--btcpay-space-s);
+    color: var(--btcpay-body-text);
+    font-weight: var(--btcpay-font-weight-bold);
+    border-top: 1px solid var(--btcpay-body-border-light);
 }
 
 /* Print */

--- a/BTCPayServer/wwwroot/main/site.css
+++ b/BTCPayServer/wwwroot/main/site.css
@@ -153,13 +153,25 @@ a.unobtrusive-link {
 
 /* Badges */
 .badge-new,
+.badge-pending,
+.badge-expired,
+.badge-invalid,
+.badge-unusual,
+.badge-processing,
+.badge-settled {
+    border-radius: 9999px;
+    padding: .4em .9em;
+    font-weight: var(--btcpay-font-weight-semibold);
+    letter-spacing: .01em;
+}
+.badge-new,
 .badge-pending {
-    background: #d4edda;
-    color: #000;
+    background: var(--btcpay-info);
+    color: var(--btcpay-info-text);
 }
 .badge-expired {
-    background: #eee;
-    color: #000;
+    background: var(--btcpay-neutral-500);
+    color: var(--btcpay-white);
 }
 .badge-invalid {
     background: var(--btcpay-danger);
@@ -269,6 +281,343 @@ h2 .icon.icon-info {
 [class*="field-validation"]:not(:empty) {
     display: inline-block;
     margin-top: .5rem;
+}
+
+/* Invoice details view */
+.invoice-detail {
+    width: 100%;
+}
+.inv-card {
+    background: var(--btcpay-bg-tile);
+    border: 1px solid var(--btcpay-body-border-light);
+    border-radius: var(--btcpay-border-radius-l);
+    padding: var(--btcpay-space-l);
+}
+.inv-stitle {
+    display: flex;
+    align-items: center;
+    gap: var(--btcpay-space-s);
+    margin-bottom: var(--btcpay-space-m);
+    color: var(--btcpay-body-text-muted);
+    font-size: var(--btcpay-font-size-m);
+    font-weight: var(--btcpay-font-weight-semibold);
+    text-transform: uppercase;
+    letter-spacing: .08em;
+}
+.inv-id-line {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: var(--btcpay-space-s);
+    color: var(--btcpay-body-text-muted);
+    font-size: var(--btcpay-font-size-m);
+}
+.invoice-detail .truncate-center {
+    gap: var(--btcpay-space-m);
+}
+
+/* Hero */
+.inv-hero-amount {
+    font-size: 2rem;
+    font-weight: var(--btcpay-font-weight-bold);
+    line-height: 1.1;
+}
+.inv-hero-label {
+    margin-bottom: var(--btcpay-space-xs);
+    color: var(--btcpay-body-text-muted);
+    font-size: var(--btcpay-font-size-m);
+    font-weight: var(--btcpay-font-weight-semibold);
+    text-transform: uppercase;
+    letter-spacing: .08em;
+}
+
+/* Label / value rows */
+.inv-row {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    gap: var(--btcpay-space-m);
+    padding: var(--btcpay-space-s) 0;
+    border-bottom: 1px solid var(--btcpay-body-border-light);
+}
+.inv-row:last-child {
+    border-bottom: 0;
+}
+.inv-rl {
+    flex-shrink: 0;
+    color: var(--btcpay-body-text-muted);
+    font-size: var(--btcpay-font-size-m);
+}
+.inv-rv {
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    gap: var(--btcpay-space-xs);
+    min-width: 0;
+    font-size: var(--btcpay-font-size-m);
+    text-align: right;
+}
+.inv-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 0 var(--btcpay-space-xl);
+}
+@media (max-width: 640px) {
+    .inv-grid {
+        grid-template-columns: 1fr;
+    }
+}
+.inv-inset {
+    display: flex;
+    flex-direction: column;
+    gap: var(--btcpay-space-s);
+    margin-top: var(--btcpay-space-m);
+    padding: var(--btcpay-space-m);
+    background: var(--btcpay-body-bg);
+    border-radius: var(--btcpay-border-radius);
+}
+.inv-inset .inv-row {
+    padding: 0;
+    border-bottom: 0;
+}
+
+/* Flat list rows (refunds, events, deliveries) and status dots */
+.inv-flat {
+    display: flex;
+    align-items: center;
+    gap: var(--btcpay-space-m);
+    padding: var(--btcpay-space-s) var(--btcpay-space-m);
+    background: var(--btcpay-body-bg);
+    border-radius: var(--btcpay-border-radius);
+}
+.inv-dot,
+.inv-method-dot {
+    display: inline-block; /* width/height are ignored on an inline span outside a flex parent */
+    flex-shrink: 0;
+    width: 8px;
+    height: 8px;
+    border-radius: 4px;
+}
+.inv-method-dot {
+    margin-right: var(--btcpay-space-xs);
+}
+
+/* Collapsible sections */
+.inv-collapse-head {
+    width: 100%;
+    display: flex;
+    align-items: center;
+    gap: var(--btcpay-space-s);
+    padding: var(--btcpay-space-m) var(--btcpay-space-l);
+    background: none;
+    border: 0;
+    color: var(--btcpay-body-text-muted);
+    font-size: var(--btcpay-font-size-m);
+    font-weight: var(--btcpay-font-weight-semibold);
+    text-transform: uppercase;
+    letter-spacing: .08em;
+}
+.inv-collapse-head .icon {
+    --icon-size: 1.5rem;
+    transition: transform .2s ease;
+}
+.inv-collapse-head[aria-expanded="true"] .icon {
+    transform: rotate(180deg);
+}
+.inv-count {
+    padding: .1rem .55rem;
+    background: var(--btcpay-body-bg);
+    border-radius: 9999px;
+    font-size: var(--btcpay-font-size-m);
+}
+
+/* Hero payment progress bar */
+.inv-progress {
+    display: block;
+    width: 100%;
+    height: 8px;
+    background: var(--btcpay-body-border-light);
+    border-radius: 4px;
+    overflow: hidden;
+}
+.inv-progress-fill {
+    display: block;
+    height: 100%;
+    border-radius: 4px;
+}
+
+/* Contextual banner icon */
+.inv-banner-icon {
+    --icon-size: 1.5rem;
+    flex-shrink: 0;
+}
+
+/* Payments table */
+.inv-payments th,
+.inv-payments td {
+    padding-right: var(--btcpay-space-l);
+}
+.inv-payments th:last-child,
+.inv-payments td:last-child {
+    padding-left: var(--btcpay-space-m);
+    padding-right: 0;
+}
+.inv-payments .tx {
+    text-align: right;
+}
+.inv-payments tr.inv-replaced td {
+    text-decoration: line-through;
+    opacity: .6;
+}
+.inv-payments tr.inv-last-payment td {
+    border-bottom: 0;
+}
+.inv-payments .inv-row-toggle .icon {
+    --icon-size: 1.25rem;
+    transition: transform .2s ease;
+}
+.inv-payments .inv-conf-check {
+    --icon-size: 1em;
+    vertical-align: -0.125em;
+    margin-right: .15em;
+}
+.inv-payments .inv-row-toggle[aria-expanded="true"] .icon {
+    transform: rotate(180deg);
+}
+.inv-payments tr.inv-details-row td {
+    padding: 0;
+}
+.inv-payments tr.inv-details-row .inv-inset {
+    margin-top: 0;
+    margin-bottom: var(--btcpay-space-s);
+}
+
+/* Activity debug events */
+.inv-debug-toggle .when-expanded {
+    display: none;
+}
+.inv-debug-toggle[aria-expanded="true"] .when-collapsed {
+    display: none;
+}
+.inv-debug-toggle[aria-expanded="true"] .when-expanded {
+    display: inline;
+}
+.inv-debug-log {
+    gap: var(--btcpay-space-xs);
+    padding: var(--btcpay-space-s) 0 0;
+    color: var(--btcpay-body-text-muted);
+    font-family: var(--btcpay-font-monospace);
+    font-size: var(--btcpay-font-size-xs);
+}
+
+/* Confirmation progress bar */
+.conf-track {
+    display: inline-block;
+    width: 60px;
+    height: 6px;
+    background: var(--btcpay-body-border-light);
+    border-radius: 3px;
+    overflow: hidden;
+    vertical-align: middle;
+}
+.conf-fill {
+    display: block;
+    height: 100%;
+    border-radius: 3px;
+}
+
+/* A link sitting in a section heading should read as an action, not a second heading */
+.inv-stitle .webhook-settings-link {
+    text-transform: none;
+    letter-spacing: normal;
+    font-size: var(--btcpay-font-size-m);
+    font-weight: var(--btcpay-font-weight-normal);
+}
+
+/* Webhooks: reuses the .inv-cart table styling, so headers and row rules match the
+   other tables on the page rather than the boxed treatment in the design. */
+.inv-webhooks__event {
+    font-size: var(--btcpay-font-size-s);
+    font-weight: var(--btcpay-font-weight-semibold);
+}
+.inv-webhooks__url {
+    font-size: var(--btcpay-font-size-s);
+    max-width: 22rem;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+}
+.inv-webhooks .redeliver,
+.inv-webhooks__payload {
+    font-size: var(--btcpay-font-size-m);
+}
+.inv-webhooks__actions > * + * {
+    margin-left: var(--btcpay-space-m);
+}
+/* Inside a card the wrapper's own bottom margin doubles up with the card padding */
+.inv-card .table-responsive {
+    margin-bottom: 0;
+}
+.inv-webhooks th,
+.inv-webhooks td {
+    padding-right: var(--btcpay-space-l);
+    vertical-align: middle;
+}
+.inv-webhooks th:last-child,
+.inv-webhooks td:last-child {
+    padding-right: 0;
+}
+.inv-webhooks tbody tr:last-child td {
+    border-bottom: 0;
+}
+
+/* Comment */
+.invoice-comment__value {
+    overflow-wrap: anywhere;
+}
+.invoice-comment__toggle {
+    margin-left: var(--btcpay-space-s);
+}
+.invoice-comment__dropdown {
+    min-width: 18rem;
+}
+
+/* Order items table */
+.inv-cart {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: var(--btcpay-font-size-m);
+}
+.inv-cart th,
+.inv-cart td {
+    padding: var(--btcpay-space-s) 0;
+}
+.inv-cart thead th {
+    color: var(--btcpay-body-text-muted);
+    font-size: var(--btcpay-font-size-s);
+    font-weight: var(--btcpay-font-weight-semibold);
+    text-transform: uppercase;
+    letter-spacing: .06em;
+    border-bottom: 1px solid var(--btcpay-body-border-light);
+}
+.inv-cart tbody td {
+    border-bottom: 1px solid var(--btcpay-body-border-light);
+}
+.inv-cart .num {
+    text-align: right;
+    white-space: nowrap;
+}
+.inv-cart tfoot td {
+    color: var(--btcpay-body-text-muted);
+}
+.inv-cart tfoot tr:first-child td {
+    padding-top: var(--btcpay-space-m);
+}
+.inv-cart tfoot .total td {
+    padding-top: var(--btcpay-space-s);
+    color: var(--btcpay-body-text);
+    font-weight: var(--btcpay-font-weight-bold);
+    border-top: 1px solid var(--btcpay-body-border-light);
 }
 
 /* Print */


### PR DESCRIPTION
## Summary

Redesigns the invoice detail view (**Invoices → Invoice**) into a card based layout, reusing existing BTCPay components and theme tokens. The redesign also answers the question of why a merchant opens this page in the first place: usually because an invoice is in an unexpected state and they need enough information to decide what to do.

## Screenshots

TODO

## What the page shows

**Header and hero.** Breadcrumb, title, status and exception badges, and the actions on one row. Below that, what was paid and what is still due, with a progress bar and the network fee totalled per currency.

**Contextual banners.** Partial, overpaid, paid late and invalid states each get a short explanation with the actions that make sense for that state.

**Order summary.** For point of sale and cart invoices, an itemised table with subtotal, tax and total.

**Payments.** One row per payment with method, amount, fee, confirmations and transaction, expandable for the details. Replaced payments are struck through.

**Activity.** Lifecycle events in plain language. Debug entries stay collapsed behind a toggle that says how many are hidden. Anything logged as a warning or an error is always shown, never collapsed.

**Invoice info and buyer.** All the well known metadata fields, including tax, tax on tip and whether the order is physical. Order Id links to the external system when an order URL is present. The comment sits here as a row with an inline editor.

**Receipt data and additional information.** Anything in the metadata beyond the well known fields, rendered as a readable table, with the raw JSON kept as a fallback.

**Webhooks.** Every delivery with its event, HTTP status code, time, a link to the exact payload that was sent, and a redeliver action on failures. The section is always shown, so an empty state can say whether nothing was sent because nothing is configured, or because this invoice simply did not trigger anything.

## Partial payments on an expired invoice

Previously the page told the merchant to send the payer an updated link no matter what state the invoice was in. Once an invoice expires that link is a dead end, so the advice was wrong exactly when it mattered.

The banner now distinguishes three cases:

* Still live: send the payer the link for the remainder.
* Expired but still monitored: payments are still detected until the monitoring date, which is now shown, so the link still works.
* Expired and no longer monitored: the link will not credit anything, and the message says so.

There is also a **Charge remainder** action. It opens the invoice form prefilled with the outstanding amount, the same currency and the same Order Id, with the original invoice recorded in the metadata. The customer pays the difference, no refund is needed, and both invoices reconcile against one order. **Issue refund** is offered alongside it for merchants who would rather return the partial payment.

## Notes for reviewers

* `HttpCode` was already stored on webhook deliveries but not exposed to the view. It is now on the delivery view model, so the status column shows the real code rather than just success or failure.
* The invoice creation page previously ignored everything except the store id, so it could not be prefilled. It now accepts an amount, currency, order id and source invoice id, which is what Charge remainder uses.
* The comment uses the same markup and classes as the pattern merged in #7464, so the existing browser test continues to drive it.

## Not included

* Automatic webhook retries are saved as separate deliveries and are not counted, so the status column shows the HTTP code without a retry position.
