### PR TITLE
Add credential management lockdown controls

### DIFF
--- a/BTCPayServer.Client/Permissions.cs
+++ b/BTCPayServer.Client/Permissions.cs
@@ -14,6 +14,7 @@ namespace BTCPayServer.Client
         public const string CanUseLightningNodeInStore = "btcpay.store.canuselightningnode";
         public const string CanModifyServerSettings = "btcpay.server.canmodifyserversettings";
         public const string CanModifyStoreSettings = "btcpay.store.canmodifystoresettings";
+        public const string CanManageStoreCredentials = "btcpay.store.canmanagestorecredentials";
         public const string CanModifyWebhooks = "btcpay.store.webhooks.canmodifywebhooks";
         public const string CanSendStoreEmail = "btcpay.store.cansendstoreemails";
         public const string CanModifyStoreSettingsUnscoped = "btcpay.store.canmodifystoresettings:";

--- a/BTCPayServer.Data/Migrations/20260831000000_AddCredentialManagementToManagerRole.cs
+++ b/BTCPayServer.Data/Migrations/20260831000000_AddCredentialManagementToManagerRole.cs
@@ -24,12 +24,6 @@ namespace BTCPayServer.Migrations
 
         protected override void Down(MigrationBuilder migrationBuilder)
         {
-            migrationBuilder.Sql("""
-                UPDATE "StoreRoles"
-                SET "Permissions" = array_remove("Permissions", 'btcpay.store.canmanagestorecredentials')
-                WHERE "Id" = 'Manager'
-                  AND "StoreDataId" IS NULL;
-                """);
         }
     }
 }

--- a/BTCPayServer.Data/Migrations/20260831000000_AddCredentialManagementToManagerRole.cs
+++ b/BTCPayServer.Data/Migrations/20260831000000_AddCredentialManagementToManagerRole.cs
@@ -1,0 +1,35 @@
+using BTCPayServer.Data;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace BTCPayServer.Migrations
+{
+    [DbContext(typeof(ApplicationDbContext))]
+    [Migration("20260831000000_AddCredentialManagementToManagerRole")]
+    public partial class AddCredentialManagementToManagerRole : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql("""
+                UPDATE "StoreRoles"
+                SET "Permissions" = COALESCE("Permissions", ARRAY[]::TEXT[]) || ARRAY['btcpay.store.canmanagestorecredentials']::TEXT[]
+                WHERE "Id" = 'Manager'
+                  AND "StoreDataId" IS NULL
+                  AND NOT (COALESCE("Permissions", ARRAY[]::TEXT[]) @> ARRAY['btcpay.store.canmanagestorecredentials']::TEXT[]);
+                """);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql("""
+                UPDATE "StoreRoles"
+                SET "Permissions" = array_remove("Permissions", 'btcpay.store.canmanagestorecredentials')
+                WHERE "Id" = 'Manager'
+                  AND "StoreDataId" IS NULL;
+                """);
+        }
+    }
+}

