### PR TITLE
PSBT signing and pending transaction status made more reliable

### DIFF
--- a/BTCPayServer.Tests/GreenfieldAPITests.cs
+++ b/BTCPayServer.Tests/GreenfieldAPITests.cs
@@ -40,6 +40,7 @@ using Newtonsoft.Json.Linq;
 using Xunit;
 using Xunit.Sdk;
 using CreateApplicationUserRequest = BTCPayServer.Client.Models.CreateApplicationUserRequest;
+using PayoutEvent = BTCPayServer.HostedServices.PayoutEvent;
 using PosViewType = BTCPayServer.Plugins.PointOfSale.PosViewType;
 
 namespace BTCPayServer.Tests
@@ -3708,18 +3709,22 @@ namespace BTCPayServer.Tests
 
             // Send just enough money to cover the smallest of the payouts.
             var fee = (await tester.PayTester.GetService<IFeeProviderFactory>().CreateFeeProvider(tester.DefaultNetwork).GetFeeRateAsync(100)).GetFee(150);
-            await tester.ExplorerNode.SendToAddressAsync(BitcoinAddress.Create((await adminClient.GetOnChainWalletReceiveAddress(admin.StoreId, "BTC", true)).Address,
+            uint256 txid = await tester.ExplorerNode.SendToAddressAsync(BitcoinAddress.Create((await adminClient.GetOnChainWalletReceiveAddress(admin.StoreId, "BTC", true)).Address,
                 tester.ExplorerClient.Network.NBitcoinNetwork), Money.Coins(0.00001m) + fee);
             await tester.ExplorerNode.GenerateAsync(1);
             await TestUtils.EventuallyAsync(async () =>
             {
                 Assert.Single(await adminClient.ShowOnChainWalletTransactions(admin.StoreId, "BTC"));
+                Assert.Contains(await adminClient.GetOnChainWalletUTXOs(admin.StoreId, "BTC"),
+                    utxo => utxo.Outpoint.Hash == txid);
 
                 payouts = await adminClient.GetStorePayouts(admin.StoreId);
                 Assert.Equal(3, payouts.Length);
             });
-            await adminClient.UpdateStoreOnChainAutomatedPayoutProcessors(admin.StoreId, "BTC",
-                new OnChainAutomatedPayoutSettings() { IntervalSeconds = TimeSpan.FromSeconds(600), FeeBlockTarget = 1000 });
+            await tester.WaitForEvent<PayoutEvent>(
+                () => adminClient.UpdateStoreOnChainAutomatedPayoutProcessors(admin.StoreId, "BTC",
+                    new OnChainAutomatedPayoutSettings() { IntervalSeconds = TimeSpan.FromSeconds(600), FeeBlockTarget = 1000 }),
+                e => e.Type == PayoutEvent.PayoutEventType.Updated && e.Payout.Id == notApprovedPayoutWithoutPullPayment.Id);
             Assert.Equal(600, Assert.Single(await adminClient.GetStoreOnChainAutomatedPayoutProcessors(admin.StoreId, "BTC")).IntervalSeconds.TotalSeconds);
 
             await TestUtils.EventuallyAsync(async () =>
@@ -3729,13 +3734,18 @@ namespace BTCPayServer.Tests
                 Assert.Single(payouts, data => data.State == PayoutState.InProgress);
             });
 
-            uint256 txid = null;
             await tester.WaitForEvent<NewOnChainTransactionEvent>(async () =>
             {
                 txid = await tester.ExplorerNode.SendToAddressAsync(BitcoinAddress.Create((await adminClient.GetOnChainWalletReceiveAddress(admin.StoreId, "BTC", true)).Address,
                     tester.ExplorerClient.Network.NBitcoinNetwork), Money.Coins(0.01m) + fee);
             }, correctEvent: ev => ev.NewTransactionEvent.TransactionData.TransactionHash == txid);
-            await tester.PayTester.GetService<PayoutProcessorService>().Restart(new PayoutProcessorService.PayoutProcessorQuery(admin.StoreId, Payouts.PayoutMethodId.Parse("BTC")));
+            await TestUtils.EventuallyAsync(async () =>
+                Assert.Contains(await adminClient.GetOnChainWalletUTXOs(admin.StoreId, "BTC"),
+                    utxo => utxo.Outpoint.Hash == txid));
+            await tester.WaitForEvent<PayoutEvent>(
+                () => tester.PayTester.GetService<PayoutProcessorService>().Restart(
+                    new PayoutProcessorService.PayoutProcessorQuery(admin.StoreId, Payouts.PayoutMethodId.Parse("BTC"))),
+                e => e.Type == PayoutEvent.PayoutEventType.Updated && e.Payout.Id == notapprovedPayoutWithPullPayment.Id);
             await TestUtils.EventuallyAsync(async () =>
             {
                 Assert.Equal(4, (await adminClient.ShowOnChainWalletTransactions(admin.StoreId, "BTC")).Count());

--- a/BTCPayServer.Tests/MultisigTests.cs
+++ b/BTCPayServer.Tests/MultisigTests.cs
@@ -177,7 +177,7 @@ public class MultisigTests(ITestOutputHelper helper) : UnitTestBase(helper)
 
     [Fact]
     [Trait("Integration", "Integration")]
-    public async Task PendingMultisigTransactionCountsFinalizedInputsAndSelfHealsStoredProgress()
+    public async Task PendingMultisigTransactionCountsFinalizedInputsAndSelfHealsStoredProgressAndState()
     {
         var dbTester = CreateDBTester();
         await dbTester.MigrateAsync();
@@ -257,6 +257,39 @@ public class MultisigTests(ITestOutputHelper helper) : UnitTestBase(helper)
         Assert.Equal(2, blob.SignaturesNeeded);
         Assert.Equal(3, blob.SignaturesTotal);
         Assert.Equal(1, blob.SignaturesCollected);
+
+        await using (var ctx = dbContextFactory.CreateContext())
+        {
+            var staleTransaction = await ctx.PendingTransactions.FindAsync(pendingTransaction.Id);
+            Assert.NotNull(staleTransaction);
+            var staleBlob = staleTransaction!.GetBlob();
+            staleBlob.CollectedSignatures.Add(new CollectedSignature
+            {
+                ReceivedPSBT = SignInputs(testPsbt.BasePsbt, testPsbt.SignerB, 1).ToBase64(),
+                Timestamp = DateTimeOffset.UtcNow
+            });
+            staleBlob.SignaturesNeeded = 2;
+            staleBlob.SignaturesTotal = 3;
+            staleBlob.SignaturesCollected = 2;
+            staleTransaction.SetBlob(staleBlob);
+            Assert.Equal(PendingTransactionState.Pending, staleTransaction.State);
+            await ctx.SaveChangesAsync();
+        }
+
+        var finalized = await pendingTransactionService.GetPendingTransaction(
+            new PendingTransactionService.PendingTransactionFullId("BTC", storeId, pendingTransaction.Id));
+        blob = finalized!.GetBlob();
+        Assert.Equal(2, blob.SignaturesNeeded);
+        Assert.Equal(3, blob.SignaturesTotal);
+        Assert.Equal(2, blob.SignaturesCollected);
+        Assert.Equal(PendingTransactionState.Signed, finalized.State);
+
+        await using (var ctx = dbContextFactory.CreateContext())
+        {
+            var persisted = await ctx.PendingTransactions.FindAsync(pendingTransaction.Id);
+            Assert.NotNull(persisted);
+            Assert.Equal(PendingTransactionState.Signed, persisted!.State);
+        }
     }
 
     [Fact]
@@ -364,6 +397,10 @@ public class MultisigTests(ITestOutputHelper helper) : UnitTestBase(helper)
         Assert.Contains(logger.Entries, entry =>
             entry.Level == LogLevel.Warning &&
             entry.Message.Contains(pendingTransaction.Id, StringComparison.Ordinal));
+
+        pendingTransaction = await pendingTransactionService.GetPendingTransaction(pendingTransactionId);
+        Assert.NotNull(pendingTransaction);
+        Assert.Equal(PendingTransactionState.Pending, pendingTransaction.State);
 
         // Per-input progress must be retained even while the aggregate remains at two.
         pendingTransaction = await pendingTransactionService.CollectSignature(

--- a/BTCPayServer.Tests/PSBTTests.cs
+++ b/BTCPayServer.Tests/PSBTTests.cs
@@ -20,6 +20,7 @@ namespace BTCPayServer.Tests
             var nestedP2wshRedeem = witnessScript.WitHash.ScriptPubKey;
             var nestedP2wsh = nestedP2wshRedeem.Hash.ScriptPubKey;
             var taproot = new Key().PubKey.GetScriptPubKey(ScriptPubKeyType.TaprootBIP86);
+            var futureWitness = PayToWitTemplate.Instance.GenerateScriptPubKey(OpcodeType.OP_2, new byte[32]);
             var legacyP2sh = witnessScript.Hash.ScriptPubKey;
 
             var previousTransaction = network.CreateTransaction();
@@ -27,7 +28,8 @@ namespace BTCPayServer.Tests
             previousTransaction.Outputs.Add(Money.Coins(1.1m), nativeP2wpkh);
             previousTransaction.Outputs.Add(Money.Coins(1.2m), nestedP2wsh);
             previousTransaction.Outputs.Add(Money.Coins(1.3m), taproot);
-            previousTransaction.Outputs.Add(Money.Coins(1.4m), legacyP2sh);
+            previousTransaction.Outputs.Add(Money.Coins(1.4m), futureWitness);
+            previousTransaction.Outputs.Add(Money.Coins(1.5m), legacyP2sh);
 
             var spendingTransaction = network.CreateTransaction();
             for (var i = 0; i < previousTransaction.Outputs.Count; i++)
@@ -40,18 +42,18 @@ namespace BTCPayServer.Tests
             psbt.Inputs[0].WitnessScript = witnessScript;
             psbt.Inputs[2].RedeemScript = nestedP2wshRedeem;
             psbt.Inputs[2].WitnessScript = witnessScript;
-            psbt.Inputs[4].RedeemScript = witnessScript;
+            psbt.Inputs[5].RedeemScript = witnessScript;
 
             Assert.All(psbt.Inputs, input => Assert.Null(input.WitnessUtxo));
 
             psbt.AddWitnessUtxoToSegwitInputs();
 
-            for (var i = 0; i < 4; i++)
+            for (var i = 0; i < 5; i++)
             {
                 Assert.NotNull(psbt.Inputs[i].WitnessUtxo);
                 Assert.Equal(previousTransaction.Outputs[i], psbt.Inputs[i].WitnessUtxo);
             }
-            Assert.Null(psbt.Inputs[4].WitnessUtxo);
+            Assert.Null(psbt.Inputs[5].WitnessUtxo);
             Assert.All(psbt.Inputs, input => Assert.Same(previousTransaction, input.NonWitnessUtxo));
         }
 

--- a/BTCPayServer.Tests/PSBTTests.cs
+++ b/BTCPayServer.Tests/PSBTTests.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using System.Threading.Tasks;
 using NBitcoin;
 using Xunit;
@@ -6,6 +7,54 @@ namespace BTCPayServer.Tests
 {
     public class PSBTTests(ITestOutputHelper helper) : UnitTestBase(helper)
     {
+        [Fact]
+        public void AddsWitnessUtxoToSegwitInputs()
+        {
+            var network = Network.RegTest;
+            var keys = new[] { new Key(), new Key() };
+            var witnessScript = PayToMultiSigTemplate.Instance.GenerateScriptPubKey(
+                2,
+                keys.Select(key => key.PubKey).ToArray());
+            var nativeP2wsh = witnessScript.WitHash.ScriptPubKey;
+            var nativeP2wpkh = new Key().PubKey.WitHash.ScriptPubKey;
+            var nestedP2wshRedeem = witnessScript.WitHash.ScriptPubKey;
+            var nestedP2wsh = nestedP2wshRedeem.Hash.ScriptPubKey;
+            var taproot = new Key().PubKey.GetScriptPubKey(ScriptPubKeyType.TaprootBIP86);
+            var legacyP2sh = witnessScript.Hash.ScriptPubKey;
+
+            var previousTransaction = network.CreateTransaction();
+            previousTransaction.Outputs.Add(Money.Coins(1.0m), nativeP2wsh);
+            previousTransaction.Outputs.Add(Money.Coins(1.1m), nativeP2wpkh);
+            previousTransaction.Outputs.Add(Money.Coins(1.2m), nestedP2wsh);
+            previousTransaction.Outputs.Add(Money.Coins(1.3m), taproot);
+            previousTransaction.Outputs.Add(Money.Coins(1.4m), legacyP2sh);
+
+            var spendingTransaction = network.CreateTransaction();
+            for (var i = 0; i < previousTransaction.Outputs.Count; i++)
+                spendingTransaction.Inputs.Add(new OutPoint(previousTransaction.GetHash(), i));
+            spendingTransaction.Outputs.Add(Money.Coins(4.5m), new Key().PubKey.WitHash.ScriptPubKey);
+
+            var psbt = PSBT.FromTransaction(spendingTransaction, network);
+            foreach (var input in psbt.Inputs)
+                input.NonWitnessUtxo = previousTransaction;
+            psbt.Inputs[0].WitnessScript = witnessScript;
+            psbt.Inputs[2].RedeemScript = nestedP2wshRedeem;
+            psbt.Inputs[2].WitnessScript = witnessScript;
+            psbt.Inputs[4].RedeemScript = witnessScript;
+
+            Assert.All(psbt.Inputs, input => Assert.Null(input.WitnessUtxo));
+
+            psbt.AddWitnessUtxoToSegwitInputs();
+
+            for (var i = 0; i < 4; i++)
+            {
+                Assert.NotNull(psbt.Inputs[i].WitnessUtxo);
+                Assert.Equal(previousTransaction.Outputs[i], psbt.Inputs[i].WitnessUtxo);
+            }
+            Assert.Null(psbt.Inputs[4].WitnessUtxo);
+            Assert.All(psbt.Inputs, input => Assert.Same(previousTransaction, input.NonWitnessUtxo));
+        }
+
         [Fact]
         [Trait("Playwright", "Playwright")]
         public async Task CanPlayWithPSBT()

--- a/BTCPayServer/Extensions/PSBTExtensions.cs
+++ b/BTCPayServer/Extensions/PSBTExtensions.cs
@@ -26,9 +26,9 @@ namespace BTCPayServer
 
                 var previousOutput = nonWitnessUtxo.Outputs[(int)input.PrevOut.N];
                 var redeemScript = input.RedeemScript;
-                if (IsSegwit(previousOutput.ScriptPubKey) ||
+                if (previousOutput.ScriptPubKey.IsScriptType(ScriptType.Witness) ||
                     redeemScript is not null &&
-                    IsSegwit(redeemScript) &&
+                    redeemScript.IsScriptType(ScriptType.Witness) &&
                     redeemScript.Hash.ScriptPubKey == previousOutput.ScriptPubKey)
                 {
                     input.WitnessUtxo = previousOutput;
@@ -36,13 +36,6 @@ namespace BTCPayServer
             }
 
             return psbt;
-        }
-
-        private static bool IsSegwit(Script scriptPubKey)
-        {
-            return PayToWitPubKeyHashTemplate.Instance.CheckScriptPubKey(scriptPubKey) ||
-                   PayToWitScriptHashTemplate.Instance.CheckScriptPubKey(scriptPubKey) ||
-                   PayToTaprootTemplate.Instance.CheckScriptPubKey(scriptPubKey);
         }
     }
 }

--- a/BTCPayServer/Extensions/PSBTExtensions.cs
+++ b/BTCPayServer/Extensions/PSBTExtensions.cs
@@ -12,5 +12,37 @@ namespace BTCPayServer
             var after = psbt.ToBase64();
             return before != after;
         }
+
+        public static PSBT AddWitnessUtxoToSegwitInputs(this PSBT psbt)
+        {
+            foreach (var input in psbt.Inputs)
+            {
+                var nonWitnessUtxo = input.NonWitnessUtxo;
+                if (input.WitnessUtxo is not null ||
+                    nonWitnessUtxo is null ||
+                    nonWitnessUtxo.GetHash() != input.PrevOut.Hash ||
+                    input.PrevOut.N >= (uint)nonWitnessUtxo.Outputs.Count)
+                    continue;
+
+                var previousOutput = nonWitnessUtxo.Outputs[(int)input.PrevOut.N];
+                var redeemScript = input.RedeemScript;
+                if (IsSegwit(previousOutput.ScriptPubKey) ||
+                    redeemScript is not null &&
+                    IsSegwit(redeemScript) &&
+                    redeemScript.Hash.ScriptPubKey == previousOutput.ScriptPubKey)
+                {
+                    input.WitnessUtxo = previousOutput;
+                }
+            }
+
+            return psbt;
+        }
+
+        private static bool IsSegwit(Script scriptPubKey)
+        {
+            return PayToWitPubKeyHashTemplate.Instance.CheckScriptPubKey(scriptPubKey) ||
+                   PayToWitScriptHashTemplate.Instance.CheckScriptPubKey(scriptPubKey) ||
+                   PayToTaprootTemplate.Instance.CheckScriptPubKey(scriptPubKey);
+        }
     }
 }

