### PR TITLE
Add public invoice checkout API

### DIFF
--- a/BTCPayServer.Client/BTCPayServerClient.Invoices.cs
+++ b/BTCPayServer.Client/BTCPayServerClient.Invoices.cs
@@ -48,6 +48,12 @@ public partial class BTCPayServerClient
         return await SendHttpRequest<InvoiceData>($"api/v1/invoices/{invoiceId}", queryPayload, HttpMethod.Get, token);
     }
 
+    public virtual async Task<InvoiceCheckoutData> GetInvoiceCheckout(string invoiceId, CancellationToken token = default)
+    {
+        if (invoiceId == null) throw new ArgumentNullException(nameof(invoiceId));
+        return await SendHttpRequest<InvoiceCheckoutData>($"api/v1/invoices/{invoiceId}/checkout", null, HttpMethod.Get, token);
+    }
+
     public virtual async Task<InvoicePaymentMethodDataModel[]> GetInvoicePaymentMethods(string invoiceId,
         bool onlyAccountedPayments = true, bool includeSensitive = false,
         CancellationToken token = default)
@@ -95,6 +101,12 @@ public partial class BTCPayServerClient
     public virtual async Task ActivateInvoicePaymentMethod(string invoiceId, string paymentMethod, CancellationToken token = default)
     {
         await SendHttpRequest($"api/v1/invoices/{invoiceId}/payment-methods/{paymentMethod}/activate", null, HttpMethod.Post, token);
+    }
+
+    public virtual async Task<InvoiceCheckoutData> ActivateInvoicePaymentMethodForCheckout(string invoiceId,
+        string paymentMethod, CancellationToken token = default)
+    {
+        return await SendHttpRequest<InvoiceCheckoutData>($"api/v1/invoices/{invoiceId}/payment-methods/{paymentMethod}/activate", null, HttpMethod.Post, token);
     }
 
     public virtual async Task<PullPaymentData> RefundInvoice(

--- a/BTCPayServer.Client/Models/InvoiceCheckoutData.cs
+++ b/BTCPayServer.Client/Models/InvoiceCheckoutData.cs
@@ -1,0 +1,55 @@
+using System;
+using BTCPayServer.Client.JsonConverters;
+using BTCPayServer.JsonConverters;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
+namespace BTCPayServer.Client.Models;
+
+public class InvoiceCheckoutData
+{
+    public string Id { get; set; }
+
+    [JsonConverter(typeof(StringEnumConverter))]
+    public InvoiceType Type { get; set; }
+
+    public string Currency { get; set; }
+
+    [JsonConverter(typeof(NumericStringJsonConverter))]
+    public decimal Amount { get; set; }
+
+    [JsonConverter(typeof(NumericStringJsonConverter))]
+    public decimal PaidAmount { get; set; }
+
+    public string CheckoutLink { get; set; }
+
+    [JsonConverter(typeof(StringEnumConverter))]
+    public InvoiceStatus Status { get; set; }
+
+    [JsonConverter(typeof(StringEnumConverter))]
+    public InvoiceExceptionStatus AdditionalStatus { get; set; }
+
+    [JsonConverter(typeof(NBitcoin.JsonConverters.DateTimeToUnixTimeConverter))]
+    public DateTimeOffset MonitoringExpiration { get; set; }
+
+    [JsonConverter(typeof(NBitcoin.JsonConverters.DateTimeToUnixTimeConverter))]
+    public DateTimeOffset ExpirationTime { get; set; }
+
+    [JsonConverter(typeof(NBitcoin.JsonConverters.DateTimeToUnixTimeConverter))]
+    public DateTimeOffset CreatedTime { get; set; }
+
+    public CheckoutOptions Checkout { get; set; } = new();
+    public InvoiceDataBase.ReceiptOptions Receipt { get; set; } = new();
+    public InvoicePaymentMethodDataModel[] PaymentMethods { get; set; } = Array.Empty<InvoicePaymentMethodDataModel>();
+
+    public class CheckoutOptions
+    {
+        public string[] PaymentMethods { get; set; }
+        public string DefaultPaymentMethod { get; set; }
+
+        [JsonProperty("redirectURL")]
+        public string RedirectURL { get; set; }
+
+        public bool RedirectAutomatically { get; set; }
+    }
+}

--- a/BTCPayServer.Tests/GreenfieldAPITests.cs
+++ b/BTCPayServer.Tests/GreenfieldAPITests.cs
@@ -16,6 +16,7 @@ using BTCPayServer.Lightning;
 using BTCPayServer.Models.AccountViewModels;
 using BTCPayServer.Models.InvoicingModels;
 using BTCPayServer.Payments;
+using BTCPayServer.Payments.Bitcoin;
 using BTCPayServer.Payments.Lightning;
 using BTCPayServer.PayoutProcessors;
 using BTCPayServer.PayoutProcessors.Lightning;
@@ -40,6 +41,7 @@ using Newtonsoft.Json.Linq;
 using Xunit;
 using Xunit.Sdk;
 using CreateApplicationUserRequest = BTCPayServer.Client.Models.CreateApplicationUserRequest;
+using GreenfieldInvoiceController = BTCPayServer.Controllers.Greenfield.GreenfieldInvoiceController;
 using PayoutEvent = BTCPayServer.HostedServices.PayoutEvent;
 using PosViewType = BTCPayServer.Plugins.PointOfSale.PosViewType;
 
@@ -67,6 +69,18 @@ namespace BTCPayServer.Tests
 
             var client = await user.CreateClient(Policies.CanViewStoreSettings);
             await AssertAPIError("unsupported-in-v2", () => client.SendHttpRequest<object>($"api/v1/stores/{user.StoreId}/payment-methods/LightningNetwork"));
+        }
+
+        [Fact]
+        public void PublicPaymentMethodDetailsAreFailClosed()
+        {
+            var serializer = JsonSerializer.CreateDefault();
+            Assert.Null(GreenfieldInvoiceController.ToPublicPaymentMethodDetails("plugin-details", serializer));
+            Assert.Null(GreenfieldInvoiceController.ToPublicPaymentMethodDetails(new PluginBitcoinPaymentPromptDetails(), serializer));
+        }
+
+        private sealed class PluginBitcoinPaymentPromptDetails : BitcoinPaymentPromptDetails
+        {
         }
 
         [Fact(Timeout = TestTimeout)]
