### PR TITLE
Update POS callback authentication guidance

### DIFF
--- a/BTCPayServer/Plugins/PointOfSale/Views/UpdatePointOfSale.cshtml
+++ b/BTCPayServer/Plugins/PointOfSale/Views/UpdatePointOfSale.cshtml
@@ -337,7 +337,7 @@ Please insert valid HTML here. Only meta tags accepted.'>
                                 <pre class="p-3">@Model.ExampleCallback</pre>
                                 <p html-translate="true"><strong>Never</strong> trust anything but <code>id</code>, <strong>ignore</strong> the other fields completely, an attacker can spoof those, they are present only for backward compatibility reason:</p>
                                 <ul>
-                                    <li html-translate="true">Send a <code>GET</code> request to <code>https://btcpay.example.com/invoices/{invoiceId}</code> with <code>Content-Type: application/json; Authorization: Basic YourLegacyAPIkey"</code>, Legacy API key can be created with Access Tokens in Store settings</li>
+                                    <li html-translate="true">Send a <code>GET</code> request to <code>https://btcpay.example.com/api/v1/invoices/{invoiceId}</code> with <code>Authorization: token YOUR_API_KEY</code>. Create the API key in Account settings and grant it the View invoices permission for this store.</li>
                                     <li html-translate="true">Verify that the <code>orderId</code> is from your backend, that the <code>price</code> is correct and that <code>status</code> is <code>settled</code></li>
                                     <li text-translate="true">You can then ship your order</li>
                                 </ul>

--- a/BTCPayServer/Plugins/Translations/Translations.Default.cs
+++ b/BTCPayServer/Plugins/Translations/Translations.Default.cs
@@ -1629,7 +1629,7 @@ namespace BTCPayServer.Plugins.Translations
   "selected": "",
   "Send": "",
   "Send {0}": "",
-  "Send a <code>GET</code> request to <code>https://btcpay.example.com/invoices/{invoiceId}</code> with <code>Content-Type: application/json; Authorization: Basic YourLegacyAPIkey\"</code>, Legacy API key can be created with Access Tokens in Store settings": "",
+  "Send a <code>GET</code> request to <code>https://btcpay.example.com/api/v1/invoices/{invoiceId}</code> with <code>Authorization: token YOUR_API_KEY</code>. Create the API key in Account settings and grant it the View invoices permission for this store.": "",
   "Send invitation email": "",
   "Send me everything": "",
   "Send requests": "",


### PR DESCRIPTION
The Point of Sale callback instructions now use the supported Greenfield invoice API and API-key authentication. They also identify the store-scoped View invoices permission needed to verify callback data.

The previous instructions referenced the removed legacy API-key flow, leaving merchants without a working verification procedure.

No screenshot is included because this only corrects text inside the existing Notification URL Callbacks help section.