### PR TITLE
Demoting an admin should invalidate its cookie

### DIFF
--- a/.agents/skills/playwright-test-patterns/SKILL.md
+++ b/.agents/skills/playwright-test-patterns/SKILL.md
@@ -22,6 +22,19 @@ Use these patterns when writing or refactoring Playwright tests in BTCPayServer.
 - Keep PMOs focused on reusable components or page flows.
 - Do not add abstraction layers that only wrap one obvious Playwright call unless it meaningfully improves readability or removes repetition.
 
+## Test Through Real Interfaces
+
+- Prefer using Playwright and/or `BTCPayServerClient` over reproducing application behavior by manually instantiating controllers.
+- Use controller instantiation only when the test is specifically about controller internals and a browser/API flow would not exercise the behavior clearly.
+
+## Assertions
+
+- Prefer Playwright's built-in `Expect` API over manually fetching elements and asserting on their state.
+- Playwright assertions automatically wait for the expected condition, making tests less verbose and less prone to flakiness.
+- Prefer `await Expect(locator).ToHaveCountAsync(1)` over `Assert.Equal(1, await locator.CountAsync())`.
+- Prefer `await Expect(locator).ToContainTextAsync(text)` over `Assert.Contains(text, await locator.TextContentAsync())`.
+- Prefer `await Expect(page).ToHaveURLAsync(...)` over direct assertions on `page.Url`.
+
 ## Selector Guidance
 
 - Prefer BEM class selectors for reusable UI hooks.

--- a/BTCPayServer.Tests/PlaywrightTests.cs
+++ b/BTCPayServer.Tests/PlaywrightTests.cs
@@ -4,6 +4,7 @@ using System.Globalization;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using System.Web;
 using BTCPayServer.Abstractions.Models;
@@ -753,13 +754,23 @@ namespace BTCPayServer.Tests
             await s.FindAlertMessage(partialText: "Password successfully set");
             user.Password = "Password@1!";
 
-            var userPage = await s.Browser.NewPageAsync();
+            await using var userContext = await s.Browser.NewContextAsync();
+            var userPage = await userContext.NewPageAsync();
             await using (await s.SwitchPage(userPage, false))
             {
                 await s.GoToLogin();
                 await s.LogIn(user.Email, user.Password);
                 await s.SkipWizard();
             }
+
+            await SetManagedUserAdmin(false);
+            await AssertCanAccessServerSettings(userPage, false);
+            await SetManagedUserAdmin(true);
+            await AssertCanAccessServerSettings(userPage, true);
+            await SetManagedUserAdmin(false);
+            await AssertCanAccessServerSettings(userPage, false);
+            await s.GoToServer(ServerNavPages.Users);
+
             // Manage user status (disable and enable)
             // Disable user
             await s.Page.Locator("#SearchTerm").ClearAsync();
@@ -774,7 +785,8 @@ namespace BTCPayServer.Tests
 
             await using (await s.SwitchPage(userPage, false))
             {
-                await s.Page.ReloadAsync();
+                await s.Page.GotoAsync(s.Link("/server/policies"), new() { WaitUntil = WaitUntilState.Commit });
+                await s.GoToLogin();
                 await s.LogIn(user.Email, user.Password);
                 await s.FindAlertMessage(StatusMessageModel.StatusSeverity.Warning, partialText: "Your user account is currently disabled");
             }
@@ -822,6 +834,40 @@ namespace BTCPayServer.Tests
             await s.Page.ClickAsync("#ConfirmContinue");
             await s.FindAlertMessage(partialText: "User deleted");
             await s.Page.AssertNoError();
