### PR TITLE
fix(plugin-manager): resolve unlisted plugins by directory slug

### DIFF
--- a/BTCPayServer.Tests/PluginManagerTests.cs
+++ b/BTCPayServer.Tests/PluginManagerTests.cs
@@ -13,6 +13,7 @@ using BTCPayServer.Plugins.PluginManagement;
 using BTCPayServer.Plugins.PluginManagement.Controllers;
 using BTCPayServer.Plugins.PluginManagement.Models;
 using BTCPayServer.Services;
+using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.Extensions.Options;
 using NBitcoin;
 using Newtonsoft.Json;
@@ -104,19 +105,6 @@ namespace BTCPayServer.Tests
             Assert.Equal(new Version(1, 3, 0), plugin.RecommendedUpdateVersion);
             var updateAction = Assert.Single(plugin.Actions, action => action.FormAction == "InstallPlugin");
             Assert.Equal("1.3.0", updateAction.Version);
-        }
-
-        [Fact]
-        public void PluginDirectoryViewModel_PrefersHighestAvailableVersionWithSatisfiedDependencies()
-        {
-            var model = CreatePluginDirectoryViewModel(
-                selectedSlug: "testplugin",
-                allAvailable: [
-                    MakeAvailablePlugin("TestPlugin", "2.0.0", ("MissingDependency", ">=1.0.0")),
-                    MakeAvailablePlugin("TestPlugin", "1.5.0")
-                ]);
-
-            Assert.Equal("1.5.0", model.SelectedPluginPanel.InstallVersion);
         }
 
         [Fact]
@@ -245,15 +233,6 @@ namespace BTCPayServer.Tests
             Assert.Null(plugin.Documentation);
         }
 
-        [Fact]
-        public void PluginDirectoryViewModel_IgnoresSelectionWhenSlugIsNotInCatalog()
-        {
-            var model = CreatePluginDirectoryViewModel(selectedSlug: "unlisted-plugin");
-
-            Assert.Null(model.SelectedPluginPanel.SelectedSlug);
-            Assert.Null(model.SelectedPluginPanel.PluginIdentifier);
-        }
-
         [Theory]
         [InlineData(null)]
         [InlineData("")]
@@ -273,7 +252,7 @@ namespace BTCPayServer.Tests
         }
 
         [Fact]
