### PR TITLE
[WIP] Allow admins to archive and delete any store

### DIFF
--- a/BTCPayServer.Tests/AdminStoreManagementTests.cs
+++ b/BTCPayServer.Tests/AdminStoreManagementTests.cs
@@ -1,0 +1,71 @@
+using System.Threading.Tasks;
+using Microsoft.Playwright;
+using Xunit;
+using static Microsoft.Playwright.Assertions;
+
+namespace BTCPayServer.Tests;
+
+[Collection(nameof(NonParallelizableCollectionDefinition))]
+public class AdminStoreManagementTests(ITestOutputHelper testOutputHelper) : UnitTestBase(testOutputHelper)
+{
+    [Fact]
+    [Trait("Playwright", "Playwright")]
+    public async Task AdminCanDeleteStoreLeftBehindByADeletedUser()
+    {
+        await using var s = CreatePlaywrightTester(newDb: true);
+        await s.StartAsync();
+
+        var admin = await s.RegisterNewUser(true);
+        await s.SkipWizard();
+        await s.Logout();
+
+        await s.GoToRegister();
+        var owner = await s.RegisterNewUser();
+        var (_, storeId) = await s.CreateNewStore();
+        await s.Logout();
+
+        await s.LogIn(admin);
+
+        await s.GoToUrl($"/stores/{storeId}/settings");
+        await Expect(s.Page.Locator("#DeleteStore")).ToHaveCountAsync(0);
+
+        await s.GoToUrl("/server/users");
+        await s.Page.Locator($"tr:has-text('{owner}')").Locator(".delete-user").ClickAsync();
+        await s.Page.Locator("#ConfirmContinue").ClickAsync();
+        await s.FindAlertMessage(partialText: "User deleted");
+
+        await s.GoToUrl("/server/stores");
+        await Expect(s.Page.Locator($"#store_{storeId}")).ToHaveCountAsync(1);
+        await s.Page.ClickAsync($"#DeleteStore-{storeId}");
+        await s.Page.Locator("#ConfirmContinue").ClickAsync();
+        await s.FindAlertMessage(partialText: "has been deleted");
+        await Expect(s.Page.Locator($"#store_{storeId}")).ToHaveCountAsync(0);
+    }
+
+    [Fact]
+    [Trait("Playwright", "Playwright")]
+    public async Task AdminCanArchiveAnotherUsersStore()
+    {
+        await using var s = CreatePlaywrightTester(newDb: true);
+        await s.StartAsync();
+
+        var admin = await s.RegisterNewUser(true);
+        await s.SkipWizard();
+        await s.Logout();
+        await s.GoToRegister();
+        await s.RegisterNewUser();
+        var (_, storeId) = await s.CreateNewStore();
+        await s.Logout();
+
+        await s.LogIn(admin);
+        await s.GoToUrl("/server/stores");
+
+        var row = s.Page.Locator($"#store_{storeId}");
+        await row.Locator(".store-list__archive").ClickAsync();
+        await s.FindAlertMessage(partialText: "has been archived");
+        await Expect(s.Page.Locator($"#store_{storeId}")).ToContainTextAsync("archived");
+
+        await s.Page.Locator($"#store_{storeId}").Locator(".store-list__archive").ClickAsync();
+        await s.FindAlertMessage(partialText: "has been unarchived");
+    }
+}

--- a/BTCPayServer/Controllers/UIServerController.cs
+++ b/BTCPayServer/Controllers/UIServerController.cs
@@ -159,6 +159,52 @@ namespace BTCPayServer.Controllers
             return View(vm);
         }
 
