### PR TITLE
build: Update SSH.NET to 2026.0.0

### DIFF
--- a/BTCPayServer/BTCPayServer.csproj
+++ b/BTCPayServer/BTCPayServer.csproj
@@ -53,7 +53,7 @@
     <PackageReference Include="Serilog" Version="4.3.0" />
     <PackageReference Include="Serilog.AspNetCore" Version="10.0.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
-    <PackageReference Include="SSH.NET" Version="2025.1.0" />
+    <PackageReference Include="SSH.NET" Version="2026.0.0" />
     <PackageReference Include="TwentyTwenty.Storage" Version="2.26.1" />
     <PackageReference Include="TwentyTwenty.Storage.Amazon" Version="2.26.1" />
     <PackageReference Include="TwentyTwenty.Storage.Azure" Version="2.26.1" />


### PR DESCRIPTION
## Summary

Updates the BTCPay Server to use SSH.NET `2026.0.0`, addressing [GHSA-q939-rpr3-3284](https://github.com/sshnet/SSH.NET/security/advisories/GHSA-q939-rpr3-3284).