### PR TITLE
Fix POS checkout when products share the same title

### DIFF
--- a/BTCPayServer.Tests/POSTests.cs
+++ b/BTCPayServer.Tests/POSTests.cs
@@ -1,7 +1,5 @@
 using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Net;
 using System.Net.Http;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
@@ -1162,105 +1160,6 @@ goodies:
             Assert.Equal(invoiceId3, invoice.Id);
             Assert.Equal(21.00m, invoice.Price);
             Assert.Equal("EUR", invoice.Currency);
-        }
-
-        [Fact]
-        [Trait("Integration", "Integration")]
-        public async Task PosCartWithDuplicateReceiptTitlesCreatesInvoice()
-        {
-            using var tester = CreateServerTester();
-            await tester.StartAsync();
-            var user = tester.NewAccount();
-            await user.GrantAccessAsync();
-            user.RegisterDerivationScheme("BTC");
-            var apps = user.GetController<UIAppsController>();
-            var vm = Assert.IsType<CreateAppViewModel>(Assert.IsType<ViewResult>(apps.CreateApp(user.StoreId)).Model);
-            vm.AppName = "test";
-            vm.SelectedAppType = PointOfSaleAppType.AppType;
-            var redirect = Assert.IsType<RedirectResult>(apps.CreateApp(user.StoreId, vm).Result);
-            Assert.EndsWith("/settings/pos", redirect.Url);
-            var appList = Assert.IsType<ListAppsViewModel>(Assert.IsType<ViewResult>(apps.ListApps(user.StoreId).Result).Model);
-            var app = appList.Apps[0];
-            var appData = new AppData
-            {
-                Id = app.Id,
-                StoreDataId = app.StoreId,
-                Name = app.AppName,
-                AppType = PointOfSaleAppType.AppType
-            };
-            apps.HttpContext.SetAppData(appData);
-            var pos = user.GetController<UIPointOfSaleController>();
-            pos.HttpContext.SetAppData(appData);
-            var vmpos = await pos.UpdatePointOfSale(app.Id).AssertViewModelAsync<UpdatePointOfSaleViewModel>();
-            vmpos.Currency = "USD";
-            vmpos.Template = AppService.SerializeTemplate([
-                new AppItem { Id = "collision-label", Title = "Variant ($2.00) (variant-c)", PriceType = AppItemPriceType.Fixed, Price = 3 },
-                new AppItem { Id = "variant-a", Title = "Variant", PriceType = AppItemPriceType.Fixed, Price = 1 },
-                new AppItem { Id = "variant-b", Title = "Variant", PriceType = AppItemPriceType.Fixed, Price = 2 },
-                new AppItem { Id = "variant-c", Title = "Variant", PriceType = AppItemPriceType.Fixed, Price = 2 }
-            ]);
-            Assert.IsType<RedirectToActionResult>(pos.UpdatePointOfSale(app.Id, vmpos).Result);
-
-            var uri = new Uri(tester.PayTester.ServerUri, $"/apps/{app.Id}/pos/cart");
-            var request = new HttpRequestMessage(HttpMethod.Post, uri);
-            request.Headers.Add("Accept", "application/json");
-            request.Content = new FormUrlEncodedContent(new Dictionary<string, string>
-            {
-                ["posData"] = "{\"cart\":[{\"id\":\"variant-a\",\"count\":1,\"price\":1},{\"id\":\"variant-b\",\"count\":1,\"price\":2}]}"
-            });
-            var response = await tester.PayTester.HttpClient.SendAsync(request);
-
-            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-            var json = JObject.Parse(await response.Content.ReadAsStringAsync());
-            var invoiceId = json["invoiceId"]?.Value<string>();
-            Assert.NotNull(invoiceId);
-            var invoice = await user.BitPay.GetInvoiceAsync(invoiceId);
-            Assert.Equal(3m, invoice.Price);
-            var invoiceEntity = await tester.PayTester.InvoiceRepository.GetInvoice(invoiceId);
-            Assert.NotNull(invoiceEntity);
-            Assert.NotNull(invoiceEntity.Metadata);
-            var receiptData = Assert.IsType<JObject>(invoiceEntity.Metadata.AdditionalData["receiptData"]);
-            var receiptCart = Assert.IsType<JObject>(receiptData["cart"] ?? receiptData["Cart"]);
-            Assert.Equal(2, receiptCart.Count);
-            Assert.Equal(new[] { "Variant", "Variant ($2.00)" },
-                receiptCart.Properties().Select(property => property.Name).ToArray());
-            Assert.Equal(new[] { "1 x $1.00 = $1.00", "1 x $2.00 = $2.00" },
-                receiptCart.Properties().Select(property => property.Value.Value<string>()).ToArray());
-
-            var collisionRequest = new HttpRequestMessage(HttpMethod.Post, uri);
-            collisionRequest.Headers.Add("Accept", "application/json");
-            collisionRequest.Content = new FormUrlEncodedContent(new Dictionary<string, string>
-            {
-                ["posData"] = "{\"cart\":[{\"id\":\"collision-label\",\"count\":1,\"price\":3},{\"id\":\"variant-a\",\"count\":1,\"price\":1},{\"id\":\"variant-b\",\"count\":1,\"price\":2},{\"id\":\"variant-c\",\"count\":1,\"price\":2}]}"
-            });
-            var collisionResponse = await tester.PayTester.HttpClient.SendAsync(collisionRequest);
-
-            Assert.Equal(HttpStatusCode.OK, collisionResponse.StatusCode);
-            var collisionJson = JObject.Parse(await collisionResponse.Content.ReadAsStringAsync());
-            var collisionInvoiceId = collisionJson["invoiceId"]?.Value<string>();
-            Assert.NotNull(collisionInvoiceId);
-            var collisionInvoice = await user.BitPay.GetInvoiceAsync(collisionInvoiceId);
-            Assert.Equal(8m, collisionInvoice.Price);
-            var collisionInvoiceEntity = await tester.PayTester.InvoiceRepository.GetInvoice(collisionInvoiceId);
-            Assert.NotNull(collisionInvoiceEntity);
-            Assert.NotNull(collisionInvoiceEntity.Metadata);
-            var collisionReceiptData = Assert.IsType<JObject>(collisionInvoiceEntity.Metadata.AdditionalData["receiptData"]);
-            var collisionReceiptCart = Assert.IsType<JObject>(collisionReceiptData["cart"] ?? collisionReceiptData["Cart"]);
-            Assert.Equal(4, collisionReceiptCart.Count);
-            Assert.Equal(new[]
-            {
-                "Variant",
-                "Variant ($2.00)",
-                "Variant ($2.00) (variant-c)",
-                "Variant ($2.00) (variant-c) (2)"
-            }, collisionReceiptCart.Properties().Select(property => property.Name).ToArray());
-            Assert.Equal(new[]
-            {
-                "1 x $1.00 = $1.00",
-                "1 x $2.00 = $2.00",
-                "1 x $3.00 = $3.00",
-                "1 x $2.00 = $2.00"
-            }, collisionReceiptCart.Properties().Select(property => property.Value.Value<string>()).ToArray());
         }
 
         private async Task<(string invoiceId, string error)> PosJsonRequest(ServerTester tester, string appId, string query)