+        // Store owners manage their own stores through UIStoresController, which requires membership.
+        // These admin-scoped equivalents are the only way to reach a store nobody owns any more,
+        // which is what is left behind when the last member's account is deleted.
+        [HttpPost("server/stores/{storeId}/archive")]
+        public async Task<IActionResult> ToggleStoreArchive(string storeId)
+        {
+            var store = await _StoreRepository.FindStore(storeId);
+            if (store == null)
+                return NotFound();
+
+            store.Archived = !store.Archived;
+            await _StoreRepository.UpdateStore(store);
+
+            TempData[WellKnownTempData.SuccessMessage] = store.Archived
+                ? StringLocalizer["The store {0} has been archived.", store.StoreName].Value
+                : StringLocalizer["The store {0} has been unarchived.", store.StoreName].Value;
+            return RedirectToAction(nameof(ListStores));
+        }
+
+        [HttpGet("server/stores/{storeId}/delete")]
+        public async Task<IActionResult> DeleteStore(string storeId)
+        {
+            var store = await _StoreRepository.FindStore(storeId);
+            if (store == null)
+                return NotFound();
+
+            return View("Confirm", new ConfirmModel(StringLocalizer["Delete store"],
+                StringLocalizer["The store <strong>{0}</strong> will be permanently deleted. This action will also delete all invoices, apps and data associated with the store. Are you sure?", Html.Encode(store.StoreName)],
+                StringLocalizer["Delete"]));
+        }
+
+        [HttpPost("server/stores/{storeId}/delete")]
+        public async Task<IActionResult> DeleteStorePost(string storeId)
+        {
+            var store = await _StoreRepository.FindStore(storeId);
+            if (store == null)
+                return NotFound();
+
+            var storeName = store.StoreName;
+            if (await _StoreRepository.DeleteStore(storeId))
+                TempData[WellKnownTempData.SuccessMessage] = StringLocalizer["The store {0} has been deleted.", storeName].Value;
+            else
+                TempData[WellKnownTempData.ErrorMessage] = StringLocalizer["The store {0} could not be deleted.", storeName].Value;
+            return RedirectToAction(nameof(ListStores));
+        }
+
         static TimeSpan ShortOperation = TimeSpan.FromSeconds(10);
         public IHtmlHelper Html { get; }
         public BTCPayServerEnvironment Environment { get; }

--- a/BTCPayServer/Views/UIServer/ListStores.cshtml
+++ b/BTCPayServer/Views/UIServer/ListStores.cshtml
@@ -16,6 +16,7 @@
             <tr>
                 <th text-translate="true">Store</th>
                 <th text-translate="true">Users</th>
+                <th class="actions-col" text-translate="true">Actions</th>
             </tr>
         </thead>
         <tbody>
@@ -34,7 +35,11 @@
                     </td>
                     <td>@store.Users.Count User@(store.Users.Count == 1 ? "" : "s")</td>
                     <td class="text-end">
-                        <div class="d-inline-flex align-items-center gap-2">
+                        <div class="d-inline-flex align-items-center gap-3">
+                            <form method="post" asp-action="ToggleStoreArchive" asp-route-storeId="@store.StoreId">
+                                <button type="submit" class="btn btn-link p-0 store-list__archive">@(store.Archived ? StringLocalizer["Unarchive"] : StringLocalizer["Archive"])</button>
+                            </form>
+                            <a asp-action="DeleteStore" asp-route-storeId="@store.StoreId" class="store-list__delete" id="DeleteStore-@store.StoreId" text-translate="true">Delete</a>
                             <button class="accordion-button collapsed only-for-js ms-0 d-inline-block" type="button" data-bs-toggle="collapse" data-bs-target="#@detailsId" aria-expanded="false" aria-controls="@detailsId">
                                 <vc:icon symbol="caret-down" />
                             </button>


### PR DESCRIPTION
## Screenshots

TODO - Server Settings then Store Overview, which gains Archive and Delete next to each store.

Closes #5868

## The problem

If a user creates their own store and their account is later deleted, the store stays on the server with nobody attached to it. The owner is gone, and a server admin only has view access to stores they are not a member of, so the delete and archive buttons never appear for them. The store sits there permanently and no one can remove it.

## What changes

Server Settings, Store Overview now has Archive and Delete next to every store.

* **Delete** asks for confirmation, then permanently removes the store along with its invoices, apps and data. This is the same removal a store owner can already perform on their own store.
* **Archive** and **Unarchive** hide or restore a store in the usual store lists, matching the toggle a store owner already has.

That gives an admin a way to clear up stores nobody owns any more, which was the case the issue described, and a way to tidy up stores that are no longer in use.

## What does not change

**Admin access to stores is otherwise the same.** Admins still get view only access to a store they are not a member of. Opening someone else's store settings still shows no delete or archive button, and this PR adds no ability to change their wallets, invoices or settings. The two new actions live only on the server store list and require server admin.

**Store owners are unaffected.** Deleting or archiving your own store works exactly as before.

## Choices made

The simple version of this would be to give server admins the modify permission on every store. That was deliberately taken away in #3297, and it would hand admins write access to every store on the instance to solve a cleanup problem. Instead the two actions are admin only routes on the server store list, so the permission an admin holds inside a store is unchanged.

## Not included

* **Deleting a user still leaves their store behind.** This PR gives admins a way to clean that up afterwards. It does not change what happens when the user is deleted. Removing the store at that moment would silently destroy invoice history, so that deserves its own discussion. This is a choice to make, and something that *could* be addressed with Server Overview features like https://github.com/btcpayserver/btcpayserver/issues/6881, but worth discussion.

* There is no Greenfield API equivalent for either action.