+
+            async Task SetManagedUserAdmin(bool isAdmin)
+            {
+                await s.GoToServer(ServerNavPages.Users);
+                await s.Page.Locator("#SearchTerm").ClearAsync();
+                await s.Page.FillAsync("#SearchTerm", user.RegisterDetails.Email);
+                await s.Page.Locator("#SearchTerm").PressAsync("Enter");
+                var rows = s.Page.Locator("#UsersList tr.user-overview-row");
+                await Expect(rows).ToHaveCountAsync(1);
+                await Expect(rows.First).ToContainTextAsync(user.RegisterDetails.Email);
+                await rows.First.Locator(".user-edit").ClickAsync();
+                var adminCheckbox = s.Page.Locator("#IsAdmin");
+                if (await adminCheckbox.IsCheckedAsync() == isAdmin)
+                    return;
+                await adminCheckbox.SetCheckedAsync(isAdmin);
+                await s.ClickPagePrimary();
+                await s.FindAlertMessage(partialText: "User successfully updated");
+            }
+
+            async Task AssertCanAccessServerSettings(IPage page, bool expected)
+            {
+                await using (await s.SwitchPage(page, false))
+                {
+                    await s.Page.GotoAsync(s.Link("/server/policies"), new() { WaitUntil = WaitUntilState.Commit });
+                    if (expected)
+                    {
+                        await Expect(s.Page).ToHaveURLAsync(s.Link("/server/policies"));
+                    }
+                    else
+                    {
+                        await Expect(s.Page).ToHaveURLAsync(new Regex("/errors/403"));
+                    }
+                }
+            }
         }
 
 

--- a/BTCPayServer.Tests/TestAccount.cs
+++ b/BTCPayServer.Tests/TestAccount.cs
@@ -22,7 +22,6 @@ using BTCPayServer.Services;
 using BTCPayServer.Services.Invoices;
 using BTCPayServer.Services.Stores;
 using BTCPayServer.Services.Wallets;
-using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
@@ -66,12 +65,8 @@ namespace BTCPayServer.Tests
         public async Task MakeAdmin(bool isAdmin = true)
         {
             using var scope = parent.PayTester.ServiceProvider.CreateScope();
-            var userManager = scope.ServiceProvider.GetRequiredService<UserManager<ApplicationUser>>();
-            var u = await userManager.FindByIdAsync(UserId);
-            if (isAdmin)
-                await userManager.AddToRoleAsync(u, Roles.ServerAdmin);
-            else
-                await userManager.RemoveFromRoleAsync(u, Roles.ServerAdmin);
+            var userService = scope.ServiceProvider.GetRequiredService<UserService>();
+            await userService.SetAdminUser(UserId, isAdmin);
             IsAdmin = isAdmin;
         }
 

--- a/BTCPayServer/Hosting/Startup.cs
+++ b/BTCPayServer/Hosting/Startup.cs
@@ -101,7 +101,7 @@ namespace BTCPayServer.Hosting
                 .PersistKeysToFileSystem(new DirectoryInfo(new DataDirectories().Configure(Configuration).DataDir));
 
             services.AddScoped<ISecurityStampValidator, BTCPayServerSecurityStampValidator>();
-            services.AddSingleton<BTCPayServerSecurityStampValidator.DisabledUsers>();
+            services.AddSingleton<BTCPayServerSecurityStampValidator.SecurityStampInvalidator>();
             services.AddIdentity<ApplicationUser, IdentityRole>()
                 .AddEntityFrameworkStores<ApplicationDbContext>()
                 .AddDefaultTokenProviders()

--- a/BTCPayServer/Plugins/Monetization/MonetizationHostedService.cs
+++ b/BTCPayServer/Plugins/Monetization/MonetizationHostedService.cs
@@ -24,7 +24,7 @@ public class MonetizationHostedService(
     EventAggregator eventAggregator,
     SettingsRepository settingsRepository,
     UserService userService,
-    BTCPayServerSecurityStampValidator.DisabledUsers disabledUsers,
+    BTCPayServerSecurityStampValidator.SecurityStampInvalidator securityStampInvalidator,
     ISettingsAccessor<MonetizationSettings> monetizationSettingsAccessor,
     IServiceScopeFactory serviceScopeFactory,
     Logs logger) : EventHostedServiceBase(eventAggregator, logger)
@@ -113,7 +113,6 @@ public class MonetizationHostedService(
                 if (userSub is not null)
                 {
                     await userService.SetDisabled(changed.User.Id, false);
-                    disabledUsers.Remove(changed.User.Id);
                     EventAggregator.Publish(new MonetizationLockoutUpdated([(changed.User.Id, false)]));
                 }
             }
