### PR TITLE
Handle reused payment destinations without failing invoice creation

### DIFF
--- a/BTCPayServer.Tests/UnitTest1.cs
+++ b/BTCPayServer.Tests/UnitTest1.cs
@@ -1275,6 +1275,80 @@ namespace BTCPayServer.Tests
         [Fact]
         [Trait("Lightning", "Lightning")]
         [Trait("Integration", "Integration")]
+        public async Task CanCreateInvoiceWhenOnChainDestinationIsAlreadyTracked()
+        {
+            using var tester = CreateServerTester();
+            tester.ActivateLightning();
+            await tester.StartAsync();
+            var user = tester.NewAccount();
+            await user.GrantAccessAsync(true);
+            await user.RegisterDerivationSchemeAsync("BTC");
+            await user.RegisterLightningNodeAsync("BTC");
+
+            var client = await user.CreateClient();
+            var onChainPaymentMethod = PaymentTypes.CHAIN.GetPaymentMethodId("BTC").ToString();
+            var lightningPaymentMethod = PaymentTypes.LN.GetPaymentMethodId("BTC").ToString();
+
+            foreach (var lazy in new[] { true, false })
+            {
+                TestLogs.LogInformation($"Testing with lazy: {lazy}");
+                Task<BTCPayServer.Client.Models.InvoiceData> CreateInvoice()
+                {
+                    return client.CreateInvoice(user.StoreId, new CreateInvoiceRequest
+                    {
+                        Amount = 1m,
+                        Currency = "USD",
+                        Checkout = new CreateInvoiceRequest.CheckoutOptions
+                        {
+                            PaymentMethods = new[] { onChainPaymentMethod, lightningPaymentMethod },
+                            LazyPaymentMethods = lazy
+                        }
+                    });
+                }
+
+                var firstInvoice = await CreateInvoice();
+                if (lazy)
+                    await client.ActivateInvoicePaymentMethod(firstInvoice.Id, "BTC");
+                var firstPaymentMethods = await client.GetInvoicePaymentMethods(firstInvoice.Id);
+                Assert.Equal(
+                    new[] { onChainPaymentMethod, lightningPaymentMethod }.OrderBy(method => method),
+                    firstPaymentMethods.Select(method => method.PaymentMethodId).OrderBy(method => method));
+                var firstOnChainPaymentMethod = Assert.Single(firstPaymentMethods,
+                    method => method.PaymentMethodId == onChainPaymentMethod);
+                Assert.Single(firstPaymentMethods, method => method.PaymentMethodId == lightningPaymentMethod);
+
+                var keyPath = KeyPath.Parse(firstOnChainPaymentMethod.AdditionalData["keyPath"].Value<string>());
+                await tester.ExplorerClient.CancelReservationAsync(user.DerivationScheme, new[] { keyPath });
+
+                var secondInvoice = await CreateInvoice();
+                if (lazy)
+                    await client.ActivateInvoicePaymentMethod(secondInvoice.Id, "BTC");
+                var secondPaymentMethods = await client.GetInvoicePaymentMethods(secondInvoice.Id);
+
+                if (lazy)
+                {
+                    var btc = secondPaymentMethods.First(s => s.PaymentMethodId == "BTC-CHAIN");
+                    Assert.Null(btc.Destination);
+                }
+                else
+                {
+                    var remainingPaymentMethod = Assert.Single(secondPaymentMethods);
+                    Assert.Equal(lightningPaymentMethod, remainingPaymentMethod.PaymentMethodId);
+                }
+
+                await TestUtils.EventuallyAsync(async () =>
+                {
+                    var logs = await tester.PayTester.InvoiceRepository.GetInvoiceLogs(secondInvoice.Id);
+                    Assert.Contains(logs, log =>
+                        log.Severity == InvoiceEventData.EventSeverity.Error &&
+                        log.Message == $"{onChainPaymentMethod}: Destination is already tracked; disabling this payment method for the new invoice");
+                });
+            }
+        }
+
+        [Fact]
+        [Trait("Lightning", "Lightning")]
+        [Trait("Integration", "Integration")]
         public async Task CanSetPaymentMethodLimits()
         {
             using var tester = CreateServerTester();

--- a/BTCPayServer/Controllers/UIInvoiceController.cs
+++ b/BTCPayServer/Controllers/UIInvoiceController.cs
@@ -28,7 +28,9 @@ using Newtonsoft.Json.Linq;
 using StoreData = BTCPayServer.Data.StoreData;
 using BTCPayServer.Payouts;
 using BTCPayServer.Plugins.Webhooks;
+using Dapper;
 using Microsoft.AspNetCore.Mvc.Localization;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Localization;
 
 namespace BTCPayServer.Controllers
@@ -237,7 +239,7 @@ namespace BTCPayServer.Controllers
             entity.UpdateTotals();
 
 
-            var creationContext = new InvoiceCreationContext(store, storeBlob, entity, logs, _handlers, invoicePaymentMethodFilter);
+            var creationContext = new InvoiceCreationContext(store, storeBlob, entity, logs, _handlers, invoicePaymentMethodFilter, _InvoiceRepository);
             creationContext.SetLazyActivation(entity.LazyPaymentMethods);
             foreach (var term in additionalSearchTerms ?? Array.Empty<string>())
                 creationContext.AdditionalSearchTerms.Add(term);
@@ -248,6 +250,7 @@ namespace BTCPayServer.Controllers
                 await FetchRates(creationContext, cancellationToken);
 
                 await creationContext.CreatePaymentPrompts();
+
                 var contexts = creationContext.PaymentMethodContexts
                                               .Where(s => s.Value.Status is PaymentMethodContext.ContextStatus.WaitingForActivation or PaymentMethodContext.ContextStatus.Created)
                                               .Select(s => s.Value)

--- a/BTCPayServer/Payments/IPaymentMethodHandler.cs
+++ b/BTCPayServer/Payments/IPaymentMethodHandler.cs
@@ -11,8 +11,10 @@ using BTCPayServer.Logging;
 using BTCPayServer.Rating;
 using BTCPayServer.Services.Invoices;
 using BTCPayServer.Services.Rates;
+using Dapper;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.EntityFrameworkCore;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
@@ -99,11 +101,12 @@ namespace BTCPayServer.Payments
 
     public class InvoiceCreationContext
     {
-        public InvoiceCreationContext(Data.StoreData store, Data.StoreBlob storeBlob, InvoiceEntity invoiceEntity, InvoiceLogs invoiceLogs, PaymentMethodHandlerDictionary handlers, IPaymentFilter? invoicePaymentMethodFilter)
+        public InvoiceCreationContext(Data.StoreData store, Data.StoreBlob storeBlob, InvoiceEntity invoiceEntity, InvoiceLogs invoiceLogs, PaymentMethodHandlerDictionary handlers, IPaymentFilter? invoicePaymentMethodFilter, InvoiceRepository invoiceRepository)
         {
             PaymentMethodContexts = new Dictionary<PaymentMethodId, PaymentMethodContext>();
             InvoiceEntity = invoiceEntity;
             Logs = invoiceLogs;
+            InvoiceRepository = invoiceRepository;
             StoreBlob = storeBlob;
             var excludeFilter = storeBlob.GetExcludedPaymentMethods(); // Here we can compose filters from other origin with PaymentFilter.Any()
             if (invoicePaymentMethodFilter != null)
@@ -115,7 +118,7 @@ namespace BTCPayServer.Payments
             {
                 if (!handlers.TryGetValue(paymentMethodConfig.Key, out var handler))
                     continue;
-                var ctx = new PaymentMethodContext(store, storeBlob, paymentMethodConfig.Value, handler, invoiceEntity, invoiceLogs);
+                var ctx = new PaymentMethodContext(store, storeBlob, paymentMethodConfig.Value, handler, invoiceEntity, invoiceLogs, invoiceRepository);
                 PaymentMethodContexts.Add(paymentMethodConfig.Key, ctx);
                 if (excludeFilter.Match(paymentMethodConfig.Key))
                     ctx.Status = PaymentMethodContext.ContextStatus.Excluded;
@@ -127,6 +130,7 @@ namespace BTCPayServer.Payments
         }
         public InvoiceEntity InvoiceEntity { get; }
         public InvoiceLogs Logs { get; }
+        InvoiceRepository InvoiceRepository { get; }
         public Data.StoreBlob StoreBlob { get; }
         public HashSet<string> AdditionalSearchTerms { get; set; } = new HashSet<string>();
 
@@ -140,9 +144,41 @@ namespace BTCPayServer.Payments
             return Task.WhenAll(PaymentMethodContexts.Select(c => c.Value.BeforeFetchingRates()));
         }
 
-        public Task CreatePaymentPrompts()
+        public async Task CreatePaymentPrompts()
         {
-            return Task.WhenAll(PaymentMethodContexts.Select(c => c.Value.CreatePaymentPrompt()));
+            await Task.WhenAll(PaymentMethodContexts.Select(c => c.Value.CreatePaymentPrompt(false)));
+            await CheckPaymentMethodConflicts(InvoiceEntity.Id, this.PaymentMethodContexts.Values.ToArray(), InvoiceRepository);
+        }
+
+        internal static async Task CheckPaymentMethodConflicts(string invoiceId, PaymentMethodContext[] contexts, InvoiceRepository invoiceRepository)
+        {
+            var tracked = contexts
+                .SelectMany(c => c.TrackedDestinations.Select(d => (pmi: c.PaymentMethodId, dest: d)))
+                .ToArray();
+            var pmis = tracked.Select(t => t.pmi.ToString()).ToList();
+            var addrs = tracked.Select(t => t.dest).ToList();
+
+            await using var ctx = invoiceRepository.DbContextFactory.CreateContext();
+            var conflicts = (await ctx.Database.GetDbConnection()
+                    .QueryAsync<string>("""
+                                        SELECT "PaymentMethodId" FROM "AddressInvoices"
+                                        JOIN unnest(@pmis, @addrs) AS t(pmi, addr)
+                                        ON t.pmi = "PaymentMethodId" AND t.addr = "Address"
+                                        WHERE "InvoiceDataId" != @invoiceId
+                                        GROUP BY 1
+                                        """, new { pmis, addrs, invoiceId }))
+                .ToHashSet();
+            if (conflicts.Count != 0)
+            {
+                foreach (var context in contexts.Where(p => conflicts.Contains(p.PaymentMethodId.ToString())))
+                {
+                    context.Logs.Write(
+                        "Destination is already tracked; disabling this payment method for the new invoice",
+                        InvoiceEventData.EventSeverity.Error);
+                    context.Status = PaymentMethodContext.ContextStatus.Failed;
+                }
+
+            }
         }
 
         public HashSet<CurrencyPair> GetCurrenciesToFetch()
@@ -258,6 +294,7 @@ namespace BTCPayServer.Payments
             Excluded
         }
         public InvoiceEntity InvoiceEntity { get; }
+        InvoiceRepository InvoiceRepository { get; }
         public PrefixedInvoiceLogs Logs { get; }
         public PaymentMethodId PaymentMethodId { get; }
         public JToken PaymentMethodConfig { get; }
@@ -271,11 +308,13 @@ namespace BTCPayServer.Payments
             JToken paymentMethodConfig,
             IPaymentMethodHandler handler,
             InvoiceEntity invoiceEntity,
-            InvoiceLogs invoiceLogs)
+            InvoiceLogs invoiceLogs,
+            InvoiceRepository invoiceRepository)
         {
             Store = store;
             StoreBlob = storeBlob;
             InvoiceEntity = invoiceEntity;
+            InvoiceRepository = invoiceRepository;
             PaymentMethodId = handler.PaymentMethodId;
             Logs = new PrefixedInvoiceLogs(invoiceLogs, $"{PaymentMethodId}: ");
             PaymentMethodConfig = paymentMethodConfig;
@@ -329,7 +368,9 @@ namespace BTCPayServer.Payments
             return Handler.ConfigurePrompt(this);
         }
 
