### PR TITLE
Fix pending multisig signature retries

### DIFF
--- a/BTCPayServer.Tests/MultisigTests.cs
+++ b/BTCPayServer.Tests/MultisigTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading;
@@ -260,17 +261,58 @@ public class MultisigTests(ITestOutputHelper helper) : UnitTestBase(helper)
 
     [Fact]
     [Trait("Integration", "Integration")]
+    public async Task PendingNonMultisigFinalizationFailureLogsAtDebugLevel()
+    {
+        var dbTester = CreateDBTester();
+        await dbTester.MigrateAsync();
+        var contextFactory = dbTester.CreateContextFactory();
+        var storeId = await CreateTestStore(contextFactory);
+        var logger = new RecordingLogger<PendingTransactionService>();
+        var pendingTransactionService = new PendingTransactionService(
+            CreateNetworkProvider(),
+            contextFactory,
+            new EventAggregator(BTCPayLogs),
+            logger);
+        var testPsbt = CreatePendingSingleSigPsbt();
+        var pendingTransaction = await pendingTransactionService.CreatePendingTransaction(
+            storeId,
+            "BTC",
+            testPsbt.BasePsbt,
+            RequestBaseUrl.FromUrl("https://example.com"),
+            cancellationToken: CancellationToken.None);
+
+        pendingTransaction = await pendingTransactionService.CollectSignature(
+            new PendingTransactionService.PendingTransactionFullId("BTC", storeId, pendingTransaction.Id),
+            SignInputs(testPsbt.BasePsbt, testPsbt.Signer, 0),
+            CancellationToken.None);
+
+        Assert.NotNull(pendingTransaction);
+        var blob = pendingTransaction.GetBlob();
+        Assert.Equal(0, blob.SignaturesNeeded);
+        Assert.Equal(0, blob.SignaturesCollected);
+        Assert.Equal(PendingTransactionState.Pending, pendingTransaction.State);
+        Assert.Contains(logger.Entries, entry =>
+            entry.Level == LogLevel.Debug &&
+            entry.Message.Contains(pendingTransaction.Id, StringComparison.Ordinal));
+        Assert.DoesNotContain(logger.Entries, entry =>
+            entry.Level == LogLevel.Warning &&
+            entry.Message.Contains(pendingTransaction.Id, StringComparison.Ordinal));
+    }
+
+    [Fact]
+    [Trait("Integration", "Integration")]
     public async Task PendingTwoOfFourMultisigRetainsProgressingPSBTsAndRetriesFinalization()
     {
         var dbTester = CreateDBTester();
         await dbTester.MigrateAsync();
         var contextFactory = dbTester.CreateContextFactory();
         var storeId = await CreateTestStore(contextFactory);
+        var logger = new RecordingLogger<PendingTransactionService>();
         var pendingTransactionService = new PendingTransactionService(
             CreateNetworkProvider(),
             contextFactory,
             new EventAggregator(BTCPayLogs),
-            LoggerFactory.CreateLogger<PendingTransactionService>());
+            logger);
         var testPsbt = CreatePendingMultisigPsbt(4);
         var pendingTransaction = await pendingTransactionService.CreatePendingTransaction(
             storeId,
@@ -319,15 +361,27 @@ public class MultisigTests(ITestOutputHelper helper) : UnitTestBase(helper)
         Assert.Equal(2, blob.CollectedSignatures.Count);
         Assert.Equal(2, blob.SignaturesCollected);
         Assert.Equal(PendingTransactionState.Pending, pendingTransaction.State);
+        Assert.Contains(logger.Entries, entry =>
+            entry.Level == LogLevel.Warning &&
+            entry.Message.Contains(pendingTransaction.Id, StringComparison.Ordinal));
 
-        // A third eligible signer must be retained, reported as 3/4, and trigger
-        // another finalization attempt. NBitcoin can now select two valid signatures.
+        // Per-input progress must be retained even while the aggregate remains at two.
         pendingTransaction = await pendingTransactionService.CollectSignature(
             pendingTransactionId,
-            SignInputs(testPsbt.BasePsbt, testPsbt.SignerC, 0, 1),
+            SignInputs(testPsbt.BasePsbt, testPsbt.Signers[2], 0),
             CancellationToken.None);
         blob = pendingTransaction!.GetBlob();
         Assert.Equal(3, blob.CollectedSignatures.Count);
+        Assert.Equal(2, blob.SignaturesCollected);
+        Assert.Equal(PendingTransactionState.Pending, pendingTransaction.State);
+
+        // Once the third signer reaches the second input, NBitcoin can select two valid signatures.
+        pendingTransaction = await pendingTransactionService.CollectSignature(
+            pendingTransactionId,
+            SignInputs(testPsbt.BasePsbt, testPsbt.Signers[2], 1),
+            CancellationToken.None);
+        blob = pendingTransaction!.GetBlob();
+        Assert.Equal(4, blob.CollectedSignatures.Count);
         Assert.Equal(3, blob.SignaturesCollected);
         Assert.Equal(PendingTransactionState.Signed, pendingTransaction.State);
     }