--- a/BTCPayServer/HostedServices/PendingTransactionService.cs
+++ b/BTCPayServer/HostedServices/PendingTransactionService.cs
@@ -349,13 +349,30 @@ public class PendingTransactionService(
         if (network is null)
             return false;
 
-        var progress = GetSignatureProgress(BuildEffectivePsbt(blob, network));
-        if (blob.SignaturesNeeded == progress.SignaturesNeeded &&
-            blob.SignaturesTotal == progress.SignaturesTotal &&
-            blob.SignaturesCollected == progress.SignaturesCollected)
+        var effectivePsbt = BuildEffectivePsbt(blob, network);
+        var progress = GetSignatureProgress(effectivePsbt);
+        var changed = blob.SignaturesNeeded != progress.SignaturesNeeded ||
+                      blob.SignaturesTotal != progress.SignaturesTotal ||
+                      blob.SignaturesCollected != progress.SignaturesCollected;
+
+        if (changed)
+            ApplyProgress(blob, progress);
+
+        if (pendingTransaction.State == PendingTransactionState.Pending &&
+            progress.SignaturesNeeded > 0 &&
+            progress.SignaturesCollected >= progress.SignaturesNeeded &&
+            effectivePsbt.TryFinalize(out _))
+        {
+            pendingTransaction.State = PendingTransactionState.Signed;
+            changed = true;
+            logger.LogInformation(
+                "Finalized pending transaction {PendingTransactionId} while refreshing stored signature progress",
+                pendingTransaction.Id);
+        }
+
+        if (!changed)
             return false;
 
-        ApplyProgress(blob, progress);
         pendingTransaction.SetBlob(blob);
         return true;
     }