-        public async Task CreatePaymentPrompt()
+        public Task CreatePaymentPrompt() => CreatePaymentPrompt(true);
+
+        public async Task CreatePaymentPrompt(bool checkPaymentMethodConflicts)
         {
             if (Status != ContextStatus.WaitingForCreation)
                 return;
@@ -372,6 +413,11 @@ namespace BTCPayServer.Payments
             {
                 Status = ContextStatus.Failed;
                 return;
+            }
+
+            if (Status == ContextStatus.Created && checkPaymentMethodConflicts)
+            {
+                await InvoiceCreationContext.CheckPaymentMethodConflicts(InvoiceEntity.Id, [this], InvoiceRepository);
             }
         }
         public ContextStatus Status { get; internal set; }

--- a/BTCPayServer/Payments/Lightning/LightningListener.cs
+++ b/BTCPayServer/Payments/Lightning/LightningListener.cs
@@ -355,7 +355,7 @@ namespace BTCPayServer.Payments.Lightning
                         }
 
                         var paymentContext = new PaymentMethodContext(store, store.GetStoreBlob(),
-                            JToken.FromObject(lnConfig, _handlers.GetLightningHandler(network).Serializer), lightningHandler, invoice, logs);
+                            JToken.FromObject(lnConfig, _handlers.GetLightningHandler(network).Serializer), lightningHandler, invoice, logs, _InvoiceRepository);
                         var paymentPrompt = paymentContext.Prompt;
                         await paymentContext.BeforeFetchingRates();
                         await paymentContext.CreatePaymentPrompt();