@@ -2160,7 +2174,8 @@ namespace BTCPayServer.Tests
             Assert.Equal($"https://example.com/invoices/{newInvoice.Id}", checkoutInvoice.Checkout.RedirectURL);
             Assert.True(checkoutInvoice.Checkout.RedirectAutomatically);
             Assert.Single(checkoutInvoice.PaymentMethods);
-            Assert.Equal(JTokenType.Null, checkoutInvoice.PaymentMethods[0].AdditionalData["accountDerivation"]?.Type);
+            Assert.Equal(new[] { "feeMode", "payjoinEnabled", "paymentMethodFeeRate", "recommendedFeeRate" },
+                checkoutInvoice.PaymentMethods[0].AdditionalData.Children<JProperty>().Select(p => p.Name).OrderBy(p => p));
 
             var checkoutJson = await anonymous.SendHttpRequest<JObject>($"api/v1/invoices/{newInvoice.Id}/checkout");
             Assert.Equal(new[]

--- a/BTCPayServer.Tests/GreenfieldAPITests.cs
+++ b/BTCPayServer.Tests/GreenfieldAPITests.cs
@@ -2134,6 +2134,7 @@ namespace BTCPayServer.Tests
             await user.SetupWebhook();
             var client = await user.CreateClient(Policies.Unrestricted);
             var viewOnly = await user.CreateClient(Policies.CanViewInvoices);
+            var basic = await user.CreateClient();
 
             //create
 
@@ -2353,6 +2354,9 @@ namespace BTCPayServer.Tests
             await client.ArchiveInvoice(invoice.Id);
             Assert.DoesNotContain(invoice.Id,
                 (await client.GetInvoices(user.StoreId)).Select(data => data.Id));
+            await AssertHttpError(404, () => anonymous.GetInvoiceCheckout(invoice.Id));
+            Assert.Equal(invoice.Id, (await viewOnly.GetInvoiceCheckout(invoice.Id)).Id);
+            Assert.Equal(invoice.Id, (await basic.GetInvoiceCheckout(invoice.Id)).Id);
 
             //unarchive
             await client.UnarchiveInvoice(invoice.Id);

--- a/BTCPayServer.Tests/GreenfieldAPITests.cs
+++ b/BTCPayServer.Tests/GreenfieldAPITests.cs
@@ -2144,12 +2144,31 @@ namespace BTCPayServer.Tests
                     Metadata = JObject.Parse($"{{\"itemCode\": \"testitem\", \"orderId\": \"{origOrderId}\"}}"),
                     Checkout = new CreateInvoiceRequest.CheckoutOptions()
                     {
-                        RedirectAutomatically = true
+                        RedirectAutomatically = true,
+                        RedirectURL = "https://example.com/invoices/{InvoiceId}"
                     },
                     AdditionalSearchTerms = new string[] { "Banana" }
                 });
             Assert.True(newInvoice.Checkout.RedirectAutomatically);
             Assert.Equal(user.StoreId, newInvoice.StoreId);
+
+            var anonymous = new BTCPayServerClient(tester.PayTester.ServerUri);
+            var checkoutInvoice = await anonymous.GetInvoiceCheckout(newInvoice.Id);
+            Assert.Equal(newInvoice.Id, checkoutInvoice.Id);
+            Assert.Equal(newInvoice.Amount, checkoutInvoice.Amount);
+            Assert.Equal(newInvoice.Currency, checkoutInvoice.Currency);
+            Assert.Equal($"https://example.com/invoices/{newInvoice.Id}", checkoutInvoice.Checkout.RedirectURL);
+            Assert.True(checkoutInvoice.Checkout.RedirectAutomatically);
+            Assert.Single(checkoutInvoice.PaymentMethods);
+            Assert.Equal(JTokenType.Null, checkoutInvoice.PaymentMethods[0].AdditionalData["accountDerivation"]?.Type);
+
+            var checkoutJson = await anonymous.SendHttpRequest<JObject>($"api/v1/invoices/{newInvoice.Id}/checkout");
+            Assert.Equal(new[]
+            {
+                "additionalStatus", "amount", "checkout", "checkoutLink", "createdTime", "currency", "expirationTime",
+                "id", "monitoringExpiration", "paidAmount", "paymentMethods", "receipt", "status", "type"
+            }, checkoutJson.Properties().Select(p => p.Name).OrderBy(p => p));
+            await AssertHttpError(404, () => anonymous.GetInvoiceCheckout("missing"));
             //list
             var invoices = await viewOnly.GetInvoices(user.StoreId);
 
