### PR TITLE
Fix typo in the multisig method name GetDerivationSchemeSettings

### DIFF
--- a/BTCPayServer/Plugins/Multisig/Controllers/UIMultisigWalletsController.cs
+++ b/BTCPayServer/Plugins/Multisig/Controllers/UIMultisigWalletsController.cs
@@ -195,7 +195,7 @@ public class UIMultisigWalletsController(
             return View("MultisigConfirm", vm);
         }
 
-        var strategy = pending.GetDiredivationSchemeSettings(network);
+        var strategy = pending.GetDerivationSchemeSettings(network);
         var wallet = walletProvider.GetWallet(network);
         if (wallet is null)
         {
@@ -237,7 +237,7 @@ public class UIMultisigWalletsController(
             return RedirectToMultisigSetup(pending.RequestId);
         }
 
-        var strategy = pending.GetDiredivationSchemeSettings(network);
+        var strategy = pending.GetDerivationSchemeSettings(network);
         var vm = new MultisigSetupViewModel
         {
             MultisigRequestId = pending.RequestId,

--- a/BTCPayServer/Plugins/Multisig/Models/MultisigSetupData.cs
+++ b/BTCPayServer/Plugins/Multisig/Models/MultisigSetupData.cs
@@ -28,7 +28,7 @@ public class MultisigSetupData
     => !string.IsNullOrEmpty(userId) &&
        Participants.Any(p => string.Equals(p.UserId, userId, StringComparison.Ordinal));
 
-    public DerivationSchemeSettings GetDiredivationSchemeSettings(BTCPayNetwork network)
+    public DerivationSchemeSettings GetDerivationSchemeSettings(BTCPayNetwork network)
     {
         var suffix = ScriptType.ToLowerInvariant() switch
         {


### PR DESCRIPTION
The method that builds the wallet settings for a multisig setup was named `GetDiredivationSchemeSettings`. It is now `GetDerivationSchemeSettings`. Only the name changed, the code inside is the same.

Nothing changes for users.
