### PR TITLE
Fix/monetization cannot override admin lockout

### DIFF
--- a/BTCPayServer/Events/UserEvent.cs
+++ b/BTCPayServer/Events/UserEvent.cs
@@ -61,6 +61,11 @@ public class UserEvent(ApplicationUser user)
         public bool Bypass { get; } = bypass;
         public RequestBaseUrl RequestBaseUrl { get; } = requestBaseUrl;
     }
+    public class DisabledChanged(ApplicationUser user, bool disabled, string? source = null) : UserEvent(user)
+    {
+        public bool Disabled { get; } = disabled;
+        public string? Source { get; } = source;
+    }
     public class Approved(ApplicationUser user, string loginLink) : UserEvent(user)
     {
         public string LoginLink { get; set; } = loginLink;

--- a/BTCPayServer/Plugins/Monetization/MonetizationHostedService.cs
+++ b/BTCPayServer/Plugins/Monetization/MonetizationHostedService.cs
@@ -3,7 +3,6 @@ using System;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using BTCPayServer.Abstractions;
 using BTCPayServer.Data;
 using BTCPayServer.Data.Subscriptions;
 using BTCPayServer.Events;
@@ -27,6 +26,7 @@ public class MonetizationHostedService(
     BTCPayServerSecurityStampValidator.SecurityStampInvalidator securityStampInvalidator,
     ISettingsAccessor<MonetizationSettings> monetizationSettingsAccessor,
     IServiceScopeFactory serviceScopeFactory,
+    SubscriptionHostedService subsService,
     Logs logger) : EventHostedServiceBase(eventAggregator, logger)
 {
     public class MonetizationLockoutUpdated((string UserId, bool LockoutEnabled)[] updated)
@@ -44,6 +44,7 @@ public class MonetizationHostedService(
         this.SubscribeAny<UserEvent.BypassMonetizationChanged>();
         this.SubscribeAny<UserEvent.Registered>();
         this.SubscribeAny<UserEvent.Deleted>();
+        this.SubscribeAny<UserEvent.DisabledChanged>();
     }
 
     protected override async Task ProcessEvent(object evt, CancellationToken cancellationToken)
@@ -112,7 +113,7 @@ public class MonetizationHostedService(
                 var userSub = await ctx.Subscribers.GetBySelector(byPassOfferingId, CustomerSelector.ByIdentity(SubscriberDataExtensions.IdentityType, changed.User.Id));
                 if (userSub is not null)
                 {
-                    await userService.SetDisabled(changed.User.Id, false);
+                    await userService.SetDisabled(changed.User.Id, false, nameof(MonetizationHostedService));
                     EventAggregator.Publish(new MonetizationLockoutUpdated([(changed.User.Id, false)]));
                 }
             }
@@ -125,7 +126,7 @@ public class MonetizationHostedService(
                     var shouldBeLocked = !userSub.IsActive || userSub.Phase == SubscriberData.PhaseTypes.Expired;
                     if (shouldBeLocked)
                     {
-                        await userService.SetDisabled(changed.User.Id, true);
+                        await userService.SetDisabled(changed.User.Id, true, nameof(MonetizationHostedService));
                         securityStampInvalidator.Invalidate(changed.User.Id);
                         EventAggregator.Publish(new MonetizationLockoutUpdated([(changed.User.Id, true)]));
                     }
@@ -148,6 +149,17 @@ public class MonetizationHostedService(
             }
         }
 
+        if (evt is UserEvent.DisabledChanged { Disabled: true, Source: not nameof(MonetizationHostedService) } disabledChanged &&
+            monetizationSettingsAccessor.Settings is { OfferingId: { } dcOfferingId })
+        {
+            await using var ctx = dbContextFactory.CreateContext();
+            var sub = await ctx.Subscribers.GetBySelector(dcOfferingId,
+                CustomerSelector.ByIdentity(SubscriberDataExtensions.IdentityType, disabledChanged.User.Id));
+            if (sub is { IsSuspended: false })
+            {
+                await subsService.Suspend(sub.Id, "Account disabled by administrator");
+            }
+        }
 
         if (evt is UserEvent.Registered reg && monetizationSettingsAccessor.Settings is
             {
@@ -198,7 +210,7 @@ public class MonetizationHostedService(
         var userId = evt.Subscriber.GetApplicationUserId();
         var user = await userManager.FindByIdAsync(userId ?? "");
         if (user is not null &&
-            await userService.SetDisabled(user.Id, !activated) is not UserService.SetDisabledResult.Error)
+            await userService.SetDisabled(user.Id, !activated, nameof(MonetizationHostedService)) is not UserService.SetDisabledResult.Error)
         {
             EventAggregator.Publish(new MonetizationLockoutUpdated([(user.Id, !activated)]));
         }

--- a/BTCPayServer/Plugins/Subscriptions/Controllers/UIPlanCheckoutController.cs
+++ b/BTCPayServer/Plugins/Subscriptions/Controllers/UIPlanCheckoutController.cs
@@ -1,4 +1,4 @@
-﻿#nullable enable
+#nullable enable
 using System.Threading;
 using System.Threading.Tasks;
 using BTCPayServer.Client.Models;
@@ -7,6 +7,7 @@ using BTCPayServer.Models;
 using BTCPayServer.Services;
 using BTCPayServer.Views.UIStoreMembership;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.Localization;

--- a/BTCPayServer/Services/UserService.cs
+++ b/BTCPayServer/Services/UserService.cs
@@ -16,6 +16,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Localization;
 using Microsoft.Extensions.Logging;
+using static BTCPayServer.Events.UserEvent;
 
 namespace BTCPayServer.Services
 {
@@ -206,7 +207,9 @@ namespace BTCPayServer.Services
             public record Error(IdentityError[] Errors) : SetDisabledResult;
         }
 
-        public async Task<SetDisabledResult> SetDisabled(string userId, bool disabled)
+        public Task<SetDisabledResult> SetDisabled(string userId, bool disabled)
+        => SetDisabled(userId, disabled, null);
+        public async Task<SetDisabledResult> SetDisabled(string userId, bool disabled, string? source)
         {
             using var scope = _serviceProvider.CreateScope();
             var userManager = scope.ServiceProvider.GetRequiredService<UserManager<ApplicationUser>>();
@@ -229,6 +232,7 @@ namespace BTCPayServer.Services
                 }
                 await using var ctx = _applicationDbContextFactory.CreateContext();
                 await ctx.Users.UpdateStoreNoActiveUserForUsers([userId]);
+                _eventAggregator.Publish(new UserEvent.DisabledChanged(user, disabled, source));
             }
 
             return res.Succeeded ? new SetDisabledResult.Success() : new SetDisabledResult.Error(res.Errors.ToArray());


### PR DESCRIPTION
Resolves https://github.com/btcpayserver/btcpayserver2/issues/160

Two separate concerns: monetization could clear an administrator lockout, and the anonymous signup form could attach a subscription to someone else's existing account.


To reproduce: Reproduced manually: registered a user, disabled it via admin, confirmed login fails with "Your user account is currently disabled." Went through /monetization/new-user with that same email, paid, got "Payment Successful." Logged in again, account was active again. No admin action involved.

I removed MonetizationHostedService from touching LockoutEnd.

also plan checkout controller only checked whether the submitted email already had a subscription to the specific offering being purchased. It never checked whether the email belonged to an existing BTCPay login account. There is now a usermanager account check


Cc. @NicolasDorier 