### PR TITLE
Make store invitation email trigger store-scoped

### DIFF
--- a/BTCPayServer.Tests/StoreInvitationTests.cs
+++ b/BTCPayServer.Tests/StoreInvitationTests.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Threading.Tasks;
+using BTCPayServer.Plugins.Emails;
+using BTCPayServer.Plugins.Emails.HostedServices;
 using BTCPayServer.Services;
 using BTCPayServer.Views.Stores;
 using Microsoft.Playwright;
@@ -36,7 +38,11 @@ public class StoreInvitationTests(ITestOutputHelper testOutputHelper) : UnitTest
         await Expect(s.Page.Locator(".store-users__require-invitation")).ToHaveCountAsync(0);
 
         // Sending an invite lands on a wizard-layout confirmation carrying the link and QR.
-        var invitationUrl = await InviteToStore(s, invitee);
+        var invitationUrl = string.Empty;
+        var trigger = await s.Server.WaitForEvent<TriggerEvent>(async () =>
+            invitationUrl = await InviteToStore(s, invitee),
+            evt => evt.Trigger == StoreMailTriggers.StoreInvitePending);
+        Assert.Equal(storeId, trigger.StoreId);
         Assert.Contains("/invitations/", invitationUrl);
 
         // The owner is not the invitee, so their own link explains itself instead of 404ing.

--- a/BTCPayServer/Controllers/UIStoresController.Users.cs
+++ b/BTCPayServer/Controllers/UIStoresController.Users.cs
@@ -106,7 +106,7 @@ public partial class UIStoresController
                     Email = user.Email,
                     Role = roleId.Role,
                     InvitationUrl = link,
-                    EmailSent = await _emailSenderFactory.IsComplete(),
+                    EmailSent = await _emailSenderFactory.IsComplete(CurrentStore.Id),
                     Expiry = created.Invitation.Invitation.ExpiresAt,
                     JustSent = true
                 });
@@ -192,7 +192,7 @@ public partial class UIStoresController
             Email = invitedUser?.Email,
             Role = StoreRoleId.Parse(invitation.Invitation.RoleId).Role,
             InvitationUrl = link,
-            EmailSent = await _emailSenderFactory.IsComplete(),
+            EmailSent = await _emailSenderFactory.IsComplete(storeId),
             Expiry = invitation.Invitation.ExpiresAt,
             JustSent = true
         });

--- a/BTCPayServer/Plugins/Emails/EmailsPlugin.cs
+++ b/BTCPayServer/Plugins/Emails/EmailsPlugin.cs
@@ -212,25 +212,6 @@ public class EmailsPlugin : BaseBTCPayServerPlugin
         };
         vms.Add(vm);
 
-        vm = new EmailTriggerViewModel()
-        {
-            Trigger = ServerMailTriggers.StoreInvitePending,
-            DefaultEmail = new()
-            {
-                To = ["{User.MailboxAddress}"],
-                Subject = "Invitation to join {StoreInvitation.StoreName}",
-                Body = CreateEmailBody($"You have been invited to join <b>{{StoreInvitation.StoreName}}</b> as {{StoreInvitation.Role}}.<br/><br/>{CallToAction("View invitation", "{StoreInvitation.Link}")}"),
-            },
-            PlaceHolders = new()
-            {
-                new ("{StoreInvitation.StoreName}", "The name of the store the user is invited to"),
-                new ("{StoreInvitation.Role}", "The role the user is invited with"),
-                new ("{StoreInvitation.Link}", "The link where the user can accept or decline the invitation"),
-            },
-            Description = "User: Store invitation",
-        };
-        vms.Add(vm);
-
         var commonPlaceholders = new List<EmailTriggerViewModel.PlaceHolder>()
         {
             new("{Admins.MailboxAddresses}", "The email addresses of the admins separated by a comma"),

--- a/BTCPayServer/Plugins/Emails/HostedServices/StoreInvitationEventHostedService.cs
+++ b/BTCPayServer/Plugins/Emails/HostedServices/StoreInvitationEventHostedService.cs
@@ -73,7 +73,7 @@ public class StoreInvitationEventHostedService(
                 ["Link"] = evt.InvitationsLink
             }
         };
-        EventAggregator.Publish(new TriggerEvent(null, ServerMailTriggers.StoreInvitePending, model, null));
+        EventAggregator.Publish(new TriggerEvent(evt.Invitation.StoreId, StoreMailTriggers.StoreInvitePending, model, null));
     }
 
     private async Task OnAccepted(StoreUserInvitationEvent.Accepted evt)

--- a/BTCPayServer/Plugins/Emails/ServerMailTriggers.cs
+++ b/BTCPayServer/Plugins/Emails/ServerMailTriggers.cs
@@ -9,5 +9,4 @@ public class ServerMailTriggers
     public const string ApprovalPending = "SRV-ApprovalPending";
     public const string EmailConfirm = "SRV-EmailConfirmation";
     public const string ApprovalRequest = "SRV-ApprovalRequest";
-    public const string StoreInvitePending = "SRV-StoreInvitePending";
 }

--- a/BTCPayServer/Plugins/Emails/StoreMailTriggers.cs
+++ b/BTCPayServer/Plugins/Emails/StoreMailTriggers.cs
@@ -5,10 +5,32 @@ namespace BTCPayServer.Plugins.Emails;
 
 public static class StoreMailTriggers
 {
+    public const string StoreInvitePending = "StoreInvitePending";
     public const string UserJoined = "StoreUserJoined";
 
     public static IEnumerable<EmailTriggerViewModel> GetViewModels()
     {
+        yield return new EmailTriggerViewModel
+        {
+            Trigger = StoreInvitePending,
+            Description = "User: Store invitation",
+            DefaultEmail = new EmailTriggerViewModel.Default
+            {
+                To = ["{User.MailboxAddress}"],
+                Subject = "Invitation to join {StoreInvitation.StoreName}",
+                Body = EmailsPlugin.CreateEmail("You have been invited to join <b>{StoreInvitation.StoreName}</b> as {StoreInvitation.Role}.", "View invitation", "{StoreInvitation.Link}")
+            },
+            PlaceHolders =
+            [
+                new("{User.Name}", "The name of the user (eg. John Doe)"),
+                new("{User.Email}", "The email of the user (eg. john.doe@example.com)"),
+                new("{User.MailboxAddress}", "The formatted mailbox address to use when sending an email. (eg. \"John Doe\" <john.doe@example.com>)"),
+                new("{StoreInvitation.StoreName}", "The name of the store the user is invited to"),
+                new("{StoreInvitation.Role}", "The role the user is invited with"),
+                new("{StoreInvitation.Link}", "The link where the user can accept or decline the invitation")
+            ]
+        };
+
         yield return new EmailTriggerViewModel
         {
             Trigger = UserJoined,


### PR DESCRIPTION
Store invitation emails can now be configured as store email rules instead of server email rules. Invitations use the invited store's email settings, including the configured server fallback when allowed.

This also ensures the invitation confirmation reports email availability for the correct store.