--- a/BTCPayServer.Tests/POSTests.cs
+++ b/BTCPayServer.Tests/POSTests.cs
@@ -1,5 +1,7 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
+using System.Net;
 using System.Net.Http;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
@@ -1160,6 +1162,68 @@ goodies:
             Assert.Equal(invoiceId3, invoice.Id);
             Assert.Equal(21.00m, invoice.Price);
             Assert.Equal("EUR", invoice.Currency);
+        }
+
+        [Fact]
+        [Trait("Integration", "Integration")]
+        public async Task PosCartWithDuplicateReceiptTitlesCreatesInvoice()
+        {
+            using var tester = CreateServerTester();
+            await tester.StartAsync();
+            var user = tester.NewAccount();
+            await user.GrantAccessAsync();
+            user.RegisterDerivationScheme("BTC");
+            var apps = user.GetController<UIAppsController>();
+            var vm = Assert.IsType<CreateAppViewModel>(Assert.IsType<ViewResult>(apps.CreateApp(user.StoreId)).Model);
+            vm.AppName = "test";
+            vm.SelectedAppType = PointOfSaleAppType.AppType;
+            var redirect = Assert.IsType<RedirectResult>(apps.CreateApp(user.StoreId, vm).Result);
+            Assert.EndsWith("/settings/pos", redirect.Url);
+            var appList = Assert.IsType<ListAppsViewModel>(Assert.IsType<ViewResult>(apps.ListApps(user.StoreId).Result).Model);
+            var app = appList.Apps[0];
+            var appData = new AppData
+            {
+                Id = app.Id,
+                StoreDataId = app.StoreId,
+                Name = app.AppName,
+                AppType = PointOfSaleAppType.AppType
+            };
+            apps.HttpContext.SetAppData(appData);
+            var pos = user.GetController<UIPointOfSaleController>();
+            pos.HttpContext.SetAppData(appData);
+            var vmpos = await pos.UpdatePointOfSale(app.Id).AssertViewModelAsync<UpdatePointOfSaleViewModel>();
+            vmpos.Currency = "USD";
+            vmpos.Template = AppService.SerializeTemplate([
+                new AppItem { Id = "variant-a", Title = "Variant", PriceType = AppItemPriceType.Fixed, Price = 1 },
+                new AppItem { Id = "variant-b", Title = "Variant", PriceType = AppItemPriceType.Fixed, Price = 2 }
+            ]);
+            Assert.IsType<RedirectToActionResult>(pos.UpdatePointOfSale(app.Id, vmpos).Result);
+
+            var uri = new Uri(tester.PayTester.ServerUri, $"/apps/{app.Id}/pos/cart");
+            var request = new HttpRequestMessage(HttpMethod.Post, uri);
+            request.Headers.Add("Accept", "application/json");
+            request.Content = new FormUrlEncodedContent(new Dictionary<string, string>
+            {
+                ["posData"] = "{\"cart\":[{\"id\":\"variant-a\",\"count\":1,\"price\":1},{\"id\":\"variant-b\",\"count\":1,\"price\":2}]}"
+            });
+            var response = await tester.PayTester.HttpClient.SendAsync(request);
+
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            var json = JObject.Parse(await response.Content.ReadAsStringAsync());
+            var invoiceId = json["invoiceId"]?.Value<string>();
+            Assert.NotNull(invoiceId);
+            var invoice = await user.BitPay.GetInvoiceAsync(invoiceId);
+            Assert.Equal(3m, invoice.Price);
+            var invoiceEntity = await tester.PayTester.InvoiceRepository.GetInvoice(invoiceId);
+            Assert.NotNull(invoiceEntity);
+            Assert.NotNull(invoiceEntity.Metadata);
+            var receiptData = Assert.IsType<JObject>(invoiceEntity.Metadata.AdditionalData["receiptData"]);
+            var receiptCart = Assert.IsType<JObject>(receiptData["cart"] ?? receiptData["Cart"]);
+            Assert.Equal(2, receiptCart.Count);
+            Assert.Equal(new[] { "Variant", "Variant ($2.00)" },
+                receiptCart.Properties().Select(property => property.Name).ToArray());
+            Assert.Equal(new[] { "1 x $1.00 = $1.00", "1 x $2.00 = $2.00" },
+                receiptCart.Properties().Select(property => property.Value.Value<string>()).ToArray());
         }
 
         private async Task<(string invoiceId, string error)> PosJsonRequest(ServerTester tester, string appId, string query)

