### PR TITLE
Add a crowdfund dashboard widget

### DIFF
--- a/BTCPayServer/Components/AppCrowdfund/AppCrowdfund.cs
+++ b/BTCPayServer/Components/AppCrowdfund/AppCrowdfund.cs
@@ -1,0 +1,138 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Threading.Tasks;
+using BTCPayServer.Client.Models;
+using BTCPayServer.Plugins.Crowdfund;
+using BTCPayServer.Plugins.Crowdfund.Models;
+using BTCPayServer.Services;
+using BTCPayServer.Services.Apps;
+using BTCPayServer.Services.Invoices;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ViewComponents;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
+using Microsoft.Extensions.Localization;
+
+namespace BTCPayServer.Components.AppCrowdfund;
+
+public class AppCrowdfund : ViewComponent
+{
+    private readonly AppService _appService;
+    private readonly InvoiceRepository _invoiceRepository;
+    private readonly DisplayFormatter _displayFormatter;
+    private readonly IStringLocalizer _localizer;
+
+    public AppCrowdfund(AppService appService, InvoiceRepository invoiceRepository, DisplayFormatter displayFormatter, IStringLocalizer stringLocalizer)
+    {
+        _appService = appService;
+        _invoiceRepository = invoiceRepository;
+        _displayFormatter = displayFormatter;
+        _localizer = stringLocalizer;
+    }
+
+    public async Task<IViewComponentResult> InvokeAsync(string appId, string appType)
+    {
+        if (appType != CrowdfundAppType.AppType)
+            return new HtmlContentViewComponentResult(new StringHtmlContent(string.Empty));
+
+        var vm = new AppCrowdfundViewModel
+        {
+            Id = appId,
+            AppType = appType,
+            DataUrl = Url.Action("AppCrowdfund", "UIApps", new { appId }),
+            InitialRendering = HttpContext.GetAppDataOrNull()?.Id != appId
+        };
+        if (vm.InitialRendering)
+            return View(vm);
+
+        var app = HttpContext.GetAppDataOrNull();
+        if (app is null || _appService.GetAppType(appType) is not CrowdfundAppType type)
+            return new HtmlContentViewComponentResult(new StringHtmlContent(string.Empty));
+
+        var cf = (ViewCrowdfundViewModel)await type.GetInfo(app);
+        var currency = cf.TargetCurrency;
+        var currentAmount = cf.Info?.CurrentAmount ?? 0m;
+        var contributions = cf.Info?.TotalContributors ?? 0;
+        var perkCount = cf.PerkCount ?? new Dictionary<string, int>();
+
+        vm.Name = app.Name;
+        vm.Tagline = string.IsNullOrWhiteSpace(cf.Tagline) ? null : cf.Tagline;
+        vm.Currency = currency;
+        vm.Recurring = !cf.NeverReset;
+        (vm.RecurrenceLabel, vm.PeriodNoun) = RecurrenceLabels(cf.ResetEvery);
+        vm.Ended = cf.Ended;
+        vm.Enabled = cf.Enabled;
+        vm.Started = cf.Started;
+        vm.HasTarget = cf.TargetAmount.HasValue;
+        vm.ProgressPercentage = cf.Info?.ProgressPercentage;
+        vm.GoalReached = (cf.Info?.ProgressPercentage ?? 0m) >= 100m;
+        vm.Contributions = contributions;
+        vm.EndDate = cf.EndDate;
+        vm.ManageUrl = await type.ConfigureLink(app);
+        vm.PublicUrl = await type.ViewLink(app);
+        vm.ReportUrl = Url.Action("StoreReports", "UIReports", new { storeId = app.StoreDataId, viewName = "Sales" });
+
+        vm.CurrentAmountFormatted = FormatAmount(currentAmount, currency);
+        vm.CurrentAmountValue = FormatAmount(currentAmount, currency, DisplayFormatter.CurrencyFormat.None);
+        if (cf.TargetAmount is decimal target)
+        {
+            vm.TargetAmountFormatted = FormatAmount(target, currency);
+            var remaining = target - currentAmount;
+            if (remaining > 0)
+                vm.RemainingFormatted = FormatAmount(remaining, currency);
+        }
+        var now = DateTime.UtcNow;
+        if (cf.EndDate is DateTime end && end > now)
+            vm.DaysLeft = (int)Math.Ceiling((end - now).TotalDays);
+        if (cf.Info?.NextResetDate is DateTime reset && reset > now)
+            vm.RenewsInDays = (int)Math.Ceiling((reset - now).TotalDays);
+
+        vm.Perks = (cf.Perks ?? Array.Empty<AppItem>())
+            .Select(p => new AppCrowdfundViewModel.PerkStat
+            {
+                Title = string.IsNullOrWhiteSpace(p.Title) ? p.Id : p.Title,
+                PriceFormatted = p.Price is decimal price ? FormatAmount(price, currency) : null,
+                Count = perkCount.TryGetValue(p.Id, out var c) ? c : 0
+            })
+            .Where(p => p.Count > 0)
+            .OrderByDescending(p => p.Count)
+            .Take(5)
+            .ToList();
+
+        var paidStatuses = new[] { BTCPayServer.Client.Models.InvoiceStatus.Processing.ToString(), BTCPayServer.Client.Models.InvoiceStatus.Settled.ToString() };
+        var paid = await AppService.GetInvoicesForApp(_invoiceRepository, app, status: paidStatuses);
+        vm.RecentContributions = paid
+            .OrderByDescending(i => i.InvoiceTime)
+            .Take(3)
+            .Select(i => new AppCrowdfundViewModel.Contribution
+            {
+                AmountFormatted = FormatAmount(i.Price, i.Currency),
+                Date = i.InvoiceTime
+            })
+            .ToList();
+        var largest = paid.OrderByDescending(i => i.Price).FirstOrDefault();
+        if (largest != null)
+            vm.LargestFormatted = FormatAmount(largest.Price, largest.Currency);
+
+        return View(vm);
+    }
+
+    private (string label, string noun) RecurrenceLabels(string resetEvery) => resetEvery switch
+    {
+        "Hour" => (_localizer["hourly"].Value, _localizer["hour"].Value),
+        "Day" => (_localizer["daily"].Value, _localizer["day"].Value),
+        "Month" => (_localizer["monthly"].Value, _localizer["month"].Value),
+        "Year" => (_localizer["yearly"].Value, _localizer["year"].Value),
+        _ => (null, null)
+    };
+
+    // Format an amount trimmed of insignificant trailing zeros (e.g. 0.10000000 BTC -> 0.1 BTC).
+    private string FormatAmount(decimal value, string currency, DisplayFormatter.CurrencyFormat format = DisplayFormatter.CurrencyFormat.Code)
+    {
+        var text = value.ToString(CultureInfo.InvariantCulture);
+        var dot = text.IndexOf('.');
+        var significant = dot < 0 ? 0 : text[(dot + 1)..].TrimEnd('0').Length;
+        return _displayFormatter.Currency(value, currency, format, significant);
+    }
+}

