### PR TITLE
Stop leaking API key in the authorize redirect URL

### DIFF
--- a/BTCPayServer/Controllers/UIManageController.APIKeys.cs
+++ b/BTCPayServer/Controllers/UIManageController.APIKeys.cs
@@ -247,7 +247,7 @@ namespace BTCPayServer.Controllers
                         Html = StringLocalizer["API key generated!"].Value + $" <code class='alert-link'>{key.Id}</code>"
                     });
 
-                    return RedirectToAction("APIKeys", new { key = key.Id });
+                    return RedirectToAction("APIKeys");
 
                 default:
                     var perms = viewModel.Permissions?.Split(';').ToArray() ?? Array.Empty<string>();


### PR DESCRIPTION
Resolve https://github.com/btcpayserver/btcpayserver2/issues/204

Before:

<img width="1785" height="1167" alt="image" src="https://github.com/user-attachments/assets/0e6eee1b-a829-42a4-b338-ce7caf9ad431" />

After:

<img width="2012" height="1235" alt="image" src="https://github.com/user-attachments/assets/528c8486-25bb-4f8b-937f-de216f6b6e92" />


Cc. @NicolasDorier 