@@ -2419,14 +2438,26 @@ namespace BTCPayServer.Tests
             paymentMethods = await client.GetInvoicePaymentMethods(invoice.Id);
             Assert.Single(paymentMethods);
             Assert.False(paymentMethods.First().Activated);
-            await client.ActivateInvoicePaymentMethod(invoice.Id,
+            checkoutInvoice = await anonymous.GetInvoiceCheckout(invoice.Id);
+            Assert.Equal(JTokenType.Null, Assert.Single(checkoutInvoice.PaymentMethods).AdditionalData?.Type);
+            checkoutInvoice = await anonymous.ActivateInvoicePaymentMethodForCheckout(invoice.Id,
                 paymentMethods.First().PaymentMethodId);
+            Assert.True(Assert.Single(checkoutInvoice.PaymentMethods).Activated);
             invoiceObject = await client.GetOnChainWalletObject(user.StoreId, "BTC", new OnChainWalletObjectId("invoice", invoice.Id), false);
             Assert.Contains(invoiceObject.Links.Select(l => l.Type), t => t == "address");
 
             paymentMethods = await client.GetInvoicePaymentMethods(invoice.Id);
             Assert.Single(paymentMethods);
             Assert.True(paymentMethods.First().Activated);
+
+            var unavailableInvoice = await client.CreateInvoice(user.StoreId,
+                new CreateInvoiceRequest { Amount = 1, Currency = "USD" });
+            var unavailablePaymentMethod = Assert.Single(await client.GetInvoicePaymentMethods(unavailableInvoice.Id));
+            await client.MarkInvoiceStatus(unavailableInvoice.Id,
+                new MarkInvoiceStatusRequest { Status = InvoiceStatus.Invalid });
+            await AssertEx.AssertApiError(400, "payment-method-unavailable", () =>
+                anonymous.ActivateInvoicePaymentMethodForCheckout(unavailableInvoice.Id,
+                    unavailablePaymentMethod.PaymentMethodId));
 
             var invoiceWithDefaultPaymentMethodLN = await client.CreateInvoice(user.StoreId,
                 new CreateInvoiceRequest()
@@ -2509,6 +2540,9 @@ namespace BTCPayServer.Tests
                 var pm = Assert.Single(await client.GetInvoicePaymentMethods(invoice.Id));
                 Assert.Single(pm.Payments);
                 Assert.Equal(-0.0001m, pm.Due);
+
+                checkoutInvoice = await anonymous.GetInvoiceCheckout(invoice.Id);
+                Assert.Single(Assert.Single(checkoutInvoice.PaymentMethods).Payments);
 
                 invoiceObject = await client.GetOnChainWalletObject(user.StoreId, "BTC", new OnChainWalletObjectId("invoice", invoice.Id), false);
                 Assert.Contains(invoiceObject.Links.Select(l => l.Type), t => t == "tx");

--- a/BTCPayServer.Tests/LightningTests.cs
+++ b/BTCPayServer.Tests/LightningTests.cs
@@ -43,6 +43,7 @@ public class LightningTests(ITestOutputHelper testOutputHelper) : UnitTestBase(t
         user.RegisterLightningNode("BTC", LightningTestImplementation.CoreLightning);
 
         var client = await user.CreateClient(Policies.Unrestricted);
+        var anonymous = new BTCPayServerClient(tester.PayTester.ServerUri);
         var invoices = new Task<Client.Models.InvoiceData>[5];
 
         // Create invoices
@@ -88,6 +89,11 @@ public class LightningTests(ITestOutputHelper testOutputHelper) : UnitTestBase(t
                 Assert.True(pm[i].AdditionalData.HasValues);
                 Assert.Equal(resp.Details.PaymentHash.ToString(), ((JObject)pm[i].AdditionalData).GetValue("paymentHash"));
                 Assert.Equal(resp.Details.Preimage.ToString(), ((JObject)pm[i].AdditionalData).GetValue("preimage"));
+
+                var checkout = await anonymous.GetInvoiceCheckout((await invoices[i]).Id);
+                var publicDetails = Assert.IsType<JObject>(Assert.Single(checkout.PaymentMethods).AdditionalData);
+                Assert.Null(publicDetails.GetValue("preimage"));
+                Assert.Null(publicDetails.GetValue("invoiceId"));
             });
         }
     }

--- a/BTCPayServer.Tests/LightningTests.cs
+++ b/BTCPayServer.Tests/LightningTests.cs
@@ -92,8 +92,8 @@ public class LightningTests(ITestOutputHelper testOutputHelper) : UnitTestBase(t
 
                 var checkout = await anonymous.GetInvoiceCheckout((await invoices[i]).Id);
                 var publicDetails = Assert.IsType<JObject>(Assert.Single(checkout.PaymentMethods).AdditionalData);
-                Assert.Null(publicDetails.GetValue("preimage"));
-                Assert.Null(publicDetails.GetValue("invoiceId"));
+                Assert.Equal(new[] { "nodeInfo", "paymentHash" },
+                    publicDetails.Properties().Select(p => p.Name).OrderBy(p => p));
             });
         }
     }

