### PR TITLE
Validate pay button server IPN url

### DIFF
--- a/BTCPayServer.Tests/FastTests.cs
+++ b/BTCPayServer.Tests/FastTests.cs
@@ -63,6 +63,22 @@ namespace BTCPayServer.Tests
             Assert.Equal("https://example.com/root/api/v1/stores/..%2Fusers%2Fme/webhooks/delivery%2F..%2Fx?email=a%2Bb%40example.com", request.RequestUri!.AbsoluteUri);
         }
 
+        [Fact]
+        public void IsLocalNetwork()
+        {
+            Assert.True(BTCPayServer.Extensions.IsLocalNetwork("127.0.0.1"));
+            Assert.True(BTCPayServer.Extensions.IsLocalNetwork("10.0.0.1"));
+            Assert.True(BTCPayServer.Extensions.IsLocalNetwork("192.168.1.1"));
+            Assert.True(BTCPayServer.Extensions.IsLocalNetwork("172.16.0.1"));
+            Assert.True(BTCPayServer.Extensions.IsLocalNetwork("169.254.0.1"));
+            Assert.True(BTCPayServer.Extensions.IsLocalNetwork("::1"));
+            Assert.True(BTCPayServer.Extensions.IsLocalNetwork("fe80::1"));
+            Assert.True(BTCPayServer.Extensions.IsLocalNetwork("localhost"));
+            Assert.True(BTCPayServer.Extensions.IsLocalNetwork("host.internal"));
+            Assert.False(BTCPayServer.Extensions.IsLocalNetwork("example.com"));
+            Assert.False(BTCPayServer.Extensions.IsLocalNetwork("1.2.3.4"));
+        }
+
         private class RequestInspectingClient : BTCPayServerClient
         {
             public RequestInspectingClient(Uri btcpayHost) : base(btcpayHost)

--- a/BTCPayServer/Extensions.cs
+++ b/BTCPayServer/Extensions.cs
@@ -639,7 +639,7 @@ namespace BTCPayServer
             }
             if (IPAddress.TryParse(server, out var ip))
             {
-                return ip.IsLocal() || ip.IsRFC1918();
+                return ip.IsLocal() || ip.IsRFC1918() || ip.IsRFC3927() || ip.IsRFC4862();
             }
             return false;
         }

--- a/BTCPayServer/Plugins/PayButton/Controllers/UIPublicPayButtonController.cs
+++ b/BTCPayServer/Plugins/PayButton/Controllers/UIPublicPayButtonController.cs
@@ -60,6 +60,11 @@ namespace BTCPayServer.Plugins.PayButton.Controllers
             if (model.Price is decimal and <= 0)
                 ModelState.AddModelError("Price", StringLocalizer["Price must be greater than 0"]);
 
+            if (!string.IsNullOrEmpty(model.ServerIpn) &&
+                Uri.TryCreate(model.ServerIpn, UriKind.Absolute, out var serverIpn) &&
+                Extensions.IsLocalNetwork(serverIpn.DnsSafeHost))
+                ModelState.AddModelError(nameof(model.ServerIpn), StringLocalizer["Server IPN URL must not target a local network address"]);
+
             if (!ModelState.IsValid || store is null)
                 return View();
 


### PR DESCRIPTION
Rejects Server IPN values targeting local network addresses on the public pay button invoice endpoint, and extends IsLocalNetwork to cover link-local ranges.