### PR TITLE
Fix missing Bootstrap styles in RTL layouts

### DIFF
--- a/BTCPayServer.Tests/StaticAssetTests.cs
+++ b/BTCPayServer.Tests/StaticAssetTests.cs
@@ -1,0 +1,34 @@
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace BTCPayServer.Tests;
+
+public class StaticAssetTests
+{
+    [Fact]
+    [Trait("Unit", "Unit")]
+    public void RtlStylesheetReferencesExist()
+    {
+        var solutionDirectory = TestUtils.TryGetSolutionDirectoryInfo();
+        var serverDirectory = Path.Combine(solutionDirectory.FullName, "BTCPayServer");
+        var viewsDirectory = Path.Combine(serverDirectory, "Views");
+        var webRootDirectory = Path.Combine(serverDirectory, "wwwroot");
+        var stylesheetPattern = new Regex("href=\"~/(?<path>[^\"]+\\.rtl\\.css)\"");
+
+        var references = Directory
+            .EnumerateFiles(viewsDirectory, "*.cshtml", SearchOption.AllDirectories)
+            .SelectMany(file => stylesheetPattern.Matches(File.ReadAllText(file))
+                .Select(match => (View: file, Asset: match.Groups["path"].Value)))
+            .ToArray();
+
+        Assert.NotEmpty(references);
+        foreach (var reference in references)
+        {
+            Assert.True(
+                File.Exists(Path.Combine(webRootDirectory, reference.Asset)),
+                $"{Path.GetRelativePath(solutionDirectory.FullName, reference.View)} references missing static asset /{reference.Asset}");
+        }
+    }
+}

--- a/BTCPayServer/Views/Shared/LayoutHead.cshtml
+++ b/BTCPayServer/Views/Shared/LayoutHead.cshtml
@@ -26,7 +26,7 @@
 }
 @if (isRtl)
 {
-    <link href="~/main/rtl/bootstrap.rtl.css" asp-append-version="true"  rel="stylesheet" />
+    <link href="~/main/bootstrap/bootstrap.rtl.css" asp-append-version="true"  rel="stylesheet" />
     <link href="~/main/rtl/layout.rtl.css" asp-append-version="true"  rel="stylesheet" />
     <link href="~/main/rtl/site.rtl.css" asp-append-version="true"  rel="stylesheet" />
     <link href="~/main/rtl.css" asp-append-version="true" rel="stylesheet" />

--- a/BTCPayServer/Views/UIInvoice/InvoiceReceiptPrint.cshtml
+++ b/BTCPayServer/Views/UIInvoice/InvoiceReceiptPrint.cshtml
@@ -23,7 +23,7 @@
     @* CSS *@
     @if (isRtl)
     {
-        <link href="~/main/rtl/bootstrap.rtl.css" asp-append-version="true" rel="stylesheet" />
+        <link href="~/main/bootstrap/bootstrap.rtl.css" asp-append-version="true" rel="stylesheet" />
         <link href="~/main/fonts/OpenSans.css" asp-append-version="true" rel="stylesheet" />
         <link href="~/main/rtl/layout.rtl.css" asp-append-version="true" rel="stylesheet" />
         <link href="~/main/rtl/site.rtl.css" asp-append-version="true" rel="stylesheet" />


### PR DESCRIPTION
## Summary

- load the committed Bootstrap RTL bundle from its actual static asset path
- fix both the shared layout and printable invoice receipt
- add a regression test that verifies every RTL stylesheet referenced by Razor views exists under `wwwroot`

## Cause

The RTL support merged in #7428 referenced `/main/rtl/bootstrap.rtl.css`, while the asset was committed as `/main/bootstrap/bootstrap.rtl.css`. The resulting 404 left the generated RTL layout overrides without their Bootstrap base and broke the Arabic UI layout.

## Tests

- RTL static-asset regression test: passed
- Full `BTCPayServer.Tests` run: project compiled; 233 passed and 59 failed before exit 137. The failures were environmental, primarily missing Playwright Chromium, plus an altcoin synchronization timeout.
