### PR TITLE
Pass store to payment method config validation

### DIFF
--- a/BTCPayServer/Controllers/GreenField/GreenfieldStorePaymentMethodsController.cs
+++ b/BTCPayServer/Controllers/GreenField/GreenfieldStorePaymentMethodsController.cs
@@ -81,7 +81,7 @@ namespace BTCPayServer.Controllers.Greenfield
             {
                 try
                 {
-                    var ctx = new PaymentMethodConfigValidationContext(authorizationService, ModelState, config, User, Store.GetPaymentMethodConfig(paymentMethodId));
+                    var ctx = new PaymentMethodConfigValidationContext(authorizationService, ModelState, config, User, Store.GetPaymentMethodConfig(paymentMethodId), Store);
                     await handler.ValidatePaymentMethodConfig(ctx);
                     config = ctx.Config;
                     if (ctx.MissingPermission is not null)

--- a/BTCPayServer/Controllers/UIStoresController.LightningLike.cs
+++ b/BTCPayServer/Controllers/UIStoresController.LightningLike.cs
@@ -170,7 +170,7 @@ public partial class UIStoresController
 
         var handler = (LightningLikePaymentHandler)_handlers[paymentMethodId];
         var ctx = new PaymentMethodConfigValidationContext(_authorizationService, ModelState,
-            JToken.FromObject(paymentMethod, handler.Serializer), User, oldConf is null ? null : JToken.FromObject(oldConf, handler.Serializer));
+            JToken.FromObject(paymentMethod, handler.Serializer), User, oldConf is null ? null : JToken.FromObject(oldConf, handler.Serializer), store);
         await handler.ValidatePaymentMethodConfig(ctx);
         if (ctx.MissingPermission is not null)
             ModelState.AddModelError(nameof(vm.ConnectionString), StringLocalizer["You do not have the permissions to change this settings"]);

--- a/BTCPayServer/Payments/IPaymentMethodHandler.cs
+++ b/BTCPayServer/Payments/IPaymentMethodHandler.cs
@@ -76,15 +76,17 @@ namespace BTCPayServer.Payments
     public class PaymentMethodConfigValidationContext
     {
         public record MissingPermissionError(string Permission, string Message);
-        public PaymentMethodConfigValidationContext(IAuthorizationService authorizationService, ModelStateDictionary modelState, JToken config, ClaimsPrincipal user, JToken? previousConfig)
+        public PaymentMethodConfigValidationContext(IAuthorizationService authorizationService, ModelStateDictionary modelState, JToken config, ClaimsPrincipal user, JToken? previousConfig, Data.StoreData store)
         {
             PreviousConfig = previousConfig;
             ModelState = modelState;
             AuthorizationService = authorizationService;
             Config = config;
             User = user;
+            Store = store;
         }
         public ClaimsPrincipal User { get; }
+        public Data.StoreData Store { get; }
         public JToken? PreviousConfig { get; }
         public JToken Config { get; set; }
         public ModelStateDictionary ModelState { get; }

--- a/BTCPayServer/Plugins/Wallets/Controllers/GreenfieldStoreOnChainPaymentMethodsController.cs
+++ b/BTCPayServer/Plugins/Wallets/Controllers/GreenfieldStoreOnChainPaymentMethodsController.cs
@@ -84,7 +84,7 @@ namespace BTCPayServer.Controllers.Greenfield
             AssertCryptoCodeWallet(paymentMethodId, out var network, out _);
 
             var handler = handlers.GetBitcoinHandler(network);
-            var ctx = new PaymentMethodConfigValidationContext(authorizationService, ModelState, request.Config, User, Store.GetPaymentMethodConfig(paymentMethodId));
+            var ctx = new PaymentMethodConfigValidationContext(authorizationService, ModelState, request.Config, User, Store.GetPaymentMethodConfig(paymentMethodId), Store);
             await handler.ValidatePaymentMethodConfig(ctx);
             if (ctx.MissingPermission is not null)
             {


### PR DESCRIPTION
Payment method validation can now know which store is being configured. This lets Lightning and plugin payment method handlers reject credentials or connection strings that belong to a different store before they are saved.

This is additive for plugin authors: existing handlers that do not need the store can ignore it, while handlers that bind credentials to a store can validate that binding directly.

Closes #7510 