### PR TITLE
Harden NFC LNURL withdraw requests against SSRF

### DIFF
--- a/BTCPayServer.Tests/NFCTests.cs
+++ b/BTCPayServer.Tests/NFCTests.cs
@@ -1,0 +1,91 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using BTCPayServer.Plugins.NFC;
+using Xunit;
+
+namespace BTCPayServer.Tests;
+
+[Trait("Fast", "Fast")]
+public class NFCTests
+{
+    [Theory]
+    [InlineData("http://127.0.0.1/withdraw")]
+    [InlineData("https://169.254.169.254/latest/meta-data/")]
+    [InlineData("http://10.0.0.1/withdraw")]
+    [InlineData("http://[::1]/withdraw")]
+    [InlineData("https://[fe80::1]/withdraw")]
+    [InlineData("https://[fc00::1]/withdraw")]
+    [InlineData("ftp://127.0.0.1/withdraw")]
+    public void RejectsUnsafeEncodedLnurlTargets(string target)
+    {
+        var encoded = LNURL.LNURL.EncodeUri(new Uri(target), "withdrawRequest", true).ToString();
+        var uri = LNURL.LNURL.Parse(encoded, out _);
+
+        Assert.False(NFCExternalHttpClientFactory.TryValidateUri(uri, out var error));
+        Assert.NotNull(error);
+    }
+
+    [Theory]
+    [InlineData("https://example.com/withdraw")]
+    [InlineData("http://93.184.216.34/withdraw")]
+    [InlineData("http://exampleexampleexampleexampleexampleexampleexampleexampleexample.onion/withdraw")]
+    public void AcceptsPublicAndOnionLnurlTargets(string target)
+    {
+        Assert.True(
+            NFCExternalHttpClientFactory.TryValidateUri(new Uri(target), out var error),
+            error);
+    }
+
+    [Theory]
+    [InlineData("127.0.0.1", false)]
+    [InlineData("169.254.169.254", false)]
+    [InlineData("10.0.0.1", false)]
+    [InlineData("100.64.0.1", false)]
+    [InlineData("192.88.99.1", false)]
+    [InlineData("192.0.2.1", false)]
+    [InlineData("198.18.0.1", false)]
+    [InlineData("198.51.100.1", false)]
+    [InlineData("203.0.113.1", false)]
+    [InlineData("224.0.0.1", false)]
+    [InlineData("240.0.0.1", false)]
+    [InlineData("::1", false)]
+    [InlineData("fe80::1", false)]
+    [InlineData("febf::1", false)]
+    [InlineData("fc00::1", false)]
+    [InlineData("2001:db8::1", false)]
+    [InlineData("2002:7f00:1::", false)]
+    [InlineData("3fff::1", false)]
+    [InlineData("64:ff9b::7f00:1", false)]
+    [InlineData("::ffff:127.0.0.1", false)]
+    [InlineData("93.184.216.34", true)]
+    [InlineData("2606:2800:220:1:248:1893:25c8:1946", true)]
+    public void ClassifiesResolvedAddresses(string value, bool expected)
+    {
+        Assert.Equal(expected, NFCExternalHttpClientFactory.IsSafeAddress(IPAddress.Parse(value)));
+    }
+
+    [Fact]
+    public void RejectsAHostnameIfAnyResolvedAddressIsUnsafe()
+    {
+        var addresses = new[]
+        {
+            IPAddress.Parse("93.184.216.34"),
+            IPAddress.Loopback
+        };
+
+        var exception = Assert.Throws<HttpRequestException>(() =>
+            NFCExternalHttpClientFactory.EnsureSafeAddresses("example.com", addresses));
+        Assert.Contains("local or non-routable", exception.Message);
+    }
+
+    [Fact]
+    public void ClearnetHandlerPinsConnectionsAndDoesNotFollowRedirectsOrUseAProxy()
+    {
+        using var handler = NFCExternalHttpClientFactory.CreateClearnetHandler();
+
+        Assert.False(handler.AllowAutoRedirect);
+        Assert.False(handler.UseProxy);
+        Assert.NotNull(handler.ConnectCallback);
+    }
+}

--- a/BTCPayServer.Tests/NFCTests.cs
+++ b/BTCPayServer.Tests/NFCTests.cs
@@ -27,9 +27,19 @@ public class NFCTests
     }
 
     [Theory]
-    [InlineData("https://example.com/withdraw")]
+    [InlineData("http://example.com/withdraw")]
     [InlineData("http://93.184.216.34/withdraw")]
