### PR TITLE
Bumping LND to 0.21.3-beta-1

### DIFF
--- a/BTCPayServer.Tests/docker-compose.altcoins.yml
+++ b/BTCPayServer.Tests/docker-compose.altcoins.yml
@@ -125,7 +125,7 @@ services:
 
   bitcoind:
     restart: unless-stopped
-    image: btcpayserver/bitcoin:31.1
+    image: btcpayserver/bitcoin:31.1-1
     environment:
       BITCOIN_NETWORK: regtest
       BITCOIN_RPCUSERS: lnd

--- a/BTCPayServer.Tests/docker-compose.altcoins.yml
+++ b/BTCPayServer.Tests/docker-compose.altcoins.yml
@@ -128,6 +128,7 @@ services:
     image: btcpayserver/bitcoin:31.1
     environment:
       BITCOIN_NETWORK: regtest
+      BITCOIN_RPCUSERS: lnd
       BITCOIN_WALLETDIR: "/data/wallets"
       BITCOIN_EXTRA_ARGS: |-
         rpcuser=ceiwHEbqWI83
@@ -232,14 +233,14 @@ services:
       LND_ENVIRONMENT: "regtest"
       LND_EXPLORERURL: "http://nbxplorer:32838/"
       LND_REST_LISTEN_HOST: http://merchant_lnd:8080
+      RPCUSER_FILE: /deps/.bitcoin/RPCUsers/lnd
       LND_EXTRA_ARGS: |
         restlisten=merchant_lnd:8080
         rpclisten=127.0.0.1:10008
         rpclisten=merchant_lnd:10009
         bitcoin.node=bitcoind
         bitcoind.rpchost=bitcoind:43782
-        bitcoind.rpcuser=ceiwHEbqWI83
-        bitcoind.rpcpass=DwubwWsoo3
+        bitcoind.rpcuser=lnd
         bitcoind.zmqpubrawblock=tcp://bitcoind:28332
         bitcoind.zmqpubrawtx=tcp://bitcoind:28333
         externalip=merchant_lnd:9735
@@ -270,14 +271,14 @@ services:
       LND_ENVIRONMENT: "regtest"
       LND_EXPLORERURL: "http://nbxplorer:32838/"
       LND_REST_LISTEN_HOST: http://customer_lnd:8080
+      RPCUSER_FILE: /deps/.bitcoin/RPCUsers/lnd
       LND_EXTRA_ARGS: |
         restlisten=customer_lnd:8080
         rpclisten=127.0.0.1:10008
         rpclisten=customer_lnd:10009
         bitcoin.node=bitcoind
         bitcoind.rpchost=bitcoind:43782
-        bitcoind.rpcuser=ceiwHEbqWI83
-        bitcoind.rpcpass=DwubwWsoo3
+        bitcoind.rpcuser=lnd
         bitcoind.zmqpubrawblock=tcp://bitcoind:28332
         bitcoind.zmqpubrawtx=tcp://bitcoind:28333
         externalip=customer_lnd:10009

--- a/BTCPayServer.Tests/docker-compose.altcoins.yml
+++ b/BTCPayServer.Tests/docker-compose.altcoins.yml
@@ -225,7 +225,7 @@ services:
       - "postgres_test_datadir:/var/lib/postgresql"
 
   merchant_lnd:
-    image: btcpayserver/lnd:v0.21.3-beta
+    image: btcpayserver/lnd:v0.21.3-beta-1
     restart: unless-stopped
     environment:
       LND_CHAIN: "btc"
@@ -263,7 +263,7 @@ services:
       - bitcoind
 
   customer_lnd:
-    image: btcpayserver/lnd:v0.21.3-beta
+    image: btcpayserver/lnd:v0.21.3-beta-1
     restart: unless-stopped
     environment:
       LND_CHAIN: "btc"

--- a/BTCPayServer.Tests/docker-compose.altcoins.yml
+++ b/BTCPayServer.Tests/docker-compose.altcoins.yml
@@ -61,7 +61,7 @@ services:
       - mailpit
 
   devlnd:
-    image: btcpayserver/bitcoin:31.1
+    image: btcpayserver/bitcoin:31.1-1
     environment:
       BITCOIN_NETWORK: regtest
       BITCOIN_WALLETDIR: "/data/wallets"

--- a/BTCPayServer.Tests/docker-compose.mutinynet.yml
+++ b/BTCPayServer.Tests/docker-compose.mutinynet.yml
@@ -167,7 +167,7 @@ services:
       - "postgres_test_datadir:/var/lib/postgresql"
 
   merchant_lnd:
-    image: btcpayserver/lnd:v0.21.3-beta
+    image: btcpayserver/lnd:v0.21.3-beta-1
     restart: unless-stopped
     environment:
       LND_CHAIN: "btc"