--- a/BTCPayServer/Components/AppCrowdfund/AppCrowdfundViewModel.cs
+++ b/BTCPayServer/Components/AppCrowdfund/AppCrowdfundViewModel.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Collections.Generic;
+
+namespace BTCPayServer.Components.AppCrowdfund;
+
+public class AppCrowdfundViewModel
+{
+    public string Id { get; set; }
+    public string AppType { get; set; }
+    public string Name { get; set; }
+    public string DataUrl { get; set; }
+    public bool InitialRendering { get; set; }
+
+    public string Tagline { get; set; }
+    public string ManageUrl { get; set; }
+    public string PublicUrl { get; set; }
+    public string ReportUrl { get; set; }
+
+    // Campaign type / status
+    public bool Recurring { get; set; }
+    public string RecurrenceLabel { get; set; }  // e.g. "monthly"
+    public string PeriodNoun { get; set; }        // e.g. "month"
+    public bool Ended { get; set; }
+    public bool Enabled { get; set; }
+    public bool Started { get; set; }
+    public bool GoalReached { get; set; }
+    public bool HasTarget { get; set; }
+
+    // Funding progress
+    public string Currency { get; set; }
+    public decimal? ProgressPercentage { get; set; }
+    public int Contributions { get; set; }
+    public string CurrentAmountFormatted { get; set; }
+    public string CurrentAmountValue { get; set; }
+    public string TargetAmountFormatted { get; set; }
+    public string RemainingFormatted { get; set; }
+    public string LargestFormatted { get; set; }
+
+    // Timing
+    public int? DaysLeft { get; set; }
+    public int? RenewsInDays { get; set; }
+    public DateTime? EndDate { get; set; }
+
+    public List<PerkStat> Perks { get; set; } = new();
+    public List<Contribution> RecentContributions { get; set; } = new();
+
+    public class PerkStat
+    {
+        public string Title { get; set; }
+        public string PriceFormatted { get; set; }
+        public int Count { get; set; }
+    }
+
+    public class Contribution
+    {
+        public string AmountFormatted { get; set; }
+        public DateTimeOffset Date { get; set; }
+    }
+}

