### PR TITLE
Return 404 for the LNURL withdraw link of an unknown pull payment

### DIFF
--- a/BTCPayServer/Controllers/UILNURLController.cs
+++ b/BTCPayServer/Controllers/UILNURLController.cs
@@ -119,7 +119,7 @@ namespace BTCPayServer
             var pmi = PayoutTypes.LN.GetPayoutMethodId(cryptoCode);
             var paymentMethodId = PaymentTypes.LN.GetPaymentMethodId(cryptoCode);
             var pp = await _pullPaymentHostedService.GetPullPayment(pullPaymentId, true);
-            if (!pp.IsRunning() || !pp.IsSupported(pmi) || !_payoutHandlers.TryGetValue(pmi, out var payoutHandler))
+            if (pp is null || !pp.IsRunning() || !pp.IsSupported(pmi) || !_payoutHandlers.TryGetValue(pmi, out var payoutHandler))
             {
                 return NotFound();
             }


### PR DESCRIPTION
Opening the LNURL withdraw link (`/{cryptoCode}/UILNURL/withdraw/pp/{pullPaymentId}`) with a pull payment id that does not exist returned a 500 server error. It now returns 404, the same as the other pull payment pages.

Nothing changes for existing pull payments.

Fixes #7562