--- a/BTCPayServer/Plugins/Wallets/Controllers/UIWalletsController.PSBT.cs
+++ b/BTCPayServer/Plugins/Wallets/Controllers/UIWalletsController.PSBT.cs
@@ -69,6 +69,7 @@ namespace BTCPayServer.Controllers
             if (psbt == null)
                 throw new NotSupportedException(StringLocalizer["You need to update your version of NBXplorer"]);
 
+            psbt.PSBT.AddWitnessUtxoToSegwitInputs();
             return psbt;
         }
 

--- a/BTCPayServer/Plugins/Wallets/Controllers/UIWalletsController.cs
+++ b/BTCPayServer/Plugins/Wallets/Controllers/UIWalletsController.cs
@@ -304,6 +304,7 @@ namespace BTCPayServer.Controllers
                 try
                 {
                     var psbtResponse = await explorer.CreatePSBTAsync(paymentMethod.AccountDerivation, createPSBT, cancellationToken);
+                    psbtResponse.PSBT.AddWitnessUtxoToSegwitInputs();
 
                     signingContext = new SigningContextModel
                     {
@@ -384,6 +385,7 @@ namespace BTCPayServer.Controllers
                 try
                 {
                     var psbtResponse = await explorer.CreatePSBTAsync(paymentMethod.AccountDerivation, createPSBT, cancellationToken);
+                    psbtResponse.PSBT.AddWitnessUtxoToSegwitInputs();
 
                     signingContext = new SigningContextModel
                     {

--- a/BTCPayServer/Plugins/Wallets/Views/ViewModels/WalletPSBTViewModel.cs
+++ b/BTCPayServer/Plugins/Wallets/Views/ViewModels/WalletPSBTViewModel.cs
@@ -42,7 +42,6 @@ namespace BTCPayServer.Plugins.Wallets.Views.ViewModels
             var psbt = await GetPSBTCore(network, modelState);
             if (psbt != null)
             {
-                psbt.AddWitnessUtxoToSegwitInputs();
                 Decoded = psbt.ToString();
                 PSBTHex = psbt.ToHex();
                 PSBT = psbt.ToBase64();

--- a/BTCPayServer/Plugins/Wallets/Views/ViewModels/WalletPSBTViewModel.cs
+++ b/BTCPayServer/Plugins/Wallets/Views/ViewModels/WalletPSBTViewModel.cs
@@ -42,6 +42,7 @@ namespace BTCPayServer.Plugins.Wallets.Views.ViewModels
             var psbt = await GetPSBTCore(network, modelState);
             if (psbt != null)
             {
+                psbt.AddWitnessUtxoToSegwitInputs();
                 Decoded = psbt.ToString();
                 PSBTHex = psbt.ToHex();
                 PSBT = psbt.ToBase64();


### PR DESCRIPTION
Addressing two transaction edge cases:

- SegWit PSBTs now include the transaction data expected by more signing devices and wallets.
- Fully signed multisig transactions no longer remain stuck as **Pending** because their stored status is stale.

On safety front - BTCPay only changes a transaction to **Signed** when it has enough signatures **and** the PSBT can be finalized successfully. Incomplete or invalid transactions remain **Pending**.

Existing PSBT data is preserved for compatibility.

* Before HWI 3.2: HWI read `non_witness_utxo`, found the referenced output, extracted its value and script, then constructed Jade’s legacy signing request. So `non_witness_utxo` alone was sufficient.
* HWI 3.2 + Jade firmware ≥ 0.1.47: HWI sends the **raw PSBT** to Jade’s new native sign_psbt implementation. HWI no longer performs that extraction first.
* We now want BTCPay-generated PSBTs to include `witness_utxo` when `non_witness_utxo` is present for a SegWit input.

We follow what Bitcoin Core is doing:
https://github.com/bitcoin/bitcoin/blob/master/src/psbt.cpp#L741-L749

<img width="1186" height="392" alt="image" src="https://github.com/user-attachments/assets/6701ac67-6c2c-4d89-abdb-18b6db19b43d" />

## Tested

- Native, nested, and Taproot SegWit PSBT inputs
- Legacy inputs remain unchanged
- Stale multisig status repairs itself and persists
- Invalid signatures do not mark a transaction as signed

No UI changes.