### PR TITLE
Restore plugin page error checks

### DIFF
--- a/BTCPayServer.Tests/GlobalSearchTests.cs
+++ b/BTCPayServer.Tests/GlobalSearchTests.cs
@@ -91,8 +91,7 @@ public class GlobalSearchTests(ITestOutputHelper helper) : UnitTestBase(helper)
         {
             TestLogs.LogInformation($"Navigating to {item.Url}");
             await s.GoToUrl(item.Url);
-            if (item.Url != "/server/plugins")
-                await s.Page.AssertNoError();
+            await s.Page.AssertNoError();
         }
 
         async Task SearchAndOpenInvoice(string query)

--- a/BTCPayServer.Tests/PlaywrightTester.cs
+++ b/BTCPayServer.Tests/PlaywrightTester.cs
@@ -428,7 +428,7 @@ namespace BTCPayServer.Tests
             await Page.ClickAsync($"#globalNavServerMenu #menu-item-{navPages}");
         }
 
-        public async Task ClickOnAllSectionLinks(string sectionSelector = "#menu-item", params string[] linksAllowedToHaveErrors)
+        public async Task ClickOnAllSectionLinks(string sectionSelector = "#menu-item")
         {
             List<string> links = [];
             var linkLocator = Page.Locator($"{sectionSelector} a.nav-link");
@@ -447,12 +447,9 @@ namespace BTCPayServer.Tests
             Assert.NotEmpty(links);
             foreach (var link in links)
             {
+                TestLogs.LogInformation($"Checking no error on {link}");
                 await GoToUrl(link);
-                if (!linksAllowedToHaveErrors.Contains(link))
-                {
-                    TestLogs.LogInformation($"Checking no error on {link}");
-                    await Page.AssertNoError();
-                }
+                await Page.AssertNoError();
             }
         }
 

--- a/BTCPayServer.Tests/PlaywrightTests.cs
+++ b/BTCPayServer.Tests/PlaywrightTests.cs
@@ -55,7 +55,7 @@ namespace BTCPayServer.Tests
             await s.SkipWizard();
             await s.GoToServer();
             await s.Page.AssertNoError();
-            await s.ClickOnAllSectionLinks("#mainNavSettings", "/server/plugins");
+            await s.ClickOnAllSectionLinks("#mainNavSettings");
             await s.GoToServer(ServerNavPages.Services);
             s.TestLogs.LogInformation("Let's check if we can access the logs");
             await s.GoToServer(ServerNavPages.Logs);


### PR DESCRIPTION
The plugin catalog is available again, so server settings and global search navigation once again treat errors on the plugin page as test failures.

This removes the temporary exception introduced in #7548.