### PR TITLE
Stop wallet Label from falling back to the derivation scheme

### DIFF
--- a/BTCPayServer/Plugins/Wallets/Controllers/GreenfieldStoreOnChainWalletsController.cs
+++ b/BTCPayServer/Plugins/Wallets/Controllers/GreenfieldStoreOnChainWalletsController.cs
@@ -70,7 +70,7 @@ namespace BTCPayServer.Controllers.Greenfield
 
             return Ok(new OnChainWalletOverviewData()
             {
-                Label = derivationScheme.ToPrettyString(),
+                Label = derivationScheme.Label ?? "Unlabeled wallet",
                 Balance = balance.Total.GetValue(network),
                 UnconfirmedBalance = balance.Unconfirmed.GetValue(network),
                 ConfirmedBalance = balance.Confirmed.GetValue(network),

--- a/BTCPayServer/Plugins/Wallets/Controllers/GreenfieldStoreOnChainWalletsController.cs
+++ b/BTCPayServer/Plugins/Wallets/Controllers/GreenfieldStoreOnChainWalletsController.cs
@@ -70,7 +70,7 @@ namespace BTCPayServer.Controllers.Greenfield
 
             return Ok(new OnChainWalletOverviewData()
             {
-                Label = derivationScheme.Label ?? "Unlabeled wallet",
+                Label = derivationScheme.Label ?? "",
                 Balance = balance.Total.GetValue(network),
                 UnconfirmedBalance = balance.Unconfirmed.GetValue(network),
                 ConfirmedBalance = balance.Confirmed.GetValue(network),


### PR DESCRIPTION
Cc. @NicolasDorier 


Confirmed in the UI the label field is empty