### PR TITLE
Require current password for account email changes

### DIFF
--- a/.agents/skills/playwright-test-patterns/SKILL.md
+++ b/.agents/skills/playwright-test-patterns/SKILL.md
@@ -33,7 +33,10 @@ Use these patterns when writing or refactoring Playwright tests in BTCPayServer.
 - Playwright assertions automatically wait for the expected condition, making tests less verbose and less prone to flakiness.
 - Prefer `await Expect(locator).ToHaveCountAsync(1)` over `Assert.Equal(1, await locator.CountAsync())`.
 - Prefer `await Expect(locator).ToContainTextAsync(text)` over `Assert.Contains(text, await locator.TextContentAsync())`.
+- Prefer `await Expect(locator).ToHaveValueAsync(value)` over `Assert.Equal(value, await locator.InputValueAsync())`.
 - Prefer `await Expect(page).ToHaveURLAsync(...)` over direct assertions on `page.Url`.
+- Do not call `WaitForLoadStateAsync` before a Playwright assertion; the `Expect` API waits for the expected state.
+- Add `using static Microsoft.Playwright.Assertions;` when using `Expect`.
 
 ## Selector Guidance
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,8 +6,9 @@ Repository-specific agent guidance has moved to project skills:
 - `.agents/skills/btcpayserver-changelog/SKILL.md`
 - `.agents/skills/btcpayserver-pr-descriptions/SKILL.md`
 - `.agents/skills/btcpayserver-configuration/SKILL.md`
+- `.agents/skills/playwright-test-patterns/SKILL.md`
 
-Load the relevant skill when creating migrations, updating/reviewing `Changelog.md`, writing/reviewing pull request descriptions, or adding/reviewing startup configuration options.
+Load the relevant skill when creating migrations, updating/reviewing `Changelog.md`, writing/reviewing pull request descriptions, adding/reviewing startup configuration options, or writing/refactoring Playwright tests.
 
 ## JSON Serialization
 

--- a/BTCPayServer.Tests/PlaywrightTests.cs
+++ b/BTCPayServer.Tests/PlaywrightTests.cs
@@ -990,6 +990,40 @@ namespace BTCPayServer.Tests
         }
 
         [Fact]
+        public async Task ChangingAccountEmailRequiresCurrentPassword()
+        {
+            await using var s = CreatePlaywrightTester();
+            await s.StartAsync();
+            var oldEmail = await s.RegisterNewUser();
+            var newEmail = $"{RandomUtils.GetUInt256().ToString()[..20]}@example.com";
+            await s.SkipWizard();
+            await s.GoToUrl("/account");
+
+            await s.Page.FillAsync("#Email", newEmail);
+            await s.ClickPagePrimary();
+            await Expect(s.Page.Locator("[data-valmsg-for=CurrentPassword]")).ToContainTextAsync("The current password is not correct.");
+
+            await s.GoToUrl("/account");
+            await Expect(s.Page.Locator("#Email")).ToHaveValueAsync(oldEmail);
+            await s.Page.FillAsync("#Email", newEmail);
+            await s.Page.FillAsync("#CurrentPassword", "incorrect");
+            await s.ClickPagePrimary();
+            await Expect(s.Page.Locator("[data-valmsg-for=CurrentPassword]")).ToContainTextAsync("The current password is not correct.");
+
+            await s.GoToUrl("/account");
+            await Expect(s.Page.Locator("#Email")).ToHaveValueAsync(oldEmail);
+            await s.Page.FillAsync("#Email", newEmail);
+            await s.Page.FillAsync("#CurrentPassword", "123456");
+            await s.ClickPagePrimary();
+            await s.FindAlertMessage(partialText: "Your profile has been updated");
+            await Expect(s.Page.Locator("#Email")).ToHaveValueAsync(newEmail);
+
+            await s.Logout();
+            await s.LogIn(newEmail, "123456");
+            await s.Page.AssertNoError();
+        }
+
+        [Fact]
         public async Task CanUseStoreTemplate()
         {
             await using var s = CreatePlaywrightTester(newDb: true);

--- a/BTCPayServer/Controllers/UIManageController.cs
+++ b/BTCPayServer/Controllers/UIManageController.cs
@@ -88,17 +88,7 @@ namespace BTCPayServer.Controllers
             var user = await _userManager.GetUserAsync(User);
             if (user == null)
                 return NotFound();
-            var blob = user.GetBlob() ?? new();
-            var model = new IndexViewModel
-            {
-                Email = user.Email,
-                Name = blob.Name,
-                ImageUrl = string.IsNullOrEmpty(blob.ImageUrl) ? null : await _uriResolver.Resolve(Request.GetAbsoluteRootUri(), UnresolvedUri.Create(blob.ImageUrl)),
-                EmailConfirmed = user.EmailConfirmed,
-                RequiresEmailConfirmation = user.RequiresEmailConfirmation,
-                AllowGreenfieldBasicAuth = blob.AllowGreenfieldBasicAuth
-            };
-            return View(model);
+            return View(await GetIndexViewModel(user));
         }
 
         [HttpGet]