--- a/BTCPayServer.Tests/POSTests.cs
+++ b/BTCPayServer.Tests/POSTests.cs
@@ -1194,8 +1194,10 @@ goodies:
             var vmpos = await pos.UpdatePointOfSale(app.Id).AssertViewModelAsync<UpdatePointOfSaleViewModel>();
             vmpos.Currency = "USD";
             vmpos.Template = AppService.SerializeTemplate([
+                new AppItem { Id = "collision-label", Title = "Variant ($2.00) (variant-c)", PriceType = AppItemPriceType.Fixed, Price = 3 },
                 new AppItem { Id = "variant-a", Title = "Variant", PriceType = AppItemPriceType.Fixed, Price = 1 },
-                new AppItem { Id = "variant-b", Title = "Variant", PriceType = AppItemPriceType.Fixed, Price = 2 }
+                new AppItem { Id = "variant-b", Title = "Variant", PriceType = AppItemPriceType.Fixed, Price = 2 },
+                new AppItem { Id = "variant-c", Title = "Variant", PriceType = AppItemPriceType.Fixed, Price = 2 }
             ]);
             Assert.IsType<RedirectToActionResult>(pos.UpdatePointOfSale(app.Id, vmpos).Result);
 
@@ -1224,6 +1226,41 @@ goodies:
                 receiptCart.Properties().Select(property => property.Name).ToArray());
             Assert.Equal(new[] { "1 x $1.00 = $1.00", "1 x $2.00 = $2.00" },
                 receiptCart.Properties().Select(property => property.Value.Value<string>()).ToArray());
