### PR TITLE
Expose host deployment environment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,3 +7,7 @@ Repository-specific agent guidance has moved to project skills:
 - `.agents/skills/btcpayserver-pr-descriptions/SKILL.md`
 
 Load the relevant skill when creating migrations, updating/reviewing `Changelog.md`, or writing/reviewing pull request descriptions.
+
+## JSON Serialization
+
+Prefer `Newtonsoft.Json` over `System.Text.Json` when adding or modifying JSON serialization code.

--- a/BTCPayServer.Tests/ServerTester.cs
+++ b/BTCPayServer.Tests/ServerTester.cs
@@ -316,8 +316,8 @@ namespace BTCPayServer.Tests
                 var btcpayHostCmd = Path.Combine(_Directory, "btcpay-host.cmd");
                 await File.WriteAllTextAsync(btcpayHostCmd, """
                     @echo off
-                    if "%~1" == "commands" (
-                        echo ["showauthorizedkeys","setauthorizedkeys"]
+                    if "%~1" == "env" (
+                        echo {"deploymentType":"tests","commands":["showauthorizedkeys","setauthorizedkeys"]}
                         exit /b 0
                     )
                     if "%~1" == "showauthorizedkeys" (
@@ -343,8 +343,8 @@ namespace BTCPayServer.Tests
                     authorized_keys_file="$(dirname "$0")/authorized_keys"
 
                     case "$1" in
-                        commands)
-                            printf '["showauthorizedkeys","setauthorizedkeys"]\n'
+                        env)
+                            printf '{"deploymentType":"tests","commands":["showauthorizedkeys","setauthorizedkeys"]}\n'
                             ;;
                         showauthorizedkeys)
                             value="$(cat "$authorized_keys_file" 2>/dev/null || true)"

--- a/BTCPayServer/HostCommands.cs
+++ b/BTCPayServer/HostCommands.cs
@@ -1,11 +1,26 @@
+using System.Collections.Generic;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
 namespace BTCPayServer;
+
+public class BTCPayHostEnvironment
+{
+    [JsonProperty("deploymentType")]
+    public string DeploymentType { get; set; }
+
+    [JsonProperty("commands")]
+    public string[] Commands { get; set; }
+    [JsonExtensionData]
+    IDictionary<string, JToken> AdditionalData { get; set; }
+}
 
 public static class HostCommands
 {
     /// <summary>
-    /// Lists the host commands supported by the current deployment.
+    /// Returns metadata about the current deployment and its supported host commands.
     /// </summary>
-    public const string Commands = "commands";
+    public const string Env = "env";
     /// <summary>
     /// Returns the current authorized SSH public keys so they can be displayed in the server UI.
     /// </summary>

--- a/BTCPayServer/Plugins/Maintenance/CheckHostCommandsHostedService.cs
+++ b/BTCPayServer/Plugins/Maintenance/CheckHostCommandsHostedService.cs
@@ -1,28 +1,21 @@
-using System;
+#nullable enable
 using System.Collections.Generic;
-using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using BTCPayServer.Logging;
 using BTCPayServer.Services;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
 
 namespace BTCPayServer.Plugins.Maintenance
 {
-    public class CheckHostCommandsHostedService : IHostedService
+    public class CheckHostCommandsHostedService(ProcessRunner processRunner, Logs logs) : IHostedService
     {
-        public Logs Logs { get; }
+        public Logs Logs { get; } = logs;
 
-        private readonly ProcessRunner _processRunner;
-        Task _testingConnection;
+        Task? _testingConnection;
         readonly CancellationTokenSource _cancellationTokenSource = new CancellationTokenSource();
-
-        public CheckHostCommandsHostedService(ProcessRunner processRunner, Logs logs)
-        {
-            Logs = logs;
-            _processRunner = processRunner;
-        }
 
         public HashSet<string> SupportedCommands { get; private set; } = new HashSet<string>();
         public bool BTCPayHostAvailable { get; private set; }
@@ -38,21 +31,23 @@ namespace BTCPayServer.Plugins.Maintenance
             var supportedCommands = new HashSet<string>();
             try
             {
-                var commands = await _processRunner.RunHostCommand(HostCommands.Commands, null, _cancellationTokenSource.Token);
-                if (commands.ExitCode == 0)
+                var env = await processRunner.RunHostCommand(HostCommands.Env, null, _cancellationTokenSource.Token);
+                if (env.ExitCode == 0)
                 {
-                    var parsedCommands = JsonSerializer.Deserialize<string[]>(commands.Output) ?? [];
-                    foreach (var command in parsedCommands)
+                    BTCPayHostEnvironment = JsonConvert.DeserializeObject<BTCPayHostEnvironment>(env.Output) ??
+                                            throw new JsonException("btcpay-host env returned null");
+                    foreach (var command in BTCPayHostEnvironment.Commands ?? [])
                     {
                         if (!string.IsNullOrWhiteSpace(command))
                             supportedCommands.Add(command.Trim());
                     }
                     BTCPayHostAvailable = true;
-                    Logs.PayServer.LogInformation("Supported host commands: {commands}", string.Join(", ", supportedCommands));
+                    Logs.PayServer.LogInformation("Host deployment type: {deploymentType}. Supported host commands: {commands}",
+                        BTCPayHostEnvironment.DeploymentType, string.Join(", ", supportedCommands));
                 }
                 else
                 {
-                    Logs.PayServer.LogInformation($"Call to 'btcpay-host commands' failed ({commands.Error})");
+                    Logs.PayServer.LogInformation($"Call to 'btcpay-host env' failed ({env.Error})");
                 }
             }
             catch
@@ -62,13 +57,16 @@ namespace BTCPayServer.Plugins.Maintenance
             SupportedCommands = supportedCommands;
         }
 
+        public BTCPayHostEnvironment? BTCPayHostEnvironment { get; set; }
+
         public async Task StopAsync(CancellationToken cancellationToken)
         {
             _cancellationTokenSource.Cancel();
             try
             {
+                if (_testingConnection is not null)
                 // Command checks run in the background, so we just wait at most 5 seconds
-                await Task.WhenAny(_testingConnection, Task.Delay(5000, _cancellationTokenSource.Token));
+                    await Task.WhenAny(_testingConnection, Task.Delay(5000, _cancellationTokenSource.Token));
             }
             catch { }
             Logs.PayServer.LogInformation($"{this.GetType().Name} successfully exited...");


### PR DESCRIPTION
BTCPay Server now asks `btcpay-host` for deployment metadata during startup instead of requesting only a command list. This allows host integrations to identify the deployment type while preserving the existing command-based availability checks for maintenance and SSH key management.

The startup log now includes both the deployment type and supported commands. Host implementations must return this shape from `btcpay-host env`:

```json
{
  "deploymentType": "btcpayserver-docker",
  "commands": ["update", "restart"]
}
```

This intentionally replaces the short-lived `btcpay-host commands` contract introduced in #7511. The Docker implementation is updated in btcpayserver/btcpayserver-docker#1081.