--- a/BTCPayServer.Data/Migrations/20260831000000_AddCredentialManagementToManagerRole.cs
+++ b/BTCPayServer.Data/Migrations/20260831000000_AddCredentialManagementToManagerRole.cs
@@ -11,6 +11,7 @@ namespace BTCPayServer.Migrations
     [Migration("20260831000000_AddCredentialManagementToManagerRole")]
     public partial class AddCredentialManagementToManagerRole : Migration
     {
+        /// <inheritdoc />
         protected override void Up(MigrationBuilder migrationBuilder)
         {
             migrationBuilder.Sql("""
@@ -22,6 +23,7 @@ namespace BTCPayServer.Migrations
                 """);
         }
 
+        /// <inheritdoc />
         protected override void Down(MigrationBuilder migrationBuilder)
         {
         }

--- a/BTCPayServer.Tests/GreenfieldAPITests.cs
+++ b/BTCPayServer.Tests/GreenfieldAPITests.cs
@@ -241,6 +241,74 @@ namespace BTCPayServer.Tests
 
         [Fact(Timeout = TestTimeout)]
         [Trait("Integration", "Integration")]
+        public async Task CredentialManagementRespectsServerAndStoreRoleLockdown()
+        {
+            TestContext.Current.CancellationToken.ThrowIfCancellationRequested();
+            using var tester = CreateServerTester();
+            await tester.StartAsync();
+            var account = tester.NewAccount();
+            await account.GrantAccessAsync();
+            var firstStoreId = account.StoreId;
+            await account.CreateStoreAsync();
+            var lockedStoreId = account.StoreId;
+
+            var storeRepository = tester.PayTester.GetService<StoreRepository>();
+            var lockedRole = new StoreRoleId(lockedStoreId, "No credential management");
+            await storeRepository.AddOrUpdateStoreRole(lockedRole, new[] { Policies.CanViewStoreSettings });
+            await storeRepository.AddOrUpdateStoreUser(lockedStoreId, account.UserId, lockedRole);
+
+            var credentialManagementService = tester.PayTester.GetService<CredentialManagementService>();
+            var principal = account.GetController<UIStoresController>().User;
+            var manageableStores = await credentialManagementService.GetManageableStores(principal);
+            Assert.Contains(manageableStores, store => store.Id == firstStoreId);
+            Assert.DoesNotContain(manageableStores, store => store.Id == lockedStoreId);
+
+            var client = await account.CreateClient();
+            await client.CreateAPIKey(new CreateApiKeyRequest
+            {
+                Permissions = new[] { Permission.Create(Policies.CanViewInvoices, firstStoreId) }
+            });
+
+            var error = await AssertAPIError("missing-permission", () => client.CreateAPIKey(new CreateApiKeyRequest
+            {
+                Permissions = new[] { Permission.Create(Policies.CanViewInvoices, lockedStoreId) }
+            }));
+            Assert.Equal(Policies.CanManageStoreCredentials,
+                Assert.IsType<GreenfieldPermissionAPIError>(error.APIError).MissingPermission);
+
+            await AssertAPIError("missing-permission", () => client.CreateAPIKey(new CreateApiKeyRequest
+            {
+                Permissions = new[] { Permission.Create(Policies.CanViewInvoices) }
+            }));
+
+            await storeRepository.AddOrUpdateStoreRole(lockedRole,
+                new[] { Policies.CanViewStoreSettings, Policies.CanManageStoreCredentials });
+            Assert.Equal(2, (await credentialManagementService.GetManageableStores(principal)).Length);
+            await client.CreateAPIKey(new CreateApiKeyRequest
+            {
+                Permissions = new[] { Permission.Create(Policies.CanViewInvoices) }
+            });
+
+            var settingsRepository = tester.PayTester.GetService<SettingsRepository>();
+            await settingsRepository.UpdateSetting(new PoliciesSettings
+            {
+                DisableNonAdminCredentialManagement = true
+            });
+            Assert.Empty(await credentialManagementService.GetManageableStores(principal));
+            await AssertAPIError("missing-permission", () => client.CreateAPIKey(new CreateApiKeyRequest
+            {
+                Permissions = new[] { Permission.Create(Policies.CanViewProfile) }
+            }));
+
+            await account.MakeAdmin();
+            await client.CreateAPIKey(new CreateApiKeyRequest
+            {
+                Permissions = new[] { Permission.Create(Policies.CanViewProfile) }
+            });
+        }
+
+        [Fact(Timeout = TestTimeout)]
+        [Trait("Integration", "Integration")]
         public async Task CanCreateReadAndDeleteFiles()
         {
             using var tester = CreateServerTester(newDb: true);

--- a/BTCPayServer.Tests/GreenfieldAPITests.cs
+++ b/BTCPayServer.Tests/GreenfieldAPITests.cs
@@ -239,6 +239,9 @@ namespace BTCPayServer.Tests
             await newUserClient.GetInvoices(store.Id);
         }
 
+        /// <summary>
+        /// Verifies that server policy and store roles constrain credential management without restricting server administrators.
+        /// </summary>
         [Fact(Timeout = TestTimeout)]
         [Trait("Integration", "Integration")]
         public async Task CredentialManagementRespectsServerAndStoreRoleLockdown()

--- a/BTCPayServer.Tests/GreenfieldAPITests.cs
+++ b/BTCPayServer.Tests/GreenfieldAPITests.cs
@@ -263,6 +263,23 @@ namespace BTCPayServer.Tests
             Assert.Contains(manageableStores, store => store.Id == firstStoreId);
             Assert.DoesNotContain(manageableStores, store => store.Id == lockedStoreId);
 
+            var apiKeyController = account.GetController<UIManageController>();
+            apiKeyController.ModelState.AddModelError("test", "Force the posted model to be rendered");
+            var viewResult = Assert.IsType<ViewResult>(await apiKeyController.AddApiKey(new UIManageController.AddApiKeyViewModel
+            {
+                PermissionValues = new List<UIManageController.AddApiKeyViewModel.PermissionValueItem>
+                {
+                    new()
+                    {
+                        Permission = Policies.CanViewInvoices,
+                        StoreMode = UIManageController.AddApiKeyViewModel.ApiKeyStoreMode.Specific,
+                        SpecificStores = new List<string> { firstStoreId, lockedStoreId }
+                    }
+                }
+            }));
+            var postedViewModel = Assert.IsType<UIManageController.AddApiKeyViewModel>(viewResult.Model);
+            Assert.Equal(new[] { firstStoreId }, Assert.Single(postedViewModel.PermissionValues).SpecificStores);
+
             var client = await account.CreateClient();
             await client.CreateAPIKey(new CreateApiKeyRequest
             {
@@ -279,6 +296,11 @@ namespace BTCPayServer.Tests
             await AssertAPIError("missing-permission", () => client.CreateAPIKey(new CreateApiKeyRequest
             {
                 Permissions = new[] { Permission.Create(Policies.CanViewInvoices) }
+            }));
+
+            await AssertAPIError("missing-permission", () => client.CreateAPIKey(new CreateApiKeyRequest
+            {
+                Permissions = new[] { Permission.Create(Policies.CanModifyServerSettings) }
             }));
 
             await storeRepository.AddOrUpdateStoreRole(lockedRole,
@@ -304,6 +326,10 @@ namespace BTCPayServer.Tests
             await client.CreateAPIKey(new CreateApiKeyRequest
             {
                 Permissions = new[] { Permission.Create(Policies.CanViewProfile) }
+            });
+            await client.CreateAPIKey(new CreateApiKeyRequest
+            {
+                Permissions = new[] { Permission.Create(Policies.CanModifyServerSettings) }
             });
         }
 

--- a/BTCPayServer/Components/GlobalNav/Default.cshtml
+++ b/BTCPayServer/Components/GlobalNav/Default.cshtml
@@ -161,7 +161,7 @@
                 <li>
                     <a id="menu-item-@nameof(ManageNavPages.Passkeys)" class="dropdown-item@(activePage == nameof(ManageNavPages.Passkeys) ? " active" : "")" asp-controller="UIManage" asp-action="Passkeys" text-translate="true">Passkeys</a>
                 </li>
-                <li>
+                <li permission="@Policies.CanManageStoreCredentials">
                     <a id="menu-item-@nameof(ManageNavPages.APIKeys)" class="dropdown-item@(activePage == nameof(ManageNavPages.APIKeys) ? " active" : "")" asp-controller="UIManage" asp-action="APIKeys" text-translate="true">API Keys</a>
                 </li>
                 <li>

--- a/BTCPayServer/Controllers/GreenField/GreenfieldApiKeysController.cs
+++ b/BTCPayServer/Controllers/GreenField/GreenfieldApiKeysController.cs
@@ -6,6 +6,7 @@ using BTCPayServer.Client;
 using BTCPayServer.Client.Models;
 using BTCPayServer.Data;
 using BTCPayServer.Security.Greenfield;
+using BTCPayServer.Services;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Cors;
 using Microsoft.AspNetCore.Identity;
@@ -18,7 +19,10 @@ namespace BTCPayServer.Controllers.Greenfield
     [ApiController]
     [Authorize(AuthenticationSchemes = AuthenticationSchemes.GreenfieldAPIKeys)]
     [EnableCors(CorsPolicies.All)]
-    public class GreenfieldApiKeysController(APIKeyRepository apiKeyRepository, UserManager<ApplicationUser> userManager) : ControllerBase
+    public class GreenfieldApiKeysController(
+        APIKeyRepository apiKeyRepository,
+        UserManager<ApplicationUser> userManager,
+        CredentialManagementService credentialManagementService) : ControllerBase
     {
         [HttpGet("~/api/v1/api-keys/current")]
         public async Task<IActionResult> GetKey()
@@ -43,6 +47,9 @@ namespace BTCPayServer.Controllers.Greenfield
         {
             request ??= new CreateApiKeyRequest();
             request.Permissions ??= System.Array.Empty<Permission>();
+
+            if (!await credentialManagementService.CanCreateApiKey(User, request.Permissions))
+                return this.CreateAPIPermissionError(Policies.CanManageStoreCredentials);
 
             var userId = (await userManager.FindByIdOrEmail(idOrEmail))?.Id;
             if (userId is null)
@@ -76,8 +83,12 @@ namespace BTCPayServer.Controllers.Greenfield
         }
         [HttpDelete("~/api/v1/api-keys/{apikey}", Order = 1)]
         [Authorize(Policy = Policies.Unrestricted, AuthenticationSchemes = AuthenticationSchemes.Greenfield)]
-        public Task<IActionResult> RevokeAPIKey(string apikey)
-        => RevokeAPIKey(User.GetId(), apikey);
+        public async Task<IActionResult> RevokeAPIKey(string apikey)
+        {
+            if (!await credentialManagementService.CanManageAccountApiKeys(User))
+                return this.CreateAPIPermissionError(Policies.CanManageStoreCredentials);
+            return await RevokeAPIKey(User.GetId(), apikey);
+        }
 
         [HttpDelete("~/api/v1/users/{idOrEmail}/api-keys/{apikey}", Order = 1)]
         [Authorize(Policy = Policies.CanManageUsers, AuthenticationSchemes = AuthenticationSchemes.Greenfield)]

--- a/BTCPayServer/Controllers/GreenField/GreenfieldApiKeysController.cs
+++ b/BTCPayServer/Controllers/GreenField/GreenfieldApiKeysController.cs
@@ -41,6 +41,9 @@ namespace BTCPayServer.Controllers.Greenfield
         public Task<IActionResult> CreateAPIKey(CreateApiKeyRequest request)
         => CreateUserAPIKey(User.GetId(), request);
 
+        /// <summary>
+        /// Creates an API key when the caller may manage every requested permission and store scope.
+        /// </summary>
         [HttpPost("~/api/v1/users/{idOrEmail}/api-keys")]
         [Authorize(Policy = Policies.CanModifyServerSettings, AuthenticationSchemes = AuthenticationSchemes.Greenfield)]
         public async Task<IActionResult> CreateUserAPIKey(string idOrEmail, CreateApiKeyRequest request)
@@ -81,6 +84,9 @@ namespace BTCPayServer.Controllers.Greenfield
             }
             return RevokeAPIKey(apiKey);
         }
+        /// <summary>
+        /// Revokes one of the current user's API keys when account credential management is allowed.
+        /// </summary>
         [HttpDelete("~/api/v1/api-keys/{apikey}", Order = 1)]
         [Authorize(Policy = Policies.Unrestricted, AuthenticationSchemes = AuthenticationSchemes.Greenfield)]
         public async Task<IActionResult> RevokeAPIKey(string apikey)

--- a/BTCPayServer/Controllers/UIManageController.APIKeys.cs
+++ b/BTCPayServer/Controllers/UIManageController.APIKeys.cs
@@ -20,6 +20,9 @@ namespace BTCPayServer.Controllers
 {
     public partial class UIManageController
     {
+        /// <summary>
+        /// Lists API keys owned by the current user.
+        /// </summary>
         [HttpGet]
         [Authorize(Policy = Policies.CanManageStoreCredentials)]
         public async Task<IActionResult> APIKeys()
@@ -33,6 +36,9 @@ namespace BTCPayServer.Controllers
             });
         }
 
+        /// <summary>
+        /// Displays permission-usage details for an API key owned by the current user.
+        /// </summary>
         [HttpGet("~/api-keys/{id}/view-analysis")]
         [Authorize(Policy = Policies.CanManageStoreCredentials)]
         public async Task<IActionResult> APIKeyPermissionAnalysis(string id)
@@ -78,6 +84,9 @@ namespace BTCPayServer.Controllers
             });
         }
 
+        /// <summary>
+        /// Displays the confirmation page for deleting an API key owned by the current user.
+        /// </summary>
         [HttpGet("~/api-keys/{id}/delete")]
         [Authorize(Policy = Policies.CanManageStoreCredentials)]
         public async Task<IActionResult> DeleteAPIKey(string id)
@@ -96,6 +105,9 @@ namespace BTCPayServer.Controllers
             });
         }
 
+        /// <summary>
+        /// Deletes an API key owned by the current user.
+        /// </summary>
         [HttpPost("~/api-keys/{id}/delete")]
         [Authorize(Policy = Policies.CanManageStoreCredentials)]
         public async Task<IActionResult> DeleteAPIKeyPost(string id)
@@ -114,6 +126,9 @@ namespace BTCPayServer.Controllers
             return RedirectToAction("APIKeys");
         }
 