--- a/BTCPayServer/Components/AppCrowdfund/Default.cshtml
+++ b/BTCPayServer/Components/AppCrowdfund/Default.cshtml
@@ -1,0 +1,208 @@
+@model BTCPayServer.Components.AppCrowdfund.AppCrowdfundViewModel
+@{
+    var pct = (int)Math.Round(Model.ProgressPercentage ?? 0m);
+    var barWidth = Math.Min(100, Math.Max(0, pct));
+}
+
+<div id="AppCrowdfund-@Model.Id" class="widget app-crowdfund">
+    @if (Model.InitialRendering)
+    {
+        <div class="loading d-flex justify-content-center p-3">
+            <div class="spinner-border text-light" role="status">
+                <span class="visually-hidden" text-translate="true">Loading...</span>
+            </div>
+        </div>
+        <script>
+            (async () => {
+                const url = @Safe.Json(Model.DataUrl);
+                const appId = @Safe.Json(Model.Id);
+                const response = await fetch(url);
+                if (response.ok) {
+                    document.getElementById(`AppCrowdfund-${appId}`).outerHTML = await response.text();
+                }
+            })();
+        </script>
+    }
+    else
+    {
+        <header class="app-crowdfund__header">
+            <div class="app-crowdfund__heading">
+                <h3 class="app-crowdfund__title">@Model.Name</h3>
+                <div class="app-crowdfund__badges">
+                    @if (Model.Recurring)
+                    {
+                        <span class="badge app-crowdfund__badge app-crowdfund__badge--recurring">
+                            <span text-translate="true">Recurring</span>@if (Model.RecurrenceLabel != null) { <span> · @Model.RecurrenceLabel</span> }
+                        </span>
+                    }
+                    else
+                    {
+                        <span class="badge app-crowdfund__badge app-crowdfund__badge--onetime" text-translate="true">One-time</span>
+                    }
+                    @if (Model.Ended)
+                    {
+                        <span class="badge app-crowdfund__badge app-crowdfund__badge--completed" text-translate="true">Completed</span>
+                    }
+                    else if (!Model.Enabled)
+                    {
+                        <span class="badge app-crowdfund__badge app-crowdfund__badge--disabled" text-translate="true">Disabled</span>
+                    }
+                    else if (!Model.Started)
+                    {
+                        <span class="badge app-crowdfund__badge app-crowdfund__badge--scheduled" text-translate="true">Scheduled</span>
+                    }
+                </div>
+            </div>
+            <div class="app-crowdfund__actions">
+                @if (Model.Ended)
+                {
+                    <a href="@Model.ReportUrl" text-translate="true">Report</a>
+                }
+                else
+                {
+                    <a href="@Model.ManageUrl" text-translate="true">Manage</a>
+                }
+                <a href="@Model.PublicUrl" target="_blank" rel="noreferrer noopener" text-translate="true">View</a>
+            </div>
+        </header>
+
+        @if (Model.Ended)
+        {
+            <div class="app-crowdfund__banner @(Model.GoalReached ? "app-crowdfund__banner--success" : "")">
+                <vc:icon symbol="@(Model.GoalReached ? "checkmark" : "info")" />
+                <span>
+                    @if (Model.GoalReached)
+                    {
+                        @ViewLocalizer["Goal reached, funded {0}%", pct]
+                    }
+                    else
+                    {
+                        @ViewLocalizer["Campaign ended, funded {0}%", pct]
+                    }
+                </span>
+            </div>
+        }
+
+        <div class="app-crowdfund__progress">
+            <div class="app-crowdfund__progress-head">
+                <span class="app-crowdfund__progress-summary">
+                    @if (Model.HasTarget)
+                    {
+                        <strong data-sensitive>@Model.CurrentAmountValue</strong>
+                        <span text-translate="true">of</span>
+                        <strong data-sensitive>@Model.TargetAmountFormatted</strong>
+                        @if (Model.Recurring && Model.PeriodNoun != null)
+                        {
+                            <span>@ViewLocalizer["this {0}", Model.PeriodNoun]</span>
+                        }
+                        <span class="app-crowdfund__progress-pct">
+                            · @pct%
+                            @if (Model.GoalReached)
+                            {
+                                <span text-translate="true">funded</span>
+                            }
+                        </span>
+                    }
+                    else
+                    {
+                        <strong data-sensitive>@Model.CurrentAmountFormatted</strong>
+                        <span text-translate="true">raised</span>
+                    }
+                </span>
+                <span class="app-crowdfund__timing">
+                    @if (Model.Ended && Model.EndDate.HasValue)
+                    {
+                        @ViewLocalizer["Ended {0}", Model.EndDate.Value.ToString("d")]
+                    }
+                    else if (Model.Recurring && Model.RenewsInDays.HasValue)
+                    {
+                        @ViewLocalizer["renews in {0} days", Model.RenewsInDays.Value]
+                    }
+                    else if (!Model.Recurring && Model.DaysLeft.HasValue)
+                    {
+                        @ViewLocalizer["{0} days left", Model.DaysLeft.Value]
+                    }
+                </span>
+            </div>
+            <div class="app-crowdfund__bar" role="progressbar" aria-valuenow="@pct" aria-valuemin="0" aria-valuemax="100" aria-label="@StringLocalizer["Funding progress"]">
+                <div class="app-crowdfund__bar-fill" style="width:@(barWidth)%"></div>
+            </div>
+        </div>
+
+        @if (Model.Contributions == 0)
+        {
+            <p class="app-crowdfund__empty text-secondary" text-translate="true">No contributions yet.</p>
+        }
+        else
+        {
+        <div class="app-crowdfund__stats">
+            <div class="app-crowdfund__stat">
+                <h6 class="app-crowdfund__stat-label" text-translate="true">Contributions</h6>
+                <div class="app-crowdfund__stat-value">@Model.Contributions</div>
+            </div>
+            @if (!Model.Ended && Model.RemainingFormatted != null)
+            {
+                <div class="app-crowdfund__stat">
+                    <h6 class="app-crowdfund__stat-label" text-translate="true">Remaining</h6>
+                    <div class="app-crowdfund__stat-value" data-sensitive>@Model.RemainingFormatted</div>
+                </div>
+            }
+            else
+            {
+                <div class="app-crowdfund__stat">
+                    <h6 class="app-crowdfund__stat-label" text-translate="true">Largest contribution</h6>
+                    <div class="app-crowdfund__stat-value" data-sensitive>@(Model.LargestFormatted ?? "—")</div>
+                </div>
+            }
+            @if (Model.RecentContributions.Count > 0)
+            {
+                var latest = Model.RecentContributions[0];
+                <div class="app-crowdfund__stat">
+                    <h6 class="app-crowdfund__stat-label" text-translate="true">Latest Contribution</h6>
+                    <div class="app-crowdfund__stat-value" data-sensitive>@latest.AmountFormatted</div>
+                    <div class="app-crowdfund__stat-sub"><span data-timeago-unixms="@latest.Date.ToUnixTimeMilliseconds()"></span></div>
+                </div>
+            }
+        </div>
+
+        @if (Model.Perks.Any())
+        {
+            <div class="app-crowdfund__perks">
+                <h6 class="app-crowdfund__section-label">
+                    @if (Model.Ended)
+                    {
+                        <span text-translate="true">Final perk sales</span>
+                    }
+                    else
+                    {
+                        <span text-translate="true">Top Perks</span>
+                    }
+                </h6>
+                @foreach (var perk in Model.Perks)
+                {
+                    <div class="app-crowdfund__perk">
+                        <span class="app-crowdfund__perk-name">
+                            @perk.Title
+                            @if (perk.PriceFormatted != null)
+                            {
+                                <span class="text-secondary">· @perk.PriceFormatted@(Model.Recurring && Model.PeriodNoun != null ? $" / {Model.PeriodNoun}" : "")</span>
+                            }
+                        </span>
+                        <span class="app-crowdfund__perk-count">
+                            @if (Model.Recurring && !Model.Ended)
+                            {
+                                @ViewLocalizer["{0} active", perk.Count]
+                            }
+                            else
+                            {
+                                @ViewLocalizer["{0} sold", perk.Count]
+                            }
+                        </span>
+                    </div>
+                }
+            </div>
+        }
+        }
+
+    }
+</div>

