### PR TITLE
Add setting for zero amount invoices

### DIFF
--- a/.agents/skills/btcpayserver-pr-descriptions/SKILL.md
+++ b/.agents/skills/btcpayserver-pr-descriptions/SKILL.md
@@ -22,6 +22,11 @@ Write pull request descriptions for the people who need to understand the change
 - Do not repeat a file-by-file or commit-by-commit summary that reviewers can already see in the diff.
 - Do not describe purely internal implementation choices unless they affect how someone uses, deploys, reviews, or tests BTCPay Server.
 
+## Greenfield API Changes
+
+- If a pull request changes Greenfield API behavior, request/response fields, models, or validation, verify whether the Swagger documentation under `BTCPayServer/wwwroot/swagger/v1/` must be updated.
+- When the Greenfield API surface changes, update the matching `swagger.template.*.json` file in the same pull request.
+
 ## Visual Evidence
 
 - Prefer screenshots for visual changes.

--- a/BTCPayServer.Client/Models/StoreBaseData.cs
+++ b/BTCPayServer.Client/Models/StoreBaseData.cs
@@ -51,6 +51,7 @@ namespace BTCPayServer.Client.Models
         public bool? LightningAmountInSatoshi { get; set; }
         public bool? LightningPrivateRouteHints { get; set; }
         public bool? OnChainWithLnInvoiceFallback { get; set; }
+        public bool? AllowZeroAmountInvoices { get; set; }
         public bool? LazyPaymentMethods { get; set; }
         public bool? RedirectAutomatically { get; set; }
 

--- a/BTCPayServer.Tests/GreenfieldAPITests.cs
+++ b/BTCPayServer.Tests/GreenfieldAPITests.cs
@@ -1422,6 +1422,7 @@ namespace BTCPayServer.Tests
                 LogoUrl = "https://example.org/logo.svg",
                 BrandColor = "#003366",
                 ApplyBrandColorToBackend = true,
+                AllowZeroAmountInvoices = true,
                 PaymentMethodCriteria = new List<PaymentMethodCriteriaData>
             {
                 new()
@@ -1438,6 +1439,7 @@ namespace BTCPayServer.Tests
             Assert.Equal("https://example.org/logo.svg", updatedStore.LogoUrl);
             Assert.Equal("#003366", updatedStore.BrandColor);
             Assert.True(updatedStore.ApplyBrandColorToBackend);
+            Assert.True(updatedStore.AllowZeroAmountInvoices);
             var s = (await client.GetStore(newStore.Id));
             Assert.Equal("B", s.Name);
             var pmc = Assert.Single(s.PaymentMethodCriteria);
@@ -2034,6 +2036,47 @@ namespace BTCPayServer.Tests
                 });
             });
             Assert.Contains("Invalid or unsupported payout method: fake payment method", validationError.Message);
+        }
+
+        [Fact(Timeout = TestTimeout)]
+        [Trait("Integration", "Integration")]
+        public async Task CreateInvoiceRespectsAllowZeroAmountInvoicesSetting()
+        {
+            using var tester = CreateServerTester();
+            await tester.StartAsync();
+            var user = tester.NewAccount();
+
+            await user.RegisterAsync(true);
+            await user.CreateStoreAsync();
+            await user.RegisterDerivationSchemeAsync("BTC");
+
+            var client = await user.CreateClient(Policies.Unrestricted);
+            var store = await client.GetStore(user.StoreId);
+            Assert.False(store.AllowZeroAmountInvoices);
+            store.PaymentMethodCriteria =
+            [
+                new PaymentMethodCriteriaData
+                {
+                    Amount = 5,
+                    Above = true,
+                    PaymentMethodId = "BTC",
+                    CurrencyCode = "USD"
+                }
+            ];
+            await client.UpdateStore(store.Id, JObject.FromObject(store).ToObject<UpdateStoreRequest>());
+
+            await AssertHttpError(400, async () =>
+                await client.CreateInvoice(user.StoreId, new CreateInvoiceRequest { Amount = 0, Currency = "USD" }));
+
+            var invoice = await client.CreateInvoice(user.StoreId, new CreateInvoiceRequest { Amount = 5, Currency = "USD" });
+            Assert.Single(await client.GetInvoicePaymentMethods(invoice.Id));
+
+            store = await client.GetStore(user.StoreId);
+            store.AllowZeroAmountInvoices = true;
+            await client.UpdateStore(store.Id, JObject.FromObject(store).ToObject<UpdateStoreRequest>());
+
+            invoice = await client.CreateInvoice(user.StoreId, new CreateInvoiceRequest { Amount = 0, Currency = "USD" });
+            Assert.Empty(await client.GetInvoicePaymentMethods(invoice.Id));
         }
 
         [Fact(Timeout = TestTimeout)]

