### PR TITLE
Validate support URL scheme to prevent stored script injection

### DIFF
--- a/BTCPayServer.Tests/GreenfieldAPITests.cs
+++ b/BTCPayServer.Tests/GreenfieldAPITests.cs
@@ -1427,11 +1427,12 @@ namespace BTCPayServer.Tests
             Assert.Equal("A", newStore.Name);
 
             // validate
-            await AssertValidationError(["CssUrl", "LogoUrl", "BrandColor"], async () =>
+            await AssertValidationError(["CssUrl", "LogoUrl", "BrandColor", "SupportUrl"], async () =>
                 await client.UpdateStore(newStore.Id, new UpdateStoreRequest
                 {
                     CssUrl = "style.css",
                     LogoUrl = "logo.svg",
+                    SupportUrl = "javascript:document.body.dataset.pwned=1",
                     BrandColor = "invalid"
                 }));
 

--- a/BTCPayServer/Controllers/GreenField/GreenfieldStoresController.cs
+++ b/BTCPayServer/Controllers/GreenField/GreenfieldStoresController.cs
@@ -352,6 +352,11 @@ namespace BTCPayServer.Controllers.Greenfield
             {
                 ModelState.AddModelError(nameof(request.BrandColor), "Brand color is not a valid HEX Color (e.g. #F7931A)");
             }
+            if (!string.IsNullOrEmpty(request.SupportUrl) &&
+                (!Uri.TryCreate(request.SupportUrl, UriKind.Absolute, out var supportUri) || supportUri.Scheme is not ("http" or "https" or "mailto")))
+            {
+                ModelState.AddModelError(nameof(request.SupportUrl), "Support URL is not a valid url");
+            }
             if (request.InvoiceExpiration < TimeSpan.FromMinutes(1) && request.InvoiceExpiration > TimeSpan.FromMinutes(60 * 24 * 24))
                 ModelState.AddModelError(nameof(request.InvoiceExpiration), "InvoiceExpiration can only be between 1 and 34560 mins");
             if (request.DisplayExpirationTimer < TimeSpan.FromMinutes(1) && request.DisplayExpirationTimer > TimeSpan.FromMinutes(60 * 24 * 24))

--- a/BTCPayServer/Controllers/UIStoresController.Settings.cs
+++ b/BTCPayServer/Controllers/UIStoresController.Settings.cs
@@ -252,7 +252,8 @@ public partial class UIStoresController
             ? string.Concat(Request.GetAbsoluteRootUri().ToString(), "checkout/payment.mp3")
             : await _uriResolver.Resolve(Request.GetAbsoluteRootUri(), storeBlob.PaymentSoundUrl);
         vm.HtmlTitle = storeBlob.HtmlTitle;
-        vm.SupportUrl = storeBlob.StoreSupportUrl;
+        vm.SupportUrl = storeBlob.StoreSupportUrl?.StartsWith("mailto:", StringComparison.OrdinalIgnoreCase) is true
+            ? storeBlob.StoreSupportUrl["mailto:".Length..] : storeBlob.StoreSupportUrl;
         vm.CheckoutText = storeBlob.CheckoutText;
         vm.DisplayExpirationTimer = (int)storeBlob.DisplayExpirationTimer.TotalMinutes;
         vm.ReceiptOptions = CheckoutAppearanceViewModel.ReceiptOptionsViewModel.Create(storeBlob.ReceiptOptions);

--- a/BTCPayServer/Controllers/UIStoresController.Settings.cs
+++ b/BTCPayServer/Controllers/UIStoresController.Settings.cs
@@ -334,6 +334,16 @@ public partial class UIStoresController
             needUpdate = true;
         }
 
+        var supportUrl = model.SupportUrl?.Trim();
+        if (string.IsNullOrEmpty(supportUrl))
+            blob.StoreSupportUrl = null;
+        else if (supportUrl.IsValidEmail())
+            blob.StoreSupportUrl = $"mailto:{supportUrl}";
+        else if (Uri.TryCreate(supportUrl, UriKind.Absolute, out var supportUri) && supportUri.Scheme is "http" or "https")
+            blob.StoreSupportUrl = supportUrl;
+        else
+            ModelState.AddModelError(nameof(model.SupportUrl), "Support URL is not a valid url");
+
         if (!ModelState.IsValid)
         {
             return View(model);
@@ -387,7 +397,6 @@ public partial class UIStoresController
         blob.RedirectAutomatically = model.RedirectAutomatically;
         blob.ReceiptOptions = model.ReceiptOptions.ToDTO();
         blob.HtmlTitle = string.IsNullOrWhiteSpace(model.HtmlTitle) ? null : model.HtmlTitle;
-        blob.StoreSupportUrl = string.IsNullOrWhiteSpace(model.SupportUrl) ? null : model.SupportUrl.IsValidEmail() ? $"mailto:{model.SupportUrl}" : model.SupportUrl;
         blob.CheckoutText = string.IsNullOrWhiteSpace(model.CheckoutText) ? null : model.CheckoutText;
         blob.DisplayExpirationTimer = TimeSpan.FromMinutes(model.DisplayExpirationTimer);
         blob.AutoDetectLanguage = model.AutoDetectLanguage;


### PR DESCRIPTION
Resolves https://github.com/btcpayserver/btcpayserver2/issues/207


`StoreSupportUrl` was stored as a free-text string with no scheme restriction. This PR enforces these validation.
Not so high as this was only possible with can modify store settings.. but still a worthy validation

Cc. @NicolasDorier 