@@ -824,6 +878,28 @@ public class MultisigTests(ITestOutputHelper helper) : UnitTestBase(helper)
         return psbt.ToBase64();
     }
 
+    private static (PSBT BasePsbt, Key Signer) CreatePendingSingleSigPsbt()
+    {
+        var network = Network.RegTest;
+        var signer = new Key();
+        var scriptPubKey = signer.PubKey.WitHash.ScriptPubKey;
+
+        var previousTransactionA = network.CreateTransaction();
+        previousTransactionA.Outputs.Add(Money.Coins(1.0m), scriptPubKey);
+        var previousTransactionB = network.CreateTransaction();
+        previousTransactionB.Outputs.Add(Money.Coins(1.1m), scriptPubKey);
+
+        var builder = network.CreateTransactionBuilder();
+        builder.AddCoins(
+            previousTransactionA.Outputs.AsCoins().First(),
+            previousTransactionB.Outputs.AsCoins().First());
+        builder.Send(new Key().PubKey.WitHash.ScriptPubKey, Money.Coins(1.5m));
+        builder.SetChange(new Key().PubKey.WitHash.ScriptPubKey);
+        builder.SendFees(Money.Satoshis(10_000));
+
+        return (builder.BuildPSBT(false), signer);
+    }
+
     private static TestPendingMultisigPsbt CreatePendingMultisigPsbt(int signerCount = 3)
     {
         if (signerCount < 2)
@@ -898,10 +974,34 @@ public class MultisigTests(ITestOutputHelper helper) : UnitTestBase(helper)
         return new StoreRepository(contextFactory, new JsonSerializerSettings(), eventAggregator, settingsRepository);
     }
 
+    private sealed class RecordingLogger<T> : ILogger<T>
+    {
+        public List<(LogLevel Level, string Message)> Entries { get; } = [];
+
+        public IDisposable BeginScope<TState>(TState state)
+        {
+            return null;
+        }
+
+        public bool IsEnabled(LogLevel logLevel)
+        {
+            return true;
+        }
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception exception,
+            Func<TState, Exception, string> formatter)
+        {
+            Entries.Add((logLevel, formatter(state, exception)));
+        }
+    }
+
     private sealed record TestPendingMultisigPsbt(PSBT BasePsbt, Key[] Signers)
     {
         public Key SignerA => Signers[0];
         public Key SignerB => Signers[1];
-        public Key SignerC => Signers[2];
     }
 }

--- a/BTCPayServer.Tests/MultisigTests.cs
+++ b/BTCPayServer.Tests/MultisigTests.cs
@@ -122,10 +122,10 @@ public class MultisigTests(ITestOutputHelper helper) : UnitTestBase(helper)
             signerAPartial,
             CancellationToken.None);
         blob = pendingTransaction!.GetBlob();
-        Assert.Equal(2, blob.CollectedSignatures.Count);
+        Assert.Single(blob.CollectedSignatures);
         Assert.Equal(1, blob.SignaturesCollected);
         Assert.Equal(PendingTransactionState.Pending, pendingTransaction.State);
-        Assert.Equal(2, signatureCollectedEvents);
+        Assert.Equal(1, signatureCollectedEvents);
 
         var signerBFirstInput = SignInputs(testPsbt.BasePsbt, testPsbt.SignerB, 0);
         pendingTransaction = await pendingTransactionService.CollectSignature(
@@ -133,10 +133,10 @@ public class MultisigTests(ITestOutputHelper helper) : UnitTestBase(helper)
             signerBFirstInput,
             CancellationToken.None);
         blob = pendingTransaction!.GetBlob();
-        Assert.Equal(3, blob.CollectedSignatures.Count);
+        Assert.Equal(2, blob.CollectedSignatures.Count);
         Assert.Equal(1, blob.SignaturesCollected);
         Assert.Equal(PendingTransactionState.Pending, pendingTransaction.State);
-        Assert.Equal(3, signatureCollectedEvents);
+        Assert.Equal(2, signatureCollectedEvents);
 
         var signerBSecondInput = SignInputs(testPsbt.BasePsbt, testPsbt.SignerB, 1);
         pendingTransaction = await pendingTransactionService.CollectSignature(
@@ -144,11 +144,11 @@ public class MultisigTests(ITestOutputHelper helper) : UnitTestBase(helper)
             signerBSecondInput,
             CancellationToken.None);
         blob = pendingTransaction!.GetBlob();
