### PR TITLE
Make the invoices report return its rows by creation date ascending

### DIFF
--- a/BTCPayServer/Services/Reporting/InvoicesReportProvider.cs
+++ b/BTCPayServer/Services/Reporting/InvoicesReportProvider.cs
@@ -86,6 +86,7 @@ public class InvoicesReportProvider : ReportProvider
             EndDate = queryContext.To,
             StartDate = queryContext.From,
             StoreId = new[] { queryContext.StoreId },
+            OrderByDesc = false,
         }, cancellation);
 
         queryContext.ViewDefinition = new ViewDefinition()


### PR DESCRIPTION
It was the only report provider left ordering descending, while all the others already sort ascending.