### PR TITLE
Bumping LND to 0.21.3-beta

### DIFF
--- a/BTCPayServer.Tests/docker-compose.altcoins.yml
+++ b/BTCPayServer.Tests/docker-compose.altcoins.yml
@@ -225,7 +225,7 @@ services:
       - "postgres_test_datadir:/var/lib/postgresql"
 
   merchant_lnd:
-    image: btcpayserver/lnd:v0.21.2-beta
+    image: btcpayserver/lnd:v0.21.3-beta
     restart: unless-stopped
     environment:
       LND_CHAIN: "btc"
@@ -263,7 +263,7 @@ services:
       - bitcoind
 
   customer_lnd:
-    image: btcpayserver/lnd:v0.21.2-beta
+    image: btcpayserver/lnd:v0.21.3-beta
     restart: unless-stopped
     environment:
       LND_CHAIN: "btc"

--- a/BTCPayServer.Tests/docker-compose.mutinynet.yml
+++ b/BTCPayServer.Tests/docker-compose.mutinynet.yml
@@ -167,7 +167,7 @@ services:
       - "postgres_test_datadir:/var/lib/postgresql"
 
   merchant_lnd:
-    image: btcpayserver/lnd:v0.21.2-beta
+    image: btcpayserver/lnd:v0.21.3-beta
     restart: unless-stopped
     environment:
       LND_CHAIN: "btc"
@@ -205,7 +205,7 @@ services:
       - bitcoind
 
   customer_lnd:
-    image: btcpayserver/lnd:v0.21.2-beta
+    image: btcpayserver/lnd:v0.21.3-beta
     restart: unless-stopped
     environment:
       LND_CHAIN: "btc"

--- a/BTCPayServer.Tests/docker-compose.testnet.yml
+++ b/BTCPayServer.Tests/docker-compose.testnet.yml
@@ -159,7 +159,7 @@ services:
       - "postgres_test_datadir:/var/lib/postgresql"
 
   merchant_lnd:
-    image: btcpayserver/lnd:v0.21.2-beta
+    image: btcpayserver/lnd:v0.21.3-beta
     restart: unless-stopped
     environment:
       LND_CHAIN: "btc"
@@ -197,7 +197,7 @@ services:
       - bitcoind
 
   customer_lnd:
-    image: btcpayserver/lnd:v0.21.2-beta
+    image: btcpayserver/lnd:v0.21.3-beta
     restart: unless-stopped
     environment:
       LND_CHAIN: "btc"

--- a/BTCPayServer.Tests/docker-compose.yml
+++ b/BTCPayServer.Tests/docker-compose.yml
@@ -210,7 +210,7 @@ services:
       - "postgres_test_datadir:/var/lib/postgresql"
 
   merchant_lnd:
-    image: btcpayserver/lnd:v0.21.2-beta
+    image: btcpayserver/lnd:v0.21.3-beta
     restart: unless-stopped
     environment:
       LND_CHAIN: "btc"
@@ -248,7 +248,7 @@ services:
       - bitcoind
 
   customer_lnd:
-    image: btcpayserver/lnd:v0.21.2-beta
+    image: btcpayserver/lnd:v0.21.3-beta
     restart: unless-stopped
     environment:
       LND_CHAIN: "btc"


### PR DESCRIPTION
Docker image: https://hub.docker.com/repository/docker/btcpayserver/lnd/tags/v0.21.3-beta
Tag: https://github.com/btcpayserver/lnd/releases/tag/basedon-v0.21.3-beta
BTCPayServer.Lightning: https://github.com/btcpayserver/BTCPayServer.Lightning/pull/194 (merged, tests passing)

This image also ships one-time wallet password migration: wallets move off the shared `hellorockstar` default to a per-instance random password written back to `walletunlock.json` (https://github.com/btcpayserver/lnd/pull/13). The LND seed backup page keeps working unchanged since it reads the password from that file; the seed-backup Playwright test uses a fixture file, so no test changes were needed.