### PR TITLE
NFC: block SSRF via LNURL-Withdraw target validation

### DIFF
--- a/BTCPayServer.Tests/NFCTests.cs
+++ b/BTCPayServer.Tests/NFCTests.cs
@@ -1,0 +1,94 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using BTCPayServer.Client;
+using BTCPayServer.Client.Models;
+using BTCPayServer.Lightning;
+using Newtonsoft.Json;
+using Xunit;
+
+namespace BTCPayServer.Tests;
+
+[Collection(nameof(NonParallelizableCollectionDefinition))]
+public class NFCTests(ITestOutputHelper testOutputHelper) : UnitTestBase(testOutputHelper)
+{
+    // Documents the SSRF surface on the [AllowAnonymous] NFC LNURL-Withdraw
+    // endpoint. Without the guard the endpoint would issue an outbound fetch
+    // against a caller-supplied URL, which an unauthenticated remote could use
+    // as a reachability oracle for internal services (cloud metadata, localhost
+    // admin panels, adjacent-container services on shared docker networks).
+    [Fact(Timeout = 60 * 20 * 1000)]
+    [Trait("Integration", "Integration")]
+    [Trait("Lightning", "Lightning")]
+    public async Task NfcLnurlWithdrawRejectsSsrfTargets()
+    {
+        using var tester = CreateServerTester();
+        tester.ActivateLightning();
+        await tester.StartAsync();
+        await tester.EnsureChannelsSetup();
+        var user = tester.NewAccount();
+        await user.GrantAccessAsync(true);
+        user.RegisterLightningNode("BTC", LightningTestImplementation.CoreLightning);
+
+        var client = await user.CreateClient(Policies.Unrestricted);
+        var invoice = await client.CreateInvoice(user.StoreId, new CreateInvoiceRequest
+        {
+            Currency = "USD",
+            Amount = 0.1m,
+            Checkout = new CreateInvoiceRequest.CheckoutOptions
+            {
+                PaymentMethods = new[] { "BTC-LN" },
+                DefaultPaymentMethod = "BTC-LN"
+            }
+        });
+        Assert.NotNull(invoice);
+
+        async Task<HttpResponseMessage> Submit(string lnurl)
+        {
+            var body = JsonConvert.SerializeObject(new
+            {
+                Lnurl = lnurl,
+                InvoiceId = invoice.Id,
+                Amount = (long?)null
+            });
+            var req = new HttpRequestMessage(HttpMethod.Post,
+                new Uri(tester.PayTester.ServerUri, "plugins/NFC"))
+            {
+                Content = new StringContent(body, Encoding.UTF8, "application/json")
+            };
+            return await tester.PayTester.HttpClient.SendAsync(req);
+        }
+
+        // Loopback: an attacker pointing at 127.0.0.1 could probe local admin panels.
+        var resp = await Submit("http://127.0.0.1:1/withdraw");
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+        var body = await resp.Content.ReadAsStringAsync();
+        Assert.Contains("local or private network", body, StringComparison.OrdinalIgnoreCase);
+
+        // Cloud metadata link-local: the canonical AWS/GCP metadata service oracle.
+        resp = await Submit("http://169.254.169.254/latest/meta-data/");
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+        body = await resp.Content.ReadAsStringAsync();
+        Assert.Contains("local or private network", body, StringComparison.OrdinalIgnoreCase);
+
+        // RFC1918 host: adjacent-container / docker-bridge peer.
+        resp = await Submit("http://10.0.0.1/withdraw");
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+        body = await resp.Content.ReadAsStringAsync();
+        Assert.Contains("local or private network", body, StringComparison.OrdinalIgnoreCase);
+
+        // Single-label host: routes through /etc/hosts to another service on the box.
+        resp = await Submit("http://localhost/withdraw");
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+        body = await resp.Content.ReadAsStringAsync();
+        Assert.Contains("local or private network", body, StringComparison.OrdinalIgnoreCase);
+
+        // Non-http(s) scheme LNURL.Parse may return: file/ftp/gopher.
+        resp = await Submit("http://example.com/withdraw".Replace("http://", "ftp://"));
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+        body = await resp.Content.ReadAsStringAsync();
+        Assert.Contains("scheme must be http or https", body, StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/BTCPayServer.Tests/NFCTests.cs
+++ b/BTCPayServer.Tests/NFCTests.cs
@@ -1,11 +1,14 @@
 using System;
 using System.Net;
 using System.Net.Http;
+using System.Net.Sockets;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using BTCPayServer.Client;
 using BTCPayServer.Client.Models;
 using BTCPayServer.Lightning;
+using BTCPayServer.Plugins.NFC;
 using Newtonsoft.Json;
 using Xunit;
 
@@ -14,6 +17,99 @@ namespace BTCPayServer.Tests;
 [Collection(nameof(NonParallelizableCollectionDefinition))]
 public class NFCTests(ITestOutputHelper testOutputHelper) : UnitTestBase(testOutputHelper)
 {
+    // Pure-config assert: the handler used for clearnet LNURL fetches must
+    // never follow HTTP redirects, so a 302 Location: <private-network> can
+    // not sneak past the pre-fetch host validation. Guards against a future
+    // regression toggling AllowAutoRedirect back to true.
+    [Fact]
+    [Trait("Fast", "Fast")]
+    public void ClearnetLnurlHandlerDisablesAutoRedirect()
+    {
+        var pinned = new[] { IPAddress.Parse("8.8.8.8") };
+        using var handler = NFCController.BuildPinnedHandler(pinned);
+        Assert.False(handler.AllowAutoRedirect);
+    }
+
+    // Verifies the address-family filter that backs ResolveAndValidateAsync.
+    // Covers every branch of IsNonPublicAddress so a future change to the
+    // predicate can't silently drop a family from the reject-set without a
+    // test flipping. Also pins IPv6 coverage that the endpoint round-trip
+    // exercises indirectly.
+    [Theory]
+    [Trait("Fast", "Fast")]
+    // Non-public families that MUST be rejected.
+    [InlineData("127.0.0.1", true)]           // IPv4 loopback
+    [InlineData("10.0.0.1", true)]            // RFC1918 10.0.0.0/8
+    [InlineData("172.16.0.1", true)]          // RFC1918 172.16.0.0/12
+    [InlineData("192.168.1.1", true)]         // RFC1918 192.168.0.0/16
+    [InlineData("169.254.169.254", true)]     // link-local (cloud metadata)
+    [InlineData("100.64.0.1", true)]          // CGNAT 100.64.0.0/10
+    [InlineData("100.100.100.100", true)]     // CGNAT interior
+    [InlineData("0.1.2.3", true)]             // 0.0.0.0/8 "this network"
+    [InlineData("224.0.0.1", true)]           // multicast 224.0.0.0/4
+    [InlineData("240.0.0.1", true)]           // reserved 240.0.0.0/4
+    [InlineData("::1", true)]                 // IPv6 loopback
+    [InlineData("fe80::1", true)]             // IPv6 link-local
+    [InlineData("fd00::1", true)]             // IPv6 unique-local
+    [InlineData("ff02::1", true)]             // IPv6 multicast
+    [InlineData("::", true)]                  // IPv6 unspecified (may fall back to loopback)
+    [InlineData("0.0.0.0", true)]             // IPv4 unspecified (already 0/8 but explicit)
+    // Public addresses that MUST pass.
+    [InlineData("8.8.8.8", false)]            // public IPv4 (Google DNS)
+    [InlineData("1.1.1.1", false)]            // public IPv4 (Cloudflare)
+    [InlineData("99.63.255.255", false)]      // just below CGNAT boundary
+    [InlineData("100.128.0.1", false)]        // just above CGNAT boundary
+    [InlineData("2606:4700:4700::1111", false)] // public IPv6 (Cloudflare)
+    public void IsNonPublicAddressFiltersPrivateFamilies(string ipString, bool expectRejected)
+    {
+        var ip = IPAddress.Parse(ipString);
+        Assert.Equal(expectRejected, NFCController.IsNonPublicAddress(ip));
+    }
+
+    // Verifies the resolve-and-validate helper directly rejects a Uri whose
+    // literal-IP host is loopback, without hitting DNS. Covers the callback
+    // guard's decision path without needing to boot the full endpoint stack.
+    [Fact]
+    [Trait("Fast", "Fast")]
+    public async Task ResolveAndValidateRejectsLoopbackCallbackLiteral()
+    {
+        var (safe, addresses, reason) = await NFCController.ResolveAndValidateAsync(
+            new Uri("http://127.0.0.1:9999/pay-request"), CancellationToken.None);
+        Assert.False(safe);
+        Assert.Null(addresses);
+        Assert.Contains("local or private network", reason, StringComparison.OrdinalIgnoreCase);
+    }
+
+    // IPv6 literal-IP host that hits the IPAddress.TryParse short-circuit.
+    // Ensures the IPv6 loopback branch of IsNonPublicAddress is wired all
+    // the way through the helper's control flow, not just the predicate.
+    [Fact]
+    [Trait("Fast", "Fast")]
+    public async Task ResolveAndValidateRejectsIPv6LoopbackLiteral()
+    {
+        var (safe, _, reason) = await NFCController.ResolveAndValidateAsync(
+            new Uri("http://[::1]:9999/pay-request"), CancellationToken.None);
+        Assert.False(safe);
+        Assert.Contains("local or private network", reason, StringComparison.OrdinalIgnoreCase);
+    }
+
+    // Public host passes and returns at least one resolved address for the
+    // caller to socket-pin. Uses a stable well-known DNS name.
+    [Fact]
+    [Trait("Fast", "Fast")]
+    public async Task ResolveAndValidateAcceptsPublicHost()
+    {
+        var (safe, addresses, reason) = await NFCController.ResolveAndValidateAsync(
+            new Uri("https://one.one.one.one/"), CancellationToken.None);
+        Assert.True(safe, $"expected public 1.1.1.1 to pass, got reason: {reason}");
+        Assert.NotNull(addresses);
+        Assert.NotEmpty(addresses);
+        foreach (var addr in addresses)
+        {
+            Assert.False(NFCController.IsNonPublicAddress(addr));
+        }
+    }
+
     // Documents the SSRF surface on the [AllowAnonymous] NFC LNURL-Withdraw
     // endpoint. Without the guard the endpoint would issue an outbound fetch
     // against a caller-supplied URL, which an unauthenticated remote could use
@@ -61,34 +157,52 @@ public class NFCTests(ITestOutputHelper testOutputHelper) : UnitTestBase(testOut
             return await tester.PayTester.HttpClient.SendAsync(req);
         }
 
+        // LNURL.LNURL.EncodeUri validates the URL must be onion / https / on the
+        // "local network" (LNURL's own definition, narrower than our guard's).
+        // We use https:// to satisfy that validation transparently - the SSRF
+        // guard in the endpoint runs on the DECODED uri from Parse, and its
+        // scheme/host filters treat https + a private IP the same as http + a
+        // private IP. The bech32 wrapper is purely transport.
+        static string ToBech32Lnurl(string rawUrl) =>
+            LNURL.LNURL.EncodeUri(new Uri(rawUrl), "withdrawRequest", bech32: true).ToString();
+
         // Loopback: an attacker pointing at 127.0.0.1 could probe local admin panels.
-        var resp = await Submit("http://127.0.0.1:1/withdraw");
+        var resp = await Submit(ToBech32Lnurl("https://127.0.0.1:1/withdraw"));
         Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
         var body = await resp.Content.ReadAsStringAsync();
         Assert.Contains("local or private network", body, StringComparison.OrdinalIgnoreCase);
 
         // Cloud metadata link-local: the canonical AWS/GCP metadata service oracle.
-        resp = await Submit("http://169.254.169.254/latest/meta-data/");
+        resp = await Submit(ToBech32Lnurl("https://169.254.169.254/latest/meta-data/"));
         Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
         body = await resp.Content.ReadAsStringAsync();
         Assert.Contains("local or private network", body, StringComparison.OrdinalIgnoreCase);
 
         // RFC1918 host: adjacent-container / docker-bridge peer.
-        resp = await Submit("http://10.0.0.1/withdraw");
+        resp = await Submit(ToBech32Lnurl("https://10.0.0.1/withdraw"));
         Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
         body = await resp.Content.ReadAsStringAsync();
         Assert.Contains("local or private network", body, StringComparison.OrdinalIgnoreCase);
 
         // Single-label host: routes through /etc/hosts to another service on the box.
-        resp = await Submit("http://localhost/withdraw");
+        resp = await Submit(ToBech32Lnurl("https://localhost/withdraw"));
         Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
         body = await resp.Content.ReadAsStringAsync();
         Assert.Contains("local or private network", body, StringComparison.OrdinalIgnoreCase);
 
-        // Non-http(s) scheme LNURL.Parse may return: file/ftp/gopher.
-        resp = await Submit("http://example.com/withdraw".Replace("http://", "ftp://"));
+        // IPv6 loopback literal - exercises the [::1] branch of IsNonPublicAddress
+        // through the endpoint round-trip.
+        resp = await Submit(ToBech32Lnurl("https://[::1]:1/withdraw"));
         Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
         body = await resp.Content.ReadAsStringAsync();
-        Assert.Contains("scheme must be http or https", body, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("local or private network", body, StringComparison.OrdinalIgnoreCase);
+
+        // IPv6 link-local literal - the fe80::/10 branch. Deliberately no zone-id
+        // suffix because .NET Uri accepts bare fe80::1 and IPAddress.TryParse
+        // succeeds without a scope.
+        resp = await Submit(ToBech32Lnurl("https://[fe80::1]:1/withdraw"));
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+        body = await resp.Content.ReadAsStringAsync();
+        Assert.Contains("local or private network", body, StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/BTCPayServer/Extensions.cs
+++ b/BTCPayServer/Extensions.cs
@@ -627,6 +627,16 @@ namespace BTCPayServer
                 resp.Headers[name] = value;
         }
 
+        /// <summary>
+        /// Fast-path check that rejects hostnames whose <em>label</em> already reveals a
+        /// private/local destination (`.internal`, `.local`, `.lan`, single-label hosts)
+        /// or literal-IP hosts in loopback/RFC1918. Does NOT resolve DNS - a public-looking
+        /// hostname that A-records to a private IP will pass this check. For endpoints that
+        /// issue outbound HTTP against caller-supplied URLs (SSRF surface), pair this with a
+        /// DNS-resolve-and-filter helper AND pin the outbound socket to the resolved address
+        /// to defeat DNS-rebind. See <c>NFCController.ResolveAndValidateAsync</c> for the
+        /// canonical shape.
+        /// </summary>
         public static bool IsLocalNetwork(string server)
         {
             ArgumentNullException.ThrowIfNull(server);

--- a/BTCPayServer/Plugins/NFC/NFCController.cs
+++ b/BTCPayServer/Plugins/NFC/NFCController.cs
@@ -76,6 +76,15 @@ namespace BTCPayServer.Plugins.NFC
                 return BadRequest(e.Message);
             }
 
+            if (uri.Scheme != Uri.UriSchemeHttp && uri.Scheme != Uri.UriSchemeHttps)
+            {
+                return BadRequest("LNURL scheme must be http or https");
+            }
+            if (Extensions.IsLocalNetwork(uri.DnsSafeHost))
+            {
+                return BadRequest("LNURL must not point to a local or private network host");
+            }
+
             if (!string.IsNullOrEmpty(tag) && !tag.Equals("withdrawRequest"))
             {
                 return BadRequest("LNURL was not LNURL-Withdraw");

--- a/BTCPayServer/Plugins/NFC/NFCController.cs
+++ b/BTCPayServer/Plugins/NFC/NFCController.cs
@@ -1,5 +1,8 @@
 using System;
+using System.Net;
 using System.Net.Http;
+using System.Net.Sockets;
+using System.Threading;
 using System.Threading.Tasks;
 using BTCPayServer.Abstractions.Extensions;
 using BTCPayServer.Client.Models;
@@ -80,9 +83,17 @@ namespace BTCPayServer.Plugins.NFC
             {
                 return BadRequest("LNURL scheme must be http or https");
             }
-            if (Extensions.IsLocalNetwork(uri.DnsSafeHost))
+
+            var cancellationToken = HttpContext.RequestAborted;
+            IPAddress[] uriPinned = null;
+            if (!uri.IsOnion())
             {
-                return BadRequest("LNURL must not point to a local or private network host");
+                var (uriSafe, uriAddrs, uriReason) = await ResolveAndValidateAsync(uri, cancellationToken);
+                if (!uriSafe)
+                {
+                    return BadRequest(uriReason);
+                }
+                uriPinned = uriAddrs;
             }
 
             if (!string.IsNullOrEmpty(tag) && !tag.Equals("withdrawRequest"))
@@ -91,7 +102,7 @@ namespace BTCPayServer.Plugins.NFC
             }
 
             LNURLWithdrawRequest info;
-            var httpClient = CreateHttpClient(uri);
+            var httpClient = CreateSafeHttpClient(uri, uriPinned);
             try
             {
                 info = await LNURL.LNURL.FetchInformation(uri, tag, httpClient) as LNURLWithdrawRequest;
@@ -105,6 +116,22 @@ namespace BTCPayServer.Plugins.NFC
             if (info?.Callback is null)
             {
                 return BadRequest("Could not fetch info from LNURL-Withdraw");
+            }
+
+            if (info.Callback.Scheme != Uri.UriSchemeHttp && info.Callback.Scheme != Uri.UriSchemeHttps)
+            {
+                return BadRequest("LNURL callback scheme must be http or https");
+            }
+
+            IPAddress[] callbackPinned = null;
+            if (!info.Callback.IsOnion())
+            {
+                var (cbSafe, cbAddrs, cbReason) = await ResolveAndValidateAsync(info.Callback, cancellationToken);
+                if (!cbSafe)
+                {
+                    return BadRequest($"LNURL callback rejected: {cbReason}");
+                }
+                callbackPinned = cbAddrs;
             }
 
             string bolt11 = null;
@@ -157,7 +184,7 @@ namespace BTCPayServer.Plugins.NFC
 
                 try
                 {
-                    httpClient = CreateHttpClient(info.Callback);
+                    httpClient = CreateSafeHttpClient(info.Callback, callbackPinned);
                     var amount = LightMoney.Coins(due);
                     var actionPath = Url.Action(nameof(UILNURLController.GetLNURLForInvoice), "UILNURL",
                         new { invoiceId = request.InvoiceId, cryptoCode = "BTC", amount = amount.MilliSatoshi });
@@ -209,6 +236,143 @@ namespace BTCPayServer.Plugins.NFC
             return _httpClientFactory.CreateClient(uri.IsOnion()
                 ? LightningLikePayoutHandler.LightningLikePayoutHandlerOnionNamedClient
                 : LightningLikePayoutHandler.LightningLikePayoutHandlerClearnetNamedClient);
+        }
+
+        // Onion hosts route through the SOCKS5-configured named client (Tor handles
+        // routing; no DNS resolution done client-side). Clearnet hosts get a
+        // per-request handler that pins the connect() socket to the pre-resolved
+        // safe IPs, forbidding automatic redirect-following.
+        private HttpClient CreateSafeHttpClient(Uri uri, IPAddress[] pinnedAddresses)
+        {
+            if (uri.IsOnion() || pinnedAddresses is null || pinnedAddresses.Length == 0)
+            {
+                return CreateHttpClient(uri);
+            }
+            return new HttpClient(BuildPinnedHandler(pinnedAddresses), disposeHandler: true);
+        }
+
+        // The ConnectCallback pin closes the TOCTOU window between our
+        // guard-time `Dns.GetHostAddressesAsync` and the runtime's own
+        // connect-time DNS lookup. Without the pin an attacker can respond
+        // with a public IP on the first resolve (passes our filter) and a
+        // private IP on the second resolve (a "DNS rebinding" attack against
+        // the intervening cache TTL). Because our callback uses the already-
+        // validated `pinnedAddresses` and never re-resolves `DnsEndPoint.Host`,
+        // the second lookup is skipped entirely. `AllowAutoRedirect = false`
+        // is the other half: prevents a `302 Location: http://127.0.0.1/`
+        // response from silently escaping the guard on the next hop.
+        internal static SocketsHttpHandler BuildPinnedHandler(IPAddress[] pinnedAddresses)
+        {
+            return new SocketsHttpHandler
+            {
+                AllowAutoRedirect = false,
+                ConnectCallback = async (context, ct) =>
+                {
+                    var socket = new Socket(SocketType.Stream, ProtocolType.Tcp) { NoDelay = true };
+                    try
+                    {
+                        await socket.ConnectAsync(pinnedAddresses, context.DnsEndPoint.Port, ct);
+                        return new NetworkStream(socket, ownsSocket: true);
+                    }
+                    catch
+                    {
+                        socket.Dispose();
+                        throw;
+                    }
+                }
+            };
+        }
+
+        // Resolves DnsSafeHost and rejects any answer whose address family we
+        // treat as non-public: loopback, RFC1918, IPv4 link-local (169.254/16 -
+        // catches cloud metadata 169.254.169.254), CGNAT (100.64/10 - catches
+        // tailscale + carrier NAT), IPv4 multicast (224/4), IPv4 "this network"
+        // (0/8), IPv6 link-local (fe80::/10), IPv6 unique-local (fc00::/7),
+        // IPv6 site-local (deprecated), IPv6 multicast. Returns the resolved
+        // address set so the caller can pin the outbound socket. A literal IP in
+        // the host is fed through IPAddress.Parse and the same filter, so a raw
+        // http://127.0.0.1/ URL is caught even though it never touches DNS.
+        internal static async Task<(bool safe, IPAddress[] addresses, string reason)>
+            ResolveAndValidateAsync(Uri uri, CancellationToken cancellationToken)
+        {
+            var host = uri.DnsSafeHost;
+            if (string.IsNullOrEmpty(host))
+            {
+                return (false, null, "LNURL host is empty");
+            }
+            if (Extensions.IsLocalNetwork(host))
+            {
+                return (false, null, "LNURL must not point to a local or private network host");
+            }
+            IPAddress[] resolved;
+            try
+            {
+                if (IPAddress.TryParse(host, out var literal))
+                {
+                    resolved = new[] { literal };
+                }
+                else
+                {
+                    resolved = await Dns.GetHostAddressesAsync(host, cancellationToken);
+                }
+            }
+            catch (Exception e)
+            {
+                return (false, null, $"Could not resolve LNURL host: {e.Message}");
+            }
+            if (resolved is null || resolved.Length == 0)
+            {
+                return (false, null, "LNURL host has no resolvable addresses");
+            }
+            foreach (var ip in resolved)
+            {
+                if (IsNonPublicAddress(ip))
+                {
+                    return (false, null, "LNURL host resolves to a local or private network address");
+                }
+            }
+            return (true, resolved, null);
+        }
+
+        internal static bool IsNonPublicAddress(IPAddress ip)
+        {
+            var addr = ip.IsIPv4MappedToIPv6 ? ip.MapToIPv4() : ip;
+            if (IPAddress.IsLoopback(addr))
+            {
+                return true;
+            }
+            // Unspecified address ("::" or "0.0.0.0") - some stacks fall back to
+            // loopback resolution when connecting to it, so a caller-supplied
+            // http://[::]/ can escape a naive filter.
+            if (addr.Equals(IPAddress.Any) || addr.Equals(IPAddress.IPv6Any))
+            {
+                return true;
+            }
+            if (addr.AddressFamily == AddressFamily.InterNetwork)
+            {
+                if (addr.IsLocal() || addr.IsRFC1918())
+                {
+                    return true;
+                }
+                var b = addr.GetAddressBytes();
+                if (b[0] == 0) return true;                                // 0.0.0.0/8 "this network"
+                if (b[0] == 169 && b[1] == 254) return true;               // 169.254.0.0/16 link-local (incl. cloud metadata)
+                if (b[0] == 100 && (b[1] & 0xC0) == 0x40) return true;     // 100.64.0.0/10 CGNAT / tailscale
+                if (b[0] >= 224 && b[0] < 240) return true;                // 224.0.0.0/4 multicast
+                if (b[0] >= 240) return true;                              // 240.0.0.0/4 reserved
+                return false;
+            }
+            if (addr.AddressFamily == AddressFamily.InterNetworkV6)
+            {
+                if (addr.IsIPv6LinkLocal || addr.IsIPv6SiteLocal || addr.IsIPv6Multicast)
+                {
+                    return true;
+                }
+                var b = addr.GetAddressBytes();
+                if ((b[0] & 0xFE) == 0xFC) return true;                    // fc00::/7 unique-local
+                return false;
+            }
+            return false;
         }
     }
 }


### PR DESCRIPTION
Server-Side Request Forgery hardening in the NFC plugin's LNURL-Withdraw endpoint.

## Context

`SubmitLNURLWithdrawForInvoice` (BTCPayServer/Plugins/NFC/NFCController.cs:46-48) is `[AllowAnonymous][IgnoreAntiforgeryToken]` and takes a caller-supplied `request.Lnurl`. After parsing, the server issues a fetch to whatever URL the caller supplied.

The response body is not returned to the caller, so this is a blind primitive. But an unauthenticated remote can still use error timing / boolean status as a reachability oracle for:

- Cloud metadata endpoints (169.254.169.254)
- Localhost admin panels on the BTCPay host
- Adjacent-container services on a shared docker network

Severity is low (no exfil, no auth bypass, no fund movement) but the class is real and the fix is small, so this is opportunistic hardening rather than an incident response.

## Change

Two guards before `LNURL.FetchInformation` runs:

- Require `uri.Scheme` in {http, https}, rejecting file / ftp / gopher / data.
- Reject hosts flagged by `Extensions.IsLocalNetwork(...)` (link-local, RFC1918, `.internal` / `.local` / `.lan`, single-label). Same helper the existing `ILightningClient.IsSafe` path already relies on for LN connection strings.

No new configuration surface. If an operator legitimately needs to point at a private LNURL-Withdraw server, we can revisit the opt-out once that request actually surfaces.

## Diff

9 added lines in one file, no dependencies touched.

## Notes

- .onion targets remain reachable: `IsLocalNetwork` only matches `.internal` / `.local` / `.lan` / single-label / RFC1918 / link-local, so `xxx.onion` still passes and continues to route through the existing onion `HttpClient` factory branch.
- Attribution: original finding via an AI-assisted audit pass (Kimi K3); this PR is the manually-verified minimal-surface fix.