--- a/BTCPayServer/Controllers/GreenField/GreenfieldInvoiceController.cs
+++ b/BTCPayServer/Controllers/GreenField/GreenfieldInvoiceController.cs
@@ -17,6 +17,7 @@ using BTCPayServer.Security.Greenfield;
 using BTCPayServer.Services;
 using BTCPayServer.Services.Invoices;
 using BTCPayServer.Services.Rates;
+using BTCPayServer.Services.Stores;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Cors;
 using Microsoft.AspNetCore.Http;
@@ -47,6 +48,7 @@ namespace BTCPayServer.Controllers.Greenfield
         private readonly PaymentMethodHandlerDictionary _handlers;
         private readonly BTCPayNetworkProvider _networkProvider;
         private readonly DefaultRulesCollection _defaultRules;
+        private readonly StoreRepository _storeRepository;
 
         public LanguageService LanguageService { get; }
 
@@ -61,7 +63,8 @@ namespace BTCPayServer.Controllers.Greenfield
             PayoutMethodHandlerDictionary payoutHandlers,
             PaymentMethodHandlerDictionary handlers,
             BTCPayNetworkProvider networkProvider,
-            DefaultRulesCollection defaultRules)
+            DefaultRulesCollection defaultRules,
+            StoreRepository storeRepository)
         {
             _invoiceController = invoiceController;
             _invoiceRepository = invoiceRepository;
@@ -77,6 +80,7 @@ namespace BTCPayServer.Controllers.Greenfield
             _handlers = handlers;
             _networkProvider = networkProvider;
             _defaultRules = defaultRules;
+            _storeRepository = storeRepository;
             LanguageService = languageService;
         }
 
@@ -135,6 +139,17 @@ namespace BTCPayServer.Controllers.Greenfield
             if (invoice is null)
                 return InvoiceNotFound();
             return Ok(ToModel(invoice, includePaymentMethods));