-        public async Task SelectedPluginPanel_ReturnsServiceUnavailableWhenCatalogLookupFails()
+        public async Task SelectedPluginPanel_ReturnsServiceUnavailableWhenDirectoryLookupFails()
         {
             using var httpClient = new HttpClient(new TestHttpMessageHandler(_ =>
                 new HttpResponseMessage(HttpStatusCode.ServiceUnavailable)))
@@ -283,6 +262,94 @@ namespace BTCPayServer.Tests
             var controller = CreatePluginManagerController(Path.GetTempPath(), [], httpClient);
 
             var result = await controller.SelectedPluginPanel("testplugin");
+
+            var statusCode = Assert.IsType<Microsoft.AspNetCore.Mvc.StatusCodeResult>(result);
+            Assert.Equal((int)HttpStatusCode.ServiceUnavailable, statusCode.StatusCode);
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task SelectedPluginPanel_LooksUpDirectoryPluginBySlug(bool includePreRelease)
+        {
+            var pluginDir = Path.Combine(Path.GetTempPath(), $"btcpay-plugin-directory-selection-test-{Guid.NewGuid():N}");
+            Directory.CreateDirectory(pluginDir);
+            Uri requestedUri = null;
+            using var httpClient = new HttpClient(new TestHttpMessageHandler(request =>
+            {
+                requestedUri = request.RequestUri;
+                return CreatePublishedVersionResponse("barebitcoin", "BTCPayServer.Plugins.BareBitcoin", "Bare Bitcoin", "2.0.1.0");
+            }));
+            httpClient.BaseAddress = new Uri("https://plugins.example/");
+            var controller = CreatePluginManagerController(
+                pluginDir,
+                [],
+                httpClient,
+                new PoliciesSettings { PluginPreReleases = includePreRelease });
+
+            try
+            {
+                var result = await controller.SelectedPluginPanel("barebitcoin");
+
+                var partial = Assert.IsType<Microsoft.AspNetCore.Mvc.PartialViewResult>(result);
+                var model = Assert.IsType<PluginSelectedPanelViewModel>(partial.Model);
+                Assert.Equal("barebitcoin", model.SelectedSlug);
+                Assert.Equal("BTCPayServer.Plugins.BareBitcoin", model.PluginIdentifier);
+                Assert.Equal("2.0.1.0", model.InstallVersion);
+                Assert.NotNull(requestedUri);
+                Assert.Equal("/api/v1/plugins/directory/barebitcoin", requestedUri.AbsolutePath);
+                var query = QueryHelpers.ParseQuery(requestedUri.Query);
+                Assert.Equal(
+                    BTCPayServerEnvironment.GetInformationalVersion().TrimStart('v').Split('+')[0],
+                    query["btcpayVersion"].ToString());
+                Assert.Equal(includePreRelease, bool.Parse(query["includePreRelease"].ToString()));
+            }
+            finally
+            {
+                Directory.Delete(pluginDir, true);
+            }
+        }
+
+        [Fact]
+        public async Task PluginDirectory_LoadsSelectedPluginBySlug()
+        {
+            var pluginDir = Path.Combine(Path.GetTempPath(), $"btcpay-plugin-directory-deep-link-test-{Guid.NewGuid():N}");
+            Directory.CreateDirectory(pluginDir);
+            using var httpClient = new HttpClient(new TestHttpMessageHandler(_ =>
+                CreatePublishedVersionResponse("barebitcoin", "BTCPayServer.Plugins.BareBitcoin", "Bare Bitcoin", "2.0.1.0")));
+            httpClient.BaseAddress = new Uri("https://plugins.example/");
+            var controller = CreatePluginManagerController(pluginDir, [], httpClient);
+
+            try
+            {
+                var result = await controller.PluginDirectory("barebitcoin");
+
+                var view = Assert.IsType<Microsoft.AspNetCore.Mvc.ViewResult>(result);
+                var model = Assert.IsType<PluginDirectoryViewModel>(view.Model);
+                Assert.Equal("barebitcoin", model.SelectedPluginPanel.SelectedSlug);
+                Assert.Equal("BTCPayServer.Plugins.BareBitcoin", model.SelectedPluginPanel.PluginIdentifier);
+            }
+            finally
+            {
+                Directory.Delete(pluginDir, true);
+            }
+        }
+
+        [Theory]
+        [InlineData("exolix-malicious", "ExolixMalicious", "1.0.0")]
+        [InlineData("exolix", null, "1.0.0")]
+        [InlineData("exolix", "Exolix", null)]
+        public async Task SelectedPluginPanel_ReturnsServiceUnavailableWhenDirectoryResponseIsInvalid(
+            string responseSlug,
+            string responseIdentifier,
+            string responseVersion)
+        {
+            using var httpClient = new HttpClient(new TestHttpMessageHandler(_ =>
+                CreatePublishedVersionResponse(responseSlug, responseIdentifier, "Exolix", responseVersion)));
+            httpClient.BaseAddress = new Uri("https://plugins.example/");
+            var controller = CreatePluginManagerController(Path.GetTempPath(), [], httpClient);
+
+            var result = await controller.SelectedPluginPanel("exolix");
 
             var statusCode = Assert.IsType<Microsoft.AspNetCore.Mvc.StatusCodeResult>(result);
             Assert.Equal((int)HttpStatusCode.ServiceUnavailable, statusCode.StatusCode);
@@ -302,9 +369,8 @@ namespace BTCPayServer.Tests
         public void PluginDirectoryViewModel_DoesNotAllowInstallForInstalledPlugin()
         {
             var model = CreatePluginDirectoryViewModel(
-                selectedSlug: "installedplugin",
                 loadedPlugins: [MakeLoadedPlugin("InstalledPlugin")],
-                allAvailable: [MakeAvailablePlugin("InstalledPlugin", "1.1.0")]);
+                selectedPlugin: MakeAvailablePlugin("InstalledPlugin", "1.1.0"));
 
             Assert.Equal("InstalledPlugin", model.SelectedPluginPanel.PluginIdentifier);
             Assert.Equal("installedplugin", model.SelectedPluginPanel.SelectedSlug);
@@ -315,9 +381,8 @@ namespace BTCPayServer.Tests
         public void PluginDirectoryViewModel_DoesNotAllowInstallForDisabledPlugin()
         {
             var model = CreatePluginDirectoryViewModel(
-                selectedSlug: "disabledplugin",
                 disabled: new Dictionary<string, Version> { { "DisabledPlugin", new Version(1, 0, 0) } },
-                allAvailable: [MakeAvailablePlugin("DisabledPlugin", "1.1.0")]);
+                selectedPlugin: MakeAvailablePlugin("DisabledPlugin", "1.1.0"));
 
             Assert.Equal("DisabledPlugin", model.SelectedPluginPanel.PluginIdentifier);
             Assert.Null(model.SelectedPluginPanel.InstallVersion);
@@ -328,8 +393,7 @@ namespace BTCPayServer.Tests
         {
             var pendingManifest = MakeAvailablePlugin("TestPlugin", "0.9.0");
             var model = CreatePluginDirectoryViewModel(
-                selectedSlug: "testplugin",
-                allAvailable: [MakeAvailablePlugin("TestPlugin", "1.0.0")],
+                selectedPlugin: MakeAvailablePlugin("TestPlugin", "1.0.0"),
                 command: ("install", "TestPlugin"),
                 pendingManifest: pendingManifest);
 
@@ -490,6 +554,27 @@ namespace BTCPayServer.Tests
             };
         }
 
+        private static HttpResponseMessage CreatePublishedVersionResponse(
+            string slug,
+            string identifier,
+            string name,
+            string version)
+        {
+            var body = JsonConvert.SerializeObject(new
+            {
+                projectSlug = slug,
+                buildId = 1,
+                manifestInfo = new
+                {
+                    identifier,
+                    name,
+                    version
+                },
+                buildInfo = new { }
+            });
+            return TestHttpMessageHandler.JsonResponse(body);
+        }
+
         private static IBTCPayServerPlugin MakeLoadedPlugin(
             string identifier,
             params (string id, string condition)[] dependencies)
@@ -528,8 +613,7 @@ namespace BTCPayServer.Tests
 
         private PluginDirectoryViewModel CreatePluginDirectoryViewModel(
             Dictionary<string, Version> disabled = null,
-            IEnumerable<PluginService.AvailablePlugin> allAvailable = null,
-            string selectedSlug = null,
+            PluginService.AvailablePlugin selectedPlugin = null,
             IEnumerable<IBTCPayServerPlugin> loadedPlugins = null,
             (string action, string plugin)? command = null,
             PluginService.AvailablePlugin pendingManifest = null)
@@ -542,7 +626,7 @@ namespace BTCPayServer.Tests
                 WritePluginState(pluginDir, disabled, command, pendingManifest);
                 using var httpClient = new HttpClient { BaseAddress = new Uri("https://plugins.example/") };
                 var controller = CreatePluginManagerController(pluginDir, loaded, httpClient);
-                return controller.CreatePluginDirectoryViewModel(selectedSlug, allAvailable?.ToArray() ?? []);
+                return controller.CreatePluginDirectoryViewModel(selectedPlugin);
             }
             finally
             {
@@ -553,9 +637,10 @@ namespace BTCPayServer.Tests
         private UIPluginManagerController CreatePluginManagerController(
             string pluginDir,
             IEnumerable<IBTCPayServerPlugin> loadedPlugins,
-            HttpClient httpClient)
+            HttpClient httpClient,
+            PoliciesSettings policiesSettings = null)
         {
-            var policiesSettings = new PoliciesSettings();
+            policiesSettings ??= new PoliciesSettings();
             var pluginService = new PluginService(
                 loadedPlugins,
                 new PluginBuilderClient(httpClient),

--- a/BTCPayServer/Plugins/PluginManager/Controllers/UIPluginManagerController.cs
+++ b/BTCPayServer/Plugins/PluginManager/Controllers/UIPluginManagerController.cs
@@ -36,10 +36,10 @@ public class UIPluginManagerController(
     [HttpGet("directory")]
     public async Task<IActionResult> PluginDirectory(string selectedSlug = null)
     {
-        var remotePlugins = string.IsNullOrWhiteSpace(selectedSlug)
-            ? []
-            : await LoadRemotePlugins();
-        var model = CreatePluginDirectoryViewModel(selectedSlug, remotePlugins);
+        var selectedPlugin = string.IsNullOrWhiteSpace(selectedSlug)
+            ? null
+            : await LoadSelectedPlugin(selectedSlug);
+        var model = CreatePluginDirectoryViewModel(selectedPlugin);
         var pluginSourceBaseUri = pluginService.GetPluginSourceBaseUri();
         var btcpayVersion = pluginService.GetShortBtcpayVersion();
         var preReleaseEnabled = policiesSettings.PluginPreReleases;
@@ -62,17 +62,17 @@ public class UIPluginManagerController(
         if (string.IsNullOrWhiteSpace(slug))
             return BadRequest();
 
-        AvailablePlugin[] remotePlugins;
+        AvailablePlugin selectedPlugin;
         try
         {
-            remotePlugins = await pluginService.GetRemotePlugins(null);
+            selectedPlugin = await pluginService.GetDirectoryPluginBySlug(slug);
         }
         catch
         {
             return StatusCode(StatusCodes.Status503ServiceUnavailable);
         }
 
-        var model = CreateSelectedPluginPanelViewModel(slug, remotePlugins, GetPluginRuntimeState());
+        var model = CreateSelectedPluginPanelViewModel(selectedPlugin, GetPluginRuntimeState());
         var pluginSourceBaseUri = pluginService.GetPluginSourceBaseUri();
         model.EmbeddedDetailsUrl = BuildPluginDetailsEmbedUrl(
             pluginSourceBaseUri,
@@ -281,9 +281,7 @@ public class UIPluginManagerController(
         };
     }
 
-    internal PluginDirectoryViewModel CreatePluginDirectoryViewModel(
-        string selectedSlug,
-        AvailablePlugin[] remotePlugins)
+    internal PluginDirectoryViewModel CreatePluginDirectoryViewModel(AvailablePlugin selectedPlugin)
     {
         var runtimeState = GetPluginRuntimeState();
 
@@ -297,25 +295,18 @@ public class UIPluginManagerController(
                 .OrderBy(identifier => identifier, StringComparer.OrdinalIgnoreCase)
                 .ToArray(),
             HasPendingActions = runtimeState.PendingCommands.Length > 0,
-            SelectedPluginPanel = CreateSelectedPluginPanelViewModel(selectedSlug, remotePlugins, runtimeState)
+            SelectedPluginPanel = CreateSelectedPluginPanelViewModel(selectedPlugin, runtimeState)
         };
     }
 
     private PluginSelectedPanelViewModel CreateSelectedPluginPanelViewModel(
-        string selectedSlug,
-        AvailablePlugin[] remotePlugins,
+        AvailablePlugin selectedPlugin,
         PluginRuntimeState runtimeState)
     {
-        if (string.IsNullOrEmpty(selectedSlug))
+        if (selectedPlugin is null)
             return new PluginSelectedPanelViewModel();
 
-        var selectedAvailable = remotePlugins.FirstOrDefault(plugin =>
-            plugin.CatalogSlug != null &&
-            plugin.CatalogSlug.Equals(selectedSlug, StringComparison.OrdinalIgnoreCase));
-        if (selectedAvailable is null)
-            return new PluginSelectedPanelViewModel();
-
-        var identifier = selectedAvailable.Identifier;
+        var identifier = selectedPlugin.Identifier;
         var loadedPlugin = runtimeState.VisibleLoadedPlugins.FirstOrDefault(plugin =>
             plugin.Identifier.Equals(identifier, StringComparison.OrdinalIgnoreCase));
         runtimeState.DisabledVersions.TryGetValue(identifier, out var disabledVersion);
@@ -333,16 +324,15 @@ public class UIPluginManagerController(
 
         return new PluginSelectedPanelViewModel
         {
-            SelectedSlug = selectedAvailable.CatalogSlug,
+            SelectedSlug = selectedPlugin.CatalogSlug,
             PluginIdentifier = identifier,
-            PluginName = selectedAvailable.Name,
+            PluginName = selectedPlugin.Name,
             InstalledVersion = loadedPlugin?.Version,
             DisabledVersion = disabledVersion,
             PendingAction = pendingAction,
             PendingVersion = pendingVersion,
             InstallVersion = canInstall
-                ? GetBestCandidate(remotePlugins.Where(plugin =>
-                    plugin.Identifier.Equals(identifier, StringComparison.OrdinalIgnoreCase)))?.Version?.ToString()
+                ? selectedPlugin.Version?.ToString()
                 : null
         };
     }
@@ -624,6 +614,23 @@ public class UIPluginManagerController(
                 Message = stringLocalizer["Remote plugins lookup failed. Try again later. Error: {0}", ex.Message].Value
             });
             return [];
+        }
+    }
+
+    private async Task<AvailablePlugin> LoadSelectedPlugin(string slug)
+    {
+        try
+        {
+            return await pluginService.GetDirectoryPluginBySlug(slug);
+        }
+        catch (Exception ex)
+        {
+            TempData.SetStatusMessageModel(new StatusMessageModel
+            {
+                Severity = StatusMessageModel.StatusSeverity.Error,
+                Message = stringLocalizer["Remote plugins lookup failed. Try again later. Error: {0}", ex.Message].Value
+            });
+            return null;
         }
     }
 

--- a/BTCPayServer/Plugins/PluginManager/PluginBuilderClient.cs
+++ b/BTCPayServer/Plugins/PluginManager/PluginBuilderClient.cs
@@ -75,6 +75,19 @@ namespace BTCPayServer.Plugins
             var result = await HttpClient.GetStringAsync($"api/v1/plugins{queryString}", cancellationToken);
             return JsonConvert.DeserializeObject<PublishedVersion[]>(result, serializerSettings) ?? throw new InvalidOperationException();
         }
+
+        public async Task<PublishedVersion> GetDirectoryPluginBySlug(string pluginSlug, string btcpayVersion, bool includePreRelease = false)
+        {
+            var queryString = $"?includePreRelease={includePreRelease}";
+            if (btcpayVersion is not null)
+                queryString += $"&btcpayVersion={Uri.EscapeDataString(btcpayVersion)}";
+
+            var result = await HttpClient.GetStringAsync(
+                $"api/v1/plugins/directory/{Uri.EscapeDataString(pluginSlug)}{queryString}");
+            return JsonConvert.DeserializeObject<PublishedVersion>(result, serializerSettings)
+                   ?? throw new InvalidOperationException();
+        }
+
         public async Task<PublishedVersion> GetPlugin(string pluginSlug, string version)
         {
             try

--- a/BTCPayServer/Plugins/PluginManager/PluginService.cs
+++ b/BTCPayServer/Plugins/PluginManager/PluginService.cs
@@ -101,6 +101,23 @@ namespace BTCPayServer.Plugins
             return plugins.ToArray();
         }
 
+        internal async Task<AvailablePlugin> GetDirectoryPluginBySlug(string pluginSlug)
+        {
+            var publishedVersion = await _pluginBuilderClient.GetDirectoryPluginBySlug(
+                pluginSlug,
+                GetShortBtcpayVersion(),
+                _policiesSettings.PluginPreReleases);
+
+            if (!string.Equals(publishedVersion.ProjectSlug, pluginSlug, StringComparison.OrdinalIgnoreCase))
+                throw new InvalidDataException($"Plugin slug {publishedVersion.ProjectSlug} does not match requested slug {pluginSlug}.");
+
+            var availablePlugin = MapToAvailablePlugin(publishedVersion);
+            if (availablePlugin is null || string.IsNullOrWhiteSpace(availablePlugin.Identifier) || availablePlugin.Version is null)
+                throw new InvalidDataException($"Plugin manifest not found or invalid. BuildId: {publishedVersion.BuildId} PluginSlug: {publishedVersion.ProjectSlug}");
+
+            return availablePlugin;
+        }
+
 #nullable enable
         private static AvailablePlugin? MapToAvailablePlugin(PublishedVersion publishedVersion)
         {


### PR DESCRIPTION
Selecting an unlisted plugin from an exact Plugin Directory search currently opens an empty details panel, preventing the plugin from being installed. Direct links to unlisted plugins have the same problem.

This PR loads the selected plugin using its exact Directory slug, allowing both listed and unlisted plugins to display their details and installation action correctly. Hidden plugins remain unavailable.

This lookup is limited to the Plugin Directory selection flow. The existing identifier and version validation used to download and install plugins remains unchanged, as does the installed-plugin update flow.

Fixes #7508