-        Assert.Equal(4, blob.CollectedSignatures.Count);
+        Assert.Equal(3, blob.CollectedSignatures.Count);
         Assert.Equal(2, blob.SignaturesCollected);
         Assert.Equal(0, Math.Max(0, (blob.SignaturesNeeded ?? 0) - (blob.SignaturesCollected ?? 0)));
         Assert.Equal(PendingTransactionState.Signed, pendingTransaction.State);
-        Assert.Equal(4, signatureCollectedEvents);
+        Assert.Equal(3, signatureCollectedEvents);
 
         var secondPendingTransaction = await pendingTransactionService.CreatePendingTransaction(
             storeId,
@@ -260,7 +260,7 @@ public class MultisigTests(ITestOutputHelper helper) : UnitTestBase(helper)
 
     [Fact]
     [Trait("Integration", "Integration")]
-    public async Task PendingTwoOfFourMultisigRetainsDistinctPSBTsAndRetriesFinalization()
+    public async Task PendingTwoOfFourMultisigRetainsProgressingPSBTsAndRetriesFinalization()
     {
         var dbTester = CreateDBTester();
         await dbTester.MigrateAsync();
@@ -287,23 +287,24 @@ public class MultisigTests(ITestOutputHelper helper) : UnitTestBase(helper)
             signerAAllInputs,
             CancellationToken.None);
 
-        // This PSBT is distinct, but adds no signature progress. Retain it and retry finalization anyway.
+        // This PSBT is distinct, but adds no signature progress. Retry finalization without retaining it.
         var signerAFirstInput = SignInputs(testPsbt.BasePsbt, testPsbt.SignerA, 0);
         pendingTransaction = await pendingTransactionService.CollectSignature(
             pendingTransactionId,
             signerAFirstInput,
             CancellationToken.None);
         var blob = pendingTransaction!.GetBlob();
-        Assert.Equal(2, blob.CollectedSignatures.Count);
+        Assert.Single(blob.CollectedSignatures);
         Assert.Equal(1, blob.SignaturesCollected);
 
-        // Repeating the exact same PSBT is still ignored.
+        // Another distinct, non-progressing PSBT must not grow the retained history either.
+        var signerASecondInput = SignInputs(testPsbt.BasePsbt, testPsbt.SignerA, 1);
         pendingTransaction = await pendingTransactionService.CollectSignature(
             pendingTransactionId,
-            signerAFirstInput,
+            signerASecondInput,
             CancellationToken.None);
         blob = pendingTransaction!.GetBlob();
-        Assert.Equal(2, blob.CollectedSignatures.Count);
+        Assert.Single(blob.CollectedSignatures);
 
         // Simulate the reported 2/4 Pending state: the second signature claims an eligible
         // pubkey, but its signature cannot finalize the transaction.
@@ -315,6 +316,7 @@ public class MultisigTests(ITestOutputHelper helper) : UnitTestBase(helper)
             invalidFourthSigner,
             CancellationToken.None);
         blob = pendingTransaction!.GetBlob();
+        Assert.Equal(2, blob.CollectedSignatures.Count);
         Assert.Equal(2, blob.SignaturesCollected);
         Assert.Equal(PendingTransactionState.Pending, pendingTransaction.State);
 
@@ -325,7 +327,7 @@ public class MultisigTests(ITestOutputHelper helper) : UnitTestBase(helper)
             SignInputs(testPsbt.BasePsbt, testPsbt.SignerC, 0, 1),
             CancellationToken.None);
         blob = pendingTransaction!.GetBlob();
-        Assert.Equal(4, blob.CollectedSignatures.Count);
+        Assert.Equal(3, blob.CollectedSignatures.Count);
         Assert.Equal(3, blob.SignaturesCollected);
         Assert.Equal(PendingTransactionState.Signed, pendingTransaction.State);
     }

--- a/BTCPayServer.Tests/MultisigTests.cs
+++ b/BTCPayServer.Tests/MultisigTests.cs
@@ -122,10 +122,10 @@ public class MultisigTests(ITestOutputHelper helper) : UnitTestBase(helper)
             signerAPartial,
             CancellationToken.None);
         blob = pendingTransaction!.GetBlob();
-        Assert.Single(blob.CollectedSignatures);
+        Assert.Equal(2, blob.CollectedSignatures.Count);
         Assert.Equal(1, blob.SignaturesCollected);
         Assert.Equal(PendingTransactionState.Pending, pendingTransaction.State);
