### PR TITLE
Harden SDK request path encoding

### DIFF
--- a/BTCPayServer.Client/BTCPayServerClient.APIKeys.cs
+++ b/BTCPayServer.Client/BTCPayServerClient.APIKeys.cs
@@ -10,13 +10,13 @@ public partial class BTCPayServerClient
 {
     public virtual async Task<ApiKeyData> GetCurrentAPIKeyInfo(CancellationToken token = default)
     {
-        return await SendHttpRequest<ApiKeyData>("api/v1/api-keys/current", null, HttpMethod.Get, token);
+        return await SendHttpRequest<ApiKeyData>($"api/v1/api-keys/current", null, HttpMethod.Get, token);
     }
 
     public virtual async Task<ApiKeyData> CreateAPIKey(CreateApiKeyRequest request, CancellationToken token = default)
     {
         if (request == null) throw new ArgumentNullException(nameof(request));
-        return await SendHttpRequest<ApiKeyData>("api/v1/api-keys", request, HttpMethod.Post, token);
+        return await SendHttpRequest<ApiKeyData>($"api/v1/api-keys", request, HttpMethod.Post, token);
     }
 
     public virtual async Task<ApiKeyData> CreateAPIKey(string userId, CreateApiKeyRequest request, CancellationToken token = default)
@@ -27,7 +27,7 @@ public partial class BTCPayServerClient
 
     public virtual async Task RevokeCurrentAPIKeyInfo(CancellationToken token = default)
     {
-        await SendHttpRequest("api/v1/api-keys/current", null, HttpMethod.Delete, token);
+        await SendHttpRequest($"api/v1/api-keys/current", null, HttpMethod.Delete, token);
     }
 
     public virtual async Task RevokeAPIKey(string apikey, CancellationToken token = default)

--- a/BTCPayServer.Client/BTCPayServerClient.Apps.cs
+++ b/BTCPayServer.Client/BTCPayServerClient.Apps.cs
@@ -44,7 +44,7 @@ public partial class BTCPayServerClient
 
     public virtual async Task<AppBaseData[]> GetAllApps(CancellationToken token = default)
     {
-        return await SendHttpRequest<AppBaseData[]>("api/v1/apps", null, HttpMethod.Get, token);
+        return await SendHttpRequest<AppBaseData[]>($"api/v1/apps", null, HttpMethod.Get, token);
     }
 
     public virtual async Task<PointOfSaleAppData> GetPosApp(string appId, CancellationToken token = default)

--- a/BTCPayServer.Client/BTCPayServerClient.Files.cs
+++ b/BTCPayServer.Client/BTCPayServerClient.Files.cs
@@ -9,7 +9,7 @@ public partial class BTCPayServerClient
 {
     public virtual async Task<FileData[]> GetFiles(CancellationToken token = default)
     {
-        return await SendHttpRequest<FileData[]>("api/v1/files", null, HttpMethod.Get, token);
+        return await SendHttpRequest<FileData[]>($"api/v1/files", null, HttpMethod.Get, token);
     }
 
     public virtual async Task<FileData> GetFile(string fileId, CancellationToken token = default)
@@ -19,7 +19,7 @@ public partial class BTCPayServerClient
 
     public virtual async Task<FileData> UploadFile(string filePath, string mimeType, CancellationToken token = default)
     {
-        return await UploadFileRequest<FileData>("api/v1/files", filePath, mimeType, "file", HttpMethod.Post, token);
+        return await UploadFileRequest<FileData>($"api/v1/files", filePath, mimeType, "file", HttpMethod.Post, token);
     }
 
     public virtual async Task DeleteFile(string fileId, CancellationToken token = default)

--- a/BTCPayServer.Client/BTCPayServerClient.Health.cs
+++ b/BTCPayServer.Client/BTCPayServerClient.Health.cs
@@ -9,6 +9,6 @@ public partial class BTCPayServerClient
 {
     public virtual async Task<ApiHealthData> GetHealth(CancellationToken token = default)
     {
-        return await SendHttpRequest<ApiHealthData>("api/v1/health", null, HttpMethod.Get, token);
+        return await SendHttpRequest<ApiHealthData>($"api/v1/health", null, HttpMethod.Get, token);
     }
 }

--- a/BTCPayServer.Client/BTCPayServerClient.Misc.cs
+++ b/BTCPayServer.Client/BTCPayServerClient.Misc.cs
@@ -9,11 +9,11 @@ public partial class BTCPayServerClient
 {
     public virtual async Task<PermissionMetadata[]> GetPermissionMetadata(CancellationToken token = default)
     {
-        return await SendHttpRequest<PermissionMetadata[]>("misc/permissions", null, HttpMethod.Get, token);
+        return await SendHttpRequest<PermissionMetadata[]>($"misc/permissions", null, HttpMethod.Get, token);
     }
 
     public virtual async Task<Language[]> GetAvailableLanguages(CancellationToken token = default)
     {
-        return await SendHttpRequest<Language[]>("misc/lang", null, HttpMethod.Get, token);
+        return await SendHttpRequest<Language[]>($"misc/lang", null, HttpMethod.Get, token);
     }
 }

--- a/BTCPayServer.Client/BTCPayServerClient.Notifications.cs
+++ b/BTCPayServer.Client/BTCPayServerClient.Notifications.cs
@@ -20,7 +20,7 @@ public partial class BTCPayServerClient
             queryPayload.Add(nameof(take), take);
         if (storeId != null)
             queryPayload.Add(nameof(storeId), storeId);
-        return await SendHttpRequest<IEnumerable<NotificationData>>("api/v1/users/me/notifications", queryPayload, HttpMethod.Get, token);
+        return await SendHttpRequest<IEnumerable<NotificationData>>($"api/v1/users/me/notifications", queryPayload, HttpMethod.Get, token);
     }
 
     public virtual async Task<NotificationData> GetNotification(string notificationId,
@@ -37,12 +37,12 @@ public partial class BTCPayServerClient
 
     public virtual async Task<NotificationSettingsData> GetNotificationSettings(CancellationToken token = default)
     {
-        return await SendHttpRequest<NotificationSettingsData>("api/v1/users/me/notification-settings", null, HttpMethod.Get, token);
+        return await SendHttpRequest<NotificationSettingsData>($"api/v1/users/me/notification-settings", null, HttpMethod.Get, token);
     }
 
     public virtual async Task<NotificationSettingsData> UpdateNotificationSettings(UpdateNotificationSettingsRequest request, CancellationToken token = default)
     {
-        return await SendHttpRequest<NotificationSettingsData>("api/v1/users/me/notification-settings", request, HttpMethod.Put, token);
+        return await SendHttpRequest<NotificationSettingsData>($"api/v1/users/me/notification-settings", request, HttpMethod.Put, token);
     }
 
     public virtual async Task RemoveNotification(string notificationId, CancellationToken token = default)

--- a/BTCPayServer.Client/BTCPayServerClient.PayoutProcessors.cs
+++ b/BTCPayServer.Client/BTCPayServerClient.PayoutProcessors.cs
@@ -11,6 +11,6 @@ public partial class BTCPayServerClient
 {
     public virtual async Task<IEnumerable<PayoutProcessorData>> GetPayoutProcessors(CancellationToken token = default)
     {
-        return await SendHttpRequest<IEnumerable<PayoutProcessorData>>("api/v1/payout-processors", null, HttpMethod.Get, token);
+        return await SendHttpRequest<IEnumerable<PayoutProcessorData>>($"api/v1/payout-processors", null, HttpMethod.Get, token);
     }
 }

--- a/BTCPayServer.Client/BTCPayServerClient.PullPayments.cs
+++ b/BTCPayServer.Client/BTCPayServerClient.PullPayments.cs
@@ -2,7 +2,6 @@ using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Web;
 using BTCPayServer.Client.Models;
 
 namespace BTCPayServer.Client;
@@ -11,34 +10,34 @@ public partial class BTCPayServerClient
 {
     public virtual async Task<PullPaymentData> CreatePullPayment(string storeId, CreatePullPaymentRequest request, CancellationToken cancellationToken = default)
     {
-        return await SendHttpRequest<PullPaymentData>($"api/v1/stores/{HttpUtility.UrlEncode(storeId)}/pull-payments", request, HttpMethod.Post, cancellationToken);
+        return await SendHttpRequest<PullPaymentData>($"api/v1/stores/{storeId}/pull-payments", request, HttpMethod.Post, cancellationToken);
     }
 
     public virtual async Task<PullPaymentData> GetPullPayment(string pullPaymentId, CancellationToken cancellationToken = default)
     {
-        return await SendHttpRequest<PullPaymentData>($"api/v1/pull-payments/{HttpUtility.UrlEncode(pullPaymentId)}", null, HttpMethod.Get, cancellationToken);
+        return await SendHttpRequest<PullPaymentData>($"api/v1/pull-payments/{pullPaymentId}", null, HttpMethod.Get, cancellationToken);
     }
 
     public virtual async Task<RegisterBoltcardResponse> RegisterBoltcard(string pullPaymentId, RegisterBoltcardRequest request, CancellationToken cancellationToken = default)
     {
-        return await SendHttpRequest<RegisterBoltcardResponse>($"api/v1/pull-payments/{HttpUtility.UrlEncode(pullPaymentId)}/boltcards", request, HttpMethod.Post, cancellationToken);
+        return await SendHttpRequest<RegisterBoltcardResponse>($"api/v1/pull-payments/{pullPaymentId}/boltcards", request, HttpMethod.Post, cancellationToken);
     }
 
     public virtual async Task<PullPaymentData[]> GetPullPayments(string storeId, bool includeArchived = false, CancellationToken cancellationToken = default)
     {
         var query = new Dictionary<string, object> { { "includeArchived", includeArchived } };
-        return await SendHttpRequest<PullPaymentData[]>($"api/v1/stores/{HttpUtility.UrlEncode(storeId)}/pull-payments", query, HttpMethod.Get, cancellationToken);
+        return await SendHttpRequest<PullPaymentData[]>($"api/v1/stores/{storeId}/pull-payments", query, HttpMethod.Get, cancellationToken);
     }
 
     public virtual async Task ArchivePullPayment(string pullPaymentId, CancellationToken cancellationToken = default)
     {
-        await SendHttpRequest($"api/v1/pull-payments/{HttpUtility.UrlEncode(pullPaymentId)}", null, HttpMethod.Delete, cancellationToken);
+        await SendHttpRequest($"api/v1/pull-payments/{pullPaymentId}", null, HttpMethod.Delete, cancellationToken);
     }
 
     public virtual async Task<PayoutData[]> GetPayouts(string pullPaymentId, bool includeCancelled = false, CancellationToken cancellationToken = default)
     {
         var query = new Dictionary<string, object> { { "includeCancelled", includeCancelled } };
-        return await SendHttpRequest<PayoutData[]>($"api/v1/pull-payments/{HttpUtility.UrlEncode(pullPaymentId)}/payouts", query, HttpMethod.Get, cancellationToken);
+        return await SendHttpRequest<PayoutData[]>($"api/v1/pull-payments/{pullPaymentId}/payouts", query, HttpMethod.Get, cancellationToken);
     }
 
     public virtual async Task<PayoutData[]> GetStorePayouts(string storeId, bool includeCancelled = false, CancellationToken cancellationToken = default)
@@ -49,17 +48,17 @@ public partial class BTCPayServerClient
 
     public virtual async Task<PayoutData> CreatePayout(string pullPaymentId, CreatePayoutRequest payoutRequest, CancellationToken cancellationToken = default)
     {
-        return await SendHttpRequest<PayoutData>($"api/v1/pull-payments/{HttpUtility.UrlEncode(pullPaymentId)}/payouts", bodyPayload: payoutRequest, HttpMethod.Post, cancellationToken);
+        return await SendHttpRequest<PayoutData>($"api/v1/pull-payments/{pullPaymentId}/payouts", bodyPayload: payoutRequest, HttpMethod.Post, cancellationToken);
     }
 
     public virtual async Task<PayoutData> GetPullPaymentPayout(string pullPaymentId, string payoutId, CancellationToken cancellationToken = default)
     {
-        return await SendHttpRequest<PayoutData>($"api/v1/pull-payments/{HttpUtility.UrlEncode(pullPaymentId)}/payouts/{payoutId}", null, HttpMethod.Get, cancellationToken);
+        return await SendHttpRequest<PayoutData>($"api/v1/pull-payments/{pullPaymentId}/payouts/{payoutId}", null, HttpMethod.Get, cancellationToken);
     }
 
     public virtual async Task<PayoutData> GetStorePayout(string payoutId, CancellationToken cancellationToken = default)
     {
-        return await SendHttpRequest<PayoutData>($"api/v1/payouts/{HttpUtility.UrlEncode(payoutId)}", null, HttpMethod.Get, cancellationToken);
+        return await SendHttpRequest<PayoutData>($"api/v1/payouts/{payoutId}", null, HttpMethod.Get, cancellationToken);
     }
 
     public virtual async Task<PayoutData> CreatePayout(string storeId, CreatePayoutThroughStoreRequest payoutRequest, CancellationToken cancellationToken = default)
@@ -69,26 +68,26 @@ public partial class BTCPayServerClient
 
     public virtual async Task CancelPayout(string payoutId, CancellationToken cancellationToken = default)
     {
-        await SendHttpRequest($"api/v1/payouts/{HttpUtility.UrlEncode(payoutId)}", null, HttpMethod.Delete, cancellationToken);
+        await SendHttpRequest($"api/v1/payouts/{payoutId}", null, HttpMethod.Delete, cancellationToken);
     }
 
     public virtual async Task<PayoutData> ApprovePayout(string payoutId, ApprovePayoutRequest request, CancellationToken cancellationToken = default)
     {
-        return await SendHttpRequest<PayoutData>($"api/v1/payouts/{HttpUtility.UrlEncode(payoutId)}", request, HttpMethod.Post, cancellationToken);
+        return await SendHttpRequest<PayoutData>($"api/v1/payouts/{payoutId}", request, HttpMethod.Post, cancellationToken);
     }
 
     public virtual async Task MarkPayoutPaid(string payoutId, CancellationToken cancellationToken = default)
     {
-        await SendHttpRequest($"api/v1/payouts/{HttpUtility.UrlEncode(payoutId)}/mark-paid", null, HttpMethod.Post, cancellationToken);
+        await SendHttpRequest($"api/v1/payouts/{payoutId}/mark-paid", null, HttpMethod.Post, cancellationToken);
     }
 
     public virtual async Task MarkPayout(string payoutId, MarkPayoutRequest request, CancellationToken cancellationToken = default)
     {
-        await SendHttpRequest($"api/v1/payouts/{HttpUtility.UrlEncode(payoutId)}/mark", request, HttpMethod.Post, cancellationToken);
+        await SendHttpRequest($"api/v1/payouts/{payoutId}/mark", request, HttpMethod.Post, cancellationToken);
     }
 
     public virtual async Task<PullPaymentLNURL> GetPullPaymentLNURL(string pullPaymentId, CancellationToken cancellationToken = default)
     {
-        return await SendHttpRequest<PullPaymentLNURL>($"api/v1/pull-payments/{HttpUtility.UrlEncode(pullPaymentId)}/lnurl", null, HttpMethod.Get, cancellationToken);
+        return await SendHttpRequest<PullPaymentLNURL>($"api/v1/pull-payments/{pullPaymentId}/lnurl", null, HttpMethod.Get, cancellationToken);
     }
 }

--- a/BTCPayServer.Client/BTCPayServerClient.ServerEmail.cs
+++ b/BTCPayServer.Client/BTCPayServerClient.ServerEmail.cs
@@ -9,11 +9,11 @@ public partial class BTCPayServerClient
 {
     public virtual async Task<ServerEmailSettingsData> GetServerEmailSettings(CancellationToken token = default)
     {
-        return await SendHttpRequest<ServerEmailSettingsData>("api/v1/server/email", null, HttpMethod.Get, token);
+        return await SendHttpRequest<ServerEmailSettingsData>($"api/v1/server/email", null, HttpMethod.Get, token);
     }
     
     public virtual async Task<ServerEmailSettingsData> UpdateServerEmailSettings(ServerEmailSettingsData request, CancellationToken token = default)
     {
-        return await SendHttpRequest<ServerEmailSettingsData>("api/v1/server/email", request, HttpMethod.Put, token);
+        return await SendHttpRequest<ServerEmailSettingsData>($"api/v1/server/email", request, HttpMethod.Put, token);
     }
 }

--- a/BTCPayServer.Client/BTCPayServerClient.ServerInfo.cs
+++ b/BTCPayServer.Client/BTCPayServerClient.ServerInfo.cs
@@ -10,11 +10,11 @@ public partial class BTCPayServerClient
 {
     public virtual async Task<ServerInfoData> GetServerInfo(CancellationToken token = default)
     {
-        return await SendHttpRequest<ServerInfoData>("api/v1/server/info", null, HttpMethod.Get, token);
+        return await SendHttpRequest<ServerInfoData>($"api/v1/server/info", null, HttpMethod.Get, token);
     }
         
     public virtual async Task<List<RoleData>> GetServerRoles(CancellationToken token = default)
     {
-        return await SendHttpRequest<List<RoleData>>("api/v1/server/roles", null, HttpMethod.Get, token);
+        return await SendHttpRequest<List<RoleData>>($"api/v1/server/roles", null, HttpMethod.Get, token);
     }
 }

--- a/BTCPayServer.Client/BTCPayServerClient.StorePayoutProcessors.cs
+++ b/BTCPayServer.Client/BTCPayServerClient.StorePayoutProcessors.cs
@@ -21,7 +21,9 @@ public partial class BTCPayServerClient
 
     public virtual async Task<IEnumerable<LightningAutomatedPayoutSettings>> GetStoreLightningAutomatedPayoutProcessors(string storeId, string? payoutMethodId = null, CancellationToken token = default)
     {
-        return await SendHttpRequest<IEnumerable<LightningAutomatedPayoutSettings>>($"api/v1/stores/{storeId}/payout-processors/LightningAutomatedPayoutSenderFactory{(payoutMethodId is null ? string.Empty : $"/{payoutMethodId}")}", null, HttpMethod.Get, token);
+        if (payoutMethodId is null)
+            return await SendHttpRequest<IEnumerable<LightningAutomatedPayoutSettings>>($"api/v1/stores/{storeId}/payout-processors/LightningAutomatedPayoutSenderFactory", null, HttpMethod.Get, token);
+        return await SendHttpRequest<IEnumerable<LightningAutomatedPayoutSettings>>($"api/v1/stores/{storeId}/payout-processors/LightningAutomatedPayoutSenderFactory/{payoutMethodId}", null, HttpMethod.Get, token);
     }
 
     public virtual async Task<LightningAutomatedPayoutSettings> UpdateStoreLightningAutomatedPayoutProcessors(string storeId, string payoutMethodId, LightningAutomatedPayoutSettings request, CancellationToken token = default)
@@ -36,6 +38,8 @@ public partial class BTCPayServerClient
 
     public virtual async Task<IEnumerable<OnChainAutomatedPayoutSettings>> GetStoreOnChainAutomatedPayoutProcessors(string storeId, string? paymentMethod = null, CancellationToken token = default)
     {
-        return await SendHttpRequest<IEnumerable<OnChainAutomatedPayoutSettings>>($"api/v1/stores/{storeId}/payout-processors/OnChainAutomatedPayoutSenderFactory{(paymentMethod is null ? string.Empty : $"/{paymentMethod}")}", null, HttpMethod.Get, token);
+        if (paymentMethod is null)
+            return await SendHttpRequest<IEnumerable<OnChainAutomatedPayoutSettings>>($"api/v1/stores/{storeId}/payout-processors/OnChainAutomatedPayoutSenderFactory", null, HttpMethod.Get, token);
+        return await SendHttpRequest<IEnumerable<OnChainAutomatedPayoutSettings>>($"api/v1/stores/{storeId}/payout-processors/OnChainAutomatedPayoutSenderFactory/{paymentMethod}", null, HttpMethod.Get, token);
     }
 }

--- a/BTCPayServer.Client/BTCPayServerClient.StoreRatesConfiguration.cs
+++ b/BTCPayServer.Client/BTCPayServerClient.StoreRatesConfiguration.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading;
@@ -14,7 +15,7 @@ public partial class BTCPayServerClient
         return await SendHttpRequest<StoreRateConfiguration>(path, null, HttpMethod.Get, token);
     }
 
