### PR TITLE
Fix: TOTP 2FA bypass via Greenfield Basic auth

### DIFF
--- a/BTCPayServer/Security/GreenField/BasicAuthenticationHandler.cs
+++ b/BTCPayServer/Security/GreenField/BasicAuthenticationHandler.cs
@@ -75,7 +75,7 @@ namespace BTCPayServer.Security.Greenfield
             }
             if (user is null)
                 return Fail($"Basic authentication failed");
-            if (user.Fido2Credentials.Any())
+            if (await signInManager.IsTwoFactorEnabledAsync(user))
             {
                 return Fail("Cannot use Basic authentication when multi-factor is enabled.");
             }


### PR DESCRIPTION
Reported by @benthecarman

It was possible to bypass 2FA with Authenticator as second factor via the Greenfield API.

It was still safe from brute force, as there are some rate limit in place.

I believe I will follow up with a PR disabling Greenfield API via Basic by default later on.

---
TOTP 2FA bypass via Greenfield Basic auth

BTCPayServer/Security/GreenField/BasicAuthenticationHandler.cs:78-90 intends to block Basic auth for MFA accounts, but the check is only user.Fido2Credentials.Any(). TOTP-only users
(flag AuthenticatorEnabled, no FIDO2 row) can call the entire ~/api/v1/* API with just email:password and get an unrestricted permission claim. The UI login correctly forces these users through 2FA, so this is a real gap. Fix: use await signInManager.IsTwoFactorEnabledAsync(user).