+        /// <summary>
+        /// Displays the API-key creation form with permissions limited to manageable stores.
+        /// </summary>
         [HttpGet]
         [Authorize(Policy = Policies.CanManageStoreCredentials)]
         public async Task<IActionResult> AddApiKey()
@@ -131,6 +146,9 @@ namespace BTCPayServer.Controllers
             return View("AddApiKey", await SetViewModelValues(new AddApiKeyViewModel()));
         }
 
+        /// <summary>
+        /// Displays an application's API-key authorization request within the caller's credential authority.
+        /// </summary>
         [HttpGet("~/api-keys/authorize")]
         [Authorize(Policy = Policies.CanManageStoreCredentials)]
         public async Task<IActionResult> AuthorizeAPIKey(string[] permissions, string applicationName = null, Uri redirect = null,
@@ -181,6 +199,9 @@ namespace BTCPayServer.Controllers
             return View(vm);
         }
 
+        /// <summary>
+        /// Processes an application's API-key authorization request after validating its permissions and scopes.
+        /// </summary>
         [HttpPost("~/api-keys/authorize")]
         [Authorize(Policy = Policies.CanManageStoreCredentials)]
         public async Task<IActionResult> AuthorizeAPIKey([FromForm] AuthorizeApiKeysViewModel viewModel)
@@ -287,6 +308,9 @@ namespace BTCPayServer.Controllers
             }
         }
 
+        /// <summary>
+        /// Creates an API key after validating the submitted permissions against the caller's manageable stores.
+        /// </summary>
         [HttpPost]
         [Authorize(Policy = Policies.CanManageStoreCredentials)]
         public async Task<IActionResult> AddApiKey(AddApiKeyViewModel viewModel)
@@ -319,6 +343,9 @@ namespace BTCPayServer.Controllers
             return RedirectToAction("APIKeys");
         }
 