-        Assert.Equal(1, signatureCollectedEvents);
+        Assert.Equal(2, signatureCollectedEvents);
 
         var signerBFirstInput = SignInputs(testPsbt.BasePsbt, testPsbt.SignerB, 0);
         pendingTransaction = await pendingTransactionService.CollectSignature(
@@ -133,10 +133,10 @@ public class MultisigTests(ITestOutputHelper helper) : UnitTestBase(helper)
             signerBFirstInput,
             CancellationToken.None);
         blob = pendingTransaction!.GetBlob();
-        Assert.Equal(2, blob.CollectedSignatures.Count);
+        Assert.Equal(3, blob.CollectedSignatures.Count);
         Assert.Equal(1, blob.SignaturesCollected);
         Assert.Equal(PendingTransactionState.Pending, pendingTransaction.State);
-        Assert.Equal(2, signatureCollectedEvents);
+        Assert.Equal(3, signatureCollectedEvents);
 
         var signerBSecondInput = SignInputs(testPsbt.BasePsbt, testPsbt.SignerB, 1);
         pendingTransaction = await pendingTransactionService.CollectSignature(
@@ -144,11 +144,11 @@ public class MultisigTests(ITestOutputHelper helper) : UnitTestBase(helper)
             signerBSecondInput,
             CancellationToken.None);
         blob = pendingTransaction!.GetBlob();
-        Assert.Equal(3, blob.CollectedSignatures.Count);
+        Assert.Equal(4, blob.CollectedSignatures.Count);
         Assert.Equal(2, blob.SignaturesCollected);
         Assert.Equal(0, Math.Max(0, (blob.SignaturesNeeded ?? 0) - (blob.SignaturesCollected ?? 0)));
         Assert.Equal(PendingTransactionState.Signed, pendingTransaction.State);
-        Assert.Equal(3, signatureCollectedEvents);
+        Assert.Equal(4, signatureCollectedEvents);
 
         var secondPendingTransaction = await pendingTransactionService.CreatePendingTransaction(
             storeId,
@@ -256,6 +256,78 @@ public class MultisigTests(ITestOutputHelper helper) : UnitTestBase(helper)
         Assert.Equal(2, blob.SignaturesNeeded);
         Assert.Equal(3, blob.SignaturesTotal);
         Assert.Equal(1, blob.SignaturesCollected);
+    }
+
+    [Fact]
+    [Trait("Integration", "Integration")]
+    public async Task PendingTwoOfFourMultisigRetainsDistinctPSBTsAndRetriesFinalization()
+    {
+        var dbTester = CreateDBTester();
+        await dbTester.MigrateAsync();
+        var contextFactory = dbTester.CreateContextFactory();
+        var storeId = await CreateTestStore(contextFactory);
+        var pendingTransactionService = new PendingTransactionService(
+            CreateNetworkProvider(),
+            contextFactory,
+            new EventAggregator(BTCPayLogs),
+            LoggerFactory.CreateLogger<PendingTransactionService>());
+        var testPsbt = CreatePendingMultisigPsbt(4);
+        var pendingTransaction = await pendingTransactionService.CreatePendingTransaction(
+            storeId,
+            "BTC",
+            testPsbt.BasePsbt,
+            RequestBaseUrl.FromUrl("https://example.com"),
+            cancellationToken: CancellationToken.None);
+        var pendingTransactionId =
+            new PendingTransactionService.PendingTransactionFullId("BTC", storeId, pendingTransaction.Id);
+
+        var signerAAllInputs = SignInputs(testPsbt.BasePsbt, testPsbt.SignerA, 0, 1);
+        pendingTransaction = await pendingTransactionService.CollectSignature(
+            pendingTransactionId,
+            signerAAllInputs,
+            CancellationToken.None);
+
+        // This PSBT is distinct, but adds no signature progress. Retain it and retry finalization anyway.
+        var signerAFirstInput = SignInputs(testPsbt.BasePsbt, testPsbt.SignerA, 0);
+        pendingTransaction = await pendingTransactionService.CollectSignature(
+            pendingTransactionId,
+            signerAFirstInput,
+            CancellationToken.None);
+        var blob = pendingTransaction!.GetBlob();
+        Assert.Equal(2, blob.CollectedSignatures.Count);
+        Assert.Equal(1, blob.SignaturesCollected);
+
+        // Repeating the exact same PSBT is still ignored.
+        pendingTransaction = await pendingTransactionService.CollectSignature(
+            pendingTransactionId,
+            signerAFirstInput,
+            CancellationToken.None);
+        blob = pendingTransaction!.GetBlob();
+        Assert.Equal(2, blob.CollectedSignatures.Count);
+
+        // Simulate the reported 2/4 Pending state: the second signature claims an eligible
+        // pubkey, but its signature cannot finalize the transaction.
+        var invalidFourthSigner = InvalidateAndReassignSignatures(
+            SignInputs(testPsbt.BasePsbt, testPsbt.SignerB, 0, 1),
+            testPsbt.Signers[3].PubKey);
+        pendingTransaction = await pendingTransactionService.CollectSignature(
+            pendingTransactionId,
+            invalidFourthSigner,
+            CancellationToken.None);
+        blob = pendingTransaction!.GetBlob();
+        Assert.Equal(2, blob.SignaturesCollected);
+        Assert.Equal(PendingTransactionState.Pending, pendingTransaction.State);
+
+        // A third eligible signer must be retained, reported as 3/4, and trigger
+        // another finalization attempt. NBitcoin can now select two valid signatures.
+        pendingTransaction = await pendingTransactionService.CollectSignature(
+            pendingTransactionId,
+            SignInputs(testPsbt.BasePsbt, testPsbt.SignerC, 0, 1),
+            CancellationToken.None);
+        blob = pendingTransaction!.GetBlob();
+        Assert.Equal(4, blob.CollectedSignatures.Count);
+        Assert.Equal(3, blob.SignaturesCollected);
+        Assert.Equal(PendingTransactionState.Signed, pendingTransaction.State);
     }
 
     [Fact]
