### PR TITLE
Respect user creation API policy for store invitations

### DIFF
--- a/BTCPayServer.Tests/GreenfieldAPITests.cs
+++ b/BTCPayServer.Tests/GreenfieldAPITests.cs
@@ -3447,6 +3447,36 @@ namespace BTCPayServer.Tests
 
         [Fact(Timeout = 60 * 2 * 1000)]
         [Trait("Integration", "Integration")]
+        public async Task StoreUserCreationRespectsNonAdminApiPolicy()
+        {
+            using var tester = CreateServerTester();
+            await tester.StartAsync();
+
+            var owner = tester.NewAccount();
+            await owner.GrantAccessAsync();
+            var client = await owner.CreateClient(Policies.CanModifyStoreSettings);
+            var settings = tester.PayTester.GetService<SettingsRepository>();
+            await settings.UpdateSetting(new PoliciesSettings
+            {
+                LockSubscription = false,
+                DisableNonAdminCreateUserApi = true
+            });
+
+            var email = $"{Guid.NewGuid():N}@example.com";
+            await AssertPermissionError(Policies.CanCreateUser, async () =>
+                await client.AddStoreUser(owner.StoreId, new AddStoreUserDataRequest { Id = email }));
+
+            await settings.UpdateSetting(new PoliciesSettings
+            {
+                LockSubscription = false,
+                DisableNonAdminCreateUserApi = false
+            });
+            var result = await client.AddStoreUser(owner.StoreId, new AddStoreUserDataRequest { Id = email });
+            Assert.NotNull(result.StoreInvitation);
+        }
+
+        [Fact(Timeout = 60 * 2 * 1000)]
+        [Trait("Integration", "Integration")]
         public async Task DisabledEnabledUserTests()
         {
             using var tester = CreateServerTester();

--- a/BTCPayServer/Controllers/GreenField/GreenfieldStoreUsersController.cs
+++ b/BTCPayServer/Controllers/GreenField/GreenfieldStoreUsersController.cs
@@ -218,7 +218,7 @@ namespace BTCPayServer.Controllers.Greenfield
             var user = await userManager.FindByIdOrEmail(id);
             if (user is null && createUser && MailboxAddressValidator.IsMailboxAddress(id))
             {
-                if (policiesSettings.LockSubscription &&
+                if ((policiesSettings.LockSubscription || policiesSettings.DisableNonAdminCreateUserApi) &&
                     !(await authorizationService.AuthorizeAsync(User, null, new PolicyRequirement(Policies.CanCreateUser))).Succeeded)
                     return (this.CreateAPIPermissionError(Policies.CanCreateUser), null, null);
 


### PR DESCRIPTION
Store owners can invite an email address that does not have an account yet. Creating that account now respects the server policy that disables non-admin user creation through the API.

Previously, the store-user API could create the account even when an administrator had disabled non-admin API user creation. Existing users can still be invited normally.