### PR TITLE
fix bootstrap RTL CSS links in layouts

### DIFF
--- a/BTCPayServer/Views/Shared/LayoutHead.cshtml
+++ b/BTCPayServer/Views/Shared/LayoutHead.cshtml
@@ -26,7 +26,7 @@
 }
 @if (isRtl)
 {
-    <link href="~/main/rtl/bootstrap.rtl.css" asp-append-version="true"  rel="stylesheet" />
+    <link href="~/main/bootstrap/bootstrap.rtl.css" asp-append-version="true"  rel="stylesheet" />
     <link href="~/main/rtl/layout.rtl.css" asp-append-version="true"  rel="stylesheet" />
     <link href="~/main/rtl/site.rtl.css" asp-append-version="true"  rel="stylesheet" />
     <link href="~/main/rtl.css" asp-append-version="true" rel="stylesheet" />

--- a/BTCPayServer/Views/UIInvoice/InvoiceReceiptPrint.cshtml
+++ b/BTCPayServer/Views/UIInvoice/InvoiceReceiptPrint.cshtml
@@ -23,7 +23,7 @@
     @* CSS *@
     @if (isRtl)
     {
-        <link href="~/main/rtl/bootstrap.rtl.css" asp-append-version="true" rel="stylesheet" />
+        <link href="~/main/bootstrap/bootstrap.rtl.css" asp-append-version="true" rel="stylesheet" />
         <link href="~/main/fonts/OpenSans.css" asp-append-version="true" rel="stylesheet" />
         <link href="~/main/rtl/layout.rtl.css" asp-append-version="true" rel="stylesheet" />
         <link href="~/main/rtl/site.rtl.css" asp-append-version="true" rel="stylesheet" />


### PR DESCRIPTION
## Fix Summary

Fix both the shared layout and printable invoice receipt

## Cause

The RTL support merged in https://github.com/btcpayserver/btcpayserver/pull/7428 referenced /main/rtl/bootstrap.rtl.css, while the asset was committed as /main/bootstrap/bootstrap.rtl.css. The resulting 404 left the generated RTL layout overrides without their Bootstrap base and broke the Arabic UI layout.

cc : @pavlenex 