--- a/BTCPayServer/Controllers/UIAppsController.Dashboard.cs
+++ b/BTCPayServer/Controllers/UIAppsController.Dashboard.cs
@@ -36,6 +36,18 @@ namespace BTCPayServer.Controllers
         }
 
         [Authorize(Policy = Policies.CanModifyStoreSettings, AuthenticationSchemes = AuthenticationSchemes.Cookie)]
+        [HttpGet("{appId}/dashboard/app-crowdfund")]
+        public IActionResult AppCrowdfund(string appId)
+        {
+            var app = HttpContext.GetAppDataOrNull();
+            if (app == null)
+                return NotFound();
+
+            app.StoreData = HttpContext.GetStoreData();
+            return ViewComponent("AppCrowdfund", new { appId = app.Id, appType = app.AppType });
+        }
+
+        [Authorize(Policy = Policies.CanModifyStoreSettings, AuthenticationSchemes = AuthenticationSchemes.Cookie)]
         [HttpGet("{appId}/dashboard/app-sales/{period}")]
         public async Task<IActionResult> AppSales(string appId, AppSalesPeriod period)
         {

--- a/BTCPayServer/Views/UIStores/Dashboard.cshtml
+++ b/BTCPayServer/Views/UIStores/Dashboard.cshtml
@@ -89,8 +89,15 @@
         <vc:store-recent-invoices store="store" initial-rendering="true" />
         @foreach (var app in Model.Apps)
         {
-            <vc:app-sales app-id="@app.Id" app-type="@app.AppType" />
-            <vc:app-top-items app-id="@app.Id" app-type="@app.AppType" />
+            if (app.AppType == BTCPayServer.Plugins.Crowdfund.CrowdfundAppType.AppType)
+            {
+                <vc:app-crowdfund app-id="@app.Id" app-type="@app.AppType" />
+            }
+            else
+            {
+                <vc:app-sales app-id="@app.Id" app-type="@app.AppType" />
+                <vc:app-top-items app-id="@app.Id" app-type="@app.AppType" />
+            }
         }
     </div>
 }

