### PR TITLE
Fix TruncateCenter rendering blank cells for short values in reports

### DIFF
--- a/BTCPayServer/Components/TruncateCenter/Default.cshtml
+++ b/BTCPayServer/Components/TruncateCenter/Default.cshtml
@@ -15,7 +15,7 @@
             }
             else
             {
-                <span class="truncate-center-start" v-text="@(Model.Text).length > 2 * @(Model.Padding) ? @(Model.Text).slice(0, @(Model.Padding)) + '…' : ''"></span>
+                <span class="truncate-center-start" v-text="@(Model.Text).length > 2 * @(Model.Padding) ? @(Model.Text).slice(0, @(Model.Padding)) + '…' : @(Model.Text)"></span>
             }
             <span class="truncate-center-end" v-text="@(Model.Text).slice(-@(Model.Padding))" v-if="@(Model.Text).length > 2 * @(Model.Padding)"></span>
         </span>
@@ -37,8 +37,17 @@
     }
     @if (!string.IsNullOrEmpty(Model.Link))
     {
-		<a @(prefix)href="@Model.Link" rel="noreferrer noopener" target="_blank">
-            <vc:icon symbol="info" />
-        </a>
+        @if (Model.IsVue)
+        {
+            <a :href="@Model.Link" v-if="@Model.Link" rel="noreferrer noopener" target="_blank">
+                <vc:icon symbol="info" />
+            </a>
+        }
+        else
+        {
+			<a href="@Model.Link" rel="noreferrer noopener" target="_blank">
+                <vc:icon symbol="info" />
+            </a>
+        }
     }
 </span>


### PR DESCRIPTION
## Problem

In Vue mode, `TruncateCenter` renders nothing visible when the value is shorter
than the truncation threshold. Reports show a blank cell with a working copy
button beside it.

On screen the text comes only from `.truncate-center-start` and
`.truncate-center-end`. The `.truncate-center-text` span holds the full value
but is `color: transparent; position: absolute` under `@media screen`, so it
serves copy and print rather than display. For a value below `2 * padding`,
`-start` evaluates to `''` and `-end` is suppressed by its own `v-if`, so
neither visible span has content.

Server rendered mode does not have this problem. `TruncateCenter.cs` falls back
to the full text when the value is not truncated:

    vm.Start = vm.IsTruncated && !vm.Elastic ? $"{text[..padding]}…" : text;

Reproduce with a report whose `tx_id` column holds a value shorter than 30
characters (the report view passes `padding="15"`). A 64 character txid renders
fine; a short id renders blank.

## Also fixed

The info icon is an anchor to the block explorer, rendered whenever
`Model.Link` is non-empty. In Vue mode `Model.Link` is a client side
expression, so the server side check only proves an expression was passed, not
that it resolves. `StoreReports.cshtml` passes `getExplorerUrl(...)`, which
returns `null` without a txid, so those rows render `<a href="null">`: an icon
that looks actionable but goes nowhere. Now guarded with `v-if`.

## Changes

`BTCPayServer/Components/TruncateCenter/Default.cshtml`

- Vue `-start` span falls back to the full value instead of `''`
- Info anchor split into Vue and non-Vue branches, Vue one guarded by `v-if`

Both are general to the component, not specific to reports.