@@ -127,7 +126,7 @@ public class MonetizationHostedService(
                     if (shouldBeLocked)
                     {
                         await userService.SetDisabled(changed.User.Id, true);
-                        disabledUsers.Add(changed.User.Id);
+                        securityStampInvalidator.Invalidate(changed.User.Id);
                         EventAggregator.Publish(new MonetizationLockoutUpdated([(changed.User.Id, true)]));
                     }
                 }
@@ -394,9 +393,7 @@ public class MonetizationHostedService(
                 })).ToArray();
         foreach (var update in updated)
             if (update.LockoutEnabled)
-                disabledUsers.Add(update.UserId);
-            else
-                disabledUsers.Remove(update.UserId);
+                securityStampInvalidator.Invalidate(update.UserId);
 
         await ctx.Users.UpdateStoreNoActiveUserForUsers(updated.Select(u => u.UserId).ToArray());
         EventAggregator.Publish(new MonetizationLockoutUpdated(updated));

--- a/BTCPayServer/Services/BTCPayServerSecurityStampValidator.cs
+++ b/BTCPayServer/Services/BTCPayServerSecurityStampValidator.cs
@@ -10,56 +10,63 @@ using Microsoft.Extensions.Options;
 
 namespace BTCPayServer.Services;
 
-public class BTCPayServerSecurityStampValidator(
-    IOptions<SecurityStampValidatorOptions> options,
-    SignInManager<ApplicationUser> signInManager,
-    ILoggerFactory logger,
-    BTCPayServerSecurityStampValidator.DisabledUsers disabledUsers)
-    : SecurityStampValidator<ApplicationUser>(options, signInManager, logger)
+public class BTCPayServerSecurityStampValidator : SecurityStampValidator<ApplicationUser>
 {
-    public class DisabledUsers
+    private readonly SignInManager<ApplicationUser> _signInManager;
+    private readonly SecurityStampInvalidator _securityStampInvalidator;
+
+    public BTCPayServerSecurityStampValidator(
+        IOptions<SecurityStampValidatorOptions> options,
+        SignInManager<ApplicationUser> signInManager,
+        ILoggerFactory logger,
+        SecurityStampInvalidator securityStampInvalidator) : base(options, signInManager, logger)
     {
-        ConcurrentDictionary<string, DateTimeOffset> _DisabledUsers = new ConcurrentDictionary<string, DateTimeOffset>();
-        public bool HasAny => !_DisabledUsers.IsEmpty;
+        _signInManager = signInManager;
+        _securityStampInvalidator = securityStampInvalidator;
+    }
+
+    /// <summary>
+    /// Security stamps are normally revalidated every <see cref="SecurityStampValidatorOptions.ValidationInterval"/>.
+    /// This forces earlier validation for selected users, so cookie claims such as roles are refreshed immediately.
+    /// </summary>
+    public class SecurityStampInvalidator
+    {
+        ConcurrentDictionary<string, DateTimeOffset> _InvalidatedStamps = new ConcurrentDictionary<string, DateTimeOffset>();
+        public bool HasAny => !_InvalidatedStamps.IsEmpty;
 
         /// <summary>
-        /// Note that you also need to invalidate the security stamp of the user
+        /// Forces the logged-in user's cookie claims, such as roles, to be refreshed immediately.
         /// </summary>
         /// <param name="user"></param>
-        public void Add(string user)
-        {
-            _DisabledUsers.TryAdd(user, DateTimeOffset.UtcNow);
-        }
-
-        public void Remove(string user)
-        {
-            _DisabledUsers.TryRemove(user, out _);
-        }
-
-        public bool Contains(string id) => _DisabledUsers.ContainsKey(id);
+        public void Invalidate(string user) => _InvalidatedStamps.AddOrUpdate(user, _ => DateTimeOffset.UtcNow, (_, _) => DateTimeOffset.UtcNow);
 
         public void Cleanup(TimeSpan validationInterval)
         {
-            if (_DisabledUsers.IsEmpty)
+            if (_InvalidatedStamps.IsEmpty)
                 return;
             var now = DateTimeOffset.UtcNow;
-            foreach (var kv in _DisabledUsers)
+            foreach (var kv in _InvalidatedStamps)
             {
                 if (now - kv.Value > validationInterval)
-                    Remove(kv.Key);
+                    _InvalidatedStamps.TryRemove(kv.Key, out _);
             }
         }
+
+        public bool TryGetValue(string id, out DateTimeOffset invalidatedAt)
+        => _InvalidatedStamps.TryGetValue(id, out invalidatedAt);
     }
 
     public override async Task ValidateAsync(CookieValidatePrincipalContext context)
     {
-        if (disabledUsers.HasAny &&
+        if (_securityStampInvalidator.HasAny &&
             context.Principal.GetIdOrNull() is string id &&
-            disabledUsers.Contains(id))
+            _securityStampInvalidator.TryGetValue(id, out var invalidatedAt) &&
+            context.Properties.IssuedUtc is {} issuedAt &&
+            issuedAt < invalidatedAt)
         {
             context.Properties.IssuedUtc = null;
         }
-        disabledUsers.Cleanup(Options.ValidationInterval);
+        _securityStampInvalidator.Cleanup(Options.ValidationInterval);
         await base.ValidateAsync(context);
     }
 }