@@ -154,7 +144,15 @@ namespace BTCPayServer.Controllers
 
             bool needUpdate = false;
             var email = user.Email;
-            if (model.Email != email)
+            var setNewEmail = model.Email != email && ModelState.IsValid;
+            if (setNewEmail && (string.IsNullOrEmpty(model.CurrentPassword) ||
+                                !await _userManager.CheckPasswordAsync(user, model.CurrentPassword)))
+            {
+                ModelState.AddModelError(nameof(model.CurrentPassword), StringLocalizer["The current password is not correct."].Value);
+                return View(await GetIndexViewModel(user, model));
+            }
+
+            if (setNewEmail)
             {
                 if (!(await _userManager.FindByEmailAsync(model.Email) is null))
                 {
@@ -354,6 +352,21 @@ namespace BTCPayServer.Controllers
         }
 
         #region Helpers
+
+        private async Task<IndexViewModel> GetIndexViewModel(ApplicationUser user, IndexViewModel model = null)
+        {
+            var blob = user.GetBlob() ?? new();
+            model ??= new IndexViewModel
+            {
+                Email = user.Email,
+                Name = blob.Name,
+                AllowGreenfieldBasicAuth = blob.AllowGreenfieldBasicAuth
+            };
+            model.ImageUrl = string.IsNullOrEmpty(blob.ImageUrl) ? null : await _uriResolver.Resolve(Request.GetAbsoluteRootUri(), UnresolvedUri.Create(blob.ImageUrl));
+            model.EmailConfirmed = user.EmailConfirmed;
+            model.RequiresEmailConfirmation = user.RequiresEmailConfirmation;
+            return model;
+        }
 
         private void AddErrors(IdentityResult result)
         {

--- a/BTCPayServer/Models/ManageViewModels/IndexViewModel.cs
+++ b/BTCPayServer/Models/ManageViewModels/IndexViewModel.cs
@@ -10,6 +10,9 @@ namespace BTCPayServer.Models.ManageViewModels
         [MaxLength(50)]
         [Display(Name = "Email")]
         public string Email { get; set; }
+        [DataType(DataType.Password)]
+        [Display(Name = "Current password")]
+        public string CurrentPassword { get; set; }
         public bool EmailConfirmed { get; set; }
         public bool RequiresEmailConfirmation { get; set; }
         [Display(Name = "Name")]

--- a/BTCPayServer/Views/UIManage/Index.cshtml
+++ b/BTCPayServer/Views/UIManage/Index.cshtml
@@ -40,6 +40,12 @@
             <span asp-validation-for="Email" class="text-danger"></span>
         </div>
         <div class="form-group">
+            <label asp-for="CurrentPassword" class="form-label"></label>
+            <input asp-for="CurrentPassword" class="form-control" autocomplete="current-password" />
+            <div class="form-text" text-translate="true">Required only when changing your email address.</div>
+            <span asp-validation-for="CurrentPassword" class="text-danger"></span>
+        </div>
+        <div class="form-group">
             <label asp-for="Name" class="form-label"></label>
             <input asp-for="Name" class="form-control" />
             <span asp-validation-for="Name" class="text-danger"></span>

--- a/Changelog.md
+++ b/Changelog.md
@@ -34,6 +34,7 @@
 * **Stores**: Block unsafe support links to prevent script injection (#7537) @TChukwuleta
 * **API Keys**: Keep new API keys out of authorization redirect URLs (#7542) @TChukwuleta
 * **Maintenance**: Validate hostnames before changing a domain @NicolasDorier
+* **Account security**: Require the current password when changing an account email (low impact, reported by llen)
 
 ### Improvements
 


### PR DESCRIPTION
Account settings now requires the current password before changing the account email, matching the protection already present in the Greenfield API. This prevents someone with temporary access to an authenticated browser session from redirecting password recovery to another email address.

This is classified as low impact because exploitation requires an existing foothold such as a stolen session cookie, XSS, or access to a shared machine. Thanks to `llen` for responsibly reporting the issue.

The 2.4.4 changelog includes the fix and attribution. An end-to-end browser test covers missing, incorrect, and correct current passwords.

<img width="1768" height="468" alt="image" src="https://github.com/user-attachments/assets/4e608a22-4aef-4cee-adc4-cd69f0f1d177" />