+        }
+
+        [AllowAnonymous]
+        [ResponseCache(NoStore = true, Location = ResponseCacheLocation.None)]
+        [HttpGet("~/api/v1/invoices/{invoiceId}/checkout")]
+        public async Task<IActionResult> GetInvoiceCheckout(string invoiceId)
+        {
+            var invoice = await GetInvoiceCheckoutEntity(invoiceId);
+            if (invoice is null)
+                return InvoiceNotFound();
+            return Ok(await ToInvoiceCheckoutModel(invoice));
         }
 
         [Authorize(Policy = Policies.CanModifyInvoices,
@@ -301,18 +316,25 @@ namespace BTCPayServer.Controllers.Greenfield
             return Ok(ToPaymentMethodModels(invoice, onlyAccountedPayments, includeSensitive));
         }
 
-        [Authorize(Policy = Policies.CanViewInvoices,
-            AuthenticationSchemes = AuthenticationSchemes.Greenfield)]
+        [AllowAnonymous]
         [HttpPost("~/api/v1/stores/{storeId}/invoices/{invoiceId}/payment-methods/{paymentMethod}/activate")]
         [HttpPost("~/api/v1/invoices/{invoiceId}/payment-methods/{paymentMethod}/activate")]
         public async Task<IActionResult> ActivateInvoicePaymentMethod(string? storeId, string invoiceId, string paymentMethod)
         {
-            if (HttpContext.GetInvoiceDataOrNull() is null)
+            var invoice = await GetInvoiceCheckoutEntity(invoiceId);
+            if (invoice is null)
                 return InvoiceNotFound();
-            if (PaymentMethodId.TryParse(paymentMethod, out var paymentMethodId))
+            if (PaymentMethodId.TryParse(paymentMethod, out var paymentMethodId) &&
+                invoice.GetPaymentPrompt(paymentMethodId) is { } prompt)
             {
-                await _invoiceActivator.ActivateInvoicePaymentMethod(invoiceId, paymentMethodId);
-                return Ok();
+                if (!prompt.Activated && !await _invoiceActivator.ActivateInvoicePaymentMethod(invoiceId, paymentMethodId))
+                {
+                    var current = await _invoiceRepository.GetInvoice(invoiceId);
+                    if (current?.GetPaymentPrompt(paymentMethodId)?.Activated is not true)
+                        return this.CreateAPIError(400, "payment-method-unavailable", "The payment method could not be activated");
+                }
+                invoice = await _invoiceRepository.GetInvoice(invoiceId);
+                return invoice is null ? InvoiceNotFound() : Ok(await ToInvoiceCheckoutModel(invoice));
             }
             ModelState.AddModelError(nameof(paymentMethod), "Invalid payment method");
             return this.CreateValidationError(ModelState);
@@ -600,7 +622,64 @@ namespace BTCPayServer.Controllers.Greenfield
             return this.CreateAPIError(404, "invoice-not-found", "The invoice was not found");
         }
 
-        private InvoicePaymentMethodDataModel[] ToPaymentMethodModels(InvoiceEntity entity, bool includeAccountedPaymentOnly, bool includeSensitive)
+        private async Task<InvoiceEntity?> GetInvoiceCheckoutEntity(string invoiceId)
+        {
+            var invoice = await _invoiceRepository.GetInvoice(invoiceId);
+            if (invoice is null)
+                return null;
+            if (!invoice.Archived)
+                return invoice;
+            var authorization = await _authorizationService.AuthorizeAsync(User, invoice.StoreId, Policies.CanViewInvoices);
+            return authorization.Succeeded ? invoice : null;
+        }
+
+        private async Task<InvoiceCheckoutData> ToInvoiceCheckoutModel(InvoiceEntity entity)
+        {
+            var store = await _storeRepository.FindStore(entity.StoreId);
+            var invoice = ToModel(entity);
+            PaymentMethodId? defaultPaymentMethod = null;
+            if (store is not null)
+            {
+                var displayedPaymentMethods = entity.GetPaymentPrompts().Select(p => p.PaymentMethodId).ToHashSet();
+                var btcId = PaymentTypes.CHAIN.GetPaymentMethodId("BTC");
+                var lnurlId = PaymentTypes.LNURL.GetPaymentMethodId("BTC");
+                var lnId = PaymentTypes.LN.GetPaymentMethodId("BTC");
+                if (store.GetStoreBlob().OnChainWithLnInvoiceFallback && displayedPaymentMethods.Contains(btcId))
+                {
+                    displayedPaymentMethods.Remove(lnId);
+                    displayedPaymentMethods.Remove(lnurlId);
+                }
+                if (displayedPaymentMethods.Contains(lnId) && displayedPaymentMethods.Contains(lnurlId))
+                    displayedPaymentMethods.Remove(lnurlId);
+                defaultPaymentMethod = entity.GetDefaultPaymentMethodId(store, _networkProvider, displayedPaymentMethods);
+            }
+            return new InvoiceCheckoutData
+            {
+                Id = invoice.Id,
+                Type = invoice.Type,
+                Currency = invoice.Currency,
+                Amount = invoice.Amount,
+                PaidAmount = invoice.PaidAmount,
+                CheckoutLink = invoice.CheckoutLink,
+                Status = invoice.Status,
+                AdditionalStatus = invoice.AdditionalStatus,
+                MonitoringExpiration = invoice.MonitoringExpiration,
+                ExpirationTime = invoice.ExpirationTime,
+                CreatedTime = invoice.CreatedTime,
+                Checkout = new InvoiceCheckoutData.CheckoutOptions
+                {
+                    PaymentMethods = invoice.Checkout.PaymentMethods,
+                    DefaultPaymentMethod = defaultPaymentMethod?.ToString() ?? invoice.Checkout.DefaultPaymentMethod,
+                    RedirectURL = entity.RedirectURL?.AbsoluteUri,
+                    RedirectAutomatically = entity.RedirectAutomatically
+                },
+                Receipt = InvoiceDataBase.ReceiptOptions.Merge(store?.GetStoreBlob().ReceiptOptions, entity.ReceiptOptions),
+                PaymentMethods = ToPaymentMethodModels(entity, false, false, true)
+            };
+        }
+
+        private InvoicePaymentMethodDataModel[] ToPaymentMethodModels(InvoiceEntity entity, bool includeAccountedPaymentOnly,
+            bool includeSensitive, bool publicCheckout = false)
         {
             return entity.GetPaymentPrompts().Select(
                 prompt =>
@@ -611,13 +690,18 @@ namespace BTCPayServer.Controllers.Greenfield
                         paymentEntity.PaymentMethodId == prompt.PaymentMethodId);
                     _paymentLinkExtensions.TryGetValue(prompt.PaymentMethodId, out var paymentLinkExtension);
 
-                    var details = prompt.Details;
+                    JToken? details = publicCheckout ? null : prompt.Details;
                     if (handler is not null && prompt.Activated)
                     {
-                        var detailsObj = handler.ParsePaymentPromptDetails(details);
+                        var detailsObj = handler.ParsePaymentPromptDetails(prompt.Details);
                         if (!includeSensitive)
                             handler.StripDetailsForNonOwner(detailsObj);
                         details = JToken.FromObject(detailsObj, handler.Serializer.ForAPI());
+                        if (publicCheckout && details is JObject publicDetails)
+                        {
+                            publicDetails.Remove("preimage");
+                            publicDetails.Remove("invoiceId");
+                        }
                     }
                     return new InvoicePaymentMethodDataModel
                     {

--- a/BTCPayServer/Controllers/GreenField/GreenfieldInvoiceController.cs
+++ b/BTCPayServer/Controllers/GreenField/GreenfieldInvoiceController.cs
@@ -11,6 +11,8 @@ using BTCPayServer.Client.Models;
 using BTCPayServer.Data;
 using BTCPayServer.HostedServices;
 using BTCPayServer.Payments;
+using BTCPayServer.Payments.Bitcoin;
+using BTCPayServer.Payments.Lightning;
 using BTCPayServer.Payouts;
 using BTCPayServer.Rating;
 using BTCPayServer.Security.Greenfield;
@@ -23,6 +25,7 @@ using Microsoft.AspNetCore.Cors;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using CreateInvoiceRequest = BTCPayServer.Client.Models.CreateInvoiceRequest;
 using InvoiceData = BTCPayServer.Client.Models.InvoiceData;
@@ -696,12 +699,9 @@ namespace BTCPayServer.Controllers.Greenfield
                         var detailsObj = handler.ParsePaymentPromptDetails(prompt.Details);
                         if (!includeSensitive)
                             handler.StripDetailsForNonOwner(detailsObj);
-                        details = JToken.FromObject(detailsObj, handler.Serializer.ForAPI());
-                        if (publicCheckout && details is JObject publicDetails)
-                        {
-                            publicDetails.Remove("preimage");
-                            publicDetails.Remove("invoiceId");
-                        }
+                        details = publicCheckout
+                            ? ToPublicPaymentMethodDetails(detailsObj, handler.Serializer.ForAPI())
+                            : JToken.FromObject(detailsObj, handler.Serializer.ForAPI());
                     }
                     return new InvoicePaymentMethodDataModel
                     {
@@ -720,6 +720,29 @@ namespace BTCPayServer.Controllers.Greenfield
                         AdditionalData = details
                     };
                 }).ToArray();