@@ -750,13 +822,16 @@ public class MultisigTests(ITestOutputHelper helper) : UnitTestBase(helper)
         return psbt.ToBase64();
     }
 
-    private static TestPendingMultisigPsbt CreatePendingMultisigPsbt()
+    private static TestPendingMultisigPsbt CreatePendingMultisigPsbt(int signerCount = 3)
     {
+        if (signerCount < 2)
+            throw new ArgumentOutOfRangeException(nameof(signerCount));
+
         var network = Network.RegTest;
-        var signerA = new Key();
-        var signerB = new Key();
-        var signerC = new Key();
-        var witnessScript = PayToMultiSigTemplate.Instance.GenerateScriptPubKey(2, signerA.PubKey, signerB.PubKey, signerC.PubKey);
+        var signers = Enumerable.Range(0, signerCount).Select(_ => new Key()).ToArray();
+        var witnessScript = PayToMultiSigTemplate.Instance.GenerateScriptPubKey(
+            2,
+            signers.Select(signer => signer.PubKey).ToArray());
         var scriptPubKey = witnessScript.WitHash.ScriptPubKey;
 
         var previousTransactionA = network.CreateTransaction();
@@ -772,7 +847,7 @@ public class MultisigTests(ITestOutputHelper helper) : UnitTestBase(helper)
         builder.SetChange(new Key().PubKey.WitHash.ScriptPubKey);
         builder.SendFees(Money.Satoshis(10_000));
 
-        return new TestPendingMultisigPsbt(builder.BuildPSBT(false), signerA, signerB, signerC);
+        return new TestPendingMultisigPsbt(builder.BuildPSBT(false), signers);
     }
 
     private static PSBT SignInputs(PSBT basePsbt, Key signer, params int[] inputIndexes)
@@ -781,6 +856,19 @@ public class MultisigTests(ITestOutputHelper helper) : UnitTestBase(helper)
         foreach (var inputIndex in inputIndexes)
         {
             psbt.Inputs[inputIndex].Sign(signer);
+        }
+
+        return psbt;
+    }
+
+    private static PSBT InvalidateAndReassignSignatures(PSBT psbt, PubKey claimedSigner)
+    {
+        foreach (var input in psbt.Inputs)
+        {
+            var signatureBytes = input.PartialSigs.Single().Value.ToBytes();
+            signatureBytes[10] ^= 1;
+            input.PartialSigs.Clear();
+            input.PartialSigs.Add(claimedSigner, new TransactionSignature(signatureBytes));
         }
 
         return psbt;
@@ -808,5 +896,10 @@ public class MultisigTests(ITestOutputHelper helper) : UnitTestBase(helper)
         return new StoreRepository(contextFactory, new JsonSerializerSettings(), eventAggregator, settingsRepository);
     }
 
-    private sealed record TestPendingMultisigPsbt(PSBT BasePsbt, Key SignerA, Key SignerB, Key SignerC);
+    private sealed record TestPendingMultisigPsbt(PSBT BasePsbt, Key[] Signers)
+    {
+        public Key SignerA => Signers[0];
+        public Key SignerB => Signers[1];
+        public Key SignerC => Signers[2];
+    }
 }

