### PR TITLE
Disable Greenfield Basic Auth by default after 5 min of user creation

### DIFF
--- a/BTCPayServer.Client/Models/ApplicationUserData.cs
+++ b/BTCPayServer.Client/Models/ApplicationUserData.cs
@@ -70,6 +70,11 @@ namespace BTCPayServer.Client.Models
         /// </summary>
         public int? StoreQuota { get; set; }
 
+        /// <summary>
+        /// whether Basic authentication is allowed for the Greenfield API
+        /// </summary>
+        public bool AllowGreenfieldBasicAuth { get; set; }
+
         [JsonExtensionData]
         public IDictionary<string, JToken> AdditionalData { get; set; } = new Dictionary<string, JToken>();
     }

--- a/BTCPayServer.Client/Models/UpdateApplicationUserRequest.cs
+++ b/BTCPayServer.Client/Models/UpdateApplicationUserRequest.cs
@@ -26,5 +26,9 @@ public class UpdateApplicationUserRequest
     /// new password of the user
     /// </summary>
     public string NewPassword { get; set; }
-}
 
+    /// <summary>
+    /// whether to allow Basic authentication for the Greenfield API
+    /// </summary>
+    public bool? AllowGreenfieldBasicAuth { get; set; }
+}

--- a/BTCPayServer.Data/Data/ApplicationUser.cs
+++ b/BTCPayServer.Data/Data/ApplicationUser.cs
@@ -62,5 +62,6 @@ namespace BTCPayServer.Data
         public string Name { get; set; }
         public string InvitationToken { get; set; }
         public int? StoreQuota { get; set; }
+        public bool AllowGreenfieldBasicAuth { get; set; }
     }
 }

