### PR TITLE
Return 409 for duplicate payment request reference IDs

### DIFF
--- a/BTCPayServer.Tests/PaymentRequestTests.cs
+++ b/BTCPayServer.Tests/PaymentRequestTests.cs
@@ -55,6 +55,9 @@ namespace BTCPayServer.Tests
             });
             var newPaymentRequest = await client.CreatePaymentRequest(user.StoreId,
                 new() { Title = "A", Currency = "USD", Amount = 1, ReferenceId = "1234"});
+            await AssertEx.AssertApiError(409, "duplicate-reference-id", () =>
+                client.CreatePaymentRequest(user.StoreId,
+                    new() { Title = "B", Currency = "USD", Amount = 1, ReferenceId = "1234" }));
 
             //list payment request
             var paymentRequests = (await viewOnly.GetPaymentRequests(user.StoreId)).ToArray();

--- a/BTCPayServer/Controllers/GreenField/GreenfieldPaymentRequestsController.cs
+++ b/BTCPayServer/Controllers/GreenField/GreenfieldPaymentRequestsController.cs
@@ -16,6 +16,8 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Cors;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
+using Microsoft.EntityFrameworkCore;
+using Npgsql;
 using PaymentRequestData = BTCPayServer.Data.PaymentRequestData;
 
 namespace BTCPayServer.Controllers.Greenfield
@@ -221,7 +223,19 @@ namespace BTCPayServer.Controllers.Greenfield
 				FormResponse = blob.FormId != request.FormId ? null : blob.FormResponse,
                 RequestBaseUrl = Request.GetRequestBaseUrl().ToString()
 			});
-			pr = await _paymentRequestRepository.CreateOrUpdatePaymentRequest(pr);
+			try
+			{
+				pr = await _paymentRequestRepository.CreateOrUpdatePaymentRequest(pr);
+			}
+			catch (DbUpdateException e) when (e.InnerException is PostgresException
+				{
+					SqlState: PostgresErrorCodes.UniqueViolation,
+					ConstraintName: "ix_paymentrequests_storedataid_referenceid"
+				})
+			{
+				return this.CreateAPIError(409, "duplicate-reference-id",
+					"A payment request with this reference ID already exists for this store.");
+			}
 			return Ok(FromModel(pr));
 		}
 

--- a/BTCPayServer/wwwroot/swagger/v1/swagger.template.payment-requests.json
+++ b/BTCPayServer/wwwroot/swagger/v1/swagger.template.payment-requests.json
@@ -79,6 +79,16 @@
                     },
                     "403": {
                         "description": "If you are authenticated but forbidden to add new payment requests"
+                    },
+                    "409": {
+                        "description": "Error codes: `duplicate-reference-id`",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProblemDetails"
+                                }
+                            }
+                        }
                     }
                 },
                 "requestBody": {
@@ -236,6 +246,16 @@
                     },
                     "403": {
                         "description": "If you are authenticated but forbidden to update the payment request"
+                    },
+                    "409": {
+                        "description": "Error codes: `duplicate-reference-id`",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProblemDetails"
+                                }
+                            }
+                        }
                     }
                 },
                 "requestBody": {


### PR DESCRIPTION
Creating or updating a payment request with a reference ID already used by the same store now returns HTTP 409 instead of causing an unhandled server error.

API clients receive the `duplicate-reference-id` error code and a clear message they can handle. The response is documented for both payment request creation and updates in the Greenfield API specification.