--- a/BTCPayServer/HostedServices/PendingTransactionService.cs
+++ b/BTCPayServer/HostedServices/PendingTransactionService.cs
@@ -236,34 +236,18 @@ public class PendingTransactionService(
         }
         else
         {
-            var failedInputIndexes = finalizationErrors is null or { Count: 0 }
-                ? "unknown"
-                : string.Join(",", finalizationErrors.Select(error => error.InputIndex).Distinct());
             var finalizationErrorDetails = FormatFinalizationErrors(finalizationErrors);
-            if ((blob.SignaturesCollected ?? 0) >= (blob.SignaturesNeeded ?? int.MaxValue))
-            {
-                logger.LogWarning(
-                    "Finalization attempt failed for pending transaction {PendingTransactionId} despite signature progress " +
-                    "{SignaturesCollected}/{SignaturesNeeded}. Failed input indexes: {FailedInputIndexes}. " +
-                    "Errors: {FinalizationErrors}",
-                    pendingTransaction.Id,
-                    blob.SignaturesCollected,
-                    blob.SignaturesNeeded,
-                    failedInputIndexes,
-                    finalizationErrorDetails);
-            }
-            else
-            {
-                logger.LogDebug(
-                    "Finalization attempt failed for pending transaction {PendingTransactionId}. Signature progress: " +
-                    "{SignaturesCollected}/{SignaturesNeeded}; failed input indexes: {FailedInputIndexes}. " +
-                    "Errors: {FinalizationErrors}",
-                    pendingTransaction.Id,
-                    blob.SignaturesCollected,
-                    blob.SignaturesNeeded,
-                    failedInputIndexes,
-                    finalizationErrorDetails);
-            }
+            var logLevel = (blob.SignaturesCollected ?? 0) >= (blob.SignaturesNeeded ?? int.MaxValue)
+                ? LogLevel.Warning
+                : LogLevel.Debug;
+            logger.Log(
+                logLevel,
+                "Finalization attempt failed for pending transaction {PendingTransactionId}. Signature progress: " +
+                "{SignaturesCollected}/{SignaturesNeeded}. Errors: {FinalizationErrors}",
+                pendingTransaction.Id,
+                blob.SignaturesCollected,
+                blob.SignaturesNeeded,
+                finalizationErrorDetails);
         }
         pendingTransaction.SetBlob(blob);
         return (pendingTransaction, retained);