@@ -205,7 +205,7 @@ services:
       - bitcoind
 
   customer_lnd:
-    image: btcpayserver/lnd:v0.21.3-beta
+    image: btcpayserver/lnd:v0.21.3-beta-1
     restart: unless-stopped
     environment:
       LND_CHAIN: "btc"

--- a/BTCPayServer.Tests/docker-compose.testnet.yml
+++ b/BTCPayServer.Tests/docker-compose.testnet.yml
@@ -19,7 +19,7 @@ services:
       - tor
 
   devlnd:
-    image: btcpayserver/bitcoin:31.1
+    image: btcpayserver/bitcoin:31.1-1
     environment:
       BITCOIN_NETWORK: testnet
       BITCOIN_WALLETDIR: "/data/wallets"

--- a/BTCPayServer.Tests/docker-compose.testnet.yml
+++ b/BTCPayServer.Tests/docker-compose.testnet.yml
@@ -159,7 +159,7 @@ services:
       - "postgres_test_datadir:/var/lib/postgresql"
 
   merchant_lnd:
-    image: btcpayserver/lnd:v0.21.3-beta
+    image: btcpayserver/lnd:v0.21.3-beta-1
     restart: unless-stopped
     environment:
       LND_CHAIN: "btc"
@@ -197,7 +197,7 @@ services:
       - bitcoind
 
   customer_lnd:
-    image: btcpayserver/lnd:v0.21.3-beta
+    image: btcpayserver/lnd:v0.21.3-beta-1
     restart: unless-stopped
     environment:
       LND_CHAIN: "btc"

--- a/BTCPayServer.Tests/docker-compose.testnet.yml
+++ b/BTCPayServer.Tests/docker-compose.testnet.yml
@@ -61,7 +61,7 @@ services:
 
   bitcoind:
     restart: unless-stopped
-    image: btcpayserver/bitcoin:31.1
+    image: btcpayserver/bitcoin:31.1-1
     environment:
       BITCOIN_NETWORK: testnet
       BITCOIN_RPCUSERS: lnd

--- a/BTCPayServer.Tests/docker-compose.testnet.yml
+++ b/BTCPayServer.Tests/docker-compose.testnet.yml
@@ -64,6 +64,7 @@ services:
     image: btcpayserver/bitcoin:31.1
     environment:
       BITCOIN_NETWORK: testnet
+      BITCOIN_RPCUSERS: lnd
       BITCOIN_WALLETDIR: "/data/wallets"
       BITCOIN_EXTRA_ARGS: |-
         rpcuser=ceiwHEbqWI83
@@ -166,14 +167,14 @@ services:
       LND_ENVIRONMENT: "testnet"
       LND_EXPLORERURL: "http://nbxplorer:32838/"
       LND_REST_LISTEN_HOST: http://merchant_lnd:8080
+      RPCUSER_FILE: /deps/.bitcoin/RPCUsers/lnd
       LND_EXTRA_ARGS: |
         restlisten=merchant_lnd:8080
         rpclisten=127.0.0.1:10008
         rpclisten=merchant_lnd:10009
         bitcoin.node=bitcoind
         bitcoind.rpchost=bitcoind:43782
-        bitcoind.rpcuser=ceiwHEbqWI83
-        bitcoind.rpcpass=DwubwWsoo3
+        bitcoind.rpcuser=lnd
         bitcoind.zmqpubrawblock=tcp://bitcoind:28332
         bitcoind.zmqpubrawtx=tcp://bitcoind:28333
         externalip=merchant_lnd:9735
@@ -204,14 +205,14 @@ services:
       LND_ENVIRONMENT: "testnet"
       LND_EXPLORERURL: "http://nbxplorer:32838/"
       LND_REST_LISTEN_HOST: http://customer_lnd:8080
+      RPCUSER_FILE: /deps/.bitcoin/RPCUsers/lnd
       LND_EXTRA_ARGS: |
         restlisten=customer_lnd:8080
         rpclisten=127.0.0.1:10008
         rpclisten=customer_lnd:10009
         bitcoin.node=bitcoind
         bitcoind.rpchost=bitcoind:43782
-        bitcoind.rpcuser=ceiwHEbqWI83
-        bitcoind.rpcpass=DwubwWsoo3
+        bitcoind.rpcuser=lnd
         bitcoind.zmqpubrawblock=tcp://bitcoind:28332
         bitcoind.zmqpubrawtx=tcp://bitcoind:28333
         externalip=customer_lnd:9735

--- a/BTCPayServer.Tests/docker-compose.yml
+++ b/BTCPayServer.Tests/docker-compose.yml
@@ -110,7 +110,7 @@ services:
 
   bitcoind:
     restart: unless-stopped
-    image: btcpayserver/bitcoin:31.1
+    image: btcpayserver/bitcoin:31.1-1
     environment:
       BITCOIN_NETWORK: regtest
       BITCOIN_RPCUSERS: lnd

