### PR TITLE
Make btcpay-host integration opt-in

### DIFF
--- a/.agents/skills/btcpayserver-configuration/SKILL.md
+++ b/.agents/skills/btcpayserver-configuration/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: btcpayserver-configuration
+description: Use when adding or reviewing BTCPay Server startup configuration options. Covers command-line registration, defaults, environment variables, tests, and documentation.
+---
+
+# BTCPay Server Configuration Options
+
+When adding a public startup configuration option, treat every supported configuration source as part of the feature.
+
+## Implementation Checklist
+
+- Choose one canonical lowercase key consistent with existing settings.
+- Register the option in `DefaultConfiguration.CreateCommandLineApplicationCore()` so the command line accepts it and `--help` documents it. Use the appropriate `CommandOptionType`, such as `BoolValue` or `SingleValue`, and include the default in the help text.
+- Add the setting and its default as a commented example in `DefaultConfiguration.GetDefaultConfigurationFileTemplate()` when it is useful to operators.
+- Read the setting through `IConfiguration`, normally with `GetOrDefault<T>(key, defaultValue)`, and make the default explicit at the point where behavior is selected.
+- Use the existing configuration providers rather than reading an environment variable directly. `DefaultConfiguration.EnvironmentVariablePrefix` maps a setting such as `exampleenabled` to `BTCPAY_EXAMPLEENABLED`.
+- Check every consumer of the affected feature. A disabled-by-default option must prevent background work and hide or disable UI that would otherwise expose an unavailable feature.
+- Update test configuration explicitly when a fixture depends on behavior that is no longer the default. Do not weaken the production default to preserve a test assumption.
+- Document all operator-facing forms that are supported: configuration-file key, `BTCPAY_` environment variable, and command-line option. Update deployment manifests separately when a deployment intentionally opts in.
+
+## Verification
+
+- Build the affected project.
+- Run focused tests for configuration parsing and every behavior gated by the option.
+- Run the application with `--help` and confirm the new command-line option is listed with an accurate description and default.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,8 +5,9 @@ Repository-specific agent guidance has moved to project skills:
 - `.agents/skills/btcpayserver-migrations/SKILL.md`
 - `.agents/skills/btcpayserver-changelog/SKILL.md`
 - `.agents/skills/btcpayserver-pr-descriptions/SKILL.md`
+- `.agents/skills/btcpayserver-configuration/SKILL.md`
 
-Load the relevant skill when creating migrations, updating/reviewing `Changelog.md`, or writing/reviewing pull request descriptions.
+Load the relevant skill when creating migrations, updating/reviewing `Changelog.md`, writing/reviewing pull request descriptions, or adding/reviewing startup configuration options.
 
 ## JSON Serialization
 

--- a/BTCPayServer.Tests/BTCPayServerTester.cs
+++ b/BTCPayServer.Tests/BTCPayServerTester.cs
@@ -163,7 +163,10 @@ namespace BTCPayServer.Tests
             config.AppendLine($"debuglog=debug.log");
             config.AppendLine($"nocsp={NoCSP.ToString().ToLowerInvariant()}");
             if (btcpayHostExecutable is not null)
+            {
                 config.AppendLine($"btcpayhostexecutable={btcpayHostExecutable}");
+                config.AppendLine("btcpayhostenabled=true");
+            }
 
             if (!String.IsNullOrEmpty(Postgres))
                 config.AppendLine($"postgres=" + Postgres);

--- a/BTCPayServer/Configuration/DefaultConfiguration.cs
+++ b/BTCPayServer/Configuration/DefaultConfiguration.cs
@@ -38,6 +38,8 @@ namespace BTCPayServer.Configuration
             app.Option("--nocsp", $"Disable CSP (default false)", CommandOptionType.BoolValue);
             app.Option("--deprecated", $"Allow deprecated settings (default:false)", CommandOptionType.BoolValue);
             app.Option("--externalservices", $"Links added to external services inside Server Settings / Services under the format service1:path2;service2:path2.(default: empty)", CommandOptionType.SingleValue);
+            app.Option("--btcpayhostenabled", "Enable the btcpay-host integration (default: false)", CommandOptionType.BoolValue);
+            app.Option("--btcpayhostexecutable", "Path to the btcpay-host executable (default: btcpay-host)", CommandOptionType.SingleValue);
             app.Option("--rootpath", "The root path in the URL to access BTCPay (default: /)", CommandOptionType.SingleValue);
             app.Option("--torrcfile", "Path to torrc file containing hidden services directories (default: empty)", CommandOptionType.SingleValue);
             app.Option("--torservices", "Tor hostnames of available services added to Server Settings (and sets onion header for btcpay). Format: btcpayserver:host.onion:80;btc-p2p:host2.onion:81,BTC-RPC:host3.onion:82,UNKNOWN:host4.onion:83. (default: empty)", CommandOptionType.SingleValue);
@@ -127,6 +129,10 @@ namespace BTCPayServer.Configuration
             builder.AppendLine("#bind=127.0.0.1");
             builder.AppendLine("#httpscertificatefilepath=devtest.pfx");
             builder.AppendLine("#httpscertificatefilepassword=toto");
+            builder.AppendLine();
+            builder.AppendLine("### Host integration ###");
+            builder.AppendLine("#btcpayhostenabled=false");
+            builder.AppendLine("#btcpayhostexecutable=btcpay-host");
             builder.AppendLine();
             builder.AppendLine("### Database ###");
             builder.AppendLine("#postgres=User ID=root;Password=myPassword;Host=localhost;Port=5432;Database=myDataBase;");

--- a/BTCPayServer/Plugins/Maintenance/CheckHostCommandsHostedService.cs
+++ b/BTCPayServer/Plugins/Maintenance/CheckHostCommandsHostedService.cs
@@ -22,6 +22,12 @@ namespace BTCPayServer.Plugins.Maintenance
 
         public Task StartAsync(CancellationToken cancellationToken)
         {
+            if (!processRunner.BTCPayHostEnabled)
+            {
+                Logs.PayServer.LogInformation("Host integration is disabled");
+                return Task.CompletedTask;
+            }
+
             _testingConnection = TestConnection();
             return Task.CompletedTask;
         }

--- a/BTCPayServer/Services/ProcessRunner.cs
+++ b/BTCPayServer/Services/ProcessRunner.cs
@@ -9,6 +9,7 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using BTCPayServer.Configuration;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 
@@ -17,6 +18,7 @@ namespace BTCPayServer.Services;
 public sealed record HostCommandResult(int ExitCode, string Output, string Error);
 public class ProcessRunner(ILoggerFactory loggerFactory, IConfiguration conf)
 {
+    public bool BTCPayHostEnabled { get; set; } = conf.GetOrDefault("btcpayhostenabled", false);
     public string BTCPayHostExecutable { get; set; } = conf["btcpayhostexecutable"] ?? "btcpay-host";
     private readonly ILogger _logger = loggerFactory.CreateLogger("BTCPayServer.ProcessRunner");
 


### PR DESCRIPTION
Host integration is now disabled by default, even when a `btcpay-host` executable is available. Deployments must explicitly enable it with `btcpayhostenabled=true` or `BTCPAY_BTCPAYHOSTENABLED=true`.

When disabled, BTCPay Server does not run `btcpay-host env`. Maintenance and SSH features backed by host commands remain hidden from Server Settings. This keeps host access unavailable unless the deployment has deliberately configured the integration.

The existing `btcpayhostexecutable` setting still selects the executable when host integration is enabled.

Related documentation: [Deployment Host Integration](https://docs.btcpayserver.org/Development/HostIntegration/).