### PR TITLE
fix(ci): use Microsoft Testing Platform

### DIFF
--- a/BTCPayServer.Tests/docker-entrypoint.sh
+++ b/BTCPayServer.Tests/docker-entrypoint.sh
@@ -6,4 +6,4 @@ if [ ! -z "$TEST_FILTERS" ]; then
 FILTERS="--filter $TEST_FILTERS"
 fi
 
-dotnet test -c ${CONFIGURATION_NAME} $FILTERS --no-build -v n --logger "console;verbosity=normal" < /dev/null
+dotnet test -c ${CONFIGURATION_NAME} $FILTERS --no-build -v n --output Normal < /dev/null

--- a/global.json
+++ b/global.json
@@ -1,0 +1,5 @@
+{
+  "test": {
+    "runner": "Microsoft.Testing.Platform"
+  }
+}


### PR DESCRIPTION
The xUnit 4 upgrade enabled Microsoft Testing Platform, while .NET 10 was still attempting to run the test suite through VSTest. This prevented CI jobs from starting any tests.

This switches test execution to Microsoft Testing Platform and updates the console output option. Existing CI and release filters remain unchanged and continue selecting the same test groups.