-    private string GetRateConfigPath(string storeId, bool? fallback)
+    private FormattableString GetRateConfigPath(string storeId, bool? fallback)
     => fallback switch
     {
         null => $"api/v1/stores/{storeId}/rates/configuration",
@@ -24,7 +25,7 @@ public partial class BTCPayServerClient
 
     public virtual async Task<List<RateSource>> GetRateSources(CancellationToken token = default)
     {
-        return await SendHttpRequest<List<RateSource>>("misc/rate-sources", null, HttpMethod.Get, token);
+        return await SendHttpRequest<List<RateSource>>($"misc/rate-sources", null, HttpMethod.Get, token);
     }
 
     public virtual async Task<StoreRateConfiguration> UpdateStoreRateConfiguration(string storeId, StoreRateConfiguration request, bool? fallback = null, CancellationToken token = default)

--- a/BTCPayServer.Client/BTCPayServerClient.Stores.cs
+++ b/BTCPayServer.Client/BTCPayServerClient.Stores.cs
@@ -11,7 +11,7 @@ public partial class BTCPayServerClient
 {
     public virtual async Task<IEnumerable<StoreData>> GetStores(CancellationToken token = default)
     {
-        return await SendHttpRequest<IEnumerable<StoreData>>("api/v1/stores", null, HttpMethod.Get, token);
+        return await SendHttpRequest<IEnumerable<StoreData>>($"api/v1/stores", null, HttpMethod.Get, token);
     }
 
     public virtual async Task<StoreData> GetStore(string storeId, CancellationToken token = default)
@@ -27,7 +27,7 @@ public partial class BTCPayServerClient
     public virtual async Task<StoreData> CreateStore(CreateStoreRequest request, CancellationToken token = default)
     {
         if (request == null) throw new ArgumentNullException(nameof(request));
-        return await SendHttpRequest<StoreData>("api/v1/stores", request, HttpMethod.Post, token);
+        return await SendHttpRequest<StoreData>($"api/v1/stores", request, HttpMethod.Post, token);
     }
 
     public async Task<StoreData> UpdateStore(string storeId, StoreData request, CancellationToken token = default)

--- a/BTCPayServer.Client/BTCPayServerClient.Subscriptions.cs
+++ b/BTCPayServer.Client/BTCPayServerClient.Subscriptions.cs
@@ -1,5 +1,4 @@
 #nullable enable
-using System;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
@@ -30,27 +29,27 @@ public partial class BTCPayServerClient
         => await SendHttpRequest<PlanCheckoutModel>($"api/v1/plan-checkout/{checkoutId}", null, HttpMethod.Get, token);
 
     public async Task<CreditModel> GetCredit(string storeId, string offeringId, string customerSelector, string currency, CancellationToken token = default)
-        => await SendHttpRequest<CreditModel>($"api/v1/stores/{storeId}/offerings/{offeringId}/subscribers/{Uri.EscapeDataString(customerSelector)}/credits/{currency}", null, HttpMethod.Get, token);
+        => await SendHttpRequest<CreditModel>($"api/v1/stores/{storeId}/offerings/{offeringId}/subscribers/{customerSelector}/credits/{currency}", null, HttpMethod.Get, token);
 
     public async Task<CreditModel> UpdateCredit(string storeId, string offeringId, string customerSelector, string currency, UpdateCreditRequest request, CancellationToken token = default)
-        => await SendHttpRequest<CreditModel>($"api/v1/stores/{storeId}/offerings/{offeringId}/subscribers/{Uri.EscapeDataString(customerSelector)}/credits/{currency}", request, HttpMethod.Post, token);
+        => await SendHttpRequest<CreditModel>($"api/v1/stores/{storeId}/offerings/{offeringId}/subscribers/{customerSelector}/credits/{currency}", request, HttpMethod.Post, token);
 
     public async Task<PlanCheckoutModel> ProceedPlanCheckout(string checkoutId, string? email = null, CancellationToken token = default)
     {
         if (email is not null)
-            return await SendHttpRequest<PlanCheckoutModel>($"api/v1/plan-checkout/{checkoutId}?email={Uri.EscapeDataString(email)}", null, HttpMethod.Post, token);
+            return await SendHttpRequest<PlanCheckoutModel>($"api/v1/plan-checkout/{checkoutId}?email={email}", null, HttpMethod.Post, token);
         else
             return await SendHttpRequest<PlanCheckoutModel>($"api/v1/plan-checkout/{checkoutId}", null, HttpMethod.Post, token);
     }
     public async Task<SubscriberModel> GetSubscriber(string storeId, string offeringId, string customerSelector, CancellationToken token = default)
-    => await SendHttpRequest<SubscriberModel>($"api/v1/stores/{storeId}/offerings/{offeringId}/subscribers/{Uri.EscapeDataString(customerSelector)}", null, HttpMethod.Get, token);
+    => await SendHttpRequest<SubscriberModel>($"api/v1/stores/{storeId}/offerings/{offeringId}/subscribers/{customerSelector}", null, HttpMethod.Get, token);
 
     public async Task DeleteSubscriber(string storeId, string offeringId, string customerSelector, CancellationToken token = default)
-        => await SendHttpRequest($"api/v1/stores/{storeId}/offerings/{offeringId}/subscribers/{Uri.EscapeDataString(customerSelector)}", null, HttpMethod.Delete, token);
+        => await SendHttpRequest($"api/v1/stores/{storeId}/offerings/{offeringId}/subscribers/{customerSelector}", null, HttpMethod.Delete, token);
 
     public async Task<SubscriberModel> SuspendSubscriber(string storeId, string offeringId, string customerSelector, string? reason = null,
         CancellationToken token = default)
-        => await SendHttpRequest<SubscriberModel>($"api/v1/stores/{storeId}/offerings/{offeringId}/subscribers/{Uri.EscapeDataString(customerSelector)}/suspend", new SuspendSubscriberRequest()
+        => await SendHttpRequest<SubscriberModel>($"api/v1/stores/{storeId}/offerings/{offeringId}/subscribers/{customerSelector}/suspend", new SuspendSubscriberRequest()
             {
                 Reason = reason
             },
@@ -60,7 +59,7 @@ public partial class BTCPayServerClient
 
     public async Task<SubscriberModel> UpdateSubscriberDates(string storeId, string offeringId, string customerSelector,
         UpdateSubscriberDatesRequest request, CancellationToken token = default)
-        => await SendHttpRequest<SubscriberModel>($"api/v1/stores/{storeId}/offerings/{offeringId}/subscribers/{Uri.EscapeDataString(customerSelector)}/dates", request, HttpMethod.Put, token);
+        => await SendHttpRequest<SubscriberModel>($"api/v1/stores/{storeId}/offerings/{offeringId}/subscribers/{customerSelector}/dates", request, HttpMethod.Put, token);
 
     public async Task<PortalSessionModel> CreatePortalSession(CreatePortalSessionRequest request, CancellationToken token = default)
         => await SendHttpRequest<PortalSessionModel>($"api/v1/subscriber-portal", request, HttpMethod.Post, token);

--- a/BTCPayServer.Client/BTCPayServerClient.Users.cs
+++ b/BTCPayServer.Client/BTCPayServerClient.Users.cs
@@ -10,27 +10,27 @@ public partial class BTCPayServerClient
 {
     public virtual async Task<ApplicationUserData> GetCurrentUser(CancellationToken token = default)
     {
-        return await SendHttpRequest<ApplicationUserData>("api/v1/users/me", null, HttpMethod.Get, token);
+        return await SendHttpRequest<ApplicationUserData>($"api/v1/users/me", null, HttpMethod.Get, token);
     }
 
     public virtual async Task<ApplicationUserData> UpdateCurrentUser(UpdateApplicationUserRequest request, CancellationToken token = default)
     {
-        return await SendHttpRequest<ApplicationUserData>("api/v1/users/me", request, HttpMethod.Put, token);
+        return await SendHttpRequest<ApplicationUserData>($"api/v1/users/me", request, HttpMethod.Put, token);
     }
 
     public virtual async Task<ApplicationUserData> UploadCurrentUserProfilePicture(string filePath, string mimeType, CancellationToken token = default)
     {
-        return await UploadFileRequest<ApplicationUserData>("api/v1/users/me/picture", filePath, mimeType, "file", HttpMethod.Post, token);
+        return await UploadFileRequest<ApplicationUserData>($"api/v1/users/me/picture", filePath, mimeType, "file", HttpMethod.Post, token);
     }
 
     public virtual async Task DeleteCurrentUserProfilePicture(CancellationToken token = default)
     {
-        await SendHttpRequest("api/v1/users/me/picture", null, HttpMethod.Delete, token);
+        await SendHttpRequest($"api/v1/users/me/picture", null, HttpMethod.Delete, token);
     }
     
     public virtual async Task<ApplicationUserData> CreateUser(CreateApplicationUserRequest request, CancellationToken token = default)
     {
-        return await SendHttpRequest<ApplicationUserData>("api/v1/users", request, HttpMethod.Post, token);
+        return await SendHttpRequest<ApplicationUserData>($"api/v1/users", request, HttpMethod.Post, token);
     }
 
     public virtual async Task DeleteUser(string userId, CancellationToken token = default)
@@ -61,7 +61,7 @@ public partial class BTCPayServerClient
 
     public virtual async Task<ApplicationUserData[]> GetUsers(CancellationToken token = default)
     {
-        return await SendHttpRequest<ApplicationUserData[]>("api/v1/users/", null, HttpMethod.Get, token);
+        return await SendHttpRequest<ApplicationUserData[]>($"api/v1/users/", null, HttpMethod.Get, token);
     }
 
     public virtual async Task DeleteCurrentUser(CancellationToken token = default)

--- a/BTCPayServer.Client/BTCPayServerClient.cs
+++ b/BTCPayServer.Client/BTCPayServerClient.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Linq;
 using System.Net.Http;
 using System.Net.Http.Headers;
+using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -78,7 +79,7 @@ public partial class BTCPayServerClient
         return JsonConvert.DeserializeObject<T>(str);
     }
 
-    public virtual async Task SendHttpRequest(string path,
+    public virtual async Task SendHttpRequest(FormattableString path,
         Dictionary<string, object> queryPayload = null,
         HttpMethod method = null, CancellationToken cancellationToken = default)
     {
@@ -86,7 +87,7 @@ public partial class BTCPayServerClient
         await HandleResponse(resp);
     }
 
-    public virtual async Task<T> SendHttpRequest<T>(string path,
+    public virtual async Task<T> SendHttpRequest<T>(FormattableString path,
         Dictionary<string, object> queryPayload = null,
         HttpMethod method = null, CancellationToken cancellationToken = default)
     {
@@ -94,7 +95,7 @@ public partial class BTCPayServerClient
         return await HandleResponse<T>(resp);
     }
 
-    public virtual async Task SendHttpRequest(string path,
+    public virtual async Task SendHttpRequest(FormattableString path,
         object bodyPayload = null,
         HttpMethod method = null, CancellationToken cancellationToken = default)
     {
@@ -102,15 +103,15 @@ public partial class BTCPayServerClient
         await HandleResponse(resp);
     }
 
-    protected virtual async Task<T> SendHttpRequest<T>(string path,
+    protected virtual async Task<T> SendHttpRequest<T>(FormattableString path,
         object bodyPayload = null,
         HttpMethod method = null, CancellationToken cancellationToken = default)
     {
         using var resp = await _httpClient.SendAsync(CreateHttpRequest(path: path, bodyPayload: bodyPayload, method: method), cancellationToken);
         return await HandleResponse<T>(resp);
     }
-        
-    protected virtual async Task<TRes> SendHttpRequest<TReq, TRes>(string path,
+
+    protected virtual async Task<TRes> SendHttpRequest<TReq, TRes>(FormattableString path,
         Dictionary<string, object> queryPayload = null,
         TReq bodyPayload = default, HttpMethod method = null, CancellationToken cancellationToken = default)
     {
@@ -118,12 +119,19 @@ public partial class BTCPayServerClient
         return await HandleResponse<TRes>(resp);
     }
 
-    protected virtual HttpRequestMessage CreateHttpRequest(string path,
+    protected virtual HttpRequestMessage CreateHttpRequest(FormattableString path,
         Dictionary<string, object> queryPayload = null,
         HttpMethod method = null)
     {
         var uriBuilder = new UriBuilder(_btcpayHost);
-        uriBuilder.Path += (uriBuilder.Path.EndsWith("/") || path.StartsWith("/") ? "" : "/") + path;
+        var encodedPath = EncodeUrlParameters(path).ToString();
+        var queryIndex = encodedPath.IndexOf('?');
+        if (queryIndex is not -1)
+        {
+            uriBuilder.Query = encodedPath[(queryIndex + 1)..];
+            encodedPath = encodedPath[..queryIndex];
+        }
+        uriBuilder.Path += (uriBuilder.Path.EndsWith("/") || encodedPath.StartsWith("/") ? "" : "/") + encodedPath;
         if (queryPayload != null && queryPayload.Any())
         {
             AppendPayloadToQuery(uriBuilder, queryPayload);
@@ -140,7 +148,7 @@ public partial class BTCPayServerClient
         return httpRequest;
     }
 
-    protected virtual HttpRequestMessage CreateHttpRequest<T>(string path,
+    protected virtual HttpRequestMessage CreateHttpRequest<T>(FormattableString path,
         Dictionary<string, object> queryPayload = null,
         T bodyPayload = default, HttpMethod method = null)
     {
@@ -153,7 +161,7 @@ public partial class BTCPayServerClient
         return request;
     }
 
-    protected virtual async Task<T> UploadFileRequest<T>(string apiPath, string filePath, string mimeType, string formFieldName, HttpMethod method = null, CancellationToken token = default)
+    protected virtual async Task<T> UploadFileRequest<T>(FormattableString apiPath, string filePath, string mimeType, string formFieldName, HttpMethod method = null, CancellationToken token = default)
     {
         using MultipartFormDataContent multipartContent = new();
         using var fileContent = new StreamContent(File.OpenRead(filePath));
@@ -164,6 +172,33 @@ public partial class BTCPayServerClient
         req.Content = multipartContent;
         using var resp = await _httpClient.SendAsync(req, token);
         return await HandleResponse<T>(resp);
+    }
+
+    private class RawStr
+    {
+        private readonly string _str;
+        public RawStr(string str)
+        {
+            _str = str;
+        }
+        public override string ToString() => _str;
+    }
+
+    private static RawStr Raw(string str) => new(str);
+
+    private static FormattableString EncodeUrlParameters(FormattableString url)
+    {
+        return FormattableStringFactory.Create(
+            url.Format,
+            url.GetArguments()
+                .Select(a =>
+                    a is RawStr ? a :
+                    a is FormattableString formattableString ? EncodeUrlParameters(formattableString) :
+                    Uri.EscapeDataString(a?.ToString() ?? string.Empty)
+                    )
+                // Avoid path transversal
+                .Select(v => v is "." or ".." ? string.Empty : v)
+                .ToArray());
     }
 
     public static void AppendPayloadToQuery(UriBuilder uri, KeyValuePair<string, object> keyValuePair)

--- a/BTCPayServer.Tests/FastTests.cs
+++ b/BTCPayServer.Tests/FastTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Net.Http;
 using System.Runtime.CompilerServices;
 using System.Security;
 using System.Text;
@@ -52,6 +53,28 @@ namespace BTCPayServer.Tests
         public FastTests(ITestOutputHelper helper) : base(helper)
         {
         }
+
+        [Fact]
+        public void BTCPayServerClientEscapesPathIdentifiers()
+        {
+            var client = new RequestInspectingClient(new Uri("https://example.com/root/"));
+            var request = client.CreateRequest($"api/v1/stores/{"../users/me"}/webhooks/{"delivery/../x"}?email={"a+b@example.com"}");
+
+            Assert.Equal("https://example.com/root/api/v1/stores/..%2Fusers%2Fme/webhooks/delivery%2F..%2Fx?email=a%2Bb%40example.com", request.RequestUri!.AbsoluteUri);
+        }
+
+        private class RequestInspectingClient : BTCPayServerClient
+        {
+            public RequestInspectingClient(Uri btcpayHost) : base(btcpayHost)
+            {
+            }
+
+            public HttpRequestMessage CreateRequest(FormattableString path)
+            {
+                return CreateHttpRequest(path);
+            }
+        }
+
         class DockerImage
         {
             public string User { get; private set; }


### PR DESCRIPTION
This adds defense-in-depth to the BTCPay Server SDK by encoding route values centrally when request URLs are built. SDK methods can keep using readable interpolated paths while unusual characters in identifiers stay part of the intended URL value.

This does not change the Greenfield API surface or require Swagger updates. It also removes older per-call encoding in a few SDK methods so values are encoded consistently in one place.

A focused regression test covers identifiers containing characters such as slashes, dots, plus signs, and email-style text.