### PR TITLE
Fix blank plugin details panel for unlisted plugins

### DIFF
--- a/BTCPayServer.Tests/PluginManagerTests.cs
+++ b/BTCPayServer.Tests/PluginManagerTests.cs
@@ -289,6 +289,138 @@ namespace BTCPayServer.Tests
         }
 
         [Fact]
+        public async Task SelectedPluginPanel_FallsBackToSearchForUnlistedPlugin()
+        {
+            var requestedQueries = new List<string>();
+            using var httpClient = new HttpClient(new TestHttpMessageHandler(request =>
+            {
+                requestedQueries.Add(request.RequestUri!.Query);
+                if (request.RequestUri.Query.Contains("searchPluginName=unlistedplugin"))
+                {
+                    return TestHttpMessageHandler.JsonResponse("""
+                                                                [{
+                                                                    "projectSlug": "unlistedplugin",
+                                                                    "buildId": 2,
+                                                                    "manifestInfo": {
+                                                                        "identifier": "UnlistedPlugin",
+                                                                        "name": "Unlisted Plugin",
+                                                                        "version": "1.0.0"
+                                                                    },
+                                                                    "buildInfo": {}
+                                                                }]
+                                                                """);
+                }
+
+                return TestHttpMessageHandler.JsonResponse("""
+                                                            [{
+                                                                "projectSlug": "listedplugin",
+                                                                "buildId": 1,
+                                                                "manifestInfo": {
+                                                                    "identifier": "ListedPlugin",
+                                                                    "name": "Listed Plugin",
+                                                                    "version": "1.0.0"
+                                                                },
+                                                                "buildInfo": {}
+                                                            }]
+                                                            """);
+            }))
+            {
+                BaseAddress = new Uri("https://plugins.example/")
+            };
+            var controller = CreatePluginManagerController(Path.GetTempPath(), [], httpClient);
+
+            var result = await controller.SelectedPluginPanel("unlistedplugin");
+
+            var view = Assert.IsType<Microsoft.AspNetCore.Mvc.PartialViewResult>(result);
+            var model = Assert.IsType<PluginSelectedPanelViewModel>(view.Model);
+            Assert.Equal("unlistedplugin", model.SelectedSlug);
+            Assert.Equal("UnlistedPlugin", model.PluginIdentifier);
+            Assert.Equal("1.0.0", model.InstallVersion);
+            Assert.Contains(requestedQueries, query => query.Contains("searchPluginName=unlistedplugin"));
+        }
+
+        [Fact]
+        public async Task SelectedPluginPanel_DoesNotFallBackToSearchWhenSlugIsListed()
+        {
+            var requestedQueries = new List<string>();
+            using var httpClient = new HttpClient(new TestHttpMessageHandler(request =>
+            {
+                requestedQueries.Add(request.RequestUri!.Query);
+                return TestHttpMessageHandler.JsonResponse("""
+                                                            [{
+                                                                "projectSlug": "testplugin",
+                                                                "buildId": 1,
+                                                                "manifestInfo": {
+                                                                    "identifier": "TestPlugin",
+                                                                    "name": "Test Plugin",
+                                                                    "version": "1.0.0"
+                                                                },
+                                                                "buildInfo": {}
+                                                            }]
+                                                            """);
+            }))
+            {
+                BaseAddress = new Uri("https://plugins.example/")
+            };
+            var controller = CreatePluginManagerController(Path.GetTempPath(), [], httpClient);
+
+            var result = await controller.SelectedPluginPanel("testplugin");
+
+            var view = Assert.IsType<Microsoft.AspNetCore.Mvc.PartialViewResult>(result);
+            var model = Assert.IsType<PluginSelectedPanelViewModel>(view.Model);
+            Assert.Equal("TestPlugin", model.PluginIdentifier);
+            Assert.DoesNotContain(requestedQueries, query => query.Contains("searchPluginName="));
+        }
+
+        [Fact]
+        public async Task PluginDirectory_LoadsUnlistedPluginForSelectedSlug()
+        {
+            using var httpClient = new HttpClient(new TestHttpMessageHandler(request =>
+            {
+                if (request.RequestUri!.Query.Contains("searchPluginName=unlistedplugin"))
+                {
+                    return TestHttpMessageHandler.JsonResponse("""
+                                                                [{
+                                                                    "projectSlug": "unlistedplugin",
+                                                                    "buildId": 2,
+                                                                    "manifestInfo": {
+                                                                        "identifier": "UnlistedPlugin",
+                                                                        "name": "Unlisted Plugin",
+                                                                        "version": "1.0.0"
+                                                                    },
+                                                                    "buildInfo": {}
+                                                                }]
+                                                                """);
+                }
+
+                return TestHttpMessageHandler.JsonResponse("""
+                                                            [{
+                                                                "projectSlug": "listedplugin",
+                                                                "buildId": 1,
+                                                                "manifestInfo": {
+                                                                    "identifier": "ListedPlugin",
+                                                                    "name": "Listed Plugin",
+                                                                    "version": "1.0.0"
+                                                                },
+                                                                "buildInfo": {}
+                                                            }]
+                                                            """);
+            }))
+            {
+                BaseAddress = new Uri("https://plugins.example/")
+            };
+            var controller = CreatePluginManagerController(Path.GetTempPath(), [], httpClient);
+
+            var result = await controller.PluginDirectory("unlistedplugin");
+
+            var view = Assert.IsType<Microsoft.AspNetCore.Mvc.ViewResult>(result);
+            var model = Assert.IsType<PluginDirectoryViewModel>(view.Model);
+            Assert.Equal("unlistedplugin", model.SelectedPluginPanel.SelectedSlug);
+            Assert.Equal("UnlistedPlugin", model.SelectedPluginPanel.PluginIdentifier);
+            Assert.Equal("1.0.0", model.SelectedPluginPanel.InstallVersion);
+        }
+
+        [Fact]
         public void PluginDirectoryViewModel_HidesInstalledAndDisabledIdentifiersForEmbed()
         {
             var model = CreatePluginDirectoryViewModel(

--- a/BTCPayServer/Plugins/PluginManager/Controllers/UIPluginManagerController.cs
+++ b/BTCPayServer/Plugins/PluginManager/Controllers/UIPluginManagerController.cs
@@ -38,7 +38,7 @@ public class UIPluginManagerController(
     {
         var remotePlugins = string.IsNullOrWhiteSpace(selectedSlug)
             ? []
-            : await LoadRemotePlugins();
+            : await LoadRemotePlugins(selectedSlug);
         var model = CreatePluginDirectoryViewModel(selectedSlug, remotePlugins);
         var pluginSourceBaseUri = pluginService.GetPluginSourceBaseUri();
         var btcpayVersion = pluginService.GetShortBtcpayVersion();
@@ -65,7 +65,7 @@ public class UIPluginManagerController(
         AvailablePlugin[] remotePlugins;
         try
         {
-            remotePlugins = await pluginService.GetRemotePlugins(null);
+            remotePlugins = await LoadRemotePluginsForSelectedSlug(slug);
         }
         catch
         {
@@ -610,11 +610,11 @@ public class UIPluginManagerController(
             .ToList();
     }
 
-    private async Task<AvailablePlugin[]> LoadRemotePlugins()
+    private async Task<AvailablePlugin[]> LoadRemotePlugins(string selectedSlug = null)
     {
         try
         {
-            return await pluginService.GetRemotePlugins(null);
+            return await LoadRemotePluginsForSelectedSlug(selectedSlug);
         }
         catch (Exception ex)
         {
@@ -625,6 +625,20 @@ public class UIPluginManagerController(
             });
             return [];
         }
+    }
+
+    private async Task<AvailablePlugin[]> LoadRemotePluginsForSelectedSlug(string selectedSlug)
+    {
+        var remotePlugins = await pluginService.GetRemotePlugins(null);
+        if (string.IsNullOrWhiteSpace(selectedSlug) ||
+            remotePlugins.Any(plugin => string.Equals(plugin.CatalogSlug, selectedSlug, StringComparison.OrdinalIgnoreCase)))
+            return remotePlugins;
+
+        var searchedPlugins = await pluginService.GetRemotePlugins(selectedSlug);
+        return remotePlugins
+            .Concat(searchedPlugins.Where(plugin =>
+                string.Equals(plugin.CatalogSlug, selectedSlug, StringComparison.OrdinalIgnoreCase)))
+            .ToArray();
     }
 
     private IActionResult RedirectToPlugins(string selectedSlug)


### PR DESCRIPTION
Fixes #7508

Unlisted plugins can be found by searching the Plugin Directory, but selecting the search result opened an empty details panel with no metadata or install button. This PR falls back to a slug-specific catalog lookup when the selected plugin is not part of the default listing, mirroring how the directory search itself surfaces unlisted plugins.

- Selecting an unlisted plugin now shows its details and allows installation.
- Direct links like `/server/plugins/directory?selectedSlug=barebitcoin` render correctly.
- Listed plugins are unaffected and do not trigger the extra lookup.

Unit tests were added covering the fallback for unlisted slugs and the no-op for listed ones.