-    [InlineData("http://exampleexampleexampleexampleexampleexampleexampleexampleexample.onion/withdraw")]
+    public void RejectsClearnetHttpLnurlTargets(string target)
+    {
+        Assert.False(NFCExternalHttpClientFactory.TryValidateUri(new Uri(target), out var error));
+        Assert.NotNull(error);
+    }
+
+    [Theory]
+    [InlineData("https://example.com/withdraw")]
+    [InlineData("https://93.184.216.34/withdraw")]
+    [InlineData("http://duckduckgogg42xjoc72x3sjasowoarfbgcmvfimaftt6twagswzczad.onion/withdraw")]
+    [InlineData("https://duckduckgogg42xjoc72x3sjasowoarfbgcmvfimaftt6twagswzczad.onion/withdraw")]
     public void AcceptsPublicAndOnionLnurlTargets(string target)
     {
         Assert.True(

--- a/BTCPayServer/Plugins/NFC/NFCController.cs
+++ b/BTCPayServer/Plugins/NFC/NFCController.cs
@@ -3,7 +3,6 @@ using System.Net.Http;
 using System.Threading.Tasks;
 using BTCPayServer.Abstractions.Extensions;
 using BTCPayServer.Client.Models;
-using BTCPayServer.Data.Payouts.LightningLike;
 using BTCPayServer.Lightning;
 using BTCPayServer.Payments;
 using BTCPayServer.Services;
@@ -21,16 +20,19 @@ namespace BTCPayServer.Plugins.NFC
     public class NFCController : Controller
     {
         private readonly IHttpClientFactory _httpClientFactory;
+        private readonly NFCExternalHttpClientFactory _externalHttpClientFactory;
         private readonly InvoiceRepository _invoiceRepository;
         private readonly InvoiceActivator _invoiceActivator;
         private readonly StoreRepository _storeRepository;
 
         public NFCController(IHttpClientFactory httpClientFactory,
+            NFCExternalHttpClientFactory externalHttpClientFactory,
             InvoiceRepository invoiceRepository,
             InvoiceActivator invoiceActivator,
             StoreRepository storeRepository)
         {
             _httpClientFactory = httpClientFactory;
+            _externalHttpClientFactory = externalHttpClientFactory;
             _invoiceRepository = invoiceRepository;
             _invoiceActivator = invoiceActivator;
             _storeRepository = storeRepository;
@@ -76,16 +78,21 @@ namespace BTCPayServer.Plugins.NFC
                 return BadRequest(e.Message);
             }
 
+            if (!NFCExternalHttpClientFactory.TryValidateUri(uri, out var uriError))
+            {
+                return BadRequest(uriError);
+            }
+
             if (!string.IsNullOrEmpty(tag) && !tag.Equals("withdrawRequest"))
             {
                 return BadRequest("LNURL was not LNURL-Withdraw");
             }
 
             LNURLWithdrawRequest info;
-            var httpClient = CreateHttpClient(uri);
+            using var initialHttpClient = _externalHttpClientFactory.CreateClient(uri);
             try
             {
-                info = await LNURL.LNURL.FetchInformation(uri, tag, httpClient) as LNURLWithdrawRequest;
+                info = await LNURL.LNURL.FetchInformation(uri, tag, initialHttpClient) as LNURLWithdrawRequest;
             }
             catch (Exception ex)
             {
@@ -96,6 +103,11 @@ namespace BTCPayServer.Plugins.NFC
             if (info?.Callback is null)
             {
                 return BadRequest("Could not fetch info from LNURL-Withdraw");
+            }
+
+            if (!NFCExternalHttpClientFactory.TryValidateUri(info.Callback, out var callbackError))
+            {
+                return BadRequest($"Invalid LNURL callback: {callbackError}");
             }
 
             string bolt11 = null;
@@ -148,12 +160,12 @@ namespace BTCPayServer.Plugins.NFC
 
                 try
                 {
-                    httpClient = CreateHttpClient(info.Callback);
                     var amount = LightMoney.Coins(due);
                     var actionPath = Url.Action(nameof(UILNURLController.GetLNURLForInvoice), "UILNURL",
                         new { invoiceId = request.InvoiceId, cryptoCode = "BTC", amount = amount.MilliSatoshi });
                     var url = Request.GetAbsoluteUri(actionPath);
-                    var resp = await httpClient.GetAsync(url);
+                    using var internalHttpClient = _httpClientFactory.CreateClient();
+                    using var resp = await internalHttpClient.GetAsync(url);
                     var response = await resp.Content.ReadAsStringAsync();
 
                     if (resp.IsSuccessStatusCode)
@@ -181,7 +193,8 @@ namespace BTCPayServer.Plugins.NFC
 
             try
             {
-                var result = await info.SendRequest(bolt11, httpClient, null, null);
+                using var callbackHttpClient = _externalHttpClientFactory.CreateClient(info.Callback);
+                var result = await info.SendRequest(bolt11, callbackHttpClient, null, null);
                 if (!string.IsNullOrEmpty(result.Status) && result.Status.Equals("ok", StringComparison.InvariantCultureIgnoreCase))
                 {
                     return Ok(result.Reason);
@@ -195,11 +208,5 @@ namespace BTCPayServer.Plugins.NFC
             }
         }
 
-        private HttpClient CreateHttpClient(Uri uri)
-        {
-            return _httpClientFactory.CreateClient(uri.IsOnion()
-                ? LightningLikePayoutHandler.LightningLikePayoutHandlerOnionNamedClient
-                : LightningLikePayoutHandler.LightningLikePayoutHandlerClearnetNamedClient);
-        }
     }
 }

--- a/BTCPayServer/Plugins/NFC/NFCExternalHttpClientFactory.cs
+++ b/BTCPayServer/Plugins/NFC/NFCExternalHttpClientFactory.cs
@@ -1,0 +1,152 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Sockets;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace BTCPayServer.Plugins.NFC
+{
+    public sealed class NFCExternalHttpClientFactory(IHttpClientFactory httpClientFactory)
+    {
+        internal const string ClearnetNamedClient = nameof(NFCExternalHttpClientFactory) + "-Clearnet";
+        internal const string OnionNamedClient = nameof(NFCExternalHttpClientFactory) + "-Onion";
+
+        private static readonly IPNetwork[] NonPublicIPv4Networks =
+        [
+            IPNetwork.Parse("0.0.0.0/8"),
+            IPNetwork.Parse("10.0.0.0/8"),
+            IPNetwork.Parse("100.64.0.0/10"),
+            IPNetwork.Parse("127.0.0.0/8"),
+            IPNetwork.Parse("169.254.0.0/16"),
+            IPNetwork.Parse("172.16.0.0/12"),
+            IPNetwork.Parse("192.0.0.0/24"),
+            IPNetwork.Parse("192.0.2.0/24"),
+            IPNetwork.Parse("192.88.99.0/24"),
+            IPNetwork.Parse("192.168.0.0/16"),
+            IPNetwork.Parse("198.18.0.0/15"),
+            IPNetwork.Parse("198.51.100.0/24"),
+            IPNetwork.Parse("203.0.113.0/24"),
+            IPNetwork.Parse("224.0.0.0/4"),
+            IPNetwork.Parse("240.0.0.0/4")
+        ];
+
+        private static readonly IPNetwork GlobalIPv6Network = IPNetwork.Parse("2000::/3");
+        private static readonly IPNetwork[] NonPublicIPv6Networks =
+        [
+            IPNetwork.Parse("2001::/23"),
+            IPNetwork.Parse("2001:db8::/32"),
+            IPNetwork.Parse("2002::/16"),
+            IPNetwork.Parse("3fff::/20")
+        ];
+
+        public HttpClient CreateClient(Uri uri)
+        {
+            if (!TryValidateUri(uri, out var error))
+            {
+                throw new ArgumentException(error, nameof(uri));
+            }
+
+            return httpClientFactory.CreateClient(uri.IsOnion() ? OnionNamedClient : ClearnetNamedClient);
+        }
+
+        internal static bool TryValidateUri(Uri uri, out string error)
+        {
+            if (uri is null || !uri.IsAbsoluteUri)
+            {
+                error = "LNURL must be an absolute URI";
+                return false;
+            }
+
+            if (uri.Scheme != Uri.UriSchemeHttp && uri.Scheme != Uri.UriSchemeHttps)
+            {
+                error = "LNURL scheme must be http or https";
+                return false;
+            }
+
+            if (uri.IsOnion())
+            {
+                error = null;
+                return true;
+            }
+
+            if (IPAddress.TryParse(uri.DnsSafeHost, out var address) && !IsSafeAddress(address))
+            {
+                error = "LNURL must not point to a local or non-routable network host";
+                return false;
+            }
+
+            error = null;
+            return true;
+        }
+
+        internal static SocketsHttpHandler CreateClearnetHandler()
+        {
+            return new SocketsHttpHandler
+            {
+                AllowAutoRedirect = false,
+                UseProxy = false,
+                ConnectCallback = ConnectAsync
+            };
+        }
+
+        internal static bool IsSafeAddress(IPAddress address)
+        {
+            ArgumentNullException.ThrowIfNull(address);
+
+            if (address.IsIPv4MappedToIPv6)
+            {
+                address = address.MapToIPv4();
+            }
+
+            return address.AddressFamily switch
+            {
+                AddressFamily.InterNetwork => NonPublicIPv4Networks.All(network => !network.Contains(address)),
+                AddressFamily.InterNetworkV6 => GlobalIPv6Network.Contains(address) &&
+                                                 NonPublicIPv6Networks.All(network => !network.Contains(address)),
+                _ => false
+            };
+        }
+
+        internal static void EnsureSafeAddresses(string host, IPAddress[] addresses)
+        {
+            if (addresses is null || addresses.Length == 0)
+            {
+                throw new HttpRequestException($"Could not resolve LNURL host '{host}'");
+            }
+
+            if (addresses.Any(address => !IsSafeAddress(address)))
+            {
+                throw new HttpRequestException("LNURL host resolved to a local or non-routable network address");
+            }
+        }
+
+        private static async ValueTask<Stream> ConnectAsync(
+            SocketsHttpConnectionContext context,
+            CancellationToken cancellationToken)
+        {
+            var host = context.DnsEndPoint.Host;
+            var addresses = IPAddress.TryParse(host, out var address)
+                ? [address]
+                : await Dns.GetHostAddressesAsync(host, cancellationToken);
+            EnsureSafeAddresses(host, addresses);
+
+            var socket = new Socket(SocketType.Stream, ProtocolType.Tcp)
+            {
+                NoDelay = true
+            };
+            try
+            {
+                await socket.ConnectAsync(addresses, context.DnsEndPoint.Port, cancellationToken);
+                return new NetworkStream(socket, ownsSocket: true);
+            }
+            catch
+            {
+                socket.Dispose();
+                throw;
+            }
+        }
+    }
+}

--- a/BTCPayServer/Plugins/NFC/NFCExternalHttpClientFactory.cs
+++ b/BTCPayServer/Plugins/NFC/NFCExternalHttpClientFactory.cs
@@ -66,7 +66,14 @@ namespace BTCPayServer.Plugins.NFC
                 return false;
             }
 
-            if (uri.IsOnion())
+            var isOnion = uri.IsOnion();
+            if (!isOnion && uri.Scheme != Uri.UriSchemeHttps)
+            {
+                error = "Clearnet LNURL scheme must be https";
+                return false;
+            }
+
+            if (isOnion)
             {
                 error = null;
                 return true;

--- a/BTCPayServer/Plugins/NFC/NFCPlugin.cs
+++ b/BTCPayServer/Plugins/NFC/NFCPlugin.cs
@@ -1,4 +1,5 @@
 using BTCPayServer.Abstractions.Models;
+using BTCPayServer.Services;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace BTCPayServer.Plugins.NFC
@@ -13,6 +14,16 @@ namespace BTCPayServer.Plugins.NFC
 
         public override void Execute(IServiceCollection applicationBuilder)
         {
+            applicationBuilder.AddSingleton<NFCExternalHttpClientFactory>();
+            applicationBuilder.AddHttpClient(NFCExternalHttpClientFactory.ClearnetNamedClient)
+                .ConfigurePrimaryHttpMessageHandler(NFCExternalHttpClientFactory.CreateClearnetHandler);
+            applicationBuilder.AddHttpClient(NFCExternalHttpClientFactory.OnionNamedClient)
+                .ConfigurePrimaryHttpMessageHandler(provider =>
+                {
+                    var handler = ActivatorUtilities.CreateInstance<Socks5HttpClientHandler>(provider);
+                    handler.AllowAutoRedirect = false;
+                    return handler;
+                });
             applicationBuilder.AddUIExtension("checkout-end", "/Plugins/NFC/Views/CheckoutEnd.cshtml");
             applicationBuilder.AddUIExtension("checkout-lightning-post-content", "/Plugins/NFC/Views/LNURLNFCPostContent.cshtml");
             applicationBuilder.AddUIExtension("checkout-bitcoin-post-content", "/Plugins/NFC/Views/LNURLNFCPostContent.cshtml");


### PR DESCRIPTION
Superseeds #7494 

`SubmitLNURLWithdrawForInvoice` (BTCPayServer/Plugins/NFC/NFCController.cs:46-48) is `[AllowAnonymous][IgnoreAntiforgeryToken]` and takes a caller-supplied `request.Lnurl`. After parsing, the server issues a fetch to whatever URL the caller supplied.

The response body is not returned to the caller, so this is a blind primitive. But an unauthenticated remote can still use error timing / boolean status as a reachability oracle for:

- Cloud metadata endpoints (169.254.169.254)
- Localhost admin panels on the BTCPay host
- Adjacent-container services on a shared docker network

Severity is low (no exfil, no auth bypass, no fund movement) but the class is real and the fix is small, so this is opportunistic hardening rather than an incident response.