+        }
+
+        internal static JObject? ToPublicPaymentMethodDetails(object details, JsonSerializer serializer)
+        {
+            var detailsType = details.GetType();
+            string[]? publicProperties =
+                detailsType == typeof(LNURLPayPaymentMethodDetails) ? ["paymentHash", "nodeInfo", "bech32Mode"] :
+                detailsType == typeof(LigthningPaymentPromptDetails) ? ["paymentHash", "nodeInfo"] :
+                detailsType == typeof(BitcoinPaymentPromptDetails) ?
+                    ["feeMode", "paymentMethodFeeRate", "assetId", "payjoinEnabled", "recommendedFeeRate"] :
+                    null;
+            if (publicProperties is null)
+                return null;
+            if (JToken.FromObject(details, serializer) is not JObject serializedDetails)
+                return null;
+
+            var result = new JObject();
+            foreach (var property in publicProperties)
+            {
+                if (serializedDetails.TryGetValue(property, out var value))
+                    result[property] = value;
+            }
+            return result;
         }
 
         public static InvoicePaymentMethodDataModel.Payment ToPaymentModel(InvoiceEntity entity, PaymentEntity paymentEntity)

--- a/BTCPayServer/Controllers/GreenField/GreenfieldInvoiceController.cs
+++ b/BTCPayServer/Controllers/GreenField/GreenfieldInvoiceController.cs
@@ -20,6 +20,7 @@ using BTCPayServer.Services;
 using BTCPayServer.Services.Invoices;
 using BTCPayServer.Services.Rates;
 using BTCPayServer.Services.Stores;
+using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Cors;
 using Microsoft.AspNetCore.Http;
@@ -633,7 +634,19 @@ namespace BTCPayServer.Controllers.Greenfield
             if (!invoice.Archived)
                 return invoice;
             var authorization = await _authorizationService.AuthorizeAsync(User, invoice.StoreId, Policies.CanViewInvoices);
-            return authorization.Succeeded ? invoice : null;
+            if (authorization.Succeeded)
+                return invoice;
+            foreach (var scheme in new[] { AuthenticationSchemes.GreenfieldAPIKeys, AuthenticationSchemes.GreenfieldBasic })
+            {
+                var authentication = await HttpContext.AuthenticateAsync(scheme);
+                if (authentication is { Succeeded: true, Principal: { } principal })
+                {
+                    HttpContext.User = principal;
+                    authorization = await _authorizationService.AuthorizeAsync(User, invoice.StoreId, Policies.CanViewInvoices);
+                    return authorization.Succeeded ? invoice : null;
+                }
+            }
+            return null;
         }
 
         private async Task<InvoiceCheckoutData> ToInvoiceCheckoutModel(InvoiceEntity entity)

--- a/BTCPayServer/wwwroot/swagger/v1/swagger.template.invoices.json
+++ b/BTCPayServer/wwwroot/swagger/v1/swagger.template.invoices.json
@@ -342,6 +342,44 @@
                 ]
             }
         },
+        "/api/v1/invoices/{invoiceId}/checkout": {
+            "get": {
+                "tags": [
+                    "Invoices"
+                ],
+                "summary": "Get invoice checkout",
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/InvoiceId"
+                    }
+                ],
+                "description": "View the public checkout information for the specified invoice, including all payment methods and payments. This endpoint does not require authentication; possession of the invoice ID grants access to this information.",
+                "operationId": "Invoices_GetInvoiceCheckout",
+                "responses": {
+                    "200": {
+                        "description": "Public invoice checkout information",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/InvoiceCheckoutData"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "The invoice was not found or is not publicly accessible",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProblemDetails"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": []
+            }
+        },
         "/api/v1/invoices/{invoiceId}/payment-methods": {
             "get": {
                 "tags": [
@@ -531,10 +569,27 @@
                 "operationId": "Invoices_ActivatePaymentMethod",
                 "responses": {
                     "200": {
-                        "description": ""
+                        "description": "The refreshed public invoice checkout information",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/InvoiceCheckoutData"
+                                }
+                            }
+                        }
                     },
                     "400": {
-                        "description": "A list of errors that occurred when updating the invoice",
+                        "description": "The payment method is invalid or could not be activated",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProblemDetails"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "The payment method identifier is invalid",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -543,18 +598,11 @@
                             }
                         }
                     },
-                    "403": {
-                        "description": "If you are authenticated but forbidden to activate the invoice payment method"
+                    "404": {
+                        "description": "The invoice was not found or is not publicly accessible"
                     }
                 },
-                "security": [
-                    {
-                        "API_Key": [
-                            "btcpay.store.canviewinvoices"
-                        ],
-                        "Basic": []
-                    }
-                ]
+                "security": []
             }
         },
         "/api/v1/invoices/{invoiceId}/refund": {
@@ -864,6 +912,112 @@
                         }
                     }
                 ]