--- a/BTCPayServer/Plugins/Bitpay/Controllers/BitpayRateController.cs
+++ b/BTCPayServer/Plugins/Bitpay/Controllers/BitpayRateController.cs
@@ -64,7 +64,7 @@ public class BitpayRateController : ControllerBase
         }
         var inv = _invoiceRepository.CreateNewInvoice(store.Id);
         inv.Currency = baseCurrency;
-        var ctx = new InvoiceCreationContext(store, store.GetStoreBlob(), inv, new Logging.InvoiceLogs(), _handlers, null);
+        var ctx = new InvoiceCreationContext(store, store.GetStoreBlob(), inv, new Logging.InvoiceLogs(), _handlers, null, _invoiceRepository);
         ctx.SetLazyActivation(true);
         await ctx.BeforeFetchingRates();
         var currencyCodes = ctx

--- a/BTCPayServer/Services/InvoiceActivator.cs
+++ b/BTCPayServer/Services/InvoiceActivator.cs
@@ -50,7 +50,7 @@ namespace BTCPayServer.Services
                 if (!_handlers.TryGetValue(paymentMethodId, out var handler))
                     return false;
                 InvoiceLogs logs = new InvoiceLogs();
-                var paymentContext = new PaymentMethodContext(store, store.GetStoreBlob(), store.GetPaymentMethodConfig(paymentMethodId), handler, invoice, logs);
+                var paymentContext = new PaymentMethodContext(store, store.GetStoreBlob(), store.GetPaymentMethodConfig(paymentMethodId), handler, invoice, logs, _invoiceRepository);
                 if (!paymentPrompt.Activated)
                     paymentContext.Logs.Write("Activating", InvoiceEventData.EventSeverity.Info);
                 try


### PR DESCRIPTION
When a payment method or plugin returns a destination that is already assigned to another invoice, invoice creation currently fails with a database constraint error and an HTTP 500 response. This is especially visible with Monero after wallet upgrades that may return a previously used address.

This change detects that conflict and disables only the affected payment method. The invoice can still be created when another payment method is available. Destination ownership is reserved atomically, so concurrent invoice creation and lazy payment-method activation cannot save a prompt that belongs to another invoice.

Lightning prompt rotation follows the same ownership rules and keeps the previous invoice usable until the replacement has been saved successfully.

Related issue: https://github.com/btcpay-monero/btcpayserver-monero-plugin/issues/57

Testing: Added coverage for sequential and concurrent destination conflicts, transaction rollback, lazy prompt activation, missing invoices, and atomic prompt updates. All 12 `DatabaseTests` pass against the current `master`.

No visual changes.