### PR TITLE
Bump Bitcoin test image to 31.1

### DIFF
--- a/BTCPayServer.Tests/docker-compose.altcoins.yml
+++ b/BTCPayServer.Tests/docker-compose.altcoins.yml
@@ -61,7 +61,7 @@ services:
       - mailpit
 
   devlnd:
-    image: btcpayserver/bitcoin:31.0
+    image: btcpayserver/bitcoin:31.1
     environment:
       BITCOIN_NETWORK: regtest
       BITCOIN_WALLETDIR: "/data/wallets"
@@ -125,7 +125,7 @@ services:
 
   bitcoind:
     restart: unless-stopped
-    image: btcpayserver/bitcoin:31.0
+    image: btcpayserver/bitcoin:31.1
     environment:
       BITCOIN_NETWORK: regtest
       BITCOIN_WALLETDIR: "/data/wallets"

--- a/BTCPayServer.Tests/docker-compose.testnet.yml
+++ b/BTCPayServer.Tests/docker-compose.testnet.yml
@@ -19,7 +19,7 @@ services:
       - tor
 
   devlnd:
-    image: btcpayserver/bitcoin:31.0
+    image: btcpayserver/bitcoin:31.1
     environment:
       BITCOIN_NETWORK: testnet
       BITCOIN_WALLETDIR: "/data/wallets"
@@ -61,7 +61,7 @@ services:
 
   bitcoind:
     restart: unless-stopped
-    image: btcpayserver/bitcoin:31.0
+    image: btcpayserver/bitcoin:31.1
     environment:
       BITCOIN_NETWORK: testnet
       BITCOIN_WALLETDIR: "/data/wallets"

--- a/BTCPayServer.Tests/docker-compose.yml
+++ b/BTCPayServer.Tests/docker-compose.yml
@@ -57,7 +57,7 @@ services:
       - mailpit
 
   devlnd:
-    image: btcpayserver/bitcoin:31.0
+    image: btcpayserver/bitcoin:31.1
     environment:
       BITCOIN_NETWORK: regtest
       BITCOIN_WALLETDIR: "/data/wallets"
@@ -110,7 +110,7 @@ services:
 
   bitcoind:
     restart: unless-stopped
-    image: btcpayserver/bitcoin:31.0
+    image: btcpayserver/bitcoin:31.1
     environment:
       BITCOIN_NETWORK: regtest
       BITCOIN_WALLETDIR: "/data/wallets"


### PR DESCRIPTION
## Summary

Updates the BTCPay Server test compose services to use the released Bitcoin Core 31.1 image.