--- a/BTCPayServer/HostedServices/PendingTransactionService.cs
+++ b/BTCPayServer/HostedServices/PendingTransactionService.cs
@@ -237,7 +237,9 @@ public class PendingTransactionService(
         else
         {
             var finalizationErrorDetails = FormatFinalizationErrors(finalizationErrors);
-            var logLevel = (blob.SignaturesCollected ?? 0) >= (blob.SignaturesNeeded ?? int.MaxValue)
+            var signaturesNeeded = blob.SignaturesNeeded ?? 0;
+            var logLevel = signaturesNeeded > 0 &&
+                           (blob.SignaturesCollected ?? 0) >= signaturesNeeded
                 ? LogLevel.Warning
                 : LogLevel.Debug;
             logger.Log(
@@ -358,16 +360,13 @@ public class PendingTransactionService(
         return true;
     }
 
-    private static PSBT BuildEffectivePsbt(PendingTransactionBlob blob, Network network, PSBT? additionalPsbt = null)
+    private static PSBT BuildEffectivePsbt(PendingTransactionBlob blob, Network network)
     {
         var effectivePsbt = PSBT.Parse(blob.PSBT, network);
         foreach (var collectedSignature in blob.CollectedSignatures)
         {
             effectivePsbt.Combine(PSBT.Parse(collectedSignature.ReceivedPSBT, network));
         }
-
-        if (additionalPsbt is not null)
-            effectivePsbt.Combine(additionalPsbt);
 
         return effectivePsbt;
     }

--- a/BTCPayServer/HostedServices/PendingTransactionService.cs
+++ b/BTCPayServer/HostedServices/PendingTransactionService.cs
@@ -233,25 +233,30 @@ public class PendingTransactionService(
             var failedInputIndexes = finalizationErrors is null or { Count: 0 }
                 ? "unknown"
                 : string.Join(",", finalizationErrors.Select(error => error.InputIndex).Distinct());
+            var finalizationErrorDetails = FormatFinalizationErrors(finalizationErrors);
             if ((blob.SignaturesCollected ?? 0) >= (blob.SignaturesNeeded ?? int.MaxValue))
             {
                 logger.LogWarning(
                     "Finalization attempt failed for pending transaction {PendingTransactionId} despite signature progress " +
-                    "{SignaturesCollected}/{SignaturesNeeded}. Failed input indexes: {FailedInputIndexes}",
+                    "{SignaturesCollected}/{SignaturesNeeded}. Failed input indexes: {FailedInputIndexes}. " +
+                    "Errors: {FinalizationErrors}",
                     pendingTransaction.Id,
                     blob.SignaturesCollected,
                     blob.SignaturesNeeded,
-                    failedInputIndexes);
+                    failedInputIndexes,
+                    finalizationErrorDetails);
             }
             else
             {
                 logger.LogDebug(
                     "Finalization attempt failed for pending transaction {PendingTransactionId}. Signature progress: " +
-                    "{SignaturesCollected}/{SignaturesNeeded}; failed input indexes: {FailedInputIndexes}",
+                    "{SignaturesCollected}/{SignaturesNeeded}; failed input indexes: {FailedInputIndexes}. " +
+                    "Errors: {FinalizationErrors}",
                     pendingTransaction.Id,
                     blob.SignaturesCollected,
                     blob.SignaturesNeeded,
-                    failedInputIndexes);
+                    failedInputIndexes,
+                    finalizationErrorDetails);
             }
         }
         pendingTransaction.SetBlob(blob);
@@ -444,6 +449,26 @@ public class PendingTransactionService(
         blob.SignaturesNeeded = progress.SignaturesNeeded;
         blob.SignaturesTotal = progress.SignaturesTotal;
         blob.SignaturesCollected = progress.SignaturesCollected;
+    }
+
+    private static string FormatFinalizationErrors(IList<PSBTError>? errors)
+    {
+        if (errors is null or { Count: 0 })
+            return "unknown";
+
+        const int maxErrors = 20;
+        const int maxMessageLength = 256;
+        var details = errors.Take(maxErrors).Select(error =>
+        {
+            var message = error.Message.Replace('\r', ' ').Replace('\n', ' ');
+            if (message.Length > maxMessageLength)
+                message = $"{message[..maxMessageLength]}…";
+            return $"input {error.InputIndex}: {message}";
+        });
+        var result = string.Join(" | ", details);
+        return errors.Count > maxErrors
+            ? $"{result} | {errors.Count - maxErrors} more error(s)"
+            : result;
     }
 
     private sealed record PendingTransactionSignatureProgress(

--- a/BTCPayServer/HostedServices/PendingTransactionService.cs
+++ b/BTCPayServer/HostedServices/PendingTransactionService.cs
@@ -197,28 +197,34 @@ public class PendingTransactionService(
             return (pendingTransaction, false);
         }
 
-        var beforeProgress = GetSignatureProgress(BuildEffectivePsbt(blob, network));
-        var mergedPsbt = BuildEffectivePsbt(blob, network, psbt);
+        var mergedPsbt = BuildEffectivePsbt(blob, network);
+        var beforeProgress = GetSignatureProgress(mergedPsbt);
+        mergedPsbt.Combine(psbt);
         var afterProgress = GetSignatureProgress(mergedPsbt);
         var meaningfulDelta = HasMeaningfulDelta(beforeProgress, afterProgress);
 
-        blob.CollectedSignatures.Add(new CollectedSignature
+        var finalized = mergedPsbt.TryFinalize(out var finalizationErrors);
+        var retained = meaningfulDelta || finalized;
+        if (retained)
         {
-            ReceivedPSBT = newPsbtBase64,
-            Timestamp = DateTimeOffset.UtcNow
-        });
+            blob.CollectedSignatures.Add(new CollectedSignature
+            {
+                ReceivedPSBT = newPsbtBase64,
+                Timestamp = DateTimeOffset.UtcNow
+            });
+        }
         ApplyProgress(blob, afterProgress);
 
         logger.LogInformation(
-            "Retrying finalization for pending transaction {PendingTransactionId} after collecting PSBT {CollectedPSBTCount}. " +
-            "Signature progress: {SignaturesCollected}/{SignaturesNeeded}; progress changed: {SignatureProgressChanged}",
+            "Retried finalization for pending transaction {PendingTransactionId}. Retained PSBT count: {CollectedPSBTCount}; " +
+            "signature progress: {SignaturesCollected}/{SignaturesNeeded}; PSBT retained: {PSBTRetained}",
             pendingTransaction.Id,
             blob.CollectedSignatures.Count,
             blob.SignaturesCollected,
             blob.SignaturesNeeded,
-            meaningfulDelta);
+            retained);
 
-        if (mergedPsbt.TryFinalize(out var finalizationErrors))
+        if (finalized)
         {
             if ((blob.SignaturesCollected ?? 0) < (blob.SignaturesNeeded ?? 0))
                 blob.SignaturesCollected = blob.SignaturesNeeded;
@@ -260,7 +266,7 @@ public class PendingTransactionService(
             }
         }
         pendingTransaction.SetBlob(blob);
-        return (pendingTransaction, true);
+        return (pendingTransaction, retained);
     }
 
 

