### PR TITLE
Return 404 when sending a verification email to a deleted user

### DIFF
--- a/BTCPayServer/Controllers/UIServerController.Users.cs
+++ b/BTCPayServer/Controllers/UIServerController.Users.cs
@@ -455,9 +455,7 @@ namespace BTCPayServer.Controllers
         {
             var user = await _UserManager.FindByIdAsync(userId);
             if (user == null)
-            {
-                throw new ApplicationException($"Unable to load user with ID '{userId}'.");
-            }
+                return NotFound();
 
             var callbackUrl = await _callbackGenerator.ForEmailConfirmation(user);
             _eventAggregator.Publish(new UserEvent.ConfirmationEmailRequested(user, callbackUrl));


### PR DESCRIPTION
On the server users page, clicking "Send verification email" for a user that was deleted in the meantime returned a 500 server error. It now returns 404, the same as the other user actions on that page.

Nothing changes when the user still exists.

Fixes #7571