--- a/BTCPayServer/wwwroot/main/site.css
+++ b/BTCPayServer/wwwroot/main/site.css
@@ -432,6 +432,142 @@ h2 .icon.icon-info {
     justify-content: space-between;
 }
 
+/* Crowdfund dashboard widget */
+.app-crowdfund .app-crowdfund__header {
+    flex-wrap: nowrap;
+    align-items: flex-start;
+    margin-bottom: var(--btcpay-space-l);
+}
+.app-crowdfund__heading {
+    flex: 1 1 auto;
+    min-width: 0;
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: var(--btcpay-space-m);
+}
+.app-crowdfund__actions {
+    display: flex;
+    gap: var(--btcpay-space-l);
+    flex-shrink: 0;
+}
+.app-crowdfund__badges {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--btcpay-space-s);
+}
+.app-crowdfund__badge {
+    font-weight: var(--btcpay-font-weight-semibold);
+}
+.app-crowdfund__badge--onetime,
+.app-crowdfund__badge--recurring {
+    color: var(--btcpay-info-dim-text);
+    background-color: var(--btcpay-info-dim-bg);
+}
+.app-crowdfund__badge--completed,
+.app-crowdfund__badge--disabled {
+    color: var(--btcpay-secondary-dim-text);
+    background-color: var(--btcpay-secondary-dim-bg);
+}
+.app-crowdfund__badge--scheduled {
+    color: var(--btcpay-warning-dim-text);
+    background-color: var(--btcpay-warning-dim-bg);
+}
+.app-crowdfund__banner {
+    display: flex;
+    align-items: center;
+    gap: var(--btcpay-space-s);
+    padding: var(--btcpay-space-s) var(--btcpay-space-m);
+    margin-bottom: var(--btcpay-space-m);
+    border-radius: var(--btcpay-border-radius);
+    background-color: var(--btcpay-neutral-200);
+    color: var(--btcpay-body-text-muted);
+}
+.app-crowdfund__banner--success {
+    background-color: var(--btcpay-success-dim-bg);
+    color: var(--btcpay-success-dim-text);
+}
+.app-crowdfund__progress {
+    margin-bottom: var(--btcpay-space-l);
+}
+.app-crowdfund__progress-head {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    gap: var(--btcpay-space-s);
+    margin-bottom: var(--btcpay-space-s);
+    font-size: var(--btcpay-font-size-l);
+}
+.app-crowdfund__progress-summary {
+    color: var(--btcpay-body-text-muted);
+}
+.app-crowdfund__progress-summary strong {
+    color: var(--btcpay-body-text);
+}
+.app-crowdfund__progress-pct {
+    font-weight: var(--btcpay-font-weight-semibold);
+}
+.app-crowdfund__timing {
+    color: var(--btcpay-body-text-muted);
+    font-weight: var(--btcpay-font-weight-semibold);
+}
+.app-crowdfund__bar {
+    height: 8px;
+    border-radius: 9999px;
+    background-color: var(--btcpay-neutral-300);
+    overflow: hidden;
+}
+.app-crowdfund__bar-fill {
+    height: 100%;
+    border-radius: inherit;
+    background-color: var(--btcpay-success);
+}
+.app-crowdfund__stats {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: var(--btcpay-space-m) var(--btcpay-space-l);
+    margin-bottom: var(--btcpay-space-m);
+}
+@media (min-width: 768px) {
+    .app-crowdfund__stats {
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+    }
+}
+.app-crowdfund__stat {
+    min-width: 0;
+}
+.app-crowdfund__stat-value {
+    font-size: var(--btcpay-font-size-l);
+    font-weight: var(--btcpay-font-weight-semibold);
+}
+.app-crowdfund__stat-sub {
+    color: var(--btcpay-body-text-muted);
+    font-weight: 400;
+    font-size: var(--btcpay-font-size-m);
+}
+.app-crowdfund .app-crowdfund__section-label {
+    margin-bottom: var(--btcpay-space-s);
+    color: var(--btcpay-body-text);
+    font-size: var(--btcpay-font-size-l);
+}
+.app-crowdfund__perk {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: var(--btcpay-space-s);
+    padding: var(--btcpay-space-s) var(--btcpay-space-m);
+    border-radius: var(--btcpay-border-radius);
+    background-color: var(--btcpay-neutral-100);
+    font-size: var(--btcpay-body-font-size);
+}
+.app-crowdfund__perk + .app-crowdfund__perk {
+    margin-top: var(--btcpay-space-xs);
+}
+.app-crowdfund__perk-count {
+    color: var(--btcpay-body-text);
+    white-space: nowrap;
+}
+
 .widget .btn-link {
     color: var(--btcpay-body-text-muted);
     padding: 0;


### PR DESCRIPTION
We re-used the Point of Sale widget and never gave the Crowdfund app it's own dedicated Dashboard widget, so here it is.

# Screenshots:

Funded One-time & New One-time
<img width="1277" height="740" alt="Screenshot 2026-07-29 at 9 32 58 PM" src="https://github.com/user-attachments/assets/a04f35fd-9537-4b96-9067-4bf86129428a" />

Completed:
<img width="1280" height="330" alt="Screenshot 2026-07-29 at 9 32 17 PM" src="https://github.com/user-attachments/assets/10a442cb-3f1f-48ad-b763-9bd382ab1997" />

Recurring:
<img width="1277" height="275" alt="Screenshot 2026-07-29 at 9 32 50 PM" src="https://github.com/user-attachments/assets/6603e826-6180-4d59-82e1-44ab4f0346a7" />

Mobile:
<img width="480" height="877" alt="Screenshot 2026-07-29 at 9 37 15 PM" src="https://github.com/user-attachments/assets/c17b1c76-d0a0-4d74-bd02-5dbd036f457a" />

The card adapts to the campaign:

- A one-time or recurring type label, plus a Completed, Scheduled, or Disabled status when relevant.
- Goal progress (or the current period's goal for recurring) with amount raised, percent funded, and time left or renewal date.
- Contributions, remaining to goal (or largest contribution once funded), and the latest contribution.
- Top Perks by sales, and links to manage the campaign, view the public page, or open the report once completed.

It lazy-loads like the other dashboard widgets, and its amounts, labels, and layout use the existing theme, are localized, and adapts to mobile.

Let me know if it's missing anything, but I think I covered all the cases.

Closes: #7471