### PR TITLE
Relay Docker test reports to GitHub Actions

### DIFF
--- a/.github/scripts/collect-artifacts.sh
+++ b/.github/scripts/collect-artifacts.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+mkdir -p /tmp/Artifacts
+docker run --rm -v "${COMPOSE_PROJECT_NAME}_tests_datadir:/data" -v /tmp/Artifacts:/host alpine sh -c "cp -r /data/. /host/" || true
+
+test_summary=/tmp/Artifacts/github-step-summary
+if [ -n "${GITHUB_STEP_SUMMARY:-}" ] && [ -f "${test_summary}" ]; then
+  cat "${test_summary}" >> "${GITHUB_STEP_SUMMARY}"
+  rm "${test_summary}"
+fi

--- a/.github/scripts/run-tests.sh
+++ b/.github/scripts/run-tests.sh
@@ -1,39 +1,42 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-compose() {
-  if command -v docker-compose >/dev/null 2>&1; then
-    docker-compose "$@"
-  else
-    docker compose "$@"
-  fi
+is_github_actions() {
+  [ "${GITHUB_ACTIONS:-false}" = "true" ] && [ -n "${GITHUB_STEP_SUMMARY:-}" ]
 }
 
+test_filters=$1
+
 cd "$(dirname "$0")/../../BTCPayServer.Tests"
-compose --version
-compose -f "docker-compose.altcoins.yml" down -v
+docker compose --version
+docker compose -f "docker-compose.altcoins.yml" down -v
 
 # Pull can fail transiently; retry to match the previous CI behavior.
 n=0
 until [ "$n" -ge 10 ]; do
-  compose -f "docker-compose.altcoins.yml" pull && break
+  docker compose -f "docker-compose.altcoins.yml" pull && break
   n=$((n+1))
   sleep 5
 done
 
-compose -f "docker-compose.altcoins.yml" build
+docker compose -f "docker-compose.altcoins.yml" build
 
 test_container_args=(
-  -e "TEST_FILTERS=$1"
+  -e "TEST_FILTERS=${test_filters}"
   -e "GITHUB_ACTIONS=${GITHUB_ACTIONS:-false}"
 )
 
-if [ "${GITHUB_ACTIONS:-false}" = "true" ] && [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+if is_github_actions; then
   test_container_args+=(
-    -e "GITHUB_STEP_SUMMARY=/tmp/github-step-summary"
+    -e "GITHUB_STEP_SUMMARY=/tmp/Artifacts/github-step-summary"
     -e "GITHUB_WORKSPACE=/source"
-    -v "${GITHUB_STEP_SUMMARY}:/tmp/github-step-summary"
   )
 fi
 
-compose -f "docker-compose.altcoins.yml" run "${test_container_args[@]}" tests
+if docker compose -f "docker-compose.altcoins.yml" run "${test_container_args[@]}" tests; then
+  test_exit_code=0
+else
+  test_exit_code=$?
+fi
+
+exit "${test_exit_code}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,16 @@ jobs:
         uses: actions/checkout@v4
       - name: Run fast and third-party tests
         run: bash .github/scripts/run-tests.sh "Fast=Fast|ThirdParty=ThirdParty"
+      - name: Collect artifacts
+        if: always()
+        run: bash .github/scripts/collect-artifacts.sh
+      - name: Upload artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: fast-tests-artifacts
+          path: /tmp/Artifacts
+          if-no-files-found: ignore
       - name: Check Bitcoin-only build
         run: bash .github/scripts/can-build.sh
 
@@ -37,9 +47,7 @@ jobs:
         run: bash .github/scripts/run-tests.sh "Playwright=Playwright"
       - name: Collect artifacts
         if: always()
-        run: |
-          mkdir -p /tmp/Artifacts
-          docker run --rm -v "${COMPOSE_PROJECT_NAME}_tests_datadir:/data" -v /tmp/Artifacts:/host alpine sh -c "cp -r /data/. /host/" || true
+        run: bash .github/scripts/collect-artifacts.sh
       - name: Upload artifacts
         if: always()
         uses: actions/upload-artifact@v4
@@ -59,9 +67,7 @@ jobs:
         run: bash .github/scripts/run-tests.sh "Playwright=Playwright-2"
       - name: Collect artifacts
         if: always()
-        run: |
-          mkdir -p /tmp/Artifacts
-          docker run --rm -v "${COMPOSE_PROJECT_NAME}_tests_datadir:/data" -v /tmp/Artifacts:/host alpine sh -c "cp -r /data/. /host/" || true
+        run: bash .github/scripts/collect-artifacts.sh
       - name: Upload artifacts
         if: always()
         uses: actions/upload-artifact@v4
@@ -79,3 +85,13 @@ jobs:
         uses: actions/checkout@v4
       - name: Run integration tests
         run: bash .github/scripts/run-tests.sh "Integration=Integration"
+      - name: Collect artifacts
+        if: always()
+        run: bash .github/scripts/collect-artifacts.sh
+      - name: Upload artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: integration-tests-artifacts
+          path: /tmp/Artifacts
+          if-no-files-found: ignore

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,18 @@ jobs:
         uses: actions/checkout@v4
       - name: Run pre-release checks
         run: bash .github/scripts/run-tests.sh "PreReleaseCheck=PreReleaseCheck"
+      - name: Collect artifacts
+        if: always()
+        run: |
+          mkdir -p /tmp/Artifacts
+          docker run --rm -v "${COMPOSE_PROJECT_NAME}_tests_datadir:/data" -v /tmp/Artifacts:/host alpine sh -c "cp -r /data/. /host/" || true
+      - name: Upload artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-checks-artifacts
+          path: /tmp/Artifacts
+          if-no-files-found: ignore
 
   plugin_compatibility:
     name: Plugin Compatibility

--- a/BTCPayServer.Tests/docker-entrypoint.sh
+++ b/BTCPayServer.Tests/docker-entrypoint.sh
@@ -1,9 +1,9 @@
 #!/bin/sh
 set -e
 
-FILTERS=" "
-if [ ! -z "$TEST_FILTERS" ]; then
-FILTERS="--filter $TEST_FILTERS"
+set --
+if [ -n "${TEST_FILTERS:-}" ]; then
+set -- --filter "$TEST_FILTERS"
 fi
 
-dotnet test -c ${CONFIGURATION_NAME} $FILTERS --no-build -v n --output Normal --report-gh
+dotnet test -c "${CONFIGURATION_NAME}" "$@" --no-build -v n --output Normal --report-gh

--- a/btcpayserver.sln
+++ b/btcpayserver.sln
@@ -19,6 +19,18 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Misc", "Misc", "{29290EC7-0
 		Docker\btcpay-host = Docker\btcpay-host
 		Dockerfile = Dockerfile
 		Build\Version.csproj = Build\Version.csproj
+		.github\FUNDING.yml = .github\FUNDING.yml
+		.github\ISSUE_TEMPLATE\config.yml = .github\ISSUE_TEMPLATE\config.yml
+		.github\ISSUE_TEMPLATE\bug_report.yml = .github\ISSUE_TEMPLATE\bug_report.yml
+		.github\workflows\codeql.yml = .github\workflows\codeql.yml
+		.github\scripts\Kukks.asc = .github\scripts\Kukks.asc
+		.github\scripts\can-build.sh = .github\scripts\can-build.sh
+		.github\scripts\check-btcpay-plugin-compat.sh = .github\scripts\check-btcpay-plugin-compat.sh
+		.github\scripts\nicolasdorier.asc = .github\scripts\nicolasdorier.asc
+		.github\scripts\rockstardev.asc = .github\scripts\rockstardev.asc
+		.github\scripts\run-tests.sh = .github\scripts\run-tests.sh
+		.github\scripts\verify-signed-commit.sh = .github\scripts\verify-signed-commit.sh
+		.github\scripts\collect-artifacts.sh = .github\scripts\collect-artifacts.sh
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BTCPayServer.Rating", "BTCPayServer.Rating\BTCPayServer.Rating.csproj", "{6DC77459-D52F-45EE-B3F3-315043D33A1B}"


### PR DESCRIPTION
GitHub Actions test summaries were generated inside the Docker test environment but could not be written to the runner-managed summary file. Directly mounting that file also fails because the test container cannot write to it.

This routes the generated report through the existing test artifacts volume and appends it to the GitHub Actions summary from the runner after tests finish. The temporary summary is removed from the volume after relaying it.

Screenshots and other files written to `TESTS_ARTIFACTS_DIR` are now uploaded for Fast, Integration, Playwright, and release-check jobs. Previously only the two Playwright jobs uploaded them. Test filters are also passed as distinct shell arguments so filters containing spaces or operators remain intact.

The investigation workflow confirmed the reporter expanded its summary from 48 bytes to 960 bytes during the Fast Tests job, and the runner successfully relayed it into the job summary.