### PR TITLE
Fix: Crowdfund page losing main image and last updated date after a contribution

### DIFF
--- a/BTCPayServer/wwwroot/crowdfund/app.js
+++ b/BTCPayServer/wwwroot/crowdfund/app.js
@@ -181,7 +181,9 @@ app = new Vue({
                 }else {
                 this.startDiff = null;
             }
-            this.lastUpdated = moment(this.srvModel.info.lastUpdated).calendar();
+            var lastUpdated = this.srvModel.info.lastUpdated;
+            // The SignalR push serializes dates as unix seconds, the initial render as ISO strings
+            this.lastUpdated = (typeof lastUpdated === 'number' ? moment.unix(lastUpdated) : moment(lastUpdated)).calendar();
             this.active = this.started && !this.ended;
             setTimeout(this.updateComputed, 1000);
         },
@@ -301,8 +303,12 @@ app = new Vue({
             })();
         }
         eventAggregator.$on("info-updated", function (model) {
-            console.warn("UPDATED", self.srvModel, arguments);
-            self.srvModel = model;
+            // Only merge the fields which change with contributions: The pushed model
+            // is built outside of an HTTP request and hence lacks the mainImageUrl.
+            self.srvModel.info = model.info;
+            self.srvModel.perkCount = model.perkCount;
+            self.srvModel.perkValue = model.perkValue;
+            self.srvModel.perks = model.perks;
         });
         eventAggregator.$on("connection-pending", function () {
             self.connectionStatus = "pending";


### PR DESCRIPTION
On a Crowdfund page that has a main image, creating a contribution invoice made the header image disappear and the footer show "Updated 01/21/1970" until the page was reloaded.

The live update that refreshes the campaign stats after a contribution is built outside of a web request, so it never includes the main image, and it sends dates in a different format (unix seconds) than the initial page load (ISO strings). Because the page replaced its entire model with the pushed one, the image was lost and the date was misread. With this change the page only takes from the push what actually changes with contributions — the funding stats and the perk counters/ordering — and accepts both date formats when displaying "Updated …". A stray debug `console.warn` in the same handler is also removed.

### Before (right after clicking Contribute, and after closing the checkout modal)

<img width="700" alt="After contribute - image gone, 1970 date" src="https://github.com/user-attachments/assets/f4f2d287-9a5b-47d5-8a61-d06fc35f36df" />
<img width="700" alt="After closing modal - page stays broken" src="https://github.com/user-attachments/assets/da8e1aec-058a-4842-8032-1f737bc3f4ca" />

### After

The page keeps its image and correct "Updated" time through invoice creation and payment, as on first load:

<img width="700" alt="Initial state, preserved after the fix" src="https://github.com/user-attachments/assets/61a7b395-532e-4b80-8c93-134552b29d14" />

### Testing

Reproduced on a v2.4.1 instance (regtest): create a crowdfund with a main image, open the public page, click Contribute — the image vanished and the date showed 1970. The same instance with the merge behavior applied to the page keeps image and date intact through invoice creation and payment. The scenario is also exercised by the existing `CanCreateCrowdfundingApp` Playwright test (contribute flow on the public page).

### Notes for reviewers

Two server-side root causes exist, and both are awkward to fix on the server, which is why this is a client-side fix:

- `CrowdfundAppType.GetInfo` only resolves `MainImageUrl` when an `HttpContext` is present; the `InfoUpdated` broadcast comes from `AppHubStreamer` (a hosted service), where there is none — and for `fileid:` images no request base URI exists there to resolve against.
- Since #6537 the global SignalR Newtonsoft payload settings register NBitcoin's converters (needed by the app hub), which serialize `DateTime` as unix seconds for every hub; payload settings cannot be scoped per hub.

The payment request page shares the same push pattern and may be worth a similar look.

Fixes #7486
