### PR TITLE
Show an error instead of 500 when confirming a removed API key

### DIFF
--- a/BTCPayServer/Controllers/UIManageController.APIKeys.cs
+++ b/BTCPayServer/Controllers/UIManageController.APIKeys.cs
@@ -221,6 +221,15 @@ namespace BTCPayServer.Controllers
                     var key = command == "authorize"
                         ? await CreateKey(viewModel, (viewModel.ApplicationIdentifier, viewModel.RedirectUrl?.AbsoluteUri))
                         : await _apiKeyRepository.GetKey(new APIKeyRepository.Selector.ByApiKey(viewModel.ApiKey));
+                    if (key is null)
+                    {
+                        TempData.SetStatusMessageModel(new StatusMessageModel
+                        {
+                            Severity = StatusMessageModel.StatusSeverity.Error,
+                            Message = StringLocalizer["The API key was not found"].Value
+                        });
+                        return RedirectToAction("APIKeys");
+                    }
                     key.Key ??= viewModel.ApiKey;
 
                     if (viewModel.RedirectUrl != null)


### PR DESCRIPTION
When an app asks you to confirm an existing API key, and that key was removed after the page was opened, clicking Confirm returned a 500 server error. Now it shows the message "The API key was not found" and opens the API keys page.

Nothing changes when the key still exists.

Fixes #7568