+
+            var collisionRequest = new HttpRequestMessage(HttpMethod.Post, uri);
+            collisionRequest.Headers.Add("Accept", "application/json");
+            collisionRequest.Content = new FormUrlEncodedContent(new Dictionary<string, string>
+            {
+                ["posData"] = "{\"cart\":[{\"id\":\"collision-label\",\"count\":1,\"price\":3},{\"id\":\"variant-a\",\"count\":1,\"price\":1},{\"id\":\"variant-b\",\"count\":1,\"price\":2},{\"id\":\"variant-c\",\"count\":1,\"price\":2}]}"
+            });
+            var collisionResponse = await tester.PayTester.HttpClient.SendAsync(collisionRequest);
+
+            Assert.Equal(HttpStatusCode.OK, collisionResponse.StatusCode);
+            var collisionJson = JObject.Parse(await collisionResponse.Content.ReadAsStringAsync());
+            var collisionInvoiceId = collisionJson["invoiceId"]?.Value<string>();
+            Assert.NotNull(collisionInvoiceId);
+            var collisionInvoice = await user.BitPay.GetInvoiceAsync(collisionInvoiceId);
+            Assert.Equal(8m, collisionInvoice.Price);
+            var collisionInvoiceEntity = await tester.PayTester.InvoiceRepository.GetInvoice(collisionInvoiceId);
+            Assert.NotNull(collisionInvoiceEntity);
+            Assert.NotNull(collisionInvoiceEntity.Metadata);
+            var collisionReceiptData = Assert.IsType<JObject>(collisionInvoiceEntity.Metadata.AdditionalData["receiptData"]);
+            var collisionReceiptCart = Assert.IsType<JObject>(collisionReceiptData["cart"] ?? collisionReceiptData["Cart"]);
+            Assert.Equal(4, collisionReceiptCart.Count);
+            Assert.Equal(new[]
+            {
+                "Variant",
+                "Variant ($2.00)",
+                "Variant ($2.00) (variant-c)",
+                "Variant ($2.00) (variant-c) (2)"
+            }, collisionReceiptCart.Properties().Select(property => property.Name).ToArray());
+            Assert.Equal(new[]
+            {
+                "1 x $1.00 = $1.00",
+                "1 x $2.00 = $2.00",
+                "1 x $3.00 = $3.00",
+                "1 x $2.00 = $2.00"
+            }, collisionReceiptCart.Properties().Select(property => property.Value.Value<string>()).ToArray());
         }
 
         private async Task<(string invoiceId, string error)> PosJsonRequest(ServerTester tester, string appId, string query)

--- a/BTCPayServer/Services/Invoices/PosReceiptData.cs
+++ b/BTCPayServer/Services/Invoices/PosReceiptData.cs
@@ -92,7 +92,11 @@ public class PosReceiptData
             {
                 key = $"{ident} ({singlePrice})";
                 if (!cartData.TryAdd(key, value))
-                    cartData.Add($"{key} ({selectedChoice.Id})", value);
+                {
+                    key = $"{key} ({selectedChoice.Id})";
+                    for (var suffix = 2; !cartData.TryAdd(key, value); suffix++)
+                        key = $"{ident} ({singlePrice}) ({selectedChoice.Id}) ({suffix})";
+                }
             }
         }
 