--- a/BTCPayServer.Tests/POSTests.cs
+++ b/BTCPayServer.Tests/POSTests.cs
@@ -182,6 +182,9 @@ fruit tea:
             await s.Server.ExplorerNode.SendToAddressAsync(BitcoinAddress.Create(address, Network.RegTest), Money.Coins(1.0m));
 
             // One 0 amount invoice
+            var store = await client.GetStore(s.StoreId);
+            store.AllowZeroAmountInvoices = true;
+            await client.UpdateStore(store.Id, store);
             var freeInvoiceId = await s.CreateInvoice(amount: 0m);
             TestLogs.LogInformation($"Free invoice ID: {freeInvoiceId}");
 
@@ -343,10 +346,14 @@ goodies:
             Assert.IsType<NotFoundResult>(publicApps
                 .ViewPointOfSale(app.Id, PosViewType.Cart, 0, choiceKey: "apple").Result);
 
+            var client = await user.CreateClient();
+            var store = await client.GetStore(user.StoreId);
+            store.AllowZeroAmountInvoices = true;
+            await client.UpdateStore(store.Id, store);
+
             var redirectToCheckout = Assert.IsType<RedirectToActionResult>(publicApps.ViewPointOfSale(app.Id, PosViewType.Cart, 0, choiceKey: "goodies").Result);
             Assert.Equal("InvoiceReceipt", redirectToCheckout.ActionName);
             var invoiceId = redirectToCheckout.RouteValues!["invoiceId"]!.ToString();
-            var client = await user.CreateClient();
             var inv = await client.GetInvoice(invoiceId);
             Assert.Equal(0, inv.Amount);
             Assert.NotEqual(InvoiceType.TopUp, inv.Type);
@@ -969,6 +976,11 @@ goodies:
                 ]
             });
 
+            var client = await s.AsTestAccount().CreateClient();
+            var store = await client.GetStore(s.StoreId);
+            store.AllowZeroAmountInvoices = true;
+            await client.UpdateStore(store.Id, store);
+
             await s.GoToUrl(keypadUrl);
             await s.Page.ClickAsync("#ItemsListToggle");
             await s.Page.WaitForSelectorAsync("#PosItems");
@@ -1119,6 +1131,11 @@ goodies:
             vmpos.Title = "App POS";
             vmpos.Currency = "EUR";
             Assert.IsType<RedirectToActionResult>(pos.UpdatePointOfSale(app.Id, vmpos).Result);
+
+            var client = await user.CreateClient();
+            var store = await client.GetStore(user.StoreId);
+            store.AllowZeroAmountInvoices = true;
+            await client.UpdateStore(store.Id, store);
 
             // Clamped requests
             var (invoiceId1, error1) = await PosJsonRequest(tester, app.Id, "amount=-21&discount=10&tip=2");

--- a/BTCPayServer.Tests/PlaywrightTests.cs
+++ b/BTCPayServer.Tests/PlaywrightTests.cs
@@ -981,7 +981,8 @@ namespace BTCPayServer.Tests
                 CelebratePayment = false,
                 DefaultLang = "fr-FR",
                 NetworkFeeMode = NetworkFeeMode.MultiplePaymentsOnly,
-                ShowStoreHeader = false
+                ShowStoreHeader = false,
+                AllowZeroAmountInvoices = true
             });
             await s.GoToServer();
             await s.Page.ClickAsync("#SetTemplate");