+            },
+            "InvoiceCheckoutData": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "id": {
+                        "$ref": "#/components/schemas/InvoiceId"
+                    },
+                    "type": {
+                        "$ref": "#/components/schemas/InvoiceType"
+                    },
+                    "currency": {
+                        "type": "string",
+                        "description": "The currency of the invoice",
+                        "example": "USD"
+                    },
+                    "amount": {
+                        "type": "string",
+                        "format": "decimal",
+                        "description": "The amount of the invoice.",
+                        "example": "5.00"
+                    },
+                    "paidAmount": {
+                        "type": "string",
+                        "format": "decimal",
+                        "description": "The actual amount paid by the customer/buyer.",
+                        "example": "5.00"
+                    },
+                    "checkoutLink": {
+                        "type": "string",
+                        "description": "The link to the checkout page"
+                    },
+                    "status": {
+                        "$ref": "#/components/schemas/InvoiceStatus"
+                    },
+                    "additionalStatus": {
+                        "$ref": "#/components/schemas/InvoiceAdditionalStatus"
+                    },
+                    "monitoringExpiration": {
+                        "description": "Expiration time for monitoring the invoice for changes",
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/UnixTimestamp"
+                            }
+                        ]
+                    },
+                    "expirationTime": {
+                        "description": "The expiration time of the invoice",
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/UnixTimestamp"
+                            }
+                        ]
+                    },
+                    "createdTime": {
+                        "description": "The creation time of the invoice",
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/UnixTimestamp"
+                            }
+                        ]
+                    },
+                    "checkout": {
+                        "$ref": "#/components/schemas/InvoiceCheckoutOptions"
+                    },
+                    "receipt": {
+                        "$ref": "#/components/schemas/ReceiptOptions"
+                    },
+                    "paymentMethods": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/InvoicePaymentMethodDataModel"
+                        }
+                    }
+                }
+            },
+            "InvoiceCheckoutOptions": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "paymentMethods": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/PaymentMethodId"
+                        },
+                        "description": "All payment methods available for this invoice."
+                    },
+                    "defaultPaymentMethod": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/PaymentMethodId"
+                            }
+                        ],
+                        "nullable": true,
+                        "description": "The payment method selected by default for checkout."
+                    },
+                    "redirectURL": {
+                        "type": "string",
+                        "nullable": true,
+                        "description": "The resolved URL to redirect the customer to after checkout."
+                    },
+                    "redirectAutomatically": {
+                        "type": "boolean",
+                        "description": "Whether checkout automatically redirects the customer when the invoice is settled."
+                    }
+                }
             },
             "InvoiceMetadata": {
                 "type": "object",
@@ -1248,6 +1402,7 @@
                     },
                     "destination": {
                         "type": "string",
+                        "nullable": true,
                         "description": "The destination the payment must be made to"
                     },
                     "paymentLink": {
@@ -1299,7 +1454,8 @@
                         "description": "If the payment method is activated (when lazy payments option is enabled"
                     },
                     "additionalData": {
-                        "description": "Additional data provided by the payment method.",
+                        "nullable": true,
+                        "description": "Additional data provided by the payment method. Sensitive wallet details are excluded from public checkout responses, including account derivations, Lightning preimages, and backend invoice identifiers.",
                         "anyOf": [
                             {
                                 "type": "object",
@@ -1336,6 +1492,7 @@
                                     },
                                     "accountDerivation": {
                                         "type": "string",
+                                        "nullable": true,
                                         "description": "The derivation scheme used to derive addresses (null if `includeSensitive` is `false`)",
                                         "example": "xpub6DVMcQAQCtGbNDTEjQGtR1GRoTKw7AzP6bVivX4gFnewcnRk1r1tbczpfsaYjKKVrmtyiwYqAEnALYzZ8yoTArVsKfZekmwLFqQp4MRgPhy"
                                     },
@@ -1355,6 +1512,7 @@
                             },
                             {
                                 "type": "object",
+                                "nullable": true,
                                 "description": "No additional information"
                             }
                         ]

--- a/BTCPayServer/wwwroot/swagger/v1/swagger.template.invoices.json
+++ b/BTCPayServer/wwwroot/swagger/v1/swagger.template.invoices.json
@@ -983,7 +983,7 @@
                     "paymentMethods": {
                         "type": "array",
                         "items": {
-                            "$ref": "#/components/schemas/InvoicePaymentMethodDataModel"
+                            "$ref": "#/components/schemas/InvoiceCheckoutPaymentMethodDataModel"
                         }
                     }
                 }
@@ -1455,7 +1455,7 @@
                     },
                     "additionalData": {
                         "nullable": true,
-                        "description": "Additional data provided by the payment method. Sensitive wallet details are excluded from public checkout responses, including account derivations, Lightning preimages, and backend invoice identifiers.",
+                        "description": "Additional data provided by the payment method.",
                         "anyOf": [
                             {
                                 "type": "object",
@@ -1518,6 +1518,157 @@
                         ]
                     }
                 }