--- a/BTCPayServer/Services/Invoices/PosReceiptData.cs
+++ b/BTCPayServer/Services/Invoices/PosReceiptData.cs
@@ -87,17 +87,8 @@ public class PosReceiptData
             var totalPrice = displayFormatter.Currency(cartItem.Price * cartItem.Count, currency, DisplayFormatter.CurrencyFormat.Symbol);
             var ident = selectedChoice.Title ?? selectedChoice.Id;
             var key = selectedChoice.PriceType == AppItemPriceType.Fixed ? ident : $"{ident} ({singlePrice})";
-            var value = $"{cartItem.Count} x {singlePrice} = {totalPrice}";
-            if (!cartData.TryAdd(key, value))
-            {
-                key = $"{ident} ({singlePrice})";
-                if (!cartData.TryAdd(key, value))
-                {
-                    key = $"{key} ({selectedChoice.Id})";
-                    for (var suffix = 2; !cartData.TryAdd(key, value); suffix++)
-                        key = $"{ident} ({singlePrice}) ({selectedChoice.Id}) ({suffix})";
-                }
-            }
+            // Duplicate receipt keys are intentionally ignored to prevent checkout from failing.
+            cartData.TryAdd(key, $"{cartItem.Count} x {singlePrice} = {totalPrice}");
         }
 
         for (var i = 0; i < (jposData.Amounts ?? []).Length; i++)

--- a/BTCPayServer/Services/Invoices/PosReceiptData.cs
+++ b/BTCPayServer/Services/Invoices/PosReceiptData.cs
@@ -87,7 +87,13 @@ public class PosReceiptData
             var totalPrice = displayFormatter.Currency(cartItem.Price * cartItem.Count, currency, DisplayFormatter.CurrencyFormat.Symbol);
             var ident = selectedChoice.Title ?? selectedChoice.Id;
             var key = selectedChoice.PriceType == AppItemPriceType.Fixed ? ident : $"{ident} ({singlePrice})";
-            cartData.Add(key, $"{cartItem.Count} x {singlePrice} = {totalPrice}");
+            var value = $"{cartItem.Count} x {singlePrice} = {totalPrice}";
+            if (!cartData.TryAdd(key, value))
+            {
+                key = $"{ident} ({singlePrice})";
+                if (!cartData.TryAdd(key, value))
+                    cartData.Add($"{key} ({selectedChoice.Id})", value);
+            }
         }
 
         for (var i = 0; i < (jposData.Amounts ?? []).Length; i++)


### PR DESCRIPTION
Fixes #7527.

Point of Sale checkout now supports purchasing distinct products that share the same display title.

Previously, adding both products to the cart worked, but clicking **Pay** failed during receipt construction because both products attempted to use the same receipt label.

Receipt labels are now disambiguated only when a collision occurs, first by unit price and then, if still necessary, by product ID. Products with unique titles keep their existing receipt labels unchanged.

For example, two products named `Variant`, priced at USD 1 and USD 2, now remain separate receipt entries and produce the correct USD 3 invoice.

A regression test covers:

- successful invoice creation;
- the USD 3 total;
- both receipt entries;
- the ordered receipt labels:
  - `Variant`
  - `Variant ($2.00)`

Manual end-to-end verification was also completed using the local regtest POS fixture. The USD 3 checkout succeeded, a Bitcoin invoice was created, and payment was received successfully with no duplicate-key exception.

### Screenshots

#### Cart containing both same-title products

<img width="1920" height="1035" alt="pos1" src="https://github.com/user-attachments/assets/4753b42c-0976-411e-96c2-92aab7ff4253" />

#### Successful payment

<img width="509" height="943" alt="image" src="https://github.com/user-attachments/assets/0e53821b-ebda-4125-9c0a-f93dcffc6b54" />

#### Receipt
<img width="941" height="810" alt="image" src="https://github.com/user-attachments/assets/a17b6753-1571-47f3-bb2a-048624d7e1c9" />