### PR TITLE
Honor store invitation bypass policy in Greenfield

### DIFF
--- a/BTCPayServer.Tests/GreenfieldAPITests.cs
+++ b/BTCPayServer.Tests/GreenfieldAPITests.cs
@@ -3447,6 +3447,34 @@ namespace BTCPayServer.Tests
 
         [Fact(Timeout = 60 * 2 * 1000)]
         [Trait("Integration", "Integration")]
+        public async Task StoreOwnerCanSkipInvitationThroughApiWhenAllowed()
+        {
+            using var tester = CreateServerTester();
+            await tester.StartAsync();
+
+            var owner = tester.NewAccount();
+            await owner.GrantAccessAsync();
+            var invitee = tester.NewAccount();
+            await invitee.GrantAccessAsync();
+            var client = await owner.CreateClient(Policies.CanModifyStoreSettings);
+            var request = new AddStoreUserDataRequest
+            {
+                Id = invitee.UserId,
+                RequireInvitation = false
+            };
+
+            await AssertPermissionError(Policies.CanModifyServerSettings, async () =>
+                await client.AddStoreUser(owner.StoreId, request));
+
+            var settings = tester.PayTester.GetService<SettingsRepository>();
+            await settings.UpdateSetting(new PoliciesSettings { AllowStoreOwnersToSkipInvitation = true });
+            await client.AddStoreUser(owner.StoreId, request);
+
+            Assert.Contains(await client.GetStoreUsers(owner.StoreId), user => user.Id == invitee.UserId);
+        }
+
+        [Fact(Timeout = 60 * 2 * 1000)]
+        [Trait("Integration", "Integration")]
         public async Task DisabledEnabledUserTests()
         {
             using var tester = CreateServerTester();

--- a/BTCPayServer/Controllers/GreenField/GreenfieldStoreUsersController.cs
+++ b/BTCPayServer/Controllers/GreenField/GreenfieldStoreUsersController.cs
@@ -107,7 +107,8 @@ namespace BTCPayServer.Controllers.Greenfield
         public async Task<IActionResult> AddStoreUser(string storeId, AddStoreUserDataRequest request)
         {
             var requireInvitation = request.RequireInvitation ?? true;
-            if (!requireInvitation && !(await authorizationService.AuthorizeAsync(User, null, Policies.CanModifyServerSettings)).Succeeded)
+            if (!requireInvitation && !policiesSettings.AllowStoreOwnersToSkipInvitation &&
+                !(await authorizationService.AuthorizeAsync(User, null, Policies.CanModifyServerSettings)).Succeeded)
                 return this.CreateAPIPermissionError(Policies.CanModifyServerSettings, "You are not allowed to add users without invitation");
 
             var (error, user, roleId) = await GetStoreUserRequest(storeId, request, null, createUser: true);


### PR DESCRIPTION
When administrators allow store owners to add users without an invitation, the Greenfield API now honors that setting too.

Previously, the setting worked in the web interface but API requests still required server-administrator permission. When the setting is disabled, the existing restriction remains unchanged.