### PR TITLE
Do not show breadcrumb when there is only the title of the page

### DIFF
--- a/BTCPayServer/Components/TitleHeader/Default.cshtml
+++ b/BTCPayServer/Components/TitleHeader/Default.cshtml
@@ -1,7 +1,13 @@
+@using BTCPayServer.Components.Breadcrumb
 @model BTCPayServer.Components.Breadcrumb.BreadcrumbViewModel
 
+@functions {
+    private bool IsTitleOnly(IReadOnlyList<BreadcrumbItem> modelItems)
+    => modelItems.Count == 1 && modelItems[0].Active && Model.Title is not null && modelItems[0].Text as string == Model.Title?.ToString();
+}
+
 <nav aria-label="breadcrumb" class="title-header-nav">
-    @if (Model.Items.Any())
+    @if (Model.Items.Any() && !IsTitleOnly(Model.Items))
     {
         <ol class="breadcrumb title-header-nav__items">
             @foreach (var item in Model.Items)


### PR DESCRIPTION
Before:
<img width="1674" height="432" alt="image" src="https://github.com/user-attachments/assets/fd7a3124-bd15-4d57-8574-fe83a9d8bee7" />

After:

<img width="2130" height="476" alt="image" src="https://github.com/user-attachments/assets/036be785-c4e8-425e-b4b4-736d71d37fbf" />