--- a/BTCPayServer.Tests/docker-compose.yml
+++ b/BTCPayServer.Tests/docker-compose.yml
@@ -57,7 +57,7 @@ services:
       - mailpit
 
   devlnd:
-    image: btcpayserver/bitcoin:31.1
+    image: btcpayserver/bitcoin:31.1-1
     environment:
       BITCOIN_NETWORK: regtest
       BITCOIN_WALLETDIR: "/data/wallets"

--- a/BTCPayServer.Tests/docker-compose.yml
+++ b/BTCPayServer.Tests/docker-compose.yml
@@ -210,7 +210,7 @@ services:
       - "postgres_test_datadir:/var/lib/postgresql"
 
   merchant_lnd:
-    image: btcpayserver/lnd:v0.21.3-beta
+    image: btcpayserver/lnd:v0.21.3-beta-1
     restart: unless-stopped
     environment:
       LND_CHAIN: "btc"
@@ -248,7 +248,7 @@ services:
       - bitcoind
 
   customer_lnd:
-    image: btcpayserver/lnd:v0.21.3-beta
+    image: btcpayserver/lnd:v0.21.3-beta-1
     restart: unless-stopped
     environment:
       LND_CHAIN: "btc"

--- a/BTCPayServer.Tests/docker-compose.yml
+++ b/BTCPayServer.Tests/docker-compose.yml
@@ -113,6 +113,7 @@ services:
     image: btcpayserver/bitcoin:31.1
     environment:
       BITCOIN_NETWORK: regtest
+      BITCOIN_RPCUSERS: lnd
       BITCOIN_WALLETDIR: "/data/wallets"
       BITCOIN_EXTRA_ARGS: |-
         rpcuser=ceiwHEbqWI83
@@ -217,14 +218,14 @@ services:
       LND_ENVIRONMENT: "regtest"
       LND_EXPLORERURL: "http://nbxplorer:32838/"
       LND_REST_LISTEN_HOST: http://merchant_lnd:8080
+      RPCUSER_FILE: /deps/.bitcoin/RPCUsers/lnd
       LND_EXTRA_ARGS: |
         restlisten=merchant_lnd:8080
         rpclisten=127.0.0.1:10008
         rpclisten=merchant_lnd:10009
         bitcoin.node=bitcoind
         bitcoind.rpchost=bitcoind:43782
-        bitcoind.rpcuser=ceiwHEbqWI83
-        bitcoind.rpcpass=DwubwWsoo3
+        bitcoind.rpcuser=lnd
         bitcoind.zmqpubrawblock=tcp://bitcoind:28332
         bitcoind.zmqpubrawtx=tcp://bitcoind:28333
         externalip=merchant_lnd:9735
@@ -255,14 +256,14 @@ services:
       LND_ENVIRONMENT: "regtest"
       LND_EXPLORERURL: "http://nbxplorer:32838/"
       LND_REST_LISTEN_HOST: http://customer_lnd:8080
+      RPCUSER_FILE: /deps/.bitcoin/RPCUsers/lnd
       LND_EXTRA_ARGS: |
         restlisten=customer_lnd:8080
         rpclisten=127.0.0.1:10008
         rpclisten=customer_lnd:10009
         bitcoin.node=bitcoind
         bitcoind.rpchost=bitcoind:43782
-        bitcoind.rpcuser=ceiwHEbqWI83
-        bitcoind.rpcpass=DwubwWsoo3
+        bitcoind.rpcuser=lnd
         bitcoind.zmqpubrawblock=tcp://bitcoind:28332
         bitcoind.zmqpubrawtx=tcp://bitcoind:28333
         externalip=customer_lnd:9735


### PR DESCRIPTION
Bumps the LND image used by the test suite to v0.21.3-beta-1 and switches the lnd test nodes to file-based Bitcoin RPC auth.

Docker image: https://hub.docker.com/repository/docker/btcpayserver/lnd/tags/v0.21.3-beta-1
Tag: https://github.com/btcpayserver/lnd/releases/tag/basedon-v0.21.3-beta-1
BTCPayServer.Lightning PR: https://github.com/btcpayserver/BTCPayServer.Lightning/pull/195

This lnd build adds support for file-based Bitcoin RPC passwords via RPCUSER_FILE (btcpayserver/lnd#14). The regtest, testnet and altcoins environments now exercise it: bitcoind (btcpayserver/bitcoin:31.1) provisions the lnd RPC user with a random password via BITCOIN_RPCUSERS, and merchant_lnd/customer_lnd authenticate through RPCUSER_FILE instead of the static rpcpassword. NBXplorer keeps the static credentials, and mutinynet keeps static creds because btcpayserver/mutinynet does not support BITCOIN_RPCUSERS.