+            },
+            "InvoiceCheckoutPaymentMethodDataModel": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "paymentMethodId": {
+                        "$ref": "#/components/schemas/PaymentMethodId"
+                    },
+                    "currency": {
+                        "type": "string",
+                        "description": "The currency of the payment method (e.g., \"BTC\" or \"LTC\")",
+                        "example": "BTC"
+                    },
+                    "destination": {
+                        "type": "string",
+                        "nullable": true,
+                        "description": "The destination the payment must be made to"
+                    },
+                    "paymentLink": {
+                        "type": "string",
+                        "nullable": true,
+                        "description": "A payment link that helps pay to the payment destination"
+                    },
+                    "rate": {
+                        "type": "string",
+                        "format": "decimal",
+                        "example": "64392.23",
+                        "description": "The rate between this payment method's currency and the invoice currency"
+                    },
+                    "paymentMethodPaid": {
+                        "type": "string",
+                        "format": "decimal",
+                        "description": "The amount paid by this payment method"
+                    },
+                    "totalPaid": {
+                        "type": "string",
+                        "format": "decimal",
+                        "description": "The total amount paid by all payment methods to the invoice, converted to this payment method's currency"
+                    },
+                    "due": {
+                        "type": "string",
+                        "format": "decimal",
+                        "description": "The total amount left to be paid, converted to this payment method's currency (will be negative if overpaid)"
+                    },
+                    "amount": {
+                        "type": "string",
+                        "format": "decimal",
+                        "description": "The invoice amount, converted to this payment method's currency"
+                    },
+                    "paymentMethodFee": {
+                        "type": "string",
+                        "format": "decimal",
+                        "description": "The added merchant fee to pay for additional costs incurred by this payment method."
+                    },
+                    "payments": {
+                        "type": "array",
+                        "nullable": false,
+                        "items": {
+                            "$ref": "#/components/schemas/Payment"
+                        },
+                        "description": "Payments made with this payment method."
+                    },
+                    "activated": {
+                        "type": "boolean",
+                        "description": "If the payment method is activated (when lazy payments option is enabled"
+                    },
+                    "additionalData": {
+                        "$ref": "#/components/schemas/InvoiceCheckoutPaymentMethodDetails"
+                    }
+                }
+            },
+            "InvoiceCheckoutPaymentMethodDetails": {
+                "description": "Harmless details exposed for built-in payment methods. Details from other payment methods are omitted.",
+                "anyOf": [
+                    {
+                        "type": "object",
+                        "title": "*-LNURL",
+                        "additionalProperties": false,
+                        "properties": {
+                            "paymentHash": {
+                                "type": "string",
+                                "nullable": true,
+                                "description": "The Lightning payment hash."
+                            },
+                            "nodeInfo": {
+                                "type": "string",
+                                "nullable": true,
+                                "description": "Public connection information for the Lightning node."
+                            },
+                            "bech32Mode": {
+                                "type": "boolean",
+                                "description": "Whether the LNURL payment link uses Bech32 encoding."
+                            }
+                        }
+                    },
+                    {
+                        "type": "object",
+                        "title": "*-LN",
+                        "additionalProperties": false,
+                        "properties": {
+                            "paymentHash": {
+                                "type": "string",
+                                "nullable": true,
+                                "description": "The Lightning payment hash."
+                            },
+                            "nodeInfo": {
+                                "type": "string",
+                                "nullable": true,
+                                "description": "Public connection information for the Lightning node."
+                            }
+                        }
+                    },
+                    {
+                        "type": "object",
+                        "title": "*-CHAIN",
+                        "additionalProperties": false,
+                        "properties": {
+                            "feeMode": {
+                                "type": "string",
+                                "description": "How the payment method fee is calculated."
+                            },
+                            "paymentMethodFeeRate": {
+                                "type": "string",
+                                "format": "decimal",
+                                "nullable": true,
+                                "description": "The fee rate charged to the customer as part of the payment method fee."
+                            },
+                            "assetId": {
+                                "type": "string",
+                                "nullable": true,
+                                "description": "The public asset identifier for an asset-based payment method."
+                            },
+                            "payjoinEnabled": {
+                                "type": "boolean",
+                                "description": "If the payjoin feature is enabled for this payment method."
+                            },
+                            "recommendedFeeRate": {
+                                "type": "string",
+                                "format": "decimal",
+                                "description": "The recommended fee rate for this payment method.",
+                                "example": "4.107"
+                            }
+                        }
+                    },
+                    {
+                        "type": "object",
+                        "nullable": true,
+                        "additionalProperties": false,
+                        "description": "No public details"
+                    }
+                ]
             },
             "Payment": {
                 "type": "object",


### PR DESCRIPTION
Third-party integrations can now retrieve the public information needed to display and monitor an invoice without an API key. Previously, this information was available to the checkout page but not through the documented Greenfield API.

`GET /api/v1/invoices/{invoiceId}/checkout` returns the invoice status, amounts, checkout settings, payment methods, and recorded payments. It also supports activating a lazily created payment method and receiving refreshed checkout data.

The invoice ID acts as the access secret, as it already does for the checkout page. Store IDs, metadata, archival state, and manual status controls are not exposed. Payment-method-specific data is fail closed: only documented harmless fields from BTCPay Server built-in Bitcoin, Lightning, and LNURL methods are returned. Unknown and plugin payment-method details are omitted, including account derivations, Lightning preimages, backend invoice identifiers, and payer-entered LNURL data.

This does not change the checkout UI or authenticated invoice responses. The matching Swagger documentation describes the anonymous routes and their restricted response.