### PR TITLE
Fix Manage billing 404 for users without subscriptions

### DIFF
--- a/.agents/skills/btcpayserver-pr-descriptions/SKILL.md
+++ b/.agents/skills/btcpayserver-pr-descriptions/SKILL.md
@@ -42,3 +42,8 @@ Write pull request descriptions for the people who need to understand the change
 - Keep the description focused on outcomes and behavior.
 - Avoid filler such as "this PR updates files" or "this PR changes logic".
 - Avoid overstating the impact; say what changed and who benefits.
+
+## GitHub CLI Formatting
+
+- When creating or editing PR descriptions with `gh pr create` or `gh pr edit`, pass real multiline Markdown so GitHub renders paragraphs, lists, and code blocks correctly.
+- Do not pass literal `\n` sequences in quoted strings. Use a heredoc, a temporary body file, or Bash ANSI-C quoting (`$'...'`) when invoking `gh` from the shell.

--- a/BTCPayServer.Tests/MonetizationTests.cs
+++ b/BTCPayServer.Tests/MonetizationTests.cs
@@ -31,6 +31,10 @@ public class MonetizationTests(ITestOutputHelper helper) : UnitTestBase(helper)
 
         await s.FindAlertMessage(partialText: "Monetization activated");
 
+        await s.GoToUrl("/account/billing");
+        await s.FindAlertMessage(StatusMessageModel.StatusSeverity.Error, partialText: "No billing subscription is associated with your account.");
+        await GoToMonetization(s);
+
         // Creating a new user, should create a new subscriber
         var ev = await s.Server.WaitForEvent<SubscriptionEvent.NewSubscriber>(async () =>
         {

--- a/BTCPayServer/Plugins/Monetization/Controllers/UIUserMonetizationController.cs
+++ b/BTCPayServer/Plugins/Monetization/Controllers/UIUserMonetizationController.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using BTCPayServer.Abstractions.Constants;
 using BTCPayServer.Abstractions.Extensions;
 using BTCPayServer.Client;
+using BTCPayServer.Controllers;
 using BTCPayServer.Data;
 using BTCPayServer.Data.Subscriptions;
 using BTCPayServer.Plugins.Subscriptions;
@@ -11,6 +12,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Localization;
 
 namespace BTCPayServer.Plugins.Monetization.Controllers;
 
@@ -20,9 +22,12 @@ public class UIUserMonetizationController(
     ApplicationDbContext ctx,
     MonetizationSettings settings,
     PoliciesSettings policies,
-    LinkGenerator linkGenerator
+    LinkGenerator linkGenerator,
+    IStringLocalizer stringLocalizer
     ) : Controller
 {
+    public IStringLocalizer StringLocalizer { get; } = stringLocalizer;
+
     [HttpGet("~/monetization/new-user")]
     [AllowAnonymous]
     public async Task<IActionResult> NewUser()
@@ -56,7 +61,10 @@ public class UIUserMonetizationController(
         var userId = User.GetId();
         var sub = await ctx.Subscribers.GetBySelector(offeringId, CustomerSelector.ByIdentity(SubscriberDataExtensions.IdentityType, userId));
         if (sub is null)
-            return NotFound();
+        {
+            TempData[WellKnownTempData.ErrorMessage] = StringLocalizer["No billing subscription is associated with your account."].Value;
+            return RedirectToAction(nameof(UIManageController.Index), "UIManage", new { area = "" });
+        }
 
         // With fast redirect, if we detect there is no can-access and we have only one plan change,
         // we go straight to a hard migration. (Which reimburses the user for the unused part of his current plan)


### PR DESCRIPTION
When a server has monetization enabled, admins and other accounts without a billing subscription could open **Manage billing** and land on a 404 page. They now return to the account page with a clear error explaining that no billing subscription is associated with their account.

This keeps valid subscribers on the billing portal, while making unsupported accounts fail with a useful message instead of a missing page.

Fixes #7499