### PR TITLE
Add store-wide tax rates as server plugin: PayButton, Crowdfund

### DIFF
--- a/BTCPayServer/Data/StoreBlob.cs
+++ b/BTCPayServer/Data/StoreBlob.cs
@@ -29,6 +29,7 @@ namespace BTCPayServer.Data
             RecommendedFeeBlockTarget = 1;
             PaymentMethodCriteria = new List<PaymentMethodCriteria>();
             ReceiptOptions = InvoiceDataBase.ReceiptOptions.CreateDefault();
+            TaxRates = new List<StoreTaxRate>();
         }
 
         [JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
@@ -41,6 +42,7 @@ namespace BTCPayServer.Data
         public bool RedirectAutomatically { get; set; }
         public bool ShowRecommendedFee { get; set; }
         public int RecommendedFeeBlockTarget { get; set; }
+        public List<StoreTaxRate> TaxRates { get; set; }
         string _DefaultCurrency;
         public string DefaultCurrency
         {

--- a/BTCPayServer/Plugins/Crowdfund/Controllers/UICrowdfundController.cs
+++ b/BTCPayServer/Plugins/Crowdfund/Controllers/UICrowdfundController.cs
@@ -18,6 +18,7 @@ using BTCPayServer.Forms;
 using BTCPayServer.Forms.Models;
 using BTCPayServer.Models;
 using BTCPayServer.Plugins.Crowdfund.Models;
+using BTCPayServer.Plugins.Tax;
 using BTCPayServer.Services;
 using BTCPayServer.Services.Apps;
 using BTCPayServer.Services.Invoices;
@@ -48,6 +49,7 @@ namespace BTCPayServer.Plugins.Crowdfund.Controllers
         UIInvoiceController invoiceController,
         FormDataService formDataService,
         IStringLocalizer stringLocalizer,
+        TaxRateResolver taxRateResolver, 
         CrowdfundAppType appType,
         Safe safe)
         : Controller
@@ -209,6 +211,15 @@ namespace BTCPayServer.Plugins.Crowdfund.Controllers
             {
                 var appPath = await appService.ViewLink(app);
                 var appUrl = HttpContext.Request.GetAbsoluteUri(appPath);
+                decimal? taxAmount = null;
+                var storeRate = taxRateResolver.Resolve(store.GetStoreBlob(), settings.TaxRateId);
+                if (storeRate != null && price is decimal p)
+                {
+                    var decimals = currencies.GetCurrencyData(settings.TargetCurrency, false)?.Divisibility ?? 2;
+                    var result = TaxCalculator.Calculate(p, storeRate.Rate, taxIncluded: false, decimals);
+                    price = result.PriceTaxIncluded;
+                    taxAmount = result.Tax;
+                }
                 var invoice = await invoiceController.CreateInvoiceCoreRaw(new CreateInvoiceRequest()
                 {
                     Amount = price,
@@ -217,6 +228,7 @@ namespace BTCPayServer.Plugins.Crowdfund.Controllers
                     {
                         OrderId = AppService.GetRandomOrderId(),
                         ItemCode = request.ChoiceKey ?? string.Empty,
+                        TaxIncluded = taxAmount,
                         ItemDesc = title,
                         BuyerEmail = request.Email
                     }.ToJObject(),
@@ -367,6 +379,7 @@ namespace BTCPayServer.Plugins.Crowdfund.Controllers
                 return NotFound();
 
             var settings = app.GetSettings<CrowdfundSettings>();
+            var store = await storeRepository.FindStore(app.StoreDataId);
             var resetEvery = Enum.GetName(typeof(CrowdfundResetEvery), settings.ResetEvery);
 
             var vm = new UpdateCrowdfundViewModel
@@ -405,7 +418,9 @@ namespace BTCPayServer.Plugins.Crowdfund.Controllers
                 SortPerksByPopularity = settings.SortPerksByPopularity,
                 Sounds = string.Join(Environment.NewLine, settings.Sounds),
                 AnimationColors = string.Join(Environment.NewLine, settings.AnimationColors),
-                FormId = settings.FormId
+                FormId = settings.FormId,
+                TaxRateId = settings.TaxRateId, 
+                TaxRates = store?.GetStoreBlob().TaxRates ?? new()
             };
             return View("UpdateCrowdfund", vm);
         }
@@ -532,7 +547,8 @@ namespace BTCPayServer.Plugins.Crowdfund.Controllers
                 SortPerksByPopularity = vm.SortPerksByPopularity,
                 Sounds = parsedSounds,
                 AnimationColors = parsedAnimationColors,
-                FormId = vm.FormId
+                FormId = vm.FormId,
+                TaxRateId = vm.TaxRateId
             };
 
             if (imageUpload?.Success is true)

--- a/BTCPayServer/Plugins/Crowdfund/Models/UpdateCrowdfundViewModel.cs
+++ b/BTCPayServer/Plugins/Crowdfund/Models/UpdateCrowdfundViewModel.cs
@@ -34,6 +34,9 @@ namespace BTCPayServer.Plugins.Crowdfund.Models
         [Display(Name = "HTML Meta Tags")]
         public string HtmlMetaTags{ get; set; }
 
+        [Display(Name = "Tax Rate")]
+        public string? TaxRateId { get; set; }
+        public List<StoreTaxRate> TaxRates { get; set; } = new();
 
         [Required]
         public string Description { get; set; }

--- a/BTCPayServer/Plugins/Crowdfund/Views/UpdateCrowdfund.cshtml
+++ b/BTCPayServer/Plugins/Crowdfund/Views/UpdateCrowdfund.cshtml
@@ -234,6 +234,17 @@
                 <select asp-for="FormId" class="form-select w-auto" asp-items="@checkoutFormOptions"></select>
                 <span asp-validation-for="FormId" class="text-danger"></span>
             </div>
+			<div class="form-group">
+				<label asp-for="TaxRateId" class="form-label"></label>
+				<select asp-for="TaxRateId" class="form-select w-auto">
+					<option value="" text-translate="true">No tax</option>
+					@foreach (var rate in Model.TaxRates)
+					{
+						<option value="@rate.Id">@rate.Name (@rate.Rate.ToString("0.##")%)</option>
+					}
+				</select>
+				<span asp-validation-for="TaxRateId" class="text-danger"></span>
+			</div>
 
             <h3 class="mt-5 mb-2" text-translate="true">Additional Options</h3>
             <div class="form-group">

--- a/BTCPayServer/Plugins/PayButton/Controllers/UIPayButtonController.cs
+++ b/BTCPayServer/Plugins/PayButton/Controllers/UIPayButtonController.cs
@@ -62,6 +62,7 @@ namespace BTCPayServer.Plugins.PayButton.Controllers
                 Currency = storeBlob.DefaultCurrency,
                 DefaultPaymentMethod = string.Empty,
                 PaymentMethods = storesController.GetEnabledPaymentMethodChoices(store),
+                TaxRates = storeBlob.TaxRates,
                 ButtonSize = 2,
                 UrlRoot = appUrl,
                 PayButtonImageUrl = appUrl + "img/paybutton/pay.svg",

--- a/BTCPayServer/Plugins/PayButton/Controllers/UIPublicPayButtonController.cs
+++ b/BTCPayServer/Plugins/PayButton/Controllers/UIPublicPayButtonController.cs
@@ -8,6 +8,7 @@ using BTCPayServer.Controllers;
 using BTCPayServer.Controllers.Greenfield;
 using BTCPayServer.Data;
 using BTCPayServer.Plugins.PayButton.Models;
+using BTCPayServer.Plugins.Tax;
 using BTCPayServer.Services.Invoices;
 using BTCPayServer.Services.Rates;
 using BTCPayServer.Services.Stores;
@@ -25,6 +26,7 @@ namespace BTCPayServer.Plugins.PayButton.Controllers
         StoreRepository storeRepository,
         IStringLocalizer stringLocalizer,
         CurrencyNameTable currencyNameTable,
+        TaxRateResolver taxRateResolver,
         LinkGenerator linkGenerator)
         : Controller
     {
@@ -65,6 +67,19 @@ namespace BTCPayServer.Plugins.PayButton.Controllers
             InvoiceEntity invoice;
             try
             {
+                decimal? taxAmount = null;
+                var priceForInvoice = model.Price ?? 0m;
+                if (!string.IsNullOrEmpty(model.TaxRateId))
+                {
+                    var storeRate = taxRateResolver.Resolve(store.GetStoreBlob(), model.TaxRateId);
+                    if (storeRate != null)
+                    {
+                        var decimals = currencyNameTable.GetCurrencyData(model.Currency, false)?.Divisibility ?? 2;
+                        var result = TaxCalculator.Calculate(priceForInvoice, storeRate.Rate, taxIncluded: false, decimals);
+                        priceForInvoice = result.PriceTaxIncluded;
+                        taxAmount = result.Tax;
+                    }
+                }
                 invoice = await invoiceController.CreateInvoiceCoreRaw(new CreateInvoiceRequest()
                 {
                     Amount = model.Price,
@@ -72,7 +87,8 @@ namespace BTCPayServer.Plugins.PayButton.Controllers
                     Metadata = new InvoiceMetadata()
                     {
                         ItemDesc = model.CheckoutDesc,
-                        OrderId = model.OrderId
+                        OrderId = model.OrderId,
+                        TaxIncluded = taxAmount
                     }.ToJObject(),
                     Checkout = new ()
                     {

--- a/BTCPayServer/Plugins/PayButton/Models/PayButtonViewModel.cs
+++ b/BTCPayServer/Plugins/PayButton/Models/PayButtonViewModel.cs
@@ -19,6 +19,8 @@ namespace BTCPayServer.Plugins.PayButton.Models
         public string CheckoutDesc { get; set; }
         public string OrderId { get; set; }
         public int ButtonSize { get; set; }
+        public string? TaxRateId { get; set; } 
+        public List<StoreTaxRate>? TaxRates { get; set; }
         public int ButtonType { get; set; }
 
         // Slider properties (ButtonType = 2)

--- a/BTCPayServer/Plugins/PayButton/Views/PayButton.cshtml
+++ b/BTCPayServer/Plugins/PayButton/Views/PayButton.cshtml
@@ -220,6 +220,13 @@
                     <option  v-for="pm in srvModel.paymentMethods" v-bind:value="pm.value">{{pm.name}}</option>
                 </select>
             </div>
+			<div class="form-group col-md-4" v-if="!srvModel.appIdEndpoint">
+				<label class="form-label" for="tax-rate" text-translate="true">Tax Rate</label>
+				<select v-model="srvModel.taxRateId" v-on:change="inputChanges" class="form-select" id="tax-rate">
+					<option value="" selected text-translate="true">No tax</option>
+					<option v-for="tr in srvModel.taxRates" v-bind:value="tr.id">{{tr.name}} ({{tr.rate}}%)</option>
+				</select>
+			</div>
             <div class="form-group" v-if="!srvModel.appIdEndpoint">
                 <label class="form-label" for="description" text-translate="true">Checkout Description</label>
                 <input name="checkoutDesc" type="text" class="form-control" id="description"

--- a/BTCPayServer/Plugins/Tax/Controllers/UIStoreTaxRatesController.cs
+++ b/BTCPayServer/Plugins/Tax/Controllers/UIStoreTaxRatesController.cs
@@ -1,0 +1,96 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using BTCPayServer.Abstractions.Constants;
+using BTCPayServer.Client;
+using BTCPayServer.Data;
+using BTCPayServer.Services.Stores;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace BTCPayServer.Plugins.Tax.Controllers
+{
+    [Route("stores/{storeId}/tax-rates")]
+    [Authorize(AuthenticationSchemes = AuthenticationSchemes.Cookie)]
+    [Authorize(Policy = Policies.CanModifyStoreSettings, AuthenticationSchemes = AuthenticationSchemes.Cookie)]
+    [Area(TaxPlugin.Area)]
+    public class UIStoreTaxRatesController(StoreRepository storeRepository) : Controller
+    {
+        private StoreData CurrentStore => HttpContext.GetStoreData();
+
+        private static List<StoreTaxRate> SortForDisplay(List<StoreTaxRate>? rates) =>
+            (rates ?? new()).OrderByDescending(r => r.IsDefault).ThenBy(r => r.Name).ToList();
+
+        [HttpGet("")]
+        public IActionResult TaxRates()
+        {
+            var blob = CurrentStore.GetStoreBlob();
+            var model = new StoreTaxRatesViewModel { TaxRates = SortForDisplay(blob.TaxRates) };
+            return View(model);
+        }
+
+        [HttpPost("")]
+        public async Task<IActionResult> AddOrUpdateTaxRate(StoreTaxRateEditViewModel model)
+        {
+            var blob = CurrentStore.GetStoreBlob();
+
+            if (!ModelState.IsValid)
+            {
+                return View(nameof(TaxRates), new StoreTaxRatesViewModel { TaxRates = SortForDisplay(blob.TaxRates) });
+            }
+
+            blob.TaxRates ??= new();
+            var existing = string.IsNullOrEmpty(model.Id) ? null : blob.TaxRates.FirstOrDefault(r => r.Id == model.Id);
+
+            if (existing != null)
+            {
+                existing.Name = model.Name!;
+                existing.Rate = model.Rate;
+            }
+            else
+            {
+                blob.TaxRates.Add(new StoreTaxRate
+                {
+                    Id = Guid.NewGuid().ToString(),
+                    Name = model.Name!,
+                    Rate = model.Rate,
+                    IsDefault = blob.TaxRates.Count == 0
+                });
+            }
+
+            CurrentStore.SetStoreBlob(blob);
+            await storeRepository.UpdateStore(CurrentStore);
+            TempData[WellKnownTempData.SuccessMessage] = "Tax rate saved";
+            return RedirectToAction(nameof(TaxRates), new { storeId = CurrentStore.Id });
+        }
+
+        [HttpPost("{taxRateId}/set-default")]
+        public async Task<IActionResult> SetDefault(string taxRateId)
+        {
+            var storeBlob = CurrentStore.GetStoreBlob();
+            if (storeBlob.TaxRates != null)
+            {
+                foreach (var r in storeBlob.TaxRates)
+                    r.IsDefault = r.Id == taxRateId;
+
+                CurrentStore.SetStoreBlob(storeBlob);
+                await storeRepository.UpdateStore(CurrentStore);
+            }
+            TempData[WellKnownTempData.SuccessMessage] = "Default tax rate updated";
+            return RedirectToAction(nameof(TaxRates), new { storeId = CurrentStore.Id });
+        }
+
+        [HttpPost("{taxRateId}/delete")]
+        public async Task<IActionResult> DeleteTaxRate(string taxRateId)
+        {
+            var storeBlob = CurrentStore.GetStoreBlob();
+            storeBlob.TaxRates?.RemoveAll(r => r.Id == taxRateId);
+            CurrentStore.SetStoreBlob(storeBlob);
+            await storeRepository.UpdateStore(CurrentStore);
+            TempData[WellKnownTempData.SuccessMessage] = "Tax rate deleted";
+            return RedirectToAction(nameof(TaxRates), new { storeId = CurrentStore.Id });
+        }
+    }
+}

--- a/BTCPayServer/Plugins/Tax/PoSOrder.cs
+++ b/BTCPayServer/Plugins/Tax/PoSOrder.cs
@@ -1,0 +1,96 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace BTCPayServer.Plugins.Tax;
+
+public class PoSOrder
+{
+    private readonly int _decimals;
+    decimal _discount;
+    decimal _tip;
+    decimal? _tipTaxRate;
+    public List<ItemLine> ItemLines = new();
+
+    public PoSOrder(int decimals)
+    {
+        _decimals = decimals;
+    }
+
+    public record ItemLine(string ItemId, int Count, decimal UnitPrice, decimal TaxRate, bool TaxIncluded = false);
+    public void AddLine(ItemLine line)
+    {
+        ItemLines.Add(line);
+    }
+
+    public class OrderSummary
+    {
+        public decimal Discount { get; set; }
+        public decimal Tax { get; set; }
+        public decimal TaxOnTip { get; set; }
+        public decimal ItemsTotal { get; set; }
+        public decimal PriceTaxExcluded { get; set; }
+        public decimal Tip { get; set; }
+        public decimal PriceTaxIncluded { get; set; }
+        public decimal PriceTaxIncludedWithTips { get; set; }
+    }
+
+    public OrderSummary Calculate()
+    {
+        var ctx = new OrderSummary();
+        foreach (var item in ItemLines)
+        {
+            var linePrice = item.UnitPrice * item.Count;
+            var discount = linePrice * _discount / 100.0m;
+            discount = Round(discount);
+            ctx.Discount += discount;
+            linePrice -= discount;
+            var result = TaxCalculator.Calculate(linePrice, item.TaxRate, item.TaxIncluded, _decimals);
+            ctx.Tax += result.Tax;
+            ctx.PriceTaxExcluded += result.PriceTaxExcluded;
+        }
+        ctx.PriceTaxExcluded = Round(ctx.PriceTaxExcluded);
+        ctx.PriceTaxIncluded = ctx.PriceTaxExcluded + ctx.Tax;
+        ctx.Tip = Round(_tip);
+        if (_tipTaxRate is { } rate && rate > 0 && ctx.Tip > 0)
+        {
+            ctx.TaxOnTip = Round(ctx.Tip * rate / 100.0m);
+            ctx.Tax += ctx.TaxOnTip;
+        }
+        ctx.PriceTaxIncludedWithTips = ctx.PriceTaxIncluded + ctx.Tip + ctx.TaxOnTip;
+        ctx.PriceTaxIncludedWithTips = Round(ctx.PriceTaxIncludedWithTips);
+        ctx.ItemsTotal = ctx.PriceTaxExcluded + ctx.Discount;
+        return ctx;
+    }
+
+    decimal Round(decimal value) => Math.Round(value, _decimals, MidpointRounding.AwayFromZero);
+
+    public void AddTip(decimal tip)
+    {
+        _tip = Round(tip);
+    }
+
+    public void SetTipTaxRate(decimal? tipTaxRate)
+    {
+        if (tipTaxRate is < 0m)
+            throw new ArgumentOutOfRangeException(nameof(tipTaxRate), "Tip tax rate cannot be negative.");
+
+        _tipTaxRate = tipTaxRate;
+    }
+    public decimal? GetTipTaxRate()
+    {
+        return _tipTaxRate;
+    }
+
+    public decimal? GetTaxRate()
+    {
+        if (!ItemLines.Any())
+            return null;
+        return ItemLines.GroupBy(i => i.TaxRate).Count() == 1 ? ItemLines[0].TaxRate : null;
+    }
+
+    public void AddDiscountRate(decimal discount)
+    {
+        _discount = discount;
+    }
+}

--- a/BTCPayServer/Plugins/Tax/StoreTaxRate.cs
+++ b/BTCPayServer/Plugins/Tax/StoreTaxRate.cs
@@ -1,0 +1,14 @@
+using System;
+using BTCPayServer.Plugins.GlobalSearch;
+using BTCPayServer.Plugins.GlobalSearch.Views;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace BTCPayServer;
+
+public class StoreTaxRate
+{
+    public string Id { get; set; } = Guid.NewGuid().ToString();
+    public string Name { get; set; } = "";
+    public decimal Rate { get; set; }
+    public bool IsDefault { get; set; }
+}

--- a/BTCPayServer/Plugins/Tax/StoreTaxRatesViewModel.cs
+++ b/BTCPayServer/Plugins/Tax/StoreTaxRatesViewModel.cs
@@ -1,0 +1,22 @@
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+
+namespace BTCPayServer.Plugins.Tax;
+
+public class StoreTaxRatesViewModel
+{
+    public List<StoreTaxRate> TaxRates { get; set; } = new();
+    public StoreTaxRateEditViewModel NewRate { get; set; } = new();
+}
+
+public class StoreTaxRateEditViewModel
+{
+    public string? Id { get; set; }
+
+    [Required]
+    [MaxLength(50)]
+    public string? Name { get; set; }
+
+    [Range(0, 100)]
+    public decimal Rate { get; set; }
+}

--- a/BTCPayServer/Plugins/Tax/TaxCalculator.cs
+++ b/BTCPayServer/Plugins/Tax/TaxCalculator.cs
@@ -1,0 +1,31 @@
+using System;
+
+namespace BTCPayServer.Plugins.Tax;
+
+public static class TaxCalculator
+{
+    public readonly record struct LineResult(decimal Tax, decimal PriceTaxExcluded, decimal PriceTaxIncluded);
+
+    public static LineResult Calculate(decimal price, decimal taxRate, bool taxIncluded, int decimals)
+    {
+        if (taxRate <= 0)
+            return new LineResult(0m, Round(price, decimals), Round(price, decimals));
+
+        decimal tax;
+        decimal priceExcluded;
+        if (taxIncluded)
+        {
+            tax = Round(price * taxRate / (100.0m + taxRate), decimals);
+            priceExcluded = price - tax;
+        }
+        else
+        {
+            tax = Round(price * taxRate / 100.0m, decimals);
+            priceExcluded = price;
+        }
+        var priceIncluded = Round(priceExcluded + tax, decimals);
+        return new LineResult(tax, Round(priceExcluded, decimals), priceIncluded);
+    }
+
+    public static decimal Round(decimal value, int decimals) => Math.Round(value, decimals, MidpointRounding.AwayFromZero);
+}

--- a/BTCPayServer/Plugins/Tax/TaxPlugin.cs
+++ b/BTCPayServer/Plugins/Tax/TaxPlugin.cs
@@ -1,0 +1,20 @@
+using BTCPayServer.Abstractions.Models;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace BTCPayServer.Plugins.Tax;
+
+public class TaxPlugin : BaseBTCPayServerPlugin
+{
+    public const string Area = "Tax";
+    public override string Identifier => "BTCPayServer.Plugins.Tax";
+    public override string Name => "Store Tax Rates";
+    public override string Description => "Store-wide tax rates that apps can individually opt into.";
+
+    public override void Execute(IServiceCollection services)
+    {
+        services.AddSingleton<TaxRateResolver>();
+        services.AddUIExtension("header-nav", "/Plugins/Tax/Views/NavExtension.cshtml");
+
+        base.Execute(services);
+    }
+}

--- a/BTCPayServer/Plugins/Tax/TaxRateResolver.cs
+++ b/BTCPayServer/Plugins/Tax/TaxRateResolver.cs
@@ -1,0 +1,17 @@
+using System.Linq;
+using BTCPayServer.Data;
+
+namespace BTCPayServer.Plugins.Tax;
+
+public class TaxRateResolver
+{
+    public StoreTaxRate? Resolve(StoreBlob storeBlob, string? taxRateId)
+    {
+        if (string.IsNullOrEmpty(taxRateId))
+            return null;
+
+        return storeBlob.TaxRates?.FirstOrDefault(r => r.Id == taxRateId);
+    }
+
+    public StoreTaxRate? GetSuggestedDefault(StoreBlob storeBlob) => storeBlob.TaxRates?.FirstOrDefault(r => r.IsDefault) ?? storeBlob.TaxRates?.FirstOrDefault();
+}

--- a/BTCPayServer/Plugins/Tax/Views/NavExtension.cshtml
+++ b/BTCPayServer/Plugins/Tax/Views/NavExtension.cshtml
@@ -1,0 +1,12 @@
+@using BTCPayServer.Client
+@model BTCPayServer.Components.MainNav.MainNavViewModel
+
+@if (Model.Store != null)
+{
+    <li class="nav-item" permission="@Policies.CanModifyStoreSettings">
+        <a layout-menu-item="TaxRates" asp-area="@BTCPayServer.Plugins.Tax.TaxPlugin.Area" asp-controller="UIStoreTaxRates" asp-action="TaxRates" asp-route-storeId="@Model.Store.Id">
+			<vc:icon symbol="pos-print" />
+            <span text-translate="true">Tax Rates</span>
+        </a>
+    </li>
+}

--- a/BTCPayServer/Plugins/Tax/Views/UIStoreTaxRates/TaxRates.cshtml
+++ b/BTCPayServer/Plugins/Tax/Views/UIStoreTaxRates/TaxRates.cshtml
@@ -1,0 +1,79 @@
+@using BTCPayServer.Views.Stores
+@using BTCPayServer.Client
+@using BTCPayServer.Abstractions.Models
+@model StoreTaxRatesViewModel
+@{
+	ViewData.SetLayoutModel(new(nameof(StoreNavPages.TaxRates), StringLocalizer["Tax Rates"]));
+	Layout = "_Layout";
+}
+
+<h2 class="mb-2 mb-lg-3">@ViewData["Title"]</h2>
+<partial name="_StatusMessage" />
+
+<div class="row">
+	<div class="col-xxl-constrain col-xl-8">
+		@if (!ViewContext.ModelState.IsValid)
+		{
+			<div asp-validation-summary="All" class="@(ViewContext.ModelState.ErrorCount.Equals(1) ? "no-marker" : "")"></div>
+		}
+
+		<form asp-action="AddOrUpdateTaxRate" asp-route-storeId="@Context.GetStoreData().Id" method="post"
+			  class="d-flex flex-wrap align-items-center gap-3" permission="@Policies.CanModifyStoreSettings">
+			<input name="Name" type="text" class="form-control" placeholder="@StringLocalizer["e.g. VAT 20%"]" style="flex: 1 1 14rem">
+			<div class="input-group" style="flex: 0 1 8rem">
+				<input name="Rate" type="number" step="0.01" min="0" max="100" class="form-control" placeholder="0">
+				<span class="input-group-text">%</span>
+			</div>
+			<button type="submit" role="button" class="btn btn-primary text-nowrap flex-grow-1 flex-sm-grow-0" id="AddTaxRate" text-translate="true">Add tax rate</button>
+		</form>
+
+		@if (Model.TaxRates.Any())
+		{
+			<div class="table-responsive-md mt-3">
+				<table class="table table-hover">
+					<thead>
+						<tr>
+							<th text-translate="true">Name</th>
+							<th text-translate="true">Rate</th>
+							<th text-translate="true">Default</th>
+							<th class="actions-col" permission="@Policies.CanModifyStoreSettings"></th>
+						</tr>
+					</thead>
+					<tbody>
+						@foreach (var rate in Model.TaxRates)
+						{
+							<tr>
+								<td>@rate.Name</td>
+								<td>@rate.Rate.ToString("0.##")%</td>
+								<td>
+									@if (rate.IsDefault)
+									{
+										<span class="badge bg-info" text-translate="true">Default</span>
+									}
+									else
+									{
+										<form asp-action="SetDefault" asp-route-storeId="@Context.GetStoreData().Id" asp-route-taxRateId="@rate.Id" method="post" class="d-inline" permission="@Policies.CanModifyStoreSettings">
+											<button type="submit" class="btn btn-link p-0" text-translate="true">Make default</button>
+										</form>
+									}
+								</td>
+								<td class="actions-col" permission="@Policies.CanModifyStoreSettings">
+									<a asp-action="DeleteTaxRate" asp-route-storeId="@Context.GetStoreData().Id" asp-route-taxRateId="@rate.Id" class="text-danger"
+									   data-bs-toggle="modal" data-bs-target="#ConfirmModal"
+									   data-description="@StringLocalizer["Apps currently referencing <strong>{0}</strong> will fall back to untaxed.", Html.Encode(rate.Name)]"
+									   text-translate="true">Delete</a>
+								</td>
+							</tr>
+						}
+					</tbody>
+				</table>
+			</div>
+		}
+		else
+		{
+			<p class="text-secondary mt-3" text-translate="true">No tax rates defined yet.</p>
+		}
+	</div>
+</div>
+
+<partial name="_Confirm" model="@(new ConfirmModel(StringLocalizer["Delete tax rate"], StringLocalizer["Apps currently referencing this rate will fall back to untaxed. Are you sure?"], StringLocalizer["Delete"]))" permission="@Policies.CanModifyStoreSettings" />

--- a/BTCPayServer/Plugins/Tax/Views/_ViewImports.cshtml
+++ b/BTCPayServer/Plugins/Tax/Views/_ViewImports.cshtml
@@ -1,0 +1,3 @@
+@using BTCPayServer.Abstractions.Extensions
+@using BTCPayServer.Plugins.Tax.Views
+@namespace BTCPayServer.Plugins.Tax.Views

--- a/BTCPayServer/Services/Apps/CrowdfundSettings.cs
+++ b/BTCPayServer/Services/Apps/CrowdfundSettings.cs
@@ -14,6 +14,7 @@ namespace BTCPayServer.Services.Apps
         public string Description { get; set; }
         public string HtmlLang { get; set; }
         public string HtmlMetaTags{ get; set; }
+        public string? TaxRateId { get; set; }
         public bool Enabled { get; set; } = true;
         public DateTime? StartDate { get; set; }
         public DateTime? EndDate { get; set; }

--- a/BTCPayServer/Views/UIStores/StoreNavPages.cs
+++ b/BTCPayServer/Views/UIStores/StoreNavPages.cs
@@ -16,6 +16,7 @@ namespace BTCPayServer.Views.Stores
         Tokens,
         Users,
         PayButton,
+        TaxRates,
         [Obsolete("Use custom categories for your plugin/integration instead")]
         Plugins,
         Webhooks,

--- a/BTCPayServer/wwwroot/paybutton/paybutton.js
+++ b/BTCPayServer/wwwroot/paybutton/paybutton.js
@@ -120,6 +120,7 @@ function inputChanges(vueApp, event, buttonSize) {
         if (srvModel.browserRedirect) html += addInput("browserRedirect", srvModel.browserRedirect);
         if (srvModel.notifyEmail) html += addInput("notifyEmail", srvModel.notifyEmail);
         if (srvModel.checkoutQueryString) html += addInput("checkoutQueryString", srvModel.checkoutQueryString);
+        if (srvModel.taxRateId) html += addInput("taxRateId", srvModel.taxRateId);
     }
 
     // Fixed amount: Add price and currency as hidden inputs


### PR DESCRIPTION
Adds a Tax plugin (Plugins/Tax/) with StoreTaxRate, TaxCalculator, TaxRateResolver, and a settings page to define named store tax rates.

BTCPay Server apps can opt into a rate via TaxRateId (Done for Corwdfund and Pay button)


<img width="2837" height="1900" alt="image" src="https://github.com/user-attachments/assets/286abfc8-934c-4f03-a0b6-73d2103774a5" />


Would love a first look plus feedback 

Cc, @NicolasDorier 