### PR TITLE
Return validation error when pull payment has no payout methods

### DIFF
--- a/BTCPayServer.Tests/PullPaymentsTests.cs
+++ b/BTCPayServer.Tests/PullPaymentsTests.cs
@@ -640,6 +640,14 @@ public class PullPaymentsTests(ITestOutputHelper helper) : UnitTestBase(helper)
         acc.RegisterLightningNode("BTC", LightningTestImplementation.CoreLightning, false);
         var storeId = (await acc.RegisterDerivationSchemeAsync("BTC", importKeysToNBX: true)).StoreId;
         var client = await acc.CreateClient();
+        var storeWithoutWallet = await client.CreateStore(new CreateStoreRequest { Name = "No wallet" });
+        await AssertEx.AssertValidationError(new[] { "PayoutMethods" }, async () =>
+            await client.CreatePullPayment(storeWithoutWallet.Id, new CreatePullPaymentRequest
+            {
+                Amount = 12.3m,
+                Currency = "BTC"
+            }));
+
         var result = await client.CreatePullPayment(storeId, new CreatePullPaymentRequest()
         {
             Name = "Test",

--- a/BTCPayServer/Controllers/GreenField/GreenfieldPullPaymentController.cs
+++ b/BTCPayServer/Controllers/GreenField/GreenfieldPullPaymentController.cs
@@ -142,6 +142,10 @@ namespace BTCPayServer.Controllers.Greenfield
                     ModelState.AddModelError(nameof(request.PayoutMethods), "At least one payout method is required");
                 }
             }
+            else if (supported.Count is 0)
+            {
+                ModelState.AddModelError(nameof(request.PayoutMethods), "At least one payout method is required");
+            }
             if (!ModelState.IsValid)
                 return this.CreateValidationError(ModelState);
 


### PR DESCRIPTION
Creating a pull payment through the Greenfield API for a store without any configured payout methods now returns a validation error for `PayoutMethods` instead of an internal server error.

This also covers requests that omit `payoutMethods`, where BTCPay Server would otherwise attempt to use the store defaults and find none.