--- a/BTCPayServer/HostedServices/PendingTransactionService.cs
+++ b/BTCPayServer/HostedServices/PendingTransactionService.cs
@@ -190,14 +190,17 @@ public class PendingTransactionService(
         var network = networkProvider.GetNetwork<BTCPayNetwork>(pendingTransaction.CryptoCode)?.NBitcoinNetwork ?? psbt.Network;
 
         if (blob.CollectedSignatures.Any(s => s.ReceivedPSBT == newPsbtBase64))
+        {
+            logger.LogInformation(
+                "Skipping finalization retry for pending transaction {PendingTransactionId}: this PSBT was already collected",
+                pendingTransaction.Id);
             return (pendingTransaction, false);
+        }
 
         var beforeProgress = GetSignatureProgress(BuildEffectivePsbt(blob, network));
         var mergedPsbt = BuildEffectivePsbt(blob, network, psbt);
         var afterProgress = GetSignatureProgress(mergedPsbt);
-
-        if (!HasMeaningfulDelta(beforeProgress, afterProgress))
-            return (pendingTransaction, false);
+        var meaningfulDelta = HasMeaningfulDelta(beforeProgress, afterProgress);
 
         blob.CollectedSignatures.Add(new CollectedSignature
         {
@@ -206,11 +209,50 @@ public class PendingTransactionService(
         });
         ApplyProgress(blob, afterProgress);
 
-        if (mergedPsbt.TryFinalize(out _))
+        logger.LogInformation(
+            "Retrying finalization for pending transaction {PendingTransactionId} after collecting PSBT {CollectedPSBTCount}. " +
+            "Signature progress: {SignaturesCollected}/{SignaturesNeeded}; progress changed: {SignatureProgressChanged}",
+            pendingTransaction.Id,
+            blob.CollectedSignatures.Count,
+            blob.SignaturesCollected,
+            blob.SignaturesNeeded,
+            meaningfulDelta);
+
+        if (mergedPsbt.TryFinalize(out var finalizationErrors))
         {
             if ((blob.SignaturesCollected ?? 0) < (blob.SignaturesNeeded ?? 0))
                 blob.SignaturesCollected = blob.SignaturesNeeded;
             pendingTransaction.State = PendingTransactionState.Signed;
+            logger.LogInformation(
+                "Finalized pending transaction {PendingTransactionId} after collecting PSBT {CollectedPSBTCount}",
+                pendingTransaction.Id,
+                blob.CollectedSignatures.Count);
+        }
+        else
+        {
+            var failedInputIndexes = finalizationErrors is null or { Count: 0 }
+                ? "unknown"
+                : string.Join(",", finalizationErrors.Select(error => error.InputIndex).Distinct());
+            if ((blob.SignaturesCollected ?? 0) >= (blob.SignaturesNeeded ?? int.MaxValue))
+            {
+                logger.LogWarning(
+                    "Finalization attempt failed for pending transaction {PendingTransactionId} despite signature progress " +
+                    "{SignaturesCollected}/{SignaturesNeeded}. Failed input indexes: {FailedInputIndexes}",
+                    pendingTransaction.Id,
+                    blob.SignaturesCollected,
+                    blob.SignaturesNeeded,
+                    failedInputIndexes);
+            }
+            else
+            {
+                logger.LogDebug(
+                    "Finalization attempt failed for pending transaction {PendingTransactionId}. Signature progress: " +
+                    "{SignaturesCollected}/{SignaturesNeeded}; failed input indexes: {FailedInputIndexes}",
+                    pendingTransaction.Id,
+                    blob.SignaturesCollected,
+                    blob.SignaturesNeeded,
+                    failedInputIndexes);
+            }
         }
         pendingTransaction.SetBlob(blob);
         return (pendingTransaction, true);
@@ -355,7 +397,7 @@ public class PendingTransactionService(
             var validExpectedPartialSigCount = input.PartialSigs.Keys.Count(multisigParams.PubKeys.Contains);
             var collected = finalized
                 ? multisigParams.SignatureCount
-                : Math.Min(validExpectedPartialSigCount, multisigParams.SignatureCount);
+                : validExpectedPartialSigCount;
             inputs.Add(new PendingTransactionInputProgress(
                 true,
                 multisigParams.SignatureCount,


### PR DESCRIPTION
Pre 2.4.0, each distinct signed PSBT was retained, combined, and finalization was retried.
Commit e48a8438 introduced:Math.Min(validExpectedPartialSigCount, multisigParams.SignatureCount)

For 2-of-4, adding signer three produces Math.Min(3, 2) == 2.
HasMeaningfulDelta therefore sees 2 → 2 and returns false.
The service exits before storing signer three and before retrying TryFinalize.
The record stays Pending; the UI only shows Broadcast for State == Signed.

In some cases NBitcoin finalization errors are thrown, added logging to identify exact issues with why edge cases are happening.