+        /// <summary>
+        /// Finds an existing key that satisfies an application's requested permissions and the current authority boundary.
+        /// </summary>
         private async Task<APIKeyData> CheckForMatchingApiKey(IEnumerable<Permission> requestedPermissions, AuthorizeApiKeysViewModel vm)
         {
             if (string.IsNullOrEmpty(vm.ApplicationIdentifier) || vm.RedirectUrl == null)
@@ -451,6 +478,9 @@ namespace BTCPayServer.Controllers
         private bool IsStorePolicy(string policy)
         => Permission.TryGetPolicyType(policy) is PolicyType.Store;
 
+        /// <summary>
+        /// Applies interactive store-scope commands while preventing escalation to stores the user cannot manage.
+        /// </summary>
         private IActionResult HandleCommands(AddApiKeyViewModel viewModel)
         {
             if (string.IsNullOrEmpty(viewModel.Command))
@@ -556,6 +586,9 @@ namespace BTCPayServer.Controllers
             return permissions.Distinct();
         }
 
+        /// <summary>
+        /// Populates an API-key view model and removes posted store scopes outside the current user's authority.
+        /// </summary>
         private async Task<T> SetViewModelValues<T>(T viewModel) where T : AddApiKeyViewModel
         {
             var allStores = await _StoreRepository.GetStoresByUserId(User.GetId());

--- a/BTCPayServer/Controllers/UIManageController.APIKeys.cs
+++ b/BTCPayServer/Controllers/UIManageController.APIKeys.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading.Tasks;
+using BTCPayServer.Abstractions.Constants;
 using BTCPayServer.Abstractions.Extensions;
 using BTCPayServer.Abstractions.Models;
 using BTCPayServer.Client;
@@ -20,6 +21,7 @@ namespace BTCPayServer.Controllers
     public partial class UIManageController
     {
         [HttpGet]
+        [Authorize(Policy = Policies.CanManageStoreCredentials)]
         public async Task<IActionResult> APIKeys()
         {
             return View(new ApiKeysViewModel()
@@ -32,6 +34,7 @@ namespace BTCPayServer.Controllers
         }
 
         [HttpGet("~/api-keys/{id}/view-analysis")]
+        [Authorize(Policy = Policies.CanManageStoreCredentials)]
         public async Task<IActionResult> APIKeyPermissionAnalysis(string id)
         {
             var key = await _apiKeyRepository.GetKey(id);
@@ -76,6 +79,7 @@ namespace BTCPayServer.Controllers
         }
 
         [HttpGet("~/api-keys/{id}/delete")]
+        [Authorize(Policy = Policies.CanManageStoreCredentials)]
         public async Task<IActionResult> DeleteAPIKey(string id)
         {
             var key = await _apiKeyRepository.GetKey(id);
@@ -93,6 +97,7 @@ namespace BTCPayServer.Controllers
         }
 
         [HttpPost("~/api-keys/{id}/delete")]
+        [Authorize(Policy = Policies.CanManageStoreCredentials)]
         public async Task<IActionResult> DeleteAPIKeyPost(string id)
         {
             var key = await _apiKeyRepository.GetKey(id);
@@ -110,6 +115,7 @@ namespace BTCPayServer.Controllers
         }
 
         [HttpGet]
+        [Authorize(Policy = Policies.CanManageStoreCredentials)]
         public async Task<IActionResult> AddApiKey()
         {
             if (!_btcPayServerEnvironment.IsSecure(HttpContext))
@@ -126,6 +132,7 @@ namespace BTCPayServer.Controllers
         }
 
         [HttpGet("~/api-keys/authorize")]
+        [Authorize(Policy = Policies.CanManageStoreCredentials)]
         public async Task<IActionResult> AuthorizeAPIKey(string[] permissions, string applicationName = null, Uri redirect = null,
             bool strict = true, bool selectiveStores = false, string applicationIdentifier = null)
         {
@@ -175,6 +182,7 @@ namespace BTCPayServer.Controllers
         }
 
         [HttpPost("~/api-keys/authorize")]
+        [Authorize(Policy = Policies.CanManageStoreCredentials)]
         public async Task<IActionResult> AuthorizeAPIKey([FromForm] AuthorizeApiKeysViewModel viewModel)
         {
             viewModel = await SetViewModelValues(viewModel);
@@ -217,9 +225,21 @@ namespace BTCPayServer.Controllers
 
                 case "authorize":
                 case "confirm":
-                    var key = command == "authorize"
-                        ? await CreateKey(viewModel, (viewModel.ApplicationIdentifier, viewModel.RedirectUrl?.AbsoluteUri))
-                        : await _apiKeyRepository.GetKey(viewModel.ApiKey);
+                    APIKeyData key;
+                    if (command == "authorize")
+                    {
+                        var requestedPermissions = GetPermissionsFromViewModel(viewModel).ToArray();
+                        if (!await _credentialManagementService.CanCreateApiKey(User, requestedPermissions))
+                            return Forbid();
+                        key = await CreateKey(viewModel, (viewModel.ApplicationIdentifier, viewModel.RedirectUrl?.AbsoluteUri));
+                    }
+                    else
+                    {
+                        key = await _apiKeyRepository.GetKey(viewModel.ApiKey);
+                        if (key is null || key.UserId != User.GetId() ||
+                            !await _credentialManagementService.CanCreateApiKey(User, Permission.ToPermissions(key.GetBlob().Permissions)))
+                            return Forbid();
+                    }
 
                     if (viewModel.RedirectUrl != null)
                     {
@@ -268,6 +288,7 @@ namespace BTCPayServer.Controllers
         }
 
         [HttpPost]
+        [Authorize(Policy = Policies.CanManageStoreCredentials)]
         public async Task<IActionResult> AddApiKey(AddApiKeyViewModel viewModel)
         {
             await SetViewModelValues(viewModel);
@@ -283,6 +304,10 @@ namespace BTCPayServer.Controllers
             {
                 return View(viewModel);
             }
+
+            var requestedPermissions = GetPermissionsFromViewModel(viewModel).ToArray();
+            if (!await _credentialManagementService.CanCreateApiKey(User, requestedPermissions))
+                return Forbid();
 
             var key = await CreateKey(viewModel);
 
@@ -340,6 +365,12 @@ namespace BTCPayServer.Controllers
                 }
 
                 if (fail)
+                {
+                    continue;
+                }
+
+                if (!await _credentialManagementService.CanCreateApiKey(User,
+                        Permission.ToPermissions(blob.Permissions)))
                 {
                     continue;
                 }
@@ -436,6 +467,15 @@ namespace BTCPayServer.Controllers
             var command = parts[1];
             var storeIndex = parts.Length == 3 ? parts[2] : null;
 
+            if (command == "change-store-mode" &&
+                permissionValueItem.StoreMode == AddApiKeyViewModel.ApiKeyStoreMode.Specific &&
+                !viewModel.CanUseAllStores)
+            {
+                ModelState.AddModelError(string.Empty,
+                    "You cannot grant API key permissions to stores where your role cannot manage credentials.");
+                return View(viewModel);
+            }
+
             ModelState.Clear();
             switch (command)
             {
@@ -518,11 +558,16 @@ namespace BTCPayServer.Controllers
 
         private async Task<T> SetViewModelValues<T>(T viewModel) where T : AddApiKeyViewModel
         {
-            var stores = await _StoreRepository.GetStoresByUserId(User.GetId());
+            var allStores = await _StoreRepository.GetStoresByUserId(User.GetId());
+            var stores = await _credentialManagementService.GetManageableStores(User);
             viewModel.Stores = stores.OrderBy(store => store.StoreName, StringComparer.InvariantCultureIgnoreCase).ToArray();
+            var manageableStoreIds = stores.Select(store => store.Id).ToHashSet();
+            viewModel.CanUseAllStores = User.IsInRole(Roles.ServerAdmin) ||
+                                        allStores.All(store => manageableStoreIds.Contains(store.Id));
 
             var isAdmin = (await _authorizationService.AuthorizeAsync(User, Policies.CanModifyServerSettings))
                 .Succeeded;
+            var initializePermissions = viewModel.PermissionValues is null;
             viewModel.PermissionValues ??= _permissionService.Definitions.Values.OrderBy(d => d.Policy)
                 .Select(definition => new AddApiKeyViewModel.PermissionValueItem()
                 {
@@ -530,6 +575,12 @@ namespace BTCPayServer.Controllers
                     Value = false,
                     Forbidden = definition.Type is PolicyType.Server && !isAdmin
                 }).ToList();
+
+            if (initializePermissions && !viewModel.CanUseAllStores)
+            {
+                foreach (var permission in viewModel.PermissionValues.Where(value => value.IsStorePolicy))
+                    permission.StoreMode = AddApiKeyViewModel.ApiKeyStoreMode.Specific;
+            }
 
             foreach (var permissionValue in viewModel.PermissionValues)
             {
@@ -560,6 +611,8 @@ namespace BTCPayServer.Controllers
             public StoreData[] Stores { get; set; }
             public string Command { get; set; }
             public List<PermissionValueItem> PermissionValues { get; set; }
+            [BindNever]
+            public bool CanUseAllStores { get; set; }
 
             public enum ApiKeyStoreMode
             {

--- a/BTCPayServer/Controllers/UIManageController.APIKeys.cs
+++ b/BTCPayServer/Controllers/UIManageController.APIKeys.cs
@@ -576,6 +576,15 @@ namespace BTCPayServer.Controllers
                     Forbidden = definition.Type is PolicyType.Server && !isAdmin
                 }).ToList();
 
+            foreach (var permissionValue in viewModel.PermissionValues.Where(value => value.IsStorePolicy))
+            {
+                permissionValue.SpecificStores ??= new List<string>();
+                permissionValue.SpecificStores = permissionValue.SpecificStores
+                    .Where(storeId => storeId is null || manageableStoreIds.Contains(storeId))
+                    .Distinct()
+                    .ToList();
+            }
+
             if (initializePermissions && !viewModel.CanUseAllStores)
             {
                 foreach (var permission in viewModel.PermissionValues.Where(value => value.IsStorePolicy))

--- a/BTCPayServer/Controllers/UIManageController.cs
+++ b/BTCPayServer/Controllers/UIManageController.cs
@@ -41,6 +41,7 @@ namespace BTCPayServer.Controllers
         private readonly IFileService _fileService;
         private readonly EventAggregator _eventAggregator;
         private readonly PermissionService _permissionService;
+        private readonly CredentialManagementService _credentialManagementService;
         readonly StoreRepository _StoreRepository;
         public IStringLocalizer StringLocalizer { get; }
 
@@ -61,7 +62,8 @@ namespace BTCPayServer.Controllers
           IStringLocalizer stringLocalizer,
           IHtmlHelper htmlHelper,
           EventAggregator eventAggregator,
-          PermissionService permissionService)
+          PermissionService permissionService,
+          CredentialManagementService credentialManagementService)
         {
             _userManager = userManager;
             _signInManager = signInManager;
@@ -80,6 +82,7 @@ namespace BTCPayServer.Controllers
             _StoreRepository = storeRepository;
             StringLocalizer = stringLocalizer;
             _permissionService = permissionService;
+            _credentialManagementService = credentialManagementService;
         }
 
         [HttpGet]

--- a/BTCPayServer/Controllers/UIManageController.cs
+++ b/BTCPayServer/Controllers/UIManageController.cs
@@ -45,6 +45,9 @@ namespace BTCPayServer.Controllers
         readonly StoreRepository _StoreRepository;
         public IStringLocalizer StringLocalizer { get; }
 
+        /// <summary>
+        /// Initializes the account-management controller and its credential authorization dependencies.
+        /// </summary>
         public UIManageController(
           UserManager<ApplicationUser> userManager,
           SignInManager<ApplicationUser> signInManager,

--- a/BTCPayServer/Hosting/BTCPayServerServices.cs
+++ b/BTCPayServer/Hosting/BTCPayServerServices.cs
@@ -84,6 +84,9 @@ namespace BTCPayServer.Hosting
             return services;
         }
 
+        /// <summary>
+        /// Registers BTCPay Server services, authorization policies, and application infrastructure.
+        /// </summary>
         public static IServiceCollection AddBTCPayServer(this IServiceCollection services, IConfiguration configuration, Logs logs)
         {
             services.TryAddScoped<CallbackGenerator>();

--- a/BTCPayServer/Hosting/BTCPayServerServices.cs
+++ b/BTCPayServer/Hosting/BTCPayServerServices.cs
@@ -149,6 +149,7 @@ namespace BTCPayServer.Hosting
             services.AddSettingsAccessor<ServerSettings>();
             //
             services.AddSingleton<PermissionService>();
+            services.AddSingleton<CredentialManagementService>();
 
             AddOnchainWalletParsers(services);
 
@@ -535,6 +536,11 @@ namespace BTCPayServer.Hosting
                     Policies.CanSendStoreEmail,
                     new PermissionDisplay("Send store emails", "Allows sending emails on behalf of all your stores."),
                     new PermissionDisplay("Send selected stores' emails", "Allows sending emails on behalf of the selected stores.")),
+                new PolicyDefinition(
+                    Policies.CanManageStoreCredentials,
+                    new PermissionDisplay("Manage API keys and access tokens", "Allows managing API keys and access tokens for all your stores."),
+                    new PermissionDisplay("Manage selected stores' API keys and access tokens", "Allows managing API keys and access tokens for the selected stores."),
+                    includedByPermissions: new[] { Policies.CanModifyStoreSettings }),
                 new PolicyDefinition(
                     Policies.CanModifyServerSettings,
                     new PermissionDisplay("Manage your server", "Grants total control on the server settings of your server."),

--- a/BTCPayServer/Plugins/Bitpay/BitpayPlugin.cs
+++ b/BTCPayServer/Plugins/Bitpay/BitpayPlugin.cs
@@ -21,6 +21,7 @@ public class BitpayPlugin : BaseBTCPayServerPlugin
     public override string Name => "Bitpay";
     public override string Description => "Add a compatibility layer to the legacy Bitpay API";
 
+    /// <inheritdoc />
     public override void Execute(IServiceCollection services)
     {
         services.AddSingleton<IHostedService, BitpayIPNSender>();

--- a/BTCPayServer/Plugins/Bitpay/BitpayPlugin.cs
+++ b/BTCPayServer/Plugins/Bitpay/BitpayPlugin.cs
@@ -41,7 +41,7 @@ public class BitpayPlugin : BaseBTCPayServerPlugin
 
         services.AddStaticSearch(new ActionResultItemViewModel()
         {
-            RequiredPolicy = Policies.CanViewStoreSettings,
+            RequiredPolicy = Policies.CanManageStoreCredentials,
             Title = "View the access tokens (for legacy API access)",
             Action = nameof(UIStoresTokenController.ListTokens),
             Controller = "UIStoresToken",

--- a/BTCPayServer/Plugins/Bitpay/Controllers/UIStoresTokenController.cs
+++ b/BTCPayServer/Plugins/Bitpay/Controllers/UIStoresTokenController.cs
@@ -128,7 +128,7 @@ public class UIStoresTokenController(
             return Challenge(AuthenticationSchemes.Cookie);
 
         if (!(await authorizationService.AuthorizeAsync(User, store.Id, Policies.CanManageStoreCredentials)).Succeeded)
-            return Challenge(AuthenticationSchemes.Cookie);
+            return Forbid(AuthenticationSchemes.Cookie);
 
         var tokenRequest = new TokenRequest()
         {

--- a/BTCPayServer/Plugins/Bitpay/Controllers/UIStoresTokenController.cs
+++ b/BTCPayServer/Plugins/Bitpay/Controllers/UIStoresTokenController.cs
@@ -24,7 +24,7 @@ namespace BTCPayServer.Plugins.Bitpay.Controllers;
 
 [Route("stores")]
 [Authorize(AuthenticationSchemes = AuthenticationSchemes.Cookie)]
-[Authorize(Policy = Policies.CanViewStoreSettings, AuthenticationSchemes = AuthenticationSchemes.Cookie)]
+[Authorize(Policy = Policies.CanManageStoreCredentials, AuthenticationSchemes = AuthenticationSchemes.Cookie)]
 [Area(BitpayPlugin.Area)]
 public class UIStoresTokenController(
     TokenRepository tokenRepository,
@@ -33,8 +33,8 @@ public class UIStoresTokenController(
     StoreRepository storeRepository,
     IHtmlHelper html,
     PaymentMethodHandlerDictionary handlers,
-    PermissionService permissionService,
-    IAuthorizationService authorizationService) : Controller
+    IAuthorizationService authorizationService,
+    CredentialManagementService credentialManagementService) : Controller
 {
     public IStringLocalizer StringLocalizer { get; } = stringLocalizer;
     public StoreData CurrentStore => HttpContext.GetStoreDataOrNull() ?? throw new InvalidOperationException("Store not found");
@@ -44,7 +44,7 @@ public class UIStoresTokenController(
     public bool StoreNotConfigured { get; set; }
     public string? GeneratedPairingCode { get; set; }
     [HttpGet("{storeId}/tokens")]
-    [Authorize(Policy = Policies.CanViewStoreSettings, AuthenticationSchemes = AuthenticationSchemes.Cookie)]
+    [Authorize(Policy = Policies.CanManageStoreCredentials, AuthenticationSchemes = AuthenticationSchemes.Cookie)]
     public async Task<IActionResult> ListTokens()
     {
         var model = new TokensViewModel();
@@ -57,22 +57,13 @@ public class UIStoresTokenController(
             Id = t.Value
         }).ToArray();
 
-        var userId = GetUserId();
-        var canModify = userId != null && (await authorizationService.AuthorizeAsync(User, CurrentStore.Id, Policies.CanModifyStoreSettings)).Succeeded;
-        if (canModify)
-        {
-            model.ApiKey = (await tokenRepository.GetLegacyAPIKeys(CurrentStore.Id)).FirstOrDefault();
-            model.EncodedApiKey = model.ApiKey == null ? "*API Key*" : Encoders.Base64.EncodeData(Encoders.ASCII.DecodeData(model.ApiKey));
-        }
-        else
-        {
-            model.EncodedApiKey = "*API Key*";
-        }
+        model.ApiKey = (await tokenRepository.GetLegacyAPIKeys(CurrentStore.Id)).FirstOrDefault();
+        model.EncodedApiKey = model.ApiKey == null ? "*API Key*" : Encoders.Base64.EncodeData(Encoders.ASCII.DecodeData(model.ApiKey));
         return View(model);
     }
 
     [HttpGet("{storeId}/tokens/{tokenId}/revoke")]
-    [Authorize(Policy = Policies.CanModifyStoreSettings, AuthenticationSchemes = AuthenticationSchemes.Cookie)]
+    [Authorize(Policy = Policies.CanManageStoreCredentials, AuthenticationSchemes = AuthenticationSchemes.Cookie)]
     public async Task<IActionResult> RevokeToken(string tokenId)
     {
         var token = await tokenRepository.GetToken(tokenId);
@@ -82,7 +73,7 @@ public class UIStoresTokenController(
     }
 
     [HttpPost("{storeId}/tokens/{tokenId}/revoke")]
-    [Authorize(Policy = Policies.CanModifyStoreSettings, AuthenticationSchemes = AuthenticationSchemes.Cookie)]
+    [Authorize(Policy = Policies.CanManageStoreCredentials, AuthenticationSchemes = AuthenticationSchemes.Cookie)]
     public async Task<IActionResult> RevokeTokenConfirm(string tokenId)
     {
         var token = await tokenRepository.GetToken(tokenId);
@@ -96,7 +87,7 @@ public class UIStoresTokenController(
     }
 
     [HttpGet("{storeId}/tokens/{tokenId}")]
-    [Authorize(Policy = Policies.CanModifyStoreSettings, AuthenticationSchemes = AuthenticationSchemes.Cookie)]
+    [Authorize(Policy = Policies.CanManageStoreCredentials, AuthenticationSchemes = AuthenticationSchemes.Cookie)]
     public async Task<IActionResult> ShowToken(string tokenId)
     {
         var token = await tokenRepository.GetToken(tokenId);
@@ -106,7 +97,7 @@ public class UIStoresTokenController(
     }
 
     [HttpGet("{storeId}/tokens/create")]
-    [Authorize(Policy = Policies.CanModifyStoreSettings, AuthenticationSchemes = AuthenticationSchemes.Cookie)]
+    [Authorize(Policy = Policies.CanManageStoreCredentials, AuthenticationSchemes = AuthenticationSchemes.Cookie)]
     public IActionResult CreateToken(string storeId)
     {
         var model = new CreateTokenViewModel();
@@ -117,7 +108,7 @@ public class UIStoresTokenController(
     }
 
     [HttpPost("{storeId}/tokens/create")]
-    [Authorize(Policy = Policies.CanModifyStoreSettings, AuthenticationSchemes = AuthenticationSchemes.Cookie)]
+    [Authorize(Policy = Policies.CanManageStoreCredentials, AuthenticationSchemes = AuthenticationSchemes.Cookie)]
     public async Task<IActionResult> CreateToken(string storeId, CreateTokenViewModel model)
     {
         if (!ModelState.IsValid)
@@ -131,12 +122,12 @@ public class UIStoresTokenController(
         var store = model.StoreId switch
         {
             null => CurrentStore,
-            _ => await storeRepository.FindStore(storeId, userId)
+            _ => await storeRepository.FindStore(storeId, User, true)
         };
         if (store == null)
             return Challenge(AuthenticationSchemes.Cookie);
 
-        if (!(await authorizationService.AuthorizeAsync(User, store.Id, Policies.CanModifyStoreSettings)).Succeeded)
+        if (!(await authorizationService.AuthorizeAsync(User, store.Id, Policies.CanManageStoreCredentials)).Succeeded)
             return Challenge(AuthenticationSchemes.Cookie);
 
         var tokenRequest = new TokenRequest()
@@ -180,7 +171,7 @@ public class UIStoresTokenController(
         var model = new CreateTokenViewModel();
         ViewBag.HidePublicKey = true;
         ViewBag.ShowStores = true;
-        var stores = (await storeRepository.GetStoresByUserId(userId)).Where(data => data.HasPolicy(userId, Policies.CanModifyStoreSettings, permissionService)).ToArray();
+        var stores = await credentialManagementService.GetManageableStores(User);
 
         model.Stores = new SelectList(stores, nameof(CurrentStore.Id), nameof(CurrentStore.StoreName));
         if (!model.Stores.Any())
@@ -199,7 +190,7 @@ public class UIStoresTokenController(
     }
 
     [HttpPost("{storeId}/tokens/apikey")]
-    [Authorize(Policy = Policies.CanModifyStoreSettings, AuthenticationSchemes = AuthenticationSchemes.Cookie)]
+    [Authorize(Policy = Policies.CanManageStoreCredentials, AuthenticationSchemes = AuthenticationSchemes.Cookie)]
     public async Task<IActionResult> GenerateAPIKey(string storeId, string command = "")
     {
         var store = HttpContext.GetStoreDataOrNull();
@@ -230,11 +221,12 @@ public class UIStoresTokenController(
         if (userId == null)
             return Challenge(AuthenticationSchemes.Cookie);
 
+        var stores = await credentialManagementService.GetManageableStores(User);
         if (selectedStore != null)
         {
-            var store = await storeRepository.FindStore(selectedStore, userId);
+            var store = stores.SingleOrDefault(candidate => candidate.Id == selectedStore);
             if (store == null)
-                return NotFound();
+                return Forbid(AuthenticationSchemes.Cookie);
             HttpContext.SetStoreData(store);
         }
 
@@ -245,7 +237,6 @@ public class UIStoresTokenController(
             return RedirectToAction(nameof(UIHomeController.Index), "UIHome");
         }
 
-        var stores = (await storeRepository.GetStoresByUserId(userId)).Where(data => data.HasPolicy(userId, Policies.CanModifyStoreSettings, permissionService)).ToArray();
         return View(new PairingModel
         {
             Id = pairing.Id,
@@ -261,7 +252,7 @@ public class UIStoresTokenController(
     }
 
     [HttpPost("/api-access-request")]
-    [Authorize(Policy = Policies.CanModifyStoreSettings, AuthenticationSchemes = AuthenticationSchemes.Cookie)]
+    [Authorize(Policy = Policies.CanManageStoreCredentials, AuthenticationSchemes = AuthenticationSchemes.Cookie)]
     public async Task<IActionResult> Pair(string pairingCode, string storeId)
     {
         var store = CurrentStore;

--- a/BTCPayServer/Plugins/Bitpay/Controllers/UIStoresTokenController.cs
+++ b/BTCPayServer/Plugins/Bitpay/Controllers/UIStoresTokenController.cs
@@ -43,6 +43,9 @@ public class UIStoresTokenController(
     [TempData]
     public bool StoreNotConfigured { get; set; }
     public string? GeneratedPairingCode { get; set; }
+    /// <summary>
+    /// Lists legacy access tokens and API-key information for the current store.
+    /// </summary>
     [HttpGet("{storeId}/tokens")]
     [Authorize(Policy = Policies.CanManageStoreCredentials, AuthenticationSchemes = AuthenticationSchemes.Cookie)]
     public async Task<IActionResult> ListTokens()
@@ -62,6 +65,9 @@ public class UIStoresTokenController(
         return View(model);
     }
 
+    /// <summary>
+    /// Displays the confirmation page for revoking a store access token.
+    /// </summary>
     [HttpGet("{storeId}/tokens/{tokenId}/revoke")]
     [Authorize(Policy = Policies.CanManageStoreCredentials, AuthenticationSchemes = AuthenticationSchemes.Cookie)]
     public async Task<IActionResult> RevokeToken(string tokenId)
@@ -72,6 +78,9 @@ public class UIStoresTokenController(
         return View("Confirm", new ConfirmModel(StringLocalizer["Revoke the token"], $"The access token with the label <strong>{html.Encode(token.Label)}</strong> will be revoked. Do you wish to continue?", "Revoke"));
     }
 
+    /// <summary>
+    /// Revokes a store access token after confirmation.
+    /// </summary>
     [HttpPost("{storeId}/tokens/{tokenId}/revoke")]
     [Authorize(Policy = Policies.CanManageStoreCredentials, AuthenticationSchemes = AuthenticationSchemes.Cookie)]
     public async Task<IActionResult> RevokeTokenConfirm(string tokenId)
@@ -86,6 +95,9 @@ public class UIStoresTokenController(
         return RedirectToAction(nameof(ListTokens), new { storeId = token?.StoreId });
     }
 
+    /// <summary>
+    /// Displays a store access token when it belongs to the current store.
+    /// </summary>
     [HttpGet("{storeId}/tokens/{tokenId}")]
     [Authorize(Policy = Policies.CanManageStoreCredentials, AuthenticationSchemes = AuthenticationSchemes.Cookie)]
     public async Task<IActionResult> ShowToken(string tokenId)
@@ -96,6 +108,9 @@ public class UIStoresTokenController(
         return View(token);
     }
 
+    /// <summary>
+    /// Displays the access-token creation form for the selected store.
+    /// </summary>
     [HttpGet("{storeId}/tokens/create")]
     [Authorize(Policy = Policies.CanManageStoreCredentials, AuthenticationSchemes = AuthenticationSchemes.Cookie)]
     public IActionResult CreateToken(string storeId)
@@ -107,6 +122,9 @@ public class UIStoresTokenController(
         return View(model);
     }
 
+    /// <summary>
+    /// Creates an access token after verifying credential-management permission for its store.
+    /// </summary>
     [HttpPost("{storeId}/tokens/create")]
     [Authorize(Policy = Policies.CanManageStoreCredentials, AuthenticationSchemes = AuthenticationSchemes.Cookie)]
     public async Task<IActionResult> CreateToken(string storeId, CreateTokenViewModel model)
@@ -161,6 +179,9 @@ public class UIStoresTokenController(
         });
     }
 
+    /// <summary>
+    /// Displays the account-level token creation form using stores the current user may manage.
+    /// </summary>
     [HttpGet("/api-tokens")]
     [AllowAnonymous]
     public async Task<IActionResult> CreateToken()
@@ -189,6 +210,9 @@ public class UIStoresTokenController(
         return CreateToken(model.StoreId, model);
     }
 
+    /// <summary>
+    /// Generates or revokes the selected store's legacy API key.
+    /// </summary>
     [HttpPost("{storeId}/tokens/apikey")]
     [Authorize(Policy = Policies.CanManageStoreCredentials, AuthenticationSchemes = AuthenticationSchemes.Cookie)]
     public async Task<IActionResult> GenerateAPIKey(string storeId, string command = "")
@@ -213,6 +237,9 @@ public class UIStoresTokenController(
         });
     }
 
+    /// <summary>
+    /// Displays a pairing request limited to stores for which the user may manage credentials.
+    /// </summary>
     [HttpGet("/api-access-request")]
     [AllowAnonymous]
     public async Task<IActionResult> RequestPairing(string pairingCode, string? selectedStore = null)
@@ -251,6 +278,9 @@ public class UIStoresTokenController(
         });
     }
 
+    /// <summary>
+    /// Approves a pairing request for a store where the user may manage credentials.
+    /// </summary>
     [HttpPost("/api-access-request")]
     [Authorize(Policy = Policies.CanManageStoreCredentials, AuthenticationSchemes = AuthenticationSchemes.Cookie)]
     public async Task<IActionResult> Pair(string pairingCode, string storeId)

--- a/BTCPayServer/Plugins/Bitpay/Views/ListTokens.cshtml
+++ b/BTCPayServer/Plugins/Bitpay/Views/ListTokens.cshtml
@@ -31,11 +31,12 @@
 </div>
 
 <partial name="_StatusMessage" />
+<partial name="_CredentialManagementAdminNotice" />
 <div class="row">
     <div class="col-xxl-constrain col-xl-8">
         <div class="settings-section__heading d-flex align-items-center justify-content-between">
             <h3 class="mb-0">@ViewData["Title"]</h3>
-            <a id="CreateNewToken" asp-action="CreateToken" class="btn btn-primary" role="button" asp-route-storeId="@Context.GetRouteValue("storeId")" permission="@Policies.CanModifyStoreSettings" text-translate="true">
+            <a id="CreateNewToken" asp-action="CreateToken" class="btn btn-primary" role="button" asp-route-storeId="@Context.GetRouteValue("storeId")" permission="@Policies.CanManageStoreCredentials" text-translate="true">
                 Create Token
             </a>
         </div>
@@ -54,7 +55,7 @@
                     <thead>
                     <tr>
                         <th text-translate="true">Label</th>
-                        <th class="text-end" permission="@Policies.CanModifyStoreSettings" text-translate="true">Actions</th>
+                        <th class="text-end" permission="@Policies.CanManageStoreCredentials" text-translate="true">Actions</th>
                     </tr>
                     </thead>
                     <tbody>
@@ -62,7 +63,7 @@
                     {
                     <tr>
                         <td>@token.Label</td>
-                        <td class="text-end" permission="@Policies.CanModifyStoreSettings">
+                        <td class="text-end" permission="@Policies.CanManageStoreCredentials">
                             <a asp-action="ShowToken" asp-route-storeId="@Context.GetRouteValue("storeId")" asp-route-tokenId="@token.Id" text-translate="true">See information</a> -
                             <a asp-action="RevokeToken" asp-route-storeId="@Context.GetRouteValue("storeId")" asp-route-tokenId="@token.Id" data-bs-toggle="modal" data-bs-target="#ConfirmModal" data-description="The access token with the label <strong>@Html.Encode(token.Label)</strong> will be revoked." data-confirm-input="REVOKE" text-translate="true">Revoke</a>
                         </td>
@@ -83,9 +84,9 @@
         <h3 class="settings-section__heading settings-section__heading--spaced" text-translate="true">Legacy API Keys</h3>
         <div class="settings-section">
         <p text-translate="true">Alternatively, you can use the invoice API by including the following HTTP Header in your requests:</p>
-		<p permission="@Policies.CanModifyStoreSettings"><code>Authorization: Basic @Model.EncodedApiKey</code></p>
+		<p permission="@Policies.CanManageStoreCredentials"><code>Authorization: Basic @Model.EncodedApiKey</code></p>
 
-        <form method="post" asp-action="GenerateAPIKey" asp-route-storeId="@Context.GetRouteValue("storeId")" permission="@Policies.CanModifyStoreSettings">
+        <form method="post" asp-action="GenerateAPIKey" asp-route-storeId="@Context.GetRouteValue("storeId")" permission="@Policies.CanManageStoreCredentials">
             <div class="form-group mb-0">
                 <label asp-for="ApiKey" class="form-label"></label>
                 <div class="d-flex">
@@ -106,4 +107,4 @@
     </div>
 </div>
 
-<partial name="_Confirm" model="@(new ConfirmModel(StringLocalizer["Revoke access token"], StringLocalizer["The access token will be revoked. Do you wish to continue?"], StringLocalizer["Revoke"]))" permission="@Policies.CanModifyStoreSettings" />
+<partial name="_Confirm" model="@(new ConfirmModel(StringLocalizer["Revoke access token"], StringLocalizer["The access token will be revoked. Do you wish to continue?"], StringLocalizer["Revoke"]))" permission="@Policies.CanManageStoreCredentials" />

--- a/BTCPayServer/Plugins/Bitpay/Views/NavExtension.cshtml
+++ b/BTCPayServer/Plugins/Bitpay/Views/NavExtension.cshtml
@@ -1,5 +1,5 @@
 @using BTCPayServer.Client
 @using BTCPayServer.Plugins.Bitpay
-<li class="nav-item nav-item-sub" permission="@Policies.CanViewStoreSettings">
+<li class="nav-item nav-item-sub" permission="@Policies.CanManageStoreCredentials">
     <a layout-menu-item="@nameof(StoreNavPages.Tokens)" asp-area="@BitpayPlugin.Area" asp-controller="UIStoresToken" asp-action="ListTokens" asp-route-storeId="@Model.Store.Id" text-translate="true">Access Tokens</a>
 </li>

--- a/BTCPayServer/Plugins/Bitpay/Views/RequestPairing.cshtml
+++ b/BTCPayServer/Plugins/Bitpay/Views/RequestPairing.cshtml
@@ -19,7 +19,7 @@
         </button>
     }
 }
-<form asp-action="Pair" method="post" permissioned="@Policies.CanModifyStoreSettings">
+<form asp-action="Pair" method="post" permissioned="@Policies.CanManageStoreCredentials">
     <div class="sticky-header">
         <vc:title-header />
 		<button id="page-primary" type="submit" class="btn btn-primary mt-3" title="@StringLocalizer["Approve this pairing demand"]" text-translate="true">Approve</button>

--- a/BTCPayServer/Plugins/GlobalSearch/GlobalSearchPlugin.cs
+++ b/BTCPayServer/Plugins/GlobalSearch/GlobalSearchPlugin.cs
@@ -22,6 +22,9 @@ public class GlobalSearchPlugin : BaseBTCPayServerPlugin
         AddDefaultStaticSearch(services);
     }
 
+    /// <summary>
+    /// Registers the built-in search entries with their corresponding authorization policies.
+    /// </summary>
     private static void AddDefaultStaticSearch(IServiceCollection services)
     {
         services.AddStaticSearch([

--- a/BTCPayServer/Plugins/GlobalSearch/GlobalSearchPlugin.cs
+++ b/BTCPayServer/Plugins/GlobalSearch/GlobalSearchPlugin.cs
@@ -225,7 +225,7 @@ public class GlobalSearchPlugin : BaseBTCPayServerPlugin
             },
             new ActionResultItemViewModel
             {
-                RequiredPolicy = Policies.CanViewProfile,
+                RequiredPolicy = Policies.CanManageStoreCredentials,
                 Title = "Manage API Keys",
                 Action = nameof(UIManageController.APIKeys),
                 Controller = "UIManage",

--- a/BTCPayServer/Security/BuiltInPermissionHandler.cs
+++ b/BTCPayServer/Security/BuiltInPermissionHandler.cs
@@ -29,6 +29,9 @@ public class BuiltInPermissionHandler(
             Permission.Create(Policies.CanManageStoreCredentials)
         });
 
+    /// <summary>
+    /// Evaluates built-in server, user, and store permissions, including the server credential-management ceiling.
+    /// </summary>
     public async Task HandleAsync(AuthorizationHandlerContext authContext, PermissionAuthorizationContext permContext)
     {
         var isAdmin = authContext.User.IsInRole(Roles.ServerAdmin);

--- a/BTCPayServer/Security/BuiltInPermissionHandler.cs
+++ b/BTCPayServer/Security/BuiltInPermissionHandler.cs
@@ -15,14 +15,19 @@ namespace BTCPayServer.Security;
 public class BuiltInPermissionHandler(
     StoreRepository storeRepository,
     PermissionService permissionService,
-    APIKeyRepository apiKeyRepository) : IPermissionHandler
+    APIKeyRepository apiKeyRepository,
+    CredentialManagementService credentialManagementService) : IPermissionHandler
 {
     public const string StoreKey = "BuiltInPermissionHandler-Store";
     public const string StoresKey = "BuiltInPermissionHandler-Stores";
 
     //TODO: In the future, we will add these store permissions to actual aspnet roles and remove this class.
     private static readonly PermissionSet ServerAdminRolePermissions =
-        new PermissionSet(new[] { Permission.Create(Policies.CanViewStoreSettings) });
+        new PermissionSet(new[]
+        {
+            Permission.Create(Policies.CanViewStoreSettings),
+            Permission.Create(Policies.CanManageStoreCredentials)
+        });
 
     public async Task HandleAsync(AuthorizationHandlerContext authContext, PermissionAuthorizationContext permContext)
     {
@@ -33,6 +38,12 @@ public class BuiltInPermissionHandler(
         switch (permContext.Permission)
         {
             case { Type: PolicyType.Store }:
+                var managesCredentials = permContext.Permission.Policy == Policies.CanManageStoreCredentials;
+                if (managesCredentials && !credentialManagementService.IsAllowedByServer(authContext.User))
+                {
+                    success = false;
+                    break;
+                }
                 if (permContext.Permission.Scope is { } storeId)
                 {
                     var store = await GetStoreData(permContext, storeId, isAdmin);
@@ -61,7 +72,7 @@ public class BuiltInPermissionHandler(
                             permContext.HttpContext.AddCachedStoreData(store);
                         }
                     }
-                    success = true;
+                    success = !managesCredentials || isAdmin || stores.Length is 0 || permissionedStores.Count is not 0;
                 }
                 break;
             case { Type: PolicyType.Server }:

--- a/BTCPayServer/Services/CredentialManagementService.cs
+++ b/BTCPayServer/Services/CredentialManagementService.cs
@@ -1,0 +1,87 @@
+#nullable enable
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using BTCPayServer.Abstractions.Constants;
+using BTCPayServer.Client;
+using BTCPayServer.Data;
+using BTCPayServer.Services.Stores;
+
+namespace BTCPayServer.Services;
+
+public class CredentialManagementService(
+    StoreRepository storeRepository,
+    PermissionService permissionService,
+    ISettingsAccessor<PoliciesSettings> policiesSettings)
+{
+    public bool IsAllowedByServer(ClaimsPrincipal user)
+    {
+        return user.IsInRole(Roles.ServerAdmin) ||
+               !policiesSettings.Settings.DisableNonAdminCredentialManagement;
+    }
+
+    public async Task<StoreData[]> GetManageableStores(ClaimsPrincipal user)
+    {
+        var userId = user.GetIdOrNull();
+        if (userId is null || !IsAllowedByServer(user))
+            return [];
+
+        var stores = await storeRepository.GetStoresByUserId(userId);
+        if (user.IsInRole(Roles.ServerAdmin))
+            return stores;
+
+        return stores
+            .Where(store => store.HasPolicy(userId, Policies.CanManageStoreCredentials, permissionService))
+            .ToArray();
+    }
+
+    public async Task<bool> CanManageAccountApiKeys(ClaimsPrincipal user)
+    {
+        var userId = user.GetIdOrNull();
+        if (userId is null || !IsAllowedByServer(user))
+            return false;
+        if (user.IsInRole(Roles.ServerAdmin))
+            return true;
+
+        var stores = await storeRepository.GetStoresByUserId(userId);
+        return stores.Length is 0 || stores.Any(store =>
+            store.HasPolicy(userId, Policies.CanManageStoreCredentials, permissionService));
+    }
+
+    public async Task<bool> CanCreateApiKey(ClaimsPrincipal user, IEnumerable<Permission> requestedPermissions)
+    {
+        if (!await CanManageAccountApiKeys(user))
+            return false;
+        if (user.IsInRole(Roles.ServerAdmin))
+            return true;
+
+        var userId = user.GetIdOrNull();
+        if (userId is null)
+            return false;
+
+        var stores = await storeRepository.GetStoresByUserId(userId);
+        var manageableStoreIds = stores
+            .Where(store => store.HasPolicy(userId, Policies.CanManageStoreCredentials, permissionService))
+            .Select(store => store.Id)
+            .ToHashSet();
+
+        foreach (var permission in requestedPermissions)
+        {
+            if (permission.Type is not PolicyType.Store && permission.Policy != Policies.Unrestricted)
+                continue;
+
+            if (permission.Scope is { } storeId)
+            {
+                if (!manageableStoreIds.Contains(storeId))
+                    return false;
+            }
+            else if (stores.Any(store => !manageableStoreIds.Contains(store.Id)))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/BTCPayServer/Services/CredentialManagementService.cs
+++ b/BTCPayServer/Services/CredentialManagementService.cs
@@ -68,6 +68,9 @@ public class CredentialManagementService(
 
         foreach (var permission in requestedPermissions)
         {
+            if (permission.Type is PolicyType.Server)
+                return false;
+
             if (permission.Type is not PolicyType.Store && permission.Policy != Policies.Unrestricted)
                 continue;
 

--- a/BTCPayServer/Services/CredentialManagementService.cs
+++ b/BTCPayServer/Services/CredentialManagementService.cs
@@ -10,17 +10,26 @@ using BTCPayServer.Services.Stores;
 
 namespace BTCPayServer.Services;
 
+/// <summary>
+/// Applies the server policy and store-role boundary for API key and access-token management.
+/// </summary>
 public class CredentialManagementService(
     StoreRepository storeRepository,
     PermissionService permissionService,
     ISettingsAccessor<PoliciesSettings> policiesSettings)
 {
+    /// <summary>
+    /// Determines whether the server-wide policy permits the user to manage credentials.
+    /// </summary>
     public bool IsAllowedByServer(ClaimsPrincipal user)
     {
         return user.IsInRole(Roles.ServerAdmin) ||
                !policiesSettings.Settings.DisableNonAdminCredentialManagement;
     }
 
+    /// <summary>
+    /// Returns stores for which the user may manage credentials under both server and store policy.
+    /// </summary>
     public async Task<StoreData[]> GetManageableStores(ClaimsPrincipal user)
     {
         var userId = user.GetIdOrNull();
@@ -36,6 +45,9 @@ public class CredentialManagementService(
             .ToArray();
     }
 
+    /// <summary>
+    /// Determines whether the user may access account-level API key management.
+    /// </summary>
     public async Task<bool> CanManageAccountApiKeys(ClaimsPrincipal user)
     {
         var userId = user.GetIdOrNull();
@@ -49,6 +61,9 @@ public class CredentialManagementService(
             store.HasPolicy(userId, Policies.CanManageStoreCredentials, permissionService));
     }
 
+    /// <summary>
+    /// Determines whether the user may create an API key with the requested permissions and store scopes.
+    /// </summary>
     public async Task<bool> CanCreateApiKey(ClaimsPrincipal user, IEnumerable<Permission> requestedPermissions)
     {
         if (!await CanManageAccountApiKeys(user))

--- a/BTCPayServer/Services/PoliciesSettings.cs
+++ b/BTCPayServer/Services/PoliciesSettings.cs
@@ -73,6 +73,16 @@ namespace BTCPayServer.Services
             set { DisableNonAdminCreateUserApi = !value; }
         }
 
+        [Display(Name = "Non-admins can manage API keys and access tokens for their Store")]
+        [JsonIgnore]
+        public bool EnableNonAdminCredentialManagement
+        {
+            get => !DisableNonAdminCredentialManagement;
+            set { DisableNonAdminCredentialManagement = !value; }
+        }
+
+        public bool DisableNonAdminCredentialManagement { get; set; }
+
         public const string DefaultPluginSource = "https://plugin-builder.btcpayserver.org";
         [UriAttribute]
         [Display(Name = "Plugin server")]

--- a/BTCPayServer/Services/PoliciesSettings.cs
+++ b/BTCPayServer/Services/PoliciesSettings.cs
@@ -73,6 +73,9 @@ namespace BTCPayServer.Services
             set { DisableNonAdminCreateUserApi = !value; }
         }
 
+        /// <summary>
+        /// Gets or sets whether non-administrators may manage credentials, using the inverse persisted lockdown flag.
+        /// </summary>
         [Display(Name = "Non-admins can manage API keys and access tokens for their Store")]
         [JsonIgnore]
         public bool EnableNonAdminCredentialManagement

--- a/BTCPayServer/Views/Shared/_CredentialManagementAdminNotice.cshtml
+++ b/BTCPayServer/Views/Shared/_CredentialManagementAdminNotice.cshtml
@@ -1,0 +1,10 @@
+@using BTCPayServer.Abstractions.Constants
+@using BTCPayServer.Services
+@inject ISettingsAccessor<PoliciesSettings> PoliciesSettings
+
+@if (User.IsInRole(Roles.ServerAdmin) && PoliciesSettings.Settings.DisableNonAdminCredentialManagement)
+{
+    <div class="alert alert-info mb-4" role="status">
+        <span text-translate="true">Credential management is disabled for non-admins. You can access this page because you are a server administrator.</span>
+    </div>
+}

--- a/BTCPayServer/Views/UIManage/APIKeys.cshtml
+++ b/BTCPayServer/Views/UIManage/APIKeys.cshtml
@@ -15,6 +15,7 @@
     </a>
 </div>
 <partial name="_StatusMessage" />
+<partial name="_CredentialManagementAdminNotice" />
 <div class="row">
     <div class="col-xl-10 col-xxl-constrain">
         <p>

--- a/BTCPayServer/Views/UIManage/AddApiKey.cshtml
+++ b/BTCPayServer/Views/UIManage/AddApiKey.cshtml
@@ -84,7 +84,10 @@
                                         <small class="text-muted text-break d-block my-2 d-lg-inline-block my-lg-0">@Model.PermissionValues[i].Permission</small>
                                     </h5>
                                     <div class="text-muted">@Model.PermissionValues[i].Description</div>
-                                    <button type="submit" class="btn btn-link p-0" name="command" value="@($"{Model.PermissionValues[i].Permission}:change-store-mode")">Give permission to all stores instead</button>
+                                    @if (Model.CanUseAllStores)
+                                    {
+                                        <button type="submit" class="btn btn-link p-0" name="command" value="@($"{Model.PermissionValues[i].Permission}:change-store-mode")">Give permission to all stores instead</button>
+                                    }
 
                                     @if (!Model.Stores.Any())
                                     {

--- a/BTCPayServer/Views/UIServer/Policies.cshtml
+++ b/BTCPayServer/Views/UIServer/Policies.cshtml
@@ -140,6 +140,16 @@
 							<span asp-validation-for="AllowCreateColdWalletForAll" class="text-danger"></span>
 						</div>
 					</div>
+                    <div class="d-flex my-3">
+                        <input asp-for="EnableNonAdminCredentialManagement" type="checkbox" class="btcpay-toggle me-3"/>
+                        <div>
+                            <label asp-for="EnableNonAdminCredentialManagement" class="form-check-label"></label>
+                            <a href="https://docs.btcpayserver.org/CustomIntegration/" target="_blank" rel="noreferrer noopener">
+                                <vc:icon symbol="info" />
+                            </a>
+                            <span asp-validation-for="EnableNonAdminCredentialManagement" class="text-danger"></span>
+                        </div>
+                    </div>
                 </div>
 
                 <div class="mb-5">


### PR DESCRIPTION
## Summary

- add a server policy controlling whether non-admins may manage API keys and access tokens
- add a store-role permission for credential management, inherited by store owners
- enforce the policy across Greenfield API keys, BitPay access tokens, legacy API keys, and pairing flows
- retain server administrator access and show a standard informational notice when non-admin access is disabled
- grant the built-in Manager role the new permission through an isolated migration

Closes #7502

## Testing

- `dotnet build BTCPayServer/BTCPayServer.csproj --no-restore -m:1 -p:NuGetAudit=false`
- `dotnet build BTCPayServer.Tests/BTCPayServer.Tests.csproj --no-restore -m:1 -p:NuGetAudit=false`
- manually verified server-admin access and informational notices on both credential pages
- manually verified a non-admin receives HTTP 403 and does not see credential navigation when the server policy is disabled
- manually verified the Manager role displays `Manage API keys and access tokens` after migration

## Screens
<img width="1460" height="866" alt="image" src="https://github.com/user-attachments/assets/462c63d6-6dca-4f55-b519-56248dc36669" />

- contextual banners when server policy **disables credential management for non-admins**

<img width="1919" height="1128" alt="image" src="https://github.com/user-attachments/assets/5e3d8828-ed4b-4486-b2c7-4e4f83afcea8" />
<img width="1919" height="1128" alt="image" src="https://github.com/user-attachments/assets/11deccbe-a599-405d-b577-6479f754d4f0" />

- store level permission control. ref https://github.com/btcpayserver/btcpayserver/issues/7502#issuecomment-5447905666

<img width="1912" height="843" alt="image" src="https://github.com/user-attachments/assets/43dcf0db-dd75-4e82-90f4-f816baaa5095" />

- No **access tokens** and `/account/apikeys` redirects to 403 ACCESS DENIED page when server lockdown policy is active

[Screencast from 2026-08-31 20-38-17.webm](https://github.com/user-attachments/assets/8a51d501-d3f4-48c2-ab3a-637666a35c70)