--- a/BTCPayServer/Services/UserService.cs
+++ b/BTCPayServer/Services/UserService.cs
@@ -26,7 +26,7 @@ namespace BTCPayServer.Services
         private readonly FileService _fileService;
         private readonly EventAggregator _eventAggregator;
         private readonly ApplicationDbContextFactory _applicationDbContextFactory;
-        private readonly BTCPayServerSecurityStampValidator.DisabledUsers _disabledUsers;
+        private readonly BTCPayServerSecurityStampValidator.SecurityStampInvalidator _securityStampInvalidator;
         private readonly IEnumerable<LoginExtension> _loginExtensions;
         private readonly ILogger<UserService> _logger;
 
@@ -36,7 +36,7 @@ namespace BTCPayServer.Services
             FileService fileService,
             EventAggregator eventAggregator,
             ApplicationDbContextFactory applicationDbContextFactory,
-            BTCPayServerSecurityStampValidator.DisabledUsers disabledUsers,
+            BTCPayServerSecurityStampValidator.SecurityStampInvalidator securityStampInvalidator,
             IEnumerable<LoginExtension> loginExtensions,
             ILogger<UserService> logger)
         {
@@ -45,7 +45,7 @@ namespace BTCPayServer.Services
             _fileService = fileService;
             _eventAggregator = eventAggregator;
             _applicationDbContextFactory = applicationDbContextFactory;
-            _disabledUsers = disabledUsers;
+            _securityStampInvalidator = securityStampInvalidator;
             _loginExtensions = loginExtensions;
             _logger = logger;
         }
@@ -212,19 +212,15 @@ namespace BTCPayServer.Services
 
             var lockedOutDeadline = disabled ? DateTimeOffset.MaxValue : (DateTimeOffset?)null;
             var res = await userManager.SetLockoutEndDateAsync(user, lockedOutDeadline);
-            // Without this, the user won't be logged out automatically when his authentication ticket expires
-            if (disabled)
-            {
-                await userManager.UpdateSecurityStampAsync(user);
-                _disabledUsers.Add(userId);
-            }
-            else
-            {
-                _disabledUsers.Remove(userId);
-            }
 
             if (res.Succeeded)
             {
+                if (disabled)
+                {
+                    await userManager.UpdateSecurityStampAsync(user);
+                    // Force immediate cookie revalidation instead of waiting for the stamp validation interval.
+                    _securityStampInvalidator.Invalidate(user.Id);
+                }
                 await using var ctx = _applicationDbContextFactory.CreateContext();
                 await ctx.Users.UpdateStoreNoActiveUserForUsers([userId]);
             }
@@ -262,6 +258,7 @@ namespace BTCPayServer.Services
 
             if (res.Succeeded)
             {
+                _securityStampInvalidator.Invalidate(user.Id);
                 _logger.LogInformation("Successfully set admin status for user {Email}", user.Email);
             }
             else


### PR DESCRIPTION
When an operator adds or removes the server administrator role from a user, the user's existing browser session now picks up that permission change immediately. A demoted administrator can no longer keep using an old session to access server settings until the regular cookie validation interval expires.

This also keeps disabled-user session invalidation working through the same immediate refresh path.