@@ -991,6 +992,7 @@ namespace BTCPayServer.Tests
             Assert.Equal("Can Use Store?", newStore.Name);
             Assert.Equal("https://test.com/", newStore.Website);
             Assert.False(newStore.CelebratePayment);
+            Assert.True(newStore.AllowZeroAmountInvoices);
             Assert.Equal("fr-FR", newStore.DefaultLang);
             Assert.Equal(NetworkFeeMode.MultiplePaymentsOnly, newStore.NetworkFeeMode);
             Assert.False(newStore.ShowStoreHeader);
@@ -1724,7 +1726,15 @@ namespace BTCPayServer.Tests
             await s.Page.ClickAsync("[data-invoice-state-badge] .dropdown-menu button:first-child");
             await TestUtils.EventuallyAsync(async () => Assert.Contains("Settled (marked)", await s.Page.ContentAsync()));
 
-            // Zero amount invoice should redirect to receipt
+            // Zero amount invoice creation is disabled by default.
+            await s.CreateInvoice(0, expectedSeverity: StatusMessageModel.StatusSeverity.Error);
+
+            var client = await s.AsTestAccount().CreateClient();
+            var store = await client.GetStore(s.StoreId);
+            store.AllowZeroAmountInvoices = true;
+            await client.UpdateStore(store.Id, store);
+
+            // Zero amount invoice should redirect to receipt when explicitly allowed.
             var zeroAmountId = await s.CreateInvoice(0);
             await s.GoToUrl($"/i/{zeroAmountId}");
             Assert.EndsWith("/receipt", s.Page.Url);

--- a/BTCPayServer.Tests/UnitTest1.cs
+++ b/BTCPayServer.Tests/UnitTest1.cs
@@ -1250,6 +1250,10 @@ namespace BTCPayServer.Tests
             Assert.Equal("EUR", invoice.Currency);
             Assert.Equal(InvoiceType.TopUp, invoice.Type);
 
+            var store = await client.GetStore(user.StoreId);
+            store.AllowZeroAmountInvoices = true;
+            await client.UpdateStore(store.Id, store);
+
             // with bitpay api
             var invoice2 = await user.BitPay.CreateInvoiceAsync(new Invoice());
             Assert.Equal("EUR", invoice2.Currency);
@@ -1625,6 +1629,10 @@ namespace BTCPayServer.Tests
             invoice4 = user.BitPay.CreateInvoice(
                 new Invoice() { Price = 0.000000019m, Currency = "BTC", FullNotifications = true }, Facade.Merchant);
             Assert.Equal(0.000000019m, invoice4.Price);
+
+            var store = await btcpayClient.GetStore(user.StoreId);
+            store.AllowZeroAmountInvoices = true;
+            await btcpayClient.UpdateStore(store.Id, store);
 
             var invoice = user.BitPay.CreateInvoice(
                 new Invoice() { Price = -0.1m, Currency = "BTC", FullNotifications = true }, Facade.Merchant);

--- a/BTCPayServer.Tests/WebhooksTests.cs
+++ b/BTCPayServer.Tests/WebhooksTests.cs
@@ -222,8 +222,11 @@ public class WebhooksTests(ITestOutputHelper log) : UnitTestBase(log)
             await user.SetupWebhook();
             var client = await user.CreateClient();
 
+            var store = await client.GetStore(user.StoreId);
+            store.AllowZeroAmountInvoices = true;
+            await client.UpdateStore(store.Id, store);
 