--- a/BTCPayServer.Tests/GreenfieldAPITests.cs
+++ b/BTCPayServer.Tests/GreenfieldAPITests.cs
@@ -1587,6 +1587,27 @@ namespace BTCPayServer.Tests
                                                         WHERE "Id"=@id
                                                         """, new{ id = user.UserId });
 
+            var basicAuthDisabled = await AssertEx.AssertApiError(401, "unauthenticated",
+                () => clientBasic.GetCurrentUser());
+            Assert.Contains("not enabled", basicAuthDisabled.Message);
+
+            var updatedUser = await clientProfile.UpdateCurrentUser(new UpdateApplicationUserRequest
+            {
+                AllowGreenfieldBasicAuth = true
+            });
+            Assert.True(updatedUser.AllowGreenfieldBasicAuth);
+            Assert.True((await clientBasic.GetCurrentUser()).AllowGreenfieldBasicAuth);
+
+            updatedUser = await clientProfile.UpdateCurrentUser(new UpdateApplicationUserRequest
+            {
+                AllowGreenfieldBasicAuth = false
+            });
+            Assert.False(updatedUser.AllowGreenfieldBasicAuth);
+            await clientProfile.UpdateCurrentUser(new UpdateApplicationUserRequest
+            {
+                AllowGreenfieldBasicAuth = true
+            });
+
             var err = await AssertEx.AssertApiError(401, "unauthenticated", async () =>
             {
                 for (var i = 0; i < 10; i++)

--- a/BTCPayServer/Controllers/GreenField/GreenfieldUsersController.cs
+++ b/BTCPayServer/Controllers/GreenField/GreenfieldUsersController.cs
@@ -204,6 +204,13 @@ namespace BTCPayServer.Controllers.Greenfield
             }
 
             var blob = user.GetBlob() ?? new();
+            if (request.AllowGreenfieldBasicAuth is { } allowGreenfieldBasicAuth &&
+                allowGreenfieldBasicAuth != blob.AllowGreenfieldBasicAuth)
+            {
+                blob.AllowGreenfieldBasicAuth = allowGreenfieldBasicAuth;
+                needUpdate = true;
+            }
+
             if (request.Name is not null && request.Name != blob.Name)
             {
                 blob.Name = request.Name;

--- a/BTCPayServer/Controllers/UIManageController.cs
+++ b/BTCPayServer/Controllers/UIManageController.cs
@@ -95,7 +95,8 @@ namespace BTCPayServer.Controllers
                 Name = blob.Name,
                 ImageUrl = string.IsNullOrEmpty(blob.ImageUrl) ? null : await _uriResolver.Resolve(Request.GetAbsoluteRootUri(), UnresolvedUri.Create(blob.ImageUrl)),
                 EmailConfirmed = user.EmailConfirmed,
-                RequiresEmailConfirmation = user.RequiresEmailConfirmation
+                RequiresEmailConfirmation = user.RequiresEmailConfirmation,
+                AllowGreenfieldBasicAuth = blob.AllowGreenfieldBasicAuth
             };
             return View(model);
         }
@@ -174,6 +175,12 @@ namespace BTCPayServer.Controllers
             }
 
             var blob = user.GetBlob() ?? new();
+            if (blob.AllowGreenfieldBasicAuth != model.AllowGreenfieldBasicAuth)
+            {
+                blob.AllowGreenfieldBasicAuth = model.AllowGreenfieldBasicAuth;
+                needUpdate = true;
+            }
+
             if (blob.Name != model.Name)
             {
                 blob.Name = model.Name;

--- a/BTCPayServer/Models/ManageViewModels/IndexViewModel.cs
+++ b/BTCPayServer/Models/ManageViewModels/IndexViewModel.cs
@@ -18,5 +18,8 @@ namespace BTCPayServer.Models.ManageViewModels
         [Display(Name = "Profile Picture")]
         public IFormFile ImageFile { get; set; }
         public string ImageUrl { get; set; }
+
+        [Display(Name = "Allow Basic authentication for Greenfield API")]
+        public bool AllowGreenfieldBasicAuth { get; set; }
     }
 }

--- a/BTCPayServer/Security/GreenField/BasicAuthenticationHandler.cs
+++ b/BTCPayServer/Security/GreenField/BasicAuthenticationHandler.cs
@@ -59,9 +59,10 @@ namespace BTCPayServer.Security.Greenfield
                 .FirstOrDefaultAsync(applicationUser =>
                     applicationUser.NormalizedUserName == userManager.NormalizeName(username));
 
-            // We disable throttling for new accounts to give time to create API keys via greenfield API.
-            if (user?.Created is not {} created ||
-                (DateTimeOffset.UtcNow - created) > TimeSpan.FromMinutes(5))
+            // Give new accounts time to create API keys via the Greenfield API.
+            TimeSpan? accountAge = user?.Created is { } created ? DateTimeOffset.UtcNow - created : null;
+            var isNewAccount = accountAge >= TimeSpan.Zero && accountAge <= TimeSpan.FromMinutes(5);
+            if (!isNewAccount)
             {
                 if (Context.Connection.RemoteIpAddress?.ToString() is string ip)
                     if (!await rateLimitService.Throttle(ZoneLimits.Login, ip))
@@ -75,6 +76,8 @@ namespace BTCPayServer.Security.Greenfield
             }
             if (user is null)
                 return Fail($"Basic authentication failed");
+            if (!isNewAccount && user.GetBlob()?.AllowGreenfieldBasicAuth is not true)
+                return Fail("Basic authentication for the Greenfield API is not enabled for this user.");
             if (await signInManager.IsTwoFactorEnabledAsync(user))
             {
                 return Fail("Cannot use Basic authentication when multi-factor is enabled.");

--- a/BTCPayServer/Services/UserService.cs
+++ b/BTCPayServer/Services/UserService.cs
@@ -86,6 +86,7 @@ namespace BTCPayServer.Services
                 Roles = roles,
                 Disabled = data.IsDisabled,
                 StoreQuota = blob.StoreQuota,
+                AllowGreenfieldBasicAuth = blob.AllowGreenfieldBasicAuth,
                 ImageUrl = string.IsNullOrEmpty(blob.ImageUrl)
                     ? null
                     : await uriResolver.Resolve(request.GetAbsoluteRootUri(), UnresolvedUri.Create(blob.ImageUrl)),

--- a/BTCPayServer/Views/UIManage/Index.cshtml
+++ b/BTCPayServer/Views/UIManage/Index.cshtml
@@ -67,6 +67,13 @@
                 <span asp-validation-for="ImageFile" class="text-danger"></span>
             </div>
         }
+        <div class="form-group">
+            <div class="form-check">
+                <input asp-for="AllowGreenfieldBasicAuth" class="form-check-input" />
+                <label asp-for="AllowGreenfieldBasicAuth" class="form-check-label"></label>
+            </div>
+            <small class="text-muted" text-translate="true">Basic authentication is less secure than API keys. New users can use it for five minutes to create an API key without enabling this setting.</small>
+        </div>
         <h3 class="mt-5 mb-4" text-translate="true">Delete Account</h3>
         <div id="danger-zone">
             <a id="delete-user" asp-action="DeleteUserPost" class="btn btn-outline-danger mb-5" data-confirm-input="@StringLocalizer["Delete"]" data-bs-toggle="modal" data-bs-target="#ConfirmModal" text-translate="true">Delete Account</a>

--- a/BTCPayServer/wwwroot/swagger/v1/swagger.template.json
+++ b/BTCPayServer/wwwroot/swagger/v1/swagger.template.json
@@ -222,7 +222,7 @@
       },
       "Basic": {
         "type": "http",
-        "description": "BTCPay Server supports authenticating and authorizing users through the Basic HTTP authentication scheme. Send the user and password encoded in base64 with the format `Basic {base64(username:password)}`. Using this authentication method implicitly provides you with the `unrestricted` permission",
+        "description": "BTCPay Server supports authenticating and authorizing users through the Basic HTTP authentication scheme during the first five minutes after account creation or when the user explicitly enables it. Send the user and password encoded in base64 with the format `Basic {base64(username:password)}`. Using this authentication method implicitly provides you with the `unrestricted` permission",
         "scheme": "Basic"
       }
     }

--- a/BTCPayServer/wwwroot/swagger/v1/swagger.template.users.json
+++ b/BTCPayServer/wwwroot/swagger/v1/swagger.template.users.json
@@ -70,6 +70,11 @@
                                         "type": "string",
                                         "description": "The new password of the user",
                                         "nullable": true
+                                    },
+                                    "allowGreenfieldBasicAuth": {
+                                        "type": "boolean",
+                                        "description": "Whether to allow Basic authentication for the Greenfield API",
+                                        "nullable": true
                                     }
                                 }
                             }
@@ -565,6 +570,10 @@
                     "disabled": {
                         "type": "boolean",
                         "description": "True if an admin has disabled the user"
+                    },
+                    "allowGreenfieldBasicAuth": {
+                        "type": "boolean",
+                        "description": "Whether Basic authentication is allowed for the Greenfield API"
                     },
                     "roles": {
                         "type": "array",


### PR DESCRIPTION
This disable basic auth by default after 5 min.

A timeout of 5min is allowed. If the user is created programatically, a small window of time is needed to create an API key.

This will decrease potential impact of bugs such as https://github.com/btcpayserver/btcpayserver/pull/7491
In practice, this authentication scheme is never used.