-           var  invoice = await client.CreateInvoice(user.StoreId, new CreateInvoiceRequest()
+            var invoice = await client.CreateInvoice(user.StoreId, new CreateInvoiceRequest()
             {
                 Amount = 0.00m,
                 Currency = "BTC"

--- a/BTCPayServer/Controllers/GreenField/GreenfieldStoresController.cs
+++ b/BTCPayServer/Controllers/GreenField/GreenfieldStoresController.cs
@@ -218,6 +218,7 @@ namespace BTCPayServer.Controllers.Greenfield
                 LightningAmountInSatoshi = storeBlob.LightningAmountInSatoshi,
                 LightningPrivateRouteHints = storeBlob.LightningPrivateRouteHints,
                 OnChainWithLnInvoiceFallback = storeBlob.OnChainWithLnInvoiceFallback,
+                AllowZeroAmountInvoices = storeBlob.AllowZeroAmountInvoices,
                 RedirectAutomatically = storeBlob.RedirectAutomatically,
                 LazyPaymentMethods = storeBlob.LazyPaymentMethods,
                 ShowRecommendedFee = storeBlob.ShowRecommendedFee,
@@ -270,6 +271,7 @@ namespace BTCPayServer.Controllers.Greenfield
             blob.LightningAmountInSatoshi = restModel.LightningAmountInSatoshi.Value;
             blob.LightningPrivateRouteHints = restModel.LightningPrivateRouteHints.Value;
             blob.OnChainWithLnInvoiceFallback = restModel.OnChainWithLnInvoiceFallback.Value;
+            blob.AllowZeroAmountInvoices = restModel.AllowZeroAmountInvoices.Value;
             blob.LazyPaymentMethods = restModel.LazyPaymentMethods.Value;
             blob.RedirectAutomatically = restModel.RedirectAutomatically.Value;
             blob.ShowRecommendedFee = restModel.ShowRecommendedFee.Value;

--- a/BTCPayServer/Controllers/UIInvoiceController.UI.cs
+++ b/BTCPayServer/Controllers/UIInvoiceController.UI.cs
@@ -1276,7 +1276,7 @@ namespace BTCPayServer.Controllers
         [HttpPost]
         [Route("invoices/{invoiceId}/changestate/{newState}")]
         [Route("stores/{storeId}/invoices/{invoiceId}/changestate/{newState}")]
-        [Authorize(AuthenticationSchemes = AuthenticationSchemes.Cookie, Policy = Policies.CanViewInvoices)]
+        [Authorize(AuthenticationSchemes = AuthenticationSchemes.Cookie, Policy = Policies.CanModifyInvoices)]
         [IgnoreAntiforgeryToken]
         public async Task<IActionResult> ChangeInvoiceState(string invoiceId, string newState)
         {

--- a/BTCPayServer/Controllers/UIInvoiceController.cs
+++ b/BTCPayServer/Controllers/UIInvoiceController.cs
@@ -229,6 +229,8 @@ namespace BTCPayServer.Controllers
                 taxIncluded = Math.Min(taxIncluded, entity.Price);
                 entity.Metadata.TaxIncluded = taxIncluded;
             }
+            if (entity.Type != InvoiceType.TopUp && entity.Price == 0m && !storeBlob.AllowZeroAmountInvoices)
+                throw new BitpayHttpException(400, "Zero-amount invoice creation is disabled for this store.");
 
             var getAppsTaggingStore = _InvoiceRepository.GetAppsTaggingStore(store.Id);
             entity.Status = InvoiceStatus.New;

--- a/BTCPayServer/Controllers/UIStoresController.Settings.cs
+++ b/BTCPayServer/Controllers/UIStoresController.Settings.cs
@@ -246,6 +246,7 @@ public partial class UIStoresController
         vm.ShowStoreHeader = storeBlob.ShowStoreHeader;
         vm.LightningAmountInSatoshi = storeBlob.LightningAmountInSatoshi;
         vm.LazyPaymentMethods = storeBlob.LazyPaymentMethods;
+        vm.AllowZeroAmountInvoices = storeBlob.AllowZeroAmountInvoices;
         vm.RedirectAutomatically = storeBlob.RedirectAutomatically;
         vm.PaymentSoundUrl = storeBlob.PaymentSoundUrl is null
             ? string.Concat(Request.GetAbsoluteRootUri().ToString(), "checkout/payment.mp3")
@@ -382,6 +383,7 @@ public partial class UIStoresController
         blob.OnChainWithLnInvoiceFallback = model.OnChainWithLnInvoiceFallback;
         blob.LightningAmountInSatoshi = model.LightningAmountInSatoshi;
         blob.LazyPaymentMethods = model.LazyPaymentMethods;
+        blob.AllowZeroAmountInvoices = model.AllowZeroAmountInvoices;
         blob.RedirectAutomatically = model.RedirectAutomatically;
         blob.ReceiptOptions = model.ReceiptOptions.ToDTO();
         blob.HtmlTitle = string.IsNullOrWhiteSpace(model.HtmlTitle) ? null : model.HtmlTitle;

--- a/BTCPayServer/Data/StoreBlob.cs
+++ b/BTCPayServer/Data/StoreBlob.cs
@@ -37,6 +37,7 @@ namespace BTCPayServer.Data
         public bool LightningAmountInSatoshi { get; set; }
         public bool LightningPrivateRouteHints { get; set; }
         public bool OnChainWithLnInvoiceFallback { get; set; }
+        public bool AllowZeroAmountInvoices { get; set; }
         public bool LazyPaymentMethods { get; set; }
         public bool RedirectAutomatically { get; set; }
         public bool ShowRecommendedFee { get; set; }

--- a/BTCPayServer/Models/StoreViewModels/CheckoutAppearanceViewModel.cs
+++ b/BTCPayServer/Models/StoreViewModels/CheckoutAppearanceViewModel.cs
@@ -50,6 +50,9 @@ namespace BTCPayServer.Models.StoreViewModels
         [Display(Name = "Only enable the payment method after user explicitly chooses it")]
         public bool LazyPaymentMethods { get; set; }
 
+        [Display(Name = "Allow creating zero-amount invoices")]
+        public bool AllowZeroAmountInvoices { get; set; }
+
         [Display(Name = "Redirect invoice to redirect url automatically after paid")]
         public bool RedirectAutomatically { get; set; }
 

--- a/BTCPayServer/Views/UIStores/CheckoutAppearance.cshtml
+++ b/BTCPayServer/Views/UIStores/CheckoutAppearance.cshtml
@@ -244,6 +244,10 @@
                     <input asp-for="LazyPaymentMethods" type="checkbox" class="btcpay-toggle me-3" />
                     <label asp-for="LazyPaymentMethods" class="form-check-label"></label>
                 </div>
+                <div class="d-flex my-3">
+                    <input asp-for="AllowZeroAmountInvoices" type="checkbox" class="btcpay-toggle me-3" />
+                    <label asp-for="AllowZeroAmountInvoices" class="form-check-label"></label>
+                </div>
                 <div class="d-flex mt-3">
                     <input asp-for="RedirectAutomatically" type="checkbox" class="btcpay-toggle me-3" />
                     <label asp-for="RedirectAutomatically" class="form-check-label"></label>

--- a/BTCPayServer/wwwroot/swagger/v1/swagger.template.stores.json
+++ b/BTCPayServer/wwwroot/swagger/v1/swagger.template.stores.json
@@ -611,6 +611,11 @@
                         "default": false,
                         "description": "Unify on-chain and lightning payment URL."
                     },
+                    "allowZeroAmountInvoices": {
+                        "type": "boolean",
+                        "default": false,
+                        "description": "If true, fixed-amount invoices with an amount of 0 can be created."
+                    },
                     "redirectAutomatically": {
                         "type": "boolean",
                         "default": false,


### PR DESCRIPTION
Close https://github.com/btcpayserver/btcpayserver/issues/7505
Not the first time a user is complaining about zero amount invoices being created, since this is a corner case, better to disable it by default.

## Summary

Zero-amount invoice creation is now controlled by a store setting.

By default, stores reject fixed-amount invoices where the amount is `0`. Merchants that intentionally use zero-amount invoices can enable the new checkout setting: **Allow creating zero-amount invoices**.

## Breaking Change

Users and integrations that rely on creating `0` amount invoices must enable this setting for their store after upgrading.

Without this setting enabled, invoice creation requests with amount `0` will fail.

Top-up invoices are not affected because they do not have a fixed invoice amount.

## Visual Evidence

<img width="2328" height="848" alt="image" src="https://github.com/user-attachments/assets/c9755df2-188e-4144-a9e1-5ef4878b42ff" />
